### PR TITLE
infinity_pool: skip redundant layout check in typed pool inserts

### DIFF
--- a/packages/infinity_pool/src/pinned/pool_local.rs
+++ b/packages/infinity_pool/src/pinned/pool_local.rs
@@ -172,7 +172,11 @@ where
     #[must_use]
     #[cfg_attr(test, mutants::skip)] // All mutations are unviable - skip them to save time.
     pub fn insert(&self, value: T) -> LocalPooledMut<T> {
-        let inner = self.inner.borrow_mut().insert(value);
+        // SAFETY: `LocalPinnedPool<T>` is a typed wrapper. The underlying opaque pool's
+        // object layout was set to `Layout::of::<T>()` at construction time and the wrapper
+        // never permits inserting any other type, so the layout match required by
+        // `insert_unchecked` is statically guaranteed.
+        let inner = unsafe { self.inner.borrow_mut().insert_unchecked(value) };
 
         LocalPooledMut::new(inner, Rc::clone(&self.inner))
     }
@@ -226,8 +230,10 @@ where
     where
         F: FnOnce(&mut MaybeUninit<T>),
     {
-        // SAFETY: Forwarding safety guarantees from caller.
-        let inner = unsafe { self.inner.borrow_mut().insert_with(f) };
+        // SAFETY: `LocalPinnedPool<T>` is a typed wrapper, so the layout match required by
+        // `insert_with_unchecked` is statically guaranteed. The closure-initialization
+        // requirement is forwarded from this method's own safety contract.
+        let inner = unsafe { self.inner.borrow_mut().insert_with_unchecked(f) };
 
         LocalPooledMut::new(inner, Rc::clone(&self.inner))
     }

--- a/packages/infinity_pool/src/pinned/pool_local.rs
+++ b/packages/infinity_pool/src/pinned/pool_local.rs
@@ -172,10 +172,11 @@ where
     #[must_use]
     #[cfg_attr(test, mutants::skip)] // All mutations are unviable - skip them to save time.
     pub fn insert(&self, value: T) -> LocalPooledMut<T> {
-        // SAFETY: `LocalPinnedPool<T>` is a typed wrapper. The underlying opaque pool's
-        // object layout was set to `Layout::of::<T>()` at construction time and the wrapper
-        // never permits inserting any other type, so the layout match required by
-        // `insert_unchecked` is statically guaranteed.
+        // SAFETY: `LocalPinnedPool<T>` is a typed wrapper. The underlying opaque pool was
+        // constructed via `RawOpaquePool::with_layout_of::<T>()`, which records
+        // `Layout::new::<T>()` as the pool's object layout, and the wrapper never permits
+        // inserting any other type. The layout match required by `insert_unchecked` is
+        // therefore statically guaranteed.
         let inner = unsafe { self.inner.borrow_mut().insert_unchecked(value) };
 
         LocalPooledMut::new(inner, Rc::clone(&self.inner))

--- a/packages/infinity_pool/src/pinned/pool_managed.rs
+++ b/packages/infinity_pool/src/pinned/pool_managed.rs
@@ -170,7 +170,16 @@ where
     #[must_use]
     #[cfg_attr(test, mutants::skip)] // All mutations are unviable - skip them to save time.
     pub fn insert(&self, value: T) -> PooledMut<T> {
-        let inner = self.inner.lock().expect(NEVER_POISONED).insert(value);
+        // SAFETY: `PinnedPool<T>` is a typed wrapper. The underlying opaque pool's object
+        // layout was set to `Layout::of::<T>()` at construction time and the wrapper never
+        // permits inserting any other type, so the layout match required by
+        // `insert_unchecked` is statically guaranteed.
+        let inner = unsafe {
+            self.inner
+                .lock()
+                .expect(NEVER_POISONED)
+                .insert_unchecked(value)
+        };
 
         // SAFETY: We apply the constraint `T: Send` as the safety requirements require.
         unsafe { PooledMut::new(inner, Arc::clone(&self.inner)) }
@@ -232,8 +241,11 @@ where
         // resume_unwind, so our state is never observed in a potentially
         // inconsistent state. The user's panic is re-thrown without tampering.
         let result = catch_unwind(AssertUnwindSafe(|| {
-            // SAFETY: Forwarding safety guarantees from caller.
-            unsafe { inner.insert_with(f) }
+            // SAFETY: `PinnedPool<T>` is a typed wrapper, so the layout match
+            // required by `insert_with_unchecked` is statically guaranteed.
+            // The closure-initialization requirement is forwarded from this
+            // method's own safety contract.
+            unsafe { inner.insert_with_unchecked(f) }
         }));
         drop(inner);
 

--- a/packages/infinity_pool/src/pinned/pool_managed.rs
+++ b/packages/infinity_pool/src/pinned/pool_managed.rs
@@ -170,10 +170,11 @@ where
     #[must_use]
     #[cfg_attr(test, mutants::skip)] // All mutations are unviable - skip them to save time.
     pub fn insert(&self, value: T) -> PooledMut<T> {
-        // SAFETY: `PinnedPool<T>` is a typed wrapper. The underlying opaque pool's object
-        // layout was set to `Layout::of::<T>()` at construction time and the wrapper never
-        // permits inserting any other type, so the layout match required by
-        // `insert_unchecked` is statically guaranteed.
+        // SAFETY: `PinnedPool<T>` is a typed wrapper. The underlying opaque pool was
+        // constructed via `RawOpaquePool::with_layout_of::<T>()`, which records
+        // `Layout::new::<T>()` as the pool's object layout, and the wrapper never permits
+        // inserting any other type. The layout match required by `insert_unchecked` is
+        // therefore statically guaranteed.
         let inner = unsafe {
             self.inner
                 .lock()


### PR DESCRIPTION
## Summary

Skip the redundant `Layout::new::<T>()` runtime check on every insert through `PinnedPool<T>` and `LocalPinnedPool<T>` by switching the four typed-wrapper insert paths to the `*_unchecked` variants of the underlying opaque pool.

## Why this is safe

`PinnedPool<T>` and `LocalPinnedPool<T>` are typed wrappers built directly on `RawOpaquePool`. At construction time the wrapper sets the underlying pool's object layout to `Layout::of::<T>()`, and the wrapper never exposes any API that lets a caller insert a value of a different type. The layout match required by `insert_unchecked` / `insert_with_unchecked` is therefore statically guaranteed by the wrapper's type signature.

The runtime `assert_eq!(Layout::new::<T>(), self.object_layout(), ...)` inside `RawOpaquePool::insert` and `insert_with` only earns its keep for the opaque/blind APIs, where the caller does not statically know the layout. For the typed wrappers it is dead weight on every insert.

Each call site carries a `SAFETY:` comment justifying the typed-wrapper invariant; for `insert_with_unchecked` the comment also acknowledges that the closure-initialization safety requirement is forwarded from the wrapper's own `# Safety` contract.

## Sites changed

- `PinnedPool::insert` (`pool_managed.rs`)
- `PinnedPool::insert_with` (`pool_managed.rs`, inside the existing `catch_unwind` wrapper)
- `LocalPinnedPool::insert` (`pool_local.rs`)
- `LocalPinnedPool::insert_with` (`pool_local.rs`)

## Measured Callgrind impact

| Benchmark | Before | After | Δ |
| --- | ---: | ---: | ---: |
| `pinned_pool_insert_into_10k` | 121 | 111 | **−10 instr (−8.3 %)** |
| `local_pinned_pool_insert_into_10k` | 96 | 86 | **−10 instr (−10.4 %)** |
| `pinned_pool_insert_into_empty` | 3780 | 3771 | −9 instr |

The 10k-item steady-state inserts see the largest *relative* improvement because the per-insert cost is otherwise small. The empty-pool case is dominated by allocation, so the savings are absolute (still −9 instructions on a single insert).

Non-insert benches (`pinned_pool_drop_handle_from_10k`, `pinned_pool_deref_handle`, etc.) are unchanged, as expected.

## Validation

- `just package=infinity_pool test` — 474 / 474 pass on Windows and Linux.
- `just package=infinity_pool miri` — 472 pass / 2 skipped / 0 fail.
- `just package=infinity_pool validate-local` clean on Windows and Linux.
- `just package=infinity_pool bench-cg infinity_pool_cg` confirms the deltas above.

## Notes on the bench numbers

The new `local_pinned_pool_insert_into_10k` bench is introduced in a separate PR (the bench-enrichment change). Reviewers wanting to reproduce the local-pool number should base off that branch; the managed-pool delta is reproducible against the existing bench scenarios on `main`.
