### PR TITLE
perf(many_cpus): single pin-state lookup in current_memory_region_id

### DIFF
--- a/packages/many_cpus/src/system_hardware.rs
+++ b/packages/many_cpus/src/system_hardware.rs
@@ -591,7 +591,13 @@ impl SystemHardware {
     #[cfg_attr(test, mutants::skip)] // Composition of tested methods.
     pub fn current_memory_region_id(&self) -> MemoryRegionId {
         self.get_pinned_memory_region_id().unwrap_or_else(|| {
-            let processor_id = self.current_processor_id();
+            // The thread is not memory-region pinned. A processor-pinned thread is
+            // always memory-region pinned too (enforced by `update_pin_status`), so
+            // it is also not processor pinned. We therefore skip `current_processor_id`
+            // and query the platform directly - going through `current_processor_id`
+            // would consult the `PIN_STATES` thread-local a second time only to find
+            // the same "not pinned" answer we already have.
+            let processor_id = self.inner.platform.current_processor_id();
             self.get_processor(processor_id).memory_region_id()
         })
     }


### PR DESCRIPTION
## Summary

Removes a redundant `PIN_STATES` thread-local lookup on the unpinned path of
`SystemHardware::current_memory_region_id`.

Previously the unpinned path consulted `PIN_STATES` twice:

1. `get_pinned_memory_region_id()` — misses (thread not memory-region pinned).
2. `current_processor_id()` → `get_pinned_processor_id()` — consults `PIN_STATES`
   again, only to also miss.

The second lookup is provably redundant: `update_pin_status` asserts that a
processor-pinned thread is always memory-region pinned too, so once we know the
thread is not memory-region pinned we already know it is not processor pinned.
The fallback therefore queries the platform directly instead of routing through
`current_processor_id`.

## Change

A one-line behavioural change (call `self.inner.platform.current_processor_id()`
directly in the `unwrap_or_else` fallback) plus an explanatory comment. The
pinned fast path and the `update_pin_status` invariant are untouched.

## Data — Callgrind (`many_cpus_hardware_tracker_cg`), instructions

| Benchmark | before | after |
|---|---|---|
| `current_memory_region_id_unpinned` | 542 | **513 (-5.4%)** |
| `current_memory_region_id_pinned` | 45 | 45 (unchanged) |
| `current_processor_id_pinned` | 47 | 47 (unchanged) |

The unpinned case is the warm read path behind `region_cached` / `region_local`
for unpinned threads. The benchmark that validates the change
(`current_memory_region_id_unpinned`) already exists in both the Callgrind and
Criterion suites.

## Validation

- `just package=many_cpus test` — 177 passed (both Windows and Linux)
- `just package=many_cpus clippy` — clean
- `just package=many_cpus validate-local` — clean on Windows and Linux (incl. Miri)
