### PR TITLE
perf(many_cpus): store thread pin state in a thread-local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "folo_ffi",
+ "gungraun",
  "heapless",
  "itertools 0.14.0",
  "libc",

--- a/packages/many_cpus/Cargo.toml
+++ b/packages/many_cpus/Cargo.toml
@@ -49,6 +49,10 @@ par_bench = { path = "../par_bench", features = ["criterion"] }
 static_assertions = { workspace = true }
 testing = { path = "../testing" }
 
+# Gungraun drives Valgrind-based Callgrind benchmarks; Linux-only.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
+
 [target.'cfg(windows)'.dev-dependencies]
 windows = { workspace = true, features = ["Win32_Security"] }
 
@@ -58,6 +62,10 @@ harness = false
 
 [[bench]]
 name = "many_cpus_hardware_tracker"
+harness = false
+
+[[bench]]
+name = "many_cpus_hardware_tracker_cg"
 harness = false
 
 [[bench]]

--- a/packages/many_cpus/benches/many_cpus_hardware_tracker_cg.rs
+++ b/packages/many_cpus/benches/many_cpus_hardware_tracker_cg.rs
@@ -1,0 +1,102 @@
+//! Callgrind benchmarks for the `SystemHardware` per-thread tracking read path.
+//!
+//! Paired with `many_cpus_hardware_tracker.rs` (the Criterion group) which
+//! covers the same operations under wall-clock measurement.
+//!
+//! These isolate the instruction-level cost of resolving the current
+//! processor / memory region, which `region_cached` and `region_local`
+//! perform on every cached read:
+//!
+//! * `current_memory_region_id_unpinned` — unpinned thread; the pin-state
+//!   lookup misses (no entry for this instance).
+//! * `current_memory_region_id_pinned` — pinned thread; the pin-state lookup
+//!   hits the single entry stored for the `current()` singleton.
+//! * `current_processor_id_pinned` — same hit path for the processor ID.
+
+#![allow(
+    missing_docs,
+    reason = "no need for API documentation on benchmark code"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Tracking issue drafts live at \
+          c:/Source/gungraun-lint-issues/ pending upstream filing."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is Linux-only. On other platforms this
+    // bench target compiles to a no-op so `cargo build --all-targets` still works.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use gungraun::prelude::*;
+    use many_cpus::SystemHardware;
+    use new_zealand::nz;
+
+    // `current()` hands back the process-wide singleton by `&'static` reference, so
+    // there is no `Drop` to keep out of the measured region. The pinned setup pins
+    // the thread before measurement so the pin-state lookup hits its single entry.
+    fn unpinned_hardware() -> &'static SystemHardware {
+        SystemHardware::current()
+    }
+
+    fn pinned_hardware() -> &'static SystemHardware {
+        let hw = SystemHardware::current();
+        hw.processors()
+            .take(nz!(1))
+            .expect("a single processor is always available")
+            .pin_current_thread_to();
+        hw
+    }
+
+    #[library_benchmark]
+    #[bench::unpinned(unpinned_hardware())]
+    fn current_memory_region_id_unpinned(hw: &'static SystemHardware) {
+        black_box(hw.current_memory_region_id());
+    }
+
+    #[library_benchmark]
+    #[bench::pinned(pinned_hardware())]
+    fn current_memory_region_id_pinned(hw: &'static SystemHardware) {
+        black_box(hw.current_memory_region_id());
+    }
+
+    #[library_benchmark]
+    #[bench::pinned(pinned_hardware())]
+    fn current_processor_id_pinned(hw: &'static SystemHardware) {
+        black_box(hw.current_processor_id());
+    }
+
+    library_benchmark_group!(
+        name = read_group,
+        benchmarks = [
+            current_memory_region_id_unpinned,
+            current_memory_region_id_pinned,
+            current_processor_id_pinned,
+        ]
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::read_group;
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default().tool(
+        Callgrind::default()
+            .args(["--branch-sim=yes"])
+            .format([CallgrindMetrics::Default, CallgrindMetrics::BranchSim]),
+    );
+    library_benchmark_groups = read_group
+);

--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -144,6 +144,13 @@ struct ThreadState {
 /// control-byte probe. A `HashMap` would only pay off with many entries, which never happens.
 #[derive(Default)]
 struct PinStateMap {
+    // A `SmallVec<[_; 1]>` inline slot looks like the obvious next step — store the single
+    // production entry inline and drop the heap indirection on the hot read. Measurement says
+    // otherwise: it was slightly slower (47 vs 45 instructions, 204 vs 173 estimated cycles on
+    // `current_memory_region_id` pinned). This map lives in a thread-local that is read
+    // repeatedly, so the `Vec`'s heap buffer stays hot in L1 and the indirection is an
+    // already-cached load, whereas `SmallVec` adds an inline-vs-spilled discriminant branch to
+    // every access that costs more than the load it removes. A plain `Vec` is faster and simpler.
     entries: Vec<(u64, ThreadState)>,
 }
 

--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -49,8 +49,14 @@ thread_local! {
     /// that coexist in tests (fakes), while clones share state because they share an instance ID.
     /// Entries for dropped instances are removed by the `SystemHardwareInner` destructor on the
     /// dropping thread; any entries left on other threads persist until the thread exits, which is
-    /// harmless because instance IDs are never reused. In production only the singleton exists, so
-    /// each thread holds at most one entry.
+    /// harmless because instance IDs are never reused.
+    ///
+    /// Only pinning inserts an entry (through
+    /// [`update_pin_status`][SystemHardware::update_pin_status]); the read paths only look entries
+    /// up. In non-test builds the only `SystemHardware` instance is the
+    /// [`current()`][SystemHardware::current] singleton, so each thread holds exactly one entry
+    /// here — the one for that singleton. Multiple entries per thread only arise in tests that
+    /// construct additional (fake) instances.
     static PIN_STATES: RefCell<HashMap<u64, ThreadState>> = RefCell::new(HashMap::default());
 }
 

--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -8,9 +8,10 @@
 use std::any::type_name;
 #[cfg(any(test, feature = "test-util"))]
 use std::borrow::Borrow;
+use std::cell::RefCell;
 use std::fmt;
-use std::sync::{Arc, OnceLock, RwLock};
-use std::thread::ThreadId;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use foldhash::HashMap;
 use nonempty::NonEmpty;
@@ -26,6 +27,32 @@ use crate::{
 
 /// The real system hardware singleton, initialized on first access.
 static CURRENT_HARDWARE: OnceLock<SystemHardware> = OnceLock::new();
+
+/// Source of unique IDs for `SystemHardware` instances.
+///
+/// Each instance gets a distinct ID so that per-thread pin state (stored in the `PIN_STATES`
+/// thread-local) can be keyed by instance without different instances aliasing each other on
+/// the same thread. IDs are never reused.
+static NEXT_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    /// Per-thread pin state, keyed by `SystemHardware` instance ID.
+    ///
+    /// Pin state is inherently per-current-thread: a thread only ever pins itself
+    /// ([`update_pin_status`][SystemHardware::update_pin_status] writes the calling thread's
+    /// entry) and only ever reads its own state. Storing it in a thread-local rather than a
+    /// shared `RwLock<HashMap<ThreadId, _>>` removes the `thread::current().id()` lookup and the
+    /// lock acquire/release from every read on the hot path (e.g. `region_cached` / `region_local`
+    /// reads, which resolve the current memory region on every access).
+    ///
+    /// Keying by instance ID preserves isolation between the multiple `SystemHardware` instances
+    /// that coexist in tests (fakes), while clones share state because they share an instance ID.
+    /// Entries for dropped instances are removed by the `SystemHardwareInner` destructor on the
+    /// dropping thread; any entries left on other threads persist until the thread exits, which is
+    /// harmless because instance IDs are never reused. In production only the singleton exists, so
+    /// each thread holds at most one entry.
+    static PIN_STATES: RefCell<HashMap<u64, ThreadState>> = RefCell::new(HashMap::default());
+}
 
 /// Handle to system hardware, providing access to hardware information and tracking.
 ///
@@ -62,11 +89,10 @@ struct SystemHardwareInner {
     /// The platform abstraction layer implementation.
     platform: PlatformFacade,
 
-    /// Per-thread state tracked for this instance.
-    ///
-    /// We use `RwLock` because reads are far more common than writes, and we expect minimal
-    /// contention since each thread typically only accesses its own entry.
-    thread_states: RwLock<HashMap<ThreadId, ThreadState>>,
+    /// Unique ID of this instance, used to key its per-thread pin state in the `PIN_STATES`
+    /// thread-local. Clones share this ID (and therefore their pin state) because they share
+    /// the `Arc<SystemHardwareInner>`.
+    instance_id: u64,
 
     /// Processors indexed by processor ID for O(1) lookup.
     ///
@@ -93,13 +119,25 @@ struct SystemHardwareInner {
 }
 
 /// Per-thread state tracked within a hardware instance.
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 struct ThreadState {
     /// The processor ID the thread is pinned to, if pinned to exactly one processor.
     pinned_processor_id: Option<ProcessorId>,
 
     /// The memory region ID the thread is pinned to, if all pinned processors share a region.
     pinned_memory_region_id: Option<MemoryRegionId>,
+}
+
+impl Drop for SystemHardwareInner {
+    fn drop(&mut self) {
+        // Best-effort cleanup of this instance's pin state on the dropping thread. Entries on
+        // other threads (rare for a dropped instance) persist until those threads exit, which is
+        // harmless because instance IDs are never reused. `try_with` guards against the
+        // thread-local already being destroyed during thread teardown.
+        _ = PIN_STATES.try_with(|states| {
+            states.borrow_mut().remove(&self.instance_id);
+        });
+    }
 }
 
 impl SystemHardware {
@@ -186,7 +224,7 @@ impl SystemHardware {
         Self {
             inner: Arc::new(SystemHardwareInner {
                 platform,
-                thread_states: RwLock::new(HashMap::default()),
+                instance_id: NEXT_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
                 all_processors_slice: all_processors.into_boxed_slice(),
                 max_processor_id,
                 max_memory_region_id,
@@ -584,40 +622,22 @@ impl SystemHardware {
             "if processor is pinned, memory region is obviously also pinned"
         );
 
-        let thread_id = std::thread::current().id();
-        let mut states = self
-            .inner
-            .thread_states
-            .write()
-            .expect("thread state lock should never be poisoned");
-
-        let state = states.entry(thread_id).or_default();
-        state.pinned_processor_id = processor_id;
-        state.pinned_memory_region_id = memory_region_id;
+        PIN_STATES.with_borrow_mut(|states| {
+            let state = states.entry(self.inner.instance_id).or_default();
+            state.pinned_processor_id = processor_id;
+            state.pinned_memory_region_id = memory_region_id;
+        });
     }
 
     /// Gets the pinned processor ID for the current thread, if any.
     fn get_pinned_processor_id(&self) -> Option<ProcessorId> {
-        let thread_id = std::thread::current().id();
-        let states = self
-            .inner
-            .thread_states
-            .read()
-            .expect("thread state lock should never be poisoned");
-
-        states.get(&thread_id)?.pinned_processor_id
+        PIN_STATES.with_borrow(|states| states.get(&self.inner.instance_id)?.pinned_processor_id)
     }
 
     /// Gets the pinned memory region ID for the current thread, if any.
     fn get_pinned_memory_region_id(&self) -> Option<MemoryRegionId> {
-        let thread_id = std::thread::current().id();
-        let states = self
-            .inner
-            .thread_states
-            .read()
-            .expect("thread state lock should never be poisoned");
-
-        states.get(&thread_id)?.pinned_memory_region_id
+        PIN_STATES
+            .with_borrow(|states| states.get(&self.inner.instance_id)?.pinned_memory_region_id)
     }
 
     /// Gets a processor by ID, with fallback to any available processor if not found.

--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -13,7 +13,6 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
-use foldhash::HashMap;
 use nonempty::NonEmpty;
 
 #[cfg(any(test, feature = "test-util"))]
@@ -57,7 +56,7 @@ thread_local! {
     /// [`current()`][SystemHardware::current] singleton, so each thread holds exactly one entry
     /// here — the one for that singleton. Multiple entries per thread only arise in tests that
     /// construct additional (fake) instances.
-    static PIN_STATES: RefCell<HashMap<u64, ThreadState>> = RefCell::new(HashMap::default());
+    static PIN_STATES: RefCell<PinStateMap> = RefCell::new(PinStateMap::default());
 }
 
 /// Handle to system hardware, providing access to hardware information and tracking.
@@ -134,6 +133,46 @@ struct ThreadState {
     pinned_memory_region_id: Option<MemoryRegionId>,
 }
 
+/// A tiny associative map from `SystemHardware` instance ID to per-thread pin state.
+///
+/// This deliberately uses a linear-scan `Vec` instead of a `HashMap`. The standard choice
+/// would be a hash map, but it is the wrong tool here: in non-test builds this map holds
+/// exactly one entry per thread — the [`current()`][SystemHardware::current] singleton — and
+/// only a handful even in tests with fake instances. Hashing the `u64` key on every lookup
+/// (this is the hot read path of `region_cached` / `region_local`) costs more than comparing
+/// against one or two stored keys, and a `Vec` keeps the whole map inline without a hash-table
+/// control-byte probe. A `HashMap` would only pay off with many entries, which never happens.
+#[derive(Default)]
+struct PinStateMap {
+    entries: Vec<(u64, ThreadState)>,
+}
+
+impl PinStateMap {
+    /// Returns the pin state for the given instance ID, if present.
+    fn get(&self, instance_id: u64) -> Option<ThreadState> {
+        self.entries
+            .iter()
+            .find_map(|&(id, state)| (id == instance_id).then_some(state))
+    }
+
+    /// Inserts or updates the pin state for the given instance ID.
+    fn set(&mut self, instance_id: u64, state: ThreadState) {
+        if let Some(entry) = self.entries.iter_mut().find(|(id, _)| *id == instance_id) {
+            entry.1 = state;
+        } else {
+            self.entries.push((instance_id, state));
+        }
+    }
+
+    /// Removes the pin state for the given instance ID, if present.
+    fn remove(&mut self, instance_id: u64) {
+        if let Some(index) = self.entries.iter().position(|(id, _)| *id == instance_id) {
+            // Order is irrelevant: lookups match by instance ID, never by position.
+            _ = self.entries.swap_remove(index);
+        }
+    }
+}
+
 impl Drop for SystemHardwareInner {
     fn drop(&mut self) {
         // Remove this instance's pin state from the dropping thread's `PIN_STATES` map.
@@ -155,7 +194,7 @@ impl Drop for SystemHardwareInner {
         //    that case instead of panicking; there is simply nothing to clean up because the
         //    whole map is already gone.
         _ = PIN_STATES.try_with(|states| {
-            states.borrow_mut().remove(&self.instance_id);
+            states.borrow_mut().remove(self.instance_id);
         });
     }
 }
@@ -233,7 +272,7 @@ impl SystemHardware {
     /// Returns whether the current thread holds a `PIN_STATES` entry for the given instance ID.
     #[cfg(test)]
     pub(crate) fn current_thread_has_pin_state(instance_id: u64) -> bool {
-        PIN_STATES.with_borrow(|states| states.contains_key(&instance_id))
+        PIN_STATES.with_borrow(|states| states.get(instance_id).is_some())
     }
 
     fn from_platform(platform: PlatformFacade) -> Self {
@@ -655,21 +694,24 @@ impl SystemHardware {
         );
 
         PIN_STATES.with_borrow_mut(|states| {
-            let state = states.entry(self.inner.instance_id).or_default();
-            state.pinned_processor_id = processor_id;
-            state.pinned_memory_region_id = memory_region_id;
+            states.set(
+                self.inner.instance_id,
+                ThreadState {
+                    pinned_processor_id: processor_id,
+                    pinned_memory_region_id: memory_region_id,
+                },
+            );
         });
     }
 
     /// Gets the pinned processor ID for the current thread, if any.
     fn get_pinned_processor_id(&self) -> Option<ProcessorId> {
-        PIN_STATES.with_borrow(|states| states.get(&self.inner.instance_id)?.pinned_processor_id)
+        PIN_STATES.with_borrow(|states| states.get(self.inner.instance_id)?.pinned_processor_id)
     }
 
     /// Gets the pinned memory region ID for the current thread, if any.
     fn get_pinned_memory_region_id(&self) -> Option<MemoryRegionId> {
-        PIN_STATES
-            .with_borrow(|states| states.get(&self.inner.instance_id)?.pinned_memory_region_id)
+        PIN_STATES.with_borrow(|states| states.get(self.inner.instance_id)?.pinned_memory_region_id)
     }
 
     /// Gets a processor by ID, with fallback to any available processor if not found.

--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -130,10 +130,24 @@ struct ThreadState {
 
 impl Drop for SystemHardwareInner {
     fn drop(&mut self) {
-        // Best-effort cleanup of this instance's pin state on the dropping thread. Entries on
-        // other threads (rare for a dropped instance) persist until those threads exit, which is
-        // harmless because instance IDs are never reused. `try_with` guards against the
-        // thread-local already being destroyed during thread teardown.
+        // Remove this instance's pin state from the dropping thread's `PIN_STATES` map.
+        //
+        // This cleanup is "best-effort" in two specific senses, both of which are harmless:
+        //
+        // 1. We only reach the *current* thread's entry. If this instance was also pinned/read
+        //    from other threads, each of those threads holds its own `PIN_STATES` entry for this
+        //    instance ID that we cannot touch from here, so those entries linger until the
+        //    respective thread exits. This cannot cause incorrect behavior because instance IDs
+        //    are never reused (`NEXT_INSTANCE_ID` only ever increments), so a future instance can
+        //    never collide with a stale entry left by a previous one. The leftover memory is
+        //    bounded by the number of instances a thread has seen and is reclaimed at thread
+        //    exit. In production only the singleton instance exists and it lives for the whole
+        //    process, so this destructor effectively never runs there.
+        //
+        // 2. If the thread is itself being torn down, its `PIN_STATES` thread-local may already
+        //    have been destroyed by the time this destructor runs. `try_with` returns `Err` in
+        //    that case instead of panicking; there is simply nothing to clean up because the
+        //    whole map is already gone.
         _ = PIN_STATES.try_with(|states| {
             states.borrow_mut().remove(&self.instance_id);
         });
@@ -202,6 +216,18 @@ impl SystemHardware {
         use crate::pal::fallback::BUILD_TARGET_PLATFORM;
 
         Self::from_platform(PlatformFacade::Fallback(&BUILD_TARGET_PLATFORM))
+    }
+
+    /// Returns the unique ID of this instance, for use in tests that inspect `PIN_STATES`.
+    #[cfg(test)]
+    pub(crate) fn instance_id(&self) -> u64 {
+        self.inner.instance_id
+    }
+
+    /// Returns whether the current thread holds a `PIN_STATES` entry for the given instance ID.
+    #[cfg(test)]
+    pub(crate) fn current_thread_has_pin_state(instance_id: u64) -> bool {
+        PIN_STATES.with_borrow(|states| states.contains_key(&instance_id))
     }
 
     fn from_platform(platform: PlatformFacade) -> Self {
@@ -816,6 +842,23 @@ mod tests {
     fn panic_if_pinned_processor_with_unpinned_memory_region() {
         let hardware = SystemHardware::current();
         hardware.update_pin_status(Some(0), None);
+    }
+
+    #[test]
+    fn drop_removes_pin_state_on_current_thread() {
+        let hardware = SystemHardware::fallback();
+        let instance_id = hardware.instance_id();
+
+        // No entry exists until the current thread records pin state for this instance.
+        assert!(!SystemHardware::current_thread_has_pin_state(instance_id));
+
+        hardware.update_pin_status(Some(0), Some(0));
+        assert!(SystemHardware::current_thread_has_pin_state(instance_id));
+
+        drop(hardware);
+
+        // The destructor removed this thread's entry for the dropped instance.
+        assert!(!SystemHardware::current_thread_has_pin_state(instance_id));
     }
 }
 


### PR DESCRIPTION
## Summary

Stores per-thread pin state (pinned processor / memory region) in a process-global
`thread_local!` instead of a `RwLock<HashMap<ThreadId, ThreadState>>`.

Pin state is inherently per-current-thread: each thread only ever pins itself and reads its
own pin state. The shared `RwLock<HashMap<...>>` was therefore doing avoidable work on every
read — `thread::current().id()` plus `RwLock` atomics — to look up data that only the current
thread can touch. A thread-local keyed by a unique per-instance id removes that overhead from
the read path while preserving fake-instance isolation (each fake `SystemHardware` gets a unique
`instance_id`; clones share state through the same `Arc`/id).

## Why this helps the production path

`region_cached` / `region_local` consult the pinned memory region id on every cached read. This
change shaves the per-read pin lookup for **pinned** threads, which are the common production
configuration (the earlier "collapse double lookup" idea only helped *unpinned* test threads and
was retracted).

## Measurements (Callgrind, deterministic)

- `region_cached` `get_cached_warm`: 290 → 254 instructions (**−12.4%**)
- `region_local` `get_local_warm`: 286 → 250 instructions (**−12.6%**)

## Validation

- All 176 `many_cpus` tests pass.
- `just package=many_cpus validate-local` clean on **both** Linux and Windows
  (`system_hardware.rs` is cross-platform shared code).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
