### PR TITLE
infinity_pool: inline `<Dropper as Drop>::drop` (#192)

### DIFF
--- a/packages/infinity_pool/src/opaque/dropper.rs
+++ b/packages/infinity_pool/src/opaque/dropper.rs
@@ -49,6 +49,11 @@ impl Dropper {
 }
 
 impl Drop for Dropper {
+    // Without `#[inline]`, `Slab::remove` lowers the dropper invocation to a PLT/dynamic-linker
+    // indirect call (verified in disassembly). The body is small — a function-pointer null check
+    // plus an indirect call to the stored drop function — and inlining it removes that overhead
+    // for every handle drop. See issue #192.
+    #[inline]
     fn drop(&mut self) {
         if let Some(drop_fn) = self.drop_fn {
             drop_fn(self.ptr);


### PR DESCRIPTION
Add `#[inline]` to `<Dropper as Drop>::drop` to eliminate the PLT/dynamic-linker indirect call observed in `Slab::remove`'s disassembly. The drop body is small (a function-pointer null check plus an indirect call to the stored drop function), so inlining removes the trampoline overhead at every handle-drop site.

## Callgrind delta

10k-occupancy pool, `just package=infinity_pool bench-cg`:

| Benchmark | Before | After | Delta |
| --- | --- | --- | --- |
| `pinned_pool_drop_handle_from_10k` | 113 | 106 | **−6.19%** (−7 instr.) |
| `opaque_pool_drop_handle_from_10k` | 114 | 107 | −6.14% (−7 instr., same code path) |
| `raw_pinned_pool_drop_full_with_10k_string` | 1,256,975 | 1,256,975 | no change |
| `raw_pinned_pool_drop_full_with_10k_u64` | 95,579 | 95,579 | no change (no drop needed) |

Both acceptance criteria from #192 (instructions ≤ baseline) are met.

The bulk-drop scenarios show no change because in those benchmarks the dropper's callee is inlinable at the call site (typed bulk drop); the win lands at the per-handle `Slab::remove` callsite that the issue specifically identified in the disassembly.

## Rationale

Per AGENTS.md's `#[inline]` rules, this is a same-crate function where the default decision is wrong: disassembly shows the dropper lowered to a PLT-indirect call, and Callgrind confirms the inline removes 7 instructions per handle drop. A justification comment is added next to the annotation so the next reader sees why we deviated from default.

Closes #192.
