### PR TITLE
cpulist: put include-docs under `doc` feature

### DIFF
--- a/crates/cpulist/Cargo.toml
+++ b/crates/cpulist/Cargo.toml
@@ -15,11 +15,11 @@ default = []
 
 [dependencies]
 folo_utils = { workspace = true }
-include-doc = { workspace = true }
 itertools = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+include-doc = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cpulist/Cargo.toml
+++ b/crates/cpulist/Cargo.toml
@@ -12,14 +12,14 @@ rust-version.workspace = true
 
 [features]
 default = []
+doc = ["include-doc"]
 
 [dependencies]
 folo_utils = { workspace = true }
 itertools = { workspace = true }
 thiserror = { workspace = true }
+include-doc = { workspace = true, optional = true }
 
-[dev-dependencies]
-include-doc = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cpulist/src/lib.rs
+++ b/crates/cpulist/src/lib.rs
@@ -25,15 +25,16 @@
 //! Basic conversion from/to strings:
 //!
 //! ```
-#![doc = source_file!("examples/cpulist_basic.rs")]
+#![cfg_attr(doc, doc = source_file!("examples/cpulist_basic.rs"))]
 //! ```
 //!
 //! The stride operator is also supported for parsing:
 //!
 //! ```
-#![doc = source_file!("examples/cpulist_stride.rs")]
+//!
+#![cfg_attr(doc, doc = source_file!("examples/cpulist_stride.rs"))]
 //! ```
-
+#[cfg(doc)]
 use include_doc::source_file;
 
 mod emit;


### PR DESCRIPTION
Thanks for the crate! However, the inclusion of `include-doc` in the base dependencies greatly bloats the deps.

The base deps are:
```
cpulist v0.2.0
├── folo_utils v0.1.0 (/home/lthiery-bg/folo/crates/folo_utils)
├── itertools v0.14.0
│   └── either v1.15.0
└── thiserror v2.0.12
    └── thiserror-impl v2.0.12 (proc-macro)
        ├── proc-macro2 v1.0.95
        │   └── unicode-ident v1.0.18
        ├── quote v1.0.40
        │   └── proc-macro2 v1.0.95 (*)
        └── syn v2.0.101
            ├── proc-macro2 v1.0.95 (*)
            ├── quote v1.0.40 (*)
            └── unicode-ident v1.0.18
```
But include doc includes
```
└── include-doc v0.2.2
    └── include-doc-macro v0.2.2 (proc-macro)
        ├── itertools v0.11.0
        │   └── either v1.15.0
        ├── proc-macro2 v1.0.95 (*)
        ├── quote v1.0.40 (*)
        ├── ra_ap_syntax v0.0.164
        │   ├── cov-mark v2.0.0
        │   ├── either v1.15.0
        │   ├── indexmap v2.9.0
        │   │   ├── equivalent v1.0.2
        │   │   └── hashbrown v0.15.3
        │   ├── itertools v0.10.5
        │   │   └── either v1.15.0
        │   ├── once_cell v1.21.3
        │   ├── ra-ap-rustc_lexer v0.1.0
        │   │   ├── unic-emoji-char v0.9.0
        │   │   │   ├── unic-char-property v0.9.0
        │   │   │   │   └── unic-char-range v0.9.0
        │   │   │   ├── unic-char-range v0.9.0
        │   │   │   └── unic-ucd-version v0.9.0
        │   │   │       └── unic-common v0.9.0
        │   │   └── unicode-xid v0.2.6
        │   ├── ra_ap_parser v0.0.164
        │   │   ├── drop_bomb v0.1.5
        │   │   ├── ra-ap-rustc_lexer v0.1.0 (*)
        │   │   └── ra_ap_limit v0.0.164
        │   ├── ra_ap_profile v0.0.164
        │   │   ├── cfg-if v1.0.0
        │   │   ├── countme v3.0.1
        │   │   │   ├── dashmap v5.5.3
        │   │   │   │   ├── cfg-if v1.0.0
        │   │   │   │   ├── hashbrown v0.14.5
        │   │   │   │   ├── lock_api v0.4.12
        │   │   │   │   │   └── scopeguard v1.2.0
        │   │   │   │   │   [build-dependencies]
        │   │   │   │   │   └── autocfg v1.4.0
        │   │   │   │   ├── once_cell v1.21.3
        │   │   │   │   └── parking_lot_core v0.9.10
        │   │   │   │       ├── cfg-if v1.0.0
        │   │   │   │       ├── libc v0.2.172
        │   │   │   │       └── smallvec v1.15.0
        │   │   │   ├── once_cell v1.21.3
        │   │   │   └── rustc-hash v1.1.0
        │   │   ├── la-arena v0.3.1
        │   │   ├── libc v0.2.172
        │   │   ├── once_cell v1.21.3
        │   │   └── perf-event v0.4.7
        │   │       ├── libc v0.2.172
        │   │       └── perf-event-open-sys v1.0.1
        │   │           └── libc v0.2.172
        │   ├── ra_ap_stdx v0.0.164
        │   │   ├── always-assert v0.1.3
        │   │   │   └── log v0.4.27
        │   │   ├── crossbeam-channel v0.5.15
        │   │   │   └── crossbeam-utils v0.8.21
        │   │   ├── jod-thread v0.1.2
        │   │   └── libc v0.2.172
        │   ├── ra_ap_text_edit v0.0.164
        │   │   ├── itertools v0.10.5 (*)
        │   │   └── text-size v1.1.1
        │   ├── rowan v0.15.16
        │   │   ├── countme v3.0.1 (*)
        │   │   ├── hashbrown v0.14.5
        │   │   ├── rustc-hash v1.1.0
        │   │   └── text-size v1.1.1
        │   ├── rustc-hash v1.1.0
        │   ├── smol_str v0.2.2
        │   └── triomphe v0.1.14
        └── syn v2.0.101 (*)
```