### PR TITLE
Precompute KeyValue per histogram bucket in nm_otel export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,16 @@ list of available commands. Some relevant ones are:
 
 The `package` argument must be the first argument to any `just` command, if used. You can specify it on most commands to scope them down to a specific package instead of running them on the entire repo (which is slow).
 
-Avoid running `just bench`, as the benchmarks take a lot of time and `just test` will anyway run
-a single benchmark iteration to validate they are still working.
+Avoid running `just bench` (wall-clock Criterion benchmarks) without explicit confirmation: they
+take a lot of time, and the numbers are also noisy and machine-dependent — running them on a
+shared machine produces results that should not be acted on. `just test` already runs a single
+iteration of every Criterion benchmark to validate that they still execute.
+
+`just bench-cg` (Callgrind / Gungraun) is different: it runs each scenario once under Valgrind's
+CPU simulator, so the instruction counts and simulated cache numbers are deterministic and
+unaffected by other processes on the machine. It is safe to run `just bench-cg` (or
+`just package=foo bench-cg`) any time without asking — including as a smoke test of a new
+Callgrind benchmark. The same applies to the `bench-cycles` recipe in packages that still use it.
 
 We generally prefer using Just commands over raw Cargo commands if there is a suitable Just command
 defined in one of the *.just files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
  "criterion",
  "foldhash 0.2.0",
  "futures",
+ "gungraun",
  "hashbrown 0.15.5",
  "many_cpus",
  "mutants",

--- a/docs/callgrind-benchmarks.md
+++ b/docs/callgrind-benchmarks.md
@@ -297,6 +297,14 @@ Practical guidelines:
 Callgrind benchmarks require Valgrind and run only on Linux (including
 WSL on Windows).
 
+Because each scenario runs once on a simulated CPU rather than wall-clock
+time on the real machine, results are deterministic run-to-run and are
+**unaffected by other load on the machine**. It is therefore safe to run
+`just bench-cg` (or `just package=foo bench-cg`) on a shared workstation
+at any time, including as a quick smoke test of a newly added Callgrind
+benchmark. This is the headline difference from `just bench`, whose
+wall-clock numbers should not be acted on when the machine is contended.
+
 Install once:
 
 ```bash

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -40,8 +40,16 @@ static_assertions = { workspace = true }
 tick = { workspace = true, features = ["tokio", "test-util"] }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 
+# Gungraun drives Valgrind-based Callgrind benchmarks; Linux-only.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
+
 [[bench]]
 name = "nm_otel_export"
+harness = false
+
+[[bench]]
+name = "nm_otel_export_cg"
 harness = false
 
 [lints]

--- a/packages/nm_otel/benches/nm_otel_export_cg.rs
+++ b/packages/nm_otel/benches/nm_otel_export_cg.rs
@@ -1,0 +1,213 @@
+//! Callgrind benchmarks for the nm-to-OpenTelemetry export hot path.
+//!
+//! Paired with `nm_otel_export.rs` which covers the same operations under wall-clock
+//! measurement. Callgrind is the primary signal for the per-bucket export cost because
+//! the per-bucket delta from this optimization is on the order of tens of instructions
+//! per bucket and would be invisible under Criterion noise on a shared machine.
+//!
+//! All scenarios drive [`Publisher::run_one_iteration_with_report`] on a fabricated
+//! [`Report`] (built via [`nm::Report::fake`] + [`nm::Histogram::fake`] +
+//! [`nm::EventMetrics::fake`]) so the measurement is decoupled from the global nm
+//! registry and reproducible run-to-run.
+//!
+//! Scenarios:
+//!
+//! * `small_steady_state` — one histogram event with 7 explicit buckets + the synthetic
+//!   `+Inf` bucket (8 buckets total). The measured call sees strictly higher cumulative
+//!   counts than the warmup, so every bucket has a positive delta and exercises the
+//!   `add_bucket_delta` hot path.
+//! * `small_no_delta` — same 8-bucket histogram, but the measured call sees the same
+//!   cumulative counts as the warmup. All bucket deltas are zero and the `if delta > 0`
+//!   branch in `add_bucket_delta` short-circuits. Guards against regressions on the
+//!   empty path.
+//! * `large_steady_state` — same shape as `small_steady_state` but with 31 explicit
+//!   buckets + `+Inf` (32 buckets total). Lets the per-bucket cost be read off by
+//!   comparing against the 8-bucket scenario.
+
+#![allow(
+    missing_docs,
+    reason = "no need for API documentation on benchmark code"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Tracking issue drafts live at \
+          c:/Source/gungraun-lint-issues/ pending upstream filing."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only. On other platforms this
+    // bench target compiles to a no-op so `cargo build --all-targets` still works.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use gungraun::prelude::*;
+    use nm::{EventMetrics, Histogram, Magnitude, Report};
+    use nm_otel::Publisher;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+    use tick::Clock;
+
+    const EVENT_NAME: &str = "cg_export_histogram";
+
+    // 7 explicit buckets + the synthetic `Magnitude::MAX` (`+Inf`) bucket = 8 buckets total.
+    // Spacing is illustrative; the bucket bound values do not affect the export hot path.
+    const SMALL_BUCKETS: &[Magnitude] = &[1, 10, 50, 100, 500, 1_000, 5_000];
+
+    // 31 explicit buckets + the synthetic `Magnitude::MAX` bucket = 32 buckets total. Mirrors
+    // the bucket count used by `nm_observe_cg::LARGE_HISTOGRAM_BUCKETS` for consistency.
+    const LARGE_BUCKETS: &[Magnitude] = &[
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
+        1_024,
+        2_048,
+        4_096,
+        8_192,
+        16_384,
+        32_768,
+        65_536,
+        131_072,
+        262_144,
+        524_288,
+        1_048_576,
+        2_097_152,
+        4_194_304,
+        8_388_608,
+        16_777_216,
+        33_554_432,
+        67_108_864,
+        134_217_728,
+        268_435_456,
+        536_870_912,
+        1_073_741_824,
+    ];
+
+    // Per-bucket non-cumulative counts injected on the warmup pass. Using ones makes the
+    // resulting cumulative sequence the bucket index, which keeps the arithmetic legible.
+    const WARMUP_PER_BUCKET_COUNT: u64 = 1;
+    const WARMUP_PLUS_INF_COUNT: u64 = 1;
+
+    // For the steady-state scenarios the measured pass uses strictly larger per-bucket
+    // counts than the warmup, so every bucket sees a positive delta and the
+    // `add_bucket_delta` hot path is exercised on every bucket.
+    const STEADY_STATE_PER_BUCKET_COUNT: u64 = 2;
+    const STEADY_STATE_PLUS_INF_COUNT: u64 = 2;
+
+    /// Inputs for one measured export call.
+    ///
+    /// `Publisher` and `Report` are paired so the bench function can run a single export
+    /// against a steady-state-initialized publisher without any allocator activity beyond
+    /// what the export itself performs.
+    type ExportInputs = (Publisher, Report);
+
+    fn build_publisher() -> Publisher {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter).build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+        Publisher::builder()
+            .provider(provider)
+            .clock(Clock::new_frozen())
+            .build()
+    }
+
+    fn make_report(buckets: &'static [Magnitude], per_bucket: u64, plus_inf: u64) -> Report {
+        let histogram = Histogram::fake(buckets, vec![per_bucket; buckets.len()], plus_inf);
+        // `count` and `sum` are not on the bucket hot path; pick values that match the
+        // bucket sequence so deltas behave intuitively.
+        let total_buckets = buckets.len().saturating_add(1);
+        let total_buckets_u64 = u64::try_from(total_buckets).unwrap_or(u64::MAX);
+        let count = per_bucket.saturating_mul(total_buckets_u64);
+        let sum: Magnitude = 0;
+        let event = EventMetrics::fake(EVENT_NAME, count, sum, Some(histogram));
+        Report::fake(vec![event])
+    }
+
+    /// Builds a publisher with one warmup export already applied.
+    ///
+    /// After this returns, the `Publisher` has registered the histogram event, allocated
+    /// its bucket-state vector, and constructed the precomputed `[KeyValue; 1]`
+    /// attribute slices. The next `run_one_iteration_with_report` call exercises only
+    /// the steady-state export path.
+    fn warm_up(buckets: &'static [Magnitude]) -> Publisher {
+        let mut publisher = build_publisher();
+        let warmup_report = make_report(buckets, WARMUP_PER_BUCKET_COUNT, WARMUP_PLUS_INF_COUNT);
+        publisher.run_one_iteration_with_report(&warmup_report);
+        publisher
+    }
+
+    fn setup_small_steady_state() -> ExportInputs {
+        let publisher = warm_up(SMALL_BUCKETS);
+        let report = make_report(
+            SMALL_BUCKETS,
+            STEADY_STATE_PER_BUCKET_COUNT,
+            STEADY_STATE_PLUS_INF_COUNT,
+        );
+        (publisher, report)
+    }
+
+    fn setup_small_no_delta() -> ExportInputs {
+        let publisher = warm_up(SMALL_BUCKETS);
+        // Same per-bucket counts as the warmup ⇒ identical cumulative sequence ⇒ zero
+        // deltas. Exercises the `if delta > 0` short-circuit in `add_bucket_delta`.
+        let report = make_report(
+            SMALL_BUCKETS,
+            WARMUP_PER_BUCKET_COUNT,
+            WARMUP_PLUS_INF_COUNT,
+        );
+        (publisher, report)
+    }
+
+    fn setup_large_steady_state() -> ExportInputs {
+        let publisher = warm_up(LARGE_BUCKETS);
+        let report = make_report(
+            LARGE_BUCKETS,
+            STEADY_STATE_PER_BUCKET_COUNT,
+            STEADY_STATE_PLUS_INF_COUNT,
+        );
+        (publisher, report)
+    }
+
+    #[library_benchmark]
+    #[bench::small_steady_state(setup_small_steady_state())]
+    #[bench::small_no_delta(setup_small_no_delta())]
+    #[bench::large_steady_state(setup_large_steady_state())]
+    fn export(inputs: ExportInputs) -> ExportInputs {
+        let (mut publisher, report) = inputs;
+        publisher.run_one_iteration_with_report(black_box(&report));
+        (publisher, report)
+    }
+
+    library_benchmark_group!(name = export_group, benchmarks = [export]);
+}
+
+#[cfg(target_os = "linux")]
+pub use linux::export_group;
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default().tool(
+        Callgrind::default()
+            .args(["--branch-sim=yes"])
+            .format([CallgrindMetrics::Default, CallgrindMetrics::BranchSim]),
+    );
+    library_benchmark_groups = export_group
+);

--- a/packages/nm_otel/src/mapping.rs
+++ b/packages/nm_otel/src/mapping.rs
@@ -37,10 +37,18 @@ struct EventInstruments {
     /// Different bucket bounds are distinguished by the `le` attribute, not by instrument name.
     bucket_counter: Option<Counter<u64>>,
 
-    /// Cached formatted bucket bounds for the `le` attribute (e.g. "10", "50", "+Inf").
+    /// Precomputed `[KeyValue; 1]` attribute slice for each histogram bucket.
+    ///
     /// Indexed by bucket index, matching the order from `histogram.magnitudes()`.
-    /// Uses `Arc<str>` to avoid cloning strings on every metric export.
-    bucket_bounds: Vec<Arc<str>>,
+    /// Building the full `KeyValue` once per bucket at registration time eliminates the
+    /// per-export `Arc<str>` clone and `KeyValue` construction that the export hot path
+    /// would otherwise perform on every call to `add_bucket_delta`.
+    ///
+    /// `[KeyValue; 1]` (not `KeyValue`) so the hot path can pass the attribute slice to
+    /// `Counter::add` as `&self.bucket_attrs[i]` without constructing a `&[KeyValue]`
+    /// reference each call. The fixed-size array's `&[KeyValue; 1]` deref-coerces to
+    /// `&[KeyValue]` directly.
+    bucket_attrs: Vec<[KeyValue; 1]>,
 }
 
 /// Manages OpenTelemetry instruments for nm metrics.
@@ -74,8 +82,8 @@ impl InstrumentRegistry {
 
     /// Gets or creates instruments for an event.
     ///
-    /// If histogram magnitudes are provided, the bucket counter and cached bucket bound
-    /// strings are also created. This avoids creating them for events without histogram data.
+    /// If histogram magnitudes are provided, the bucket counter and cached bucket attribute
+    /// arrays are also created. This avoids creating them for events without histogram data.
     fn instruments(
         &mut self,
         event_name: &EventName,
@@ -99,7 +107,7 @@ impl InstrumentRegistry {
                     count_counter: meter.u64_counter(event_name.to_string()).build(),
                     sum_gauge: meter.i64_gauge(sum_name).build(),
                     bucket_counter: None,
-                    bucket_bounds: Vec::new(),
+                    bucket_attrs: Vec::new(),
                 };
                 // Cache miss — clone the key here so the hit path stays clone-free.
                 &mut vacant
@@ -109,13 +117,17 @@ impl InstrumentRegistry {
             }
         };
 
-        // Lazily create the bucket counter and cache bucket bounds if histogram data provided.
+        // Lazily create the bucket counter and cache bucket attributes if histogram data
+        // provided. Building the `KeyValue` once per bucket here eliminates per-export
+        // `Arc<str>` clone and `KeyValue::new` work in `add_bucket_delta`.
         if let Some(mags) = magnitudes
             && instruments.bucket_counter.is_none()
         {
             let bucket_name = format!("{event_name}{BUCKET_SUFFIX}");
             instruments.bucket_counter = Some(meter.u64_counter(bucket_name).build());
-            instruments.bucket_bounds = mags.map(format_bucket_bound).collect();
+            instruments.bucket_attrs = mags
+                .map(|m| [KeyValue::new(LE_ATTRIBUTE, format_bucket_bound(m))])
+                .collect();
         }
 
         instruments
@@ -158,11 +170,11 @@ pub(crate) fn export_report(
                 .histogram_deltas(histogram.magnitudes(), histogram.counts())
                 .enumerate()
             {
-                let le_value = event_instruments
-                    .bucket_bounds
+                let attrs = event_instruments
+                    .bucket_attrs
                     .get(i)
-                    .expect("bucket_bounds length matches histogram bucket count");
-                add_bucket_delta(bucket_counter, delta, le_value);
+                    .expect("bucket_attrs length matches histogram bucket count");
+                add_bucket_delta(bucket_counter, delta, attrs);
             }
         }
     }
@@ -181,13 +193,16 @@ fn add_count_delta(counter: &Counter<u64>, delta: u64) {
 
 /// Adds a bucket delta to a counter if positive.
 ///
+/// `attrs` is a fixed-size attribute array stored in the registry. `&[KeyValue; 1]`
+/// auto-coerces to `&[KeyValue]` at the `Counter::add` call site, so no per-call
+/// slice or `KeyValue` construction is required on the hot path.
+///
 /// This is a separate function to allow skipping equivalent mutations - adding 0 to a counter
 /// produces the same observable result as not calling add at all.
 #[cfg_attr(test, mutants::skip)]
-fn add_bucket_delta(counter: &Counter<u64>, delta: u64, le_value: &Arc<str>) {
+fn add_bucket_delta(counter: &Counter<u64>, delta: u64, attrs: &[KeyValue; 1]) {
     if delta > 0 {
-        let attributes = [KeyValue::new(LE_ATTRIBUTE, Arc::<str>::clone(le_value))];
-        counter.add(delta, &attributes);
+        counter.add(delta, attrs);
     }
 }
 


### PR DESCRIPTION
Closes #166.

## What changed

Each `Publisher::run_one_iteration` call previously rebuilt a `[KeyValue; 1]` array containing a cloned `Arc<str>` for every bucket of every histogram event. With 50 histogram events and 8 buckets each that is ~400 such constructions per export iteration that produced an immutable result every time.

`InstrumentRegistry::instruments()` now precomputes the `Vec<[KeyValue; 1]>` once on the first call that provides histogram magnitudes, in the same registration order used by `histogram_deltas`. The export hot path passes `&self.bucket_attrs[i]` directly to `Counter::add`; the fixed-size array `&[KeyValue; 1]` auto-coerces to `&[KeyValue]` at the call site, so no per-call slice or `KeyValue` construction remains.

## Files touched

- `packages/nm_otel/src/mapping.rs` — replaced the `bucket_bounds: Vec<Arc<str>>` cache with `bucket_attrs: Vec<[KeyValue; 1]>`, updated `instruments()` to build the precomputed arrays once, and changed `add_bucket_delta`'s signature to take `&[KeyValue; 1]`.
- `packages/nm_otel/Cargo.toml` — added the Linux-only `gungraun` dev-dep and registered the new bench target.
- `packages/nm_otel/benches/nm_otel_export_cg.rs` — new Callgrind bench paired with the existing `nm_otel_export.rs` Criterion bench.

## Benchmark results

Callgrind is the primary signal because the per-bucket saving (one `Arc::clone` + one `KeyValue::new` + one stack `[KeyValue; 1]` initialization) is on the order of tens of instructions, which is below the Criterion noise floor on this codebase. Numbers below are from `just package=nm_otel bench-cg` on the same toolchain, run with `mapping.rs` from `origin/main` (before) vs this PR (after).

| Scenario | Buckets | Deltas | Instructions (before → after) | Δ | Estimated cycles (before → after) | Δ |
|---|---|---|---|---|---|---|
| `small_steady_state` | 8 (7 explicit + `+Inf`) | all positive | 6,667 → 6,325 | **−342 (−5.13%)** | 9,671 → 9,025 | −646 (−6.68%) |
| `small_no_delta` | 8 | all zero (short-circuits) | 1,232 → 1,226 | −6 (−0.49%) | 2,205 → 2,129 | −76 (−3.45%) |
| `large_steady_state` | 32 (31 explicit + `+Inf`) | all positive | 24,968 → 23,618 | **−1,350 (−5.41%)** | 34,760 → 32,530 | −2,230 (−6.42%) |

Per-bucket cost on the all-positive path drops by a consistent ~42 instructions:

* Small: 342 saved across 8 buckets = **42.75 instr / bucket**.
* Large: 1,350 saved across 32 buckets = **42.19 instr / bucket**.

That maps cleanly to the eliminated work: one atomic `Arc::clone`, one `KeyValue::new(&'static str, Arc<str>)` (a key-string clone + `OtelString::RefCounted` wrap), and the stack-`[KeyValue; 1]` initialization. The `small_no_delta` row is the regression guard: the `if delta > 0` short-circuit in `add_bucket_delta` runs before any of the removed work would have executed, so the optimization correctly produces no measurable change on the empty path (and importantly does not regress it).

L1 cache hits also drop ~6% on the steady-state scenarios — same root cause, fewer per-bucket loads/stores.

Run yourself with `just package=nm_otel bench-cg` (or `wsl -e bash -l -c "just package=nm_otel bench-cg"` from Windows).

## Validation

`just package=nm_otel validate-local` passes on both Windows and WSL Linux. The Linux build covers `--all-targets --all-features` and so includes the new Callgrind bench compilation. Functional behavior is covered by the existing nm_otel test suite — the precomputed attribute arrays produce identical exported metrics — no test changes were needed.

## Out of scope

The KeyValue precomputation is the surgical change. Other potential follow-ups (e.g. switching to non-`Arc` strings for the bucket label, or pooling `Counter` clones) are explicitly not addressed here; the issue's "Rejected alternatives" section explains why.
