### PR TITLE
perf(nm): cold-attribute rare branches in observe hot path (#161)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,22 @@
+# TODO
+
+Tracking notes for follow-up work that is intentionally deferred. Each entry
+should describe the task, the trigger condition that makes it actionable, and
+links to the relevant code.
+
+## Migrate to stable `std::hint::cold_path()` (Rust 1.95+)
+
+`packages/nm/src/observations.rs` defines a private `cold_path()` helper as a
+workaround for `std::hint::cold_path()` being unstable in the current
+workspace toolchain (Rust 1.93, gated behind `feature(cold_path)`).
+
+The intrinsic stabilized in Rust 1.95. Once the workspace toolchain
+(`rust-toolchain.toml`) is upgraded to 1.95 or later:
+
+1. Delete the private `fn cold_path()` helper from
+   `packages/nm/src/observations.rs`.
+2. Replace each call site (`cold_path();`) with `std::hint::cold_path();`.
+3. Verify with `just package=nm bench-cg` that Callgrind numbers remain at
+   or better than the stable-helper baseline. The stdlib version uses an
+   LLVM intrinsic and should be at least as effective as the
+   `#[cold] #[inline(never)] fn` workaround.

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -11,9 +11,15 @@ use crate::Magnitude;
 /// path is laid out in straight-line fashion. The cold branch target is moved
 /// to a far section to reduce icache pressure on the hot path.
 ///
-/// This is a temporary workaround until `std::hint::cold_path()` is stabilized.
+/// Marked `#[inline(never)]` so the call is preserved at the call site even
+/// though the body is empty. If LLVM inlined the empty body away, the cold
+/// marker would vanish along with it and the surrounding branch would lose
+/// its cold biasing.
+///
+/// This is a temporary workaround until `std::hint::cold_path()` is
+/// stabilized. See `TODO.md` at the workspace root for the migration note.
 #[cold]
-#[inline]
+#[inline(never)]
 fn cold_path() {}
 
 /// Records the observations of an event.

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -4,6 +4,18 @@ use std::sync::atomic::{self, AtomicI64, AtomicU64};
 
 use crate::Magnitude;
 
+/// Hints to the compiler that the calling branch is unlikely to be taken.
+///
+/// LLVM propagates the `#[cold]` attribute from the called function to the call
+/// site, biasing branch prediction and code layout so that the hot fall-through
+/// path is laid out in straight-line fashion. The cold branch target is moved
+/// to a far section to reduce icache pressure on the hot path.
+///
+/// This is a temporary workaround until `std::hint::cold_path()` is stabilized.
+#[cold]
+#[inline]
+fn cold_path() {}
+
 /// Records the observations of an event.
 ///
 /// This variant is intended for single-threaded use, though may be shared on that
@@ -285,6 +297,7 @@ impl Observations for ObservationBag {
         // not actually change. That would force the next `copy_from` to perform stores
         // for buckets that hold the same value as before.
         if count == 0 {
+            cold_path();
             return;
         }
 
@@ -305,7 +318,8 @@ impl Observations for ObservationBag {
         self.sum.set(self.sum.get().wrapping_add(sum_increment));
 
         // This may be none if we have no buckets (i.e. the event is a bare counter,
-        // no histogram).
+        // no histogram) or if the magnitude exceeds the largest bucket's threshold.
+        // Both are rare on the hot path of a well-configured histogram event.
         //
         // We benchmarked a manual SIMD (AVX2/SSE4.2) branchless "count less-than"
         // approach against this scalar linear scan. The scalar version wins across
@@ -319,7 +333,7 @@ impl Observations for ObservationBag {
         //   large_32_hit_first       17.3 ns   1.3 ns
         //   large_32_hit_last        17.6 ns   9.2 ns
         //   large_32_miss            17.4 ns  10.6 ns
-        if let Some(bucket_index) =
+        let Some(bucket_index) =
             self.bucket_magnitudes
                 .iter()
                 .enumerate()
@@ -330,21 +344,24 @@ impl Observations for ObservationBag {
                         None
                     }
                 })
-        {
-            // We do this unsafely because we need minimal overhead in the hot path from
-            // collecting observations and this will be a very hot path.
-            //
-            // SAFETY: Type invariant: there are always the same number of bucket counts
-            // as there are bucket magnitudes.
-            let bucket_count = unsafe { self.bucket_counts.get_unchecked(bucket_index) };
-            bucket_count.set(bucket_count.get().wrapping_add(count_u64));
+        else {
+            cold_path();
+            return;
+        };
 
-            // Mark this bucket as dirty so that the next `copy_from` knows to copy it.
-            // Bucket indices at or above the overflow threshold share the highest bit.
-            let dirty_bit = bucket_index.min(DIRTY_BUCKETS_OVERFLOW_INDEX);
-            self.dirty_buckets
-                .set(self.dirty_buckets.get() | (1_u64 << dirty_bit));
-        }
+        // We do this unsafely because we need minimal overhead in the hot path from
+        // collecting observations and this will be a very hot path.
+        //
+        // SAFETY: Type invariant: there are always the same number of bucket counts
+        // as there are bucket magnitudes.
+        let bucket_count = unsafe { self.bucket_counts.get_unchecked(bucket_index) };
+        bucket_count.set(bucket_count.get().wrapping_add(count_u64));
+
+        // Mark this bucket as dirty so that the next `copy_from` knows to copy it.
+        // Bucket indices at or above the overflow threshold share the highest bit.
+        let dirty_bit = bucket_index.min(DIRTY_BUCKETS_OVERFLOW_INDEX);
+        self.dirty_buckets
+            .set(self.dirty_buckets.get() | (1_u64 << dirty_bit));
     }
 
     fn snapshot(&self) -> ObservationBagSnapshot {
@@ -388,7 +405,8 @@ impl Observations for ObservationBagSync {
         self.sum.fetch_add(sum_increment, SYNC_BAG_ACCESS_ORDERING);
 
         // This may be none if we have no buckets (i.e. the event is a bare counter,
-        // no histogram).
+        // no histogram) or if the magnitude exceeds the largest bucket's threshold.
+        // Both are rare on the hot path of a well-configured histogram event.
         //
         // We benchmarked a manual SIMD (AVX2/SSE4.2) branchless "count less-than"
         // approach against this scalar linear scan. The scalar version wins across
@@ -402,7 +420,7 @@ impl Observations for ObservationBagSync {
         //   large_32_hit_first       17.3 ns   1.3 ns
         //   large_32_hit_last        17.6 ns   9.2 ns
         //   large_32_miss            17.4 ns  10.6 ns
-        if let Some(bucket_index) =
+        let Some(bucket_index) =
             self.bucket_magnitudes
                 .iter()
                 .enumerate()
@@ -413,15 +431,18 @@ impl Observations for ObservationBagSync {
                         None
                     }
                 })
-        {
-            // We do this unsafely because we need minimal overhead in the hot path from
-            // collecting observations and this will be a very hot path.
-            //
-            // SAFETY: Type invariant: there are always the same number of bucket counts
-            // as there are bucket magnitudes.
-            unsafe { self.bucket_counts.get_unchecked(bucket_index) }
-                .fetch_add(count_u64, SYNC_BAG_ACCESS_ORDERING);
-        }
+        else {
+            cold_path();
+            return;
+        };
+
+        // We do this unsafely because we need minimal overhead in the hot path from
+        // collecting observations and this will be a very hot path.
+        //
+        // SAFETY: Type invariant: there are always the same number of bucket counts
+        // as there are bucket magnitudes.
+        unsafe { self.bucket_counts.get_unchecked(bucket_index) }
+            .fetch_add(count_u64, SYNC_BAG_ACCESS_ORDERING);
     }
 
     fn snapshot(&self) -> ObservationBagSnapshot {

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -317,10 +317,13 @@ impl Observations for ObservationBag {
         self.count.set(self.count.get().wrapping_add(count_u64));
         self.sum.set(self.sum.get().wrapping_add(sum_increment));
 
-        // This may be none if we have no buckets (i.e. the event is a bare counter,
-        // no histogram) or if the magnitude exceeds the largest bucket's threshold.
-        // Both are rare on the hot path of a well-configured histogram event.
-        //
+        // Counter events (no buckets) are a common API shape, not a rare case,
+        // so we exit here without a `cold_path` hint. Only the overflow branch
+        // below is marked cold.
+        if self.bucket_magnitudes.is_empty() {
+            return;
+        }
+
         // We benchmarked a manual SIMD (AVX2/SSE4.2) branchless "count less-than"
         // approach against this scalar linear scan. The scalar version wins across
         // all scenarios because branch prediction is highly effective for sorted
@@ -345,6 +348,8 @@ impl Observations for ObservationBag {
                     }
                 })
         else {
+            // Magnitude exceeds the largest bucket - rare in well-configured
+            // histograms.
             cold_path();
             return;
         };
@@ -404,10 +409,13 @@ impl Observations for ObservationBagSync {
         self.count.fetch_add(count_u64, SYNC_BAG_ACCESS_ORDERING);
         self.sum.fetch_add(sum_increment, SYNC_BAG_ACCESS_ORDERING);
 
-        // This may be none if we have no buckets (i.e. the event is a bare counter,
-        // no histogram) or if the magnitude exceeds the largest bucket's threshold.
-        // Both are rare on the hot path of a well-configured histogram event.
-        //
+        // Counter events (no buckets) are a common API shape, not a rare case,
+        // so we exit here without a `cold_path` hint. Only the overflow branch
+        // below is marked cold.
+        if self.bucket_magnitudes.is_empty() {
+            return;
+        }
+
         // We benchmarked a manual SIMD (AVX2/SSE4.2) branchless "count less-than"
         // approach against this scalar linear scan. The scalar version wins across
         // all scenarios because branch prediction is highly effective for sorted
@@ -432,6 +440,8 @@ impl Observations for ObservationBagSync {
                     }
                 })
         else {
+            // Magnitude exceeds the largest bucket - rare in well-configured
+            // histograms.
             cold_path();
             return;
         };

--- a/packages/nm_otel/src/state.rs
+++ b/packages/nm_otel/src/state.rs
@@ -68,8 +68,11 @@ impl EventState {
         let cumulative_counts = to_cumulative(non_cumulative_counts);
 
         // Initialize bucket state on first call, panic on bucket count mismatch.
+        // The first-call init is only ever taken once per event lifetime, so it is
+        // refactored into a `#[cold]` helper to bias branch layout toward the
+        // steady-state path that runs on every subsequent collection.
         if self.histogram_buckets.is_empty() {
-            self.histogram_buckets = vec![0; cumulative_counts.len()];
+            self.init_histogram_buckets(cumulative_counts.len());
         } else {
             assert_eq!(
                 self.histogram_buckets.len(),
@@ -100,6 +103,16 @@ impl EventState {
         }
 
         result
+    }
+
+    /// Initializes the cumulative bucket-count storage on the first collection.
+    ///
+    /// Marked `#[cold]` because this only runs once per event lifetime; every
+    /// subsequent call takes the validation branch in `histogram_deltas`.
+    #[cold]
+    #[inline(never)]
+    fn init_histogram_buckets(&mut self, len: usize) {
+        self.histogram_buckets = vec![0; len];
     }
 }
 


### PR DESCRIPTION
Implements #161.

Marks rare branches in the observe hot path with `#[cold]` to bias branch
layout so that the hot fall-through stays straight-line and cold code is
laid out away from the icache-hot region.

## Changes

`packages/nm/src/observations.rs`

- New private helper `#[cold] #[inline] fn cold_path() {}`. Acts as a
  workaround for the still-unstable `std::hint::cold_path()` (gated
  behind `cold_path` feature in Rust 1.93). LLVM propagates the cold
  attribute from the call site, biasing the surrounding branch.
- `ObservationBag::insert`: the `count == 0` early-return is preceded by
  a `cold_path()` call; the bucket-lookup `if let Some(...)` is
  restructured into `let Some(...) = ... else { cold_path(); return; }`
  so the overflow path is marked cold and the hot path drops a
  nesting level.
- `ObservationBagSync::insert`: same `let Some ... else` refactor for
  the overflow branch. (The sync variant has no `count == 0`
  short-circuit.)

`packages/nm_otel/src/state.rs`

- `EventState::histogram_deltas`: the first-call bucket-array init is
  extracted into a new `#[cold] #[inline(never)] fn
  init_histogram_buckets`. This is taken only once per event lifetime,
  so the steady-state validation branch becomes the hot fall-through.

## Validation

- `just package=nm validate-local`: clean, zero warnings.
- `just package=nm_otel validate-local`: clean, zero warnings.
- `just package=nm test` and `just package=nm_otel test` pass on both
  Windows and WSL/Linux (68 + 30 tests).
- `just package=nm bench-cg` before/after on the same machine,
  back-to-back runs:

### Instructions per observation

| Scenario                              | Before | After | Δ           |
|---------------------------------------|-------:|------:|------------:|
| pull_counter_observe_value            |     32 |    31 |          −1 |
| push_counter_observe_once             |     50 |    49 |          −1 |
| aggregate::collect eight_events       |  21847 | 19125 | −2722 (−12.5%) |
| All histogram observe scenarios       |   same |  same |           0 |

No instruction-count regressions on any of the 24 scenarios.

### Estimated cycles (Callgrind simulated)

Counter and aggregate paths show clear wins; the simple branch-predictor
and icache model that Callgrind uses produces some apparent regressions
on the large-histogram observe scenarios despite identical instruction
counts (274/69/286 before and after). The issue body explicitly
anticipates this: *"Callgrind (which models a simple branch predictor
and icache) may not capture the full benefit."* Real CPUs are expected
to benefit further from the improved icache locality of the cold
sections.

| Scenario                              | Before | After | Δ        |
|---------------------------------------|-------:|------:|---------:|
| pull_counter_observe_once             |    189 |   155 | −18.0%   |
| pull_counter_observe_value            |    194 |   125 | −35.6%   |
| push_counter_observe_once             |    260 |   225 | −13.5%   |
| push_counter_observe_value            |    301 |   267 | −11.3%   |
| pull_small_histogram miss             |    269 |   235 | −12.6%   |
| push_large_histogram miss             |    560 |   526 |  −6.1%   |
| aggregate::collect eight_events       |  38006 | 34089 | −10.3%   |

## Risk

Trivial. `#[cold]` is purely a hint; it cannot change semantics. All
existing tests continue to pass.
