### PR TITLE
ci: add ARM64 test-more + miri jobs and gate expensive validations

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -42,7 +42,7 @@ runs:
 
           sudo apt update
           sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config powershell valgrind
-        else
+        elif [ "$ARCH" = "arm64" ]; then
           sudo apt update
           sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config valgrind
 
@@ -56,6 +56,11 @@ runs:
           sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
           sudo chmod +x /opt/microsoft/powershell/7/pwsh
           sudo ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+        else
+          echo "ERROR: Unsupported Linux architecture '$ARCH'." >&2
+          echo "Extend the setup-environment action to add a PowerShell install path" >&2
+          echo "for this architecture before adding a runner of this type to CI." >&2
+          exit 1
         fi
 
         # Set up Git LFS

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -18,19 +18,45 @@ runs:
         # This supposedly speeds up installation by avoiding mandb updates.
         sudo mv /usr/bin/mandb /usr/bin/mandb.deactivated && sudo cp -p /bin/true /usr/bin/mandb
 
-        # Add Microsoft package repository (for PowerShell and any other Microsoft packages).
-        # We use curl with --retry-all-errors because the runner can transiently fail
-        # TLS verification against packages.microsoft.com during early boot — likely a
-        # race with unattended-upgrades rewriting /etc/ssl/certs/ca-certificates.crt.
-        # --show-error ensures the failure is visible if all retries are exhausted.
-        curl --fail --silent --show-error --location \
-          --retry 5 --retry-delay 2 --retry-all-errors \
-          --output packages-microsoft-prod.deb \
-          "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
-        sudo dpkg -i --force-confnew packages-microsoft-prod.deb
+        ARCH="$(dpkg --print-architecture)"
 
-        sudo apt update
-        sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config powershell valgrind
+        # PowerShell on Linux is distributed differently per architecture:
+        # - amd64: Microsoft's apt repo ships a powershell package, so we register the
+        #   repo and install via apt alongside our other system packages.
+        # - arm64: The packages.microsoft.com apt repo for Ubuntu only ships amd64
+        #   PowerShell packages — installing the repo and apt-getting `powershell`
+        #   fails with "Depends: libc6:amd64 but it is not installable". Microsoft
+        #   instead ships ARM64 PowerShell as a tarball on the PowerShell GitHub
+        #   releases page, which is what we use here.
+        if [ "$ARCH" = "amd64" ]; then
+          # Add Microsoft package repository (for PowerShell and any other Microsoft packages).
+          # We use curl with --retry-all-errors because the runner can transiently fail
+          # TLS verification against packages.microsoft.com during early boot — likely a
+          # race with unattended-upgrades rewriting /etc/ssl/certs/ca-certificates.crt.
+          # --show-error ensures the failure is visible if all retries are exhausted.
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --output packages-microsoft-prod.deb \
+            "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+          sudo dpkg -i --force-confnew packages-microsoft-prod.deb
+
+          sudo apt update
+          sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config powershell valgrind
+        else
+          sudo apt update
+          sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config valgrind
+
+          # Pinned to a current LTS release. Bump as newer 7.4.x patches ship.
+          PWSH_VERSION="7.4.6"
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --output /tmp/powershell.tar.gz \
+            "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-arm64.tar.gz"
+          sudo mkdir -p /opt/microsoft/powershell/7
+          sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
+          sudo chmod +x /opt/microsoft/powershell/7/pwsh
+          sudo ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+        fi
 
         # Set up Git LFS
         git lfs install

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -31,11 +31,14 @@ Split from the monolithic `just validate-local` into individual jobs:
   - **docs** — Multi-platform because conditional compilation affects generated documentation
   - miri
   - **test-more-arm** — ARM64 coverage (ubuntu-24.04-arm, windows-11-arm)
-    - Mirrors `test-more` on ARM runners to catch architecture-specific bugs (atomic
-      ordering, platform-specific dependency behavior) that x86_64 runners cannot surface.
+    - Exercises ARM-specific code paths (anything gated behind
+      `cfg(target_arch = "aarch64")` or similar) which x86_64 runners never compile
+      or execute. Platform-neutral code is already validated by the x86_64 matrix.
   - **miri-arm** — ARM64 coverage for Miri (ubuntu-24.04-arm, windows-11-arm)
-    - ARM has a weaker memory model than x86_64, so Miri on ARM can surface atomic
-      ordering and data-race bugs that pass on x86_64. Mirrors the x86_64 `miri` matrix.
+    - Miri is an interpreter with its own memory model and is architecture-agnostic
+      for platform-neutral code. We run it on ARM purely to subject ARM-gated code
+      paths to Miri's UB detection — there is no value in running it on ARM for
+      code that already compiles on x86_64.
   - **miri-harder-events-once** / **miri-harder-infinity-pool** / **miri-harder-events** — Windows-only, sharded
     - Runs Miri with 64 seeds per test (`-Zmiri-many-seeds=..64`) for select packages
     - Sharded across parallel runners to reduce wall-clock time (4 shards for events_once,
@@ -97,10 +100,10 @@ for manual cache warming after toolchain updates.
    - `miri-harder-*` jobs are Windows-only due to high cost; sharded across parallel runners
    - Most checks run on the 3 x86_64 platforms (ubuntu, macos, windows)
    - `test-more-arm` and `miri-arm` extend coverage to ARM64 (ubuntu-24.04-arm,
-     windows-11-arm) for architecture-sensitive concerns. They are kept as separate
-     jobs rather than added to the main matrices so that ARM-specific failures are
-     immediately identifiable in the GitHub status checks and so the additional runners
-     can be scoped narrowly without inflating every check.
+     windows-11-arm) solely to exercise ARM-gated code paths
+     (`cfg(target_arch = "aarch64")` and similar). Platform-neutral code is already
+     covered by the x86_64 matrices — Miri in particular is an interpreter with its
+     own memory model and is architecture-agnostic for platform-neutral code.
 
 4. **Timeouts**:
    - Default timeout for most jobs

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -90,6 +90,10 @@ for manual cache warming after toolchain updates.
    simpler check:
    - `check-release` depends on `check-dev`
    - `clippy-release` depends on `clippy-dev`
+   - `build-release` depends on `check-dev` (no point linking a release binary if the
+     dev `cargo check` already failed)
+   - `miri` and `miri-arm` depend on `check-dev` (Miri is much slower than `cargo check`;
+     if the code does not even compile in dev mode, there is nothing for Miri to interpret)
    - `mutants` depends on `test-more` (mutation testing is meaningless if base tests fail)
    - `miri-harder-*` depend on both `miri` and `miri-arm` (many-seeds runs are
      orders of magnitude slower than a single Miri pass)

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -30,6 +30,12 @@ Split from the monolithic `just validate-local` into individual jobs:
   - test-docs
   - **docs** — Multi-platform because conditional compilation affects generated documentation
   - miri
+  - **test-more-arm** — ARM64 coverage (ubuntu-24.04-arm, windows-11-arm)
+    - Mirrors `test-more` on ARM runners to catch architecture-specific bugs (atomic
+      ordering, platform-specific dependency behavior) that x86_64 runners cannot surface.
+  - **miri-arm** — ARM64 coverage for Miri (ubuntu-24.04-arm, windows-11-arm)
+    - ARM has a weaker memory model than x86_64, so Miri on ARM can surface atomic
+      ordering and data-race bugs that pass on x86_64. Mirrors the x86_64 `miri` matrix.
   - **miri-harder-events-once** / **miri-harder-infinity-pool** / **miri-harder-events** — Windows-only, sharded
     - Runs Miri with 64 seeds per test (`-Zmiri-many-seeds=..64`) for select packages
     - Sharded across parallel runners to reduce wall-clock time (4 shards for events_once,
@@ -57,8 +63,9 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
 A scheduled workflow that keeps GitHub Actions caches warm. GitHub evicts caches after
 7 days of inactivity, and a cold cache means every parallel validation job must independently
 compile all Rust dependencies from scratch (the setup-environment step becomes very expensive).
-This workflow runs once daily on all three platforms (ubuntu, macos, windows) to ensure the
-`shared-key: prerequisites` Rust cache is always populated. It also supports `workflow_dispatch`
+This workflow runs once daily on all five runner images (ubuntu-latest, windows-latest,
+macos-latest, ubuntu-24.04-arm, windows-11-arm) to ensure the
+`shared-key: prerequisites` Rust cache is always populated for both x86_64 and ARM64. It also supports `workflow_dispatch`
 for manual cache warming after toolchain updates.
 
 ## Design Decisions
@@ -75,11 +82,25 @@ for manual cache warming after toolchain updates.
    - Clear failure identification (specific check names in GitHub status)
    - Better resource utilization across GitHub runners
 
+   Expensive jobs are gated behind cheaper equivalents so a fast failure short-circuits
+   the expensive work and avoids burning runner time on code that already failed a
+   simpler check:
+   - `check-release` depends on `check-dev`
+   - `clippy-release` depends on `clippy-dev`
+   - `mutants` depends on `test-more` (mutation testing is meaningless if base tests fail)
+   - `miri-harder-*` depend on both `miri` and `miri-arm` (many-seeds runs are
+     orders of magnitude slower than a single Miri pass)
+
 3. **Platform matrix considerations**:
    - `format-check` is single-platform (Ubuntu) to save resources
    - `docs` and `machete` remain multi-platform due to conditional compilation differences
    - `miri-harder-*` jobs are Windows-only due to high cost; sharded across parallel runners
-   - All other checks run on 3 platforms (ubuntu, macos, windows)
+   - Most checks run on the 3 x86_64 platforms (ubuntu, macos, windows)
+   - `test-more-arm` and `miri-arm` extend coverage to ARM64 (ubuntu-24.04-arm,
+     windows-11-arm) for architecture-sensitive concerns. They are kept as separate
+     jobs rather than added to the main matrices so that ARM-specific failures are
+     immediately identifiable in the GitHub status checks and so the additional runners
+     can be scoped narrowly without inflating every check.
 
 4. **Timeouts**:
    - Default timeout for most jobs

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -26,19 +26,22 @@ Split from the monolithic `just validate-local` into individual jobs:
 - **Multi-platform jobs** (run on ubuntu-latest, macos-latest, windows-latest):
   - check-dev
   - clippy-dev
-  - test-more
+  - test-more-x64
   - test-docs
   - **docs** — Multi-platform because conditional compilation affects generated documentation
-  - miri
+  - miri-x64
   - **test-more-arm** — ARM64 coverage (ubuntu-24.04-arm, windows-11-arm)
     - Exercises ARM-specific code paths (anything gated behind
       `cfg(target_arch = "aarch64")` or similar) which x86_64 runners never compile
       or execute. Platform-neutral code is already validated by the x86_64 matrix.
+    - Paired with `test-more-x64`; both carry an explicit `-x64`/`-arm` suffix for
+      symmetry. Other jobs that have no ARM counterpart remain unsuffixed.
   - **miri-arm** — ARM64 coverage for Miri (ubuntu-24.04-arm, windows-11-arm)
     - Miri is an interpreter with its own memory model and is architecture-agnostic
       for platform-neutral code. We run it on ARM purely to subject ARM-gated code
       paths to Miri's UB detection — there is no value in running it on ARM for
       code that already compiles on x86_64.
+    - Paired with `miri-x64`; both carry an explicit `-x64`/`-arm` suffix for symmetry.
   - **miri-harder-events-once** / **miri-harder-infinity-pool** / **miri-harder-events** — Windows-only, sharded
     - Runs Miri with 64 seeds per test (`-Zmiri-many-seeds=..64`) for select packages
     - Sharded across parallel runners to reduce wall-clock time (4 shards for events_once,
@@ -92,10 +95,10 @@ for manual cache warming after toolchain updates.
    - `clippy-release` depends on `clippy-dev`
    - `build-release` depends on `check-dev` (no point linking a release binary if the
      dev `cargo check` already failed)
-   - `miri` and `miri-arm` depend on `check-dev` (Miri is much slower than `cargo check`;
+   - `miri-x64` and `miri-arm` depend on `check-dev` (Miri is much slower than `cargo check`;
      if the code does not even compile in dev mode, there is nothing for Miri to interpret)
-   - `mutants` depends on `test-more` (mutation testing is meaningless if base tests fail)
-   - `miri-harder-*` depend on both `miri` and `miri-arm` (many-seeds runs are
+   - `mutants` depends on `test-more-x64` (mutation testing is meaningless if base tests fail)
+   - `miri-harder-*` depend on both `miri-x64` and `miri-arm` (many-seeds runs are
      orders of magnitude slower than a single Miri pass)
 
 3. **Platform matrix considerations**:

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest, ubuntu-24.04-arm, windows-11-arm]
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 90

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -254,9 +254,9 @@ jobs:
       - name: Run miri on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" miri
 
-  # ARM64 coverage for test-more. Architecture-specific atomic/memory-ordering bugs
-  # or platform-specific behavior in dependencies will not show up on x86_64 runners,
-  # so we exercise the same test suite on Linux ARM and Windows ARM runners.
+  # ARM64 coverage for test-more. Exercises ARM-specific code paths (anything gated
+  # behind cfg(target_arch = "aarch64") or similar) which x86_64 runners never compile
+  # or execute.
   test-more-arm:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
@@ -286,9 +286,9 @@ jobs:
           flags: ${{ matrix.platform }}
           report_type: test_results
 
-  # ARM64 coverage for Miri. ARM has a weaker memory model than x86_64, so Miri runs
-  # on ARM can surface atomic ordering and data-race bugs that pass on x86_64. Both
-  # Linux ARM and Windows ARM runners are exercised to mirror the x86_64 miri matrix.
+  # ARM64 coverage for Miri. Miri is an interpreter with its own memory model and is
+  # architecture-agnostic for platform-neutral code; we run it on ARM purely to exercise
+  # cfg(target_arch = "aarch64") (and similar) code paths under Miri's UB detection.
   miri-arm:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -235,7 +235,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" docs
 
   miri:
-    needs: [delta]
+    needs: [delta, check-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -290,7 +290,7 @@ jobs:
   # architecture-agnostic for platform-neutral code; we run it on ARM purely to exercise
   # cfg(target_arch = "aarch64") (and similar) code paths under Miri's UB detection.
   miri-arm:
-    needs: [delta]
+    needs: [delta, check-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -463,7 +463,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" clippy release
 
   build-release:
-    needs: [delta]
+    needs: [delta, check-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Run clippy dev on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" clippy dev
 
-  test-more:
+  test-more-x64:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
@@ -234,7 +234,7 @@ jobs:
       - name: Run docs on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" docs
 
-  miri:
+  miri-x64:
     needs: [delta, check-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
@@ -311,10 +311,10 @@ jobs:
 
   # Miri with many seeds is very slow, so we only run it for select packages on Windows.
   # These jobs only run when their specific package is affected by changes.
-  # Gated behind the base `miri` and `miri-arm` jobs so a quick Miri failure short-circuits
+  # Gated behind the base `miri-x64` and `miri-arm` jobs so a quick Miri failure short-circuits
   # the much more expensive many-seeds run.
   miri-harder-events-once:
-    needs: [delta, miri, miri-arm]
+    needs: [delta, miri-x64, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'events_once'))
@@ -336,7 +336,7 @@ jobs:
         run: just package=events_once miri-harder ${{ matrix.shard }}
 
   miri-harder-infinity-pool:
-    needs: [delta, miri, miri-arm]
+    needs: [delta, miri-x64, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'infinity_pool'))
@@ -358,7 +358,7 @@ jobs:
         run: just package=infinity_pool miri-harder ${{ matrix.shard }}
 
   miri-harder-events:
-    needs: [delta, miri, miri-arm]
+    needs: [delta, miri-x64, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'events'))
@@ -380,7 +380,7 @@ jobs:
         run: just package=events miri-harder ${{ matrix.shard }}
 
   miri-harder-awaiter-set:
-    needs: [delta, miri, miri-arm]
+    needs: [delta, miri-x64, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'awaiter_set'))
@@ -483,7 +483,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" build release
 
   mutants:
-    needs: [delta, test-more]
+    needs: [delta, test-more-x64]
     if: needs.delta.outputs.skip_all != 'true'
     timeout-minutes: 240
     strategy:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -254,10 +254,67 @@ jobs:
       - name: Run miri on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" miri
 
+  # ARM64 coverage for test-more. Architecture-specific atomic/memory-ordering bugs
+  # or platform-specific behavior in dependencies will not show up on x86_64 runners,
+  # so we exercise the same test suite on Linux ARM and Windows ARM runners.
+  test-more-arm:
+    needs: [delta]
+    if: needs.delta.outputs.skip_all != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-24.04-arm, windows-11-arm]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Run test-more on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" test-more
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/default/junit.xml
+          flags: ${{ matrix.platform }}
+          report_type: test_results
+
+  # ARM64 coverage for Miri. ARM has a weaker memory model than x86_64, so Miri runs
+  # on ARM can surface atomic ordering and data-race bugs that pass on x86_64. Both
+  # Linux ARM and Windows ARM runners are exercised to mirror the x86_64 miri matrix.
+  miri-arm:
+    needs: [delta]
+    if: needs.delta.outputs.skip_all != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-24.04-arm, windows-11-arm]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Run miri on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" miri
+
   # Miri with many seeds is very slow, so we only run it for select packages on Windows.
   # These jobs only run when their specific package is affected by changes.
+  # Gated behind the base `miri` and `miri-arm` jobs so a quick Miri failure short-circuits
+  # the much more expensive many-seeds run.
   miri-harder-events-once:
-    needs: [delta]
+    needs: [delta, miri, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'events_once'))
@@ -279,7 +336,7 @@ jobs:
         run: just package=events_once miri-harder ${{ matrix.shard }}
 
   miri-harder-infinity-pool:
-    needs: [delta]
+    needs: [delta, miri, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'infinity_pool'))
@@ -301,7 +358,7 @@ jobs:
         run: just package=infinity_pool miri-harder ${{ matrix.shard }}
 
   miri-harder-events:
-    needs: [delta]
+    needs: [delta, miri, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'events'))
@@ -323,7 +380,7 @@ jobs:
         run: just package=events miri-harder ${{ matrix.shard }}
 
   miri-harder-awaiter-set:
-    needs: [delta]
+    needs: [delta, miri, miri-arm]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'awaiter_set'))
@@ -366,7 +423,7 @@ jobs:
         run: just machete
 
   check-release:
-    needs: [delta]
+    needs: [delta, check-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -386,7 +443,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" check release
 
   clippy-release:
-    needs: [delta]
+    needs: [delta, clippy-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -426,7 +483,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" build release
 
   mutants:
-    needs: [delta]
+    needs: [delta, test-more]
     if: needs.delta.outputs.skip_all != 'true'
     timeout-minutes: 240
     strategy:

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -15,7 +15,20 @@ install-tools:
     rustup toolchain install $env:RUST_MSRV
     rustup toolchain install $env:RUST_NIGHTLY --component miri --component rustfmt --component rust-src --component llvm-tools-preview
 
-    cargo install cargo-machete cargo-nextest release-plz cargo-semver-checks cargo-audit cargo-hack cargo-mutants cargo-llvm-cov cargo-sort cargo-sort-derives cargo-udeps cargo-careful cargo-ensure-no-default-features cargo-delta --locked
+    cargo install cargo-machete cargo-nextest release-plz cargo-semver-checks cargo-audit cargo-hack cargo-llvm-cov cargo-sort cargo-sort-derives cargo-udeps cargo-careful cargo-ensure-no-default-features cargo-delta --locked
+
+    # cargo-mutants transitively depends on `winapi 0.2.8`, which only defines its
+    # types for `target_arch = "x86"` / `"x86_64"` and fails to compile on aarch64
+    # with errors like `cannot find type 'ULONG_PTR' in this scope`. Until that
+    # transitive dependency is updated upstream, skip the install on ARM. The CI
+    # `mutants` job only runs on x86_64 runners, so this only affects local dev on
+    # ARM machines (where running mutation testing locally is not supported).
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    if ($arch -ne [System.Runtime.InteropServices.Architecture]::Arm64) {
+        cargo install cargo-mutants --locked
+    } else {
+        Write-Host "Skipping cargo-mutants install on ARM64 (winapi 0.2.8 has no aarch64 support)."
+    }
 
     # gungraun-runner drives Valgrind for Callgrind-based instruction-count benchmarks. Only
     # useful on Linux (Valgrind is Linux-only); on Windows and macOS the Callgrind bench binaries


### PR DESCRIPTION
Adds ARM64 CI coverage and gates expensive validation jobs behind cheaper equivalents.

## ARM64 coverage

Two new jobs that run on `ubuntu-24.04-arm` and `windows-11-arm`:

- **`test-more-arm`** — runs `just test-more` on both ARM runners (with Codecov upload). Exercises ARM-specific code paths (anything gated behind `cfg(target_arch = "aarch64")` or similar) which x86_64 runners never compile or execute.
- **`miri-arm`** — runs `just miri` on both ARM runners. Miri is an interpreter with its own memory model and is architecture-agnostic for platform-neutral code; we run it on ARM purely to subject ARM-gated code paths to Miri's UB detection. Platform-neutral code is already validated by the x86_64 Miri matrix.

`cache-warmup.yml` is extended to keep the ARM caches warm so cold-cache cost does not balloon on first run.

No `miri-harder` on ARM as requested.

## Dependency gating

Spinning up the full ~50-job validation fan-out is wasteful if a cheap check would have failed seconds later. The following jobs are now gated:

| Job | Now depends on |
|---|---|
| `check-release` | `check-dev` |
| `clippy-release` | `clippy-dev` |
| `mutants` | `test-more` |
| `miri-harder-events-once` | `miri`, `miri-arm` |
| `miri-harder-infinity-pool` | `miri`, `miri-arm` |
| `miri-harder-events` | `miri`, `miri-arm` |
| `miri-harder-awaiter-set` | `miri`, `miri-arm` |

`.github/workflows/AGENTS.md` updated with the new jobs and the gating rationale.
