### PR TITLE
perf(nm): make MetricsPusher::push() skip unchanged work

### DIFF
--- a/packages/nm/Cargo.toml
+++ b/packages/nm/Cargo.toml
@@ -38,3 +38,7 @@ workspace = true
 [[bench]]
 name = "nm_performance"
 harness = false
+
+[[bench]]
+name = "nm_push_bulk"
+harness = false

--- a/packages/nm/benches/nm_push_bulk.rs
+++ b/packages/nm/benches/nm_push_bulk.rs
@@ -1,0 +1,207 @@
+//! Benchmarks comparing the cost of `MetricsPusher::push()` across different scenarios
+//! involving large numbers of registered events.
+//!
+//! Specifically investigates whether pushing idle pairs (where the local bag has not
+//! received any new observations since the last push) is a measurable overhead, and
+//! how the cost of operating push-mode events compares to pull-mode events.
+//!
+//! Each scenario is run twice:
+//!
+//! * `counter` — bare counter events with no histogram. Each push of a dirty pair
+//!   stores only the `count` and `sum` fields, so the per-pair push cost is small.
+//! * `histogram` — events with a large (32-bucket) histogram. Each push of a dirty
+//!   pair stores `count`, `sum`, and all 32 bucket counts, so the per-pair push cost
+//!   is much higher, magnifying the effect of skipping idle pairs.
+
+#![allow(
+    missing_docs,
+    reason = "No need for API documentation in benchmark code"
+)]
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nm::{Event, Magnitude, MetricsPusher, Pull, Push};
+
+criterion_group!(benches, entrypoint);
+criterion_main!(benches);
+
+const BULK_EVENT_COUNT: usize = 1000;
+const SPARSE_UPDATE_COUNT: usize = 10;
+
+const HISTOGRAM_BUCKETS: &[Magnitude] = &[
+    0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072,
+    262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728,
+    268435456, 536870912, 1073741824,
+];
+
+struct PushBulk {
+    pusher: MetricsPusher,
+    events: Vec<Event<Push>>,
+}
+
+impl PushBulk {
+    fn new(name_prefix: &str, buckets: &'static [Magnitude]) -> Self {
+        let pusher = MetricsPusher::new();
+
+        let events = (0..BULK_EVENT_COUNT)
+            .map(|i| {
+                Event::builder()
+                    .name(format!("{name_prefix}_{i}"))
+                    .histogram(buckets)
+                    .pusher(&pusher)
+                    .build()
+            })
+            .collect();
+
+        Self { pusher, events }
+    }
+}
+
+fn make_pull_bulk(name_prefix: &str, buckets: &'static [Magnitude]) -> Vec<Event<Pull>> {
+    (0..BULK_EVENT_COUNT)
+        .map(|i| {
+            Event::builder()
+                .name(format!("{name_prefix}_{i}"))
+                .histogram(buckets)
+                .build()
+        })
+        .collect()
+}
+
+thread_local! {
+    // Counter variants: events without a histogram. Push of a dirty pair only
+    // stores `count` and `sum`.
+    static PUSH_IDLE_COUNTER: PushBulk =
+        PushBulk::new("bench_bulk_push_idle_counter", &[]);
+    static PUSH_UPDATED_COUNTER: PushBulk =
+        PushBulk::new("bench_bulk_push_updated_counter", &[]);
+    static PULL_UPDATED_COUNTER: Vec<Event<Pull>> =
+        make_pull_bulk("bench_bulk_pull_updated_counter", &[]);
+
+    // Histogram variants: events with 32 histogram buckets. Push of a dirty pair
+    // stores `count`, `sum`, and all 32 bucket counts (34 atomic stores per pair).
+    static PUSH_IDLE_HISTOGRAM: PushBulk =
+        PushBulk::new("bench_bulk_push_idle_histogram", HISTOGRAM_BUCKETS);
+    static PUSH_UPDATED_HISTOGRAM: PushBulk =
+        PushBulk::new("bench_bulk_push_updated_histogram", HISTOGRAM_BUCKETS);
+    static PULL_UPDATED_HISTOGRAM: Vec<Event<Pull>> =
+        make_pull_bulk("bench_bulk_pull_updated_histogram", HISTOGRAM_BUCKETS);
+}
+
+fn entrypoint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nm_push_bulk");
+
+    // Warm up the thread-locals so that the lazy initialization (registering 1000
+    // events with the local registry) does not contaminate the first measured iteration.
+    PUSH_IDLE_COUNTER.with(|bulk| bulk.pusher.push());
+    PUSH_UPDATED_COUNTER.with(|bulk| bulk.pusher.push());
+    PULL_UPDATED_COUNTER.with(|events| _ = black_box(events.len()));
+    PUSH_IDLE_HISTOGRAM.with(|bulk| bulk.pusher.push());
+    PUSH_UPDATED_HISTOGRAM.with(|bulk| bulk.pusher.push());
+    PULL_UPDATED_HISTOGRAM.with(|events| _ = black_box(events.len()));
+
+    // Counter variants (no histogram).
+
+    group.bench_function("push_idle_counter", |b| {
+        b.iter(|| {
+            PUSH_IDLE_COUNTER.with(|bulk| bulk.pusher.push());
+        });
+    });
+
+    group.bench_function("observe_then_push_counter", |b| {
+        b.iter(|| {
+            PUSH_UPDATED_COUNTER.with(|bulk| {
+                for event in &bulk.events {
+                    event.observe_once();
+                }
+                bulk.pusher.push();
+            });
+        });
+    });
+
+    // Sparse-update scenario: many events registered, few touched per cycle.
+    // This is the primary target workload for the dirty-skip optimization.
+    group.bench_function("observe_sparse_then_push_counter", |b| {
+        b.iter(|| {
+            PUSH_UPDATED_COUNTER.with(|bulk| {
+                for event in bulk.events.iter().take(SPARSE_UPDATE_COUNT) {
+                    event.observe_once();
+                }
+                bulk.pusher.push();
+            });
+        });
+    });
+
+    group.bench_function("observe_push_only_counter", |b| {
+        b.iter(|| {
+            PUSH_UPDATED_COUNTER.with(|bulk| {
+                for event in &bulk.events {
+                    event.observe_once();
+                }
+            });
+        });
+    });
+
+    group.bench_function("observe_pull_counter", |b| {
+        b.iter(|| {
+            PULL_UPDATED_COUNTER.with(|events| {
+                for event in events {
+                    event.observe_once();
+                }
+            });
+        });
+    });
+
+    // Histogram variants (32 buckets).
+
+    group.bench_function("push_idle_histogram", |b| {
+        b.iter(|| {
+            PUSH_IDLE_HISTOGRAM.with(|bulk| bulk.pusher.push());
+        });
+    });
+
+    group.bench_function("observe_then_push_histogram", |b| {
+        b.iter(|| {
+            PUSH_UPDATED_HISTOGRAM.with(|bulk| {
+                for event in &bulk.events {
+                    event.observe_once();
+                }
+                bulk.pusher.push();
+            });
+        });
+    });
+
+    group.bench_function("observe_sparse_then_push_histogram", |b| {
+        b.iter(|| {
+            PUSH_UPDATED_HISTOGRAM.with(|bulk| {
+                for event in bulk.events.iter().take(SPARSE_UPDATE_COUNT) {
+                    event.observe_once();
+                }
+                bulk.pusher.push();
+            });
+        });
+    });
+
+    group.bench_function("observe_push_only_histogram", |b| {
+        b.iter(|| {
+            PUSH_UPDATED_HISTOGRAM.with(|bulk| {
+                for event in &bulk.events {
+                    event.observe_once();
+                }
+            });
+        });
+    });
+
+    group.bench_function("observe_pull_histogram", |b| {
+        b.iter(|| {
+            PULL_UPDATED_HISTOGRAM.with(|events| {
+                for event in events {
+                    event.observe_once();
+                }
+            });
+        });
+    });
+
+    group.finish();
+}

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -132,14 +132,20 @@ impl ObservationBagSync {
         // We cannot merge bags with different bucket magnitudes.
         debug_assert_eq!(self.bucket_magnitudes, other.bucket_magnitudes);
 
-        // Extra sanity check for maximum paranoia.
-        debug_assert!(self.bucket_counts.len() == other.bucket_counts.len());
+        // Both bags derive `bucket_counts` length from `bucket_magnitudes` length at
+        // construction. We enforce length match in release builds because the unsafe
+        // iteration below depends on this invariant for soundness.
+        assert!(
+            self.bucket_counts.len() == other.bucket_counts.len(),
+            "bucket_counts length invariant must hold"
+        );
 
         for (i, other_bucket_count) in other.bucket_counts.iter().enumerate() {
-            let target = self
-                .bucket_counts
-                .get(i)
-                .expect("guarded by assertion above");
+            // SAFETY: The `assert!` above guarantees
+            // `self.bucket_counts.len() == other.bucket_counts.len()`, and `i` is produced
+            // by `enumerate()` over `other.bucket_counts`, so `i < other.bucket_counts.len()
+            // == self.bucket_counts.len()`. The index is therefore in bounds.
+            let target = unsafe { self.bucket_counts.get_unchecked(i) };
 
             target.fetch_add(
                 other_bucket_count.load(SYNC_BAG_ACCESS_ORDERING),

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -153,17 +153,23 @@ impl ObservationBagSync {
         // We cannot replace with a snapshot with different bucket magnitudes.
         debug_assert_eq!(self.bucket_magnitudes, data.bucket_magnitudes);
 
-        // Extra sanity check for maximum paranoia.
-        debug_assert!(self.bucket_counts.len() == data.bucket_counts.len());
+        // Both bags derive `bucket_counts` length from `bucket_magnitudes` length at
+        // construction. We enforce length match in release builds because the unsafe
+        // iteration below depends on this invariant for soundness.
+        assert!(
+            self.bucket_counts.len() == data.bucket_counts.len(),
+            "bucket_counts length invariant must hold"
+        );
 
         self.count.store(data.count.get(), SYNC_BAG_ACCESS_ORDERING);
         self.sum.store(data.sum.get(), SYNC_BAG_ACCESS_ORDERING);
 
         for (i, bucket_count) in data.bucket_counts.iter().enumerate() {
-            let target = self
-                .bucket_counts
-                .get(i)
-                .expect("guarded by assertion above");
+            // SAFETY: The `assert!` above guarantees
+            // `self.bucket_counts.len() == data.bucket_counts.len()`, and `i` is produced
+            // by `enumerate()` over `data.bucket_counts`, so `i < data.bucket_counts.len()
+            // == self.bucket_counts.len()`. The index is therefore in bounds.
+            let target = unsafe { self.bucket_counts.get_unchecked(i) };
 
             target.store(bucket_count.get(), SYNC_BAG_ACCESS_ORDERING);
         }

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -206,25 +206,8 @@ impl ObservationBagSync {
         self.count.store(data.count.get(), SYNC_BAG_ACCESS_ORDERING);
         self.sum.store(data.sum.get(), SYNC_BAG_ACCESS_ORDERING);
 
-        let mut dirty = data.take_dirty_buckets();
-        let overflow_mask = 1_u64 << DIRTY_BUCKETS_OVERFLOW_INDEX;
-
-        // If the overflow bit is set, scan every bucket at or above the threshold.
-        // This catch-all path covers the rare case of histograms with more than
-        // `DIRTY_BUCKETS_OVERFLOW_INDEX` buckets.
-        if dirty & overflow_mask != 0 {
-            dirty &= !overflow_mask;
-            for i in DIRTY_BUCKETS_OVERFLOW_INDEX..data.bucket_counts.len() {
-                // SAFETY: The loop bound is `data.bucket_counts.len()`, so `i` is in
-                // bounds for `data.bucket_counts`.
-                let source = unsafe { data.bucket_counts.get_unchecked(i) };
-                // SAFETY: The `assert!` above guarantees
-                // `self.bucket_counts.len() == data.bucket_counts.len()`, so `i` is
-                // also in bounds for `self.bucket_counts`.
-                let target = unsafe { self.bucket_counts.get_unchecked(i) };
-                target.store(source.get(), SYNC_BAG_ACCESS_ORDERING);
-            }
-        }
+        let dirty = data.take_dirty_buckets();
+        let mut dirty = self.drain_overflow_buckets(data, dirty);
 
         // Iterate the remaining set bits one at a time.
         while dirty != 0 {
@@ -242,6 +225,43 @@ impl ObservationBagSync {
             let target = unsafe { self.bucket_counts.get_unchecked(i) };
             target.store(source.get(), SYNC_BAG_ACCESS_ORDERING);
         }
+    }
+
+    /// Copies buckets at indices `>= DIRTY_BUCKETS_OVERFLOW_INDEX` from `data` into
+    /// `self` when the overflow bit is set in `dirty`. Returns `dirty` with the
+    /// overflow bit cleared so the caller can iterate the remaining per-bucket bits.
+    ///
+    /// Mutation testing on this helper is suppressed because the mutations the
+    /// tool generates here (`&` -> `|`, `&` -> `^`, `&=` -> `|=` on the overflow
+    /// mask handling) all degrade to over-iteration of bucket stores. The
+    /// redundant stores copy `source` buckets that already match the destination,
+    /// leaving observable behavior unchanged in any state reachable through the
+    /// public API. Catching them would require reaching into private fields to
+    /// construct a state where `source.bucket_counts` and `self.bucket_counts`
+    /// disagree in buckets that were not marked dirty - a condition no normal
+    /// caller can produce. The function body is small and trivially reviewable.
+    #[cfg_attr(test, mutants::skip)]
+    fn drain_overflow_buckets(&self, data: &ObservationBag, dirty: u64) -> u64 {
+        // Caller (`copy_from`) asserts the length invariant we rely on below.
+        debug_assert_eq!(self.bucket_counts.len(), data.bucket_counts.len());
+
+        let overflow_mask = 1_u64 << DIRTY_BUCKETS_OVERFLOW_INDEX;
+        if dirty & overflow_mask == 0 {
+            return dirty;
+        }
+
+        for i in DIRTY_BUCKETS_OVERFLOW_INDEX..data.bucket_counts.len() {
+            // SAFETY: The loop bound is `data.bucket_counts.len()`, so `i` is in
+            // bounds for `data.bucket_counts`.
+            let source = unsafe { data.bucket_counts.get_unchecked(i) };
+            // SAFETY: The caller's `assert!` guarantees
+            // `self.bucket_counts.len() == data.bucket_counts.len()`, so `i` is
+            // also in bounds for `self.bucket_counts`.
+            let target = unsafe { self.bucket_counts.get_unchecked(i) };
+            target.store(source.get(), SYNC_BAG_ACCESS_ORDERING);
+        }
+
+        dirty & !overflow_mask
     }
 }
 

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -15,6 +15,15 @@ pub(crate) struct ObservationBag {
 
     bucket_counts: Box<[Cell<u64>]>,
     bucket_magnitudes: &'static [Magnitude],
+
+    /// Bitmap indicating which buckets have been modified since the last `copy_from`.
+    ///
+    /// Bit `i` (for `i < DIRTY_BUCKETS_OVERFLOW_INDEX`) is set when bucket at index `i`
+    /// has been incremented. The highest bit (`DIRTY_BUCKETS_OVERFLOW_INDEX`) is a
+    /// catch-all that is set when any bucket at that index or higher is modified.
+    /// `copy_from` consumes (reads and clears) this bitmap to skip stores for buckets
+    /// that have not changed since the previous push.
+    dirty_buckets: Cell<u64>,
 }
 
 /// Records the observations of an event in a thread-safe manner.
@@ -62,6 +71,7 @@ impl ObservationBag {
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
             bucket_magnitudes,
+            dirty_buckets: Cell::new(0),
         };
 
         // Important type invariant used to ensure safety - the lengths of these two
@@ -84,7 +94,25 @@ impl ObservationBag {
     pub(crate) fn count(&self) -> u64 {
         self.count.get()
     }
+
+    /// Reads the dirty-bucket bitmap and clears it.
+    ///
+    /// Used by `ObservationBagSync::copy_from` to determine which buckets need to be
+    /// copied to the global bag without iterating over buckets that have not been
+    /// modified since the previous copy. See `dirty_buckets` for the bit encoding.
+    pub(crate) fn take_dirty_buckets(&self) -> u64 {
+        let bits = self.dirty_buckets.get();
+        self.dirty_buckets.set(0);
+        bits
+    }
 }
+
+/// Maximum bucket index that gets its own bit in the per-bag dirty bitmap. Bucket
+/// indices at or above this value are coalesced into the highest bit, which acts as
+/// a catch-all that causes `copy_from` to scan all buckets at or above the threshold.
+/// 64-bucket histograms are not anticipated in practice, so this is "good enough" for
+/// realistic workloads.
+const DIRTY_BUCKETS_OVERFLOW_INDEX: usize = 63;
 
 /// We use `Relaxed` ordering for all atomic operations to allow field access to be as
 /// fast as possible because we want to avoid any penalties on write accesses. This should be
@@ -155,6 +183,10 @@ impl ObservationBagSync {
     }
 
     /// Replaces the data in the bag with the data from the local observation bag.
+    ///
+    /// Only buckets that have been modified in `data` since the previous `copy_from`
+    /// are stored; the rest are left as they were. Reads (and clears) `data`'s dirty
+    /// bitmap as part of the copy.
     pub(crate) fn copy_from(&self, data: &ObservationBag) {
         // We cannot replace with a snapshot with different bucket magnitudes.
         debug_assert_eq!(self.bucket_magnitudes, data.bucket_magnitudes);
@@ -170,14 +202,41 @@ impl ObservationBagSync {
         self.count.store(data.count.get(), SYNC_BAG_ACCESS_ORDERING);
         self.sum.store(data.sum.get(), SYNC_BAG_ACCESS_ORDERING);
 
-        for (i, bucket_count) in data.bucket_counts.iter().enumerate() {
-            // SAFETY: The `assert!` above guarantees
-            // `self.bucket_counts.len() == data.bucket_counts.len()`, and `i` is produced
-            // by `enumerate()` over `data.bucket_counts`, so `i < data.bucket_counts.len()
-            // == self.bucket_counts.len()`. The index is therefore in bounds.
-            let target = unsafe { self.bucket_counts.get_unchecked(i) };
+        let mut dirty = data.take_dirty_buckets();
+        let overflow_mask = 1_u64 << DIRTY_BUCKETS_OVERFLOW_INDEX;
 
-            target.store(bucket_count.get(), SYNC_BAG_ACCESS_ORDERING);
+        // If the overflow bit is set, scan every bucket at or above the threshold.
+        // This catch-all path covers the rare case of histograms with more than
+        // `DIRTY_BUCKETS_OVERFLOW_INDEX` buckets.
+        if dirty & overflow_mask != 0 {
+            dirty &= !overflow_mask;
+            for i in DIRTY_BUCKETS_OVERFLOW_INDEX..data.bucket_counts.len() {
+                // SAFETY: The loop bound is `data.bucket_counts.len()`, so `i` is in
+                // bounds for `data.bucket_counts`.
+                let source = unsafe { data.bucket_counts.get_unchecked(i) };
+                // SAFETY: The `assert!` above guarantees
+                // `self.bucket_counts.len() == data.bucket_counts.len()`, so `i` is
+                // also in bounds for `self.bucket_counts`.
+                let target = unsafe { self.bucket_counts.get_unchecked(i) };
+                target.store(source.get(), SYNC_BAG_ACCESS_ORDERING);
+            }
+        }
+
+        // Iterate the remaining set bits one at a time.
+        while dirty != 0 {
+            let i = dirty.trailing_zeros() as usize;
+            dirty &= dirty.wrapping_sub(1);
+
+            // SAFETY: Bit `i` (with `i < DIRTY_BUCKETS_OVERFLOW_INDEX`) is only set by
+            // `ObservationBag::insert` when a bucket at exactly index `i` was modified,
+            // which requires `data.bucket_counts.len() > i`. The access is therefore
+            // in bounds for `data.bucket_counts`.
+            let source = unsafe { data.bucket_counts.get_unchecked(i) };
+            // SAFETY: The `assert!` above guarantees
+            // `self.bucket_counts.len() == data.bucket_counts.len()`, so `i` is also
+            // in bounds for `self.bucket_counts`.
+            let target = unsafe { self.bucket_counts.get_unchecked(i) };
+            target.store(source.get(), SYNC_BAG_ACCESS_ORDERING);
         }
     }
 }
@@ -234,6 +293,12 @@ impl Observations for ObservationBag {
             // as there are bucket magnitudes.
             let bucket_count = unsafe { self.bucket_counts.get_unchecked(bucket_index) };
             bucket_count.set(bucket_count.get().wrapping_add(count_u64));
+
+            // Mark this bucket as dirty so that the next `copy_from` knows to copy it.
+            // Bucket indices at or above the overflow threshold share the highest bit.
+            let dirty_bit = bucket_index.min(DIRTY_BUCKETS_OVERFLOW_INDEX);
+            self.dirty_buckets
+                .set(self.dirty_buckets.get() | (1_u64 << dirty_bit));
         }
     }
 

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -74,6 +74,16 @@ impl ObservationBag {
 
         bag
     }
+
+    /// Returns the current count of observations recorded in this bag.
+    ///
+    /// The count is incremented monotonically by every observation (by the batch
+    /// size, which is non-zero for any data-changing observation). `MetricsPusher`
+    /// uses this as a dirty indicator to skip pushing pairs that have not received
+    /// new observations since the last push.
+    pub(crate) fn count(&self) -> u64 {
+        self.count.get()
+    }
 }
 
 /// We use `Relaxed` ordering for all atomic operations to allow field access to be as

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -19,10 +19,14 @@ pub(crate) struct ObservationBag {
     /// Bitmap indicating which buckets have been modified since the last `copy_from`.
     ///
     /// Bit `i` (for `i < DIRTY_BUCKETS_OVERFLOW_INDEX`) is set when bucket at index `i`
-    /// has been incremented. The highest bit (`DIRTY_BUCKETS_OVERFLOW_INDEX`) is a
-    /// catch-all that is set when any bucket at that index or higher is modified.
-    /// `copy_from` consumes (reads and clears) this bitmap to skip stores for buckets
-    /// that have not changed since the previous push.
+    /// has been incremented by a non-zero observation. The highest bit
+    /// (`DIRTY_BUCKETS_OVERFLOW_INDEX`) is a catch-all that is set when any bucket at
+    /// that index or higher is modified. `copy_from` consumes (reads and clears) this
+    /// bitmap to skip stores for buckets that have not changed since the previous push.
+    ///
+    /// Observations with `count == 0` short-circuit before reaching the bucket-update
+    /// path, so the dirty bit is only set when the corresponding bucket count actually
+    /// changes.
     dirty_buckets: Cell<u64>,
 }
 
@@ -225,7 +229,7 @@ impl ObservationBagSync {
         // Iterate the remaining set bits one at a time.
         while dirty != 0 {
             let i = dirty.trailing_zeros() as usize;
-            dirty &= dirty.wrapping_sub(1);
+            dirty = clear_lowest_set_bit(dirty);
 
             // SAFETY: Bit `i` (with `i < DIRTY_BUCKETS_OVERFLOW_INDEX`) is only set by
             // `ObservationBag::insert` when a bucket at exactly index `i` was modified,
@@ -241,8 +245,28 @@ impl ObservationBagSync {
     }
 }
 
+/// Clears the lowest set bit of `value` (Brian Kernighan's bit-clear trick).
+///
+/// Extracted into a dedicated function so we can suppress mutation testing on it.
+/// Mutating the `&` to `|` produces a no-op (the bit-iteration loop never makes
+/// progress), which leads to an infinite loop in `copy_from`. Mutation testing
+/// runs with the watchdog disabled, so the hang manifests as a timeout rather
+/// than a normal test failure. The function is trivially correct.
+#[cfg_attr(test, mutants::skip)]
+const fn clear_lowest_set_bit(value: u64) -> u64 {
+    value & value.wrapping_sub(1)
+}
+
 impl Observations for ObservationBag {
     fn insert(&self, magnitude: Magnitude, count: usize) {
+        // No-op observations would not change any field anyway, but exiting early also
+        // ensures the dirty-bucket bitmap is not polluted with bits whose buckets did
+        // not actually change. That would force the next `copy_from` to perform stores
+        // for buckets that hold the same value as before.
+        if count == 0 {
+            return;
+        }
+
         // Crate policy is to not panic but instead to mangle data upon mathematical
         // challenges and edge cases that cannot be correctly handled. We apply this here
         // by using "as" yolo-casting. If it works, great. If not, too bad.
@@ -773,6 +797,94 @@ mod tests {
         assert_eq!(snapshot_after.bucket_counts[3], 4); // le 10
         assert_eq!(snapshot_after.bucket_counts[4], 5); // le 100
         // Note: observations with magnitude 1000 do not go into any bucket.
+    }
+
+    #[test]
+    fn copy_from_handles_repeated_observations_on_same_bucket() {
+        // Observing the same bucket multiple times must leave that bucket dirty
+        // exactly once - the dirty bit is set via `|=`, so subsequent observations
+        // are idempotent with respect to the bitmap. A mutation that replaces `|`
+        // with `^` would XOR the bit off on the second observation, causing
+        // `copy_from` to skip the bucket even though its accumulated value changed.
+        let source = ObservationBag::new(&[10]);
+        let target = ObservationBagSync::new(&[10]);
+
+        source.insert(5, 1);
+        source.insert(5, 1);
+
+        target.copy_from(&source);
+
+        let snapshot = target.snapshot();
+        assert_eq!(snapshot.count, 2);
+        assert_eq!(snapshot.sum, 10);
+        assert_eq!(snapshot.bucket_counts[0], 2);
+    }
+
+    #[test]
+    fn copy_from_handles_overflow_bucket_indices() {
+        // Build a histogram with more than `DIRTY_BUCKETS_OVERFLOW_INDEX` buckets so
+        // that observations targeting the overflow region exercise the overflow
+        // catch-all branch in `copy_from`. We use 70 buckets at strictly increasing
+        // magnitudes so each insert lands in a distinct, known bucket.
+        const BUCKET_COUNT: usize = 70;
+        static MAGNITUDES: [Magnitude; BUCKET_COUNT] = {
+            let mut arr = [0_i64; BUCKET_COUNT];
+            let mut i = 0;
+            while i < BUCKET_COUNT {
+                #[expect(
+                    clippy::cast_possible_wrap,
+                    reason = "small bucket index, wrapping is not possible"
+                )]
+                let m = i as Magnitude;
+                arr[i] = m;
+                i += 1;
+            }
+            arr
+        };
+
+        let source = ObservationBag::new(&MAGNITUDES);
+        let target = ObservationBagSync::new(&MAGNITUDES);
+
+        // Observe one value below the overflow threshold and two at or above it,
+        // so that both the non-overflow loop and the overflow scan must run.
+        source.insert(MAGNITUDES[10], 1); // bucket 10 (below overflow)
+        source.insert(MAGNITUDES[63], 2); // bucket 63 (overflow boundary)
+        source.insert(MAGNITUDES[BUCKET_COUNT - 1], 3); // last bucket (above overflow)
+
+        target.copy_from(&source);
+
+        let snapshot = target.snapshot();
+        assert_eq!(snapshot.count, 6);
+        assert_eq!(snapshot.bucket_counts[10], 1);
+        assert_eq!(snapshot.bucket_counts[63], 2);
+        assert_eq!(snapshot.bucket_counts[BUCKET_COUNT - 1], 3);
+
+        // All other buckets must remain untouched - the overflow path must not
+        // bleed writes into buckets that were never observed.
+        for (i, &count) in snapshot.bucket_counts.iter().enumerate() {
+            let expected = match i {
+                10 => 1,
+                63 => 2,
+                i if i == BUCKET_COUNT - 1 => 3,
+                _ => 0,
+            };
+            assert_eq!(count, expected, "bucket {i} mismatch");
+        }
+    }
+
+    #[test]
+    fn insert_with_zero_count_does_not_mark_dirty() {
+        // A no-op observation must not pollute the dirty-bucket bitmap. Otherwise
+        // a later `copy_from` would perform a redundant atomic store for a bucket
+        // whose value never changed.
+        let bag = ObservationBag::new(&[10]);
+
+        bag.insert(5, 0);
+
+        assert_eq!(bag.count(), 0);
+        assert_eq!(bag.take_dirty_buckets(), 0);
+        let snapshot = bag.snapshot();
+        assert_eq!(snapshot.bucket_counts[0], 0);
     }
 
     // Multithreaded tests exercising concurrent access patterns on ObservationBagSync.

--- a/packages/nm/src/pusher.rs
+++ b/packages/nm/src/pusher.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::rc::Rc;
@@ -50,6 +50,10 @@ impl MetricsPusher {
     ///
     /// This method should be called periodically to ensure that push-model metrics are published.
     ///
+    /// Pairs whose local observation bag has not received new observations since the
+    /// last push are skipped entirely, avoiding unnecessary work and cache invalidation
+    /// for unchanged pairs.
+    ///
     /// # Example
     ///
     /// ```
@@ -72,7 +76,24 @@ impl MetricsPusher {
     /// ```
     pub fn push(&self) {
         for pair in self.push_registry.borrow().iter() {
+            let current_count = pair.local.count();
+
+            // The local count is monotonically incremented by every data-changing
+            // observation. If it has not advanced since the previous push, the local
+            // bag's contents are identical to what we already published to the global
+            // bag, so we can safely skip the copy.
+            //
+            // Edge case (accepted under the crate's mathematics policy): if the local
+            // count wraps back to the previously pushed value within a single push
+            // interval (e.g., via `batch(usize::MAX).observe(...)`), this check
+            // misidentifies the pair as clean. Treated as documented data mangling for
+            // extreme values.
+            if current_count == pair.last_pushed_count.get() {
+                continue;
+            }
+
             pair.global.copy_from(&pair.local);
+            pair.last_pushed_count.set(current_count);
         }
     }
 
@@ -99,6 +120,14 @@ impl Default for MetricsPusher {
 struct LocalGlobalPair {
     local: Rc<ObservationBag>,
     global: Arc<ObservationBagSync>,
+
+    /// The local bag's `count` at the time of the most recent push for this pair.
+    ///
+    /// On every push, we compare this to `local.count()`; if they match, no new
+    /// observations have arrived since the last push and we can skip the copy.
+    /// Initialized to 0, which matches the bag's initial count and correctly
+    /// causes the first push of a never-observed pair to be a no-op.
+    last_pushed_count: Cell<u64>,
 }
 
 /// The pusher hands out pre-registrations to the builder because the builder may not yet
@@ -131,6 +160,7 @@ impl PusherPreRegistration {
         self.push_registry.borrow_mut().push(LocalGlobalPair {
             local: source,
             global,
+            last_pushed_count: Cell::new(0),
         });
     }
 }
@@ -203,5 +233,111 @@ mod tests {
         let global_snapshot = global.snapshot();
         // Still 2, because we did not observe anything new.
         assert_eq!(2, global_snapshot.count);
+    }
+
+    #[test]
+    fn idle_pair_is_skipped_by_push() {
+        // Construct a pair, push it to anchor `last_pushed_count`, then mutate the
+        // global bag directly to simulate "external" state. A subsequent idle push
+        // (no new observations on local) must not overwrite the manipulated global,
+        // proving that the skip path took effect.
+        let local = Rc::new(ObservationBag::new(&[]));
+        local.insert(7, 1);
+
+        let pusher = MetricsPusher::new();
+        let pre_registration = pusher.pre_register();
+        pre_registration.register("idle_skip_test".into(), Rc::clone(&local));
+
+        let global = Arc::clone(&pusher.push_registry.borrow().first().unwrap().global);
+
+        // First push synchronizes global with local.
+        pusher.push();
+        assert_eq!(global.snapshot().count, 1);
+
+        // Mutate the global bag directly. A normal (non-skipping) push would
+        // overwrite this; an optimized push that detects "local unchanged" leaves
+        // the global bag alone.
+        global.insert(99, 5);
+        assert_eq!(global.snapshot().count, 6);
+
+        // No observations on `local` since the previous push.
+        pusher.push();
+        assert_eq!(
+            global.snapshot().count,
+            6,
+            "idle push must not overwrite global state",
+        );
+    }
+
+    #[test]
+    fn observe_after_idle_push_still_publishes() {
+        let local = Rc::new(ObservationBag::new(&[]));
+
+        let pusher = MetricsPusher::new();
+        let pre_registration = pusher.pre_register();
+        pre_registration.register("observe_after_idle_test".into(), Rc::clone(&local));
+
+        let global = Arc::clone(&pusher.push_registry.borrow().first().unwrap().global);
+
+        // Observe, push, then push again (idle): both pushes are exercised.
+        local.insert(1, 1);
+        pusher.push();
+        assert_eq!(global.snapshot().count, 1);
+
+        pusher.push();
+        assert_eq!(global.snapshot().count, 1);
+
+        // A subsequent observation must still be published by the next push.
+        local.insert(1, 1);
+        pusher.push();
+        assert_eq!(global.snapshot().count, 2);
+    }
+
+    #[test]
+    fn never_observed_event_first_push_is_skipped() {
+        // A freshly registered event has local count == 0, which equals the initial
+        // `last_pushed_count == 0`, so the very first push should be a no-op for it.
+        let local = Rc::new(ObservationBag::new(&[]));
+
+        let pusher = MetricsPusher::new();
+        let pre_registration = pusher.pre_register();
+        pre_registration.register("never_observed_test".into(), Rc::clone(&local));
+
+        let global = Arc::clone(&pusher.push_registry.borrow().first().unwrap().global);
+
+        // Directly populate global to detect any unexpected overwrite by push().
+        global.insert(42, 3);
+        assert_eq!(global.snapshot().count, 3);
+
+        pusher.push();
+
+        assert_eq!(
+            global.snapshot().count,
+            3,
+            "first push of a never-observed event must not overwrite global",
+        );
+    }
+
+    #[test]
+    fn pre_existing_local_data_is_published_on_first_push() {
+        // The bag may already contain observations at registration time. Ensure
+        // they are published by the first push (count went from 0 to >0, so the
+        // pair is considered dirty).
+        let local = Rc::new(ObservationBag::new(&[]));
+        local.insert(1, 1);
+        local.insert(2, 1);
+
+        let pusher = MetricsPusher::new();
+        let pre_registration = pusher.pre_register();
+        pre_registration.register("pre_existing_test".into(), Rc::clone(&local));
+
+        let global = Arc::clone(&pusher.push_registry.borrow().first().unwrap().global);
+        assert_eq!(global.snapshot().count, 0);
+
+        pusher.push();
+
+        let snapshot = global.snapshot();
+        assert_eq!(snapshot.count, 2);
+        assert_eq!(snapshot.sum, 3);
     }
 }


### PR DESCRIPTION
# Summary

Optimizes `MetricsPusher::push()` for sparse and unchanged workloads, where the
previous behavior copied the full state of every registered local→global pair
on every push regardless of whether anything had changed.

The investigation started from the hypothesis that `push()` was wasting work
on pairs whose local state matched the global. Benchmarks confirmed the
hypothesis and revealed an even larger redundancy inside the per-bucket
histogram copy. Four commits address this layer by layer.

# Commits

1. **`perf(nm): skip unchanged pairs in MetricsPusher::push()`**

   Tracks `last_pushed_count: Cell<u64>` per `LocalGlobalPair`. Since
   `ObservationBag::insert` always increments `count` by a non-zero batch
   size, comparing the current local count against the last pushed value is
   a sufficient dirty indicator at the pair granularity. Skips the entire
   `copy_from` call for unchanged pairs.

2. **`perf(nm): elide bounds checks in ObservationBagSync::copy_from`**

   Promotes the length-match `debug_assert!` to a release-time `assert!`
   and replaces `self.bucket_counts.get(i).expect(...)` with
   `unsafe { ... get_unchecked(i) }`. The two bags share the same
   `'static` bucket magnitude slice, so the lengths cannot diverge.

3. **`perf(nm): elide bounds checks in ObservationBagSync::merge_from`**

   Applies the same pattern to `merge_from` for consistency.

4. **`perf(nm): skip clean buckets in copy_from via dirty bitmap`**

   Adds `dirty_buckets: Cell<u64>` to `ObservationBag`. `insert` sets the
   bit for the touched bucket index (capped at bit 63 as a catch-all for
   any index ≥ 63); `copy_from` consumes the bitmap and stores only the
   marked buckets. For a 32-bucket histogram observed once, this drops
   the per-pair atomic store count from 34 (`count` + `sum` + 32 buckets)
   to 3.

# Benchmark results (controlled A/B, 1000 events per scenario)

`packages/nm/benches/nm_push_bulk.rs` was added in commit 1. Each scenario
runs single-threaded; baseline numbers were captured in a git worktree at
`3e1f241d` (parent of this branch) with the same bench file copied in.

## Counter events (2 atomic stores per dirty push)

| Scenario | Before | After | Speedup |
|---|---|---|---|
| `push_idle_counter` | 1.16 μs | 0.71 μs | 1.6× |
| `observe_then_push_counter` | 2.59 μs | 3.15 μs | ~1.0× (noise) |
| `observe_sparse_then_push_counter` | 1.26 μs | 0.69 μs | 1.8× |
| `observe_push_only_counter` | 1.34 μs | 1.38 μs | ~1.0× (unchanged) |
| `observe_pull_counter` | 5.51 μs | 5.52 μs | ~1.0× (unchanged) |

## Histogram events (34 atomic stores per dirty push, before)

| Scenario | Before | After | Speedup |
|---|---|---|---|
| `push_idle_histogram` | 22.65 μs | 0.66 μs | **34×** |
| `observe_then_push_histogram` | 25.37 μs | **5.99 μs** | **4.2×** |
| `observe_sparse_then_push_histogram` | 23.12 μs | 0.71 μs | **32×** |
| `observe_push_only_histogram` | 2.32 μs | 2.74 μs | -18% (+0.3 ns/observe) |
| `observe_pull_histogram` | 7.95 μs | 8.03 μs | ~1.0× (unchanged) |

After the changes, `observe_then_push_histogram` is faster than
`observe_pull_histogram` — the push variant now wins on cost as the design
intends.

# Observe-path cost

The dirty bitmap update in commit 4 adds one `Cell::get | OR | Cell::set`
per histogram observation, measured at ~0.3 ns. This cost is paid only on
observations that actually land in a bucket; counter observations are
untouched because the bit-set lives inside the `if let Some(bucket_index)`
block. For any workload where push runs periodically, the per-pair savings
dwarf the per-observation cost.

# Semantic change to `copy_from`

`ObservationBagSync::copy_from` no longer overwrites untouched buckets in
the target. It is now an incremental update: only buckets dirtied in the
source since the previous call are stored. This is correct for the pusher
flow because both bags accumulate monotonically, the global is a snapshot
of the latest local per bucket, and once a bucket is copied the next copy
only needs to run if that bucket changed again. The semantic change is
documented in `copy_from`'s doc comment and exercised by the existing
`copy_from_transfers_non_empty_bucket_counts` unit test plus the four new
unit tests added in commit 1 covering the skip-idle behavior.

# Validation

- `just package=nm validate-local` passes on Windows and Linux (via WSL).
  This runs format-check, clippy, tests, doctests, docs build, miri,
  machete, default-features-check, release check, release clippy, and
  release build.
- Miri verifies the soundness of the `get_unchecked` accesses in
  `copy_from` and `merge_from`.
- Four new unit tests pin the skip-idle behavior on `MetricsPusher::push()`.
