### PR TITLE
Increase workflow timeouts and add cache warmup

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -46,11 +46,20 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
 - **mutants** — `timeout-minutes: 90`
   - Runs mutation testing (very slow)
   
-- **run-examples** — `timeout-minutes: 30`
+- **run-examples** — `timeout-minutes: 90`
   - Executes all example binaries
   
-- **hack** — `timeout-minutes: 30`
+- **hack** — `timeout-minutes: 90`
   - Tests all feature combinations with `cargo hack --feature-powerset`
+
+### cache-warmup.yml
+
+A scheduled workflow that keeps GitHub Actions caches warm. GitHub evicts caches after
+7 days of inactivity, and a cold cache means every parallel validation job must independently
+compile all Rust dependencies from scratch (the setup-environment step becomes very expensive).
+This workflow runs once daily on all three platforms (ubuntu, macos, windows) to ensure the
+`shared-key: prerequisites` Rust cache is always populated. It also supports `workflow_dispatch`
+for manual cache warming after toolchain updates.
 
 ## Design Decisions
 

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -1,0 +1,26 @@
+name: Cache warmup
+
+# Keeps GitHub Actions caches warm to prevent expensive cold setups in validation
+# workflows. GitHub evicts caches after 7 days of inactivity, so periodic access
+# ensures the Rust compilation cache is always available for real CI runs.
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  warmup:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -258,7 +258,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: windows-latest
 
     steps:
@@ -280,7 +280,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: windows-latest
 
     steps:
@@ -398,7 +398,7 @@ jobs:
   run-examples:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -419,7 +419,7 @@ jobs:
   hack:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Reduces the impact of cold GitHub Actions caches on CI run times.

### Changes

- **Increased timeouts**: All workflow jobs now have a minimum timeout of 90 minutes (up from 30-60 on some jobs), giving non-cached environment setup enough time to complete.
- **Cache warmup workflow**: New `cache-warmup.yml` runs daily on all three platforms (ubuntu, windows, macos) to keep the `shared-key: prerequisites` Rust compilation cache warm. GitHub evicts caches after 7 days of inactivity, so daily access prevents expiration. Also supports `workflow_dispatch` for manual warming after toolchain updates.
- **Documentation**: Updated `AGENTS.md` with details on the new workflow.

### Why

When the Rust cache expires, every parallel validation job independently compiles all dependencies from scratch, causing long setup times and occasional timeouts. The warmup workflow ensures the cache is always populated.
