### PR TITLE
perf(events_once): collapse LocalEvent::set state transition (#202)

### DIFF
--- a/packages/events_once/benches/events_once_cg.rs
+++ b/packages/events_once/benches/events_once_cg.rs
@@ -87,8 +87,7 @@ mod linux {
     }
 
     fn make_local_endpoints_bound() -> LocalEndpoints {
-        let (sender, receiver) = LocalEvent::<i32>::boxed();
-        (sender, Box::pin(receiver))
+        make_local_endpoints()
     }
 
     fn make_sync_pool() -> EventPool<i32> {

--- a/packages/events_once/benches/events_once_cg.rs
+++ b/packages/events_once/benches/events_once_cg.rs
@@ -62,6 +62,23 @@ mod linux {
         Box::pin(receiver)
     }
 
+    fn make_local_endpoints() -> LocalEndpoints {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        (sender, Box::pin(receiver))
+    }
+
+    fn make_local_sender_only() -> BoxedLocalSender<i32> {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        drop(receiver);
+        sender
+    }
+
+    fn make_local_receiver_only() -> Pin<Box<BoxedLocalReceiver<i32>>> {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        drop(sender);
+        Box::pin(receiver)
+    }
+
     fn make_sync_endpoints_bound() -> SyncEndpoints {
         // The BOUND state is the initial state of every freshly constructed event: no value
         // has been set, no awaiter has been registered. Dropping the sender from this state
@@ -292,6 +309,39 @@ mod linux {
         receiver
     }
 
+    #[library_benchmark]
+    #[bench::connected(make_local_endpoints())]
+    fn local_set_connected(input: LocalEndpoints) -> Pin<Box<BoxedLocalReceiver<i32>>> {
+        let (sender, receiver) = input;
+        sender.send(black_box(42));
+        receiver
+    }
+
+    #[library_benchmark]
+    #[bench::disconnected(make_local_sender_only())]
+    fn local_set_disconnected(sender: BoxedLocalSender<i32>) {
+        sender.send(black_box(42));
+    }
+
+    #[library_benchmark]
+    #[bench::connected(make_local_endpoints())]
+    fn local_poll_connected(input: LocalEndpoints) -> LocalEndpoints {
+        let (sender, mut receiver) = input;
+        let mut cx = task::Context::from_waker(Waker::noop());
+        _ = black_box(receiver.as_mut().poll(&mut cx));
+        (sender, receiver)
+    }
+
+    #[library_benchmark]
+    #[bench::disconnected(make_local_receiver_only())]
+    fn local_poll_disconnected(
+        mut receiver: Pin<Box<BoxedLocalReceiver<i32>>>,
+    ) -> Pin<Box<BoxedLocalReceiver<i32>>> {
+        let mut cx = task::Context::from_waker(Waker::noop());
+        _ = black_box(receiver.as_mut().poll(&mut cx));
+        receiver
+    }
+
     // ---------- Cancellation paths ----------
     //
     // Sender dropped without sending, from BOUND state - the receiver has not yet
@@ -333,8 +383,12 @@ mod linux {
         benchmarks = [
             sync_set_connected,
             sync_set_disconnected,
+            local_set_connected,
+            local_set_disconnected,
             sync_poll_connected,
             sync_poll_disconnected,
+            local_poll_connected,
+            local_poll_disconnected,
             sync_sender_dropped_from_bound,
             local_sender_dropped_from_bound,
         ]

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -226,6 +226,7 @@ impl<T: 'static> LocalEvent<T> {
     /// Sets the value of the event and notifies the awaiter, if there is one.
     ///
     /// Returns `Err` if the receiver has already disconnected and we must clean up the event now.
+    #[inline]
     pub(crate) fn set(&self, result: T) -> Result<(), Disconnected> {
         let value_cell = self.value.get();
 
@@ -241,8 +242,18 @@ impl<T: 'static> LocalEvent<T> {
             value_cell.write(MaybeUninit::new(result));
         }
 
-        let previous_state = self.state.get();
-        self.state.set(previous_state.wrapping_add(1));
+        // We transition directly to EVENT_SET. The sync variant uses a `+= 1`
+        // trick that exits the BOUND path in a single atomic fetch_add and uses
+        // an intermediate EVENT_SIGNALING state to act as a mutex against the
+        // concurrent receiver. LocalEvent is single-threaded, so the SIGNALING
+        // intermediate has no purpose, and the non-atomic equivalent of `+= 1`
+        // (load + add + store) is one instruction wider than a direct store.
+        // `Cell::replace` emits a single load + store sequence and collapses
+        // the AWAITING branch's two state writes (SIGNALING then SET) into
+        // one. In the DISCONNECTED branch the SET we just stored is a
+        // don't-care because the event is about to be deallocated, and no
+        // external observer can witness the transient state.
+        let previous_state = self.state.replace(EVENT_SET);
 
         match previous_state {
             EVENT_BOUND => {
@@ -253,22 +264,28 @@ impl<T: 'static> LocalEvent<T> {
             EVENT_AWAITING => {
                 // There was someone listening via the receiver. We need to
                 // notify the awaiter that they can come back for the value now.
+                //
+                // The state is already EVENT_SET (set by the replace above), so
+                // the reentrant receiver poll triggered by `wake()` will observe
+                // a terminal state and proceed straight to value extraction.
 
-                // SAFETY: The only other potential references to the field are other short-lived
-                // references in this type, which cannot exist at the moment because
-                // the type is single-threaded and does not let any references escape.
-                let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
-                // SAFETY: UnsafeCell pointer is never null.
-                let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
+                // Extract the waker in a tight scope so the `&mut MaybeUninit<Waker>`
+                // borrow is released before the wake callback fires, matching the
+                // callback-safety guidance in docs/callback-safety.md.
+                let waker = {
+                    // SAFETY: The only other potential references to the field are other
+                    // short-lived references in this type, which cannot exist at the moment
+                    // because the type is single-threaded and does not let any references
+                    // escape.
+                    let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
+                    // SAFETY: UnsafeCell pointer is never null.
+                    let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
 
-                // We extract the waker and consider the field uninitialized again.
-                // SAFETY: We were in EVENT_AWAITING which guarantees there is a waker in there.
-                let waker = unsafe { awaiter_cell.assume_init_read() };
-
-                // Before sending the wake signal we must transition into `EVENT_SET` state, so
-                // as soon as it wakes up it can grab the result. Granted, as this specific type
-                // is a single-threaded signal, the order of operations does not actually matter.
-                self.state.set(EVENT_SET);
+                    // We extract the waker and consider the field uninitialized again.
+                    // SAFETY: We were in EVENT_AWAITING which guarantees there is a waker
+                    // in there.
+                    unsafe { awaiter_cell.assume_init_read() }
+                };
 
                 // Come and get it.
                 waker.wake();
@@ -526,10 +543,14 @@ impl<T: 'static> fmt::Debug for LocalEvent<T> {
 #[expect(clippy::undocumented_unsafe_blocks, reason = "test code, be concise")]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::cell::RefCell;
     use std::panic::{RefUnwindSafe, UnwindSafe};
+    use std::pin::Pin;
+    use std::rc::Rc;
     use std::task::{self, Poll};
 
     use static_assertions::{assert_impl_all, assert_not_impl_any};
+    use testing::{ReentrantWakerData, with_watchdog};
 
     use super::*;
     use crate::IntoValueError;
@@ -1127,5 +1148,66 @@ mod tests {
         });
 
         assert!(called);
+    }
+
+    // Regression test for the synchronous reentrancy hazard in `set`. A waker
+    // fired by the sender's `send` that synchronously polls the receiver must
+    // observe a terminal state (SET) and read out the value, not see the
+    // intermediate state from the +1 collapse. This also exercises the
+    // callback-safety contract that the awaiter cell is drained before the
+    // wake callback runs.
+    #[test]
+    #[cfg_attr(miri, ignore)] // Custom raw waker is not Miri-compatible.
+    fn boxed_send_with_reentrant_waker_observes_set() {
+        type ObservedResult = Poll<Result<i32, Disconnected>>;
+
+        with_watchdog(|| {
+            let (sender, receiver) = LocalEvent::<i32>::boxed();
+            let receiver_holder: Rc<RefCell<Option<Pin<Box<_>>>>> =
+                Rc::new(RefCell::new(Some(Box::pin(receiver))));
+            let receiver_for_waker = Rc::clone(&receiver_holder);
+
+            let reentrant_observed: Rc<RefCell<Option<ObservedResult>>> =
+                Rc::new(RefCell::new(None));
+            let observed_for_waker = Rc::clone(&reentrant_observed);
+
+            let waker_data = ReentrantWakerData::new(move || {
+                // Synchronously poll the receiver from inside the waker.
+                // The receiver should observe EVENT_SET and return Ready(Ok(42)).
+                let mut holder = receiver_for_waker.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let noop = Waker::noop();
+                let mut cx = task::Context::from_waker(noop);
+                let result = receiver.as_mut().poll(&mut cx);
+                *observed_for_waker.borrow_mut() = Some(result);
+            });
+            // SAFETY: `waker_data` outlives the waker and the test is single-threaded.
+            let waker = unsafe { waker_data.waker() };
+
+            // First poll transitions BOUND -> AWAITING and stores the
+            // reentrant waker.
+            {
+                let mut holder = receiver_holder.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let mut cx = task::Context::from_waker(&waker);
+                assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+            }
+
+            // Send a value. This calls `set` which transitions AWAITING -> SET
+            // and then invokes the waker, which must observe the SET state
+            // and consume the value reentrantly.
+            sender.send(42);
+
+            assert!(waker_data.was_woken());
+            let observed = reentrant_observed.borrow_mut().take();
+            assert!(
+                matches!(observed, Some(Poll::Ready(Ok(42)))),
+                "reentrant poll should observe SET and read the value",
+            );
+
+            // The receiver was consumed reentrantly; the receiver_holder still
+            // owns the Pin<Box> shell, drop it to release.
+            drop(receiver_holder.borrow_mut().take());
+        });
     }
 }

--- a/packages/events_once/src/core/state.rs
+++ b/packages/events_once/src/core/state.rs
@@ -11,12 +11,21 @@
 //!                 this state is a mutex of sorts, to stop a receiver from updating event state;
 //!                 we transition into the "set" state from this state, at which point the receiver
 //!                 is welcome to receive the payload.
+//!                 Only the thread-safe `Event` variant ever observes this state; the
+//!                 single-threaded `LocalEvent` variant transitions directly from `awaiting`
+//!                 to `set` because no concurrent receiver can witness the intermediate value.
 //! 4 - disconnected - one of the endpoints has disconnected before completing the send/receive.
 //!
-//! A key optimization is that the "send" transition is a simple `+= 1` operation:
+//! A key optimization in the thread-safe `Event` variant is that the "send" transition is a
+//! simple `+= 1` operation, executed via a single atomic `fetch_add`:
 //!
 //! * If nobody is listening, we get `bound + 1 = set`
 //! * If a receiver is listening, we get `awaiting + 1 = signaling`
+//!
+//! This trick is specific to the thread-safe variant because it compresses the read-and-write
+//! into one atomic instruction. The single-threaded `LocalEvent` variant cannot benefit from
+//! the encoding (a non-atomic `Cell` `+= 1` lowers to a separate load + add + store), so it
+//! transitions directly to the target state instead.
 //!
 //! These states are also used to coordinate which of the endpoints drops the event itself:
 //! * If the receiver disconnects first, it will set the `disconnected` state and the sender


### PR DESCRIPTION
## Summary

Closes #202.

Collapses the multiple field updates in `LocalEvent::set` into a single state transition by replacing the `state.get() + state.set(prev + 1)` pattern with `state.replace(EVENT_SET)`. The `+= 1` trick is specific to the sync variant where `fetch_add(1, Release)` compiles to a single `lock xadd` instruction. In `LocalEvent`, the non-atomic equivalent lowers to three separate instructions (`movzx` + `lea` + `mov`), giving up an instruction relative to a direct store.

The single-threaded variant has no need for the intermediate `EVENT_SIGNALING` state (which acts as a mutex against the concurrent receiver in the sync variant), so the redundant second `state.set(EVENT_SET)` in the AWAITING branch is removed at the same time.

## Why `#[inline]`

Without `#[inline]`, the smaller `LocalEvent::set` body shifts rustc's inlining decisions for unrelated functions in the same compilation unit (e.g. `infinity_pool::opaque::slab::Slab::remove` gets pulled out of inlining). This is the "inline cascade" warned about in `packages/events_once/AGENTS.md`. Adding `#[inline]` pins the boundary and gives a net improvement on the primary lifecycle targets.

## Callgrind impact vs `main`

| Benchmark | Main | After | Δ |
| --- | --- | --- | --- |
| `sync_pooled_lifecycle` | 270 | **267** | **−3** |
| `sync_lake_lifecycle` | 370 | **367** | **−3** |
| `sync_poll_connected` | 71 | **68** | **−3** |
| `local_embedded_lifecycle` | 45 | 44 | −1 |
| `local_set_connected` | 19 | **18** | **−1** (issue goal) |
| `local_boxed_lifecycle` | 217 | 218 | +1 |
| `local_pooled_lifecycle` | 217 | 220 | +3 |
| `local_lake_lifecycle` | 295 | 298 | +3 |

The three "primary target" lifecycle benches (`sync_pooled` / `sync_lake` per `packages/events_once/AGENTS.md`) each improve by 3 instructions. The local lifecycle benches each gain 1-3 instructions but `LocalEvent` continues to dominate `Event` on every scenario where it already did — the pooled / lake / embedded paths remain ~50-70 instructions faster than the sync counterparts.

## Bench coverage

Filled the missing local partial-state Callgrind benches: `local_set_connected`, `local_set_disconnected`, `local_poll_connected`, `local_poll_disconnected`. These complete the parity-with-sync grid described in `packages/events_once/AGENTS.md`'s benchmark coverage policy.

## Regression test

Added `boxed_send_with_reentrant_waker_observes_set`: polls a `LocalEvent` receiver, sends from a waker that re-enters and synchronously polls the receiver again. The reentrant poll must observe `EVENT_SET` and read out the value, verifying that the state machine and the awaiter cell are both in a consistent terminal state before `wake()` runs — i.e. the callback-safety contract from `docs/callback-safety.md`.

## Validation

- `just package=events_once test`: 211 passed
- `just package=events_once validate-local`: 208 nextest tests + 3 skipped, zero warnings
- `just package=events_once miri`: 208 passed
- `just package=events_once bench-cg`: numbers above (deterministic, re-ran twice)
