### PR TITLE
docs(events_once): correct BOUND cancellation comment

### DIFF
--- a/packages/events_once/benches/events_once_cg.rs
+++ b/packages/events_once/benches/events_once_cg.rs
@@ -82,7 +82,9 @@ mod linux {
     fn make_sync_endpoints_bound() -> SyncEndpoints {
         // The BOUND state is the initial state of every freshly constructed event: no value
         // has been set, no awaiter has been registered. Dropping the sender from this state
-        // is the fast path of cancellation - the receiver has not yet asked for the value.
+        // exercises the cheaper of the two cancellation paths because there is no waker to
+        // consume and no wake to deliver - but it is also the less common case in practice,
+        // see the AWAITING helper below.
         make_sync_endpoints()
     }
 


### PR DESCRIPTION
Tiny follow-up to #210.

The `make_sync_endpoints_bound()` helper still described BOUND drop as "the fast path of cancellation". That wording predates the AWAITING benches and suggests BOUND is the case the implementation is optimized around — which is exactly the framing #210 corrected by adding the AWAITING benches and noting that AWAITING is the more common state in practice.

Replaces it with a neutral description that:

- Acknowledges BOUND drop is structurally cheaper (no waker to consume, no wake to deliver).
- Points the reader at the AWAITING helper below for the common-case context.

Doc-only, no measurable changes.
