### PR TITLE
Add testing::assert_panics helper (#171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,11 @@ It is good to create tests that verify expected panics/errors are returned. Howe
 check for a specific error/panic message - these are not part of the public API and create
 fragile tests. Just verify that an error of an expected type occurs or any panic occurs.
 
+For tests that must verify a panic but also continue running afterwards (e.g. to check that
+a data structure is still in a valid state), use `testing::assert_panics(|| ...)` instead of
+hand-rolling `catch_unwind(AssertUnwindSafe(...))`. When a canary substring check is warranted,
+use `testing::assert_panics_with(|| ..., |message| assert!(message.contains("canary")))`.
+
 # Keep the house in order
 
 Do not only focus on the immediate task at hand but also consider how it affects the codebase

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "pastey",
  "rand 0.9.2",
  "static_assertions",
+ "testing",
 ]
 
 [[package]]
@@ -1149,6 +1150,7 @@ dependencies = [
  "opentelemetry_sdk",
  "par_bench",
  "static_assertions",
+ "testing",
  "tick",
  "tokio",
 ]

--- a/packages/infinity_pool/Cargo.toml
+++ b/packages/infinity_pool/Cargo.toml
@@ -27,6 +27,7 @@ criterion = { workspace = true }
 mutants = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 static_assertions = { workspace = true }
+testing = { path = "../testing" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 gungraun = { workspace = true, features = ["default"] }

--- a/packages/infinity_pool/src/opaque/slab.rs
+++ b/packages/infinity_pool/src/opaque/slab.rs
@@ -654,6 +654,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use static_assertions::{assert_impl_all, assert_not_impl_any};
+    use testing::assert_panics;
 
     use super::*;
 
@@ -855,16 +856,13 @@ mod tests {
 
         let original_index = panicking_handle.index();
 
-        // Remove the object - this should panic during drop but still remove the object
-        let panic_result = catch_unwind(AssertUnwindSafe(|| {
+        // Remove the object - this should panic during drop but still remove the object.
+        assert_panics(|| {
             // SAFETY: panicking_handle is valid and from this slab
             unsafe {
                 slab.remove(panicking_handle);
             }
-        }));
-
-        // The removal should have panicked
-        assert!(panic_result.is_err());
+        });
 
         // But the slab should still be in a valid state:
         // 1. The object should be removed (count should be 0)
@@ -1754,7 +1752,7 @@ mod tests {
 
         DROP_COUNT.store(0, Ordering::SeqCst);
 
-        let drop_result = catch_unwind(AssertUnwindSafe(|| {
+        assert_panics(|| {
             let layout = SlabLayout::new(Layout::new::<AlwaysPanickingDrop>());
             let mut slab = Slab::new(layout, DropPolicy::MayDropContents);
 
@@ -1771,10 +1769,7 @@ mod tests {
             assert_eq!(slab.len(), 4);
 
             // Slab drops here - should call drop() on all 4 objects even though they all panic
-        }));
-
-        // The slab drop should have panicked due to the panicking object drops
-        assert!(drop_result.is_err());
+        });
 
         // But all 4 objects should have had their drop() called
         assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 4);

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -37,6 +37,7 @@ opentelemetry-stdout = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "testing"] }
 par_bench = { path = "../par_bench", features = ["alloc_tracker", "criterion"] }
 static_assertions = { workspace = true }
+testing = { path = "../testing" }
 tick = { workspace = true, features = ["tokio", "test-util"] }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 

--- a/packages/nm_otel/src/state.rs
+++ b/packages/nm_otel/src/state.rs
@@ -217,7 +217,7 @@ impl<I> HistogramDeltas<'_, I> {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use testing::assert_panics;
 
     use super::*;
 
@@ -401,8 +401,8 @@ mod tests {
         assert_eq!(state.histogram_buckets.len(), 3);
     }
 
-    // Panic tests use `catch_unwind` around the panic-triggering call rather than
-    // `#[should_panic]`. Setup of the first call runs outside `catch_unwind`, so any
+    // Panic tests use `assert_panics` around the panic-triggering call rather than
+    // `#[should_panic]`. Setup of the first call runs outside `assert_panics`, so any
     // mutation that breaks setup (e.g. the infinite-iterator mutation, which causes
     // `Iterator::eq` to return `false` and the `assert!` to fire) fails the test
     // normally instead of being incorrectly satisfied by `#[should_panic]`. The
@@ -410,7 +410,7 @@ mod tests {
     // which drives the iterator just past the last successful yield and then triggers
     // the bucket-count panic; if `next()` were mutated to be infinite, `eq` would
     // mismatch on the first comparison and return without panicking, leaving
-    // `panic_result.is_ok()` and failing the final assertion below.
+    // `assert_panics` to fail because no panic occurred.
 
     #[test]
     fn event_state_histogram_deltas_bucket_count_mismatch_panics() {
@@ -429,7 +429,7 @@ mod tests {
         // Second call with 4 buckets - should panic when the iterator is consumed past
         // the established bucket count. Yielded values on the first 3 items: cumulative
         // equals the previously established values [5, 15, 18], so all deltas are 0.
-        let panic_result = catch_unwind(AssertUnwindSafe(|| {
+        assert_panics(|| {
             let magnitudes4 = [10, 50, 100, 500];
             let non_cumulative4 = [5, 10, 3, 2];
             let expected_pre_panic: [(Magnitude, u64, u64); 3] =
@@ -437,9 +437,7 @@ mod tests {
             _ = state
                 .histogram_deltas(magnitudes4, non_cumulative4)
                 .eq(expected_pre_panic);
-        }));
-
-        assert!(panic_result.is_err());
+        });
     }
 
     #[test]
@@ -459,15 +457,13 @@ mod tests {
         // Second call yields only 2 buckets - should panic when the source iterator
         // is exhausted before all established buckets have been visited. Cumulative
         // [7, 19] against previous [5, 15] gives deltas [2, 4].
-        let panic_result = catch_unwind(AssertUnwindSafe(|| {
+        assert_panics(|| {
             let magnitudes2 = [10, 50];
             let non_cumulative2 = [7, 12];
             let expected_pre_panic: [(Magnitude, u64, u64); 2] = [(10, 7, 2), (50, 19, 4)];
             _ = state
                 .histogram_deltas(magnitudes2, non_cumulative2)
                 .eq(expected_pre_panic);
-        }));
-
-        assert!(panic_result.is_err());
+        });
     }
 }

--- a/packages/region_cached/src/region_cached.rs
+++ b/packages/region_cached/src/region_cached.rs
@@ -536,7 +536,7 @@ mod tests {
 
     use many_cpus::fake::{HardwareBuilder, ProcessorBuilder};
     use static_assertions::assert_impl_all;
-    use testing::with_watchdog;
+    use testing::{assert_panics, with_watchdog};
 
     use super::*;
     use crate::{RegionCachedCopyExt, RegionCachedExt, region_cached};
@@ -786,12 +786,11 @@ mod tests {
             assert_eq!(local.get_cached(), 42);
 
             // Second call with panicking closure.
-            let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+            assert_panics(|| {
                 local.with_cached(|_| {
                     panic!("User callback panicked!");
                 })
-            }));
-            assert!(panic_result.is_err());
+            });
 
             // Third call should still work and return the cached value.
             assert_eq!(local.get_cached(), 42);
@@ -810,12 +809,11 @@ mod tests {
             pin_to_processor(&hardware, 0);
 
             // First call with panicking closure should fail but not break state.
-            let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+            assert_panics(|| {
                 local.with_cached(|_| {
                     panic!("User callback panicked during initialization!");
                 })
-            }));
-            assert!(panic_result.is_err());
+            });
 
             // Second call should successfully initialize and work.
             assert_eq!(local.get_cached(), 42);

--- a/packages/region_local/src/region_local.rs
+++ b/packages/region_local/src/region_local.rs
@@ -441,7 +441,7 @@ mod tests {
 
     use many_cpus::fake::{HardwareBuilder, ProcessorBuilder};
     use static_assertions::assert_impl_all;
-    use testing::with_watchdog;
+    use testing::{assert_panics, with_watchdog};
 
     use super::*;
     use crate::{RegionLocalExt, region_local};
@@ -688,12 +688,11 @@ mod tests {
             assert_eq!(local.get_local(), 42);
 
             // Second call with panicking closure.
-            let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+            assert_panics(|| {
                 local.with_local(|_| {
                     panic!("User callback panicked!");
                 })
-            }));
-            assert!(panic_result.is_err());
+            });
 
             // Third call should still work and return the initialized value.
             assert_eq!(local.get_local(), 42);
@@ -712,12 +711,11 @@ mod tests {
             pin_to_processor(&hardware, 0);
 
             // First call with panicking closure should fail but not break state.
-            let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+            assert_panics(|| {
                 local.with_local(|_| {
                     panic!("User callback panicked during initialization!");
                 })
-            }));
-            assert!(panic_result.is_err());
+            });
 
             // Second call should successfully initialize and work.
             assert_eq!(local.get_local(), 42);

--- a/packages/testing/src/assert_panics.rs
+++ b/packages/testing/src/assert_panics.rs
@@ -13,6 +13,12 @@ use std::panic::{self, AssertUnwindSafe};
 /// Use [`assert_panics_with`] when the test needs to inspect the panic
 /// message (e.g. to check a canary substring).
 ///
+/// The default panic hook still runs before the panic is caught, so the
+/// expected panic's message and backtrace are printed to stderr during the
+/// test run. This is intentional — silencing the hook would also hide
+/// genuinely unexpected panics from elsewhere in the test. Treat the stderr
+/// output as expected noise for tests that exercise panicking code paths.
+///
 /// # Panics
 ///
 /// Panics if the closure does not panic.
@@ -55,6 +61,10 @@ where
 /// inspector receives an empty string. Standard `panic!()` invocations
 /// always produce one of these payload types.
 ///
+/// The default panic hook still runs before the panic is caught, so the
+/// expected panic's message and backtrace are printed to stderr during the
+/// test run. See [`assert_panics`] for the rationale.
+///
 /// # Panics
 ///
 /// Panics if the closure does not panic.
@@ -82,17 +92,16 @@ where
         panic!("closure did not panic as expected");
     };
 
-    let message = extract_panic_message(&*payload);
-    inspector(&message);
+    inspector(extract_panic_message(&*payload));
 }
 
-fn extract_panic_message(payload: &(dyn Any + Send)) -> String {
+fn extract_panic_message(payload: &(dyn Any + Send)) -> &str {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_owned()
+        s
     } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
+        s.as_str()
     } else {
-        String::new()
+        ""
     }
 }
 

--- a/packages/testing/src/assert_panics.rs
+++ b/packages/testing/src/assert_panics.rs
@@ -1,0 +1,185 @@
+use std::any::Any;
+use std::panic::{self, AssertUnwindSafe};
+
+/// Asserts that the closure panics.
+///
+/// Captures the panic so the surrounding test can keep running and make
+/// further assertions about state after the panic.
+///
+/// Prefer `#[should_panic]` when the panic is the only thing the test
+/// verifies. This helper is for the case where the test must also assert on
+/// post-panic state.
+///
+/// Use [`assert_panics_with`] when the test needs to inspect the panic
+/// message (e.g. to check a canary substring).
+///
+/// # Panics
+///
+/// Panics if the closure does not panic.
+///
+/// # Example
+///
+/// ```rust
+/// use std::cell::Cell;
+///
+/// use testing::assert_panics;
+///
+/// let counter = Cell::new(0);
+/// assert_panics(|| {
+///     counter.set(counter.get() + 1);
+///     panic!("something went wrong");
+/// });
+/// assert_eq!(counter.get(), 1);
+/// ```
+#[track_caller]
+pub fn assert_panics<F, R>(f: F)
+where
+    F: FnOnce() -> R,
+{
+    let Err(_payload) = panic::catch_unwind(AssertUnwindSafe(f)) else {
+        panic!("closure did not panic as expected");
+    };
+}
+
+/// Asserts that the closure panics and invokes the inspector with the panic
+/// message.
+///
+/// Captures the panic so the surrounding test can keep running and make
+/// further assertions about state after the panic. The inspector receives
+/// the panic message and can perform additional assertions on it — typically
+/// a canary substring check for a stable keyword inherent to the scenario
+/// (see the "Canary substrings" exception in `AGENTS.md`). Avoid asserting
+/// on the full message.
+///
+/// If the panic payload is neither `&'static str` nor `String`, the
+/// inspector receives an empty string. Standard `panic!()` invocations
+/// always produce one of these payload types.
+///
+/// # Panics
+///
+/// Panics if the closure does not panic.
+///
+/// # Example
+///
+/// ```rust
+/// use testing::assert_panics_with;
+///
+/// assert_panics_with(
+///     || {
+///         let x: u32 = u32::MAX;
+///         _ = x.checked_add(1).expect("overflow detected");
+///     },
+///     |message| assert!(message.contains("overflow")),
+/// );
+/// ```
+#[track_caller]
+pub fn assert_panics_with<F, R, I>(f: F, inspector: I)
+where
+    F: FnOnce() -> R,
+    I: FnOnce(&str),
+{
+    let Err(payload) = panic::catch_unwind(AssertUnwindSafe(f)) else {
+        panic!("closure did not panic as expected");
+    };
+
+    let message = extract_panic_message(&*payload);
+    inspector(&message);
+}
+
+fn extract_panic_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::cell::Cell;
+    use std::panic;
+
+    use super::*;
+
+    #[test]
+    fn assert_panics_returns_when_closure_panics() {
+        assert_panics(|| panic!("boom"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_panics_panics_when_closure_does_not_panic() {
+        assert_panics(|| {
+            // Intentionally does not panic.
+        });
+    }
+
+    #[test]
+    fn assert_panics_allows_post_panic_state_assertions() {
+        let value = Cell::new(0);
+        assert_panics(|| {
+            value.set(7);
+            panic!("after mutation");
+        });
+        assert_eq!(value.get(), 7);
+    }
+
+    #[test]
+    fn assert_panics_with_passes_str_message_to_inspector() {
+        let captured = Cell::new(None);
+        assert_panics_with(
+            || panic!("static string panic"),
+            |message| captured.set(Some(message.to_owned())),
+        );
+        assert_eq!(
+            captured.into_inner().as_deref(),
+            Some("static string panic")
+        );
+    }
+
+    #[test]
+    fn assert_panics_with_passes_string_message_to_inspector() {
+        let captured = Cell::new(None);
+        assert_panics_with(
+            || {
+                let dynamic = format!("dynamic {} panic", 42);
+                panic!("{}", dynamic);
+            },
+            |message| captured.set(Some(message.to_owned())),
+        );
+        assert_eq!(captured.into_inner().as_deref(), Some("dynamic 42 panic"));
+    }
+
+    #[test]
+    fn assert_panics_with_passes_empty_string_for_non_string_payload() {
+        let captured = Cell::new(None);
+        assert_panics_with(
+            || panic::panic_any(42_u32),
+            |message| captured.set(Some(message.to_owned())),
+        );
+        assert_eq!(captured.into_inner().as_deref(), Some(""));
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_panics_with_panics_when_closure_does_not_panic() {
+        assert_panics_with(
+            || {
+                // Intentionally does not panic.
+            },
+            |_| {},
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_panics_with_propagates_inspector_panic() {
+        assert_panics_with(
+            || panic!("the closure panic"),
+            |message| assert!(message.contains("nonexistent canary")),
+        );
+    }
+}

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -4,12 +4,14 @@
 
 //! Private helpers for testing and examples in Folo packages.
 
+mod assert_panics;
 mod reentrant_waker;
 
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+pub use assert_panics::{assert_panics, assert_panics_with};
 pub use reentrant_waker::ReentrantWakerData;
 
 #[cfg(windows)]

--- a/packages/vicinal/src/scheduler.rs
+++ b/packages/vicinal/src/scheduler.rs
@@ -269,6 +269,7 @@ mod tests {
     use events_once::EventPool;
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
+    use testing::assert_panics;
 
     use crate::{Pool, Scheduler};
 
@@ -311,8 +312,6 @@ mod tests {
 
     #[test]
     fn spawn_captures_panic() {
-        use std::panic;
-
         let pool = Pool::new();
         let scheduler = pool.scheduler();
 
@@ -320,8 +319,7 @@ mod tests {
             panic!("test panic");
         });
 
-        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| block_on(handle)));
-        assert!(result.is_err());
+        assert_panics(|| block_on(handle));
     }
 
     #[test]


### PR DESCRIPTION
Closes #171.

## Summary

Codifies the recurring `catch_unwind(AssertUnwindSafe(...))` + `assert!(panic_result.is_err())` test pattern into two small helpers in the `testing` crate:

- `assert_panics(|| ...)` — the common case (panic + post-panic state).
- `assert_panics_with(|| ..., |message| ...)` — inspector receives the panic message so tests can verify a canary substring (per the AGENTS.md exception for stable keywords inherent to the scenario).

Both helpers are `#[track_caller]` so failures point at the test, not the helper. The panic hook is not silenced (keeps the helper thread-safe and avoids the global-hook footgun). An empty string is passed to the inspector if the panic payload is neither `&'static str` nor `String`.

## Design notes

The issue's strawman returned no value (`-> ()`). I prototyped a return-the-message variant, but the `String` destructor forced ugly `drop(...)` boilerplate at every call site that did not care about the message. Two functions reads better and keeps both call shapes uncluttered.

## Migrations

Migrates 9 call sites that match the "expect panic then keep going" pattern. The issue listed 7; while doing the work I noticed two more that fit the same pattern:

- `nm_otel::state` — bucket-count mismatch / fewer-buckets panic tests (×2)
- `region_local::region_local` — `callback_panic_during_*` tests (×2)
- `region_cached::region_cached` — `callback_panic_during_*` tests (×2)
- `infinity_pool::opaque::slab::remove_with_panicking_drop_keeps_slab_valid`
- `infinity_pool::opaque::slab::slab_drop_calls_all_object_drops_even_when_they_panic` (not in original list)
- `vicinal::scheduler::spawn_captures_panic` (not in original list)

Production code that captures payloads for forwarding or `resume_unwind` remains on raw `catch_unwind` as the issue instructs.

## Other changes

- Added `testing` as a dev-dependency in `nm_otel` and `infinity_pool` (other migrated packages already had it).
- One-line nudge in `AGENTS.md` under "Testing for panics and errors" pointing at the helpers for the "keep going after the panic" use case.

## Validation

`just package={testing,nm_otel,region_local,region_cached,infinity_pool,vicinal} validate-local` passes on both Windows and Linux (WSL). `just clippy` (full workspace) clean.

Mutation coverage on migrated tests is preserved: the original `nm_otel` panic tests depended on the closure panicking only when iteration consumed past the expected count; `assert_panics` panics if the closure does not panic, catching the same infinite-iterator mutation as before.
