### PR TITLE
feat(fast_time): add UnwindSafe + RefUnwindSafe assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,3 +645,9 @@ Avoid unnecessary and repetitive prefixes and suffixes.
 For example:
 
 * Builder methods are just a noun. It is `FooBuilder::bar(value)` not `FooBuilder::with_bar(value)`.
+
+# Creating GitHub pull requests
+
+When creating PRs with `gh pr create`, do not pass the `--body` flag with an inline string because
+PowerShell mangles backticks and special characters. Instead, write the PR body to a temporary file
+and use `--body-file path/to/file.md`.

--- a/packages/fast_time/src/clock.rs
+++ b/packages/fast_time/src/clock.rs
@@ -162,9 +162,11 @@ impl Default for Clock {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
     use super::*;
 
-    static_assertions::assert_impl_all!(Clock: Clone, Send);
+    static_assertions::assert_impl_all!(Clock: Clone, Send, UnwindSafe, RefUnwindSafe);
 
     #[test]
     fn now_is_approximately_now() {

--- a/packages/fast_time/src/instant.rs
+++ b/packages/fast_time/src/instant.rs
@@ -264,10 +264,14 @@ impl From<Instant> for std::time::Instant {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
     use mockall::Sequence;
 
     use super::*;
     use crate::pal::{MockPlatform, MockTimeSource};
+
+    static_assertions::assert_impl_all!(Instant: UnwindSafe, RefUnwindSafe);
 
     #[test]
     fn saturating_duration_since_can_math() {

--- a/packages/fast_time/src/pal/linux/bindings/real.rs
+++ b/packages/fast_time/src/pal/linux/bindings/real.rs
@@ -44,3 +44,13 @@ impl Bindings for BuildTargetBindings {
         Instant::now()
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    static_assertions::assert_impl_all!(BuildTargetBindings: UnwindSafe, RefUnwindSafe);
+}

--- a/packages/fast_time/src/pal/linux/platform.rs
+++ b/packages/fast_time/src/pal/linux/platform.rs
@@ -26,3 +26,13 @@ impl Platform for BuildTargetPlatform {
         Self::TimeSource::new(self.bindings.clone())
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    static_assertions::assert_impl_all!(BuildTargetPlatform: UnwindSafe, RefUnwindSafe);
+}

--- a/packages/fast_time/src/pal/linux/time_source.rs
+++ b/packages/fast_time/src/pal/linux/time_source.rs
@@ -58,10 +58,14 @@ impl TimeSource for TimeSourceImpl {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
     use mockall::Sequence;
 
     use super::*;
     use crate::pal::linux::bindings::MockBindings;
+
+    static_assertions::assert_impl_all!(TimeSourceImpl: UnwindSafe, RefUnwindSafe);
 
     #[test]
     fn smoke_test() {

--- a/packages/fast_time/src/pal/rust.rs
+++ b/packages/fast_time/src/pal/rust.rs
@@ -24,3 +24,14 @@ impl TimeSource for RustTimeSource {
         Instant::now()
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    static_assertions::assert_impl_all!(RustPlatform: UnwindSafe, RefUnwindSafe);
+    static_assertions::assert_impl_all!(RustTimeSource: UnwindSafe, RefUnwindSafe);
+}

--- a/packages/fast_time/src/pal/windows/bindings/real.rs
+++ b/packages/fast_time/src/pal/windows/bindings/real.rs
@@ -21,3 +21,13 @@ impl Bindings for BuildTargetBindings {
         Instant::now()
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    static_assertions::assert_impl_all!(BuildTargetBindings: UnwindSafe, RefUnwindSafe);
+}

--- a/packages/fast_time/src/pal/windows/platform.rs
+++ b/packages/fast_time/src/pal/windows/platform.rs
@@ -26,3 +26,13 @@ impl Platform for BuildTargetPlatform {
         Self::TimeSource::new(self.bindings.clone())
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    static_assertions::assert_impl_all!(BuildTargetPlatform: UnwindSafe, RefUnwindSafe);
+}

--- a/packages/fast_time/src/pal/windows/time_source.rs
+++ b/packages/fast_time/src/pal/windows/time_source.rs
@@ -56,10 +56,14 @@ impl TimeSource for TimeSourceImpl {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
     use mockall::Sequence;
 
     use super::*;
     use crate::pal::windows::bindings::MockBindings;
+
+    static_assertions::assert_impl_all!(TimeSourceImpl: UnwindSafe, RefUnwindSafe);
 
     #[test]
     fn smoke_test() {


### PR DESCRIPTION
## Summary

Add static assertions verifying that all `fast_time` types implement `UnwindSafe + RefUnwindSafe`. All types already satisfy the auto trait requirements, so no explicit `impl` blocks are needed - the assertions serve as a regression guard.

Also add guidance to `AGENTS.md` on using `--body-file` for `gh pr create` to avoid PowerShell mangling backticks in PR descriptions.

## Types verified

**Public types:**
- `Instant`
- `Clock`

**Internal types (Windows + Linux):**
- `TimeSourceImpl`
- `BuildTargetPlatform`
- `BuildTargetBindings`
- `RustPlatform`
- `RustTimeSource`
