### PR TITLE
infinity_pool: hoist MRU layout into separate Option field (experiment on top of #182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "num-integer",
  "pastey",
  "rand 0.9.2",
+ "smallvec",
  "static_assertions",
  "testing",
 ]

--- a/packages/awaiter_set/benches/awaiter_set_cg.rs
+++ b/packages/awaiter_set/benches/awaiter_set_cg.rs
@@ -206,10 +206,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{atomic_group, register_group, removal_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{atomic_group, register_group, removal_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/events/benches/events_cg.rs
+++ b/packages/events/benches/events_cg.rs
@@ -118,10 +118,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{local_group, sync_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{local_group, sync_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/events_once/benches/events_once_cg.rs
+++ b/packages/events_once/benches/events_once_cg.rs
@@ -174,10 +174,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{lifecycle_group, partial_state_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{lifecycle_group, partial_state_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/fast_time/benches/fast_time_clock_cg.rs
+++ b/packages/fast_time/benches/fast_time_clock_cg.rs
@@ -113,10 +113,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::clock_group;
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::clock_group;
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/future_deque/benches/future_deque_cg.rs
+++ b/packages/future_deque/benches/future_deque_cg.rs
@@ -236,10 +236,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{local_group, sync_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{local_group, sync_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/infinity_pool/Cargo.toml
+++ b/packages/infinity_pool/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 new_zealand = { workspace = true }
 num-integer = { workspace = true }
 pastey = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 alloc_tracker = { path = "../alloc_tracker" }

--- a/packages/infinity_pool/benches/infinity_pool_cg.rs
+++ b/packages/infinity_pool/benches/infinity_pool_cg.rs
@@ -17,7 +17,12 @@
 //! and untyped pools, and against `Arc::pin` and `Box::pin` baselines:
 //!
 //! * `local_pinned_pool_insert_into_10k` — single-threaded path.
-//! * `blind_pool_insert_into_10k` — untyped path.
+//! * `blind_pool_insert_into_10k` — untyped path (single layout).
+//! * `blind_pool_insert_into_10k_n5_layouts` — dispatch over 5 distinct layouts.
+//! * `blind_pool_insert_into_10k_n8_layouts` — dispatch over 8 distinct layouts.
+//! * `blind_pool_insert_into_10k_n16_layouts` — dispatch over 16 layouts (heap spill).
+//! * `blind_pool_insert_into_10k_n8_layouts_adversarial` — measured key is *not* the
+//!   most-recently used; exercises the worst-case linear-scan path.
 //! * `arc_pin_baseline_insert` — `Arc::pin` for comparison.
 //! * `box_pin_baseline_insert` — `Box::pin` for comparison.
 //!
@@ -108,6 +113,91 @@ mod linux {
         BlindPoolState { pool, anchors }
     }
 
+    // Populates the dispatch with N - 1 extra inner pools by inserting and immediately
+    // dropping one item of each anchor type. The inner `RawOpaquePool` instances remain
+    // in the dispatch even after all items are removed, so the measured `pool.insert::<u64>`
+    // call must traverse a dispatch with N distinct `LayoutKey` entries.
+    //
+    // The 10k u64 anchor inserts that follow ensure u64 is the most-recently-used entry
+    // in the dispatch — the typical pattern in real `BlindPool` workloads where one or
+    // two layouts dominate. This is the scenario the move-to-front linear scan is
+    // designed to make cheap.
+    fn make_populated_blind_pool_n5_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // 4 extra layouts so the dispatch holds 5 entries once u64 is added.
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        BlindPoolState { pool, anchors }
+    }
+
+    fn make_populated_blind_pool_n8_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // 7 extra layouts so the dispatch holds 8 entries once u64 is added.
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        BlindPoolState { pool, anchors }
+    }
+
+    fn make_populated_blind_pool_n16_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // 15 extra layouts via varied byte-array sizes (size N, align 1) plus u128 so the
+        // dispatch holds 16 entries once u64 is added. This exceeds the inline capacity
+        // of the dispatch and forces heap spillover.
+        drop(pool.insert::<[u8; 1]>([0; 1]));
+        drop(pool.insert::<[u8; 2]>([0; 2]));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 4]>([0; 4]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        drop(pool.insert::<[u8; 7]>([0; 7]));
+        drop(pool.insert::<[u8; 9]>([0; 9]));
+        drop(pool.insert::<[u8; 10]>([0; 10]));
+        drop(pool.insert::<[u8; 11]>([0; 11]));
+        drop(pool.insert::<[u8; 12]>([0; 12]));
+        drop(pool.insert::<[u8; 13]>([0; 13]));
+        drop(pool.insert::<[u8; 14]>([0; 14]));
+        drop(pool.insert::<[u8; 15]>([0; 15]));
+        drop(pool.insert::<u128>(0));
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        BlindPoolState { pool, anchors }
+    }
+
+    // Adversarial setup for the dispatch: builds an 8-entry dispatch where the measured
+    // key (u64) is *not* the most-recently used. The dispatch internally maintains
+    // most-recently-used order, so an insert here cannot benefit from the front fast
+    // path and must walk through the other entries before finding u64.
+    //
+    // This complements the locality-friendly `make_populated_blind_pool_n8_layouts`
+    // helper and quantifies the worst-case scan cost.
+    fn make_adversarial_blind_pool_n8_layouts() -> BlindPoolState {
+        let pool = BlindPool::new();
+        // u64 first so it is initially in the dispatch with anchor items, then 7 extras
+        // inserted afterward — each pushes u64 further back in MRU order. Final MRU
+        // order: [u128, [u8; 6], [u8; 5], [u8; 3], u32, u16, u8, u64].
+        let anchors: Vec<BlindPooledMut<u64>> =
+            (0..ANCHOR_COUNT).map(|i| pool.insert::<u64>(i)).collect();
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        drop(pool.insert::<u128>(0));
+        BlindPoolState { pool, anchors }
+    }
+
     // State for the drop benchmark: a populated pool plus a freshly-inserted
     // extra handle that the bench drops. The pool keeps its 10k anchors so
     // the drop only frees one slot in a fully-populated slab.
@@ -165,6 +255,42 @@ mod linux {
         (state, handle)
     }
 
+    #[library_benchmark]
+    #[bench::populated(make_populated_blind_pool_n5_layouts())]
+    fn blind_pool_insert_into_10k_n5_layouts(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_populated_blind_pool_n8_layouts())]
+    fn blind_pool_insert_into_10k_n8_layouts(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_populated_blind_pool_n16_layouts())]
+    fn blind_pool_insert_into_10k_n16_layouts(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_adversarial_blind_pool_n8_layouts())]
+    fn blind_pool_insert_into_10k_n8_layouts_adversarial(
+        state: BlindPoolState,
+    ) -> (BlindPoolState, BlindPooledMut<u64>) {
+        let handle = black_box(&state.pool).insert::<u64>(black_box(ANCHOR_COUNT));
+        (state, handle)
+    }
+
     // ---------- Drop path ----------
 
     #[library_benchmark]
@@ -210,6 +336,10 @@ mod linux {
             pinned_pool_insert_into_10k,
             local_pinned_pool_insert_into_10k,
             blind_pool_insert_into_10k,
+            blind_pool_insert_into_10k_n5_layouts,
+            blind_pool_insert_into_10k_n8_layouts,
+            blind_pool_insert_into_10k_n16_layouts,
+            blind_pool_insert_into_10k_n8_layouts_adversarial,
             arc_pin_baseline_insert,
             box_pin_baseline_insert,
         ]

--- a/packages/infinity_pool/benches/infinity_pool_cg.rs
+++ b/packages/infinity_pool/benches/infinity_pool_cg.rs
@@ -488,10 +488,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{deref_group, drop_group, insert_group, iter_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{deref_group, drop_group, insert_group, iter_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/infinity_pool/benches/infinity_pool_vs_std.rs
+++ b/packages/infinity_pool/benches/infinity_pool_vs_std.rs
@@ -542,6 +542,15 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
         drop(pool.insert::<u128>(0));
     });
 
+    // Adversarial wall-clock counterpart of the Callgrind
+    // `blind_pool_insert_into_10k_n8_layouts_adversarial` scenario. The dispatch holds 8
+    // entries. Each iteration of the inner timed loop performs a u128 insert immediately
+    // before each u64 insert: the u128 insert always moves itself to the front of the
+    // dispatch's MRU order, which forces the subsequent u64 insert to be the most-distant
+    // entry in MRU order — exactly the worst-case linear scan the typical-case benches
+    // never observe (because their tight u64-only loop keeps u64 permanently at front).
+    blind_pool_churn_n8_layouts_adversarial(&mut group, &allocs);
+
     // LocalBlindPool (single-threaded, reference counted, multiple types) with churn
     let allocs_op = allocs.operation("LocalBlindPool");
     group.bench_function("LocalBlindPool", |b| {
@@ -686,6 +695,81 @@ fn blind_pool_churn_with_extra_layouts<F>(
                     for _ in 0..BATCH_SIZE {
                         let target_index = rng.random_range(0..handles.len());
                         handles.swap_remove(target_index);
+                    }
+                }
+            }
+            start.elapsed()
+        });
+    });
+}
+
+// Adversarial-MRU counterpart of `blind_pool_churn_with_extra_layouts`. Each measured
+// u64 insert is preceded by a u128 insert. The u128 insert always moves itself to
+// the front of the dispatch's MRU order, so each subsequent u64 insert must scan past
+// every other entry before finding u64 — the worst case the MTF dispatch is designed
+// to be tolerable but slower at. The dispatch holds 8 distinct layouts (7 extras + u64);
+// the inserted u128 handle is one of those 7 extras, so the dispatch size is invariant.
+// Both inserts contribute to the measured time; what matters across branches is the
+// relative cost of the adversarial path.
+fn blind_pool_churn_n8_layouts_adversarial(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    allocs: &alloc_tracker::Session,
+) {
+    let label = "BlindPool_8layouts_adversarial";
+    let allocs_op = allocs.operation(label);
+    group.bench_function(label, |b| {
+        b.iter_custom(|iters| {
+            let mut all_pools = Vec::with_capacity(iters as usize);
+            let mut all_u64_handles = Vec::with_capacity(iters as usize);
+            let mut all_u128_handles = Vec::with_capacity(iters as usize);
+
+            for _ in 0..iters {
+                let pool = BlindPool::new();
+                // 7 extra layouts so the dispatch holds 8 entries once u64 is added.
+                drop(pool.insert::<u8>(0));
+                drop(pool.insert::<u16>(0));
+                drop(pool.insert::<u32>(0));
+                drop(pool.insert::<[u8; 3]>([0; 3]));
+                drop(pool.insert::<[u8; 5]>([0; 5]));
+                drop(pool.insert::<[u8; 6]>([0; 6]));
+                drop(pool.insert::<u128>(0));
+                all_pools.push(pool);
+                all_u64_handles
+                    .push(Vec::with_capacity((INITIAL_ITEMS + BATCH_SIZE) as usize));
+                all_u128_handles
+                    .push(Vec::with_capacity((INITIAL_ITEMS + BATCH_SIZE) as usize));
+            }
+
+            for (pool, handles) in all_pools.iter_mut().zip(all_u64_handles.iter_mut()) {
+                for i in 0..INITIAL_ITEMS {
+                    handles.push(pool.insert::<u64>(i));
+                }
+            }
+
+            let _span = allocs_op.measure_thread().iterations(iters);
+            let start = Instant::now();
+            for ((pool, u64_handles), u128_handles) in all_pools
+                .iter_mut()
+                .zip(all_u64_handles.iter_mut())
+                .zip(all_u128_handles.iter_mut())
+            {
+                let mut rng = SmallRng::seed_from_u64(42);
+                let mut next_value = INITIAL_ITEMS;
+
+                for _ in 0..BATCH_COUNT {
+                    for _ in 0..BATCH_SIZE {
+                        // The u128 insert bumps u128 to the front of MRU; the u64
+                        // insert that follows is then the most distant entry.
+                        u128_handles.push(pool.insert::<u128>(0));
+                        u64_handles.push(pool.insert::<u64>(next_value));
+                        next_value = next_value.wrapping_add(1);
+                    }
+
+                    for _ in 0..BATCH_SIZE {
+                        let target_index = rng.random_range(0..u64_handles.len());
+                        u64_handles.swap_remove(target_index);
+                        let target_index = rng.random_range(0..u128_handles.len());
+                        u128_handles.swap_remove(target_index);
                     }
                 }
             }

--- a/packages/infinity_pool/benches/infinity_pool_vs_std.rs
+++ b/packages/infinity_pool/benches/infinity_pool_vs_std.rs
@@ -503,6 +503,45 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
         });
     });
 
+    // BlindPool variants where the dispatch holds extra distinct layouts so the per-insert
+    // dispatch traversal touches more entries. The churn pattern still operates on u64
+    // values; the extra layouts only populate the dispatch and exercise the lookup path.
+    // These pair 1:1 with the Callgrind scenarios `blind_pool_insert_into_10k_n{5,8,16}_layouts`.
+    blind_pool_churn_with_extra_layouts(&mut group, &allocs, "BlindPool_5layouts", |pool| {
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+    });
+
+    blind_pool_churn_with_extra_layouts(&mut group, &allocs, "BlindPool_8layouts", |pool| {
+        drop(pool.insert::<u8>(0));
+        drop(pool.insert::<u16>(0));
+        drop(pool.insert::<u32>(0));
+        drop(pool.insert::<u128>(0));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+    });
+
+    blind_pool_churn_with_extra_layouts(&mut group, &allocs, "BlindPool_16layouts", |pool| {
+        drop(pool.insert::<[u8; 1]>([0; 1]));
+        drop(pool.insert::<[u8; 2]>([0; 2]));
+        drop(pool.insert::<[u8; 3]>([0; 3]));
+        drop(pool.insert::<[u8; 4]>([0; 4]));
+        drop(pool.insert::<[u8; 5]>([0; 5]));
+        drop(pool.insert::<[u8; 6]>([0; 6]));
+        drop(pool.insert::<[u8; 7]>([0; 7]));
+        drop(pool.insert::<[u8; 9]>([0; 9]));
+        drop(pool.insert::<[u8; 10]>([0; 10]));
+        drop(pool.insert::<[u8; 11]>([0; 11]));
+        drop(pool.insert::<[u8; 12]>([0; 12]));
+        drop(pool.insert::<[u8; 13]>([0; 13]));
+        drop(pool.insert::<[u8; 14]>([0; 14]));
+        drop(pool.insert::<[u8; 15]>([0; 15]));
+        drop(pool.insert::<u128>(0));
+    });
+
     // LocalBlindPool (single-threaded, reference counted, multiple types) with churn
     let allocs_op = allocs.operation("LocalBlindPool");
     group.bench_function("LocalBlindPool", |b| {
@@ -599,6 +638,60 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     group.finish();
 
     allocs.print_to_stdout();
+}
+
+// Drives the BlindPool churn measurement for a pool that has been pre-populated with extra
+// inner pools via `extra_layouts`. The inner pools persist in the dispatch even after the
+// inserted handles drop, so the measured churn exercises a dispatch with N distinct
+// `LayoutKey` entries (where N = 1 + number of extra layouts added by the closure).
+fn blind_pool_churn_with_extra_layouts<F>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    allocs: &alloc_tracker::Session,
+    label: &'static str,
+    extra_layouts: F,
+) where
+    F: Fn(&BlindPool),
+{
+    let allocs_op = allocs.operation(label);
+    group.bench_function(label, |b| {
+        b.iter_custom(|iters| {
+            let mut all_pools = Vec::with_capacity(iters as usize);
+            let mut all_handles = Vec::with_capacity(iters as usize);
+
+            for _ in 0..iters {
+                let pool = BlindPool::new();
+                extra_layouts(&pool);
+                all_pools.push(pool);
+                all_handles.push(Vec::with_capacity((INITIAL_ITEMS + BATCH_SIZE) as usize));
+            }
+
+            for (pool, handles) in all_pools.iter_mut().zip(all_handles.iter_mut()) {
+                for i in 0..INITIAL_ITEMS {
+                    handles.push(pool.insert(i));
+                }
+            }
+
+            let _span = allocs_op.measure_thread().iterations(iters);
+            let start = Instant::now();
+            for (pool, handles) in all_pools.iter_mut().zip(all_handles.iter_mut()) {
+                let mut rng = SmallRng::seed_from_u64(42);
+                let mut next_value = INITIAL_ITEMS;
+
+                for _ in 0..BATCH_COUNT {
+                    for _ in 0..BATCH_SIZE {
+                        handles.push(pool.insert(next_value));
+                        next_value = next_value.wrapping_add(1);
+                    }
+
+                    for _ in 0..BATCH_SIZE {
+                        let target_index = rng.random_range(0..handles.len());
+                        handles.swap_remove(target_index);
+                    }
+                }
+            }
+            start.elapsed()
+        });
+    });
 }
 
 criterion_group!(benches, churn_insertion_benchmark);

--- a/packages/infinity_pool/src/blind/core.rs
+++ b/packages/infinity_pool/src/blind/core.rs
@@ -1,14 +1,13 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use crate::{LayoutKey, RawOpaquePool, RawOpaquePoolThreadSafe};
+use crate::{LayoutDispatch, RawOpaquePool, RawOpaquePoolThreadSafe};
 
 // These are the core data sets shared by the pool objects and the handle objects.
 pub(crate) type BlindPoolCore = Arc<Mutex<BlindPoolInnerMap>>;
 pub(crate) type LocalBlindPoolCore = Rc<RefCell<LocalBlindPoolInnerMap>>;
 
-pub(crate) type BlindPoolInnerMap = BTreeMap<LayoutKey, RawOpaquePoolThreadSafe>;
-pub(crate) type LocalBlindPoolInnerMap = BTreeMap<LayoutKey, RawOpaquePool>;
-pub(crate) type RawBlindPoolInnerMap = BTreeMap<LayoutKey, RawOpaquePool>;
+pub(crate) type BlindPoolInnerMap = LayoutDispatch<RawOpaquePoolThreadSafe>;
+pub(crate) type LocalBlindPoolInnerMap = LayoutDispatch<RawOpaquePool>;
+pub(crate) type RawBlindPoolInnerMap = LayoutDispatch<RawOpaquePool>;

--- a/packages/infinity_pool/src/blind/layout_dispatch.rs
+++ b/packages/infinity_pool/src/blind/layout_dispatch.rs
@@ -1,0 +1,288 @@
+use smallvec::SmallVec;
+
+use crate::LayoutKey;
+
+/// Inline capacity chosen to cover the documented "handful of distinct layouts" common case
+/// fully inline. Each entry is `(LayoutKey, V)` where `V` is a `RawOpaquePool`-sized value
+/// (~152 bytes on x64), so the inline footprint is ~1.3 KiB on 64-bit targets.
+///
+/// Beyond this capacity, the underlying `SmallVec` falls back to heap allocation. Lookup
+/// remains correct; only the cache locality on the cold spill path is reduced.
+const INLINE_CAPACITY: usize = 8;
+
+/// Dispatches by `LayoutKey` to an associated value, optimized for a small number of distinct
+/// keys with strong locality of reference.
+///
+/// Storage is a `SmallVec` of `(LayoutKey, V)` entries with inline capacity sized for the
+/// typical case so no heap allocation is needed when the pool holds a handful of distinct
+/// object layouts. Lookup is a linear scan, and on every successful lookup the matching
+/// entry is moved to position 0 ("move-to-front"). Newly inserted entries are also placed
+/// at position 0. The combination keeps the most-recently used key at the front, so
+/// repeated inserts of the same type — the common case in `BlindPool` workloads — find
+/// their entry on the first comparison.
+///
+/// Iteration order of `values()` / `values_mut()` is therefore not part of the contract.
+//
+// This is a deviation from the standard `BTreeMap<LayoutKey, V>` we used previously, and
+// also from the obvious "sorted SmallVec + binary_search_by_key" pattern proposed in
+// issue #176. Both alternatives were rejected by direct Callgrind measurement against
+// this implementation: at the single-digit `N` we observe in `BlindPool` workloads,
+// `BTreeMap`'s tree descent and `binary_search_by_key`'s per-iteration constant factor
+// (mid computation, conditional bound updates, end-of-loop check) both lose to a tight
+// load-compare-branch scan over an MRU-ordered slice.
+//
+// A `HashMap` (e.g. with FxHash on the 8-byte `LayoutKey`) was considered but not
+// measured. It would need to beat a one-iteration linear scan plus a single equality
+// check on the hot path, which seems unlikely given hash + bucket probe overhead, but
+// has not been verified empirically.
+//
+// Beyond the inline capacity, the underlying `SmallVec` falls back to heap allocation;
+// correctness is preserved, only cache locality on the cold spill path is reduced.
+//
+// Moving entries via `SmallVec::insert` or `SmallVec::swap` is safe: the value type
+// stores its bulk data in separately allocated buffers (e.g. slab vectors) and is not
+// self-referential to the enclosing struct.
+#[derive(Debug)]
+pub(crate) struct LayoutDispatch<V> {
+    entries: SmallVec<[(LayoutKey, V); INLINE_CAPACITY]>,
+}
+
+impl<V> LayoutDispatch<V> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: SmallVec::new(),
+        }
+    }
+
+    /// Returns a shared reference to the value associated with `key`, if present.
+    pub(crate) fn get(&self, key: LayoutKey) -> Option<&V> {
+        self.entries.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    }
+
+    /// Returns a unique reference to the value associated with `key`, if present.
+    pub(crate) fn get_mut(&mut self, key: LayoutKey) -> Option<&mut V> {
+        self.entries
+            .iter_mut()
+            .find(|(k, _)| *k == key)
+            .map(|(_, v)| v)
+    }
+
+    /// Returns the value associated with `key`, inserting one produced by `f` if not present.
+    ///
+    /// The matching (or newly inserted) entry is positioned at index 0, so the next call
+    /// with the same key returns on the first comparison.
+    pub(crate) fn get_or_insert_with<F>(&mut self, key: LayoutKey, f: F) -> &mut V
+    where
+        F: FnOnce() -> V,
+    {
+        // Fast path: the most-recently-used entry is at position 0 by construction of this
+        // dispatch, so a check against `entries[0].0` short-circuits the iterator setup
+        // and the secondary `get_mut` access on the hot repeated-lookup path.
+        if let Some((k0, _)) = self.entries.first()
+            && *k0 == key
+        {
+            return &mut self
+                .entries
+                .get_mut(0)
+                .expect("first entry exists per the immediately preceding `first()`")
+                .1;
+        }
+
+        if let Some(idx) = self.entries.iter().position(|(k, _)| *k == key) {
+            self.entries.swap(0, idx);
+        } else {
+            self.entries.insert(0, (key, f()));
+        }
+
+        &mut self
+            .entries
+            .get_mut(0)
+            .expect("either swapped to position 0 or inserted at position 0")
+            .1
+    }
+
+    /// Returns an iterator over the values in current MRU order.
+    pub(crate) fn values(&self) -> impl Iterator<Item = &V> {
+        self.entries.iter().map(|(_, v)| v)
+    }
+
+    /// Returns an iterator over the values for mutation, in current MRU order.
+    pub(crate) fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.entries.iter_mut().map(|(_, v)| v)
+    }
+}
+
+impl<V> Default for LayoutDispatch<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::alloc::Layout;
+
+    use testing::assert_panics;
+
+    use super::*;
+
+    fn key_from_size_align(size: usize, align: usize) -> LayoutKey {
+        LayoutKey::new(Layout::from_size_align(size, align).unwrap())
+    }
+
+    #[test]
+    fn new_dispatch_is_empty() {
+        let dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        assert_eq!(dispatch.values().count(), 0);
+        assert!(dispatch.get(key_from_size_align(1, 1)).is_none());
+    }
+
+    #[test]
+    fn default_dispatch_is_empty() {
+        let dispatch: LayoutDispatch<u32> = LayoutDispatch::default();
+
+        assert_eq!(dispatch.values().count(), 0);
+    }
+
+    #[test]
+    fn get_or_insert_with_inserts_value() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        let key = key_from_size_align(4, 4);
+
+        let value = dispatch.get_or_insert_with(key, || 42);
+
+        assert_eq!(*value, 42);
+        assert_eq!(dispatch.values().count(), 1);
+    }
+
+    #[test]
+    fn get_or_insert_with_returns_existing_without_calling_constructor() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        let key = key_from_size_align(4, 4);
+
+        _ = dispatch.get_or_insert_with(key, || 42);
+
+        let value =
+            dispatch.get_or_insert_with(key, || panic!("must not call ctor for existing key"));
+        assert_eq!(*value, 42);
+        assert_eq!(dispatch.values().count(), 1);
+    }
+
+    #[test]
+    fn get_returns_inserted_value() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        let key = key_from_size_align(4, 4);
+
+        _ = dispatch.get_or_insert_with(key, || 99);
+
+        assert_eq!(dispatch.get(key), Some(&99));
+    }
+
+    #[test]
+    fn get_returns_none_for_absent_key() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+        _ = dispatch.get_or_insert_with(key_from_size_align(4, 4), || 1);
+
+        assert!(dispatch.get(key_from_size_align(8, 8)).is_none());
+    }
+
+    #[test]
+    fn insertions_are_retained_regardless_of_key_order() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        // Insert with arbitrary key order; lookup must find every key.
+        _ = dispatch.get_or_insert_with(key_from_size_align(8, 8), || 80);
+        _ = dispatch.get_or_insert_with(key_from_size_align(2, 2), || 20);
+        _ = dispatch.get_or_insert_with(key_from_size_align(4, 4), || 40);
+        _ = dispatch.get_or_insert_with(key_from_size_align(1, 1), || 10);
+        _ = dispatch.get_or_insert_with(key_from_size_align(16, 16), || 160);
+
+        assert_eq!(dispatch.get(key_from_size_align(1, 1)), Some(&10));
+        assert_eq!(dispatch.get(key_from_size_align(2, 2)), Some(&20));
+        assert_eq!(dispatch.get(key_from_size_align(4, 4)), Some(&40));
+        assert_eq!(dispatch.get(key_from_size_align(8, 8)), Some(&80));
+        assert_eq!(dispatch.get(key_from_size_align(16, 16)), Some(&160));
+        assert_eq!(dispatch.values().count(), 5);
+    }
+
+    #[test]
+    fn repeated_get_or_insert_with_keeps_key_at_front() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        let key_a = key_from_size_align(1, 1);
+        let key_b = key_from_size_align(2, 2);
+        let key_c = key_from_size_align(4, 4);
+
+        _ = dispatch.get_or_insert_with(key_a, || 10);
+        _ = dispatch.get_or_insert_with(key_b, || 20);
+        _ = dispatch.get_or_insert_with(key_c, || 30);
+
+        // Calling get_or_insert_with with an existing key should move it to the front,
+        // so the next call with the same key finds it without scanning the others.
+        _ = dispatch.get_or_insert_with(key_a, || panic!("must not construct"));
+
+        // Inspect MRU order via values() — key_a was last accessed, must be at front.
+        let values: Vec<u32> = dispatch.values().copied().collect();
+        assert_eq!(values.first().copied(), Some(10));
+    }
+
+    #[test]
+    fn values_mut_modifies_in_place() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        _ = dispatch.get_or_insert_with(key_from_size_align(4, 4), || 1);
+        _ = dispatch.get_or_insert_with(key_from_size_align(8, 8), || 2);
+
+        for v in dispatch.values_mut() {
+            *v = v.wrapping_mul(10);
+        }
+
+        let mut values: Vec<u32> = dispatch.values().copied().collect();
+        values.sort_unstable();
+        assert_eq!(values, vec![10, 20]);
+    }
+
+    #[test]
+    fn spills_to_heap_past_inline_capacity_and_remains_correct() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        // Use INLINE_CAPACITY + 4 distinct layouts to force heap spill.
+        let count = INLINE_CAPACITY.checked_add(4).unwrap();
+        for i in 0..count {
+            let size = i.checked_add(1).unwrap();
+            let value = u32::try_from(i).unwrap();
+            _ = dispatch.get_or_insert_with(key_from_size_align(size, 1), || value);
+        }
+
+        assert_eq!(dispatch.values().count(), count);
+
+        for i in 0..count {
+            let size = i.checked_add(1).unwrap();
+            let value = u32::try_from(i).unwrap();
+            assert_eq!(dispatch.get(key_from_size_align(size, 1)), Some(&value));
+        }
+    }
+
+    #[test]
+    fn constructor_panic_leaves_dispatch_unchanged() {
+        let mut dispatch: LayoutDispatch<u32> = LayoutDispatch::new();
+
+        let key_a = key_from_size_align(4, 4);
+        let key_b = key_from_size_align(8, 8);
+
+        _ = dispatch.get_or_insert_with(key_a, || 10);
+
+        // The constructor for a new key panics. The dispatch must be left intact:
+        // no new entry should have been added, and the existing entry must still
+        // be accessible.
+        assert_panics(|| {
+            _ = dispatch.get_or_insert_with(key_b, || panic!("ctor failure"));
+        });
+
+        assert_eq!(dispatch.get(key_a), Some(&10));
+        assert_eq!(dispatch.get(key_b), None);
+        assert_eq!(dispatch.values().count(), 1);
+    }
+}

--- a/packages/infinity_pool/src/blind/layout_dispatch.rs
+++ b/packages/infinity_pool/src/blind/layout_dispatch.rs
@@ -2,26 +2,29 @@ use smallvec::SmallVec;
 
 use crate::LayoutKey;
 
-/// Inline capacity chosen to cover the documented "handful of distinct layouts" common case
-/// fully inline. Each entry is `(LayoutKey, V)` where `V` is a `RawOpaquePool`-sized value
-/// (~152 bytes on x64), so the inline footprint is ~1.3 KiB on 64-bit targets.
+/// Inline capacity for the secondary `rest` `SmallVec` — sized so that, together with the
+/// hoisted `front` slot, total inline capacity matches the documented "handful of distinct
+/// layouts" common case fully inline.
 ///
-/// Beyond this capacity, the underlying `SmallVec` falls back to heap allocation. Lookup
-/// remains correct; only the cache locality on the cold spill path is reduced.
-const INLINE_CAPACITY: usize = 8;
+/// Beyond this capacity the `SmallVec` falls back to heap allocation. Lookup remains correct;
+/// only the cache locality on the cold spill path is reduced.
+const REST_INLINE_CAPACITY: usize = 7;
+
+/// Total inline capacity including the hoisted `front` slot.
+#[cfg(test)]
+const INLINE_CAPACITY: usize = REST_INLINE_CAPACITY + 1;
 
 /// Dispatches by `LayoutKey` to an associated value, optimized for a small number of distinct
 /// keys with strong locality of reference.
 ///
-/// Storage is a `SmallVec` of `(LayoutKey, V)` entries with inline capacity sized for the
-/// typical case so no heap allocation is needed when the pool holds a handful of distinct
-/// object layouts. Lookup is a linear scan, and on every successful lookup the matching
-/// entry is moved to position 0 ("move-to-front"). Newly inserted entries are also placed
-/// at position 0. The combination keeps the most-recently used key at the front, so
-/// repeated inserts of the same type — the common case in `BlindPool` workloads — find
-/// their entry on the first comparison.
+/// Storage is split into a hoisted `front: Option<(LayoutKey, V)>` slot that holds the
+/// most-recently-used entry, plus a `SmallVec` of `(LayoutKey, V)` entries for the rest.
+/// On every successful lookup the matching entry is promoted into `front` (the previous
+/// `front` is demoted into the `SmallVec`). The combination keeps the most-recently used
+/// key in a dedicated field, so repeated inserts of the same type — the common case in
+/// `BlindPool` workloads — find their entry without touching the `SmallVec` at all.
 ///
-/// Iteration order of `values()` / `values_mut()` is therefore not part of the contract.
+/// Iteration order of `values()` / `values_mut()` is not part of the contract.
 //
 // This is a deviation from the standard `BTreeMap<LayoutKey, V>` we used previously, and
 // also from the obvious "sorted SmallVec + binary_search_by_key" pattern proposed in
@@ -39,29 +42,41 @@ const INLINE_CAPACITY: usize = 8;
 // Beyond the inline capacity, the underlying `SmallVec` falls back to heap allocation;
 // correctness is preserved, only cache locality on the cold spill path is reduced.
 //
-// Moving entries via `SmallVec::insert` or `SmallVec::swap` is safe: the value type
-// stores its bulk data in separately allocated buffers (e.g. slab vectors) and is not
-// self-referential to the enclosing struct.
+// Moving entries via `SmallVec::push` or replacing the `front` slot is safe: the value
+// type stores its bulk data in separately allocated buffers (e.g. slab vectors) and is
+// not self-referential to the enclosing struct.
 #[derive(Debug)]
 pub(crate) struct LayoutDispatch<V> {
-    entries: SmallVec<[(LayoutKey, V); INLINE_CAPACITY]>,
+    front: Option<(LayoutKey, V)>,
+    rest: SmallVec<[(LayoutKey, V); REST_INLINE_CAPACITY]>,
 }
 
 impl<V> LayoutDispatch<V> {
     pub(crate) fn new() -> Self {
         Self {
-            entries: SmallVec::new(),
+            front: None,
+            rest: SmallVec::new(),
         }
     }
 
     /// Returns a shared reference to the value associated with `key`, if present.
     pub(crate) fn get(&self, key: LayoutKey) -> Option<&V> {
-        self.entries.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+        if let Some((k, v)) = &self.front
+            && *k == key
+        {
+            return Some(v);
+        }
+        self.rest.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
     }
 
     /// Returns a unique reference to the value associated with `key`, if present.
     pub(crate) fn get_mut(&mut self, key: LayoutKey) -> Option<&mut V> {
-        self.entries
+        // Copy out the front key first so the immutable borrow does not extend into the
+        // mutable-access branch (Polonius limitation in current borrow-checker).
+        if self.front.as_ref().is_some_and(|(k, _)| *k == key) {
+            return self.front.as_mut().map(|(_, v)| v);
+        }
+        self.rest
             .iter_mut()
             .find(|(k, _)| *k == key)
             .map(|(_, v)| v)
@@ -69,46 +84,56 @@ impl<V> LayoutDispatch<V> {
 
     /// Returns the value associated with `key`, inserting one produced by `f` if not present.
     ///
-    /// The matching (or newly inserted) entry is positioned at index 0, so the next call
+    /// The matching (or newly inserted) entry is promoted into `front`, so the next call
     /// with the same key returns on the first comparison.
     pub(crate) fn get_or_insert_with<F>(&mut self, key: LayoutKey, f: F) -> &mut V
     where
         F: FnOnce() -> V,
     {
-        // Fast path: the most-recently-used entry is at position 0 by construction of this
-        // dispatch, so a check against `entries[0].0` short-circuits the iterator setup
-        // and the secondary `get_mut` access on the hot repeated-lookup path.
-        if let Some((k0, _)) = self.entries.first()
-            && *k0 == key
-        {
+        // Fast path: the most-recently-used entry sits in the hoisted `front` slot, so a
+        // single Option discriminant + key compare resolves the hit without touching the
+        // SmallVec at all on the hot repeated-lookup path.
+        if self.front.as_ref().is_some_and(|(k, _)| *k == key) {
             return &mut self
-                .entries
-                .get_mut(0)
-                .expect("first entry exists per the immediately preceding `first()`")
+                .front
+                .as_mut()
+                .expect("front matched in the immediately preceding check")
                 .1;
         }
 
-        if let Some(idx) = self.entries.iter().position(|(k, _)| *k == key) {
-            self.entries.swap(0, idx);
+        // Either find the entry in `rest` and promote it, or construct a new one. Either
+        // way, the previous `front` (if any) is demoted into `rest`.
+        let new_front = if let Some(idx) = self.rest.iter().position(|(k, _)| *k == key) {
+            self.rest.swap_remove(idx)
         } else {
-            self.entries.insert(0, (key, f()));
+            (key, f())
+        };
+        let demoted = self.front.replace(new_front);
+        if let Some(old) = demoted {
+            self.rest.push(old);
         }
 
         &mut self
-            .entries
-            .get_mut(0)
-            .expect("either swapped to position 0 or inserted at position 0")
+            .front
+            .as_mut()
+            .expect("front was just assigned via `replace`")
             .1
     }
 
     /// Returns an iterator over the values in current MRU order.
     pub(crate) fn values(&self) -> impl Iterator<Item = &V> {
-        self.entries.iter().map(|(_, v)| v)
+        self.front
+            .iter()
+            .map(|(_, v)| v)
+            .chain(self.rest.iter().map(|(_, v)| v))
     }
 
     /// Returns an iterator over the values for mutation, in current MRU order.
     pub(crate) fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
-        self.entries.iter_mut().map(|(_, v)| v)
+        self.front
+            .iter_mut()
+            .map(|(_, v)| v)
+            .chain(self.rest.iter_mut().map(|(_, v)| v))
     }
 }
 

--- a/packages/infinity_pool/src/blind/mod.rs
+++ b/packages/infinity_pool/src/blind/mod.rs
@@ -1,4 +1,5 @@
 mod core;
+mod layout_dispatch;
 mod layout_key;
 mod pool_local;
 mod pool_managed;
@@ -6,6 +7,7 @@ mod pool_raw;
 
 pub(crate) use core::*;
 
+pub(crate) use layout_dispatch::*;
 pub(crate) use layout_key::*;
 pub use pool_local::*;
 pub use pool_managed::*;

--- a/packages/infinity_pool/src/blind/pool_local.rs
+++ b/packages/infinity_pool/src/blind/pool_local.rs
@@ -137,7 +137,7 @@ impl LocalBlindPool {
 
         let core = self.core.borrow();
 
-        core.get(&key)
+        core.get(key)
             .map(RawOpaquePool::capacity)
             .unwrap_or_default()
     }
@@ -267,9 +267,7 @@ fn ensure_inner_pool<'a, T: 'static>(
     let layout = Layout::new::<T>();
     let key = LayoutKey::new(layout);
 
-    pools
-        .entry(key)
-        .or_insert_with(|| RawOpaquePool::with_layout(layout))
+    pools.get_or_insert_with(key, || RawOpaquePool::with_layout(layout))
 }
 
 #[cfg(test)]

--- a/packages/infinity_pool/src/blind/pool_managed.rs
+++ b/packages/infinity_pool/src/blind/pool_managed.rs
@@ -131,7 +131,7 @@ impl BlindPool {
 
         let core = self.core.lock().expect(NEVER_POISONED);
 
-        core.get(&key)
+        core.get(key)
             .map(|pool| pool.capacity())
             .unwrap_or_default()
     }
@@ -278,7 +278,7 @@ fn ensure_inner_pool<'a, T: Send + 'static>(
     let layout = Layout::new::<T>();
     let key = LayoutKey::new(layout);
 
-    core.entry(key).or_insert_with(|| {
+    core.get_or_insert_with(key, || {
         // SAFETY: We always require `T: Send`.
         unsafe { RawOpaquePoolThreadSafe::new(RawOpaquePool::with_layout(layout)) }
     })

--- a/packages/infinity_pool/src/blind/pool_raw.rs
+++ b/packages/infinity_pool/src/blind/pool_raw.rs
@@ -285,7 +285,7 @@ impl RawBlindPool {
     fn inner_pool_of<T>(&self) -> Option<&RawOpaquePool> {
         let key = LayoutKey::with_layout_of::<T>();
 
-        self.pools.get(&key)
+        self.pools.get(key)
     }
 
     fn inner_pool_of_mut<T>(&mut self) -> &mut RawOpaquePool {
@@ -296,16 +296,18 @@ impl RawBlindPool {
     }
 
     fn inner_pool_mut(&mut self, layout: Layout, key: LayoutKey) -> &mut RawOpaquePool {
-        self.pools.entry(key).or_insert_with(|| {
+        let drop_policy = self.drop_policy;
+
+        self.pools.get_or_insert_with(key, || {
             RawOpaquePool::builder()
-                .drop_policy(self.drop_policy)
+                .drop_policy(drop_policy)
                 .layout(layout)
                 .build()
         })
     }
 
     fn try_inner_pool_mut(&mut self, key: LayoutKey) -> Option<&mut RawOpaquePool> {
-        self.pools.get_mut(&key)
+        self.pools.get_mut(key)
     }
 }
 

--- a/packages/infinity_pool/src/handles/blind_local.rs
+++ b/packages/infinity_pool/src/handles/blind_local.rs
@@ -197,7 +197,7 @@ impl Drop for Remover {
         let mut core = RefCell::borrow_mut(&self.core);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: The remover controls the shared object lifetime and is the only thing

--- a/packages/infinity_pool/src/handles/blind_local_mut.rs
+++ b/packages/infinity_pool/src/handles/blind_local_mut.rs
@@ -193,7 +193,7 @@ where
         let mut core = RefCell::borrow_mut(&core);
 
         let pool = core
-            .get_mut(&key)
+            .get_mut(key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove
@@ -293,7 +293,7 @@ impl<T: ?Sized> Drop for LocalBlindPooledMut<T> {
         let mut core = RefCell::borrow_mut(&self.core);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove

--- a/packages/infinity_pool/src/handles/blind_managed.rs
+++ b/packages/infinity_pool/src/handles/blind_managed.rs
@@ -200,7 +200,7 @@ impl Drop for Remover {
         let mut core = self.core.lock().expect(NEVER_POISONED);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: The remover controls the shared object lifetime and is the only thing

--- a/packages/infinity_pool/src/handles/blind_managed_mut.rs
+++ b/packages/infinity_pool/src/handles/blind_managed_mut.rs
@@ -183,7 +183,7 @@ where
         let mut core = core.lock().expect(NEVER_POISONED);
 
         let pool = core
-            .get_mut(&key)
+            .get_mut(key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove
@@ -283,7 +283,7 @@ impl<T: ?Sized> Drop for BlindPooledMut<T> {
         let mut core = self.core.lock().expect(NEVER_POISONED);
 
         let pool = core
-            .get_mut(&self.key)
+            .get_mut(self.key)
             .expect("if the handle still exists, the inner pool must still exist");
 
         // SAFETY: We are a managed unique handle, so we are the only one who is allowed to remove

--- a/packages/linked/benches/linked_instance_per_thread_cg.rs
+++ b/packages/linked/benches/linked_instance_per_thread_cg.rs
@@ -197,10 +197,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{acquire_group, baseline_group, ref_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{acquire_group, baseline_group, ref_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/nm/benches/nm_observe_cg.rs
+++ b/packages/nm/benches/nm_observe_cg.rs
@@ -387,10 +387,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{aggregate_group, pull_group, push_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{aggregate_group, pull_group, push_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/nm_otel/benches/nm_otel_export_cg.rs
+++ b/packages/nm_otel/benches/nm_otel_export_cg.rs
@@ -197,10 +197,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::export_group;
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::export_group;
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/region_cached/benches/region_cached_cg.rs
+++ b/packages/region_cached/benches/region_cached_cg.rs
@@ -144,10 +144,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{baseline_group, read_group, write_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{baseline_group, read_group, write_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(

--- a/packages/region_local/benches/region_local_cg.rs
+++ b/packages/region_local/benches/region_local_cg.rs
@@ -140,10 +140,9 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{baseline_group, read_group, write_group};
-
-#[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{baseline_group, read_group, write_group};
 
 #[cfg(target_os = "linux")]
 gungraun::main!(


### PR DESCRIPTION
Follow-up experiment on top of #182. Restructures `LayoutDispatch<V>`: instead of a single `SmallVec<[(LayoutKey, V); 8]>` with move-to-front, hoist the most-recently-used entry into a dedicated `front: Option<(LayoutKey, V)>` slot, with the remaining entries in a `rest: SmallVec<[(LayoutKey, V); 7]>`.

The fast path on `get_or_insert_with` now resolves the MRU entry through a plain Option discriminant + key compare — the `SmallVec` is never touched on the hot repeated-lookup path. On a miss, the matched entry is promoted into `front` and the old `front` is demoted into `rest`.

## Performance (Callgrind, insert into 10k pool)

Comparison against #182 baseline (current PR-branch result), with #182's Δ-vs-BTreeMap in parentheses:

| Bench               | #182 (MTF) | This PR | Δ      | Δ-vs-BTreeMap |
|---------------------|------------|---------|--------|---------------|
| N=1                 | 194        | 187     | **-7** | +21 (was +28) |
| N=5                 | 197        | 189     | **-7** | -35 (was -27) |
| N=8                 | 196        | 189     | **-7** | -64 (was -57) |
| N=16                | 198        | 188     | **-10**| -17 (was -7)  |
| N=8 adversarial     | 364        | 540     | +176   | n/a           |

The common-case win (~7 insns) is consistent across all N. The adversarial bench (target sitting at the back of MTF order) regresses by 176 because each MTF-miss now performs `swap_remove` + `replace` + `push` on the two storages instead of a single `swap` on a unified vector. This trade-off only matters for workloads that hammer the cold MTF-miss path repeatedly, which is contrary to the documented BlindPool common case (small handful of layouts, repeated access to the same one).

## Why a separate PR

Worth a closer look before deciding to merge:

* The adversarial regression is real — wanted it visible rather than buried as a follow-up commit on #182.
* The miss path is now noticeably more complex (promote/demote logic across two storages).
* Wall-clock Criterion numbers are needed to confirm the Callgrind delta translates to a real-world win.

## Validation

* `just package=infinity_pool validate-local` clean on Windows and Linux: 485 lib tests, 43 doctests, 483 Miri tests.
* All 11 `LayoutDispatch` unit tests pass, including `constructor_panic_leaves_dispatch_unchanged`.

Related: #176, #182.
