### PR TITLE
docs(future_deque): record why the local variant keeps atomic wakers

### DIFF
--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -19,6 +19,14 @@ pub(crate) trait FutureHandle<T> {
 /// (auto-remove on drop), while the Local variant uses local handles
 /// (auto-remove on drop via Rc-based pool reference).
 pub(crate) struct FutureDequeCore<T, H> {
+    // Shared parent waker, read by every slot's waker. This stays `Arc<Mutex<Waker>>`
+    // even for the `!Send` `LocalFutureDeque` variant — do not "optimize" it to a
+    // non-atomic `Rc<Cell<Option<Waker>>>` (or make `WakerMeta`'s `ref_count`/`activated`
+    // non-atomic) for the local variant. `std::task::Waker` is unconditionally `Send +
+    // Sync`, so a `!Send` future polled here can still clone the `Waker` it receives and
+    // wake it from another thread (see the `WakerCaptureFuture` /
+    // `concurrent_signals_during_active_poll` tests). That wake path reads this field and
+    // the `WakerMeta` atomics off-thread, so any non-atomic variant would be a data race.
     pub(crate) shared_parent: Arc<Mutex<Waker>>,
     slots: VecDeque<Slot<T, H>>,
 }

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -22,9 +22,9 @@ pub(crate) struct FutureDequeCore<T, H> {
     // Shared parent waker, read by every slot's waker. This stays `Arc<Mutex<Waker>>`
     // even for the `!Send` `LocalFutureDeque` variant — do not "optimize" it to a
     // non-atomic `Rc<Cell<Option<Waker>>>` (or make `WakerMeta`'s `ref_count`/`activated`
-    // non-atomic) for the local variant. `std::task::Waker` is unconditionally `Send +
-    // Sync`, so a `!Send` future polled here can still clone the `Waker` it receives and
-    // wake it from another thread (see the `WakerCaptureFuture` /
+    // non-atomic) for the local variant. `std::task::Waker` is unconditionally
+    // `Send + Sync`, so a `!Send` future polled here can still clone the `Waker` it
+    // receives and wake it from another thread (see the `WakerCaptureFuture` /
     // `concurrent_signals_during_active_poll` tests). That wake path reads this field and
     // the `WakerMeta` atomics off-thread, so any non-atomic variant would be a data race.
     pub(crate) shared_parent: Arc<Mutex<Waker>>,

--- a/packages/future_deque/src/waker_meta.rs
+++ b/packages/future_deque/src/waker_meta.rs
@@ -13,6 +13,11 @@ use infinity_pool::{PinnedPool, Pooled, PooledMut};
 // Each WakerMeta is reference-counted: one reference for the owning Slot, plus one per
 // outstanding waker clone. When the refcount reaches zero, the metadata is removed from
 // the pool and its slot is available for reuse.
+//
+// The atomic `ref_count`/`activated` and the `Arc<Mutex<Waker>>` parent are mandatory even
+// when this metadata backs a `!Send` `LocalFutureDeque`: the `std::task::Waker` built from
+// it is `Send + Sync` and may be cloned/woken/dropped from another thread. See the design
+// comment on `FutureDequeCore::shared_parent` for why a non-atomic local variant is unsound.
 pub(crate) struct WakerMeta {
     ref_count: AtomicUsize,
 


### PR DESCRIPTION
## Summary

Documentation-only. Records, as `//` design comments, why `future_deque`'s waker machinery
stays thread-safe even for the `!Send` `LocalFutureDeque` variant — so a future reader does
not "optimize" it into a data race.

- At `FutureDequeCore::shared_parent`: the parent waker stays `Arc<Mutex<Waker>>` (and
  `WakerMeta`'s `ref_count` / `activated` stay atomic) for **both** variants. Do not switch the
  local variant to a non-atomic `Rc<Cell<Option<Waker>>>`.
- Cross-reference added at `WakerMeta`.

**Why it would be unsound:** `std::task::Waker` is unconditionally `Send + Sync`, so a `!Send`
future polled by `LocalFutureDeque` can still clone the `Waker` it receives and wake (or drop)
it from another thread. That wake path reads `shared_parent` and the `WakerMeta` atomics
off-thread. This pattern is exercised by the existing `WakerCaptureFuture` /
`concurrent_signals_during_active_poll` tests. A non-atomic local variant would be a data race.

No functional change; comment-only. Builds clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
