### PR TITLE
ci: gate careful and miri jobs on test-more

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -97,7 +97,12 @@ for manual cache warming after toolchain updates.
      dev `cargo check` already failed)
    - `miri-x64` and `miri-arm` depend on `check-dev` (Miri is much slower than `cargo check`;
      if the code does not even compile in dev mode, there is nothing for Miri to interpret)
+   - `miri-x64` also depends on `test-more-x64`, and `miri-arm` also depends on
+     `test-more-arm` (there is no point running the slow Miri interpreter unless the tests
+     already pass in their base configuration)
    - `mutants` depends on `test-more-x64` (mutation testing is meaningless if base tests fail)
+   - `careful` depends on `test-more-x64` (running the slow `cargo careful` test pass is
+     pointless unless the tests already pass in their base configuration)
    - `miri-harder-*` depend on both `miri-x64` and `miri-arm` (many-seeds runs are
      orders of magnitude slower than a single Miri pass)
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -238,7 +238,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" docs-default-features
 
   miri-x64:
-    needs: [delta, check-dev]
+    needs: [delta, check-dev, test-more-x64]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -293,7 +293,7 @@ jobs:
   # architecture-agnostic for platform-neutral code; we run it on ARM purely to exercise
   # cfg(target_arch = "aarch64") (and similar) code paths under Miri's UB detection.
   miri-arm:
-    needs: [delta, check-dev]
+    needs: [delta, check-dev, test-more-arm]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -549,7 +549,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" hack
 
   careful:
-    needs: [delta]
+    needs: [delta, test-more-x64]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false


### PR DESCRIPTION
Gate the slower validation jobs behind `test-more` so they only run once the
tests pass in their base configuration.

- `careful` now depends on `test-more-x64`.
- `miri-x64` now depends on `test-more-x64`.
- `miri-arm` now depends on `test-more-arm`.

Updated `.github/workflows/AGENTS.md` to document the rationale for the new
gating.
