### PR TITLE
perf(infinity_pool): inline RawOpaquePool::insert_with_unchecked

### DIFF
--- a/packages/infinity_pool/src/opaque/pool_raw.rs
+++ b/packages/infinity_pool/src/opaque/pool_raw.rs
@@ -367,6 +367,7 @@ impl RawOpaquePool {
     ///
     /// The closure must correctly initialize the object. All fields that
     /// are not `MaybeUninit` must be initialized when the closure returns.
+    #[inline]
     pub unsafe fn insert_with_unchecked<T, F>(&mut self, f: F) -> RawPooledMut<T>
     where
         F: FnOnce(&mut MaybeUninit<T>),


### PR DESCRIPTION
Annotates `RawOpaquePool::insert_with_unchecked` with `#[inline]`.

This is a generic function on the hot insert path for every `OpaquePool`
variant. Its body is small (a vacancy lookup, a slab insert, a length
update, and a vacancy-tracker bump), but as a generic it is monomorphized
into each caller's CGU. Pre-change disassembly of the Callgrind bench
binary showed many `call` references to a single non-inlined copy.
Annotating with `#[inline]` exposes it for cross-crate inlining and
folds it into callers.

## Measurements

`just package=infinity_pool bench-cg` (Callgrind, instruction counts):

### Insert wins (7 variants)

| bench                                  | before | after | delta  |
| -------------------------------------- | -----: | ----: | -----: |
| pinned_pool_insert_into_10k            |    120 |   112 |  -6.7% |
| local_pinned_pool_insert_into_10k      |     91 |    74 | -18.7% |
| blind_pool_insert_into_10k             |    191 |   170 | -11.0% |
| blind_pool_insert_with_5_layouts       |    221 |   199 | -10.0% |
| opaque_pool_insert_into_10k            |    130 |   109 | -16.2% |
| local_opaque_pool_insert_into_10k      |    101 |    83 | -17.8% |
| raw_opaque_pool_insert_into_10k        |    118 |   102 | -13.6% |

### Cold-path regression (1 variant)

| bench                                       | before | after | delta  |
| ------------------------------------------- | -----: | ----: | -----: |
| local_opaque_pool_drop_handle_from_10k      |     79 |    87 | +10.1% |

Acceptable per `packages/infinity_pool/AGENTS.md`: pools are designed
for long-lived, steady-state workloads where insert is the hot path and
handle drop / teardown is comparatively cold. The other drop benches
(`pinned_pool_drop_handle_from_10k`, `opaque_pool_drop_handle_from_10k`,
`raw_opaque_pool_remove_from_10k`) show no change or noise-level
movement.

### Net effect

~115 instructions saved per call across the insert hot path vs +8 on
one drop variant — a decisive net positive.

## Validation

- `just package=infinity_pool test`: 476/476 pass.
- `just package=infinity_pool validate-local`: clean (no clippy/fmt
  warnings).

## Justification per AGENTS.md `#[inline]` rules

Rule 2 applies: a generic same-crate function on a hot path was not being
inlined into downstream callers. Per the rule, benchmarks were used to
verify the annotation actually helps and to confirm whether to keep or
revert. The numbers move substantially (6.7-18.7% on every insert
variant), so the annotation is kept.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
