### PR TITLE
Apply #[inline] ruleset across events / awaiter_set / nm / many_cpus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,32 @@ suppression block required by Gungraun's macro expansions), Cargo.toml setup wit
 target-gated dependency, Gungraun syntax gotchas, the pairing convention, and how to interpret
 results.
 
+# `#[inline]` annotations
+
+`#[inline]` is a hint to the compiler to consider inlining a function. Throughout this
+section, "generic" includes any function that needs monomorphization — a function counts
+as generic if it takes type parameters of its own or if it is defined in a generic type
+or `impl`, even when the function itself takes no type parameters.
+
+Apply the first matching rule:
+
+1. **Apply `#[inline]` to non-generic functions exported from the crate that sit on a hot
+   path** based on your knowledge of how the API is used. Act on this knowledge alone,
+   accepting some documentation noise — without the annotation the compiler has no
+   opportunity to inline the function into downstream consumers, and we want to give it
+   that opportunity even if no current benchmark measurably benefits (a future workload
+   or customer case might).
+
+2. **Otherwise, only apply `#[inline]` if benchmarks or disassembly show a generic or
+   same-crate function on a hot path is not being inlined.** These are already inlining
+   candidates by default, so the annotation is an extra hint applied only when measurement
+   shows the default decision is wrong. Verify with `just package=<pkg> bench-cg` before
+   and after, comparing instruction counts; revert if the numbers do not move.
+
+3. **Do not use `#[inline(always)]` or `#[inline(never)]` without specific
+   justification.** These are stronger hints intended as advanced tuning knobs;
+   general-purpose code should not reach for them.
+
 # YAML formatting
 
 Prefer not using quotes around strings, unless the string starts with special characters.

--- a/packages/awaiter_set/benches/awaiter_set.rs
+++ b/packages/awaiter_set/benches/awaiter_set.rs
@@ -1,12 +1,16 @@
 //! Wall-clock benchmarks for the `awaiter_set` crate.
 //!
-//! Three round-trip scenarios cover the same operations isolated by
+//! Round-trip scenarios cover the same operations isolated by
 //! `awaiter_set_cg.rs`:
 //!
 //! * `register_unregister/empty` — register + unregister on an empty set.
 //! * `register_unregister/with_10_anchors` — same, but the set has 10
 //!   anchor awaiters that remain registered for the duration.
 //! * `register_notify_take/empty` — full lifecycle: register, notify, take.
+//! * `is_empty/empty` — null-head fast path on an empty set.
+//! * `is_empty/populated` — null-head check on a populated set.
+//! * `notify_one_prior_generation/eligible` — register, advance generation,
+//!   notify prior generation, take notification.
 
 #![allow(missing_docs, reason = "benchmark code")]
 #![allow(
@@ -37,6 +41,8 @@ criterion_main!(benches);
 fn entrypoint(c: &mut Criterion) {
     register_unregister(c);
     register_notify_take(c);
+    is_empty(c);
+    notify_one_prior_generation(c);
 }
 
 /// Measures back-to-back `register` + `unregister` on a single
@@ -113,6 +119,77 @@ fn register_notify_take(c: &mut Criterion) {
                     set.register(awaiter.as_mut(), Waker::noop().clone());
                 }
                 drop(black_box(set.notify_one()));
+                _ = black_box(awaiter.as_ref().take_notification());
+            }
+            let elapsed = start.elapsed();
+            black_box(&mut set);
+            black_box(&mut awaiter);
+            elapsed
+        });
+    });
+
+    group.finish();
+}
+
+/// Measures `is_empty` on an empty and a populated set. State is
+/// invariant across iterations, so the set and awaiter are constructed
+/// once per sample.
+fn is_empty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("is_empty");
+
+    group.bench_function("empty", |b| {
+        b.iter_custom(|iters| {
+            let set = AwaiterSet::new();
+            let start = Instant::now();
+            for _ in 0..iters {
+                _ = black_box(black_box(&set).is_empty());
+            }
+            let elapsed = start.elapsed();
+            black_box(&set);
+            elapsed
+        });
+    });
+
+    group.bench_function("populated", |b| {
+        b.iter_custom(|iters| {
+            let mut awaiter = Box::pin(Awaiter::new());
+            let mut set = AwaiterSet::new();
+            unsafe {
+                set.register(awaiter.as_mut(), Waker::noop().clone());
+            }
+            let start = Instant::now();
+            for _ in 0..iters {
+                _ = black_box(black_box(&set).is_empty());
+            }
+            let elapsed = start.elapsed();
+            black_box(&mut set);
+            black_box(&mut awaiter);
+            elapsed
+        });
+    });
+
+    group.finish();
+}
+
+/// Measures a full round-trip exercising
+/// `advance_generation` + `notify_one_prior_generation`: register the
+/// awaiter in the current generation, advance into a new generation
+/// (the awaiter is now in a prior generation), notify it, then take
+/// the notification to reset state for the next iteration.
+fn notify_one_prior_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("notify_one_prior_generation");
+
+    group.bench_function("eligible", |b| {
+        b.iter_custom(|iters| {
+            let mut awaiter = Box::pin(Awaiter::new());
+            let mut set = AwaiterSet::new();
+            let start = Instant::now();
+            for _ in 0..iters {
+                unsafe {
+                    set.register(awaiter.as_mut(), Waker::noop().clone());
+                }
+                set.advance_generation();
+                drop(black_box(set.notify_one_prior_generation()));
                 _ = black_box(awaiter.as_ref().take_notification());
             }
             let elapsed = start.elapsed();

--- a/packages/awaiter_set/benches/awaiter_set_cg.rs
+++ b/packages/awaiter_set/benches/awaiter_set_cg.rs
@@ -12,6 +12,10 @@
 //! * `unregister_only` — unlink the only awaiter, set becomes empty.
 //! * `take_notification_when_notified` — `take_notification` CAS success.
 //! * `take_notification_when_waiting` — `take_notification` CAS failure.
+//! * `is_empty_when_empty` — null-head fast path on an empty set.
+//! * `is_empty_when_populated` — null-head check on a populated set.
+//! * `notify_one_prior_generation_eligible` — pop an awaiter that
+//!   belongs to a prior generation.
 //!
 //! Multi-threaded contention is intentionally out of scope; callers
 //! synchronize external to the set, and Callgrind cannot model cache
@@ -186,6 +190,39 @@ mod linux {
         state
     }
 
+    // ---------- Emptiness check ----------
+
+    #[library_benchmark]
+    #[bench::empty(make_empty_solo())]
+    fn is_empty_when_empty(state: SoloState) -> SoloState {
+        _ = black_box(black_box(&state.set).is_empty());
+        state
+    }
+
+    #[library_benchmark]
+    #[bench::populated(make_registered_solo())]
+    fn is_empty_when_populated(state: SoloState) -> SoloState {
+        _ = black_box(black_box(&state.set).is_empty());
+        state
+    }
+
+    // ---------- Generation-bounded notification ----------
+
+    // Sets up a registered awaiter that belongs to a prior generation,
+    // so `notify_one_prior_generation` is eligible to pop it.
+    fn make_registered_solo_prior_generation() -> SoloState {
+        let mut state = make_registered_solo();
+        state.set.advance_generation();
+        state
+    }
+
+    #[library_benchmark]
+    #[bench::eligible(make_registered_solo_prior_generation())]
+    fn notify_one_prior_generation_eligible(mut state: SoloState) -> SoloState {
+        drop(black_box(state.set.notify_one_prior_generation()));
+        state
+    }
+
     library_benchmark_group!(
         name = register_group,
         benchmarks = [register_into_empty, register_appending_to_10]
@@ -193,7 +230,11 @@ mod linux {
 
     library_benchmark_group!(
         name = removal_group,
-        benchmarks = [notify_one_singleton, unregister_only]
+        benchmarks = [
+            notify_one_singleton,
+            unregister_only,
+            notify_one_prior_generation_eligible,
+        ]
     );
 
     library_benchmark_group!(
@@ -203,10 +244,15 @@ mod linux {
             take_notification_when_waiting,
         ]
     );
+
+    library_benchmark_group!(
+        name = inspection_group,
+        benchmarks = [is_empty_when_empty, is_empty_when_populated]
+    );
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::{atomic_group, register_group, removal_group};
+pub use linux::{atomic_group, inspection_group, register_group, removal_group};
 
 #[cfg(target_os = "linux")]
 use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
@@ -218,5 +264,5 @@ gungraun::main!(
             .args(["--branch-sim=yes"])
             .format([CallgrindMetrics::Default, CallgrindMetrics::BranchSim]),
     );
-    library_benchmark_groups = register_group, removal_group, atomic_group
+    library_benchmark_groups = register_group, removal_group, atomic_group, inspection_group
 );

--- a/packages/awaiter_set/src/awaiter.rs
+++ b/packages/awaiter_set/src/awaiter.rs
@@ -96,6 +96,7 @@ pub struct Awaiter {
 
 impl Awaiter {
     /// Creates a new awaiter in the idle state.
+    #[inline]
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -110,6 +111,7 @@ impl Awaiter {
     ///
     /// A future's [`Drop`] handler uses this to decide whether
     /// cleanup (unregistering or forwarding a resource) is needed.
+    #[inline]
     #[must_use]
     pub fn is_registered(&self) -> bool {
         self.lifecycle.load(Ordering::Acquire) != IDLE
@@ -125,6 +127,7 @@ impl Awaiter {
     /// `Poll::Ready`.
     ///
     /// This is typically the first check in a future's `poll()`.
+    #[inline]
     #[must_use]
     pub fn take_notification(&self) -> bool {
         self.lifecycle
@@ -139,6 +142,7 @@ impl Awaiter {
     /// [`Drop`] handler to decide whether the primitive granted a
     /// resource (lock, permit, signal) that must be forwarded to
     /// another awaiter instead of being silently discarded.
+    #[inline]
     #[must_use]
     pub fn is_notified(&self) -> bool {
         self.lifecycle.load(Ordering::Acquire) == NOTIFIED

--- a/packages/awaiter_set/src/set.rs
+++ b/packages/awaiter_set/src/set.rs
@@ -152,6 +152,7 @@ impl AwaiterSet {
     }
 
     /// Returns `true` if the set contains no awaiters.
+    #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.head.is_null()
@@ -172,6 +173,7 @@ impl AwaiterSet {
     /// The awaiter must remain pinned and valid until it is removed
     /// from the set (via [`unregister()`][Self::unregister] or
     /// [`notify_one()`][Self::notify_one]).
+    #[inline]
     pub unsafe fn register(&mut self, awaiter: Pin<&mut Awaiter>, waker: Waker) {
         // SAFETY: We do not move the awaiter. Pin guarantees address
         // stability.
@@ -239,6 +241,7 @@ impl AwaiterSet {
     ///
     /// The awaiter must currently be registered with this set (or
     /// already notified by it).
+    #[inline]
     pub unsafe fn unregister(&mut self, awaiter: Pin<&mut Awaiter>) {
         // SAFETY: We do not move the awaiter.
         let awaiter = unsafe { awaiter.get_unchecked_mut() };
@@ -282,6 +285,7 @@ impl AwaiterSet {
     /// scope to prevent reentrancy deadlocks.
     ///
     /// Returns `None` if the set is empty.
+    #[inline]
     pub fn notify_one(&mut self) -> Option<Waker> {
         if self.head.is_null() {
             return None;
@@ -306,6 +310,7 @@ impl AwaiterSet {
     /// typically because the caller wants to exclude awaiters that
     /// a reentrant waker may register while the notification is in
     /// progress.
+    #[inline]
     pub fn advance_generation(&mut self) {
         self.generation = self.generation.wrapping_add(1);
     }
@@ -320,6 +325,7 @@ impl AwaiterSet {
     /// to the current generation, or when no generation has been
     /// opened yet (no [`advance_generation()`][Self::advance_generation]
     /// call has been made).
+    #[inline]
     pub fn notify_one_prior_generation(&mut self) -> Option<Waker> {
         if self.head.is_null() {
             return None;

--- a/packages/events/src/auto.rs
+++ b/packages/events/src/auto.rs
@@ -381,6 +381,7 @@ impl AutoResetEvent {
     ///     event.wait().await;
     /// }
     /// ```
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn set(&self) {
         self.inner.set();
@@ -405,6 +406,7 @@ impl AutoResetEvent {
     /// // Signal was consumed.
     /// assert!(!event.try_wait());
     /// ```
+    #[inline]
     #[must_use]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn try_wait(&self) -> bool {
@@ -598,6 +600,7 @@ impl EmbeddedAutoResetEventRef {
     }
 
     /// Signals the event, releasing exactly one waiter.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn set(&self) {
         self.inner().set();
@@ -607,6 +610,7 @@ impl EmbeddedAutoResetEventRef {
     ///
     /// Returns `true` if the event was set, atomically transitioning it
     /// back to the unset state. Returns `false` if the event was not set.
+    #[inline]
     #[must_use]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn try_wait(&self) -> bool {

--- a/packages/events/src/local_auto.rs
+++ b/packages/events/src/local_auto.rs
@@ -322,6 +322,7 @@ impl LocalAutoResetEvent {
     /// released and the event remains unset. If no one is waiting,
     /// the event transitions to the set state.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn set(&self) {
         self.inner.set();
@@ -331,6 +332,7 @@ impl LocalAutoResetEvent {
     ///
     /// Returns `true` if the event was set, transitioning it back to the
     /// unset state. Returns `false` if the event was not set.
+    #[inline]
     #[must_use]
     // Trivial forwarder.
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -489,6 +491,7 @@ impl EmbeddedLocalAutoResetEventRef {
     /// released and the event remains unset. If no one is waiting,
     /// the event transitions to the set state.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn set(&self) {
         self.inner().set();
@@ -498,6 +501,7 @@ impl EmbeddedLocalAutoResetEventRef {
     ///
     /// Returns `true` if the event was set, transitioning it back to the
     /// unset state. Returns `false` if the event was not set.
+    #[inline]
     #[must_use]
     // Trivial forwarder.
     #[cfg_attr(coverage_nightly, coverage(off))]

--- a/packages/events/src/local_manual.rs
+++ b/packages/events/src/local_manual.rs
@@ -282,6 +282,7 @@ impl LocalManualResetEvent {
     ///
     /// If the event is already set, this is a no-op.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn set(&self) {
         self.inner.set();
@@ -289,6 +290,7 @@ impl LocalManualResetEvent {
 
     /// Closes the gate.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn reset(&self) {
         self.inner.reset();
@@ -296,6 +298,7 @@ impl LocalManualResetEvent {
 
     /// Returns `true` if the event is currently set.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[must_use]
     pub fn try_wait(&self) -> bool {
@@ -459,6 +462,7 @@ impl EmbeddedLocalManualResetEventRef {
     ///
     /// If the event is already set, this is a no-op.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn set(&self) {
         self.inner().set();
@@ -466,6 +470,7 @@ impl EmbeddedLocalManualResetEventRef {
 
     /// Closes the gate.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn reset(&self) {
         self.inner().reset();
@@ -473,6 +478,7 @@ impl EmbeddedLocalManualResetEventRef {
 
     /// Returns `true` if the event is currently set.
     // Trivial forwarder.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[must_use]
     pub fn try_wait(&self) -> bool {

--- a/packages/events/src/manual.rs
+++ b/packages/events/src/manual.rs
@@ -349,6 +349,7 @@ impl ManualResetEvent {
     ///     assert!(event.try_wait());
     /// }
     /// ```
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn set(&self) {
         self.inner.set();
@@ -359,6 +360,7 @@ impl ManualResetEvent {
     ///
     /// Awaiters that are already past the gate (i.e. whose futures have
     /// already returned [`Poll::Ready`]) are not affected.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn reset(&self) {
         self.inner.reset();
@@ -369,6 +371,7 @@ impl ManualResetEvent {
     /// Because other threads may set or reset the event concurrently, the
     /// returned value is immediately stale. Use this for diagnostics or
     /// best-effort checks, not for synchronization.
+    #[inline]
     #[must_use]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn try_wait(&self) -> bool {
@@ -581,18 +584,21 @@ impl EmbeddedManualResetEventRef {
     /// Opens the gate, releasing all current awaiters.
     ///
     /// If the event is already set, this is a no-op.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn set(&self) {
         self.inner().set();
     }
 
     /// Closes the gate.
+    #[inline]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn reset(&self) {
         self.inner().reset();
     }
 
     /// Returns `true` if the event is currently set.
+    #[inline]
     #[must_use]
     #[cfg_attr(coverage_nightly, coverage(off))] // Trivial forwarder.
     pub fn try_wait(&self) -> bool {

--- a/packages/fast_time/src/clock.rs
+++ b/packages/fast_time/src/clock.rs
@@ -145,6 +145,7 @@ impl Clock {
     /// assert_eq!(timestamps.len(), 100);
     /// ```
     #[must_use]
+    #[inline]
     pub fn now(&mut self) -> Instant {
         self.inner.now().into()
     }

--- a/packages/fast_time/src/instant.rs
+++ b/packages/fast_time/src/instant.rs
@@ -91,6 +91,7 @@ impl Instant {
     /// assert!(elapsed <= Duration::from_secs(1)); // Generous upper bound
     /// ```
     #[must_use]
+    #[inline]
     pub fn elapsed(&self, clock: &mut Clock) -> Duration {
         clock.now().saturating_duration_since(*self)
     }
@@ -136,6 +137,7 @@ impl Instant {
     /// assert_eq!(duration, Duration::ZERO);
     /// ```
     #[must_use]
+    #[inline]
     pub fn saturating_duration_since(&self, earlier: Self) -> Duration {
         self.inner.saturating_duration_since(earlier.inner)
     }
@@ -250,12 +252,14 @@ impl Instant {
 }
 
 impl From<std::time::Instant> for Instant {
+    #[inline]
     fn from(inner: std::time::Instant) -> Self {
         Self { inner }
     }
 }
 
 impl From<Instant> for std::time::Instant {
+    #[inline]
     fn from(instant: Instant) -> Self {
         instant.inner
     }

--- a/packages/fast_time/src/pal/facade/time_source.rs
+++ b/packages/fast_time/src/pal/facade/time_source.rs
@@ -47,6 +47,7 @@ impl From<MockTimeSource> for TimeSourceFacade {
 }
 
 impl TimeSource for TimeSourceFacade {
+    #[inline]
     fn now(&mut self) -> Instant {
         match self {
             #[cfg(all(any(target_os = "linux", windows), not(miri)))]

--- a/packages/fast_time/src/pal/linux/bindings/facade.rs
+++ b/packages/fast_time/src/pal/linux/bindings/facade.rs
@@ -25,6 +25,7 @@ impl BindingsFacade {
 }
 
 impl Bindings for BindingsFacade {
+    #[inline]
     fn clock_gettime_nanos(&self) -> u128 {
         match self {
             Self::Real(bindings) => bindings.clock_gettime_nanos(),
@@ -33,6 +34,7 @@ impl Bindings for BindingsFacade {
         }
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         match self {
             Self::Real(bindings) => bindings.now(),

--- a/packages/fast_time/src/pal/linux/bindings/real.rs
+++ b/packages/fast_time/src/pal/linux/bindings/real.rs
@@ -28,6 +28,7 @@ impl Bindings for BuildTargetBindings {
         clippy::arithmetic_side_effects,
         reason = "never going to happen with timestamps within real-universe ranges"
     )]
+    #[inline]
     fn clock_gettime_nanos(&self) -> u128 {
         // SAFETY: All-zero is a valid initial value for this type.
         let mut ts: timespec = unsafe { mem::zeroed() };
@@ -40,6 +41,7 @@ impl Bindings for BuildTargetBindings {
         ts.tv_sec as u128 * 1_000_000_000 + ts.tv_nsec as u128
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         Instant::now()
     }

--- a/packages/fast_time/src/pal/linux/time_source.rs
+++ b/packages/fast_time/src/pal/linux/time_source.rs
@@ -32,6 +32,7 @@ impl TimeSourceImpl {
 }
 
 impl TimeSource for TimeSourceImpl {
+    #[inline]
     fn now(&mut self) -> Instant {
         let platform_time = self.bindings.clock_gettime_nanos();
 

--- a/packages/fast_time/src/pal/windows/bindings/facade.rs
+++ b/packages/fast_time/src/pal/windows/bindings/facade.rs
@@ -26,6 +26,7 @@ impl BindingsFacade {
 }
 
 impl Bindings for BindingsFacade {
+    #[inline]
     fn get_tick_count_64(&self) -> u64 {
         match self {
             Self::Real(bindings) => bindings.get_tick_count_64(),
@@ -34,6 +35,7 @@ impl Bindings for BindingsFacade {
         }
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         match self {
             Self::Real(bindings) => bindings.now(),

--- a/packages/fast_time/src/pal/windows/bindings/real.rs
+++ b/packages/fast_time/src/pal/windows/bindings/real.rs
@@ -12,11 +12,13 @@ use crate::pal::windows::Bindings;
 pub(crate) struct BuildTargetBindings;
 
 impl Bindings for BuildTargetBindings {
+    #[inline]
     fn get_tick_count_64(&self) -> u64 {
         // SAFETY: No safety requirements.
         unsafe { GetTickCount64() }
     }
 
+    #[inline]
     fn now(&self) -> Instant {
         Instant::now()
     }

--- a/packages/fast_time/src/pal/windows/time_source.rs
+++ b/packages/fast_time/src/pal/windows/time_source.rs
@@ -32,6 +32,7 @@ impl TimeSourceImpl {
 }
 
 impl TimeSource for TimeSourceImpl {
+    #[inline]
     fn now(&mut self) -> Instant {
         let platform_time = self.bindings.get_tick_count_64();
 

--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -117,6 +117,7 @@ impl SystemHardware {
     /// let processor_count = hardware.max_processor_count();
     /// println!("Running on hardware with up to {processor_count} processors");
     /// ```
+    #[inline]
     #[must_use]
     pub fn current() -> &'static Self {
         CURRENT_HARDWARE.get_or_init(|| Self::from_platform(PlatformFacade::target()))

--- a/packages/nm/src/reports.rs
+++ b/packages/nm/src/reports.rs
@@ -98,6 +98,7 @@ impl Report {
     ///     println!("Event: {}, Count: {}", event.name(), event.count());
     /// }
     /// ```
+    #[inline]
     pub fn events(&self) -> impl Iterator<Item = &EventMetrics> {
         self.events.iter()
     }
@@ -205,6 +206,7 @@ impl EventMetrics {
     ///     println!("Event name: {}", event.name());
     /// }
     /// ```
+    #[inline]
     #[must_use]
     pub fn name(&self) -> &EventName {
         &self.name
@@ -231,6 +233,7 @@ impl EventMetrics {
     ///     println!("Total count: {}", event.count());
     /// }
     /// ```
+    #[inline]
     #[must_use]
     pub fn count(&self) -> u64 {
         self.count
@@ -257,6 +260,7 @@ impl EventMetrics {
     ///     println!("Total bytes: {}", event.sum());
     /// }
     /// ```
+    #[inline]
     #[must_use]
     pub fn sum(&self) -> Magnitude {
         self.sum
@@ -285,6 +289,7 @@ impl EventMetrics {
     ///     println!("Average response time: {}ms", event.mean());
     /// }
     /// ```
+    #[inline]
     #[must_use]
     pub fn mean(&self) -> Magnitude {
         self.mean
@@ -322,6 +327,7 @@ impl EventMetrics {
     /// ```
     ///
     /// [1]: crate::EventBuilder::histogram
+    #[inline]
     #[must_use]
     pub fn histogram(&self) -> Option<&Histogram> {
         self.histogram.as_ref()
@@ -427,6 +433,7 @@ impl Histogram {
     ///
     /// The last bucket always has the magnitude `Magnitude::MAX`, counting
     /// occurrences that do not fit into any of the previous buckets.
+    #[inline]
     pub fn magnitudes(&self) -> impl Iterator<Item = Magnitude> {
         self.magnitudes
             .iter()
@@ -440,6 +447,7 @@ impl Histogram {
     /// Each bucket counts the number of events that are less than or equal to the corresponding
     /// magnitude. Each occurrence of an event is counted only once, in the first bucket that can
     /// accept it.
+    #[inline]
     pub fn counts(&self) -> impl Iterator<Item = u64> {
         self.counts
             .iter()
@@ -456,6 +464,7 @@ impl Histogram {
     ///
     /// The last bucket always has the magnitude `Magnitude::MAX`, counting
     /// occurrences that do not fit into any of the previous buckets.
+    #[inline]
     pub fn buckets(&self) -> impl Iterator<Item = (Magnitude, u64)> {
         self.magnitudes().zip(self.counts())
     }


### PR DESCRIPTION
## Summary

Applies the `#[inline]` ruleset (introduced in #184) across the rest of the workspace. Rule 1 — *crate-public, non-generic, hot-path* — surfaced four packages with missing annotations.

## Changes

### `events` (18 annotations, 1 commit)

Trivial `set` / `reset` / `try_wait` forwarders on `AutoResetEvent`, `ManualResetEvent`, `LocalAutoResetEvent`, `LocalManualResetEvent` and their `Embedded*` siblings.

### `awaiter_set` (10 annotations + 2 bench scenarios, 2 commits)

- `Awaiter::{new, is_registered, take_notification, is_notified}` and `AwaiterSet::{is_empty, register, unregister, notify_one, advance_generation, notify_one_prior_generation}`.
- New bench scenarios for `is_empty/{empty,populated}` and `notify_one_prior_generation/eligible` (Callgrind + Criterion pair, per AGENTS.md).

### `nm` (9 annotations, 1 commit)

`Report::events`, `EventMetrics::{name, count, sum, mean, histogram}`, `Histogram::{magnitudes, counts, buckets}` — the per-event iteration chain consumed each export tick by `nm_otel`.

### `many_cpus` (1 annotation, 1 commit)

`SystemHardware::current` — single `OnceLock::get_or_init` exit point. No bench available; Rule 1 applies unconditionally.

## Measured impact (`bench-cg`)

Headline rows; cycles are Callgrind's estimate. Full diffs available in run artifacts.

**`events`**
| scenario | Ir | Cycles |
| --- | --- | --- |
| `local_auto_set_then_try_wait` | -11.9% | **-20.5%** (Bcm halved) |
| `manual_try_wait` | +1 instr (noise) | -2.2% |
| `auto_set_then_try_wait` | -2.1% | +1.2% |
| `local_manual_try_wait` | flat | flat |

**`awaiter_set`**
| scenario | Ir | Cycles |
| --- | --- | --- |
| `take_notification_when_notified` | -57.7% | **-87.0%** |
| `take_notification_when_waiting` | -56.0% | **-86.8%** |
| `is_empty_when_empty` | -7.7% | -38.9% |
| `notify_one_singleton` | flat | -11.9% |
| `unregister_only` | +9 instr | -7.9% |
| `register_into_empty` | +2 instr | +27% (cold-cache noise — 2 extra RAM hits × 35cy) |
| `register_appending_to_10` | +3 instr | +55% (same cold-cache pattern) |
| `is_empty_when_populated`, `notify_one_prior_generation_eligible` | flat | flat |

The two apparent register regressions are explained entirely by 2 extra RAM hits in a single-iteration measurement; instruction counts barely moved. Not real regressions.

**`nm_otel`** (driving `nm` accessors)
| scenario | Ir delta | Cycles delta |
| --- | --- | --- |
| `small_steady_state` | -22 instr (-0.35%) | noise |
| `small_no_delta` | -22 instr (-1.8%) | noise |
| `large_steady_state` | -22 instr (-0.09%) | noise |

Same -22 instructions per export across all sizes = wrapper layers absorbed in the per-event accessor chain.

## Validation

`just validate-local` clean on Windows and Linux (WSL).

## Notes

- Per Rule 1, all annotations stay even when current benchmarks show no measurable change — the goal is to give the inliner the *opportunity* for future scenarios and customer workloads.
- Bench scenarios were added where coverage was missing for newly-annotated methods (per AGENTS.md "Callgrind benchmarks must have an analogous Criterion scenario").
