### PR TITLE
ci(setup-env): replace wget -q with curl + retries to fix flaky exit-5 failures

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -10,11 +10,23 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        # Print each command before executing so a future silent failure points at
+        # the offending line. The script previously used "wget -q" which masked an
+        # intermittent SSL verification failure as a context-free "exit code 5".
+        set -x
+
         # This supposedly speeds up installation by avoiding mandb updates.
         sudo mv /usr/bin/mandb /usr/bin/mandb.deactivated && sudo cp -p /bin/true /usr/bin/mandb
 
         # Add Microsoft package repository (for PowerShell and any other Microsoft packages).
-        wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+        # We use curl with --retry-all-errors because the runner can transiently fail
+        # TLS verification against packages.microsoft.com during early boot — likely a
+        # race with unattended-upgrades rewriting /etc/ssl/certs/ca-certificates.crt.
+        # --show-error ensures the failure is visible if all retries are exhausted.
+        curl --fail --silent --show-error --location \
+          --retry 5 --retry-delay 2 --retry-all-errors \
+          --output packages-microsoft-prod.deb \
+          "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
         sudo dpkg -i --force-confnew packages-microsoft-prod.deb
 
         sudo apt update


### PR DESCRIPTION
## Problem

The `Install dependencies (Linux)` step in our `setup-environment` composite action occasionally fails with a context-free `##[error]Process completed with exit code 5.` (~1% of CI runs — confirmed 2 instances out of 111 failed runs in the past ~2 months).

## Investigation

In both observed failures the step exited in ~70–100 ms after the script started, with **zero captured output**:

| Run | t=script start | t=exit 5 | Δ |
|---|---|---|---|
| [26472528006](https://github.com/folo-rs/folo/actions/runs/26472528006) (mutants) | 50.833 | 50.905 | 72 ms |
| [26339056661](https://github.com/folo-rs/folo/actions/runs/26339056661) (coverage) | 27.402 | 27.504 | 102 ms |

That window is too short for the apt/dpkg/git-lfs commands the user-visible step name implies — all of those produce diagnostic output before they can fail. The only command in the script that can silently exit with code 5 is `wget`:

> 5  SSL verification failure.
> — `man wget`

The `-q` flag suppresses error messages, so the actual failure was invisible.

## Likely root cause

A transient race during early runner boot where `unattended-upgrades` / `apt-daily.service` rewrites `/etc/ssl/certs/ca-certificates.crt` while our `wget` is reading it, leaving the CA bundle momentarily inconsistent and causing TLS verification to fail. Cannot be reproduced on demand, which fits the user-reported pattern.

## Fix

1. `set -x` at the top of the script — future silent failures will point directly at the offending line in the CI log.
2. Replace `wget -q` with `curl --fail --silent --show-error --location --retry 5 --retry-delay 2 --retry-all-errors`:
    - `--retry-all-errors` retries TLS handshake/verification failures (the suspected cause), not just transient network errors.
    - `--show-error` (paired with `--silent`) keeps the happy path quiet but surfaces the real error if all retries are exhausted.

No behavior change on the happy path; this only changes how transient failures are handled and diagnosed.