### PR TITLE
Add many_cpus fallback PAL for unsupported platforms

### DIFF
--- a/.vscode/dictionary.txt
+++ b/.vscode/dictionary.txt
@@ -6,6 +6,7 @@ clippy
 cloneable
 cpulist
 cpus
+cpuset
 Dataless
 Deque
 doctest
@@ -31,6 +32,7 @@ pointee
 println
 reentrancy
 repr
+sched
 scopeguard
 Symcrypt
 taskset

--- a/packages/many_cpus/src/clients/hw_tracker_facade.rs
+++ b/packages/many_cpus/src/clients/hw_tracker_facade.rs
@@ -7,15 +7,15 @@ use crate::{HardwareTrackerClient, HardwareTrackerClientImpl, MemoryRegionId, Pr
 
 #[derive(Clone, Debug)]
 pub(crate) enum HardwareTrackerClientFacade {
-    Real(&'static HardwareTrackerClientImpl),
+    Target(&'static HardwareTrackerClientImpl),
 
     #[cfg(test)]
     Mock(Arc<MockHardwareTrackerClient>),
 }
 
 impl HardwareTrackerClientFacade {
-    pub(crate) const fn real() -> Self {
-        Self::Real(&HardwareTrackerClientImpl)
+    pub(crate) const fn target() -> Self {
+        Self::Target(&HardwareTrackerClientImpl)
     }
 
     #[cfg(test)]
@@ -36,7 +36,7 @@ impl HardwareTrackerClient for HardwareTrackerClientFacade {
         memory_region_id: Option<MemoryRegionId>,
     ) {
         match self {
-            Self::Real(real) => {
+            Self::Target(real) => {
                 real.update_pin_status(processor_id, memory_region_id);
             }
             #[cfg(test)]

--- a/packages/many_cpus/src/lib.rs
+++ b/packages/many_cpus/src/lib.rs
@@ -58,6 +58,22 @@
 //! The functionality may also work on other operating systems if they offer compatible platform
 //! APIs but this is not actively tested.
 //!
+//! ## Unsupported platforms
+//!
+//! On operating systems without native support (such as macOS, BSD variants, etc.), this package
+//! provides a fallback implementation that allows code to compile and run with graceful degradation:
+//!
+//! * Processor count is determined via `std::thread::available_parallelism()`
+//! * All processors are simulated as being in a single memory region (region 0)
+//! * All processors are marked as Performance class
+//! * Thread pinning operations succeed but do not actually pin threads to processors
+//! * Current processor tracking uses stable thread-local IDs derived from thread IDs
+//!
+//! While this fallback behavior maintains API compatibility and allows applications to function,
+//! it does not provide the performance benefits of actual processor pinning and topology awareness.
+//! Applications running on unsupported platforms will not see performance improvements from using
+//! this package but will still function correctly.
+//!
 //! # Quick start
 //!
 //! The simplest scenario is when you want to start a thread on every processor in the default

--- a/packages/many_cpus/src/pal.rs
+++ b/packages/many_cpus/src/pal.rs
@@ -17,6 +17,17 @@ mod windows;
 #[cfg(windows)]
 pub use windows::*;
 
+// The fallback module is compiled in test mode on all platforms, and as the primary
+// implementation on unsupported platforms. However, we only glob-import it when it is
+// the primary implementation (i.e. on unsupported platforms). On supported platforms
+// in test mode, it must be accessed via the explicit path `fallback::` to avoid ambiguity
+// with the platform-specific implementation.
+#[cfg(any(test, not(any(target_os = "linux", windows))))]
+pub(crate) mod fallback;
+
+#[cfg(not(any(target_os = "linux", windows)))]
+pub(crate) use fallback::*;
+
 #[cfg(test)]
 mod mocks;
 #[cfg(test)]

--- a/packages/many_cpus/src/pal/fallback/mod.rs
+++ b/packages/many_cpus/src/pal/fallback/mod.rs
@@ -1,0 +1,5 @@
+mod platform;
+mod processor;
+
+pub(crate) use platform::*;
+pub(crate) use processor::*;

--- a/packages/many_cpus/src/pal/fallback/platform.rs
+++ b/packages/many_cpus/src/pal/fallback/platform.rs
@@ -1,0 +1,286 @@
+use std::cell::RefCell;
+use std::num::NonZeroUsize;
+use std::sync::OnceLock;
+use std::thread::ThreadId;
+
+use nonempty::NonEmpty;
+
+use super::ProcessorImpl;
+use crate::pal::{AbstractProcessor, Platform, ProcessorFacade};
+use crate::{MemoryRegionId, ProcessorId};
+
+thread_local! {
+    /// The processor ID assigned to the current thread.
+    ///
+    /// This is computed from the thread ID on first access and remains stable for the lifetime
+    /// of the thread. This simulates a thread being scheduled on a specific processor, even
+    /// though we do not actually perform any pinning on unsupported platforms.
+    static THREAD_PROCESSOR_ID: RefCell<Option<ProcessorId>> = const { RefCell::new(None) };
+
+    /// The set of processor IDs that the current thread is "pinned" to.
+    ///
+    /// On unsupported platforms, we do not actually pin threads to processors, but we track
+    /// the simulated pinning state to maintain API compatibility.
+    static THREAD_PINNED_PROCESSORS: RefCell<Option<NonEmpty<ProcessorId>>> =
+        const { RefCell::new(None) };
+}
+
+/// Fallback platform implementation for operating systems without native support.
+///
+/// This implementation provides graceful degradation on unsupported platforms by:
+/// - Using `std::thread::available_parallelism()` to determine processor count
+/// - Simulating all processors as being in a single memory region (region 0)
+/// - Marking all processors are Performance class
+/// - Pretending to pin threads without actual OS-level affinity changes
+/// - Using stable thread-local processor IDs derived from thread IDs
+///
+/// This allows code to compile and run on any platform, though without the performance benefits
+/// of actual processor pinning and topology awareness.
+#[derive(Debug)]
+pub(crate) struct BuildTargetPlatform;
+
+static PROCESSOR_COUNT: OnceLock<usize> = OnceLock::new();
+
+/// Singleton instance of `BuildTargetPlatform`, used by public API types
+/// to hook up to the correct PAL implementation.
+pub(crate) static BUILD_TARGET_PLATFORM: BuildTargetPlatform = BuildTargetPlatform;
+
+impl BuildTargetPlatform {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+
+    #[expect(clippy::unused_self, reason = "matches Platform trait signature")]
+    pub(crate) fn processor_count(&self) -> usize {
+        *PROCESSOR_COUNT.get_or_init(|| {
+            std::thread::available_parallelism()
+                .map(NonZeroUsize::get)
+                .unwrap_or(1)
+        })
+    }
+
+    fn get_processors(&self) -> NonEmpty<ProcessorFacade> {
+        let processor_count = self.processor_count();
+
+        let processors = (0..processor_count)
+            .map(|id| {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "unrealistic to have more than u32::MAX processors"
+                )]
+                let id = id as ProcessorId;
+                ProcessorFacade::Fallback(ProcessorImpl::new(id))
+            })
+            .collect::<Vec<_>>();
+
+        NonEmpty::from_vec(processors).expect("processor count is at least 1, so this cannot fail")
+    }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn thread_processor_id(thread_id: ThreadId) -> ProcessorId {
+        THREAD_PROCESSOR_ID.with_borrow_mut(|cached_id| {
+            if let Some(id) = *cached_id {
+                return id;
+            }
+
+            // Compute a stable processor ID from the thread ID.
+            // We use a simple hash to distribute threads across processors.
+            let thread_id_hash = {
+                use std::collections::hash_map::DefaultHasher;
+                use std::hash::{Hash, Hasher};
+
+                let mut hasher = DefaultHasher::new();
+                thread_id.hash(&mut hasher);
+                hasher.finish()
+            };
+
+            let processor_count = BUILD_TARGET_PLATFORM.processor_count() as u64;
+
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "result of modulo is guaranteed to be less than processor_count"
+            )]
+            #[expect(clippy::arithmetic_side_effects, reason = "modulo cannot overflow")]
+            let processor_id = (thread_id_hash % processor_count) as ProcessorId;
+
+            *cached_id = Some(processor_id);
+            processor_id
+        })
+    }
+}
+
+impl Platform for BuildTargetPlatform {
+    fn get_all_processors(&self) -> NonEmpty<ProcessorFacade> {
+        self.get_processors()
+    }
+
+    fn pin_current_thread_to<P>(&self, processors: &NonEmpty<P>)
+    where
+        P: AsRef<ProcessorFacade>,
+    {
+        // We do not actually pin threads on unsupported platforms, but we track the simulated
+        // pinning state for API compatibility.
+        let processor_ids_vec: Vec<_> = processors.iter().map(|p| p.as_ref().id()).collect();
+        let processor_ids = NonEmpty::from_vec(processor_ids_vec)
+            .expect("processors is NonEmpty, so this cannot fail");
+
+        THREAD_PINNED_PROCESSORS.with_borrow_mut(|pinned| {
+            *pinned = Some(processor_ids);
+        });
+    }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn current_processor_id(&self) -> ProcessorId {
+        // If the thread is pinned to a single processor, return that processor ID.
+        // This matches the behavior of real platforms where pinned threads actually run
+        // on the pinned processor.
+        THREAD_PINNED_PROCESSORS.with_borrow(|pinned| {
+            if let Some(processors) = pinned
+                && processors.len() == 1
+            {
+                return *processors.first();
+            }
+
+            // If not pinned or pinned to multiple processors, return the thread's natural ID.
+            Self::thread_processor_id(std::thread::current().id())
+        })
+    }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn current_thread_processors(&self) -> NonEmpty<ProcessorId> {
+        THREAD_PINNED_PROCESSORS.with_borrow(|pinned| {
+            pinned.clone().unwrap_or_else(|| {
+                // If not pinned, return all processor IDs.
+                let ids_vec: Vec<_> = self
+                    .get_processors()
+                    .iter()
+                    .map(AbstractProcessor::id)
+                    .collect();
+                NonEmpty::from_vec(ids_vec)
+                    .expect("processor count is at least 1, so this cannot fail")
+            })
+        })
+    }
+
+    fn max_processor_id(&self) -> ProcessorId {
+        // This will never wrap because we are guaranteed at least one processor.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "processor count is guaranteed to fit in u32"
+        )]
+        let max_id = self.processor_count().wrapping_sub(1) as ProcessorId;
+        max_id
+    }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn max_memory_region_id(&self) -> MemoryRegionId {
+        // All processors are in memory region 0 on the fallback platform.
+        0
+    }
+
+    fn max_processor_time(&self) -> f64 {
+        // We assume no resource quota restrictions on unsupported platforms.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "acceptable precision loss for large processor counts"
+        )]
+        let max_time = self.processor_count() as f64;
+        max_time
+    }
+
+    fn active_processor_count(&self) -> usize {
+        self.processor_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EfficiencyClass;
+
+    #[test]
+    fn has_at_least_one_processor() {
+        let platform = BuildTargetPlatform::new();
+        assert!(platform.processor_count() >= 1);
+        assert!(!platform.get_processors().is_empty());
+    }
+
+    #[test]
+    fn all_processors_in_region_zero() {
+        let platform = BuildTargetPlatform::new();
+        for processor in platform.get_processors().iter() {
+            assert_eq!(processor.memory_region_id(), 0);
+        }
+    }
+
+    #[test]
+    fn all_processors_are_performance() {
+        let platform = BuildTargetPlatform::new();
+        for processor in platform.get_processors().iter() {
+            assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
+        }
+    }
+
+    #[test]
+    fn processor_ids_are_sequential() {
+        let platform = BuildTargetPlatform::new();
+        for (index, processor) in platform.get_processors().iter().enumerate() {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "test data is small enough to fit"
+            )]
+            let expected_id = index as ProcessorId;
+            assert_eq!(processor.id(), expected_id);
+        }
+    }
+
+    #[test]
+    fn max_processor_id_is_count_minus_one() {
+        let platform = BuildTargetPlatform::new();
+        let max_id = platform.max_processor_id();
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "test data is small enough to fit"
+        )]
+        let expected_max = (platform.processor_count() - 1) as ProcessorId;
+        assert_eq!(max_id, expected_max);
+    }
+
+    #[test]
+    fn current_processor_id_is_stable_within_thread() {
+        let platform = BuildTargetPlatform::new();
+        let id1 = platform.current_processor_id();
+        let id2 = platform.current_processor_id();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn pinning_updates_current_thread_processors() {
+        let platform = BuildTargetPlatform::new();
+
+        let processors = platform.get_processors();
+        let first_processor = processors.first();
+        let single_processor = nonempty::nonempty![first_processor];
+
+        platform.pin_current_thread_to(&single_processor);
+
+        let current = platform.current_thread_processors();
+        assert_eq!(current.len(), 1);
+        assert_eq!(*current.first(), first_processor.id());
+    }
+
+    #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "exact comparison is appropriate for this test"
+    )]
+    fn max_processor_time_equals_processor_count() {
+        let platform = BuildTargetPlatform::new();
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "test comparison with acceptable precision"
+        )]
+        let expected_time = platform.processor_count() as f64;
+        assert_eq!(platform.max_processor_time(), expected_time);
+    }
+}

--- a/packages/many_cpus/src/pal/fallback/processor.rs
+++ b/packages/many_cpus/src/pal/fallback/processor.rs
@@ -1,0 +1,38 @@
+use derive_more::derive::Display;
+
+use crate::pal::AbstractProcessor;
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+
+/// A fallback processor implementation for unsupported platforms.
+///
+/// This processor always reports itself as being in memory region 0 with Performance efficiency
+/// class. The actual hardware topology is not inspected on unsupported platforms.
+#[derive(Clone, Copy, Debug, Display, Eq, Hash, PartialEq)]
+#[display("ProcessorImpl({id})")]
+pub(crate) struct ProcessorImpl {
+    id: ProcessorId,
+}
+
+impl ProcessorImpl {
+    pub(crate) fn new(id: ProcessorId) -> Self {
+        Self { id }
+    }
+}
+
+impl AbstractProcessor for ProcessorImpl {
+    fn id(&self) -> ProcessorId {
+        self.id
+    }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn memory_region_id(&self) -> MemoryRegionId {
+        // All processors are in the same memory region on the fallback platform.
+        0
+    }
+
+    fn efficiency_class(&self) -> EfficiencyClass {
+        // We do not have real topology information, so we assume all processors
+        // are performance processors.
+        EfficiencyClass::Performance
+    }
+}

--- a/packages/many_cpus/src/pal/linux/bindings/facade.rs
+++ b/packages/many_cpus/src/pal/linux/bindings/facade.rs
@@ -12,15 +12,15 @@ use crate::pal::linux::{Bindings, BuildTargetBindings};
 /// Enum to hide the real/mock choice behind a single wrapper type.
 #[derive(Clone)]
 pub(crate) enum BindingsFacade {
-    Real(&'static BuildTargetBindings),
+    Target(&'static BuildTargetBindings),
 
     #[cfg(test)]
     Mock(Arc<MockBindings>),
 }
 
 impl BindingsFacade {
-    pub(crate) const fn real() -> Self {
-        Self::Real(&BuildTargetBindings)
+    pub(crate) const fn target() -> Self {
+        Self::Target(&BuildTargetBindings)
     }
 
     #[cfg(test)]
@@ -32,7 +32,7 @@ impl BindingsFacade {
 impl Bindings for BindingsFacade {
     fn sched_setaffinity_current(&self, cpuset: &cpu_set_t) -> Result<(), io::Error> {
         match self {
-            Self::Real(bindings) => bindings.sched_setaffinity_current(cpuset),
+            Self::Target(bindings) => bindings.sched_setaffinity_current(cpuset),
             #[cfg(test)]
             Self::Mock(mock) => mock.sched_setaffinity_current(cpuset),
         }
@@ -40,7 +40,7 @@ impl Bindings for BindingsFacade {
 
     fn sched_getcpu(&self) -> i32 {
         match self {
-            Self::Real(bindings) => bindings.sched_getcpu(),
+            Self::Target(bindings) => bindings.sched_getcpu(),
             #[cfg(test)]
             Self::Mock(mock) => mock.sched_getcpu(),
         }
@@ -48,7 +48,7 @@ impl Bindings for BindingsFacade {
 
     fn sched_getaffinity_current(&self) -> Result<cpu_set_t, io::Error> {
         match self {
-            Self::Real(bindings) => bindings.sched_getaffinity_current(),
+            Self::Target(bindings) => bindings.sched_getaffinity_current(),
             #[cfg(test)]
             Self::Mock(mock) => mock.sched_getaffinity_current(),
         }
@@ -58,7 +58,7 @@ impl Bindings for BindingsFacade {
 impl Debug for BindingsFacade {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Real(inner) => inner.fmt(f),
+            Self::Target(inner) => inner.fmt(f),
             #[cfg(test)]
             Self::Mock(inner) => inner.fmt(f),
         }

--- a/packages/many_cpus/src/pal/linux/filesystem/facade.rs
+++ b/packages/many_cpus/src/pal/linux/filesystem/facade.rs
@@ -9,15 +9,15 @@ use crate::pal::linux::{BuildTargetFilesystem, Filesystem};
 /// Enum to hide the different filesystem implementations behind a single wrapper type.
 #[derive(Clone)]
 pub(crate) enum FilesystemFacade {
-    Real(&'static BuildTargetFilesystem),
+    Target(&'static BuildTargetFilesystem),
 
     #[cfg(test)]
     Mock(Arc<MockFilesystem>),
 }
 
 impl FilesystemFacade {
-    pub(crate) const fn real() -> Self {
-        Self::Real(&BuildTargetFilesystem)
+    pub(crate) const fn target() -> Self {
+        Self::Target(&BuildTargetFilesystem)
     }
 
     #[cfg(test)]
@@ -29,7 +29,7 @@ impl FilesystemFacade {
 impl Filesystem for FilesystemFacade {
     fn get_cpuinfo_contents(&self) -> String {
         match self {
-            Self::Real(filesystem) => filesystem.get_cpuinfo_contents(),
+            Self::Target(filesystem) => filesystem.get_cpuinfo_contents(),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_cpuinfo_contents(),
         }
@@ -37,7 +37,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_numa_node_cpulist_contents(&self, node_index: u32) -> String {
         match self {
-            Self::Real(filesystem) => filesystem.get_numa_node_cpulist_contents(node_index),
+            Self::Target(filesystem) => filesystem.get_numa_node_cpulist_contents(node_index),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_numa_node_cpulist_contents(node_index),
         }
@@ -45,7 +45,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_cpu_online_contents(&self, cpu_index: u32) -> Option<String> {
         match self {
-            Self::Real(filesystem) => filesystem.get_cpu_online_contents(cpu_index),
+            Self::Target(filesystem) => filesystem.get_cpu_online_contents(cpu_index),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_cpu_online_contents(cpu_index),
         }
@@ -53,7 +53,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_numa_node_possible_contents(&self) -> Option<String> {
         match self {
-            Self::Real(filesystem) => filesystem.get_numa_node_possible_contents(),
+            Self::Target(filesystem) => filesystem.get_numa_node_possible_contents(),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_numa_node_possible_contents(),
         }
@@ -61,7 +61,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_proc_self_status_contents(&self) -> String {
         match self {
-            Self::Real(filesystem) => filesystem.get_proc_self_status_contents(),
+            Self::Target(filesystem) => filesystem.get_proc_self_status_contents(),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_proc_self_status_contents(),
         }
@@ -69,7 +69,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_proc_self_cgroup(&self) -> Option<String> {
         match self {
-            Self::Real(filesystem) => filesystem.get_proc_self_cgroup(),
+            Self::Target(filesystem) => filesystem.get_proc_self_cgroup(),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_proc_self_cgroup(),
         }
@@ -77,7 +77,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_v1_cgroup_cpu_quota(&self, cgroup_name: &str) -> Option<String> {
         match self {
-            Self::Real(filesystem) => filesystem.get_v1_cgroup_cpu_quota(cgroup_name),
+            Self::Target(filesystem) => filesystem.get_v1_cgroup_cpu_quota(cgroup_name),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_v1_cgroup_cpu_quota(cgroup_name),
         }
@@ -85,7 +85,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_v1_cgroup_cpu_period(&self, cgroup_name: &str) -> Option<String> {
         match self {
-            Self::Real(filesystem) => filesystem.get_v1_cgroup_cpu_period(cgroup_name),
+            Self::Target(filesystem) => filesystem.get_v1_cgroup_cpu_period(cgroup_name),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_v1_cgroup_cpu_period(cgroup_name),
         }
@@ -93,7 +93,7 @@ impl Filesystem for FilesystemFacade {
 
     fn get_v2_cgroup_cpu_quota_and_period(&self, cgroup_name: &str) -> Option<String> {
         match self {
-            Self::Real(filesystem) => filesystem.get_v2_cgroup_cpu_quota_and_period(cgroup_name),
+            Self::Target(filesystem) => filesystem.get_v2_cgroup_cpu_quota_and_period(cgroup_name),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_v2_cgroup_cpu_quota_and_period(cgroup_name),
         }
@@ -103,7 +103,7 @@ impl Filesystem for FilesystemFacade {
 impl Debug for FilesystemFacade {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Real(inner) => inner.fmt(f),
+            Self::Target(inner) => inner.fmt(f),
             #[cfg(test)]
             Self::Mock(inner) => inner.fmt(f),
         }

--- a/packages/many_cpus/src/pal/windows/bindings/facade.rs
+++ b/packages/many_cpus/src/pal/windows/bindings/facade.rs
@@ -16,15 +16,15 @@ use crate::pal::windows::{Bindings, BuildTargetBindings};
 /// Hide the real/mock bindings choice behind a single type.
 #[derive(Clone)]
 pub(crate) enum BindingsFacade {
-    Real(&'static BuildTargetBindings),
+    Target(&'static BuildTargetBindings),
 
     #[cfg(test)]
     Mock(Arc<MockBindings>),
 }
 
 impl BindingsFacade {
-    pub(crate) const fn real() -> Self {
-        Self::Real(&BuildTargetBindings)
+    pub(crate) const fn target() -> Self {
+        Self::Target(&BuildTargetBindings)
     }
 
     #[cfg(test)]
@@ -36,7 +36,7 @@ impl BindingsFacade {
 impl Bindings for BindingsFacade {
     fn get_active_processor_count(&self, group_number: u16) -> u32 {
         match self {
-            Self::Real(bindings) => bindings.get_active_processor_count(group_number),
+            Self::Target(bindings) => bindings.get_active_processor_count(group_number),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_active_processor_count(group_number),
         }
@@ -44,7 +44,7 @@ impl Bindings for BindingsFacade {
 
     fn get_maximum_processor_count(&self, group_number: u16) -> u32 {
         match self {
-            Self::Real(bindings) => bindings.get_maximum_processor_count(group_number),
+            Self::Target(bindings) => bindings.get_maximum_processor_count(group_number),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_maximum_processor_count(group_number),
         }
@@ -52,7 +52,7 @@ impl Bindings for BindingsFacade {
 
     fn get_maximum_processor_group_count(&self) -> u16 {
         match self {
-            Self::Real(bindings) => bindings.get_maximum_processor_group_count(),
+            Self::Target(bindings) => bindings.get_maximum_processor_group_count(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_maximum_processor_group_count(),
         }
@@ -60,7 +60,7 @@ impl Bindings for BindingsFacade {
 
     fn get_current_processor_number_ex(&self) -> PROCESSOR_NUMBER {
         match self {
-            Self::Real(bindings) => bindings.get_current_processor_number_ex(),
+            Self::Target(bindings) => bindings.get_current_processor_number_ex(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_current_processor_number_ex(),
         }
@@ -74,7 +74,7 @@ impl Bindings for BindingsFacade {
     ) -> Result<()> {
         match self {
             // SAFETY: Forwarding safety requirements to caller.
-            Self::Real(bindings) => unsafe {
+            Self::Target(bindings) => unsafe {
                 bindings.get_logical_processor_information_ex(
                     relationship_type,
                     buffer,
@@ -95,7 +95,7 @@ impl Bindings for BindingsFacade {
 
     fn get_numa_highest_node_number(&self) -> u32 {
         match self {
-            Self::Real(bindings) => bindings.get_numa_highest_node_number(),
+            Self::Target(bindings) => bindings.get_numa_highest_node_number(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_numa_highest_node_number(),
         }
@@ -103,7 +103,7 @@ impl Bindings for BindingsFacade {
 
     fn get_current_process_default_cpu_set_masks(&self) -> Vec<GROUP_AFFINITY> {
         match self {
-            Self::Real(bindings) => bindings.get_current_process_default_cpu_set_masks(),
+            Self::Target(bindings) => bindings.get_current_process_default_cpu_set_masks(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_current_process_default_cpu_set_masks(),
         }
@@ -111,7 +111,7 @@ impl Bindings for BindingsFacade {
 
     fn get_current_thread_cpu_set_masks(&self) -> Vec<GROUP_AFFINITY> {
         match self {
-            Self::Real(bindings) => bindings.get_current_thread_cpu_set_masks(),
+            Self::Target(bindings) => bindings.get_current_thread_cpu_set_masks(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_current_thread_cpu_set_masks(),
         }
@@ -119,7 +119,7 @@ impl Bindings for BindingsFacade {
 
     fn set_current_thread_cpu_set_masks(&self, masks: &[GROUP_AFFINITY]) {
         match self {
-            Self::Real(bindings) => bindings.set_current_thread_cpu_set_masks(masks),
+            Self::Target(bindings) => bindings.set_current_thread_cpu_set_masks(masks),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.set_current_thread_cpu_set_masks(masks),
         }
@@ -127,7 +127,7 @@ impl Bindings for BindingsFacade {
 
     fn get_current_job_cpu_set_masks(&self) -> Vec<GROUP_AFFINITY> {
         match self {
-            Self::Real(bindings) => bindings.get_current_job_cpu_set_masks(),
+            Self::Target(bindings) => bindings.get_current_job_cpu_set_masks(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_current_job_cpu_set_masks(),
         }
@@ -135,7 +135,7 @@ impl Bindings for BindingsFacade {
 
     fn get_current_thread_legacy_group_affinity(&self) -> GROUP_AFFINITY {
         match self {
-            Self::Real(bindings) => bindings.get_current_thread_legacy_group_affinity(),
+            Self::Target(bindings) => bindings.get_current_thread_legacy_group_affinity(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_current_thread_legacy_group_affinity(),
         }
@@ -143,7 +143,7 @@ impl Bindings for BindingsFacade {
 
     fn get_current_job_cpu_rate_control(&self) -> Option<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION> {
         match self {
-            Self::Real(bindings) => bindings.get_current_job_cpu_rate_control(),
+            Self::Target(bindings) => bindings.get_current_job_cpu_rate_control(),
             #[cfg(test)]
             Self::Mock(bindings) => bindings.get_current_job_cpu_rate_control(),
         }
@@ -153,7 +153,7 @@ impl Bindings for BindingsFacade {
 impl Debug for BindingsFacade {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Real(inner) => inner.fmt(f),
+            Self::Target(inner) => inner.fmt(f),
             #[cfg(test)]
             Self::Mock(inner) => inner.fmt(f),
         }


### PR DESCRIPTION
Implements a fallback Platform Abstraction Layer (PAL) for `many_cpus` that enables compilation on operating systems without native support (macOS, BSD, etc.). Applications compile and run correctly but without performance benefits from actual processor pinning and topology awareness.

## Implementation

**New fallback PAL** (fallback):
- Uses `std::thread::available_parallelism()` for processor count
- Simulates all processors as Performance class in memory region 0
- Provides stable thread-local processor IDs via thread ID hashing
- Tracks simulated pinning state without OS-level affinity changes
- Correctly reports pinned processor ID when pinned to single processor

**Renamed "Real" → "Target"** throughout PAL for clarity:
- Updated all facade enums and methods (~150 references)
- `PlatformFacade::Real` → `PlatformFacade::Target`
- `as_real()` → `as_target()`, etc.

**Facade enhancements**:
- Added `Fallback` variant (test-only on supported platforms)
- Fallback compiled on all platforms in test mode
- Becomes primary implementation on unsupported platforms

## Testing

Added 27 integration tests across 3 new `tests_fallback` modules:
- `hardware_tracker::tests_fallback` (8 tests)
- `processor_set::tests_fallback` (9 tests)
- `processor_set_builder::tests_fallback` (10 tests)

All 124 tests in `many_cpus` pass. Full validation suite passes.

## Documentation

- Added "Unsupported platforms" section to package docs
- Documented fallback behavior and limitations
- Comprehensive inline documentation

## Breaking Changes

None. Internal refactoring only; public API unchanged.