### PR TITLE
Codify infinity_pool optimization lessons from closed issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,6 +695,39 @@ The justification should cover:
 Without this, the next reader will reasonably assume the deviation is accidental or unnecessary
 and try to "fix" it back to the standard pattern. The comment is what prevents that wasted cycle.
 
+# Performance optimization principles
+
+When proposing or applying performance optimizations:
+
+* **Optimizations must be motivated by user-facing scenarios, not raw benchmark deltas.**
+  A Callgrind win on a synthetic micro-benchmark is not by itself sufficient justification. Ask:
+  *what real workload does this help, and is that workload a design target of this package?* If
+  the answer is "I would have to invent one", the change should usually not land.
+* **Prefer surgical interventions over architectural rewrites.** A 5-line `#[inline]`, a
+  single-field type change (`fn` → `Option<fn>`), or an `unreachable!()` → `unreachable_unchecked!()`
+  swap is the right shape of optimization PR when measurement points at a specific instruction
+  the compiler is emitting. Multi-file restructurings (changing in-memory representation,
+  monomorphizing on type traits, deferring initialization, swapping data structures) are an
+  order of magnitude harder to land and need correspondingly stronger motivation.
+* **Preserve defensive runtime checks even if they cost a handful of instructions.** A runtime
+  `unreachable!()`, `debug_assert!`, or `Option::expect` arm is often there to surface
+  thread-safety bugs, state-machine corruption, or other "this should never happen but if it
+  does we want to know" conditions. Do not remove these to save a `cmpq` — if you have a
+  measured need to remove the check, prefer the surgical alternative (`unreachable_unchecked!`,
+  `debug_assert!` instead of `assert!`, etc.) that keeps the contract documented.
+* **Stay idiomatic Rust.** Manually controlling memory representation (`repr(C)` for layout
+  stability, `alloc_zeroed` on hand-crafted layouts, explicit discriminant encoding) leans
+  toward "coding Rust as if it were C" and is rarely worth the resulting reader confusion
+  and soundness review burden. Trust the compiler's layout decisions unless there is a
+  concrete cross-language interop or ABI requirement that forces your hand.
+* **First-insert and teardown costs are usually not worth optimizing.** Most data structures
+  in this workspace target long-lived, steady-state workloads. Optimizations whose entire
+  value is in the construction or destruction path (first allocation, bulk drop, etc.)
+  rarely pay for the complexity they introduce.
+
+When filing a performance issue, state explicitly which of these criteria the proposal meets.
+If you have to invent a scenario to motivate it, the issue should probably not be filed.
+
 # Hide async entrypoint in examples
 
 In inline code examples that use `.await`, do not render the async

--- a/packages/infinity_pool/AGENTS.md
+++ b/packages/infinity_pool/AGENTS.md
@@ -1,0 +1,70 @@
+# Agent notes for infinity_pool
+
+## Design intent: long-lived pools
+
+`infinity_pool` is designed for **long-lived pools**, not short-lived or
+one-shot ones. This drives several deliberate trade-offs that should not be
+"optimized away":
+
+* **Slab initialization cost on the first insert is intentional.** Initializing
+  all slot metadata up front when a slab is allocated keeps the steady-state
+  insert path as simple as possible (no per-op branch to check whether the slot
+  has been touched yet). Schemes that defer initialization (`MaybeUninit` +
+  high-water mark, piecewise lazy init) save the empty-pool first-insert cost
+  at the price of permanently slowing the steady-state path — the wrong
+  trade.
+* **First-insert / empty-pool latency is not a target.** Pools that are
+  constructed, used briefly, and then dropped are not the workload we
+  optimize for. Optimizations whose entire value is in the first insert
+  (`alloc_zeroed`, lazy init, etc.) are only acceptable if they add no
+  meaningful complexity.
+* **Per-slab bulk drop is an edge case.** Optimizing `Slab::drop` (e.g. with
+  an `any_needs_drop` flag, occupancy bitmap, etc.) is not worth the design
+  complexity unless a concrete user-facing scenario motivates it. Pools that
+  drop are pools that are being torn down — the cost is amortized over the
+  pool's entire lifetime.
+
+## Pooled types typically need `Drop`
+
+Real-world payloads (`String`, complex structs, smart pointers) usually have
+non-trivial drop. Optimizations specialized on `!mem::needs_drop::<T>()` for
+typed pools deliver minimal practical value because the common case is the
+opposite. Do not propose monomorphizing `Slab` on `needs_drop::<T>()` or
+similar specializations unless a concrete drop-free workload motivates it.
+
+The surgical complement — making the per-handle dropper invocation a no-op
+when `T` does not need drop, with no other type-level changes — has already
+landed and represents the right level of effort for this trade-off.
+
+## `SlotMeta` runtime checks are intentional
+
+The `unreachable!()` arm in the slot-meta state machine is intentional
+defense-in-depth: a panic there indicates a corrupted state machine, which
+in practice means a thread-safety bug. Do not remove it to save a `cmpq`.
+If a measured need to remove the check ever arises, use `unreachable_unchecked!()`
+as a surgical alternative — do not propose representation changes (`repr(C)`
+slot metadata) for this purpose.
+
+## Stay idiomatic — do not "code Rust as if it were C"
+
+Manually controlling the in-memory representation of slab metadata
+(`repr(C)` slot structs, `alloc_zeroed`-friendly layouts, explicit
+discriminant encoding) is explicitly out of scope. Trust the Rust compiler's
+layout decisions. If a niche encoding is being exploited and could in
+principle change between rustc releases, that is the language's concern,
+not ours.
+
+## What good infinity_pool optimizations look like
+
+[PR #194](https://github.com/folo-rs/folo/pull/194) (`#[inline]` on
+`<Dropper as Drop>::drop`) is the canonical example: 5 lines added, no
+behavior change, Callgrind delta verified (−6% on
+`pinned_pool_drop_handle_from_10k`), and a justifying inline comment per
+the workspace `#[inline]` policy. Surgical interventions that change one
+small thing, preserve all invariants, and are backed by a disassembly
+observation are the kind of optimization that lands.
+
+Optimization proposals that touch slot-metadata representation, monomorphize
+`Slab` on type traits, defer slab initialization, or add per-slab tracking
+state are unlikely to land without a concrete user-facing scenario that
+motivates the design complexity.


### PR DESCRIPTION
Codifies the feedback from issues #187–#193 (5 of 7 closed NOT_PLANNED, 1
landed as PR #194 — `#[inline]` on `Dropper::drop`) so the same proposals
do not get re-filed in a future session.

## Repo-scoped `AGENTS.md` — new "Performance optimization principles"

A short section after "Justify deviations from standard patterns" with five
criteria, distilled from the dispositions on the rejected issues:

1. Optimizations need a user-facing scenario, not just a benchmark delta.
2. Prefer surgical interventions (`#[inline]`, single-field type changes,
   `unreachable!()` → `unreachable_unchecked!()`) over architectural rewrites.
3. Preserve defensive runtime checks — they often catch thread-safety bugs.
4. Stay idiomatic; do not "code Rust as if it were C" (`repr(C)`,
   `alloc_zeroed` on hand-crafted layouts, manual discriminant encoding).
5. First-insert and teardown costs are usually not worth optimizing.

## New `packages/infinity_pool/AGENTS.md` — package design intent

Documents the package-specific takeaways:

* Long-lived pools are the design target; upfront slab init is intentional.
* Per-slab bulk drop is an edge case.
* Pooled types typically need `Drop` — do not specialize on `needs_drop`.
* The `SlotMeta` `unreachable!()` is a safety check, not pure overhead.
* No manual representation control (no `repr(C)` slot meta, no
  `alloc_zeroed` of hand-crafted layouts).
* Cites PR #194 as the canonical example of what good `infinity_pool`
  optimization PRs look like.

## Why this matters

Without these notes, future Callgrind-driven analysis would surface the
same five candidates (lazy slot init, occupancy bitmap, `needs_drop`
specialization, `repr(C)` SlotMeta, `alloc_zeroed`) as "promising
optimization opportunities" again. Each one looks compelling on paper
and produces real benchmark numbers, but each conflicts with stated
design intent. Capturing the rejection rationale here turns the recent
issue triage into permanent guardrails.

Docs-only; no code changes.
