### PR TITLE
Add #[inline] guidelines and apply to fast_time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,32 @@ suppression block required by Gungraun's macro expansions), Cargo.toml setup wit
 target-gated dependency, Gungraun syntax gotchas, the pairing convention, and how to interpret
 results.
 
+# `#[inline]` annotations
+
+`#[inline]` is a hint to the compiler to consider inlining a function. Throughout this
+section, "generic" includes any function that needs monomorphization — a function counts
+as generic if it takes type parameters of its own or if it is defined in a generic type
+or `impl`, even when the function itself takes no type parameters.
+
+Apply the first matching rule:
+
+1. **Apply `#[inline]` to non-generic functions exported from the crate that sit on a hot
+   path** based on your knowledge of how the API is used. Act on this knowledge alone,
+   accepting some documentation noise — without the annotation the compiler has no
+   opportunity to inline the function into downstream consumers, and we want to give it
+   that opportunity even if no current benchmark measurably benefits (a future workload
+   or customer case might).
+
+2. **Otherwise, only apply `#[inline]` if benchmarks or disassembly show a generic or
+   same-crate function on a hot path is not being inlined.** These are already inlining
+   candidates by default, so the annotation is an extra hint applied only when measurement
+   shows the default decision is wrong. Verify with `just package=<pkg> bench-cg` before
+   and after, comparing instruction counts; revert if the numbers do not move.
+
+3. **Do not use `#[inline(always)]` or `#[inline(never)]` without specific
+   justification.** These are stronger hints intended as advanced tuning knobs;
+   general-purpose code should not reach for them.
+
 # YAML formatting
 
 Prefer not using quotes around strings, unless the string starts with special characters.

--- a/packages/fast_time/src/clock.rs
+++ b/packages/fast_time/src/clock.rs
@@ -145,6 +145,7 @@ impl Clock {
     /// assert_eq!(timestamps.len(), 100);
     /// ```
     #[must_use]
+    #[inline]
     pub fn now(&mut self) -> Instant {
         self.inner.now().into()
     }

--- a/packages/fast_time/src/instant.rs
+++ b/packages/fast_time/src/instant.rs
@@ -91,6 +91,7 @@ impl Instant {
     /// assert!(elapsed <= Duration::from_secs(1)); // Generous upper bound
     /// ```
     #[must_use]
+    #[inline]
     pub fn elapsed(&self, clock: &mut Clock) -> Duration {
         clock.now().saturating_duration_since(*self)
     }
@@ -136,6 +137,7 @@ impl Instant {
     /// assert_eq!(duration, Duration::ZERO);
     /// ```
     #[must_use]
+    #[inline]
     pub fn saturating_duration_since(&self, earlier: Self) -> Duration {
         self.inner.saturating_duration_since(earlier.inner)
     }
@@ -250,12 +252,14 @@ impl Instant {
 }
 
 impl From<std::time::Instant> for Instant {
+    #[inline]
     fn from(inner: std::time::Instant) -> Self {
         Self { inner }
     }
 }
 
 impl From<Instant> for std::time::Instant {
+    #[inline]
     fn from(instant: Instant) -> Self {
         instant.inner
     }

--- a/packages/fast_time/src/pal/facade/time_source.rs
+++ b/packages/fast_time/src/pal/facade/time_source.rs
@@ -47,6 +47,7 @@ impl From<MockTimeSource> for TimeSourceFacade {
 }
 
 impl TimeSource for TimeSourceFacade {
+    #[inline]
     fn now(&mut self) -> Instant {
         match self {
             #[cfg(all(any(target_os = "linux", windows), not(miri)))]

--- a/packages/fast_time/src/pal/linux/bindings/facade.rs
+++ b/packages/fast_time/src/pal/linux/bindings/facade.rs
@@ -25,6 +25,7 @@ impl BindingsFacade {
 }
 
 impl Bindings for BindingsFacade {
+    #[inline]
     fn clock_gettime_nanos(&self) -> u128 {
         match self {
             Self::Real(bindings) => bindings.clock_gettime_nanos(),
@@ -33,6 +34,7 @@ impl Bindings for BindingsFacade {
         }
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         match self {
             Self::Real(bindings) => bindings.now(),

--- a/packages/fast_time/src/pal/linux/bindings/real.rs
+++ b/packages/fast_time/src/pal/linux/bindings/real.rs
@@ -28,6 +28,7 @@ impl Bindings for BuildTargetBindings {
         clippy::arithmetic_side_effects,
         reason = "never going to happen with timestamps within real-universe ranges"
     )]
+    #[inline]
     fn clock_gettime_nanos(&self) -> u128 {
         // SAFETY: All-zero is a valid initial value for this type.
         let mut ts: timespec = unsafe { mem::zeroed() };
@@ -40,6 +41,7 @@ impl Bindings for BuildTargetBindings {
         ts.tv_sec as u128 * 1_000_000_000 + ts.tv_nsec as u128
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         Instant::now()
     }

--- a/packages/fast_time/src/pal/linux/time_source.rs
+++ b/packages/fast_time/src/pal/linux/time_source.rs
@@ -32,6 +32,7 @@ impl TimeSourceImpl {
 }
 
 impl TimeSource for TimeSourceImpl {
+    #[inline]
     fn now(&mut self) -> Instant {
         let platform_time = self.bindings.clock_gettime_nanos();
 

--- a/packages/fast_time/src/pal/windows/bindings/facade.rs
+++ b/packages/fast_time/src/pal/windows/bindings/facade.rs
@@ -26,6 +26,7 @@ impl BindingsFacade {
 }
 
 impl Bindings for BindingsFacade {
+    #[inline]
     fn get_tick_count_64(&self) -> u64 {
         match self {
             Self::Real(bindings) => bindings.get_tick_count_64(),
@@ -34,6 +35,7 @@ impl Bindings for BindingsFacade {
         }
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         match self {
             Self::Real(bindings) => bindings.now(),

--- a/packages/fast_time/src/pal/windows/bindings/real.rs
+++ b/packages/fast_time/src/pal/windows/bindings/real.rs
@@ -12,11 +12,13 @@ use crate::pal::windows::Bindings;
 pub(crate) struct BuildTargetBindings;
 
 impl Bindings for BuildTargetBindings {
+    #[inline]
     fn get_tick_count_64(&self) -> u64 {
         // SAFETY: No safety requirements.
         unsafe { GetTickCount64() }
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         Instant::now()
     }

--- a/packages/fast_time/src/pal/windows/time_source.rs
+++ b/packages/fast_time/src/pal/windows/time_source.rs
@@ -32,6 +32,7 @@ impl TimeSourceImpl {
 }
 
 impl TimeSource for TimeSourceImpl {
+    #[inline]
     fn now(&mut self) -> Instant {
         let platform_time = self.bindings.get_tick_count_64();
 


### PR DESCRIPTION
## Summary

Codifies a workspace ruleset for `#[inline]` annotations in `AGENTS.md` and applies it as a worked example to `fast_time`.

Background: in release builds each crate is partitioned across multiple codegen units, so even same-crate cross-module calls are not guaranteed to be inlined by default. The three rules below capture the heuristic we settled on after experimenting with the inliner's behaviour.

## Ruleset (AGENTS.md)

1. **Apply `#[inline]` to crate-public, non-generic functions on a hot path** (judged by API analysis — no benchmark required). This is the only case where the annotation actually changes what is available to other crates' codegen.
2. **Otherwise apply `#[inline]` only when bench-cg or disassembly shows a generic or same-crate function on a hot path is not being inlined.** Generics and same-crate functions are always inlining candidates by default; the annotation only nudges the heuristic.
3. **Do not use `#[inline(always)]` or `#[inline(never)]` without specific justification.** Those are stronger hints reserved for advanced tuning.

## Applied to `fast_time`

Rule 1 on the PAL chain: `Clock::now`, `Instant::elapsed`, `Instant::saturating_duration_since`, the `From` impls, and the Linux / Windows `TimeSource` + `Bindings` facade chain.

`bench-cg` deltas:
- `clock_now`: **-4.4%**
- `instant_elapsed`: **-3.7%**
- `saturating_duration_since`: **-1.1%**

## Validation

`just validate-local` clean on Windows and Linux (WSL).

## Follow-up

A follow-up PR applies Rule 1 across the rest of the workspace (`events`, `awaiter_set`, `nm`, `many_cpus`) with measurement.
