### PR TITLE
Fix intra-doc links to feature-gated items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,13 @@ Ensure `Cargo.toml` contains:
 all-features = true
 ```
 
+Intra-doc links from ungated documentation to feature-gated items (modules, types, trait
+`impl`s that only exist under a non-default feature) break when docs are built without that
+feature. Never drop the link or paste a raw URL to dodge the warning — use the
+feature-conditional `#[cfg_attr(..., doc = "...")]` doc-line pattern instead. See
+[docs/api-docs.md](docs/api-docs.md) for the full rationale, anti-patterns, and examples. The
+`docs-default-features` validation step exists to catch this class of error.
+
 # Do not use `\n` in println!() statements
 
 To empty an empty line to the terminal, use use `println!();` instead of

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1,0 +1,102 @@
+# API documentation conventions
+
+This document collects conventions for writing API documentation (`///` and `//!` comments)
+that are easy to get subtly wrong and that our tooling enforces.
+
+## Intra-doc links to feature-gated items
+
+### The problem
+
+An item — a module, type, trait, function, or trait `impl` — may only exist under a non-default
+cfg, for example:
+
+```rust
+#[cfg(any(test, feature = "test-util"))]
+pub mod fake;
+
+#[cfg(any(test, feature = "futures-stream"))]
+impl<T> futures_core::Stream for FutureDeque<T> { /* ... */ }
+```
+
+If a doc comment contains an intra-doc link to such an item, the link resolves only when the
+gating feature is enabled. Building the documentation **without** that feature (which is what
+happens by default, and what the `docs-default-features` validation step does) then fails with:
+
+```text
+error: unresolved link to `futures_core::Stream`
+   = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
+```
+
+This is easy to miss locally, because `validate-local`'s main docs build and docs.rs both use
+`--all-features`, where the linked item *does* exist. The dedicated `docs-default-features`
+check exists specifically to catch this class of error.
+
+### The anti-patterns
+
+1. **Unconditional link to a gated item.** A plain `[\`Stream\`][futures_core::Stream]` in an
+   ungated doc comment. Builds fine with `--all-features`, fails with default features.
+
+2. **Dropping the link to dodge the warning.** Writing `` `Stream` `` (no link), or pasting a
+   full `https://docs.rs/...` URL instead of an intra-doc link, purely to avoid the broken-link
+   error. This silently degrades the documentation for users who *do* enable the feature — they
+   lose the clickable, version-correct link rustdoc would otherwise generate.
+
+### The fix: feature-conditional doc lines
+
+Split the affected doc line into two `cfg_attr` doc attributes — one that emits the proper
+intra-doc link when the gating cfg is active, and a plain-text fallback otherwise. Use `#![...]`
+(inner) for module/crate-level `//!` docs and `#[...]` (outer) for item-level `///` docs.
+
+Crate/module-level (`//!`) example:
+
+```rust
+#![cfg_attr(
+    any(test, feature = "test-util"),
+    doc = "See the [`fake`] module for detailed examples and API documentation."
+)]
+#![cfg_attr(
+    not(any(test, feature = "test-util")),
+    doc = "See the `fake` module (available with the `test-util` feature) for detailed examples and API documentation."
+)]
+```
+
+Item-level (`///`) example, interleaved with the surrounding doc block:
+
+```rust
+/// `Poll::Pending` when the respective end is not yet ready.
+///
+#[cfg_attr(
+    any(test, feature = "futures-stream"),
+    doc = "With the `futures-stream` feature, `FutureDeque` also implements [`Stream`][futures_core::Stream], yielding completed results from the front."
+)]
+#[cfg_attr(
+    not(any(test, feature = "futures-stream")),
+    doc = "With the `futures-stream` feature, `FutureDeque` also implements `Stream`, yielding completed results from the front."
+)]
+///
+/// # Examples
+```
+
+Rules for applying the pattern:
+
+- **The cfg condition must exactly match the gate on the linked item.** If the item is
+  `#[cfg(any(test, feature = "foo"))]`, the link branch uses `any(test, feature = "foo")` and the
+  fallback uses `not(any(test, feature = "foo"))`. Including `test` keeps the link live in test
+  builds (where the item also exists).
+- **The fallback must carry the same information**, minus the broken link. Mention the feature by
+  name so a reader on default features still understands the capability exists and how to enable
+  it.
+- **`#[doc = "..."]` is exactly equivalent to a `///` line.** You can freely interleave
+  `#[cfg_attr(..., doc = "...")]` attributes between `///` lines; rustdoc renders them in source
+  order. Keep a blank `///` line on either side if the surrounding text is separate paragraphs.
+- **Long `doc = "..."` strings are acceptable here.** rustfmt does not reflow string literals, so
+  a single-line doc string that exceeds the usual 100-column guideline is fine — it cannot be
+  wrapped without changing the rendered output.
+
+### Why not `#[doc(cfg(...))]`?
+
+`doc(cfg(...))` (via the `doc_cfg` feature) controls the "available on feature X" *badge* rustdoc
+renders next to an item; it does not make an intra-doc link conditional. The two mechanisms are
+complementary: `doc_cfg` is configured once at the crate root (see the "Feature-gated
+documentation" section of [AGENTS.md](../AGENTS.md)) and annotates gated *items*, whereas the
+feature-conditional doc-line pattern above fixes *links* from ungated docs to gated items.

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -16,13 +16,27 @@
 //! - [`Operation`] - Calculates mean memory allocation per operation
 //!
 //! Additionally, when the `panic_on_next_alloc` feature is enabled:
-//! - [`panic_on_next_alloc`] - Function to enable panic-on-next-allocation for debugging
+#![cfg_attr(
+    feature = "panic_on_next_alloc",
+    doc = "- [`panic_on_next_alloc`] - Function to enable panic-on-next-allocation for debugging"
+)]
+#![cfg_attr(
+    not(feature = "panic_on_next_alloc"),
+    doc = "- `panic_on_next_alloc` - Function to enable panic-on-next-allocation for debugging"
+)]
 //!
 //! This package is not meant for use in production, serving only as a development tool.
 //!
 //! # Features
 //!
-//! - `panic_on_next_alloc`: Enables the [`panic_on_next_alloc`] function for debugging
+#![cfg_attr(
+    feature = "panic_on_next_alloc",
+    doc = "- `panic_on_next_alloc`: Enables the [`panic_on_next_alloc`] function for debugging"
+)]
+#![cfg_attr(
+    not(feature = "panic_on_next_alloc"),
+    doc = "- `panic_on_next_alloc`: Enables the `panic_on_next_alloc` function for debugging"
+)]
 //!   unexpected allocations. This feature adds some overhead to allocations, so it is optional.
 //!  
 //! # Simple usage

--- a/packages/future_deque/src/future_deque.rs
+++ b/packages/future_deque/src/future_deque.rs
@@ -55,8 +55,14 @@ impl<T> FutureHandle<T> for BlindPooledMut<dyn ErasedFuture<T>> {
 /// end has a completed future, `Poll::Ready(None)` when the deque is empty, or
 /// `Poll::Pending` when the respective end is not yet ready.
 ///
-/// With the `futures-stream` feature, `FutureDeque` also implements
-/// [`Stream`][futures_core::Stream], yielding completed results from the front.
+#[cfg_attr(
+    any(test, feature = "futures-stream"),
+    doc = "With the `futures-stream` feature, `FutureDeque` also implements [`Stream`][futures_core::Stream], yielding completed results from the front."
+)]
+#[cfg_attr(
+    not(any(test, feature = "futures-stream")),
+    doc = "With the `futures-stream` feature, `FutureDeque` also implements `Stream`, yielding completed results from the front."
+)]
 ///
 /// # Examples
 ///

--- a/packages/future_deque/src/local_future_deque.rs
+++ b/packages/future_deque/src/local_future_deque.rs
@@ -53,8 +53,14 @@ impl<T> FutureHandle<T> for LocalBlindPooledMut<dyn ErasedFuture<T>> {
 /// end has a completed future, `Poll::Ready(None)` when the deque is empty, or
 /// `Poll::Pending` when the respective end is not yet ready.
 ///
-/// With the `futures-stream` feature, `LocalFutureDeque` also
-/// implements [`Stream`][futures_core::Stream], yielding completed results from the front.
+#[cfg_attr(
+    any(test, feature = "futures-stream"),
+    doc = "With the `futures-stream` feature, `LocalFutureDeque` also implements [`Stream`][futures_core::Stream], yielding completed results from the front."
+)]
+#[cfg_attr(
+    not(any(test, feature = "futures-stream")),
+    doc = "With the `futures-stream` feature, `LocalFutureDeque` also implements `Stream`, yielding completed results from the front."
+)]
 ///
 /// # Examples
 ///

--- a/packages/par_bench/src/lib.rs
+++ b/packages/par_bench/src/lib.rs
@@ -125,7 +125,14 @@
 //!
 //! # Resource usage tracking
 //!
-//! When either the `alloc_tracker` or `all_the_time` features are enabled, the [`ResourceUsageExt`]
+#![cfg_attr(
+    any(feature = "alloc_tracker", feature = "all_the_time"),
+    doc = "When either the `alloc_tracker` or `all_the_time` features are enabled, the [`ResourceUsageExt`]"
+)]
+#![cfg_attr(
+    not(any(feature = "alloc_tracker", feature = "all_the_time")),
+    doc = "When either the `alloc_tracker` or `all_the_time` features are enabled, the `ResourceUsageExt`"
+)]
 //! extension trait becomes available, providing convenient resource usage tracking for benchmarks:
 //!
 //! ```ignore

--- a/packages/par_bench/src/run.rs
+++ b/packages/par_bench/src/run.rs
@@ -98,7 +98,7 @@ impl Run {
     )]
     #[cfg_attr(
         not(any(test, feature = "criterion")),
-        doc = "   or `execute_criterion_on()`."
+        doc = "   or `execute_criterion_on()` (available with the `criterion` feature)."
     )]
     ///
     /// You can skip optional steps but cannot go back in the sequence.

--- a/packages/par_bench/src/run.rs
+++ b/packages/par_bench/src/run.rs
@@ -92,7 +92,14 @@ impl Run {
     /// 5. Optionally set measurement wrappers with [`measure_wrapper()`](crate::configure::RunWithIterState::measure_wrapper)
     /// 6. **Required**: Set the benchmark function with [`iter()`](crate::configure::RunWithWrapperState::iter)
     /// 7. **Required**: Execute the run with either [`execute_on()`][crate::ConfiguredRun::execute_on]
-    ///    or [`execute_criterion_on()`][crate::ConfiguredRun::execute_criterion_on].
+    #[cfg_attr(
+        any(test, feature = "criterion"),
+        doc = "   or [`execute_criterion_on()`][crate::ConfiguredRun::execute_criterion_on]."
+    )]
+    #[cfg_attr(
+        not(any(test, feature = "criterion")),
+        doc = "   or `execute_criterion_on()`."
+    )]
     ///
     /// You can skip optional steps but cannot go back in the sequence.
     ///

--- a/packages/par_bench/src/run_configured.rs
+++ b/packages/par_bench/src/run_configured.rs
@@ -66,7 +66,7 @@ where
     )]
     #[cfg_attr(
         not(any(test, feature = "criterion")),
-        doc = "to use `execute_criterion_on()`."
+        doc = "to use `execute_criterion_on()` (available with the `criterion` feature)."
     )]
     ///
     /// # Panics

--- a/packages/par_bench/src/run_configured.rs
+++ b/packages/par_bench/src/run_configured.rs
@@ -60,7 +60,14 @@ where
     /// returning the result.
     ///
     /// If you are executing the benchmark in a Criterion context, you may find it more convenient
-    /// to use [`execute_criterion_on()`][Self::execute_criterion_on].
+    #[cfg_attr(
+        any(test, feature = "criterion"),
+        doc = "to use [`execute_criterion_on()`][Self::execute_criterion_on]."
+    )]
+    #[cfg_attr(
+        not(any(test, feature = "criterion")),
+        doc = "to use `execute_criterion_on()`."
+    )]
     ///
     /// # Panics
     ///


### PR DESCRIPTION
## Problem

The `docs-default-features` validation step (which builds docs with **default** features, unlike the main docs build and docs.rs which use `--all-features`) was failing workspace-wide with `unresolved link` errors. Several `///`/`//!` comments link to items that only exist under a non-default feature, so the links dangle when that feature is off.

Affected packages:

- **`future_deque`** — links to `[`Stream`][futures_core::Stream]` (the `impl Stream` is gated behind `futures-stream`).
- **`alloc_tracker`** — links to `[`panic_on_next_alloc`]` (the function is gated behind `panic_on_next_alloc`).
- **`par_bench`** — links to `[`ResourceUsageExt`]` (gated behind `alloc_tracker`/`all_the_time`) and `execute_criterion_on()` (gated behind `criterion`).

## Fix

Apply the feature-conditional `#[cfg_attr(..., doc = "...")]` doc-line pattern (introduced for `many_cpus` in #228) at every affected site: emit the proper intra-doc link when the gating cfg is active, and a plain-text fallback that still names the feature otherwise. The cfg condition exactly matches each linked item's gate.

## Documentation

Added `docs/api-docs.md` documenting the problem, the two anti-patterns (unconditional links and dropping the link to dodge the warning), the fix with `//!` and `///` examples, application rules, and why this is distinct from `#[doc(cfg(...))]`. Referenced it from the "Feature-gated documentation" section of `AGENTS.md`.

## Validation

- `just docs-default-features` (full workspace) — green.
- `--all-features` docs build for each touched package — green.
- `cargo fmt --check` and `cargo clippy --all-targets` on touched packages — clean.
