### PR TITLE
perf(nm): inline observe-path forwarders (#157)

### DIFF
--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -278,6 +278,7 @@ const fn clear_lowest_set_bit(value: u64) -> u64 {
 }
 
 impl Observations for ObservationBag {
+    #[inline]
     fn insert(&self, magnitude: Magnitude, count: usize) {
         // No-op observations would not change any field anyway, but exiting early also
         // ensures the dirty-bucket bitmap is not polluted with bits whose buckets did
@@ -367,6 +368,7 @@ impl Observations for ObservationBag {
 }
 
 impl Observations for ObservationBagSync {
+    #[inline]
     fn insert(&self, magnitude: Magnitude, count: usize) {
         // Crate policy is to not panic but instead to mangle data upon mathematical
         // challenges and edge cases that cannot be correctly handled. We apply this here

--- a/packages/nm/src/publish_model.rs
+++ b/packages/nm/src/publish_model.rs
@@ -50,6 +50,7 @@ impl PublishModelPrivate for Push {
         self.observations.snapshot()
     }
 
+    #[inline]
     fn insert(&self, magnitude: Magnitude, count: usize) {
         self.observations.insert(magnitude, count);
     }
@@ -73,6 +74,7 @@ impl PublishModelPrivate for Pull {
         self.observations.snapshot()
     }
 
+    #[inline]
     fn insert(&self, magnitude: Magnitude, count: usize) {
         self.observations.insert(magnitude, count);
     }


### PR DESCRIPTION
Closes #157.

Mark the `insert` methods in the `Event::observe_* → PublishModelPrivate::insert → ObservationBag*::insert` call chain `#[inline]`:

- `ObservationBag::insert`
- `ObservationBagSync::insert`
- `PublishModelPrivate::insert` on `Push`
- `PublishModelPrivate::insert` on `Pull`

The `Event` and `ObservationBatch` `observe_*` forwarders were already `#[inline]`, so this completes the chain from the public observe entry points all the way down to the atomic increment / Cell write that records the observation.

I was personally skeptical that this would matter (cross-CGU inlining may already work on `--release`), so I deliberately collected real evidence before and after. Both Callgrind and the disassembly disagree with my skepticism.

## Callgrind (`just package=nm bench-cg`)

| Scenario                                            | Before | After | Δ instr | Δ % |
|-----------------------------------------------------|-------:|------:|--------:|-----:|
| `pull_counter_observe_once`                         |     43 |    29 |     -14 | -32.6% |
| `pull_counter_observe_value`                        |     45 |    32 |     -13 | -28.9% |
| `pull_counter_observe_batch` (all sizes 1..=10k)    |     59 |    50 |      -9 | -15.3% |
| `pull_small_histogram_observe` hit_first            |     66 |    57 |      -9 | -13.6% |
| `pull_small_histogram_observe` hit_last             |     94 |    85 |      -9 |  -9.6% |
| `pull_small_histogram_observe` miss                 |     94 |    85 |      -9 |  -9.6% |
| `pull_large_histogram_observe` hit_first            |     65 |    57 |      -8 | -12.3% |
| `pull_large_histogram_observe` hit_last             |    282 |   274 |      -8 |  -2.8% |
| `pull_large_histogram_observe` miss                 |    282 |   274 |      -8 |  -2.8% |
| `push_counter_observe_once`                         |     62 |    50 |     -12 | -19.4% |
| `push_counter_observe_value`                        |     63 |    54 |      -9 | -14.3% |
| `push_small_histogram_observe` hit_first            |     78 |    69 |      -9 | -11.5% |
| `push_small_histogram_observe` hit_last             |    106 |    97 |      -9 |  -8.5% |
| `push_small_histogram_observe` miss                 |    100 |    91 |      -9 |  -9.0% |
| `push_large_histogram_observe` hit_first            |     79 |    69 |     -10 | -12.7% |
| `push_large_histogram_observe` hit_last             |    296 |   286 |     -10 |  -3.4% |
| `push_large_histogram_observe` miss                 |    290 |   280 |     -10 |  -3.4% |
| `collect` (8-event aggregate)                       |  20942 | 18708 |   -2234 | -10.7% |
| `push` dirty                                        |    263 |   263 |       0 |   0.0% |
| `push` idle                                         |    185 |   185 |       0 |   0.0% |

Counter paths shed 9–14 instructions per observe; histograms shed 8–10. The `push dirty`/`push idle` paths are unchanged because they do not go through `insert`. Cycles estimates move proportionally.

## Disassembly

`pull_counter_observe_once` benchmark body in the same release build (gungraun's `__gungraun_wrapper_mod::pull_counter_observe_once`):

**Before** — bench body still calls into a separate `insert` function:

```text
   mov    %rsi,%rbx
   mov    %rdi,%r14
   mov    %rsi,(%rsp)
   mov    %rsp,%rax
   mov    (%rsp),%rdi
   add    $0x60,%rdi
   mov    $0x1,%esi          ; magnitude = 1
   mov    $0x1,%edx          ; count = 1
   call   *0x65d67(%rip)     ; <-- call to ObservationBagSync::insert
   ; ... copy Event return value ...
```

**After** — observe chain fully inlined down to two atomic increments plus the bucket loop:

```text
   mov    0x60(%rax),%rcx       ; rcx = &observations
   lock incq 0x30(%rcx)         ; count.fetch_add(1)
   lock incq 0x38(%rcx)         ; sum.fetch_add(1)
   mov    0x20(%rcx),%rdx       ; bucket_magnitudes.ptr
   mov    0x28(%rcx),%rdi       ; bucket_magnitudes.len
   shl    $0x3,%rdi
   mov    $0xffffffffffffffff,%r8
1: test   %rdi,%rdi
   je     <skip loop>            ; len==0 for a counter, loop skipped
   ; ... bucket compare loop ...
```

No remaining function call on the hot observe path.

## Validation

- `just package=nm test` — 68/68 pass (debug + release).
- `just package=nm miri` — 68/68 pass.
- `just package=nm validate-local` — clean (no Clippy warnings, no build errors).
- `just package=nm bench-cg` — no regressions, every observe scenario improves.

## Risk

Trivial. `#[inline]` is a compiler hint; it cannot change semantics. Verified by tests + Miri.
