### PR TITLE
awaiter_set: skip dead Inner writes in unregister (-16% via Callgrind)

### DIFF
--- a/packages/awaiter_set/src/awaiter.rs
+++ b/packages/awaiter_set/src/awaiter.rs
@@ -27,8 +27,13 @@ pub(crate) struct Inner {
     // notify_one).
     pub(crate) waker: Option<Waker>,
 
-    // Idle/Notified: null. Waiting: linked-set pointers maintained
-    // by AwaiterSet.
+    // Linked-set pointers maintained by AwaiterSet. Defined only while
+    // the awaiter is WAITING — on transitions out of WAITING the prior
+    // values are left stale rather than spending two stores to clear
+    // them (no code path reads next/prev outside WAITING, and
+    // `register` fully overwrites both on the next IDLE -> WAITING
+    // transition). `Inner::idle()` initializes them to null for
+    // freshly-constructed awaiters.
     pub(crate) next: *mut Awaiter,
     pub(crate) prev: *mut Awaiter,
 
@@ -37,10 +42,16 @@ pub(crate) struct Inner {
     // `notify_one_prior_generation` to distinguish awaiters that
     // were already registered when a generation advance occurred
     // from awaiters registered later (typically by a reentrant
-    // waker firing during the drain). Zero is reserved as the
-    // "idle"/sentinel value and is never produced by registration
-    // because `AwaiterSet::generation` starts at 1 and is
-    // monotonically non-decreasing.
+    // waker firing during the drain).
+    //
+    // Defined only while the awaiter is WAITING — transitions out of
+    // WAITING leave the prior generation stale (no code path reads
+    // `generation` outside WAITING) and `register` fully overwrites
+    // it on the next IDLE -> WAITING transition. Zero is reserved as
+    // a sentinel never produced by registration because
+    // `AwaiterSet::generation` starts at 1 and is monotonically
+    // non-decreasing; `Inner::idle()` initializes the field to zero
+    // for freshly-constructed awaiters.
     pub(crate) generation: u64,
 
     // Debug-only sentinel that records which AwaiterSet owns this
@@ -48,7 +59,10 @@ pub(crate) struct Inner {
     // operations like `unregister` or `notify_one` are not invoked on
     // an awaiter that lives in a different set — a class of corruption
     // that the lifecycle field alone cannot detect because the awaiter
-    // still appears WAITING. Zero means "not in any set".
+    // still appears WAITING. Zero means "not in any set" and is
+    // explicitly restored on every transition out of WAITING (the
+    // other link/generation fields are left stale, but this sentinel
+    // is preserved so the cross-set assertion remains reliable).
     #[cfg(debug_assertions)]
     pub(crate) owning_set_id: u64,
 }

--- a/packages/awaiter_set/src/set.rs
+++ b/packages/awaiter_set/src/set.rs
@@ -271,7 +271,16 @@ impl AwaiterSet {
         // `inner_ref` borrow has ended (its values were copied into `next`/`prev`),
         // so no other `Inner` reference is live.
         let inner = unsafe { awaiter.inner_mut() };
-        *inner = Inner::idle();
+        // Drop the waker; the link fields and generation are dead writes in IDLE
+        // (no code path reads them while the awaiter is idle) and `register` fully
+        // overwrites all of them on the next IDLE -> WAITING transition. Clearing
+        // `owning_set_id` in debug builds preserves the "0 = not in any set"
+        // sentinel for diagnostic clarity.
+        drop(inner.waker.take());
+        #[cfg(debug_assertions)]
+        {
+            inner.owning_set_id = 0;
+        }
         awaiter.set_lifecycle(IDLE, Ordering::Release);
     }
 


### PR DESCRIPTION
## Summary

`AwaiterSet::unregister` was overwriting the entire `Inner` via `*inner = Inner::idle()` when transitioning an awaiter back to IDLE. Four fields (`waker`, `next`, `prev`, `generation`; plus `owning_set_id` in debug builds) were stored, but only the `waker` actually carries information that needs to be cleared (its destructor must run). The link/generation fields are not read in IDLE state and are fully overwritten on the next `register` call.

## Change

Drop only the waker; leave the link/generation fields as stale data. Continue to zero `owning_set_id` in debug builds to preserve the "0 = not in any set" diagnostic sentinel.

## Measurements (Callgrind, deterministic)

| Bench | Before | After | Delta |
| --- | --- | --- | --- |
| `unregister_only` | 57 instr / 235 cycles | 48 instr / 221 cycles | **-15.8% instr / -6.0% cycles** |

Other Callgrind benches in the same suite move by ±1 instruction (in either direction); this is compilation layout noise unrelated to the change.

Criterion benches were too noisy on the test machine to draw further conclusions from (e.g. `is_empty/populated` showed ±40% drift despite no code path touching that scenario). On a steady environment the Callgrind delta should map to a wall-clock improvement on `unregister`-dominated workloads.

## Risk

Low. The change relies on the existing invariant that `register` fully overwrites `Inner` on the IDLE → WAITING transition (verifiable inline a few lines up). Tests pass; the `debug_assert_owns` sentinel is preserved for debug builds.

## Validation

- `just package=awaiter_set test` — 46/46 pass
- `just package=awaiter_set validate-local` — clean (Miri, clippy, fmt, etc.)
- `just package=awaiter_set bench-cg` — see table above

Part of a stack of 5 PRs implementing Tier A+B from the Callgrind optimization survey.
