### PR TITLE
AGENTS.md: forbid parking_lot due to Miri incompatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -774,6 +774,16 @@ and verified via `just package=<name> miri-harder`, which runs Miri with many ra
 highly effective at detecting data races, incorrect memory orderings, and other concurrency bugs
 that are nearly impossible to catch with single-threaded tests alone.
 
+# parking_lot is forbidden — use std::sync primitives
+
+Do not use `parking_lot::Mutex`, `parking_lot::RwLock`, or other primitives from the `parking_lot`
+crate. They rely on OS-specific syscalls that Miri cannot model, so introducing them breaks our
+Miri-based correctness validation. Use `std::sync::Mutex`, `std::sync::RwLock`, and other
+std-provided synchronization primitives instead — these are Miri-compatible.
+
+This rule applies even when `parking_lot` would offer a measurable performance benefit: Miri
+coverage is more valuable than the fast-path savings.
+
 # Mutation testing coverage and skipping mutations
 
 We expect all mutations to either be unviable or to be caught. Uncaught mutations and mutants that


### PR DESCRIPTION
## Summary

Forbid `parking_lot` in this workspace and document the constraint in `AGENTS.md`.

## Motivation

`parking_lot::Mutex`, `parking_lot::RwLock`, and similar primitives rely on OS-specific syscalls (e.g. `futex` on Linux, `WaitOnAddress`/`WakeByAddressSingle` on Windows) that Miri cannot model. Introducing `parking_lot` would silently break Miri-based correctness validation across the workspace.

We rely on Miri to catch data races and memory ordering bugs in concurrent code. Trading Miri coverage for the (modest) fast-path savings `parking_lot` offers is not a worthwhile bargain — bugs caught by Miri are nearly impossible to catch any other way.

## Change

Add a new section to `AGENTS.md` before the mutation-testing section, stating the rule and the rationale, and directing contributors to `std::sync` primitives instead.

No code is changed.
