### PR TITLE
[NO MERGE] Use mio to implement the outgoing TCP connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "mio",
  "mockall",
  "negative-impl",
  "oneshot",
@@ -918,6 +919,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]

--- a/crates/folo/Cargo.toml
+++ b/crates/folo/Cargo.toml
@@ -40,6 +40,7 @@ hyper = { version = "1.4.1", features = [
     "client",
     "server",
 ], optional = true }
+mio = { version = "1.0.2", features = ["os-poll", "net"] }
 negative-impl = "0"
 oneshot = { version = "0", features = ["async"] }
 paste = "1"

--- a/crates/folo/examples/grpc_client_folo.rs
+++ b/crates/folo/examples/grpc_client_folo.rs
@@ -1,22 +1,42 @@
 //! This example runs a server that responds to any request with "Hello, world!"
 
-use std::{error::Error, net::SocketAddr};
+use std::{
+    error::Error,
+    net::ToSocketAddrs,
+};
 
-use folo::net::TcpStream;
+use folo::{
+    net::TcpStream,
+    rt::{spawn_sync, SynchronousTaskType},
+    time::{Clock, Stopwatch},
+};
 
 #[folo::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let ip: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+    let clock = Clock::new();
 
-    match TcpStream::connect(ip).await {
-        Ok(stream) => {
-            println!("Connected: {}", stream.peer_addr());
+    // This can be blocking call, run it in a synchronous task
+    let sockets = spawn_sync(SynchronousTaskType::Syscall, || {
+        "microsoft.com:443".to_socket_addrs()
+    })
+    .await?;
+
+    for socket in sockets {
+        let stopwatch = Stopwatch::with_clock(&clock);
+
+        match TcpStream::connect(socket).await {
+            Ok(stream) => {
+                println!(
+                    "Connected: {}, Took: {}ms",
+                    stream.peer_addr(),
+                    stopwatch.elapsed().as_millis()
+                );
+            }
+            Err(e) => {
+                eprintln!("Failed to connect: {}", e);
+            }
         }
-        Err(e) => {
-            eprintln!("Failed to connect: {}", e);
-        }
-    } 
+    }
 
     Ok(())
 }
-

--- a/crates/folo/examples/grpc_client_folo.rs
+++ b/crates/folo/examples/grpc_client_folo.rs
@@ -1,0 +1,22 @@
+//! This example runs a server that responds to any request with "Hello, world!"
+
+use std::{error::Error, net::SocketAddr};
+
+use folo::net::TcpStream;
+
+#[folo::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let ip: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+    match TcpStream::connect(ip).await {
+        Ok(stream) => {
+            println!("Connected: {}", stream.peer_addr());
+        }
+        Err(e) => {
+            eprintln!("Failed to connect: {}", e);
+        }
+    } 
+
+    Ok(())
+}
+

--- a/crates/folo/src/hyper.rs
+++ b/crates/folo/src/hyper.rs
@@ -265,3 +265,6 @@ impl Future for DelayWrapper {
 
 unsafe impl Send for DelayWrapper {}
 unsafe impl Sync for DelayWrapper {}
+
+
+

--- a/crates/folo/src/net.rs
+++ b/crates/folo/src/net.rs
@@ -1,6 +1,8 @@
 mod tcp_connection;
 mod tcp_server;
 pub(crate) mod winsock;
+mod tcp_stream;
 
 pub use tcp_connection::*;
 pub use tcp_server::*;
+pub use tcp_stream::*;

--- a/crates/folo/src/net/tcp_stream.rs
+++ b/crates/folo/src/net/tcp_stream.rs
@@ -1,0 +1,131 @@
+use std::{
+    cell::{Cell, RefCell}, collections::HashMap, future, net::SocketAddr, rc::Rc, task::{Poll, Waker}, time::Duration
+};
+
+use mio::{event::Event, Events, Poll as MioPoll, Token};
+
+type StreamId = u32;
+
+thread_local! {
+    // The local mio poll instance bound to current thread.
+    static LOCAL_POLL: RefCell<MioPoll> = RefCell::new(MioPoll::new().expect("should never fail"));
+
+    // The local events buffer bound to current thread.
+    static EVENTS: RefCell<Events> = RefCell::new(Events::with_capacity(1024));
+
+    // The pending IO events bound to current thread.
+    static PENDING_EVENTS: RefCell<HashMap<Token,IoEvent>> = RefCell::new(HashMap::new());
+
+    // The last used token and stream id.
+    static LAST_TOKEN: Cell<Token> = Cell::new(Token(0));
+    static LAST_STREAM_ID: Cell<u32> = Cell::new(0);
+}
+
+pub(crate) fn poll_local_events() -> std::io::Result<()> {
+    LOCAL_POLL.with_borrow_mut(|poll| poll_local_events_inner(poll))
+}
+
+pub struct TcpStream {
+    inner: Rc<TcpStreamInner>,
+}
+
+impl TcpStream {
+    pub async fn connect(addr: impl Into<SocketAddr>) -> std::io::Result<Self> {
+        // Generate the identifiers for the stream
+        let token = next_token();
+        let id = next_stream_id();
+        let mut io = mio::net::TcpStream::connect(addr.into())?;
+
+        // Register the stream with the poll so we can react to an connection event
+        LOCAL_POLL.with_borrow_mut(|poll| {
+            poll.registry().register(
+                &mut io,
+                token,
+                mio::Interest::READABLE | mio::Interest::WRITABLE,
+            )
+        })?;
+
+        let stream = Rc::new(TcpStreamInner {
+            id,
+            io,
+            connected: RefCell::new(None),
+        });
+
+        let clone: Rc<TcpStreamInner> = Rc::clone(&stream);
+
+        future::poll_fn(|context| {
+            try_register_event(
+                token,
+                IoEvent::Connect(Rc::clone(&clone), context.waker().clone()),
+            );
+
+            let mut connected = clone.connected.borrow_mut();
+
+            if let Some(connected) = connected.take() {
+                Poll::Ready(connected)
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        Ok(TcpStream { inner: stream })
+    }
+
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.inner
+            .io
+            .peer_addr()
+            .expect("stream is connected at this point")
+    }
+}
+
+enum IoEvent {
+    Connect(Rc<TcpStreamInner>, Waker),
+}
+
+struct TcpStreamInner {
+    id: StreamId,
+    io: mio::net::TcpStream,
+    connected: RefCell<Option<Result<SocketAddr, std::io::Error>>>,
+}
+
+fn try_register_event(token: Token, ev: IoEvent) {
+    PENDING_EVENTS.with_borrow_mut(|events| {
+        events.entry(token).or_insert(ev);
+    });
+}
+
+fn poll_local_events_inner(poll: &mut MioPoll) -> std::io::Result<()> {
+    EVENTS.with_borrow_mut(|events| {
+        poll.poll(events, Some(Duration::ZERO))?;
+        events.iter().for_each(|ev| handle_event(ev));
+
+        Ok(())
+    })
+}
+
+fn handle_event(e: &Event) {
+    PENDING_EVENTS.with_borrow_mut(|events| {
+        if let Some(io) = events.remove(&e.token()) {
+            match io {
+                IoEvent::Connect(stream, waker) => {
+                    *stream.connected.borrow_mut() = Some(stream.io.peer_addr());
+                    waker.wake();
+                }
+            }
+        }
+    })
+}
+
+fn next_token() -> Token {
+    let token = Token(LAST_TOKEN.get().0.wrapping_add(1));
+    LAST_TOKEN.set(token);
+    token
+}
+
+fn next_stream_id() -> StreamId {
+    let id = LAST_STREAM_ID.get().wrapping_add(1);
+    LAST_STREAM_ID.set(id);
+    id
+}


### PR DESCRIPTION
I am just experimenting with MIO API and using it to implement the outgoing TCP connections. Just checking if MIO can play nicely with FOLO.

The idea is to use the MIO APIs to manage the nitty-gritty details about how sockets are managed by the operating system. All IO is lock-less and bound to particular async worker.

Only connection establishment is implemented.