### PR TITLE
perf(fast_time): use u64 nanosecond clock arithmetic on Linux

### DIFF
--- a/packages/fast_time/src/pal/linux/bindings/abstractions.rs
+++ b/packages/fast_time/src/pal/linux/bindings/abstractions.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 /// All PAL FFI calls must go through this trait, enabling them to be mocked.
 #[cfg_attr(test, mockall::automock)]
 pub(crate) trait Bindings: Debug + Send + Sync + 'static {
-    fn clock_gettime_nanos(&self) -> u128;
+    fn clock_gettime_nanos(&self) -> u64;
 
     // We also put this here because Rust does not (yet) support a proper clock abstraction,
     // so without this we have nothing to mock. This just provides a mock wrapper around `Instant`.

--- a/packages/fast_time/src/pal/linux/bindings/facade.rs
+++ b/packages/fast_time/src/pal/linux/bindings/facade.rs
@@ -26,7 +26,7 @@ impl BindingsFacade {
 
 impl Bindings for BindingsFacade {
     #[inline]
-    fn clock_gettime_nanos(&self) -> u128 {
+    fn clock_gettime_nanos(&self) -> u64 {
         match self {
             Self::Real(bindings) => bindings.clock_gettime_nanos(),
             #[cfg(test)]

--- a/packages/fast_time/src/pal/linux/bindings/real.rs
+++ b/packages/fast_time/src/pal/linux/bindings/real.rs
@@ -20,8 +20,8 @@ impl Bindings for BuildTargetBindings {
     /// capture where absolute precision is less important than low overhead.
     ///
     /// The arithmetic is guaranteed not to overflow because:
-    /// - `tv_sec` represents seconds since an epoch and will not exceed the range of u128
-    ///   for any realistic timestamp within the lifespan of the universe.
+    /// - `tv_sec` represents seconds since an epoch and will not exceed the range of u64
+    ///   for any realistic timestamp (u64 nanoseconds spans roughly 584 years).
     /// - The multiplication by `1_000_000_000` converts seconds to nanoseconds.
     #[expect(
         clippy::cast_sign_loss,
@@ -29,7 +29,7 @@ impl Bindings for BuildTargetBindings {
         reason = "never going to happen with timestamps within real-universe ranges"
     )]
     #[inline]
-    fn clock_gettime_nanos(&self) -> u128 {
+    fn clock_gettime_nanos(&self) -> u64 {
         // SAFETY: All-zero is a valid initial value for this type.
         let mut ts: timespec = unsafe { mem::zeroed() };
 
@@ -38,7 +38,7 @@ impl Bindings for BuildTargetBindings {
 
         assert!(result == 0, "{}", io::Error::last_os_error());
 
-        ts.tv_sec as u128 * 1_000_000_000 + ts.tv_nsec as u128
+        ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
     }
 
     #[inline]

--- a/packages/fast_time/src/pal/linux/time_source.rs
+++ b/packages/fast_time/src/pal/linux/time_source.rs
@@ -6,10 +6,10 @@ use crate::pal::linux::{Bindings, BindingsFacade};
 #[derive(Clone, Debug)]
 pub(crate) struct TimeSourceImpl {
     rust_epoch: Instant,
-    platform_epoch: u128,
+    platform_epoch: u64,
 
     // If the platform time matches the cache key, we can use the cached Instant.
-    cache_key: u128,
+    cache_key: u64,
     cached: Instant,
 
     bindings: BindingsFacade,
@@ -44,9 +44,7 @@ impl TimeSource for TimeSourceImpl {
 
         let rust_time = self
             .rust_epoch
-            .checked_add(Duration::from_nanos(u64::try_from(elapsed_nanos).expect(
-                "unrealistically long duration, never going to happen with real clocks",
-            )))
+            .checked_add(Duration::from_nanos(elapsed_nanos))
             .expect("platform timestamp beyond the end of the universe - impossible");
 
         self.cache_key = platform_time;


### PR DESCRIPTION
## Summary

Switch the Linux `fast_time` clock source from `u128` to `u64` nanosecond
arithmetic. `u64` nanoseconds spans ~584 years, far beyond the range of
`CLOCK_MONOTONIC_COARSE`, so the wider type bought us nothing while costing
extra instructions on every `Clock::now()` call.

The change:

* `Bindings::clock_gettime_nanos` now returns `u64` (abstraction, facade, real).
* `TimeSourceImpl` stores `platform_epoch` / `cache_key` as `u64`.
* Removes the `u64::try_from(...).expect(...)` narrowing in `now()` and the
  associated `u128` multiply/add in the real binding.

Windows already used `u64` (`get_tick_count_64`), so no mirrored change is
needed — this only brings Linux in line.

## Measurement

Callgrind (`just package=fast_time bench-cg`), deterministic instruction counts:

| scenario    | before | after | delta    |
|-------------|-------:|------:|----------|
| `clock_now` |    108 |    88 | **−18.5%** |

`clock_now` uses a fresh `Clock`, so it always takes the cache-miss
arithmetic path — a deterministic, reproducible measurement.

(The `instant_elapsed` scenario is timing-sensitive — its instruction count
depends on whether `CLOCK_MONOTONIC_COARSE` ticks during the Valgrind run, so
it flips between the cache-hit and cache-miss path between runs. Filed
separately; not a regression from this change, which can only reduce work on
both paths.)

## Validation

`just package=fast_time validate-local` passes on Linux.
