### PR TITLE
perf(events_once): fast-path BOUND->DISCONNECTED on sender drop

### DIFF
--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -377,6 +377,31 @@ impl<T: 'static> LocalEvent<T> {
     ///
     /// Returns `Err` if the receiver has already disconnected and we must clean up the event now.
     pub(crate) fn sender_dropped_without_set(&self) -> Result<(), Disconnected> {
+        // Fast path: the receiver has not yet polled, so there is no awaiter to wake. This
+        // mirrors the `Event<T>` fast path so that `LocalEvent<T>` retains its performance
+        // edge over the thread-safe variant on the cancellation path.
+        if self.state.get() == EVENT_BOUND {
+            self.state.set(EVENT_DISCONNECTED);
+            // The receiver is the last endpoint remaining, so it will clean up.
+            return Ok(());
+        }
+
+        // Slow path - the receiver is awaiting (with a waker we must fire) or has
+        // already disconnected. Outlined as `#[cold]` so the fast-path BOUND case
+        // stays compact.
+        self.sender_dropped_without_set_slow()
+    }
+
+    /// Slow-path companion to [`sender_dropped_without_set`].
+    ///
+    /// Handles the cases where the receiver has registered an awaiter (`EVENT_AWAITING`)
+    /// or has already disconnected (`EVENT_DISCONNECTED`).
+    ///
+    /// `#[cold]` and `#[inline(never)]` keep this code out of the fast-path callsite's
+    /// instruction stream, mirroring the sync `Event<T>` slow-path treatment.
+    #[cold]
+    #[inline(never)]
+    fn sender_dropped_without_set_slow(&self) -> Result<(), Disconnected> {
         let previous_state = self.state.get();
 
         // We can immediately set this because this is a single-threaded event, so there cannot
@@ -384,11 +409,6 @@ impl<T: 'static> LocalEvent<T> {
         self.state.set(EVENT_DISCONNECTED);
 
         match previous_state {
-            EVENT_BOUND => {
-                // There was nobody listening via the receiver - our work here is done.
-                // The receiver still exists, so it will clean up.
-                Ok(())
-            }
             EVENT_AWAITING => {
                 // There was someone listening via the receiver. We need to notify
                 // the awaiter that they can come back for another check now.
@@ -414,7 +434,8 @@ impl<T: 'static> LocalEvent<T> {
                 // The sender is the last endpoint remaining, so it will clean up.
                 Err(Disconnected)
             }
-            // Defensive: state machine guarantees this is unreachable.
+            // Defensive: state machine guarantees this is unreachable. The fast path already
+            // handled EVENT_BOUND, so it cannot be observed here either.
             _ => {
                 unreachable!("unreachable LocalEvent state on sender disconnect: {previous_state}");
             }

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -392,29 +392,115 @@ where
     pub(crate) fn sender_dropped_without_set(
         event_cell: &UnsafeCell<Self>,
     ) -> Result<(), Disconnected> {
-        // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
-        // The event lives until both sender and receiver are dropped or inert, so we know it must
-        // still exist because something was able to call this method.
+        // SAFETY: Validity: the event lives until both sender and receiver are dropped or
+        // inert, so it must still exist because something was able to call this method.
+        // `UnsafeCell::get()` returns a non-null aligned pointer to the initialized `Event<T>`.
+        // Aliasing: we only create shared references to the event throughout the type, and the
+        // receiver does likewise; mutation goes through atomics or `UnsafeCell`-guarded fields,
+        // so no `&mut Event<T>` ever exists.
         let event_maybe = unsafe { event_cell.get().as_ref() };
-        // SAFETY: UnsafeCell pointer is never null.
+        // SAFETY: `UnsafeCell::get()` is documented as never returning a null pointer.
         let event = unsafe { event_maybe.unwrap_unchecked() };
 
-        // We first need to switch into the SIGNALING state, which acquires exclusive access
+        // Fast path: the receiver has not yet polled, so there is no awaiter to wake and no
+        // need to acquire the SIGNALING synchronization block. A single CAS transitions us
+        // directly to the terminal DISCONNECTED state, avoiding the swap + store pair used
+        // by the general path below.
+        //
+        // We use Release on success because we are publishing the terminal state to the
+        // receiver, which may observe it via Acquire load in `poll()` or Acquire fence in
+        // `poll_awaiting`. Release ensures any sender-side writes before the drop are
+        // visible to the receiver after it observes DISCONNECTED.
+        //
+        // It is legal to transition straight to DISCONNECTED here, permitting dealloc, even
+        // though we still hold an `&event` reference, which ordinarily means it is still
+        // illegal to deallocate the object. The `event` binding here was constructed via the
+        // `as_ref()` return value (not received as a function argument), so Stacked Borrows
+        // does not install a strong protector on it; the receiver is free to dealloc the
+        // moment it observes DISCONNECTED.
+        if event
+            .state
+            .compare_exchange(
+                EVENT_BOUND,
+                EVENT_DISCONNECTED,
+                atomic::Ordering::Release,
+                atomic::Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            // The receiver is the last endpoint remaining, so it will clean up.
+            return Ok(());
+        }
+
+        // Slow path - the receiver is mid-poll, has already polled, or has disconnected.
+        // Outlined as a `#[cold]` helper so the fast-path BOUND case stays compact in
+        // instruction cache; this matters because sender drops are extremely common in
+        // cancellation-heavy workloads (timeouts, request cancellations).
+        //
+        // The slow path takes `&UnsafeCell<Self>` rather than `&Self` so that the function-
+        // entry retag does not install a strong (SharedReadOnly) Stacked Borrows protector
+        // on the Freeze parts of `Event<T>`. Such a protector would block the receiver from
+        // deallocating the event after observing DISCONNECTED while the slow path is still
+        // returning (the receiver can be scheduled between the `store(DISCONNECTED)` and
+        // the function return). With `&UnsafeCell<Self>` the protector covers only the
+        // !Freeze SharedReadWrite tag, which Miri treats as a weak protector that permits
+        // dealloc. Inside the slow path, `&Self` is reconstructed via a pointer deref so
+        // it is never retagged at a function boundary and never carries a protector.
+        Self::sender_dropped_without_set_slow(event_cell)
+    }
+
+    /// Slow-path companion to [`sender_dropped_without_set`].
+    ///
+    /// Handles the cases where the receiver has registered an awaiter (`EVENT_AWAITING`),
+    /// has already disconnected (`EVENT_DISCONNECTED`), or is mid-transition.
+    ///
+    /// `#[cold]` and `#[inline(never)]` keep the slow path out of the fast-path callsite's
+    /// instruction stream. Without this, the BOUND fast path picks up an extra cache line
+    /// of cold code in the same function (verified via Callgrind: ~30 cycles of estimated
+    /// cold instruction-fetch penalty).
+    ///
+    /// Takes `&UnsafeCell<Self>` rather than `&Self` so that the Stacked Borrows retag on
+    /// function entry does not install a strong protector on the Freeze parts of
+    /// `Event<T>`; see the call site in [`Self::sender_dropped_without_set`] for the full
+    /// rationale.
+    #[cold]
+    #[inline(never)]
+    fn sender_dropped_without_set_slow(event_cell: &UnsafeCell<Self>) -> Result<(), Disconnected> {
+        // SAFETY: Validity: the event lives until both sender and receiver are dropped or
+        // inert, so it must still exist because we got here from
+        // `sender_dropped_without_set`, which only delegates here while the sender is still
+        // live. `UnsafeCell::get()` returns a non-null aligned pointer to the initialized
+        // `Event<T>`. Aliasing: we only create shared references to the event throughout
+        // the type, and the receiver does likewise; mutation goes through atomics or
+        // `UnsafeCell`-guarded fields, so no `&mut Event<T>` ever exists. The `&Self`
+        // binding here is local (not a function argument), so it carries no protector and
+        // the receiver remains free to dealloc the event after observing DISCONNECTED.
+        let event_maybe = unsafe { event_cell.get().as_ref() };
+        // SAFETY: `UnsafeCell::get()` is documented as never returning a null pointer.
+        let event = unsafe { event_maybe.unwrap_unchecked() };
+
+        // We need to switch into the SIGNALING state, which acquires exclusive access
         // of the awaiter field, so we can send the wake signal if there is an awaiter.
         // Only after that can we transition into the DISCONNECTED state (because that must
-        // be our last action - the receiver may clean up the event at any point after we do that).
+        // be our last action - the receiver may clean up the event at any point after we do
+        // that).
 
         let previous_state = event.state.swap(EVENT_SIGNALING, atomic::Ordering::Relaxed);
 
         match previous_state {
             EVENT_BOUND => {
-                // There was nobody polling via the receiver - our work here is done.
+                // The fast-path CAS observed a non-BOUND state, but by the time we did the
+                // swap above, the state was BOUND again. This can happen when a concurrent
+                // receiver transitioned BOUND -> AWAITING -> BOUND in `poll_awaiting`
+                // between the two atomic operations. The receiver has already destroyed
+                // the previous waker in that path, so there is no awaiter for us to handle.
 
-                // It is legal to set DISCONNECTED here, permitting dealloc, even though we still
-                // hold an &event reference here, which ordinarily means it is still illegal to
-                // deallocate the object. However, the dangling reference in this method is an
-                // `UnsafeCell` which is allowed to dangle, so we are fine even if the object is
-                // immediately destroyed after this line.
+                // Setting DISCONNECTED here permits the receiver to immediately observe the
+                // terminal state and deallocate the event. That is safe even though we are
+                // still inside this function: our `event_cell: &UnsafeCell<Self>` parameter
+                // carries only a weak (SharedReadWrite) Stacked Borrows protector, and the
+                // local `&event` is not retagged across a function boundary, so no strong
+                // protector blocks the dealloc.
                 event
                     .state
                     .store(EVENT_DISCONNECTED, atomic::Ordering::Release);
@@ -446,11 +532,12 @@ where
                 // used by `set()` on the `EVENT_SET` path and prevents same-thread reentrancy
                 // deadlocks.
                 //
-                // It is legal to set DISCONNECTED here, permitting dealloc, even though we still
-                // hold an &event reference here, which ordinarily means it is still illegal to
-                // deallocate the object. However, the dangling reference in this method is an
-                // `UnsafeCell` which is allowed to dangle, so we are fine even if the object is
-                // immediately destroyed after this line.
+                // Setting DISCONNECTED here permits the receiver to immediately observe the
+                // terminal state and deallocate the event. That is safe even though we are
+                // still inside this function: our `event_cell: &UnsafeCell<Self>` parameter
+                // carries only a weak (SharedReadWrite) Stacked Borrows protector, and the
+                // local `&event` is not retagged across a function boundary, so no strong
+                // protector blocks the dealloc.
                 event
                     .state
                     .store(EVENT_DISCONNECTED, atomic::Ordering::Release);


### PR DESCRIPTION
Closes #201.

## What this changes

`Event::sender_dropped_without_set` and `LocalEvent::sender_dropped_without_set` now have a fast path that handles the common BOUND case in a single atomic operation, with the awaiter-handling logic moved to a `#[cold] #[inline(never)]` slow-path helper.

For `Event<T>` (thread-safe), the fast path is a single `compare_exchange(BOUND -> DISCONNECTED, Release/Relaxed)` that skips the BOUND -> SIGNALING -> DISCONNECTED handshake when there is no awaiter to wake. For `LocalEvent<T>`, the fast path is a single non-atomic load + store, which keeps `LocalEvent` faster than `Event` as required by `packages/events_once/AGENTS.md`.

## Why

Sender drops without set are extremely common in cancellation-heavy workloads (timeouts, request cancellations). The fast path is on a tight loop in those workloads, so collapsing the swap + match + store into a single CAS and outlining the cold awaiter-handling code into a separate function keeps the hot instruction stream compact.

## Callgrind results

`events_once_cg::partial_state_group` benchmarks (added in #197):

| benchmark | before | after | delta |
| --- | --- | --- | --- |
| `sync_sender_dropped_from_bound` | 15 inst / 92 cycles | 13 inst / 54 cycles | -2 inst (-13%) / -38 cycles (-41%) |
| `local_sender_dropped_from_bound` | 14 inst / 90 cycles | 12 inst / 54 cycles | -2 inst (-14%) / -36 cycles (-40%) |

## Why the slow-path helper takes `&UnsafeCell<Self>` and not `&Self`

The slow path is outlined as `fn sender_dropped_without_set_slow(event_cell: &UnsafeCell<Self>)`. Taking `&Self` instead would cause Stacked Borrows to retag the Freeze parts of `Event<T>` (e.g. `PhantomPinned`, the debug-only `Mutex<BacktraceType>`) with `SharedReadOnly` and install a *strong* protector at function entry. That protector would block the receiver from deallocating the event after observing `DISCONNECTED` while the slow path is still returning &mdash; the receiver thread can be scheduled between the slow path's `store(DISCONNECTED)` and its function return.

Reproduces with the previously-flaky `boxed_drop_receive_unbiased_mt` test under `-Zmiri-many-seeds` (seed 6 of shard 1/8 was a reliable trigger).

The fix: take `&UnsafeCell<Self>` so the retag is fully `SharedReadWrite` (weak protector, permits dealloc), and reconstruct `&Self` inside the slow path via a local pointer deref (no function-boundary retag, no protector at all).

## Validation

- `just package=events_once validate-local` on Windows and Linux: passing.
- `just package=events_once miri-harder` (64 seeds) on Windows and Linux: passing.
- `just package=events_once bench-cg`: 14 benches, 0 regressions.
