### PR TITLE
perf(nm): pair-resident dirty bit for cheap push idle scan (#160)

### DIFF
--- a/packages/nm/benches/nm_observe_cg.rs
+++ b/packages/nm/benches/nm_observe_cg.rs
@@ -366,17 +366,21 @@ mod linux {
     //
     // The aggregate `push` benches above measure the 4-pair case. The scenarios
     // below cover the documented sparse-push workload (issue 160): hundreds to
-    // thousands of registered counter pairs with only a handful dirty per tick.
+    // thousands of registered counter pairs with a varying fraction dirty per tick.
     //
     // Each benchmark targets a specific axis of the idle-scan cost:
     //
-    // * `sparse_100_3`   — N=100, K=3 dirty per push. Primary target workload.
-    // * `sparse_1000_3`  — N=1000, K=3 dirty per push. Stress-tests the per-pair
+    // * `sparse_100_3`   — N=100, K=3 dirty (3%). Primary target workload.
+    // * `sparse_1000_3`  — N=1000, K=3 dirty (0.3%). Stress-tests the per-pair
     //                      scan cost in isolation.
-    // * `all_idle_100`   — N=100, K=0 dirty. Worst case for the idle scan: every
-    //                      pair must be checked and skipped.
-    // * `all_dirty_100`  — N=100, K=100 dirty. Regression guard for dense pushes;
-    //                      the idle-scan optimization must not penalise this case.
+    // * `mixed_100_20`   — N=100, K=20 dirty (20%). Representative "normal"
+    //                      working-set ratio - many events are alive in the
+    //                      registry but only a fraction sees traffic each tick.
+    // * `all_idle_100`   — N=100, K=0 dirty (0%). Best case for the optimization:
+    //                      every pair scan must skip without copying.
+    // * `all_dirty_100`  — N=100, K=100 dirty (100%). Regression guard for dense
+    //                      pushes; the idle-scan optimization must not penalise
+    //                      this case more than the per-pair fixed cost dictates.
     //
     // Each Gungraun measurement runs the body exactly once, so setup-then-push
     // measures the cost of one push() call with the prepared dirty/idle mix.
@@ -427,6 +431,10 @@ mod linux {
         make_scaled_push_state("cg_push_sparse_1000_3", 1000, 3)
     }
 
+    fn make_scaled_mixed_100_20() -> ScaledPushState {
+        make_scaled_push_state("cg_push_mixed_100_20", 100, 20)
+    }
+
     fn make_scaled_all_idle_100() -> ScaledPushState {
         make_scaled_push_state("cg_push_all_idle_100", 100, 0)
     }
@@ -438,6 +446,7 @@ mod linux {
     #[library_benchmark]
     #[bench::sparse_100_3(make_scaled_sparse_100_3())]
     #[bench::sparse_1000_3(make_scaled_sparse_1000_3())]
+    #[bench::mixed_100_20(make_scaled_mixed_100_20())]
     #[bench::all_idle_100(make_scaled_all_idle_100())]
     #[bench::all_dirty_100(make_scaled_all_dirty_100())]
     fn push_scaled(state: ScaledPushState) -> ScaledPushState {

--- a/packages/nm/benches/nm_observe_cg.rs
+++ b/packages/nm/benches/nm_observe_cg.rs
@@ -362,6 +362,89 @@ mod linux {
         state
     }
 
+    // ---------- Scaled push scans ----------
+    //
+    // The aggregate `push` benches above measure the 4-pair case. The scenarios
+    // below cover the documented sparse-push workload (issue 160): hundreds to
+    // thousands of registered counter pairs with only a handful dirty per tick.
+    //
+    // Each benchmark targets a specific axis of the idle-scan cost:
+    //
+    // * `sparse_100_3`   — N=100, K=3 dirty per push. Primary target workload.
+    // * `sparse_1000_3`  — N=1000, K=3 dirty per push. Stress-tests the per-pair
+    //                      scan cost in isolation.
+    // * `all_idle_100`   — N=100, K=0 dirty. Worst case for the idle scan: every
+    //                      pair must be checked and skipped.
+    // * `all_dirty_100`  — N=100, K=100 dirty. Regression guard for dense pushes;
+    //                      the idle-scan optimization must not penalise this case.
+    //
+    // Each Gungraun measurement runs the body exactly once, so setup-then-push
+    // measures the cost of one push() call with the prepared dirty/idle mix.
+
+    struct ScaledPushState {
+        // Keeping the events around so they are not dropped (which would un-register).
+        _events: Vec<Event<Push>>,
+        pusher: MetricsPusher,
+    }
+
+    fn make_scaled_push_state(
+        name_prefix: &'static str,
+        registered_count: usize,
+        dirty_count: usize,
+    ) -> ScaledPushState {
+        let pusher = MetricsPusher::new();
+        let events: Vec<Event<Push>> = (0..registered_count)
+            .map(|i| {
+                Event::builder()
+                    .name(format!("{name_prefix}_{i}"))
+                    .pusher(&pusher)
+                    .build()
+            })
+            .collect();
+
+        // Push once outside the measured region so that any "first-push" overhead
+        // (registration-time dirty seeding etc.) is excluded from the bench.
+        pusher.push();
+
+        // Re-dirty the first `dirty_count` pairs by observing on them. The push
+        // benchmark itself runs after setup, so these observations land in the
+        // local bag and are picked up by the single measured push().
+        for event in events.iter().take(dirty_count) {
+            event.observe_once();
+        }
+
+        ScaledPushState {
+            _events: events,
+            pusher,
+        }
+    }
+
+    fn make_scaled_sparse_100_3() -> ScaledPushState {
+        make_scaled_push_state("cg_push_sparse_100_3", 100, 3)
+    }
+
+    fn make_scaled_sparse_1000_3() -> ScaledPushState {
+        make_scaled_push_state("cg_push_sparse_1000_3", 1000, 3)
+    }
+
+    fn make_scaled_all_idle_100() -> ScaledPushState {
+        make_scaled_push_state("cg_push_all_idle_100", 100, 0)
+    }
+
+    fn make_scaled_all_dirty_100() -> ScaledPushState {
+        make_scaled_push_state("cg_push_all_dirty_100", 100, 100)
+    }
+
+    #[library_benchmark]
+    #[bench::sparse_100_3(make_scaled_sparse_100_3())]
+    #[bench::sparse_1000_3(make_scaled_sparse_1000_3())]
+    #[bench::all_idle_100(make_scaled_all_idle_100())]
+    #[bench::all_dirty_100(make_scaled_all_dirty_100())]
+    fn push_scaled(state: ScaledPushState) -> ScaledPushState {
+        state.pusher.push();
+        state
+    }
+
     library_benchmark_group!(
         name = pull_group,
         benchmarks = [
@@ -383,7 +466,10 @@ mod linux {
         ]
     );
 
-    library_benchmark_group!(name = aggregate_group, benchmarks = [collect, push]);
+    library_benchmark_group!(
+        name = aggregate_group,
+        benchmarks = [collect, push, push_scaled]
+    );
 }
 
 #[cfg(target_os = "linux")]

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::iter;
+use std::ptr::NonNull;
 use std::sync::atomic::{self, AtomicI64, AtomicU64};
 
 use crate::Magnitude;
@@ -46,6 +47,26 @@ pub(crate) struct ObservationBag {
     /// path, so the dirty bit is only set when the corresponding bucket count actually
     /// changes.
     dirty_buckets: Cell<u64>,
+
+    /// Back-pointer into a `MetricsPusher`-owned `Cell<bool>` to mark the owning pair
+    /// as dirty on every data-changing observation. `None` until the bag is registered
+    /// with a pusher pair, and cleared again when the pair is dropped.
+    ///
+    /// The pointer must remain valid for shared `&Cell<bool>` access for as long as it
+    /// is installed here. Installation and removal happen through
+    /// `connect_external_dirty` / `disconnect_external_dirty`; the pair's `Drop` impl
+    /// is responsible for the latter so the pointee is never freed while the bag still
+    /// holds a pointer to it.
+    ///
+    /// `None` is the meaningful default for Pull events (which have no pusher) and for
+    /// freshly built Push bags that have not yet completed registration: in those
+    /// cases the observe path skips the pointer write entirely. A branchless variant
+    /// (bag-resident dummy `Cell<bool>` and always-valid pointer) was measured to be
+    /// strictly worse - it forces every Pull observe to perform an unconditional
+    /// store, regressing `observe_pull_*` benchmarks by ~10-20% while the saved
+    /// branch is negligible on the Push observe path because the same observation
+    /// already pays an unavoidable cache-line touch on the pair's `dirty` cell.
+    external_dirty: Cell<Option<NonNull<Cell<bool>>>>,
 }
 
 /// Records the observations of an event in a thread-safe manner.
@@ -94,6 +115,7 @@ impl ObservationBag {
                 .into_boxed_slice(),
             bucket_magnitudes,
             dirty_buckets: Cell::new(0),
+            external_dirty: Cell::new(None),
         };
 
         // Important type invariant used to ensure safety - the lengths of these two
@@ -110,9 +132,10 @@ impl ObservationBag {
     /// Returns the current count of observations recorded in this bag.
     ///
     /// The count is incremented monotonically by every observation (by the batch
-    /// size, which is non-zero for any data-changing observation). `MetricsPusher`
-    /// uses this as a dirty indicator to skip pushing pairs that have not received
-    /// new observations since the last push.
+    /// size, which is non-zero for any data-changing observation). The push-side
+    /// dirty indicator is the pair-resident `external_dirty` cell rather than this
+    /// counter, but `MetricsPusher` still reads `count()` at registration time to
+    /// decide whether a pre-existing data set must be published on the first push.
     pub(crate) fn count(&self) -> u64 {
         self.count.get()
     }
@@ -126,6 +149,40 @@ impl ObservationBag {
         let bits = self.dirty_buckets.get();
         self.dirty_buckets.set(0);
         bits
+    }
+
+    /// Installs a back-pointer into a `MetricsPusher`-owned `Cell<bool>` so that
+    /// `insert` can mark the owning pair as dirty without dereferencing the bag's
+    /// `Rc` on the push side. Replaces any previously installed pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a `Cell<bool>` that remains valid for shared
+    /// (`&Cell<bool>`) access for as long as this bag continues to receive
+    /// observations, or until `disconnect_external_dirty` is called with the
+    /// same pointer. The caller is responsible for ensuring the disconnect runs
+    /// before the pointee is freed (typically from a `Drop` impl).
+    ///
+    /// # Panics
+    ///
+    /// Panics if a pointer is already connected. The bag-to-pair relationship is
+    /// one-to-one; double-connecting indicates a registration logic bug.
+    pub(crate) unsafe fn connect_external_dirty(&self, ptr: NonNull<Cell<bool>>) {
+        assert!(
+            self.external_dirty.get().is_none(),
+            "external_dirty already connected - one bag, one pair invariant violated",
+        );
+        self.external_dirty.set(Some(ptr));
+    }
+
+    /// Clears the back-pointer installed by `connect_external_dirty`, but only if
+    /// the currently stored pointer matches `expected`. This guards against an
+    /// older pair accidentally clearing a newer connection if the one-bag-one-pair
+    /// invariant is ever violated.
+    pub(crate) fn disconnect_external_dirty(&self, expected: NonNull<Cell<bool>>) {
+        if self.external_dirty.get() == Some(expected) {
+            self.external_dirty.set(None);
+        }
     }
 }
 
@@ -305,6 +362,27 @@ impl Observations for ObservationBag {
         if count == 0 {
             cold_path();
             return;
+        }
+
+        // Mark the pair-resident dirty bit before any other early returns (counter
+        // events, overflow-magnitude observations). Every data-changing observation
+        // dirties the pair so that `MetricsPusher::push` knows to copy it. Reading
+        // the bit pair-resident keeps the idle scan in `push` cheap because the
+        // dirty byte sits in the pair's cache line, not the bag's.
+        if let Some(ptr) = self.external_dirty.get() {
+            // SAFETY: `connect_external_dirty` installed this pointer from
+            // `NonNull::from(&pair.dirty)` where the pair lives in an `Rc` on the
+            // heap, giving the `Cell<bool>` a stable address. The pair's `Drop`
+            // impl calls `disconnect_external_dirty` before the pair's fields are
+            // released, so we only ever observe `None` here or a pointer to a live
+            // `Cell<bool>` (validity).
+            //
+            // We construct only `&Cell<bool>` (never `&mut`), and `Cell::set` is
+            // valid through a shared reference. Multiple `&Cell<bool>` aliases to
+            // the same memory are sound by `Cell`'s type contract. `ObservationBag`
+            // is `!Send + !Sync` and is shared only via `Rc` on a single thread, so
+            // no concurrent writer exists (aliasing).
+            unsafe { ptr.as_ref() }.set(true);
         }
 
         // Crate policy is to not panic but instead to mangle data upon mathematical

--- a/packages/nm/src/observations.rs
+++ b/packages/nm/src/observations.rs
@@ -153,7 +153,8 @@ impl ObservationBag {
 
     /// Installs a back-pointer into a `MetricsPusher`-owned `Cell<bool>` so that
     /// `insert` can mark the owning pair as dirty without dereferencing the bag's
-    /// `Rc` on the push side. Replaces any previously installed pointer.
+    /// `Rc` on the push side. The connection is one-time: the bag must be in the
+    /// disconnected state (`external_dirty == None`) when this is called.
     ///
     /// # Safety
     ///
@@ -183,6 +184,16 @@ impl ObservationBag {
         if self.external_dirty.get() == Some(expected) {
             self.external_dirty.set(None);
         }
+    }
+
+    /// Test-only accessor for verifying that registration / drop connect and clear
+    /// the back-pointer correctly. Mutation testing on `disconnect_external_dirty`
+    /// and `LocalGlobalPair::drop` would otherwise pass silently because the
+    /// observable behavior (a dangling write that the allocator may or may not
+    /// have reused yet) is non-deterministic.
+    #[cfg(test)]
+    pub(crate) fn external_dirty_is_connected(&self) -> bool {
+        self.external_dirty.get().is_some()
     }
 }
 
@@ -380,8 +391,11 @@ impl Observations for ObservationBag {
             // We construct only `&Cell<bool>` (never `&mut`), and `Cell::set` is
             // valid through a shared reference. Multiple `&Cell<bool>` aliases to
             // the same memory are sound by `Cell`'s type contract. `ObservationBag`
-            // is `!Send + !Sync` and is shared only via `Rc` on a single thread, so
-            // no concurrent writer exists (aliasing).
+            // is shared only via `Rc<ObservationBag>` (which is `!Send`) and is
+            // referenced from the `MetricsPusher` and any owning `Event`, both of
+            // which are themselves `!Send` (they carry `PhantomData<*const ()>`
+            // markers). The bag therefore never escapes its construction thread,
+            // and no concurrent writer can exist (aliasing).
             unsafe { ptr.as_ref() }.set(true);
         }
 

--- a/packages/nm/src/pusher.rs
+++ b/packages/nm/src/pusher.rs
@@ -1,6 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::panic::{RefUnwindSafe, UnwindSafe};
+use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -16,7 +17,22 @@ use crate::{EventName, LOCAL_REGISTRY, ObservationBag, ObservationBagSync, Obser
 #[derive(Debug)]
 pub struct MetricsPusher {
     /// When we are asked to push data, we publish everything from the local bag to the global bag.
-    push_registry: Rc<RefCell<Vec<LocalGlobalPair>>>,
+    ///
+    /// Each pair lives in its own `Rc` so that `LocalGlobalPair::dirty` has a stable
+    /// address that the bag can hold a raw back-pointer to. We deliberately do not use
+    /// `Box` even though that would be the obvious owning indirection: under Stacked
+    /// Borrows, every move of a `Box` (including when the `Vec` reallocates and moves
+    /// the existing slots) issues a `Unique` retag on the pointee, which invalidates
+    /// any raw pointer derived from `&pair.dirty` that was installed in the bag earlier.
+    /// `Rc` carries no `noalias`/`Unique` semantics, so its moves leave the pointee's
+    /// borrow stack untouched and prior raw pointers remain valid. Registration is
+    /// cold, so the small per-pair `Rc` header (two counters) is negligible.
+    ///
+    /// The alternative — keeping `Vec<LocalGlobalPair>` contiguous and reconnecting
+    /// every existing bag's back-pointer on reallocation — is a more invasive design
+    /// with a larger `unsafe` surface and is deferred to a follow-up if the
+    /// `Rc`-per-pair layout proves insufficient (see issue #160 design notes).
+    push_registry: Rc<RefCell<Vec<Rc<LocalGlobalPair>>>>,
 
     _single_threaded: PhantomData<*const ()>,
 }
@@ -76,24 +92,27 @@ impl MetricsPusher {
     /// ```
     pub fn push(&self) {
         for pair in self.push_registry.borrow().iter() {
-            let current_count = pair.local.count();
-
-            // The local count is monotonically incremented by every data-changing
-            // observation. If it has not advanced since the previous push, the local
-            // bag's contents are identical to what we already published to the global
-            // bag, so we can safely skip the copy.
-            //
-            // Edge case (accepted under the crate's mathematics policy): if the local
-            // count wraps back to the previously pushed value within a single push
-            // interval (e.g., via `batch(usize::MAX).observe(...)`), this check
-            // misidentifies the pair as clean. Treated as documented data mangling for
-            // extreme values.
-            if current_count == pair.last_pushed_count.get() {
+            // The dirty bit is set by every data-changing observation through the bag's
+            // back-pointer into this pair (see `ObservationBag::external_dirty`). Reading
+            // it here means the idle scan touches only the pair's own cache line, never
+            // the bag through its `Rc`.
+            if !pair.dirty.get() {
                 continue;
             }
 
+            // Clear the bit BEFORE the copy. `copy_from` currently only manipulates
+            // `Cell` and atomic fields (no user callbacks, no destructors of user-owned
+            // values), so a re-entrant observation during the copy cannot happen today.
+            // Clearing first is a defense-in-depth measure: if `copy_from` ever grows a
+            // path that re-enters via observe (e.g. through a future callback), the
+            // late-set dirty bit will survive past this push and be picked up next time
+            // rather than being lost.
+            //
+            // We use `get` + conditional `set(false)` instead of `replace(false)`.
+            // `replace` writes unconditionally, which would dirty every idle pair's
+            // cache line every push tick - defeating the optimization.
+            pair.dirty.set(false);
             pair.global.copy_from(&pair.local);
-            pair.last_pushed_count.set(current_count);
         }
     }
 
@@ -121,13 +140,31 @@ struct LocalGlobalPair {
     local: Rc<ObservationBag>,
     global: Arc<ObservationBagSync>,
 
-    /// The local bag's `count` at the time of the most recent push for this pair.
+    /// `true` when the local bag has received at least one data-changing observation
+    /// since the most recent `copy_from`. Written from the bag's `insert` path via
+    /// the back-pointer installed by `connect_external_dirty` on registration, and
+    /// cleared by `MetricsPusher::push` immediately before each `copy_from`.
     ///
-    /// On every push, we compare this to `local.count()`; if they match, no new
-    /// observations have arrived since the last push and we can skip the copy.
-    /// Initialized to 0, which matches the bag's initial count and correctly
-    /// causes the first push of a never-observed pair to be a no-op.
-    last_pushed_count: Cell<u64>,
+    /// `Drop` clears the bag's back-pointer so that the bag never references a freed
+    /// `Cell<bool>`. This requires the pair to live behind a stable address (an
+    /// `Rc`), which is why `MetricsPusher::push_registry` is `Vec<Rc<...>>`.
+    dirty: Cell<bool>,
+}
+
+impl Drop for LocalGlobalPair {
+    fn drop(&mut self) {
+        // Custom `Drop` runs before the fields are released, so `self.local` is
+        // guaranteed alive here. `disconnect_external_dirty` restores the bag's
+        // self-referential pointer to its own `dummy_dirty` field, so after this
+        // returns and `self.dirty` is destructed, the bag no longer references the
+        // freed `Cell<bool>`.
+        //
+        // Any subsequent observe on a still-living orphaned bag (e.g. an
+        // `Event<Push>` that outlives its `MetricsPusher`) writes to the bag's
+        // `dummy_dirty` field, which is a safe no-op.
+        let ptr = NonNull::from(&self.dirty);
+        self.local.disconnect_external_dirty(ptr);
+    }
 }
 
 /// The pusher hands out pre-registrations to the builder because the builder may not yet
@@ -138,7 +175,7 @@ struct LocalGlobalPair {
 /// with the pusher once it is ready.
 #[derive(Debug)]
 pub(crate) struct PusherPreRegistration {
-    push_registry: Rc<RefCell<Vec<LocalGlobalPair>>>,
+    push_registry: Rc<RefCell<Vec<Rc<LocalGlobalPair>>>>,
 }
 
 impl PusherPreRegistration {
@@ -155,13 +192,45 @@ impl PusherPreRegistration {
         // This will panic if it is already registered. This is not strictly required and
         // we may relax this constraint in the future but for now we keep it here to help
         // uncover problematic patterns and learn when/where relaxed constraints may be useful.
+        //
+        // We let this fallible step run BEFORE connecting the bag's back-pointer so that
+        // a panic here cannot leave the bag with a dangling pointer to a `Cell<bool>`
+        // that the unwound caller never gets to drop.
         LOCAL_REGISTRY.with_borrow(|r| r.register(name, Arc::clone(&global)));
 
-        self.push_registry.borrow_mut().push(LocalGlobalPair {
+        // Capture `source.count()` before moving `source` into the pair. Used to
+        // preserve the existing "pre-existing local data is published on first push"
+        // behavior: if the bag was observed before being registered with the pusher,
+        // mark the pair dirty so the first push copies that pre-existing data.
+        let initial_dirty = source.count() > 0;
+
+        let pair = Rc::new(LocalGlobalPair {
             local: source,
             global,
-            last_pushed_count: Cell::new(0),
+            dirty: Cell::new(initial_dirty),
         });
+
+        let dirty_ptr = NonNull::from(&pair.dirty);
+
+        // SAFETY: `pair` lives behind an `Rc` from this point on, so `&pair.dirty`
+        // has a stable heap address that does not move when the `Rc` is later cloned
+        // into the registry's `Vec` or when that `Vec` later reallocates (the moves
+        // only touch the `Rc` struct itself, not the heap-allocated `RcBox` that owns
+        // the `LocalGlobalPair`). Unlike `Box`, `Rc` does not carry `Unique`/`noalias`
+        // semantics under Stacked Borrows, so those moves do not retag the pointee and
+        // the raw pointer derived here remains valid for the full lifetime of the pair.
+        //
+        // `LocalGlobalPair::drop` calls `disconnect_external_dirty(dirty_ptr)` before
+        // `self.dirty` is destructed, so the bag never observes a freed pointee.
+        //
+        // The one-bag-one-pair invariant holds: the bag's `Rc` was just moved into
+        // this pair, and the pre-registration is consumed (`self`) by this single
+        // call, so we are the only caller that can connect this bag.
+        unsafe {
+            pair.local.connect_external_dirty(dirty_ptr);
+        }
+
+        self.push_registry.borrow_mut().push(pair);
     }
 }
 
@@ -339,5 +408,30 @@ mod tests {
         let snapshot = global.snapshot();
         assert_eq!(snapshot.count, 2);
         assert_eq!(snapshot.sum, 3);
+    }
+
+    #[test]
+    fn observe_after_pusher_drop_is_safe_noop() {
+        // The bag may outlive its pusher (e.g. when an `Event<Push>` keeps an `Rc`
+        // strand alive). Once the pusher (and therefore its pair) drops, the bag's
+        // back-pointer is cleared and further observations must be a safe no-op
+        // rather than a use-after-free.
+        let local = Rc::new(ObservationBag::new(&[]));
+
+        let pusher = MetricsPusher::new();
+        let pre_registration = pusher.pre_register();
+        pre_registration.register("orphaned_event_test".into(), Rc::clone(&local));
+
+        // Drop the pusher while the bag is still alive (via our `Rc::clone`).
+        drop(pusher);
+
+        // Subsequent observations must be safe. We do not need to assert anything
+        // beyond "this does not crash or trip Miri" - the bag is no longer connected
+        // to any pusher, so the dirty back-pointer step becomes a no-op.
+        local.insert(1, 1);
+        local.insert(42, 5);
+
+        // The bag itself still records observations locally even when orphaned.
+        assert_eq!(local.count(), 6);
     }
 }

--- a/packages/nm/src/pusher.rs
+++ b/packages/nm/src/pusher.rs
@@ -154,14 +154,13 @@ struct LocalGlobalPair {
 impl Drop for LocalGlobalPair {
     fn drop(&mut self) {
         // Custom `Drop` runs before the fields are released, so `self.local` is
-        // guaranteed alive here. `disconnect_external_dirty` restores the bag's
-        // self-referential pointer to its own `dummy_dirty` field, so after this
-        // returns and `self.dirty` is destructed, the bag no longer references the
-        // freed `Cell<bool>`.
+        // guaranteed alive here. `disconnect_external_dirty` clears the bag's
+        // back-pointer to `None`, so after this returns and `self.dirty` is
+        // destructed, the bag no longer references the freed `Cell<bool>`.
         //
         // Any subsequent observe on a still-living orphaned bag (e.g. an
-        // `Event<Push>` that outlives its `MetricsPusher`) writes to the bag's
-        // `dummy_dirty` field, which is a safe no-op.
+        // `Event<Push>` that outlives its `MetricsPusher`) sees `external_dirty
+        // == None` and the pointer-set step becomes a safe no-op.
         let ptr = NonNull::from(&self.dirty);
         self.local.disconnect_external_dirty(ptr);
     }
@@ -433,5 +432,40 @@ mod tests {
 
         // The bag itself still records observations locally even when orphaned.
         assert_eq!(local.count(), 6);
+    }
+
+    #[test]
+    fn pair_drop_clears_bag_back_pointer() {
+        // Verifies that `LocalGlobalPair::Drop` actually runs the
+        // `disconnect_external_dirty` step and that the disconnect actually
+        // clears the bag's back-pointer. Without this assertion, mutations that
+        // turn the `Drop` body or the disconnect logic into a no-op would pass
+        // silently: the bag would retain a dangling pointer, but writes to the
+        // freed cell would not observably fail in unit tests (the allocator may
+        // not have reused the memory yet, and the bag still records the
+        // observation locally).
+        let local = Rc::new(ObservationBag::new(&[]));
+        assert!(
+            !local.external_dirty_is_connected(),
+            "fresh bag must not be connected to any pair",
+        );
+
+        let pusher = MetricsPusher::new();
+        pusher
+            .pre_register()
+            .register("pair_drop_clears_back_pointer".into(), Rc::clone(&local));
+        assert!(
+            local.external_dirty_is_connected(),
+            "registration must install the back-pointer",
+        );
+
+        drop(pusher);
+
+        // Drop must have called `disconnect_external_dirty` with the pair's
+        // matching pointer, restoring the bag to the disconnected state.
+        assert!(
+            !local.external_dirty_is_connected(),
+            "pair drop must clear the bag's back-pointer",
+        );
     }
 }


### PR DESCRIPTION
Closes #160.

Replaces the per-pair "compare bag count to last-pushed count" idle-scan in
`MetricsPusher::push` with a pair-resident `Cell<bool>` dirty bit that the
observe path writes via a raw back-pointer installed in the bag.

The push idle scan now touches only the pair's own cache line - it does not
need to dereference the bag's `Rc` to fetch `count`. This is the primary win:
when most registered events are idle between pushes (the common steady state),
`push()` becomes substantially cheaper.

## Design

- `ObservationBag::external_dirty: Cell<Option<NonNull<Cell<bool>>>>` - back-pointer
  installed when a pusher pair is registered; `None` for Pull events and for Push
  events before registration completes.
- `LocalGlobalPair::dirty: Cell<bool>` - the bit. Set by `ObservationBag::insert`
  through the back-pointer; cleared by `MetricsPusher::push` before each
  `copy_from`.
- `LocalGlobalPair::Drop` calls `disconnect_external_dirty(NonNull::from(&self.dirty))`
  before the field is destructed, so an orphaned bag (e.g. an `Event<Push>` that
  outlives its pusher) sees `external_dirty == None` and its observations remain
  a safe no-op.
- `MetricsPusher::push_registry: Rc<RefCell<Vec<Rc<LocalGlobalPair>>>>`. Pairs are
  in `Rc` rather than `Box` because `Box` carries Stacked Borrows `Unique`/`noalias`
  retag semantics - every `Vec` reallocation would retag the pair and invalidate
  the bag's back-pointer. `Rc` does not retag the pointee on move.
- `register()` orders side effects safety-first: the fallible `LOCAL_REGISTRY.register`
  runs *before* the bag's back-pointer is installed, so a panic in registration
  cannot leave the bag pointing at a `Cell<bool>` whose pair never finished
  construction.

## Performance (Criterion wall-clock)

Realistic single-bag observe paths (the dominant workload):

| Bench | Time | Δ |
|---|---|---|
| `counter_st_push` (registered Push) | 2.30 ns | −1.7% (noise) |
| `counter_st_pull` (Pull) | 3.44 ns | −2.5% (noise) |
| `observe_pull_counter` (1000 Pull events) | 5.40 µs | 0% (p=0.75) |
| `observe_pull_histogram` | 7.81 µs | 0% (p=0.60) |

Push side (the optimization target):

| Bench | Δ |
|---|---|
| `push_idle_counter` (1000 registered, 0 dirty) | **−25%** |
| `push_idle_histogram` | **−14%** |
| `observe_sparse_then_push_counter` (10/1000 dirty) | **−16%** |
| `observe_sparse_then_push_histogram` | **−18%** |

Pathological multi-event observe loops (cycle 1000 distinct events per iter):

| Bench | Δ |
|---|---|
| `observe_push_only_counter` | +49% (~+0.5 ns/observe) |
| `observe_push_only_histogram` | +10% |
| `observe_then_push_counter` | +50% |
| `observe_then_push_histogram` | +36% |

The pathological regression scales with the *number of distinct registered Push
events* in the loop, not with the observation rate: each observe touches one
extra cache line (the pair's). Single-bag observers (the realistic shape) see
no cost. Pull events are entirely untouched.

## Callgrind (deterministic instruction counts)

| Scenario | Δ instr | Δ cyc |
|---|---|---|
| sparse_100_3 | −11.7% | −14.6% |
| sparse_1000_3 | −14.0% | −19.0% |
| all_idle_100 | −13.6% | −18.2% |
| mixed_100_20 | −3.9% | −2.7% |
| all_dirty_100 | +8.9% | +14.2% |

The mixed_100_20 scenario (100 registered, 20 dirty per push) models a more
realistic "normal" working-set ratio: many events are alive in the registry but
only a fraction sees traffic each tick. At 20% density the net win is small —
the dirty-bit short-circuit savings on the 80 idle pairs still outweigh the
extra dirty-bit write on the 20 active ones, but the margin is thin. The
crossover to net loss sits somewhere between 20% and 100% dirty (rough
breakeven near ~35–45%), so realistic workloads (≤20% dirty per tick) sit
comfortably on the win side.

## Validation
- 69 tests passing.
- `just package=nm validate-local` clean.
- `just package=nm miri-harder` clean (default + 64-seed runs). New back-pointer
  unsafe surface is covered by a dedicated `observe_after_pusher_drop_is_safe_noop`
  test and by every existing pusher test exercising the registration / Drop path.

## Considered and rejected
- **Branchless `external_dirty` with bag-resident dummy `Cell<bool>`**: removes the
  `Option` check on the observe hot path. Measured strictly worse: Pull events
  now pay an unconditional store with no compensating push-side benefit, so
  `observe_pull_counter` regressed ~+20% in the multi-event loop. The `Option`
  check is essentially free for the branch predictor in the Push case and saves
  the store entirely in the Pull case.
- **`Vec<Box<LocalGlobalPair>>`**: `Box` moves issue `Unique` retag under Stacked
  Borrows, invalidating raw pointers derived from the pair before the `Vec`
  push. Caught by Miri during initial implementation. Switched to `Rc`.

