### PR TITLE
feat: PublisherBuilder accepts any implementation of MeterProvider

### DIFF
--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -21,7 +21,6 @@ foldhash = { workspace = true }
 futures = { workspace = true }
 nm = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
-opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 tick = { workspace = true }
 
 [dev-dependencies]

--- a/packages/nm_otel/examples/nm_otel_console.rs
+++ b/packages/nm_otel/examples/nm_otel_console.rs
@@ -89,7 +89,7 @@ async fn main() {
 
     // Create the nm-to-OpenTelemetry publisher.
     let mut nm_publisher = Publisher::builder()
-        .provider(provider.clone())
+        .provider(provider)
         .clock(clock)
         .interval(Duration::from_secs(2))
         .build();

--- a/packages/nm_otel/examples/nm_otel_console.rs
+++ b/packages/nm_otel/examples/nm_otel_console.rs
@@ -89,7 +89,7 @@ async fn main() {
 
     // Create the nm-to-OpenTelemetry publisher.
     let mut nm_publisher = Publisher::builder()
-        .provider(provider)
+        .provider(provider.clone())
         .clock(clock)
         .interval(Duration::from_secs(2))
         .build();

--- a/packages/nm_otel/src/lib.rs
+++ b/packages/nm_otel/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! Use [`PublisherBuilder`] to configure the publisher:
 //!
-//! - `interval()` - how often to collect and export metrics (default: 5 seconds)
+//! - `interval()` - how often to collect and export metrics (default: 60 seconds)
 //! - `meter_name()` - OpenTelemetry meter name (default: "nm")
 //! - `provider()` - any [`MeterProvider`][opentelemetry::metrics::MeterProvider] implementation
 //!

--- a/packages/nm_otel/src/lib.rs
+++ b/packages/nm_otel/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! - `interval()` - how often to collect and export metrics (default: 5 seconds)
 //! - `meter_name()` - OpenTelemetry meter name (default: "nm")
-//! - `provider()` - custom [`SdkMeterProvider`][opentelemetry_sdk::metrics::SdkMeterProvider]
+//! - `provider()` - any [`MeterProvider`][opentelemetry::metrics::MeterProvider] implementation
 //!
 //! ## Requirements
 //!

--- a/packages/nm_otel/src/publisher.rs
+++ b/packages/nm_otel/src/publisher.rs
@@ -349,4 +349,14 @@ mod tests {
 
         // If this completes without panic, state tracking is working.
     }
+
+    #[test]
+    fn builder_debug_formatting() {
+        let (provider, _exporter) = create_test_provider();
+
+        let builder = Publisher::builder().provider(provider);
+        let debug = format!("{builder:?}");
+
+        assert!(debug.contains("PublisherBuilder"));
+    }
 }

--- a/packages/nm_otel/src/publisher.rs
+++ b/packages/nm_otel/src/publisher.rs
@@ -1,12 +1,12 @@
 //! Publisher for exporting nm metrics to OpenTelemetry.
 
+use std::fmt;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::time::Duration;
 
 use futures::StreamExt;
 use nm::Report;
-use opentelemetry::metrics::{Meter, MeterProvider as _};
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry::metrics::{Meter, MeterProvider};
 use tick::{Clock, PeriodicTimer};
 
 use crate::mapping::{InstrumentRegistry, export_report};
@@ -37,12 +37,24 @@ const DEFAULT_METER_NAME: &str = "nm";
 ///     .interval(Duration::from_secs(5))
 ///     .build();
 /// ```
-#[derive(Debug)]
 pub struct PublisherBuilder {
-    provider: Option<SdkMeterProvider>,
+    provider: Option<Box<dyn MeterProvider>>,
     clock: Option<Clock>,
     interval: Duration,
     meter_name: &'static str,
+}
+
+// dyn MeterProvider does not implement Debug, so we provide a manual implementation
+// that omits the provider field.
+impl fmt::Debug for PublisherBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublisherBuilder")
+            .field("provider", &self.provider.as_ref().map(|_| ".."))
+            .field("clock", &self.clock)
+            .field("interval", &self.interval)
+            .field("meter_name", &self.meter_name)
+            .finish()
+    }
 }
 
 // PublisherBuilder wraps OpenTelemetry SDK types that use trait objects internally.
@@ -63,10 +75,11 @@ impl PublisherBuilder {
 
     /// Sets the OpenTelemetry meter provider.
     ///
+    /// Accepts any [`MeterProvider`] implementation.
     /// This is required - the builder will panic if not set.
     #[must_use]
-    pub fn provider(mut self, provider: SdkMeterProvider) -> Self {
-        self.provider = Some(provider);
+    pub fn provider(mut self, provider: impl MeterProvider + 'static) -> Self {
+        self.provider = Some(Box::new(provider));
         self
     }
 
@@ -141,7 +154,10 @@ impl PublisherBuilder {
 /// # let exporter = InMemoryMetricExporter::default();
 /// # let reader = PeriodicReader::builder(exporter).build();
 /// # let provider = SdkMeterProvider::builder().with_reader(reader).build();
-/// # let mut publisher = Publisher::builder().provider(provider).clock(Clock::new_frozen()).build();
+/// # let mut publisher = Publisher::builder()
+/// #     .provider(provider)
+/// #     .clock(Clock::new_frozen())
+/// #     .build();
 /// # async fn example(mut publisher: nm_otel::Publisher) {
 /// // Spawn as a background task in your async runtime.
 /// publisher.publish_forever().await;
@@ -192,7 +208,8 @@ impl Publisher {
 
     /// Runs the publisher forever, collecting and exporting metrics at each interval.
     ///
-    /// This method never returns under normal operation. Drop the future to cancel the publishing.
+    /// This method never returns under normal operation. Drop the future to cancel
+    /// the publishing.
     pub async fn publish_forever(&mut self) {
         let mut timer = PeriodicTimer::new(&self.clock, self.interval);
 
@@ -227,7 +244,7 @@ impl Publisher {
 mod tests {
     use std::panic::{RefUnwindSafe, UnwindSafe};
 
-    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
     use static_assertions::assert_impl_all;
 
     use super::*;

--- a/packages/nm_otel/src/publisher.rs
+++ b/packages/nm_otel/src/publisher.rs
@@ -57,8 +57,8 @@ impl fmt::Debug for PublisherBuilder {
     }
 }
 
-// PublisherBuilder wraps OpenTelemetry SDK types that use trait objects internally.
-// The trait objects are not auto-RefUnwindSafe but are used only for metrics export
+// PublisherBuilder stores an OpenTelemetry MeterProvider trait object.
+// The trait object is not auto-RefUnwindSafe but is used only for metrics export
 // configuration. Inconsistent state after a caught panic cannot affect safety.
 impl UnwindSafe for PublisherBuilder {}
 impl RefUnwindSafe for PublisherBuilder {}


### PR DESCRIPTION
With this change, the `opentelemetry_sdk` dep is no longer required and thisc reate will work any `MeterProvider`