### PR TITLE
fix: add missing #[serial] to flaky workspace test

### DIFF
--- a/packages/cargo-detect-package/AGENTS.md
+++ b/packages/cargo-detect-package/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent notes for cargo-detect-package
+
+## When `#[serial]` is required on tests
+
+Tests in `workspace::tests` that depend on the process-global current working directory must be
+marked `#[serial]` from the `serial_test` crate. This includes:
+
+* Tests that explicitly call `std::env::set_current_dir` (obvious).
+* Tests that **implicitly** depend on the current directory being inside a Cargo workspace. For
+  example, `validate_workspace_context_nonexistent_file` does not change the directory itself but
+  calls `validate_workspace_context`, which internally calls `current_dir()` and then
+  `find_workspace_root()`. If a concurrent test has changed the working directory to a location
+  outside any workspace, `find_workspace_root` fails with a different error than expected, causing
+  the test to flake.
+
+The rule is simple: if a test calls any function that reads or writes the process current directory,
+it must be `#[serial]`.

--- a/packages/cargo-detect-package/src/workspace.rs
+++ b/packages/cargo-detect-package/src/workspace.rs
@@ -142,6 +142,7 @@ mod tests {
     use crate::pal::FilesystemFacade;
 
     #[test]
+    #[serial] // This test depends on the current directory being inside a Cargo workspace.
     fn validate_workspace_context_nonexistent_file() {
         // Nonexistent files are now rejected by validate_workspace_context, not detect_package.
         let fs = FilesystemFacade::target();


### PR DESCRIPTION
## Problem

`validate_workspace_context_nonexistent_file` was missing `#[serial]`, causing flaky failures when it ran concurrently with tests that change the working directory to a non-workspace temp directory.

## Fix

- Added `#[serial]` to the test
- Created `packages/cargo-detect-package/AGENTS.md` documenting when `#[serial]` is required
