### PR TITLE
Tidy Cargo dependency declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,9 @@ name = "argh_shared"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "atomic-waker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,30 +12,28 @@ rust-version = "1.88"
 [workspace.dependencies]
 all_the_time = { version = "0.4.18", path = "packages/all_the_time", default-features = false }
 alloc_tracker = { version = "0.5.22", path = "packages/alloc_tracker", default-features = false }
-arc-swap = { version = "1.7", default-features = false }
-argh = { version = "0.1.13", default-features = false, features = ["help"] }
+arc-swap = { version = "1.7.0", default-features = false }
+argh = { version = "0.1.13", default-features = false, features = ["default"] }
 awaiter_set = { version = "0.1.4", path = "packages/awaiter_set", default-features = false }
-axum = { version = "0.8", default-features = false }
+axum = { version = "0.8.0", default-features = false }
+cpu-time = { version = "1.0.0", default-features = false }
 cpulist = { version = "1.1.2", path = "packages/cpulist", default-features = false }
 criterion = { version = "0.8.2", default-features = false }
-deranged = { version = "0.5", default-features = false }
-derive_more = { version = "2.0", default-features = false }
-event-listener = { version = "5.4", default-features = false, features = [
+deranged = { version = "0.5.0", default-features = false }
+derive_more = { version = "2.0.0", default-features = false }
+event-listener = { version = "5.4.0", default-features = false, features = [
     "std",
 ] }
 events = { version = "0.7.4", path = "packages/events", default-features = false }
 events_once = { version = "0.5.25", path = "packages/events_once", default-features = false }
-fake_headers = { version = "0.0", default-features = false }
+fake_headers = { version = "0.0.5", default-features = false }
 fast_time = { version = "0.1.20", path = "packages/fast_time", default-features = false }
-foldhash = { version = "0.2", default-features = false, features = ["std"] }
+foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
 folo_ffi = { version = "0.1.14", path = "packages/folo_ffi", default-features = false }
-frozen-collections = { version = "0.8", default-features = false }
+frozen-collections = { version = "0.8.0", default-features = false }
 future_deque = { version = "0.1.7", path = "packages/future_deque", default-features = false }
-futures = { version = "0.3", default-features = false, features = [
-    "std",
-    "executor",
-] }
-futures-core = { version = "0.3", default-features = false }
+futures = { version = "0.3.11", default-features = false, features = ["std"] }
+futures-core = { version = "0.3.31", default-features = false }
 # Keep this version in lockstep with the `gungraun-runner` install line in
 # `justfiles/just_setup.just` and the install command in `docs/callgrind-benchmarks.md`.
 # The runner is invoked by the Callgrind bench binaries via an encoded payload and
@@ -45,32 +43,29 @@ futures-core = { version = "0.3", default-features = false }
 # Pinned with `=` to prevent `cargo update` from drifting Cargo.lock away from the installed
 # runner version. When bumping, update all three locations together.
 gungraun = { version = "=0.19.0", default-features = false }
-hash_hasher = { version = "2.0", default-features = false }
-hashbrown = { version = "0.17.1", default-features = false, features = [
-    "default-hasher",
-    "inline-more",
-] }
-heapless = { version = "0.9", default-features = false }
-http = { version = "1.2", default-features = false, features = ["std"] }
+hash_hasher = { version = "2.0.0", default-features = false }
+hashbrown = { version = "0.17.1", default-features = false }
+heapless = { version = "0.9.1", default-features = false }
+http = { version = "1.2.0", default-features = false, features = ["std"] }
 infinity_pool = { version = "0.8.16", path = "packages/infinity_pool", default-features = false }
-itertools = { version = "0.14", default-features = false, features = [
+itertools = { version = "0.14.0", default-features = false, features = [
     "use_std",
 ] }
-libc = { version = "0.2", default-features = false }
+libc = { version = "0.2.172", default-features = false }
 linked = { version = "1.0.11", path = "packages/linked", default-features = false }
 linked_macros = { version = "1.0.11", path = "packages/linked_macros", default-features = false }
 linked_macros_impl = { version = "1.0.11", path = "packages/linked_macros_impl", default-features = false }
 many_cpus = { version = "2.4.3", path = "packages/many_cpus", default-features = false }
 mockall = { version = "0.14.0", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
-negative-impl = { version = "0.1", default-features = false }
+negative-impl = { version = "0.1.0", default-features = false }
 new_zealand = { version = "1.0.6", path = "packages/new_zealand", default-features = false }
 nm = { version = "0.1.34", path = "packages/nm", default-features = false }
 nm_otel = { version = "0.4.4", path = "packages/nm_otel", default-features = false }
-nonempty = { version = "0.12", default-features = false }
+nonempty = { version = "0.12.0", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
-ohno = { version = "0.3", default-features = false }
+ohno = { version = "0.3.0", default-features = false }
 oneshot = { version = "0.2.1", default-features = false, features = [
     "std",
     "async",
@@ -79,28 +74,28 @@ opentelemetry = { version = "0.32.0", default-features = false }
 opentelemetry-stdout = { version = "0.32.0", default-features = false }
 opentelemetry_sdk = { version = "0.32.1", default-features = false }
 pastey = { version = "0.2.3", default-features = false }
-pin-project = { version = "1.1", default-features = false }
-proc-macro2 = { version = "1.0", default-features = false }
-quote = { version = "1.0", default-features = false }
+pin-project = { version = "1.1.0", default-features = false }
+proc-macro2 = { version = "1.0.103", default-features = false }
+quote = { version = "1.0.42", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std"] }
 rsevents = { version = "0.3.1", default-features = false }
-scc = { version = "3.0", default-features = false }
-scopeguard = { version = "1.2", default-features = false }
-seq-macro = { version = "0.3", default-features = false }
-serial_test = { version = "3.2", default-features = false }
-simple-mermaid = { version = "0.2", default-features = false }
+scc = { version = "3.0.2", default-features = false }
+scopeguard = { version = "1.2.0", default-features = false }
+seq-macro = { version = "0.3.0", default-features = false }
+serial_test = { version = "3.2.0", default-features = false }
+simple-mermaid = { version = "0.2.0", default-features = false }
 smallvec = { version = "1.15.0", default-features = false }
-static_assertions = { version = "1", default-features = false }
-syn = { version = "2.0", default-features = false }
-tempfile = { version = "3.20", default-features = false }
+static_assertions = { version = "1.1.0", default-features = false }
+syn = { version = "2.0.111", default-features = false }
+tempfile = { version = "3.20.0", default-features = false }
 threadpool = { version = "1.8.1", default-features = false }
 tick = { version = "0.3.0", default-features = false }
-tokio = { version = "1.43", default-features = false }
+tokio = { version = "1.48.0", default-features = false }
 toml = { version = "1.1.2", default-features = false }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
-trybuild = { version = "1.0", default-features = false }
+tracing = { version = "0.1.30", default-features = false, features = ["std"] }
+trybuild = { version = "1.0.0", default-features = false }
 vicinal = { version = "0.1.22", path = "packages/vicinal", default-features = false }
-windows = { version = "0.62", default-features = false, features = ["std"] }
+windows = { version = "0.62.0", default-features = false, features = ["std"] }
 
 [workspace.lints.rust]
 # https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 all-features = true
 
 [dependencies]
-cpu-time = "1.0.0"
+cpu-time = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/packages/awaiter_set/Cargo.toml
+++ b/packages/awaiter_set/Cargo.toml
@@ -19,7 +19,7 @@ simple-mermaid = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 mutants = { workspace = true }
 static_assertions = { workspace = true }
 

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -33,7 +33,7 @@ awaiter_set = { workspace = true }
 alloc_tracker = { path = "../alloc_tracker" }
 criterion = { workspace = true }
 event-listener = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 many_cpus = { path = "../many_cpus" }
 mutants = { workspace = true }
 new_zealand = { workspace = true }

--- a/packages/events_once/Cargo.toml
+++ b/packages/events_once/Cargo.toml
@@ -22,7 +22,7 @@ infinity_pool = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 oneshot = { workspace = true }
 pin-project = { workspace = true }
 static_assertions = { workspace = true }

--- a/packages/future_deque/Cargo.toml
+++ b/packages/future_deque/Cargo.toml
@@ -23,7 +23,7 @@ infinity_pool = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 events_once = { path = "../events_once" }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 futures-core = { workspace = true }
 mutants = { workspace = true }
 static_assertions = { workspace = true }

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -20,7 +20,7 @@ test-util = ["nm/test-util"]
 [dependencies]
 foldhash = { workspace = true }
 futures = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, features = ["default-hasher", "inline-more"] }
 nm = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 tick = { workspace = true }

--- a/packages/vicinal/Cargo.toml
+++ b/packages/vicinal/Cargo.toml
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 all_the_time = { path = "../all_the_time" }
 alloc_tracker = { path = "../alloc_tracker" }
 criterion = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 many_cpus = { path = "../many_cpus", features = ["test-util"] }
 mutants = { workspace = true }
 static_assertions = { workspace = true }


### PR DESCRIPTION
Tidies Cargo dependency declarations via the `ss-cargo-deps-tidy` skill workflow.

## Workspace-level normalization

- Padded 31 workspace-level dependency versions to three semver components for consistency (e.g. `"1.7"` → `"1.7.0"`).
- Added `cpu-time` to `[workspace.dependencies]` (previously declared as a bare-string at the package level in `all_the_time`) and now referenced via `workspace = true`.
- Replaced `argh` workspace feature `["help"]` with `["default"]` to match the skill's CLI-library allowlist (covers `help` and `serde`).

## Feature scoping

Moved non-allowlisted workspace-level features down to the consuming packages:

- `futures` `executor` → moved into the dev-deps of `awaiter_set`, `events`, `events_once`, `future_deque`, and `vicinal` (the only crates that use `futures::executor`).
- `hashbrown` `default-hasher` and `inline-more` → moved into `nm_otel`, the only consumer.

This avoids implicitly activating these features for every workspace crate that pulls in `futures` or `hashbrown`.

## Minimum-version bumps

Stage 7 of the workflow verifies that `[workspace.dependencies]` versions actually build by temporarily pinning every version with `=` and running `cargo generate-lockfile` + `cargo check` on all three profile combinations. Bumped the following minimums to the lowest non-yanked, API-compatible release that resolves cleanly and compiles:

| Crate | New minimum | Reason |
|---|---|---|
| `fake_headers` | `0.0.5` | `0.0.0` does not exist on crates.io; 0.0.x are mutually incompatible |
| `futures` | `0.3.11` | `0.3.0` through `0.3.10` yanked |
| `futures-core` | `0.3.31` | required by transitive `tick v0.3.0` |
| `heapless` | `0.9.1` | `0.9.0` yanked |
| `libc` | `0.2.172` | required by transitive `socket2 v0.6.0` (via `tokio`) |
| `proc-macro2` | `1.0.103` | required by transitive `ohno_macros` |
| `quote` | `1.0.42` | required by transitive `ohno_macros` |
| `scc` | `3.0.2` | `3.0.0` yanked |
| `static_assertions` | `1.1.0` | `1.0.0` has macro hygiene bug preventing `const_assert_eq!` from being called cross-crate |
| `syn` | `2.0.111` | required by transitive `ohno_macros` |
| `tokio` | `1.48.0` | required by transitive `tick v0.3.0` |
| `tracing` | `0.1.30` | `0.1.5` lacks the positional-message macro syntax used in `vicinal` |

## Verification

All three skill-mandated checks pass:

- `cargo check --workspace --all-targets`
- `cargo check --workspace --all-targets --release`
- `cargo check --workspace --all-targets --all-features`