### PR TITLE
ci: include runner image version in Rust cache key

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -33,6 +33,12 @@ runs:
         # This enables more reuse, e.g. the Copilot workflow can reuse artifacts from the
         # validate workflow, which speeds up copilot executions.
         shared-key: prerequisites
+        # Include the runner image version (e.g. macos-15-arm64 20260511.0048.1) in the
+        # cache key. Cached binaries can subtly depend on image-specific dylibs and tools,
+        # so caches must not flow across image versions even when the lockfile and rust
+        # toolchain are identical. ImageVersion is set automatically on every GitHub-hosted
+        # runner. env-vars is additive on top of the rust-cache defaults.
+        env-vars: ImageVersion
     
     - name: Install just
       shell: bash

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -88,6 +88,10 @@ for manual cache warming after toolchain updates.
 5. **Shared infrastructure**:
    - All jobs use the common `.github/actions/setup-environment` action
    - Rust cache uses `shared-key: prerequisites` for cross-job cache sharing
+   - Cache key includes the runner image version via `env-vars: ImageVersion`
+     so caches do not flow across runner image releases (cached binaries can
+     subtly depend on image-specific dylibs and system tools, even when the
+     lockfile and rust toolchain are identical)
    - `fail-fast: false` ensures all platform checks complete even if one fails
 
 ## Maintenance Notes

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -33,6 +33,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: cargo-delta
+          # See setup-environment/action.yml for the rationale behind including
+          # the runner image version in the cache key.
+          env-vars: ImageVersion
 
       - name: Install cargo-delta
         run: cargo install cargo-delta --locked


### PR DESCRIPTION
## Summary

Append `ImageVersion` to the `env-vars` input on both `Swatinem/rust-cache@v2` call sites in this repo (the `prerequisites` cache shared by every validation job, and the `cargo-delta` cache used by the `delta` job). `env-vars` is additive on top of rust-cache's defaults (`CARGO CC CFLAGS CXX CMAKE RUST`), so the env-hash segment of the cache key now also reflects the runner image release identifier (for example `20260511.0048.1` on `macos-15-arm64`).

## Motivation

`~/.cargo` and target-dir contents (cargo plugins, registry artifacts, build outputs) can subtly depend on image-specific dylibs and system tools. Without `ImageVersion` in the key, a cache produced on one runner image gets restored on a different image even when the lockfile and rust toolchain are identical. That cross-image flow has now been observed to cause real breakage in the wild — see the macOS `cargo → rustup-init shim` regression on `macos-15-arm64/20260511.0048.1` discussed in:

- [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341)
- [actions/runner-images#14097](https://github.com/actions/runner-images/issues/14097)
- [actions/runner-images#14099](https://github.com/actions/runner-images/issues/14099)

It is also a latent risk for future image rollouts on any platform (libssl, glibc, SDK or Visual Studio component bumps, etc.).

## Why `ImageVersion` (and only `ImageVersion`)

- `ImageVersion` — changes whenever the image changes. Highest granularity (e.g. `20260511.0048.1`).
- `ImageOS` — only changes on OS-major bumps; a subset of `ImageVersion`.
- `runner.os` / `os.type()` + `os.arch()` — already included by rust-cache as a `Darwin-arm64`-style suffix.

`ImageVersion` already implies the other two, so including it alone is sufficient and minimal.

## Trade-offs

- **One cold rebuild per platform per image release.** GitHub ships new runner images approximately every 1–2 weeks per platform. After each rollout the affected platform's cache key changes once and the daily `cache-warmup` repopulates it.
- **Mixed-pool transient cold starts.** During a gradual rollout, old and new images are concurrently assignable. Until `cache-warmup` happens to land on each variant, jobs assigned to a not-yet-warmed image will cold-start. Worst case is on the order of ~24 h of intermittent misses per platform per rollout.
- **Storage.** Two image variants may be cached concurrently for a short window. The `prerequisites` cache is ~150 MB on macOS — well within GitHub's 10 GB per-repo budget and 7-day eviction window.

## What this does NOT do

This is defense-in-depth, not a targeted fix for the current macOS `cargo → rustup-init` regression. That bug is in the new image's Homebrew rustup-init setup and the rust-cache `cache-bin: true` interaction; the targeted workaround (`cache-bin: false`) is intentionally left as a separate decision.

## Verification

- Verified `env-vars` semantics directly against [`Swatinem/rust-cache` `src/config.ts`](https://github.com/Swatinem/rust-cache/blob/master/src/config.ts): user-supplied prefixes are appended to the defaults, matched by prefix against `process.env`, and hashed into the env segment of the cache key.
- CI on this PR will exercise the new keys across all three platforms via the `Validation` workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
