### PR TITLE
Audit and codify reentrancy contract for callbacks (#148)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,18 @@ let entity = unsafe {
 };
 ```
 
+# Reentrancy through callbacks
+
+User-supplied callbacks (`Waker::wake`, `Drop` impls, observer closures, etc.) can
+re-enter the data structure they were invoked from and silently corrupt invariants
+without violating any borrow-checker, type-system, or Miri rule. Never invoke a user
+callback while holding a borrow or lock on shared state, never `mem::take`/`swap`/
+`replace` shared state when the callback could re-enter through the original location,
+and document the reentrancy contract (with parity tests across thread-safe and
+single-threaded variants) on every public async primitive. See
+[docs/callback-safety.md](docs/callback-safety.md) for the full rationale, anti-patterns,
+and examples.
+
 # Whitespace
 
 There should be an empty line between functions.

--- a/docs/callback-safety.md
+++ b/docs/callback-safety.md
@@ -1,0 +1,87 @@
+# Callback safety
+
+User-supplied callbacks (`Waker::wake`, `Drop` impls, observer closures, stored `FnOnce`
+values, panics propagated through `catch_unwind`, etc.) can re-enter the data structure
+they were invoked from. The corruption that results is logical, not memory-safety: the
+borrow checker, Miri, and the type system can all be satisfied while a reentrant callback
+silently breaks an invariant. Three rules apply repo-wide.
+
+## 1. No callbacks under borrows of shared state
+
+A user-supplied callback must never be invoked while a `&mut` borrow or lock on
+caller-owned shared state is held. Release the borrow before the callback, then
+re-acquire on the next iteration if needed.
+
+Bad — the lock is held while the waker runs, which may deadlock or alias if the waker
+re-enters:
+
+```rust
+let mut guard = state.lock().unwrap();
+let waker = guard.take_waker();
+waker.wake();
+```
+
+Good — release the lock before invoking the callback:
+
+```rust
+let waker = {
+    let mut guard = state.lock().unwrap();
+    guard.take_waker()
+};
+waker.wake();
+```
+
+The same rule applies to `UnsafeCell`-protected single-threaded state. A `&mut` borrow
+through `UnsafeCell::get()` must be released before any user callback fires, otherwise
+a reentrant access on the same thread creates an aliasing `&mut` that Miri flags as UB.
+
+## 2. No `mem::take` / `mem::swap` / `mem::replace` on shared state if a callback can re-enter through the original location
+
+The "snapshot and drain" anti-pattern is:
+
+```rust
+let snapshot = mem::take(&mut self.items);
+for item in snapshot {
+    item.callback();  // BUG: may mutate self.items, leaving snapshot stale.
+}
+```
+
+Intrusive data structures (linked lists, slabs, doubly-linked sets) are particularly
+fragile because internal pointers may cross between the snapshot and the original
+location. A reentrant callback that operates on the "live" data structure observes a
+fresh empty container, and any state changes it makes (registrations, removals) are
+silently lost when the snapshot is dropped.
+
+Prefer a rescan-from-head loop that operates on the live data structure:
+
+```rust
+loop {
+    let item = {
+        let mut guard = self.items.lock().unwrap();
+        let Some(item) = guard.pop_front() else { break };
+        item
+    };
+    item.callback();
+}
+```
+
+`mem::replace` of a state field followed by a user callback is sound only when the
+caller-visible data structure is fully consistent at the point the callback runs and
+the callback cannot reach back through the same location. Document the chain of
+reasoning inline; do not rely on the borrow checker alone, because raw-pointer paths
+and interior mutability can route around it.
+
+State-machine transitions that must be observed by reentrant code (such as transitioning
+to a terminal state before invoking a wake callback) must complete *before* the
+callback runs. Symmetric paths in the same primitive (set vs. disconnect, success vs.
+failure) must use the same ordering.
+
+## 3. Document reentrancy contracts on public async primitives
+
+Every public async primitive must have a `# Reentrancy` section in its API docs that
+spells out which reentrant operations from inside a `Waker::wake` callback are sound
+(drop self, drop sibling, set, reset, register new, etc.). When adding a new async
+primitive, ship matching reentrancy parity tests for every thread-safe and
+single-threaded variant — at minimum: reentrant set, reentrant drop of self and
+sibling, reentrant register during set, and any operation called out as sound in the
+docs.

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -959,14 +959,16 @@ impl<T: Send + 'static> fmt::Debug for Event<T> {
 )]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::cell::RefCell;
     use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe, catch_unwind, resume_unwind};
+    use std::rc::Rc;
     use std::sync::Barrier;
     use std::task::Poll;
     use std::{task, thread};
 
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
-    use testing::with_watchdog;
+    use testing::{ReentrantWakerData, with_watchdog};
 
     use super::*;
     use crate::IntoValueError;
@@ -2056,11 +2058,6 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // Custom raw waker is not Miri-compatible.
     fn boxed_sender_drop_with_reentrant_waker_does_not_deadlock() {
-        use std::cell::RefCell;
-        use std::rc::Rc;
-
-        use testing::ReentrantWakerData;
-
         type ObservedResult = Poll<Result<i32, Disconnected>>;
 
         with_watchdog(|| {

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -440,13 +440,12 @@ where
                 // SAFETY: We were in EVENT_AWAITING which guarantees there is a waker in there.
                 let waker = unsafe { awaiter_cell.assume_init_read() };
 
-                // Come and get it.
+                // Transition out of `EVENT_SIGNALING` before the wake so that a synchronously
+                // reentrant waker (one that polls the receiver inline) observes a terminal
+                // state instead of spinning in `poll_signaling`. This matches the ordering
+                // used by `set()` on the `EVENT_SET` path and prevents same-thread reentrancy
+                // deadlocks.
                 //
-                // As the event is multithreaded, the receiver may already have returned to us
-                // before we send this wake signal - that is fine. If that happens, this signal
-                // is simply a no-op.
-                waker.wake();
-
                 // It is legal to set DISCONNECTED here, permitting dealloc, even though we still
                 // hold an &event reference here, which ordinarily means it is still illegal to
                 // deallocate the object. However, the dangling reference in this method is an
@@ -455,6 +454,13 @@ where
                 event
                     .state
                     .store(EVENT_DISCONNECTED, atomic::Ordering::Release);
+
+                // Come and get it.
+                //
+                // As the event is multithreaded, the receiver may already have returned to us
+                // before we send this wake signal - that is fine. If that happens, this signal
+                // is simply a no-op.
+                waker.wake();
 
                 // The receiver is the last endpoint remaining, so it will clean up.
                 Ok(())
@@ -2038,6 +2044,73 @@ mod tests {
                 send_thread.join().unwrap();
                 drop_thread.join().unwrap();
             });
+        });
+    }
+
+    // Regression test for the synchronous reentrancy hazard in
+    // `sender_dropped_without_set`. A waker fired by the sender drop that
+    // synchronously polls the receiver must observe a terminal state
+    // (DISCONNECTED), not the transient SIGNALING state — otherwise the
+    // reentrant poll would spin in `poll_signaling` while the sender is
+    // blocked inside `wake()`, producing a same-thread deadlock.
+    #[test]
+    #[cfg_attr(miri, ignore)] // Custom raw waker is not Miri-compatible.
+    fn boxed_sender_drop_with_reentrant_waker_does_not_deadlock() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        use testing::ReentrantWakerData;
+
+        type ObservedResult = Poll<Result<i32, Disconnected>>;
+
+        with_watchdog(|| {
+            let (sender, receiver) = Event::<i32>::boxed();
+            let receiver_holder: Rc<RefCell<Option<Pin<Box<_>>>>> =
+                Rc::new(RefCell::new(Some(Box::pin(receiver))));
+            let receiver_for_waker = Rc::clone(&receiver_holder);
+
+            let reentrant_observed: Rc<RefCell<Option<ObservedResult>>> =
+                Rc::new(RefCell::new(None));
+            let observed_for_waker = Rc::clone(&reentrant_observed);
+
+            let waker_data = ReentrantWakerData::new(move || {
+                // Synchronously poll the receiver from inside the waker.
+                // With the buggy ordering this would enter `poll_signaling`
+                // and spin while we are still blocked inside `wake()`.
+                let mut holder = receiver_for_waker.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let noop = Waker::noop();
+                let mut cx = task::Context::from_waker(noop);
+                let result = receiver.as_mut().poll(&mut cx);
+                *observed_for_waker.borrow_mut() = Some(result);
+            });
+            // SAFETY: `waker_data` outlives the waker and the test is single-threaded.
+            let waker = unsafe { waker_data.waker() };
+
+            // First poll transitions BOUND -> AWAITING and stores the
+            // reentrant waker.
+            {
+                let mut holder = receiver_holder.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let mut cx = task::Context::from_waker(&waker);
+                assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+            }
+
+            // Drop the sender. This calls `sender_dropped_without_set`,
+            // which transitions AWAITING -> SIGNALING, then must
+            // transition to DISCONNECTED before invoking the waker so
+            // that the reentrant poll observes a terminal state.
+            drop(sender);
+
+            assert!(waker_data.was_woken());
+            let observed = reentrant_observed.borrow_mut().take();
+            assert!(
+                matches!(observed, Some(Poll::Ready(Err(Disconnected)))),
+                "reentrant poll should observe DISCONNECTED",
+            );
+
+            // Drop the receiver to release its half of the event.
+            drop(receiver_holder.borrow_mut().take());
         });
     }
 }

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -174,6 +174,16 @@ impl<T, H: FutureHandle<T>> FutureDequeCore<T, H> {
             };
 
             if let Poll::Ready(value) = poll_result {
+                // Replace the slot atomically before dropping the old `Slot::Pending`. The
+                // pool handle inside the old slot may invoke a user-supplied `Drop` impl on
+                // the wrapped future when it is dropped at the end of this statement. By the
+                // time that user code runs, the slot is already fully `Ready { value }`, so a
+                // reentrant observer (if one were possible) would see consistent state.
+                // `FutureDequeCore` is not exposed behind any shared interior mutability, so
+                // user code reachable through the future's drop cannot obtain a second
+                // `&mut FutureDequeCore` while we hold this borrow. The `shared_parent` mutex
+                // is also not held at this point (released above after cloning the parent
+                // waker), so a reentrant wake through the parent waker path does not deadlock.
                 let old = std::mem::replace(slot, Slot::Ready { value });
 
                 // Release the Slot's metadata reference. The handle is dropped as

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -176,9 +176,9 @@ impl<T, H: FutureHandle<T>> FutureDequeCore<T, H> {
             if let Poll::Ready(value) = poll_result {
                 // Replace the slot atomically before dropping the old `Slot::Pending`. The
                 // pool handle inside the old slot may invoke a user-supplied `Drop` impl on
-                // the wrapped future when it is dropped at the end of this statement. By the
-                // time that user code runs, the slot is already fully `Ready { value }`, so a
-                // reentrant observer (if one were possible) would see consistent state.
+                // the wrapped future when `old` is dropped below (after `release_ref(meta)`).
+                // By the time that user code runs, the slot is already fully `Ready { value }`,
+                // so a reentrant observer (if one were possible) would see consistent state.
                 // `FutureDequeCore` is not exposed behind any shared interior mutability, so
                 // user code reachable through the future's drop cannot obtain a second
                 // `&mut FutureDequeCore` while we hold this borrow. The `shared_parent` mutex

--- a/packages/infinity_pool/src/opaque/slab.rs
+++ b/packages/infinity_pool/src/opaque/slab.rs
@@ -206,7 +206,9 @@ impl Slab {
         // to act. We only ever create this one dropper for the object, so no double-drop can occur.
         let dropper = unsafe { Dropper::new(object_ptr) };
 
-        // Update the slot metadata to mark it as occupied and store the dropper.
+        // Update the slot metadata to mark it as occupied and store the dropper. The
+        // previous meta is `SlotMeta::Vacant` (no dropper), so this `mem::replace` does
+        // not invoke any user code as part of dropping the returned value.
         let previous_meta = mem::replace(slot_meta, SlotMeta::Occupied { _dropper: dropper });
 
         self.next_free_slot_index = match previous_meta {
@@ -330,6 +332,10 @@ impl Slab {
         // SAFETY: Forwarding safety requirements from the caller (object must be present in slab).
         let slot_meta = unsafe { self.slot_meta_mut(handle.index()) };
 
+        // Replace the slot meta with `Vacant` before reading out the object. The old
+        // meta would normally drop the user-supplied object via its dropper, but we
+        // `mem::forget` it below so no user code runs from this `mem::replace` — the
+        // object is handed to the caller instead.
         let old_meta = mem::replace(
             slot_meta,
             SlotMeta::Vacant {

--- a/packages/many_cpus_benchmarking/src/run.rs
+++ b/packages/many_cpus_benchmarking/src/run.rs
@@ -622,6 +622,11 @@ impl BenchmarkBatch {
     fn wait(&mut self) -> Duration {
         let thread_count = self.join_handles.len();
 
+        // Take the join handles out so we can join them outside any borrow of `self`.
+        // Worker threads may still be running user payload code while we join, but the
+        // join is not reentrant: no mutex or partially mutated shared state is held
+        // during the wait, so any callback the workers run (or panic they propagate)
+        // cannot observe inconsistent state through this struct.
         let join_handles = mem::replace(&mut self.join_handles, Box::new([]));
 
         let mut total_elapsed_nanos: u128 = 0;
@@ -722,6 +727,10 @@ impl BenchmarkBatch {
 
 impl Drop for BenchmarkBatch {
     fn drop(&mut self) {
+        // Take the join handles out before iterating; no shared borrow is held while
+        // joining. Worker threads may still be unwinding user code, but the join is
+        // not reentrant — there is no partial state on `self` for a callback to
+        // observe.
         let join_handles = mem::replace(&mut self.join_handles, Box::new([]));
 
         for handle in join_handles {

--- a/packages/vicinal/src/pool.rs
+++ b/packages/vicinal/src/pool.rs
@@ -176,6 +176,13 @@ impl PoolInner {
         // ensure_workers_spawned() will not add any new handles to the list after
         // we release the lock (or if it does, it will see the shutdown flag and
         // return early).
+        //
+        // The mutex is held only for the duration of the `mem::take` itself and is
+        // released before we begin joining. Worker threads may still be running user
+        // task code, but the join is not reentrant — no borrow of caller-owned
+        // shared state is held while we wait. A worker that calls back into the
+        // pool (for example to spawn additional workers) sees the shutdown flag and
+        // exits without touching the now-empty handle list.
         let handles = mem::take(&mut *self.worker_handles.lock().expect(NEVER_POISONED));
 
         for handle in handles {


### PR DESCRIPTION
Closes #148.

## Summary

Repo-wide follow-up to #141, which fixed a logical-corruption bug in `LocalManualResetEvent::set()` where a "snapshot and drain" pattern silently broke invariants when a waker re-entered the structure. This PR codifies the rules that prevent this class of bug and audits the remaining suspect sites in the workspace.

## Changes

### Documentation

- New `docs/callback-safety.md` captures the three reentrancy rules with anti-patterns and examples:
  1. No callbacks under borrows of shared state.
  2. No `mem::take` / `mem::swap` / `mem::replace` of shared state when a callback can re-enter through the original location.
  3. Public async primitives must document reentrancy and ship parity tests across thread-safe and single-threaded variants.
- `AGENTS.md` carries a one-paragraph summary that links to the new doc.

### Audit (inline justification comments added)

Every remaining `mem::take` / `mem::replace` / `mem::swap` production site that touches caller-visible state now has an inline comment explaining why a reentrant callback cannot corrupt the structure:

- `packages/future_deque/src/future_deque_core.rs` — slot fully `Ready` before user `Drop` runs; no shared interior mutability; mutex released earlier.
- `packages/infinity_pool/src/opaque/slab.rs` — both the insert path (previous meta is `Vacant`, no dropper) and the `remove_unpin` path (`mem::forget` of the meta, no user code runs from the replace).
- `packages/many_cpus_benchmarking/src/run.rs` — `JoinHandle` iteration in both `wait` and `Drop` runs outside any borrow on shared state.
- `packages/vicinal/src/pool.rs` — shutdown flag is set before the take; mutex is held only for the swap.

### Bug fix surfaced by the audit

`events_once::core::sync::sender_dropped_without_set` (on the `EVENT_AWAITING` path) invoked the awaiter waker **before** transitioning the state machine out of `EVENT_SIGNALING`. A synchronously reentrant waker that polled the receiver landed in `poll_signaling`, spinning while the sender was still blocked inside `wake()` — a same-thread deadlock. The transition to `EVENT_DISCONNECTED` is now performed before the wake, matching the ordering used by the `set()` path. The single-threaded `local.rs` counterpart already had the correct ordering.

A new regression test `boxed_sender_drop_with_reentrant_waker_does_not_deadlock` uses `testing::ReentrantWakerData` to assert that the reentrant poll observes `Poll::Ready(Err(Disconnected))`. The test was verified to hang with the previous ordering and pass with the fix.

## Validation

- `just validate-local` on Windows — clean.
- `wsl -e bash -l -c "just validate-local"` on Linux — clean.
- `events_once` test suite: 210 passed, 0 failed.
- Confirmed the new regression test fails (watchdog timeout) when the state-transition fix is reverted.
