### PR TITLE
infinity_pool: skip Dropper fn-ptr call for !needs_drop types

### DIFF
--- a/packages/infinity_pool/src/opaque/dropper.rs
+++ b/packages/infinity_pool/src/opaque/dropper.rs
@@ -7,7 +7,13 @@ use std::ptr::{self, NonNull};
 #[derive(Debug)]
 pub(crate) struct Dropper {
     ptr: NonNull<()>,
-    drop_fn: fn(NonNull<()>),
+
+    // `None` when `T` does not need dropping (e.g. primitives, `Copy` types). Storing `None`
+    // avoids an indirect call through a fn pointer that resolves to a no-op `drop_in_place`,
+    // saving instructions on every handle remove for trivially-droppable payloads.
+    //
+    // `fn` pointers have a null niche, so wrapping in `Option` does not grow `Dropper`.
+    drop_fn: Option<fn(NonNull<()>)>,
 }
 
 impl Dropper {
@@ -23,11 +29,17 @@ impl Dropper {
     ///    or letting it go out of scope) while the `Dropper` exists.
     /// 3. Only one `Dropper` instance exists for any given target at a time.
     pub(crate) unsafe fn new<T>(target: NonNull<T>) -> Self {
-        let drop_fn = drop_fn::<T>;
+        let drop_fn = if mem::needs_drop::<T>() {
+            let drop_fn = drop_fn::<T>;
 
-        // Erase the type of the pointer in the function arguments.
-        // SAFETY: We are just changing the target of the pointer arg, everything is ABI-equal.
-        let drop_fn = unsafe { mem::transmute::<fn(NonNull<T>), fn(NonNull<()>)>(drop_fn) };
+            // Erase the type of the pointer in the function arguments.
+            // SAFETY: We are just changing the target of the pointer arg, everything is ABI-equal.
+            let drop_fn = unsafe { mem::transmute::<fn(NonNull<T>), fn(NonNull<()>)>(drop_fn) };
+
+            Some(drop_fn)
+        } else {
+            None
+        };
 
         Self {
             ptr: target.cast(),
@@ -38,7 +50,9 @@ impl Dropper {
 
 impl Drop for Dropper {
     fn drop(&mut self) {
-        (self.drop_fn)(self.ptr);
+        if let Some(drop_fn) = self.drop_fn {
+            drop_fn(self.ptr);
+        }
     }
 }
 
@@ -56,7 +70,17 @@ mod tests {
     use std::mem;
     use std::rc::Rc;
 
+    use static_assertions::const_assert_eq;
+
     use super::*;
+
+    // The whole point of using `Option<fn(_)>` instead of a separate `bool` is to exploit the
+    // null niche of function pointers. If this assertion breaks, the optimization has
+    // regressed and `Dropper` grew, which would in turn grow `SlotMeta`.
+    const_assert_eq!(
+        size_of::<Option<fn(NonNull<()>)>>(),
+        size_of::<fn(NonNull<()>)>()
+    );
 
     /// Test helper that tracks whether it has been dropped.
     struct DropTracker {
@@ -159,5 +183,45 @@ mod tests {
 
         // Prevent double-drop by forgetting the original.
         mem::forget(stack_complex);
+    }
+
+    #[test]
+    fn dropper_skips_drop_for_trivial_types() {
+        // For a type that does not need dropping, we expect the dropper to store `None`
+        // and short-circuit on drop — no `drop_in_place` call should be made through the
+        // function pointer.
+        let mut value: u64 = 0x1234_5678_9abc_def0;
+
+        // SAFETY: `u64` is `Copy` and does not need dropping; the target outlives the dropper.
+        let dropper = unsafe { Dropper::new(NonNull::from(&mut value)) };
+
+        assert!(
+            dropper.drop_fn.is_none(),
+            "Dropper for !needs_drop type should not carry a drop function"
+        );
+
+        drop(dropper);
+
+        // Value should still be intact since no drop logic ran against it.
+        assert_eq!(value, 0x1234_5678_9abc_def0);
+    }
+
+    #[test]
+    fn dropper_records_drop_fn_for_droppable_types() {
+        let (tracker, _dropped_flag) = DropTracker::new();
+        let mut stack_value = tracker;
+
+        // SAFETY: target outlives dropper; we mem::forget the original below to prevent double-drop.
+        let dropper = unsafe { Dropper::new(NonNull::from(&mut stack_value)) };
+
+        assert!(
+            dropper.drop_fn.is_some(),
+            "Dropper for needs_drop type should carry a drop function"
+        );
+
+        drop(dropper);
+
+        // Prevent double-drop by forgetting the original.
+        mem::forget(stack_value);
     }
 }


### PR DESCRIPTION
Implements #177.

In `Dropper`, store `drop_fn` as `Option<fn(NonNull<()>)>` instead of
`fn(NonNull<()>)`. Construct `None` for `T` where `mem::needs_drop::<T>()`
is false. On `Dropper::drop`, branch on the option instead of unconditionally
calling the function pointer.

## Why this works

* `fn` pointer has a null niche, so `Option<fn(NonNull<()>)>` is still 8 bytes.
  `Dropper` stays at 16 bytes; `SlotMeta` stays at 16 bytes — no growth.
  A `const_assert_eq!` is added to lock in the niche-packing assumption.
* For `T` where `!mem::needs_drop::<T>()` (primitives, `Copy` types, etc.),
  the indirection through `drop_fn::<T>` was resolving to a no-op
  `drop_in_place::<T>` today, but the function pointer call still happened.
  This change removes that call.

## Callgrind impact

Measured on `bench-cg`:

* `pinned_pool_insert_into_10k`: 121 → 110 instructions (-11)
* `pinned_pool_drop_handle_from_10k`: 113 → 114 instructions (+1)
* `blind_pool_insert_into_10k`: 200 → 184 instructions (-16)

Net savings on the insert path are larger than expected because storing
`None` (a compile-time zero) is cheaper than loading and storing a
function-pointer address. The drop path is essentially neutral — the
compiler was already folding the monomorphized `drop_in_place::<u64>`
no-op away, so removing the unconditional call did not save further
instructions; the added niche check costs one. Net across an
insert/drop cycle: ~10 instructions saved.

## Tests

* `dropper_skips_drop_for_trivial_types` confirms `Dropper` for `u64`
  stores `None` and skips the drop callback.
* `dropper_records_drop_fn_for_droppable_types` confirms `Dropper`
  for a `Drop`-bearing type still carries a callback.
* Existing drop-tracker tests continue to pass and exercise the call path.
