### PR TITLE
refactor(nm_otel): hoist duplicated event.histogram() call

### DIFF
--- a/packages/nm_otel/src/mapping.rs
+++ b/packages/nm_otel/src/mapping.rs
@@ -146,11 +146,12 @@ pub(crate) fn export_report(
     for event in report.events() {
         let event_name = event.name();
         let event_state = state.event_state(event_name);
+        let histogram = event.histogram();
 
         // Get cached instruments for this event (creates them if first time seeing this event).
         // Pass histogram magnitudes if present so bucket counter and bounds can be created.
         let event_instruments =
-            instruments.instruments(event_name, event.histogram().map(nm::Histogram::magnitudes));
+            instruments.instruments(event_name, histogram.map(nm::Histogram::magnitudes));
 
         // Export count as counter (delta).
         let count_delta = event_state.count_delta(event.count());
@@ -160,7 +161,7 @@ pub(crate) fn export_report(
         event_instruments.sum_gauge.record(event.sum(), &[]);
 
         // Export histogram buckets if present.
-        if let Some(histogram) = event.histogram() {
+        if let Some(histogram) = histogram {
             let bucket_counter = event_instruments
                 .bucket_counter
                 .as_ref()


### PR DESCRIPTION
## Summary

Hoist the duplicated `event.histogram()` call in `export_report` into a single
`let histogram = event.histogram();` binding and reuse it for both the
`instruments(...)` call and the bucket-export `if let`.

## This is a readability-only change, not a performance change

`Report::histogram()` is `#[inline]` and returns `self.histogram.as_ref()`,
and `event` is not mutated between the two call sites, so the compiler already
eliminates the duplicate call. Verified with Callgrind
(`just package=nm_otel bench-cg`): all export scenarios are **bit-for-bit
identical** before and after (`small_steady_state` 6274|6274, `small_no_delta`
1197|1197, `large_steady_state` 23471|23471).

The value is purely that the source no longer reads the same accessor twice.

## Validation

`just package=nm_otel validate-local` passes on Linux.
