### PR TITLE
docs(events_once): codify performance priorities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -728,6 +728,11 @@ When proposing or applying performance optimizations:
 When filing a performance issue, state explicitly which of these criteria the proposal meets.
 If you have to invent a scenario to motivate it, the issue should probably not be filed.
 
+Some packages have package-scoped optimization guidance that refines these principles for
+their domain (e.g. `packages/events_once/AGENTS.md` codifies the relative priority of pooled,
+embedded and boxed events, and the expectation that `LocalEvent` beats `Event`). Always check
+for a package-local `AGENTS.md` when planning optimization work in a specific crate.
+
 # Hide async entrypoint in examples
 
 In inline code examples that use `.await`, do not render the async

--- a/packages/events_once/AGENTS.md
+++ b/packages/events_once/AGENTS.md
@@ -11,14 +11,15 @@ scenarios is:
 
 1. **Pooled events** (`EventPool::rent` / `LocalEventPool::rent`) — primary
    performance target. Anyone reaching for `events_once` for high throughput
-   uses pooled or laked events.
-2. **Embedded / laked events** — also primary. Embedded events live inside
-   user storage with no allocator hop; laked events extend pooling to
-   variable T.
-3. **Boxed events** (`Event::new_in_box`) — least important. Any
-   performance-conscious user will use one of the variants above. Boxed events
-   exist primarily for convenience and for cases where the caller cannot bound
-   the event's lifetime to a specific scope.
+   uses pooled events or events rented from an `EventLake`.
+2. **Embedded events and events rented from an `EventLake`** — also primary.
+   Embedded events live inside user storage with no allocator hop; events
+   rented from a lake (`EventLake` / `LocalEventLake`) extend pooling to
+   variable `T`.
+3. **Boxed events** (`Event::boxed()` / `LocalEvent::boxed()`) — least
+   important. Any performance-conscious user will use one of the variants
+   above. Boxed events exist primarily for convenience and for cases where
+   the caller cannot bound the event's lifetime to a specific scope.
 
 Within all variants:
 
@@ -49,7 +50,8 @@ The package's Callgrind benchmark suite is expected to cover every
 combination of:
 
 * event variant (sync `Event`, local `LocalEvent`)
-* storage strategy (boxed, pooled, embedded / by-ref, laked)
+* storage strategy (boxed, pooled, embedded / by-ref, rented from an
+  `EventLake`)
 * primary lifecycle outcome (send + receive happy path, sender dropped,
   receiver dropped before polling)
 
@@ -80,6 +82,6 @@ confirm whether the function is being inlined.
 Inlining is asymmetric and not transitive: inlining a function with a body
 that is too large into its caller can prevent the caller from being inlined
 into ITS caller. When tempted to add `#[inline]` to a heavy method (e.g.
-`PooledRef::release_event`, which takes a mutex), measure first — the
-"inline cascade" can regress overall numbers even though the local symbol
-gets inlined.
+the `EventRef::release_event` impl for `PooledRef`, which locks the pool
+mutex), measure first — the "inline cascade" can regress overall numbers
+even though the local symbol gets inlined.

--- a/packages/events_once/AGENTS.md
+++ b/packages/events_once/AGENTS.md
@@ -1,0 +1,85 @@
+# events_once package guidelines
+
+These guidelines document conventions, priorities and constraints specific to the
+`events_once` package. They complement the workspace-wide guidance in the
+repository root `AGENTS.md`.
+
+## Performance priorities
+
+When weighing optimization candidates, the relative importance of user-facing
+scenarios is:
+
+1. **Pooled events** (`EventPool::rent` / `LocalEventPool::rent`) — primary
+   performance target. Anyone reaching for `events_once` for high throughput
+   uses pooled or laked events.
+2. **Embedded / laked events** — also primary. Embedded events live inside
+   user storage with no allocator hop; laked events extend pooling to
+   variable T.
+3. **Boxed events** (`Event::new_in_box`) — least important. Any
+   performance-conscious user will use one of the variants above. Boxed events
+   exist primarily for convenience and for cases where the caller cannot bound
+   the event's lifetime to a specific scope.
+
+Within all variants:
+
+* **Steady-state send + receive on the happy path** dominates priority.
+* **Cancellation paths** (sender dropped without setting, receiver dropped
+  before polling) are secondary — they must not regress unboundedly, but
+  optimizations targeting only cancellation are lower priority than wins on
+  the happy path.
+
+## LocalEvent is expected to beat thread-safe Event
+
+The single-threaded `LocalEvent<T>` variant **must** be at least as fast as,
+and ideally faster than, the thread-safe `Event<T>` variant on equivalent
+operations.
+
+`LocalEvent` does not perform atomic operations, does not contend on a mutex
+when used with `LocalEventPool`, and does not need fences. If a benchmark
+shows `LocalEvent` losing to `Event` on the same scenario, that is a bug or a
+missed optimization opportunity, not a tolerable cost of the simpler
+single-threaded design.
+
+When adding new operations or refactoring existing ones, verify with
+Callgrind that the local variant retains its performance edge.
+
+## Benchmark coverage policy
+
+The package's Callgrind benchmark suite is expected to cover every
+combination of:
+
+* event variant (sync `Event`, local `LocalEvent`)
+* storage strategy (boxed, pooled, embedded / by-ref, laked)
+* primary lifecycle outcome (send + receive happy path, sender dropped,
+  receiver dropped before polling)
+
+When undertaking optimization work in this package, fill any missing scenarios
+proactively as part of the work. Do not gate optimization on the absence of
+a benchmark — add the benchmark, then measure, then decide.
+
+Per the repository convention, every Callgrind scenario should have an
+analogous Criterion scenario where one is meaningful (the reverse is not
+required); see the workspace-level `docs/callgrind-benchmarks.md`.
+
+## `#[inline]` annotations have outsized impact in this package
+
+Empirical evidence (see PR #194 and follow-ups): every layer of the event
+machinery is a thin generic forwarder calling the next layer (e.g.
+`Future::poll` -> `ReceiverCore::poll` -> `Event::poll` -> `EventRef::get` ->
+`Deref::deref`). rustc's cross-crate inline heuristic refuses to export MIR
+for functions that do not look like leaves, so the chain breaks at whichever
+forwarder rustc decides to keep monomorphic.
+
+When adding new methods on the public hot path (rent, send, poll, drop), or
+when refactoring an existing one, run `just package=events_once bench-cg`
+**before and after**. If an apparently trivial change moves more than ~5
+instructions on the lifecycle benchmarks, suspect an inlining regression and
+inspect the bench binary's disassembly with `objdump -d -Mintel -C` to
+confirm whether the function is being inlined.
+
+Inlining is asymmetric and not transitive: inlining a function with a body
+that is too large into its caller can prevent the caller from being inlined
+into ITS caller. When tempted to add `#[inline]` to a heavy method (e.g.
+`PooledRef::release_event`, which takes a mutex), measure first — the
+"inline cascade" can regress overall numbers even though the local symbol
+gets inlined.


### PR DESCRIPTION
Codifies the design priorities and conventions for the `events_once` package as a package-scoped `AGENTS.md`, plus a cross-reference from the workspace-level `AGENTS.md` so future optimization work in this crate is routed through the right principles before benchmarks are measured.

The priorities documented here were settled in conversation with @sandersaares while exploring new optimization candidates after the prior session's lessons-learned doc was merged.

## What this PR adds

* `packages/events_once/AGENTS.md` containing:
  * **Performance priorities** — pooled / lake / embedded events are the primary perf target; boxed is the least important variant; cancellation paths are secondary to the happy path.
  * **LocalEvent expected to beat thread-safe Event** — the single-threaded variant must not lose to the atomic variant on equivalent operations. If it does, that is a bug or missed optimization.
  * **Benchmark coverage policy** — every (variant × storage strategy × lifecycle outcome) combination should be covered; missing scenarios are filled as part of optimization work, not gated on.
  * **Inline annotations have outsized impact in this package** — empirical guidance for future contributors covering the cross-crate inline heuristic, the asymmetric inline cascade (inlining a heavy callee can prevent caller-side inlining), and the practical 'measure with bench-cg before and after' rule.

* A pointer in `AGENTS.md` (workspace root, 'Performance optimization principles' section) directing readers to check for package-scoped `AGENTS.md` before planning optimization work — with `events_once` cited as the canonical example.

## What this PR does not change

No source files, benchmarks, or APIs are modified. This is documentation only. Subsequent PRs in this series will apply the principles to actual code changes.

## Validation

No code changes, no validation needed beyond reading the prose.
