### PR TITLE
bench(events_once): add AWAITING-state cancellation benchmarks

### DIFF
--- a/packages/events_once/benches/events_once_cg.rs
+++ b/packages/events_once/benches/events_once_cg.rs
@@ -90,6 +90,25 @@ mod linux {
         make_local_endpoints()
     }
 
+    fn make_sync_endpoints_awaiting() -> SyncEndpoints {
+        // The AWAITING state is reached after the receiver has polled the event once and
+        // registered a waker. In practice this is the most common state when a sender is
+        // dropped without sending: most events that are ever awaited are awaited
+        // immediately after subscription, so cancellation typically catches the event with
+        // an awaiter already registered.
+        let (sender, mut receiver) = make_sync_endpoints();
+        let mut cx = task::Context::from_waker(Waker::noop());
+        _ = black_box(receiver.as_mut().poll(&mut cx));
+        (sender, receiver)
+    }
+
+    fn make_local_endpoints_awaiting() -> LocalEndpoints {
+        let (sender, mut receiver) = make_local_endpoints();
+        let mut cx = task::Context::from_waker(Waker::noop());
+        _ = black_box(receiver.as_mut().poll(&mut cx));
+        (sender, receiver)
+    }
+
     fn make_sync_pool() -> EventPool<i32> {
         EventPool::<i32>::new()
     }
@@ -343,9 +362,15 @@ mod linux {
 
     // ---------- Cancellation paths ----------
     //
-    // Sender dropped without sending, from BOUND state - the receiver has not yet
-    // polled. This is the fast cancellation path: no waker is registered, the
-    // sender just signals DISCONNECTED.
+    // Sender dropped without sending. Two sub-cases are measured because cancellation can
+    // catch the event in different states with very different costs:
+    //
+    // - BOUND: the receiver has not yet polled. No waker is registered, no wake to deliver.
+    // - AWAITING: the receiver has polled and parked a waker. We must wake the receiver and
+    //   (for the sync variant) acquire the SIGNALING handshake to safely consume the waker
+    //   before we publish the terminal DISCONNECTED state. AWAITING is the more common
+    //   state in practice: most events that get awaited are awaited immediately after
+    //   subscription.
 
     #[library_benchmark]
     #[bench::bound(make_sync_endpoints_bound())]
@@ -358,6 +383,24 @@ mod linux {
     #[library_benchmark]
     #[bench::bound(make_local_endpoints_bound())]
     fn local_sender_dropped_from_bound(input: LocalEndpoints) -> Pin<Box<BoxedLocalReceiver<i32>>> {
+        let (sender, receiver) = input;
+        drop(sender);
+        receiver
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(make_sync_endpoints_awaiting())]
+    fn sync_sender_dropped_from_awaiting(input: SyncEndpoints) -> Pin<Box<BoxedReceiver<i32>>> {
+        let (sender, receiver) = input;
+        drop(sender);
+        receiver
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(make_local_endpoints_awaiting())]
+    fn local_sender_dropped_from_awaiting(
+        input: LocalEndpoints,
+    ) -> Pin<Box<BoxedLocalReceiver<i32>>> {
         let (sender, receiver) = input;
         drop(sender);
         receiver
@@ -390,6 +433,8 @@ mod linux {
             local_poll_disconnected,
             sync_sender_dropped_from_bound,
             local_sender_dropped_from_bound,
+            sync_sender_dropped_from_awaiting,
+            local_sender_dropped_from_awaiting,
         ]
     );
 }


### PR DESCRIPTION
Sender-drop cancellation can catch an event in two very different states, with very
different costs:

- **BOUND**: the receiver has not yet polled. No waker registered, no wake to deliver.
  Already covered by `sync_sender_dropped_from_bound` / `local_sender_dropped_from_bound`.
- **AWAITING**: the receiver has polled once and parked a waker. The sender (sync variant)
  must acquire the SIGNALING handshake to safely consume the waker, deliver the wake, and
  publish DISCONNECTED.

AWAITING is the more common cancellation state in practice: most events that are ever
awaited are awaited immediately after subscription, so by the time the sender is dropped
the receiver has typically already registered.

This PR adds:

- `sync_sender_dropped_from_awaiting`
- `local_sender_dropped_from_awaiting`

The new benches poll the receiver once with `Waker::noop()` during per-iteration setup,
then measure the cost of dropping the sender. They document the structural minimum cost of
awaited cancellation:

| Bench                                  | Instructions | RAM Hits | Estimated Cycles |
| -------------------------------------- | -----------: | -------: | ---------------: |
| `sync_sender_dropped_from_awaiting`    |           24 |        4 |              174 |
| `local_sender_dropped_from_awaiting`   |           20 |        3 |              139 |
| `sync_sender_dropped_from_bound`       |           15 |        3 |              126 |
| `local_sender_dropped_from_bound`      |           14 |        2 |               90 |

### Why this matters

Future optimizers of the BOUND fast path will see a single number and might be tempted to
shave instructions there. But any detection cost added to BOUND (a load, a branch, a CAS
that misses) tends to surface on the AWAITING path as code-layout / cache effects.
Surfacing the AWAITING cost as its own bench makes it impossible to miss this trade-off in
future PRs.

Related: investigation in #201 / #209 found AWAITING to be at a structural minimum (2
atomics + wake) and every BOUND-only fast path variant regresses AWAITING.
