### PR TITLE
perf(infinity_pool): split slab-vacancy lookup into hot/cold paths

### DIFF
--- a/packages/infinity_pool/src/opaque/pool_raw.rs
+++ b/packages/infinity_pool/src/opaque/pool_raw.rs
@@ -489,14 +489,33 @@ impl RawOpaquePool {
         RawOpaquePoolIterator::new(self)
     }
 
-    /// Adds a new slab if needed.
+    /// Returns the index of a slab with a vacant slot, allocating a new slab if necessary.
+    ///
+    /// The fast path is a single cached lookup in the vacancy tracker. The cold path
+    /// — allocating a new slab when every existing slab is full — is outlined into
+    /// [`Self::allocate_slab_for_insert`] so the fast path stays small enough to inline
+    /// into the per-insert hot path of every `OpaquePool` variant.
     #[must_use]
+    #[inline]
     fn index_of_slab_to_insert_into(&mut self) -> usize {
         if let Some(index) = self.vacancy_tracker.next_vacancy() {
             // There is a vacancy, so use it.
             return index;
         }
 
+        self.allocate_slab_for_insert()
+    }
+
+    /// Allocates a new slab and returns its index.
+    ///
+    /// This is the cold path of [`Self::index_of_slab_to_insert_into`]: it only runs
+    /// when every existing slab is full. Marked `#[cold]` and `#[inline(never)]` to keep
+    /// the slab-allocation code (and its call into the global allocator) out of the
+    /// per-insert fast path's instruction-cache footprint.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    fn allocate_slab_for_insert(&mut self) -> usize {
         // If we got here, there are no vacancies and we need to extend the pool.
         debug_assert_eq!(self.len(), self.capacity());
 


### PR DESCRIPTION
Closes #203.

Splits `RawOpaquePool::index_of_slab_to_insert_into` into:

- An `#[inline]` thin fast-path wrapper that performs the cached vacancy lookup
  and returns the index. Small enough to fold into the per-insert hot path of
  every `OpaquePool` variant.
- A `#[cold] #[inline(never)]` `allocate_slab_for_insert` helper holding the
  rare slab-allocation path (global allocator call, vacancy tracker resize, Vec
  growth). Marking it `#[cold]` keeps it out of the fast path's instruction
  cache footprint and signals the call site as unlikely to the optimizer.

Same behavior, just a structural split.

## Measurements

`just package=infinity_pool bench-cg` (Callgrind, instruction counts):

### Insert wins (7 variants)

| bench                                  | before | after | delta  |
| -------------------------------------- | -----: | ----: | -----: |
| pinned_pool_insert_into_10k            |    112 |   109 |  -2.7% |
| local_pinned_pool_insert_into_10k      |     74 |    70 |  -5.4% |
| blind_pool_insert_into_10k             |    170 |   164 |  -3.5% |
| blind_pool_insert_with_5_layouts       |    199 |   194 |  -2.5% |
| opaque_pool_insert_into_10k            |    109 |   105 |  -3.7% |
| local_opaque_pool_insert_into_10k      |     83 |    80 |  -3.6% |
| raw_opaque_pool_insert_into_10k        |    102 |    98 |  -3.9% |

### Drop-path bonus

| bench                                       | before | after | delta  |
| ------------------------------------------- | -----: | ----: | -----: |
| local_opaque_pool_drop_handle_from_10k      |     87 |    69 | -20.7% |

The drop benchmark improvement is a bonus: removing the cold-path body from
the insert function evidently freed up enough inlining budget elsewhere in
the CGU that the drop path tightened up as well. The other drop benches
(`pinned_pool_drop_handle_from_10k`, `opaque_pool_drop_handle_from_10k`,
`raw_opaque_pool_remove_from_10k`) are unchanged or noise-level.

### Cold-path benches

`pinned_pool_insert_into_empty` (which exercises the new cold path on its
single insert): 3771 → 3743 instructions (-0.7%). Within noise — the cold
path is dominated by the actual slab allocation, not the call indirection.

### Net effect

~27 instructions saved per insert across the 7 insert variants, plus an
unexpected -18 on `local_opaque_pool_drop_handle_from_10k`. No regressions.

## Validation

- `just package=infinity_pool validate-local` (Windows): clean.
- `just package=infinity_pool validate-local` (Linux/WSL): clean.
- All tests pass: 476 nextest, 474 Miri, 44 doctests.

## Justification per AGENTS.md `#[inline]` rules

The new `#[inline]` on the fast-path wrapper applies Rule 2: a same-crate
function on a hot path was not being inlined into its single caller in
`insert_with_unchecked`, because its body included an unconditional branch
into the slab-allocation cold path. Outlining the cold path makes the
wrapper a 2-instruction leaf that rustc's `cross_crate_inlinable` heuristic
now accepts.

The `#[inline(never)]` on the cold helper applies Rule 3 with explicit
justification (per the comment): we want the allocator call and Vec growth
permanently out of the per-insert fast path's I-cache footprint.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
