### PR TITLE
infinity_pool: replace BlindPool BTreeMap dispatch with MTF SmallVec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,8 +443,10 @@ including: which operations warrant Callgrind coverage, scenario selection guide
 (default case, branching extremes, state/occupancy variants, size sensitivity, initialization
 vs steady state, sibling variants), the bench file template (including the file-scope lint
 suppression block required by Gungraun's macro expansions), Cargo.toml setup with the
-target-gated dependency, Gungraun syntax gotchas, the pairing convention, and how to interpret
-results.
+target-gated dependency, Gungraun syntax gotchas, the pairing convention, how to interpret
+results, and why design decisions motivated by a Callgrind delta should always be
+cross-validated against the Criterion counterpart (real CPUs can absorb or amplify a
+simulated cost by orders of magnitude).
 
 # YAML formatting
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "num-integer",
  "pastey",
  "rand 0.9.2",
+ "smallvec",
  "static_assertions",
  "testing",
 ]

--- a/docs/callgrind-benchmarks.md
+++ b/docs/callgrind-benchmarks.md
@@ -381,6 +381,48 @@ Two important caveats:
    ordering effects do not show up. Multithreaded behavior must be covered
    by Criterion + `par_bench`.
 
+### Cross-validate design decisions against Criterion
+
+Callgrind is excellent for *spotting* a delta and *attributing* it to a
+specific code path, but the absolute magnitude of that delta on real
+hardware is unpredictable. The simulator has no out-of-order execution, no
+modern branch predictor, no prefetcher, and a fixed cache geometry — all
+of which real CPUs use to absorb (or sometimes amplify) instruction-count
+deltas. Two failure modes are common enough to plan for:
+
+* **Absorbed:** Callgrind shows a worrying instruction-count increase that
+  wall-clock barely registers. Branch prediction nails the new branches,
+  ILP overlaps the extra arithmetic with the surrounding load latency, the
+  added comparisons live entirely in registers. A +20% Callgrind delta on
+  a hot path can shrink to +2% wall-clock.
+* **Amplified:** Callgrind shows a small instruction-count delta but
+  wall-clock shows a much larger regression. The new code introduces a
+  hard-to-predict branch, a `swap_remove`+`push` pair that touches more
+  cache lines than the in-place rotation it replaced, or a store-load
+  dependency the OoO engine cannot hide. A +50% Callgrind delta can
+  blow up to +100% or worse wall-clock.
+
+Therefore, when a Callgrind delta is driving a *design decision* (which
+data structure to use, which fast path to add, whether a regression on
+one axis is acceptable in exchange for a win on another), **run the
+Criterion counterpart on the same scenario before committing to the
+design.** Treat Callgrind as the hypothesis generator and Criterion as
+the verifier:
+
+* If wall-clock agrees in direction and rough magnitude, the change is safe
+  to ship and the Callgrind number is a fair summary.
+* If wall-clock disagrees in direction, the design needs to be revisited
+  — the simulated cost was misleading.
+* If wall-clock confirms the direction but the magnitude differs sharply,
+  document both numbers in the PR description. Reviewers should see the
+  real-world cost, not just the simulated one.
+
+This is especially important for *worst-case* / adversarial scenarios. A
+typical-case Criterion churn loop will often hide a worst-case regression
+because the hot path keeps the data structure in the cheap state — you
+need a dedicated adversarial Criterion bench to expose what the
+adversarial Callgrind scenario actually costs in cycles.
+
 ### Regression handling
 
 Gungraun's auto-diff exits non-zero on any regression, however small. This

--- a/packages/infinity_pool/Cargo.toml
+++ b/packages/infinity_pool/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 new_zealand = { workspace = true }
 num-integer = { workspace = true }
 pastey = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 alloc_tracker = { path = "../alloc_tracker" }

--- a/packages/infinity_pool/benches/infinity_pool_cg.rs
+++ b/packages/infinity_pool/benches/infinity_pool_cg.rs
@@ -17,7 +17,12 @@
 //! and untyped pools, and against `Arc::pin` and `Box::pin` baselines:
 //!
 //! * `local_pinned_pool_insert_into_10k` — single-threaded path.
-//! * `blind_pool_insert_into_10k` — untyped path.
+//! * `blind_pool_insert_into_10k` — untyped path (single layout).
+//! * `blind_pool_insert_into_10k_n5_layouts` — dispatch over 5 distinct layouts.
+//! * `blind_pool_insert_into_10k_n8_layouts` — dispatch over 8 distinct layouts.
+//! * `blind_pool_insert_into_10k_n16_layouts` — dispatch over 16 layouts (heap spill).
+//! * `blind_pool_insert_into_10k_n8_layouts_adversarial` — measured key is *not* the
+//!   most-recently used; exercises the worst-case linear-scan path.
 //! * `arc_pin_baseline_insert` — `Arc::pin` for comparison.
 //! * `box_pin_baseline_insert` — `Box::pin` for comparison.
 //!
@@ -108,6 +113,91 @@ mod linux {
         BlindPoolState { pool, anchors }
     }
 
+    // Populates the dispatch with N - 1 extra inner pools by inserting and immediately
+    // dropping one item of each anchor type. The inner `RawOpaquePool` instances remain
+    // in the dispatch even after all items are removed, so the measured `pool.insert::<u64>`
+    // call must traverse a dispatch with N distinct `LayoutKey` entries.
+    //
+    // The 10k u64 anchor inserts that follow ensure u64 is the most-recently-used entry
+    // in the dispatch — the typical pattern in real `BlindPool` workloads where one or
+    // two layouts dominate. This is the scenario the move-to-front linear scan is
+    // designed to make cheap.
+    fn make_populated_blind_pool_n5_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // 4 extra layouts so the dispatch holds 5 entries once u64 is added.
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        BlindPoolState { pool, anchors }
+    }
+
+    fn make_populated_blind_pool_n8_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // 7 extra layouts so the dispatch holds 8 entries once u64 is added.
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        BlindPoolState { pool, anchors }
+    }
+
+    fn make_populated_blind_pool_n16_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // 15 extra layouts via varied byte-array sizes (size N, align 1) plus u128 so the
+        // dispatch holds 16 entries once u64 is added. This exceeds the inline capacity
+        // of the dispatch and forces heap spillover.
+        drop(pool.insert::<[u8; 1]>([0; 1]));
+        drop(pool.insert::<[u8; 2]>([0; 2]));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 4]>([0; 4]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        drop(pool.insert::<[u8; 7]>([0; 7]));
+        drop(pool.insert::<[u8; 9]>([0; 9]));
+        drop(pool.insert::<[u8; 10]>([0; 10]));
+        drop(pool.insert::<[u8; 11]>([0; 11]));
+        drop(pool.insert::<[u8; 12]>([0; 12]));
+        drop(pool.insert::<[u8; 13]>([0; 13]));
+        drop(pool.insert::<[u8; 14]>([0; 14]));
+        drop(pool.insert::<[u8; 15]>([0; 15]));
+        drop(pool.insert::<u128>(0));
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        BlindPoolState { pool, anchors }
+    }
+
+    // Adversarial setup for the dispatch: builds an 8-entry dispatch where the measured
+    // key (u64) is *not* the most-recently used. The dispatch internally maintains
+    // most-recently-used order, so an insert here cannot benefit from the front fast
+    // path and must walk through the other entries before finding u64.
+    //
+    // This complements the locality-friendly `make_populated_blind_pool_n8_layouts`
+    // helper and quantifies the worst-case scan cost.
+    fn make_adversarial_blind_pool_n8_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // u64 first so it is initially in the dispatch with anchor items, then 7 extras
+        // inserted afterward — each pushes u64 further back in MRU order. Final MRU
+        // order: [u128, [u8; 6], [u8; 5], [u8; 3], u32, u16, u8, u64].
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        drop(pool.insert::<u128>(0));
+        BlindPoolState { pool, anchors }
+    }
+
     // State for the drop benchmark: a populated pool plus a freshly-inserted
     // extra handle that the bench drops. The pool keeps its 10k anchors so
     // the drop only frees one slot in a fully-populated slab.
@@ -165,6 +255,42 @@ mod linux {
         (state, handle)
     }
 
+    #[library_benchmark]
+    #[bench::populated(make_populated_blind_pool_n5_layouts())]
+    fn blind_pool_insert_into_10k_n5_layouts(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_populated_blind_pool_n8_layouts())]
+    fn blind_pool_insert_into_10k_n8_layouts(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_populated_blind_pool_n16_layouts())]
+    fn blind_pool_insert_into_10k_n16_layouts(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_adversarial_blind_pool_n8_layouts())]
+    fn blind_pool_insert_into_10k_n8_layouts_adversarial(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
     // ---------- Drop path ----------
 
     #[library_benchmark]
@@ -210,6 +336,10 @@ mod linux {
             pinned_pool_insert_into_10k,
             local_pinned_pool_insert_into_10k,
             blind_pool_insert_into_10k,
+            blind_pool_insert_into_10k_n5_layouts,
+            blind_pool_insert_into_10k_n8_layouts,
+            blind_pool_insert_into_10k_n16_layouts,
+            blind_pool_insert_into_10k_n8_layouts_adversarial,
             arc_pin_baseline_insert,
             box_pin_baseline_insert,
         ]

--- a/packages/infinity_pool/benches/infinity_pool_vs_std.rs
+++ b/packages/infinity_pool/benches/infinity_pool_vs_std.rs
@@ -542,6 +542,15 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
         drop(pool.insert::<u128>(0));
     });
 
+    // Adversarial wall-clock counterpart of the Callgrind
+    // `blind_pool_insert_into_10k_n8_layouts_adversarial` scenario. The dispatch holds 8
+    // entries. Each iteration of the inner timed loop performs a u128 insert immediately
+    // before each u64 insert: the u128 insert always moves itself to the front of the
+    // dispatch's MRU order, which forces the subsequent u64 insert to be the most-distant
+    // entry in MRU order — exactly the worst-case linear scan the typical-case benches
+    // never observe (because their tight u64-only loop keeps u64 permanently at front).
+    blind_pool_churn_n8_layouts_adversarial(&mut group, &allocs);
+
     // LocalBlindPool (single-threaded, reference counted, multiple types) with churn
     let allocs_op = allocs.operation("LocalBlindPool");
     group.bench_function("LocalBlindPool", |b| {
@@ -686,6 +695,81 @@ fn blind_pool_churn_with_extra_layouts<F>(
                     for _ in 0..BATCH_SIZE {
                         let target_index = rng.random_range(0..handles.len());
                         handles.swap_remove(target_index);
+                    }
+                }
+            }
+            start.elapsed()
+        });
+    });
+}
+
+// Adversarial-MRU counterpart of `blind_pool_churn_with_extra_layouts`. Each measured
+// u64 insert is preceded by a u128 insert. The u128 insert always moves itself to
+// the front of the dispatch's MRU order, so each subsequent u64 insert must scan past
+// every other entry before finding u64 — the worst case the MTF dispatch is designed
+// to be tolerable but slower at. The dispatch holds 8 distinct layouts (7 extras + u64);
+// the inserted u128 handle is one of those 7 extras, so the dispatch size is invariant.
+// Both inserts contribute to the measured time; what matters across branches is the
+// relative cost of the adversarial path.
+fn blind_pool_churn_n8_layouts_adversarial(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    allocs: &alloc_tracker::Session,
+) {
+    let label = "BlindPool_8layouts_adversarial";
+    let allocs_op = allocs.operation(label);
+    group.bench_function(label, |b| {
+        b.iter_custom(|iters| {
+            let mut all_pools = Vec::with_capacity(iters as usize);
+            let mut all_u64_handles = Vec::with_capacity(iters as usize);
+            let mut all_u128_handles = Vec::with_capacity(iters as usize);
+
+            for _ in 0..iters {
+                let pool = BlindPool::new();
+                // 7 extra layouts so the dispatch holds 8 entries once u64 is added.
+                drop(pool.insert::<u8>(0));
+                drop(pool.insert::<u16>(0));
+                drop(pool.insert::<u32>(0));
+                drop(pool.insert::<[u8; 3]>([0; 3]));
+                drop(pool.insert::<[u8; 5]>([0; 5]));
+                drop(pool.insert::<[u8; 6]>([0; 6]));
+                drop(pool.insert::<u128>(0));
+                all_pools.push(pool);
+                all_u64_handles
+                    .push(Vec::with_capacity((INITIAL_ITEMS + BATCH_SIZE) as usize));
+                all_u128_handles
+                    .push(Vec::with_capacity((INITIAL_ITEMS + BATCH_SIZE) as usize));
+            }
+
+            for (pool, handles) in all_pools.iter_mut().zip(all_u64_handles.iter_mut()) {
+                for i in 0..INITIAL_ITEMS {
+                    handles.push(pool.insert::<u64>(i));
+                }
+            }
+
+            let _span = allocs_op.measure_thread().iterations(iters);
+            let start = Instant::now();
+            for ((pool, u64_handles), u128_handles) in all_pools
+                .iter_mut()
+                .zip(all_u64_handles.iter_mut())
+                .zip(all_u128_handles.iter_mut())
+            {
+                let mut rng = SmallRng::seed_from_u64(42);
+                let mut next_value = INITIAL_ITEMS;
+
+                for _ in 0..BATCH_COUNT {
+                    for _ in 0..BATCH_SIZE {
+                        // The u128 insert bumps u128 to the front of MRU; the u64
+                        // insert that follows is then the most distant entry.
+                        u128_handles.push(pool.insert::<u128>(0));
+                        u64_handles.push(pool.insert::<u64>(next_value));
+                        next_value = next_value.wrapping_add(1);
+                    }
+
+                    for _ in 0..BATCH_SIZE {
+                        let target_index = rng.random_range(0..u64_handles.len());
+                        u64_handles.swap_remove(target_index);
+                        let target_index = rng.random_range(0..u128_handles.len());
+                        u128_handles.swap_remove(target_index);
                     }
                 }
             }

--- a/packages/infinity_pool/benches/infinity_pool_vs_std.rs
+++ b/packages/infinity_pool/benches/infinity_pool_vs_std.rs
@@ -503,6 +503,45 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
         });
     });
 
+    // BlindPool variants where the dispatch holds extra distinct layouts so the per-insert
+    // dispatch traversal touches more entries. The churn pattern still operates on u64
+    // values; the extra layouts only populate the dispatch and exercise the lookup path.
+    // These pair 1:1 with the Callgrind scenarios `blind_pool_insert_into_10k_n{5,8,16}_layouts`.
+    blind_pool_churn_with_extra_layouts(&mut group, &allocs, "BlindPool_5layouts", |pool| {
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+    });
+
+    blind_pool_churn_with_extra_layouts(&mut group, &allocs, "BlindPool_8layouts", |pool| {
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+    });
+
+    blind_pool_churn_with_extra_layouts(&mut group, &allocs, "BlindPool_16layouts", |pool| {
+        drop(pool.insert::<[u8; 1]>([0; 1]));
+        drop(pool.insert::<[u8; 2]>([0; 2]));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 4]>([0; 4]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        drop(pool.insert::<[u8; 7]>([0; 7]));
+        drop(pool.insert::<[u8; 9]>([0; 9]));
+        drop(pool.insert::<[u8; 10]>([0; 10]));
+        drop(pool.insert::<[u8; 11]>([0; 11]));
+        drop(pool.insert::<[u8; 12]>([0; 12]));
+        drop(pool.insert::<[u8; 13]>([0; 13]));
+        drop(pool.insert::<[u8; 14]>([0; 14]));
+        drop(pool.insert::<[u8; 15]>([0; 15]));
+        drop(pool.insert::<u128>(0));
+    });
+
     // LocalBlindPool (single-threaded, reference counted, multiple types) with churn
     let allocs_op = allocs.operation("LocalBlindPool");
     group.bench_function("LocalBlindPool", |b| {
@@ -599,6 +638,60 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     group.finish();
 
     allocs.print_to_stdout();
+}
+
+// Drives the BlindPool churn measurement for a pool that has been pre-populated with extra
+// inner pools via `extra_layouts`. The inner pools persist in the dispatch even after the
+// inserted handles drop, so the measured churn exercises a dispatch with N distinct
+// `LayoutKey` entries (where N = 1 + number of extra layouts added by the closure).
+fn blind_pool_churn_with_extra_layouts<F>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    allocs: &alloc_tracker::Session,
+    label: &'static str,
+    extra_layouts: F,
+) where
+    F: Fn(&BlindPool),
+{
+    let allocs_op = allocs.operation(label);
+    group.bench_function(label, |b| {
+        b.iter_custom(|iters| {
+            let mut all_pools = Vec::with_capacity(iters as usize);
+            let mut all_handles = Vec::with_capacity(iters as usize);
+
+            for _ in 0..iters {
+                let pool = BlindPool::new();
+                extra_layouts(&pool);
+                all_pools.push(pool);
+                all_handles.push(Vec::with_capacity((INITIAL_ITEMS + BATCH_SIZE) as usize));
+            }
+
+            for (pool, handles) in all_pools.iter_mut().zip(all_handles.iter_mut()) {
+                for i in 0..INITIAL_ITEMS {
+                    handles.push(pool.insert(i));
+                }
+            }
+
+            let _span = allocs_op.measure_thread().iterations(iters);
+            let start = Instant::now();
+            for (pool, handles) in all_pools.iter_mut().zip(all_handles.iter_mut()) {
+                let mut rng = SmallRng::seed_from_u64(42);
+                let mut next_value = INITIAL_ITEMS;
+
+                for _ in 0..BATCH_COUNT {
+                    for _ in 0..BATCH_SIZE {
+                        handles.push(pool.insert(next_value));
+                        next_value = next_value.wrapping_add(1);
+                    }
+
+                    for _ in 0..BATCH_SIZE {
+                        let target_index = rng.random_range(0..handles.len());
+                        handles.swap_remove(target_index);
+                    }
+                }
+            }
+            start.elapsed()
+        });
+    });
 }
 
 criterion_group!(benches, churn_insertion_benchmark);

--- a/packages/infinity_pool/src/blind/core.rs
+++ b/packages/infinity_pool/src/blind/core.rs
@@ -1,14 +1,13 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use crate::{LayoutKey, RawOpaquePool, RawOpaquePoolThreadSafe};
+use crate::{LayoutDispatch, RawOpaquePool, RawOpaquePoolThreadSafe};
 
 // These are the core data sets shared by the pool objects and the handle objects.
 pub(crate) type BlindPoolCore = Arc<Mutex<BlindPoolInnerMap>>;
 pub(crate) type LocalBlindPoolCore = Rc<RefCell<LocalBlindPoolInnerMap>>;
 
-pub(crate) type BlindPoolInnerMap = BTreeMap<LayoutKey, RawOpaquePoolThreadSafe>;
-pub(crate) type LocalBlindPoolInnerMap = BTreeMap<LayoutKey, RawOpaquePool>;
-pub(crate) type RawBlindPoolInnerMap = BTreeMap<LayoutKey, RawOpaquePool>;
+pub(crate) type BlindPoolInnerMap = LayoutDispatch<RawOpaquePoolThreadSafe>;
+pub(crate) type LocalBlindPoolInnerMap = LayoutDispatch<RawOpaquePool>;
+pub(crate) type RawBlindPoolInnerMap = LayoutDispatch<RawOpaquePool>;

--- a/packages/infinity_pool/src/blind/layout_dispatch.rs
+++ b/packages/infinity_pool/src/blind/layout_dispatch.rs
@@ -1,0 +1,288 @@
+use smallvec::SmallVec;
+
+use crate::LayoutKey;
+
+/// Inline capacity chosen to cover the documented "handful of distinct layouts" common case
+/// fully inline. Each entry is `(LayoutKey, V)` where `V` is a `RawOpaquePool`-sized value
+/// (~152 bytes on x64), so the inline footprint is ~1.3 KiB on 64-bit targets.
+///
+/// Beyond this capacity, the underlying `SmallVec` falls back to heap allocation. Lookup
+/// remains correct; only the cache locality on the cold spill path is reduced.
+const INLINE_CAPACITY: usize = 8;
+
+/// Dispatches by `LayoutKey` to an associated value, optimized for a small number of distinct
+/// keys with strong locality of reference.
+///
+/// Storage is a `SmallVec` of `(LayoutKey, V)` entries with inline capacity sized for the
+/// typical case so no heap allocation is needed when the pool holds a handful of distinct
+/// object layouts. Lookup is a linear scan, and on every successful lookup the matching
+/// entry is moved to position 0 ("move-to-front"). Newly inserted entries are also placed
+/// at position 0. The combination keeps the most-recently used key at the front, so
+/// repeated inserts of the same type — the common case in `BlindPool` workloads — find
+/// their entry on the first comparison.
+///
+/// Iteration order of `values()` / `values_mut()` is therefore not part of the contract.
+//
+// This is a deviation from the standard `BTreeMap<LayoutKey, V>` we used previously, and
+// also from the obvious "sorted SmallVec + binary_search_by_key" pattern proposed in
+// issue #176. Both alternatives were rejected by direct Callgrind measurement against
+// this implementation: at the single-digit `N` we observe in `BlindPool` workloads,
+// `BTreeMap`'s tree descent and `binary_search_by_key`'s per-iteration constant factor
+// (mid computation, conditional bound updates, end-of-loop check) both lose to a tight
+// load-compare-branch scan over an MRU-ordered slice.
+//
+// A `HashMap` (e.g. with FxHash on the 8-byte `LayoutKey`) was considered but not
+// measured. It would need to beat a one-iteration linear scan plus a single equality
+// check on the hot path, which seems unlikely given hash + bucket probe overhead, but
+// has not been verified empirically.
+//
+// Beyond the inline capacity, the underlying `SmallVec` falls back to heap allocation;
+// correctness is preserved, only cache locality on the cold spill path is reduced.
+//
+// Moving entries via `SmallVec::insert` or `SmallVec::swap` is safe: the value type
+// stores its bulk data in separately allocated buffers (e.g. slab vectors) and is not
+// self-referential to the enclosing struct.
+#[derive(Debug)]
+pub(crate) struct LayoutDispatch<V> {
+    entries: SmallVec<[(LayoutKey, V); INLINE_CAPACITY]>,
+}
+
+impl<V> LayoutDispatch<V> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: SmallVec::new(),
+        }
+    }
+
+    /// Returns a shared reference to the value associated with `key`, if present.
+    pub(crate) fn get(&self, key: LayoutKey) -> Option<&V> {
+        self.entries.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    }
+
+    /// Returns a unique reference to the value associated with `key`, if present.
+    pub(crate) fn get_mut(&mut self, key: LayoutKey) -> Option<&mut V> {
+        self.entries
+            .iter_mut()
+            .find(|(k, _)| *k == key)
+            .map(|(_, v)| v)
+    }
+
+    /// Returns the value associated with `key`, inserting one produced by `f` if not present.
+    ///
+    /// The matching (or newly inserted) entry is positioned at index 0, so the next call
+    /// with the same key returns on the first comparison.
+    pub(crate) fn get_or_insert_with<F>(&mut self, key: LayoutKey, f: F) -> &mut V
+    where
+        F: FnOnce() -> V,
+    {
+        // Fast path: the most-recently-used entry is at position 0 by construction of this
+        // dispatch, so a check against `entries[0].0` short-circuits the iterator setup
+        // and the secondary `get_mut` access on the hot repeated-lookup path.
+        if let Some((k0, _)) = self.entries.first()
+            && *k0 == key
+        {
+            return &mut self
+                .entries
+                .get_mut(0)
+                .expect("first entry exists per the immediately preceding `first()`")
+                .1;
+        }
+
+        if let Some(idx) = self.entries.iter().position(|(k, _)| *k == key) {
+            self.entries.swap(0, idx);
+        } else {
+            self.entries.insert(0, (key, f()));
+        }
+
+        &mut self
+            .entries
+            .get_mut(0)
+            .expect("either swapped to position 0 or inserted at position 0")
+            .1
+    }
+
+    /// Returns an iterator over the values in current MRU order.
+    pub(crate) fn values(&self) -> impl Iterator<Item = &V> {
+        self.entries.iter().map(|(_, v)| v)
+    }
+
+    /// Returns an iterator over the values for mutation, in current MRU order.
+    pub(crate) fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.entries.iter_mut().map(|(_, v)| v)
+    }
+}
+
+impl<V> Default for LayoutDispatch<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::alloc::Layout;
+
+    use testing::assert_panics;
+
+    use super::*;
+
+    fn key_from_size_align(size: usize, align: usize) -> LayoutKey {
+        LayoutKey::new(Layout::from_size_align(size, align).unwrap())
+    }
+
+    #[test]
+    fn new_dispatch_is_empty() {
+        let dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        assert_eq!(dispatch.values().count(), 0);
+        assert!(dispatch.get(key_from_size_align(1, 1)).is_none());
+    }
+
+    #[test]
+    fn default_dispatch_is_empty() {
+        let dispatch: LayoutDispatch<u32> = LayoutDispatch::default();
+
+        assert_eq!(dispatch.values().count(), 0);
+    }
+
+    #[test]
+    fn get_or_insert_with_inserts_value() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        let key = key_from_size_align(4, 4);
+
+        let value = dispatch.get_or_insert_with(key, || 42);
+
+        assert_eq!(*value, 42);
+        assert_eq!(dispatch.values().count(), 1);
+    }
+
+    #[test]
+    fn get_or_insert_with_returns_existing_without_calling_constructor() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        let key = key_from_size_align(4, 4);
+
+        _ = dispatch.get_or_insert_with(key, || 42);
+
+        let value =
+            dispatch.get_or_insert_with(key, || panic!("must not call ctor for existing key"));
+        assert_eq!(*value, 42);
+        assert_eq!(dispatch.values().count(), 1);
+    }
+
+    #[test]
+    fn get_returns_inserted_value() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        let key = key_from_size_align(4, 4);
+
+        _ = dispatch.get_or_insert_with(key, || 99);
+
+        assert_eq!(dispatch.get(key), Some(&99));
+    }
+
+    #[test]
+    fn get_returns_none_for_absent_key() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        _ = dispatch.get_or_insert_with(key_from_size_align(4, 4), || 1);
+
+        assert!(dispatch.get(key_from_size_align(8, 8)).is_none());
+    }
+
+    #[test]
+    fn insertions_are_retained_regardless_of_key_order() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        // Insert with arbitrary key order; lookup must find every key.
+        _ = dispatch.get_or_insert_with(key_from_size_align(8, 8), || 80);
+        _ = dispatch.get_or_insert_with(key_from_size_align(2, 2), || 20);
+        _ = dispatch.get_or_insert_with(key_from_size_align(4, 4), || 40);
+        _ = dispatch.get_or_insert_with(key_from_size_align(1, 1), || 10);
+        _ = dispatch.get_or_insert_with(key_from_size_align(16, 16), || 160);
+
+        assert_eq!(dispatch.get(key_from_size_align(1, 1)), Some(&10));
+        assert_eq!(dispatch.get(key_from_size_align(2, 2)), Some(&20));
+        assert_eq!(dispatch.get(key_from_size_align(4, 4)), Some(&40));
+        assert_eq!(dispatch.get(key_from_size_align(8, 8)), Some(&80));
+        assert_eq!(dispatch.get(key_from_size_align(16, 16)), Some(&160));
+        assert_eq!(dispatch.values().count(), 5);
+    }
+
+    #[test]
+    fn repeated_get_or_insert_with_keeps_key_at_front() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        let key_a = key_from_size_align(1, 1);
+        let key_b = key_from_size_align(2, 2);
+        let key_c = key_from_size_align(4, 4);
+
+        _ = dispatch.get_or_insert_with(key_a, || 10);
+        _ = dispatch.get_or_insert_with(key_b, || 20);
+        _ = dispatch.get_or_insert_with(key_c, || 30);
+
+        // Calling get_or_insert_with with an existing key should move it to the front,
+        // so the next call with the same key finds it without scanning the others.
+        _ = dispatch.get_or_insert_with(key_a, || panic!("must not construct"));
+
+        // Inspect MRU order via values() — key_a was last accessed, must be at front.
+        let values: Vec<u32> = dispatch.values().copied().collect();
+        assert_eq!(values.first().copied(), Some(10));
+    }
+
+    #[test]
+    fn values_mut_modifies_in_place() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        _ = dispatch.get_or_insert_with(key_from_size_align(4, 4), || 1);
+        _ = dispatch.get_or_insert_with(key_from_size_align(8, 8), || 2);
+
+        for v in dispatch.values_mut() {
+            *v = v.wrapping_mul(10);
+        }
+
+        let mut values: Vec<u32> = dispatch.values().copied().collect();
+        values.sort_unstable();
+        assert_eq!(values, vec![10, 20]);
+    }
+
+    #[test]
+    fn spills_to_heap_past_inline_capacity_and_remains_correct() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        // Use INLINE_CAPACITY + 4 distinct layouts to force heap spill.
+        let count = INLINE_CAPACITY.checked_add(4).unwrap();
+        for i in 0..count {
+            let size = i.checked_add(1).unwrap();
+            let value = u32::try_from(i).unwrap();
+            _ = dispatch.get_or_insert_with(key_from_size_align(size, 1), || value);
+        }
+
+        assert_eq!(dispatch.values().count(), count);
+
+        for i in 0..count {
+            let size = i.checked_add(1).unwrap();
+            let value = u32::try_from(i).unwrap();
+            assert_eq!(dispatch.get(key_from_size_align(size, 1)), Some(&value));
+        }
+    }
+
+    #[test]
+    fn constructor_panic_leaves_dispatch_unchanged() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        let key_a = key_from_size_align(4, 4);
+        let key_b = key_from_size_align(8, 8);
+
+        _ = dispatch.get_or_insert_with(key_a, || 10);
+
+        // The constructor for a new key panics. The dispatch must be left intact:
+        // no new entry should have been added, and the existing entry must still
+        // be accessible.
+        assert_panics(|| {
+            _ = dispatch.get_or_insert_with(key_b, || panic!("ctor failure"));
+        });
+
+        assert_eq!(dispatch.get(key_a), Some(&10));
+        assert_eq!(dispatch.get(key_b), None);
+        assert_eq!(dispatch.values().count(), 1);
+    }
+}

--- a/packages/infinity_pool/src/blind/mod.rs
+++ b/packages/infinity_pool/src/blind/mod.rs
@@ -1,4 +1,5 @@
 mod core;
+mod layout_dispatch;
 mod layout_key;
 mod pool_local;
 mod pool_managed;
@@ -6,6 +7,7 @@ mod pool_raw;
 
 pub(crate) use core::*;
 
+pub(crate) use layout_dispatch::*;
 pub(crate) use layout_key::*;
 pub use pool_local::*;
 pub use pool_managed::*;

--- a/packages/infinity_pool/src/blind/pool_local.rs
+++ b/packages/infinity_pool/src/blind/pool_local.rs
@@ -137,7 +137,7 @@ impl LocalBlindPool {
 
         let core = self.core.borrow();
 
-        core.get(&key)
+        core.get(key)
             .map(RawOpaquePool::capacity)
             .unwrap_or_default()
     }
@@ -267,9 +267,7 @@ fn ensure_inner_pool<'a, T: 'static>(
     let layout = Layout::new::<T>();
     let key = LayoutKey::new(layout);
 
-    pools
-        .entry(key)
-        .or_insert_with(|| RawOpaquePool::with_layout(layout))
+    pools.get_or_insert_with(key, || RawOpaquePool::with_layout(layout))
 }
 
 #[cfg(test)]

--- a/packages/infinity_pool/src/blind/pool_managed.rs
+++ b/packages/infinity_pool/src/blind/pool_managed.rs
@@ -131,7 +131,7 @@ impl BlindPool {
 
         let core = self.core.lock().expect(NEVER_POISONED);
 
-        core.get(&key)
+        core.get(key)
             .map(|pool| pool.capacity())
             .unwrap_or_default()
     }
@@ -278,7 +278,7 @@ fn ensure_inner_pool<'a, T: Send + 'static>(
     let layout = Layout::new::<T>();
     let key = LayoutKey::new(layout);
 
-    core.entry(key).or_insert_with(|| {
+    core.get_or_insert_with(key, || {
         // SAFETY: We always require `T: Send`.
         unsafe { RawOpaquePoolThreadSafe::new(RawOpaquePool::with_layout(layout)) }
     })

--- a/packages/infinity_pool/src/blind/pool_raw.rs
+++ b/packages/infinity_pool/src/blind/pool_raw.rs
@@ -285,7 +285,7 @@ impl RawBlindPool {
     fn inner_pool_of<T>(&self) -> Option<&RawOpaquePool> {
         let key = LayoutKey::with_layout_of::<T>();
 
-        self.pools.get(&key)
+        self.pools.get(key)
     }
 
     fn inner_pool_of_mut<T>(&mut self) -> &mut RawOpaquePool {
@@ -296,16 +296,18 @@ impl RawBlindPool {
     }
 
     fn inner_pool_mut(&mut self, layout: Layout, key: LayoutKey) -> &mut RawOpaquePool {
-        self.pools.entry(key).or_insert_with(|| {
+        let drop_policy = self.drop_policy;
+
+        self.pools.get_or_insert_with(key, || {
             RawOpaquePool::builder()
-                .drop_policy(self.drop_policy)
+                .drop_policy(drop_policy)
                 .layout(layout)
                 .build()
         })
     }
 
     fn try_inner_pool_mut(&mut self, key: LayoutKey) -> Option<&mut RawOpaquePool> {
-        self.pools.get_mut(&key)
+        self.pools.get_mut(key)
     }
 }
 

--- a/packages/infinity_pool/src/handles/blind_local.rs
+++ b/packages/infinity_pool/src/handles/blind_local.rs
@@ -197,7 +197,7 @@ impl Drop for Remover {
         let mut core = RefCell::borrow_mut(&self.core);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: The remover controls the shared object lifetime and is the only thing

--- a/packages/infinity_pool/src/handles/blind_local_mut.rs
+++ b/packages/infinity_pool/src/handles/blind_local_mut.rs
@@ -193,7 +193,7 @@ where
         let mut core = RefCell::borrow_mut(&core);
 
         let pool = core
-            .get_mut(&key)
+            .get_mut(key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove
@@ -293,7 +293,7 @@ impl<T: ?Sized> Drop for LocalBlindPooledMut<T> {
         let mut core = RefCell::borrow_mut(&self.core);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove

--- a/packages/infinity_pool/src/handles/blind_managed.rs
+++ b/packages/infinity_pool/src/handles/blind_managed.rs
@@ -200,7 +200,7 @@ impl Drop for Remover {
         let mut core = self.core.lock().expect(NEVER_POISONED);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: The remover controls the shared object lifetime and is the only thing

--- a/packages/infinity_pool/src/handles/blind_managed_mut.rs
+++ b/packages/infinity_pool/src/handles/blind_managed_mut.rs
@@ -183,7 +183,7 @@ where
         let mut core = core.lock().expect(NEVER_POISONED);
 
         let pool = core
-            .get_mut(&key)
+            .get_mut(key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove
@@ -283,7 +283,7 @@ impl<T: ?Sized> Drop for BlindPooledMut<T> {
         let mut core = self.core.lock().expect(NEVER_POISONED);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove


### PR DESCRIPTION
Replace `BlindPool`/`LocalBlindPool`/`RawBlindPool` `BTreeMap<LayoutKey, RawOpaquePool>` dispatch with a new `LayoutDispatch<V>` backed by an unsorted `SmallVec<[(LayoutKey, V); 8]>` plus a move-to-front (MTF) heuristic and a front fast-path on `get_or_insert_with`.

## Why not the issue's sorted-vec + binary search?

I prototyped the original proposal first and measured it under Callgrind. At the layout counts BlindPool actually hits, `binary_search_by_key` + sorted-position `insert` was **slower than the BTreeMap baseline**:

| N layouts | BTreeMap baseline | Sorted SmallVec + binary search |
|-----------|-------------------|---------------------------------|
| 1         | 166               | 191                             |
| 5         | 224               | 240                             |
| 8         | 253               | 240                             |
| 16        | 205               | 250                             |

Root cause: at N ≤ 16, the constant overhead of `binary_search_by_key` (loop setup, mid-index math, hard-to-predict branches) plus the element shifts needed to keep the array sorted on insert outweigh the gain over BTreeMap's tree walk. Pivoted from sorted/binary to unsorted/MTF after seeing the numbers.

## Current design

* Unsorted `SmallVec<[(LayoutKey, V); 8]>`.
* `get_or_insert_with`: front fast-path checks `entries.first()` and short-circuits if it matches; otherwise linear-scans, swaps the hit to position 0 (MTF), or inserts at position 0 on miss.
* No iteration-order contract — confirmed callers only sum/iterate.

## Performance (Callgrind, insert into 10k pool)

| N layouts            | BTreeMap | This PR | Delta            |
|----------------------|----------|---------|------------------|
| 1                    | 166      | 194     | +28 (uncommon)   |
| 5                    | 224      | 197     | **-27**          |
| 8                    | 253      | 196     | **-57**          |
| 16                   | 205      | 198     | -7 (heap spill)  |
| 8 (adversarial MTF)  | 253      | 364     | +111 (worst case) |

The adversarial bench (`blind_pool_insert_into_10k_n8_layouts_adversarial`) places the target layout at the back of the MTF order to exercise the full linear scan; it documents the worst case rather than the expected case.

The +28 at N=1 is accepted: an N=1 BlindPool would normally use PinnedPool instead, so the hot N=1 path is not the design target.

## Impact

* **No public API changes.**
* `RawBlindPool` size: ~32 bytes → ~1304 bytes (8 inline entries × 160 bytes each).
* `BlindPool`/`LocalBlindPool` unchanged at 8 bytes (Arc/Rc handles).

## Validation

* `just package=infinity_pool validate-local` clean on Windows and Linux: 485 lib tests, 43 doctests, 483 Miri tests.
* 11 unit tests in `layout_dispatch.rs`, including `constructor_panic_leaves_dispatch_unchanged` (uses `testing::assert_panics`).
* Paired Criterion + Callgrind benches at N=5/8/16 plus the adversarial N=8 case.

Closes #176.
