### PR TITLE
awaiter_set: skip dead Inner writes on notify_one path (-8% via Callgrind)

### DIFF
--- a/packages/awaiter_set/src/awaiter.rs
+++ b/packages/awaiter_set/src/awaiter.rs
@@ -27,8 +27,13 @@ pub(crate) struct Inner {
     // notify_one).
     pub(crate) waker: Option<Waker>,
 
-    // Idle/Notified: null. Waiting: linked-set pointers maintained
-    // by AwaiterSet.
+    // Linked-set pointers maintained by AwaiterSet. Defined only while
+    // the awaiter is WAITING — on transitions out of WAITING the prior
+    // values are left stale rather than spending two stores to clear
+    // them (no code path reads next/prev outside WAITING, and
+    // `register` fully overwrites both on the next IDLE -> WAITING
+    // transition). `Inner::idle()` initializes them to null for
+    // freshly-constructed awaiters.
     pub(crate) next: *mut Awaiter,
     pub(crate) prev: *mut Awaiter,
 
@@ -37,10 +42,16 @@ pub(crate) struct Inner {
     // `notify_one_prior_generation` to distinguish awaiters that
     // were already registered when a generation advance occurred
     // from awaiters registered later (typically by a reentrant
-    // waker firing during the drain). Zero is reserved as the
-    // "idle"/sentinel value and is never produced by registration
-    // because `AwaiterSet::generation` starts at 1 and is
-    // monotonically non-decreasing.
+    // waker firing during the drain).
+    //
+    // Defined only while the awaiter is WAITING — transitions out of
+    // WAITING leave the prior generation stale (no code path reads
+    // `generation` outside WAITING) and `register` fully overwrites
+    // it on the next IDLE -> WAITING transition. Zero is reserved as
+    // a sentinel never produced by registration because
+    // `AwaiterSet::generation` starts at 1 and is monotonically
+    // non-decreasing; `Inner::idle()` initializes the field to zero
+    // for freshly-constructed awaiters.
     pub(crate) generation: u64,
 
     // Debug-only sentinel that records which AwaiterSet owns this
@@ -48,7 +59,10 @@ pub(crate) struct Inner {
     // operations like `unregister` or `notify_one` are not invoked on
     // an awaiter that lives in a different set — a class of corruption
     // that the lifecycle field alone cannot detect because the awaiter
-    // still appears WAITING. Zero means "not in any set".
+    // still appears WAITING. Zero means "not in any set" and is
+    // explicitly restored on every transition out of WAITING (the
+    // other link/generation fields are left stale, but this sentinel
+    // is preserved so the cross-set assertion remains reliable).
     #[cfg(debug_assertions)]
     pub(crate) owning_set_id: u64,
 }

--- a/packages/awaiter_set/src/set.rs
+++ b/packages/awaiter_set/src/set.rs
@@ -385,16 +385,17 @@ impl AwaiterSet {
             self.unlink(prev, next);
         }
 
-        // Take the waker and clear the link fields before publishing
-        // the notification via the atomic lifecycle store.
+        // Take the waker (transferring ownership to the caller) before publishing
+        // the notification via the atomic lifecycle store. The link fields and
+        // generation are dead writes in NOTIFIED/IDLE (no code path reads them
+        // outside WAITING) and `register` fully overwrites all of them on the next
+        // IDLE -> WAITING transition. Clearing `owning_set_id` in debug builds
+        // preserves the "0 = not in any set" sentinel for diagnostic clarity.
         // SAFETY: Access is serialized by this `&mut self` lock scope; the previous
         // `inner_ref` borrow has ended (its values were copied into `next`/`prev`),
         // so no other `Inner` reference is live.
         let inner = unsafe { awaiter.inner_mut() };
         let waker = inner.waker.take();
-        inner.next = ptr::null_mut();
-        inner.prev = ptr::null_mut();
-        inner.generation = 0;
         #[cfg(debug_assertions)]
         {
             inner.owning_set_id = 0;

--- a/packages/awaiter_set/src/set.rs
+++ b/packages/awaiter_set/src/set.rs
@@ -271,7 +271,16 @@ impl AwaiterSet {
         // `inner_ref` borrow has ended (its values were copied into `next`/`prev`),
         // so no other `Inner` reference is live.
         let inner = unsafe { awaiter.inner_mut() };
-        *inner = Inner::idle();
+        // Drop the waker; the link fields and generation are dead writes in IDLE
+        // (no code path reads them while the awaiter is idle) and `register` fully
+        // overwrites all of them on the next IDLE -> WAITING transition. Clearing
+        // `owning_set_id` in debug builds preserves the "0 = not in any set"
+        // sentinel for diagnostic clarity.
+        drop(inner.waker.take());
+        #[cfg(debug_assertions)]
+        {
+            inner.owning_set_id = 0;
+        }
         awaiter.set_lifecycle(IDLE, Ordering::Release);
     }
 


### PR DESCRIPTION
## Summary

Companion to #213. The internal `AwaiterSet::remove` helper (used by `notify_one` and `notify_one_prior_generation`) was clearing `next`, `prev`, and `generation` to zero before publishing the NOTIFIED lifecycle. These three stores are dead writes — no code path reads those fields while the awaiter is in NOTIFIED or IDLE, and the next `register` call fully overwrites them on the IDLE → WAITING transition.

## Change

Take the waker (transferring ownership to the caller as before) and skip clearing the link fields. `owning_set_id` is still zeroed in debug builds to preserve the "0 = not in any set" sentinel.

## Measurements (Callgrind, deterministic)

| Bench | Before | After | Delta |
| --- | --- | --- | --- |
| `notify_one_singleton` | 48 instr / 286 cycles | 44 instr / 280 cycles | **-8.3% instr / -2.1% cycles** |
| `notify_one_prior_generation_eligible` | 51 instr / 257 cycles | 47 instr / 251 cycles | **-7.8% instr / -2.3% cycles** |

All other benches in the suite are unchanged.

## Risk

Low — same correctness argument as the unregister PR. Tests pass; the `debug_assert_owns` sentinel is preserved for debug builds.

## Stack

Stacked on #213. Should land after it.
