### PR TITLE
Add cargo-freeze-deps subcommand

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -87,6 +87,7 @@
                 "alloc_tracker",
                 "benchmarks",
                 "cargo-detect-package",
+                "cargo-freeze-deps",
                 "cpulist",
                 "events",
                 "events_once",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "linked",
  "many_cpus",
  "many_cpus_benchmarking",
- "scc 3.7.1",
+ "scc",
  "windows",
 ]
 
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -230,6 +230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-freeze-deps"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "mutants 0.0.4",
+ "semver",
+ "serial_test",
+ "tempfile",
+ "toml_edit",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,9 +249,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -939,9 +951,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1106,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "many_cpus"
@@ -1171,9 +1183,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1785,21 +1797,12 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd 3.0.10",
-]
-
-[[package]]
-name = "scc"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcd12b6caff5213cc3c03123cde8c3db5e413008a63b0c0ba35e6275825ea92"
 dependencies = [
  "saa",
- "sdd 4.8.6",
+ "sdd",
 ]
 
 [[package]]
@@ -1807,12 +1810,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdd"
@@ -1889,21 +1886,20 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "once_cell",
  "parking_lot",
- "scc 2.4.0",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1912,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simple-mermaid"
@@ -1936,9 +1932,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
@@ -2133,6 +2129,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,9 +2239,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -2242,9 +2251,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unty-next"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bce2adbe4c8e63c3e7f79e9249b5409fb3c9bce989dd44337493cf1c8d7dea0"
+checksum = "9fa66022bbd1ab992fad72bdedcfd07a0023b6f5ecc83d50121e39e3a3caed41"
 
 [[package]]
 name = "vicinal"
@@ -2538,6 +2547,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2635,18 +2647,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ arc-swap = { version = "1.7.0", default-features = false }
 argh = { version = "0.1.13", default-features = false, features = ["default"] }
 awaiter_set = { version = "0.1.6", path = "packages/awaiter_set", default-features = false }
 axum = { version = "0.8.0", default-features = false }
+cargo-freeze-deps = { version = "0.1.0", path = "packages/cargo-freeze-deps", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }
 cpulist = { version = "1.1.3", path = "packages/cpulist", default-features = false }
 criterion = { version = "0.8.2", default-features = false }
@@ -81,6 +82,7 @@ rand = { version = "0.10.1", default-features = false, features = ["std"] }
 rsevents = { version = "0.3.1", default-features = false }
 scc = { version = "3.0.2", default-features = false }
 scopeguard = { version = "1.2.0", default-features = false }
+semver = { version = "1.0.28", default-features = false, features = ["std"] }
 seq-macro = { version = "0.3.0", default-features = false }
 serial_test = { version = "3.2.0", default-features = false }
 simple-mermaid = { version = "0.2.0", default-features = false }
@@ -92,6 +94,7 @@ threadpool = { version = "1.8.1", default-features = false }
 tick = { version = "0.3.0", default-features = false }
 tokio = { version = "1.48.0", default-features = false }
 toml = { version = "1.1.2", default-features = false }
+toml_edit = { version = "0.25.12", default-features = false }
 tracing = { version = "0.1.30", default-features = false, features = ["std"] }
 trybuild = { version = "1.0.0", default-features = false }
 vicinal = { version = "0.1.26", path = "packages/vicinal", default-features = false }

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+# Cargo has its own logic for naming and expects dashes. Okay.
+name = "cargo-freeze-deps"
+description = "A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file to their literal values"
+publish = true
+version = "0.1.0"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+argh = { workspace = true }
+semver = { workspace = true }
+toml_edit = { workspace = true, features = ["parse", "display"] }
+
+[dev-dependencies]
+mutants = { workspace = true }
+serial_test = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/cargo-freeze-deps/README.md
+++ b/packages/cargo-freeze-deps/README.md
@@ -1,0 +1,81 @@
+# cargo-freeze-deps
+
+A Cargo subcommand that rewrites a `Cargo.toml` file in place, freezing every floating
+dependency version requirement to its literal `=X.Y.Z` form.
+
+## Usage
+
+Install via `cargo install cargo-freeze-deps` and then:
+
+```text
+cargo freeze-deps [--path PATH] [--output PATH]
+```
+
+### Arguments
+
+* `-p, --path <PATH>`: path to the `Cargo.toml` file to read. Defaults to `./Cargo.toml`
+  in the current directory.
+* `-o, --output <PATH>`: path to write the rewritten file to. Defaults to the input path
+  (rewriting in place).
+
+The tool works on both workspace-level and package-level `Cargo.toml` files — whichever
+dependency tables the input file contains are processed.
+
+## What gets rewritten
+
+The following dependency tables are processed:
+
+* `[dependencies]`
+* `[dev-dependencies]`
+* `[build-dependencies]`
+* `[target.<spec>.dependencies]`, `[target.<spec>.dev-dependencies]`,
+  `[target.<spec>.build-dependencies]`
+* `[workspace.dependencies]`
+
+For each dependency entry that carries a `version` field — whether as a bare string
+(`dep = "1.2.3"`), an inline table (`dep = { version = "1.2.3", ... }`), or a detached
+table (`[dependencies.dep]` `version = "1.2.3"`) — the version requirement is rewritten
+to its frozen literal.
+
+Dependencies without a version field (pure `path`, `git`, or `workspace = true`) are
+left untouched.
+
+`[patch]` and `[replace]` tables are not processed.
+
+## Freezing rules
+
+Each version requirement is rewritten to its lowest matching literal `=major.minor.patch`,
+zero-filling any missing components per Cargo's expectations.
+
+| Input              | Output                  |
+| ------------------ | ----------------------- |
+| `1.2.3`            | `=1.2.3`                |
+| `1`                | `=1.0.0`                |
+| `1.2`              | `=1.2.0`                |
+| `=1.2`             | `=1.2.0`                |
+| `^1.2.3`           | `=1.2.3`                |
+| `~1.2.3`           | `=1.2.3`                |
+| `>=1.2.3`          | `=1.2.3`                |
+| `>= 1.2.3`         | `=1.2.3`                |
+| `<=1.2.3`          | `=1.2.3`                |
+| `1.*`              | `=1.0.0`                |
+| `1.2.*`            | `=1.2.0`                |
+| `1.2.3-rc.1`       | `=1.2.3-rc.1`           |
+| `1.2.3+build.42`   | `=1.2.3` (build dropped) |
+
+### Requirements left unchanged
+
+* Strict inequalities without an equals component: `<1.2.3`, `>1.2.3`.
+* Bare `*` (no major number to pin to).
+* Multi-comparator requirements such as `">=0.5, <1.0"` — freezing these would either
+  silently drop part of the original constraint or require knowledge of which versions
+  exist on the registry. Hand-freeze them if needed.
+
+## Errors
+
+The tool fails fast — if any single version requirement is malformed, no file is written.
+
+## Formatting
+
+Comments and overall layout are preserved on round-trip via `toml_edit`. Quote style for
+the rewritten version string is reset to the `toml_edit` default (double quotes).

--- a/packages/cargo-freeze-deps/src/freeze.rs
+++ b/packages/cargo-freeze-deps/src/freeze.rs
@@ -1,0 +1,724 @@
+// Cargo.toml document walker.
+//
+// Parses a Cargo.toml document with `toml_edit` (so comments and layout are preserved on
+// round-trip), walks every standard dependency table, and rewrites each entry's `version`
+// string to its frozen form.
+
+use toml_edit::{DocumentMut, Formatted, Item, TableLike, Value};
+
+use crate::version::freeze_requirement;
+use crate::{RunError, RunOutcome};
+
+/// Standard dependency tables that can appear at the root of a package-level Cargo.toml.
+const PACKAGE_DEP_TABLES: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
+
+/// Freezes every floating dependency version in `content` and returns the rewritten document
+/// alongside a summary of how many versions were frozen vs left unchanged.
+///
+/// The returned string has the same comments and overall layout as the input — only the
+/// rewritten version literals differ.
+pub(crate) fn freeze_document(content: &str) -> Result<(String, RunOutcome), RunError> {
+    let mut doc: DocumentMut = content
+        .parse()
+        .map_err(|e: toml_edit::TomlError| RunError::Parse(e.to_string()))?;
+
+    let mut outcome = RunOutcome {
+        frozen_count: 0,
+        skipped_count: 0,
+    };
+
+    process_package_level(doc.as_table_mut(), &mut outcome)?;
+    process_workspace_level(doc.as_table_mut(), &mut outcome)?;
+    process_target_level(doc.as_table_mut(), &mut outcome)?;
+
+    Ok((doc.to_string(), outcome))
+}
+
+/// Processes `[dependencies]`, `[dev-dependencies]`, and `[build-dependencies]` at the
+/// document root (i.e. the package-level dependency tables).
+fn process_package_level(
+    root: &mut dyn TableLike,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    for table_name in PACKAGE_DEP_TABLES {
+        if let Some(table) = root.get_mut(table_name).and_then(Item::as_table_like_mut) {
+            freeze_dependency_table(table, outcome)?;
+        }
+    }
+    Ok(())
+}
+
+/// Processes `[workspace.dependencies]` if a `[workspace]` table is present.
+fn process_workspace_level(
+    root: &mut dyn TableLike,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    let Some(workspace) = root.get_mut("workspace").and_then(Item::as_table_like_mut) else {
+        return Ok(());
+    };
+
+    if let Some(deps) = workspace
+        .get_mut("dependencies")
+        .and_then(Item::as_table_like_mut)
+    {
+        freeze_dependency_table(deps, outcome)?;
+    }
+
+    Ok(())
+}
+
+/// Processes every `[target.<spec>.dependencies]`, `[target.<spec>.dev-dependencies]`, and
+/// `[target.<spec>.build-dependencies]` table.
+fn process_target_level(
+    root: &mut dyn TableLike,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    let Some(target) = root.get_mut("target").and_then(Item::as_table_like_mut) else {
+        return Ok(());
+    };
+
+    for (_target_spec, target_entry) in target.iter_mut() {
+        let Some(target_table) = target_entry.as_table_like_mut() else {
+            continue;
+        };
+
+        for table_name in PACKAGE_DEP_TABLES {
+            if let Some(table) = target_table
+                .get_mut(table_name)
+                .and_then(Item::as_table_like_mut)
+            {
+                freeze_dependency_table(table, outcome)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Freezes every entry in a single dependency table.
+fn freeze_dependency_table(
+    table: &mut dyn TableLike,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    for (key, entry) in table.iter_mut() {
+        let dep_name = key.get().to_string();
+        freeze_dependency_entry(&dep_name, entry, outcome)?;
+    }
+    Ok(())
+}
+
+/// Freezes a single dependency entry, which can be:
+///
+/// 1. A bare string value: `dep = "1.2.3"`.
+/// 2. An inline table: `dep = { version = "1.2.3", features = [...] }`.
+/// 3. A detached table block: `[dependencies.dep]` followed by `version = "1.2.3"`.
+fn freeze_dependency_entry(
+    dep_name: &str,
+    entry: &mut Item,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    match entry {
+        Item::Value(Value::String(s)) => {
+            // Form 1: bare string.
+            freeze_version_string(dep_name, s, outcome)?;
+        }
+        Item::Value(Value::InlineTable(t)) => {
+            // Form 2: inline table.
+            if let Some(version_value) = t.get_mut("version") {
+                freeze_version_in_value(dep_name, version_value, outcome)?;
+            }
+        }
+        Item::Table(t) => {
+            // Form 3: detached table.
+            if let Some(version_item) = t.get_mut("version") {
+                freeze_version_in_item(dep_name, version_item, outcome)?;
+            }
+        }
+        // Other forms (array of tables, etc.) are not valid Cargo dependency entries —
+        // skip rather than error so unrelated future TOML shapes don't break us.
+        _ => {}
+    }
+
+    Ok(())
+}
+
+/// Freezes the `version` field when accessed as a `toml_edit::Value`.
+fn freeze_version_in_value(
+    dep_name: &str,
+    version_value: &mut Value,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    match version_value {
+        Value::String(s) => freeze_version_string(dep_name, s, outcome),
+        other => Err(RunError::UnexpectedVersionType {
+            dep: dep_name.to_string(),
+            actual_type: other.type_name().to_string(),
+        }),
+    }
+}
+
+/// Freezes the `version` field when accessed as a `toml_edit::Item`.
+fn freeze_version_in_item(
+    dep_name: &str,
+    version_item: &mut Item,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    match version_item {
+        Item::Value(Value::String(s)) => freeze_version_string(dep_name, s, outcome),
+        Item::Value(other) => Err(RunError::UnexpectedVersionType {
+            dep: dep_name.to_string(),
+            actual_type: other.type_name().to_string(),
+        }),
+        Item::None => Ok(()),
+        Item::Table(_) | Item::ArrayOfTables(_) => Err(RunError::UnexpectedVersionType {
+            dep: dep_name.to_string(),
+            actual_type: "table".to_string(),
+        }),
+    }
+}
+
+/// Replaces the underlying version literal while preserving the surrounding decor
+/// (whitespace and inline comments around the value).
+fn freeze_version_string(
+    dep_name: &str,
+    formatted: &mut Formatted<String>,
+    outcome: &mut RunOutcome,
+) -> Result<(), RunError> {
+    let original = formatted.value().as_str();
+
+    let frozen = freeze_requirement(original).map_err(|source| RunError::InvalidVersion {
+        dep: dep_name.to_string(),
+        version: original.to_string(),
+        source,
+    })?;
+
+    let Some(frozen) = frozen else {
+        outcome.skipped_count = outcome
+            .skipped_count
+            .checked_add(1)
+            .expect("skipped_count cannot overflow usize for a single Cargo.toml file");
+        return Ok(());
+    };
+
+    // No-op rewrite (already at the target literal) should not be counted as a change.
+    if frozen == original {
+        return Ok(());
+    }
+
+    // Preserve the surrounding whitespace and comments by cloning the decor and reapplying
+    // it to the new value. `Formatted::new` resets decor to default; that's why we explicitly
+    // copy it across.
+    let decor = formatted.decor().clone();
+    let mut replacement = Formatted::new(frozen);
+    *replacement.decor_mut() = decor;
+    *formatted = replacement;
+
+    outcome.frozen_count = outcome
+        .frozen_count
+        .checked_add(1)
+        .expect("frozen_count cannot overflow usize for a single Cargo.toml file");
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn freeze(content: &str) -> (String, RunOutcome) {
+        freeze_document(content).expect("test inputs are expected to be well-formed")
+    }
+
+    // -- Dependency entry forms -----------------------------------------------------------
+
+    #[test]
+    fn bare_string_form() {
+        let input = r#"
+[dependencies]
+serde = "1.2.3"
+"#;
+        let expected = r#"
+[dependencies]
+serde = "=1.2.3"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, expected);
+        assert_eq!(outcome.frozen_count, 1);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn inline_table_form() {
+        let input = r#"
+[dependencies]
+serde = { version = "1.2.3", features = ["derive"] }
+"#;
+        let expected = r#"
+[dependencies]
+serde = { version = "=1.2.3", features = ["derive"] }
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, expected);
+        assert_eq!(outcome.frozen_count, 1);
+    }
+
+    #[test]
+    fn detached_table_form() {
+        let input = r#"
+[dependencies.serde]
+version = "1.2.3"
+features = ["derive"]
+"#;
+        let expected = r#"
+[dependencies.serde]
+version = "=1.2.3"
+features = ["derive"]
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, expected);
+        assert_eq!(outcome.frozen_count, 1);
+    }
+
+    // -- Dependency table kinds -----------------------------------------------------------
+
+    #[test]
+    fn dev_dependencies_processed() {
+        let input = r#"
+[dev-dependencies]
+mockall = "0.14.0"
+"#;
+        let expected = r#"
+[dev-dependencies]
+mockall = "=0.14.0"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn build_dependencies_processed() {
+        let input = r#"
+[build-dependencies]
+cc = "1.0"
+"#;
+        let expected = r#"
+[build-dependencies]
+cc = "=1.0.0"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn workspace_dependencies_processed() {
+        let input = r#"
+[workspace.dependencies]
+serde = "1.2.3"
+"#;
+        let expected = r#"
+[workspace.dependencies]
+serde = "=1.2.3"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn target_specific_dependencies_processed() {
+        let input = r#"
+[target."cfg(unix)".dependencies]
+libc = "0.2.172"
+
+[target."cfg(windows)".dependencies]
+windows = "0.62.0"
+"#;
+        let expected = r#"
+[target."cfg(unix)".dependencies]
+libc = "=0.2.172"
+
+[target."cfg(windows)".dependencies]
+windows = "=0.62.0"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, expected);
+        assert_eq!(outcome.frozen_count, 2);
+    }
+
+    #[test]
+    fn target_dev_and_build_deps_processed() {
+        let input = r#"
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.27.0"
+
+[target.'cfg(unix)'.build-dependencies]
+cc = "1.0.0"
+"#;
+        let (_, outcome) = freeze(input);
+        assert_eq!(outcome.frozen_count, 2);
+    }
+
+    #[test]
+    fn detached_target_dependency_table() {
+        // `[target.'cfg(unix)'.dependencies.foo]` is the detached form of an entry inside a
+        // target-specific dependency table.
+        let input = r#"
+[target.'cfg(unix)'.dependencies.libc]
+version = "0.2.172"
+default-features = false
+"#;
+        let expected = r#"
+[target.'cfg(unix)'.dependencies.libc]
+version = "=0.2.172"
+default-features = false
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    // -- Entries without a version field --------------------------------------------------
+
+    #[test]
+    fn workspace_inheritance_left_unchanged() {
+        let input = "
+[dependencies]
+serde = { workspace = true }
+";
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn path_only_dependency_left_unchanged() {
+        let input = r#"
+[dependencies]
+my_crate = { path = "../my_crate" }
+"#;
+        let (output, _) = freeze(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn git_only_dependency_left_unchanged() {
+        let input = r#"
+[dependencies]
+my_crate = { git = "https://example.com/repo.git", rev = "deadbeef" }
+"#;
+        let (output, _) = freeze(input);
+        assert_eq!(output, input);
+    }
+
+    // -- Mixed sources with version field -------------------------------------------------
+
+    #[test]
+    fn path_plus_version_freezes_version() {
+        let input = r#"
+[dependencies]
+my_crate = { path = "../my_crate", version = "0.1.0" }
+"#;
+        let expected = r#"
+[dependencies]
+my_crate = { path = "../my_crate", version = "=0.1.0" }
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn git_plus_version_freezes_version() {
+        let input = r#"
+[dependencies]
+my_crate = { git = "https://example.com/repo.git", version = "0.1.0" }
+"#;
+        let expected = r#"
+[dependencies]
+my_crate = { git = "https://example.com/repo.git", version = "=0.1.0" }
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    // -- Non-freezable versions left as-is, counted as skipped ----------------------------
+
+    #[test]
+    fn strict_less_left_unchanged_and_counted() {
+        let input = r#"
+[dependencies]
+serde = "<1.2.3"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 1);
+    }
+
+    #[test]
+    fn multi_comparator_left_unchanged_and_counted() {
+        let input = r#"
+[dependencies]
+serde = ">=1.0.0, <2.0.0"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 1);
+    }
+
+    #[test]
+    fn bare_star_left_unchanged_and_counted() {
+        let input = r#"
+[dependencies]
+serde = "*"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.skipped_count, 1);
+    }
+
+    // -- Already-frozen versions are not counted as new freezes ---------------------------
+
+    #[test]
+    fn already_frozen_is_no_op() {
+        let input = r#"
+[dependencies]
+serde = "=1.2.3"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    // -- Decor preservation ---------------------------------------------------------------
+
+    #[test]
+    fn comments_preserved_above_entry() {
+        let input = r#"
+[dependencies]
+# Important serialization library.
+serde = "1.2.3"
+# Async runtime.
+tokio = "1.48.0"
+"#;
+        let expected = r#"
+[dependencies]
+# Important serialization library.
+serde = "=1.2.3"
+# Async runtime.
+tokio = "=1.48.0"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn suffix_comments_preserved() {
+        let input = r#"
+[dependencies]
+serde = "1.2.3" # pinned for compatibility
+"#;
+        let expected = r#"
+[dependencies]
+serde = "=1.2.3" # pinned for compatibility
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn inline_table_suffix_comments_preserved() {
+        let input = r#"
+[dependencies]
+serde = { version = "1.2.3", features = ["derive"] } # the heart of our config
+"#;
+        let expected = r#"
+[dependencies]
+serde = { version = "=1.2.3", features = ["derive"] } # the heart of our config
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    #[test]
+    fn detached_table_comments_preserved() {
+        let input = r#"
+# Crates we own
+[dependencies.my_crate]
+# Always pinned to a tested version.
+version = "0.1.0"
+path = "../my_crate"
+"#;
+        let expected = r#"
+# Crates we own
+[dependencies.my_crate]
+# Always pinned to a tested version.
+version = "=0.1.0"
+path = "../my_crate"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    // -- Tables we do NOT process ---------------------------------------------------------
+
+    #[test]
+    fn patch_table_left_unchanged() {
+        let input = r#"
+[patch.crates-io]
+serde = "1.2.3"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn replace_table_left_unchanged() {
+        let input = r#"
+[replace]
+"serde:1.2.3" = { version = "1.2.4" }
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+    }
+
+    #[test]
+    fn package_metadata_version_field_left_unchanged() {
+        // The package's own `version` field is not a dependency version requirement.
+        let input = r#"
+[package]
+name = "my_crate"
+version = "1.2.3"
+
+[dependencies]
+serde = "1.2.3"
+"#;
+        let expected = r#"
+[package]
+name = "my_crate"
+version = "1.2.3"
+
+[dependencies]
+serde = "=1.2.3"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+
+    // -- Error cases ----------------------------------------------------------------------
+
+    #[test]
+    fn invalid_toml_returns_parse_error() {
+        let input = "this is = not [valid toml";
+        match freeze_document(input).unwrap_err() {
+            RunError::Parse(_) => {}
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_version_returns_typed_error_with_dep_name() {
+        let input = r#"
+[dependencies]
+serde = "garbage"
+"#;
+        match freeze_document(input).unwrap_err() {
+            RunError::InvalidVersion { dep, version, .. } => {
+                assert_eq!(dep, "serde");
+                assert_eq!(version, "garbage");
+            }
+            other => panic!("expected InvalidVersion error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_string_version_returns_typed_error() {
+        let input = "
+[dependencies]
+serde = { version = 123 }
+";
+        match freeze_document(input).unwrap_err() {
+            RunError::UnexpectedVersionType { dep, .. } => {
+                assert_eq!(dep, "serde");
+            }
+            other => panic!("expected UnexpectedVersionType error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_string_version_in_detached_table_returns_typed_error() {
+        let input = "
+[dependencies.serde]
+version = 123
+";
+        match freeze_document(input).unwrap_err() {
+            RunError::UnexpectedVersionType { dep, .. } => {
+                assert_eq!(dep, "serde");
+            }
+            other => panic!("expected UnexpectedVersionType error, got {other:?}"),
+        }
+    }
+
+    // -- Aggregated counts and idempotency ------------------------------------------------
+
+    #[test]
+    fn counts_are_accumulated_across_tables() {
+        let input = r#"
+[dependencies]
+serde = "1.2.3"
+tokio = "<1.0"
+
+[dev-dependencies]
+mockall = "0.14.0"
+
+[workspace.dependencies]
+shared = ">1.0, <2.0"
+"#;
+        let (_, outcome) = freeze(input);
+        assert_eq!(outcome.frozen_count, 2);
+        assert_eq!(outcome.skipped_count, 2);
+    }
+
+    #[test]
+    fn idempotent_double_freeze() {
+        let input = r#"
+[dependencies]
+serde = "1.2.3"
+tokio = "^1.48"
+"#;
+        let (once, _) = freeze(input);
+        let (twice, second_outcome) = freeze(&once);
+        assert_eq!(once, twice);
+        // Already frozen; nothing else should be rewritten.
+        assert_eq!(second_outcome.frozen_count, 0);
+    }
+
+    // -- Other edge cases -----------------------------------------------------------------
+
+    #[test]
+    fn empty_file_returns_empty_output() {
+        let (output, outcome) = freeze("");
+        assert_eq!(output, "");
+        assert_eq!(outcome.frozen_count, 0);
+    }
+
+    #[test]
+    fn file_without_dependency_tables_returns_unchanged() {
+        let input = r#"
+[package]
+name = "lonely"
+version = "0.1.0"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+    }
+
+    #[test]
+    fn single_quoted_input_rewritten_with_double_quotes() {
+        // Quote-style reset is acceptable: the tool is explicitly opt-in for rewrites and
+        // toml_edit's default value formatting uses double quotes.
+        let input = "
+[dependencies]
+serde = '1.2.3'
+";
+        let expected = r#"
+[dependencies]
+serde = "=1.2.3"
+"#;
+        assert_eq!(freeze(input).0, expected);
+    }
+}

--- a/packages/cargo-freeze-deps/src/freeze.rs
+++ b/packages/cargo-freeze-deps/src/freeze.rs
@@ -721,4 +721,112 @@ serde = "=1.2.3"
 "#;
         assert_eq!(freeze(input).0, expected);
     }
+
+    // -- Defensive-branch coverage --------------------------------------------------------
+
+    #[test]
+    fn workspace_table_without_dependencies_processed_cleanly() {
+        // Exercises the `None` branch of `process_workspace_level` (the workspace exists
+        // but has no `dependencies` table).
+        let input = r#"
+[workspace]
+members = ["a", "b"]
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn target_entry_that_is_not_a_table_is_skipped() {
+        // Exercises the `continue` branch of `process_target_level` when a value directly
+        // under `[target]` is not table-like (a malformed but parseable case).
+        let input = r#"
+[target]
+stray = "value"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.172"
+"#;
+        let expected = r#"
+[target]
+stray = "value"
+
+[target.'cfg(unix)'.dependencies]
+libc = "=0.2.172"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, expected);
+        assert_eq!(outcome.frozen_count, 1);
+    }
+
+    #[test]
+    fn detached_table_without_version_is_skipped() {
+        // Exercises the `None` branch of form-3 handling in `freeze_dependency_entry`
+        // (a detached dependency table that has no `version` field).
+        let input = r#"
+[dependencies.my_crate]
+path = "../my_crate"
+features = ["serde"]
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, input);
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn non_string_non_table_dependency_entry_is_skipped() {
+        // Exercises the wildcard `_ => {}` arm of `freeze_dependency_entry` for entries
+        // that are neither bare strings, inline tables, nor detached tables. An integer
+        // value is not a valid Cargo dependency entry but is valid TOML, so we skip it
+        // defensively rather than error out.
+        let input = r#"
+[dependencies]
+weird = 123
+serde = "1.2.3"
+"#;
+        let expected = r#"
+[dependencies]
+weird = 123
+serde = "=1.2.3"
+"#;
+        let (output, outcome) = freeze(input);
+        assert_eq!(output, expected);
+        assert_eq!(outcome.frozen_count, 1);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn freeze_version_in_item_handles_item_none() {
+        // Exercises the `Item::None` arm of `freeze_version_in_item`. This variant is
+        // never produced by `get_mut` on a real parsed document, so we exercise it
+        // directly to keep the defensive arm covered.
+        let mut item = Item::None;
+        let mut outcome = RunOutcome {
+            frozen_count: 0,
+            skipped_count: 0,
+        };
+        freeze_version_in_item("dep", &mut item, &mut outcome).unwrap();
+        assert_eq!(outcome.frozen_count, 0);
+        assert_eq!(outcome.skipped_count, 0);
+    }
+
+    #[test]
+    fn freeze_version_in_item_rejects_table_version() {
+        // Exercises the `Item::Table | Item::ArrayOfTables` arm of `freeze_version_in_item`
+        // — a `version` key that resolves to a nested table rather than a string. Real
+        // user-authored TOML can produce this with `[dependencies.serde.version]`.
+        let mut item = Item::Table(toml_edit::Table::new());
+        let mut outcome = RunOutcome {
+            frozen_count: 0,
+            skipped_count: 0,
+        };
+        let err = freeze_version_in_item("dep", &mut item, &mut outcome).unwrap_err();
+        match err {
+            RunError::UnexpectedVersionType { dep, .. } => assert_eq!(dep, "dep"),
+            other => panic!("expected UnexpectedVersionType, got {other:?}"),
+        }
+    }
 }

--- a/packages/cargo-freeze-deps/src/lib.rs
+++ b/packages/cargo-freeze-deps/src/lib.rs
@@ -4,32 +4,10 @@
 //! A Cargo subcommand that freezes every floating dependency version in a Cargo.toml file
 //! to its literal `=X.Y.Z` form.
 
-use std::fs;
-
 mod freeze;
+mod run;
 mod types;
 mod version;
 
-use freeze::freeze_document;
+pub use run::run;
 pub use types::*;
-
-/// Core entry point of the tool, extracted for direct testability.
-///
-/// Reads the Cargo.toml file at `input.path`, freezes every floating dependency version
-/// requirement, and writes the result either back to the input path (when `input.output`
-/// is `None`) or to the explicit output path.
-///
-/// # Errors
-///
-/// See [`RunError`] for the full taxonomy of failures.
-#[doc(hidden)]
-pub fn run(input: &RunInput) -> Result<RunOutcome, RunError> {
-    let content = fs::read_to_string(&input.path).map_err(RunError::Io)?;
-
-    let (rewritten, outcome) = freeze_document(&content)?;
-
-    let output_path = input.output.as_ref().unwrap_or(&input.path);
-    fs::write(output_path, rewritten).map_err(RunError::Io)?;
-
-    Ok(outcome)
-}

--- a/packages/cargo-freeze-deps/src/lib.rs
+++ b/packages/cargo-freeze-deps/src/lib.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! A Cargo subcommand that freezes every floating dependency version in a Cargo.toml file
+//! to its literal `=X.Y.Z` form.
+
+use std::fs;
+
+mod freeze;
+mod types;
+mod version;
+
+use freeze::freeze_document;
+pub use types::*;
+
+/// Core entry point of the tool, extracted for direct testability.
+///
+/// Reads the Cargo.toml file at `input.path`, freezes every floating dependency version
+/// requirement, and writes the result either back to the input path (when `input.output`
+/// is `None`) or to the explicit output path.
+///
+/// # Errors
+///
+/// See [`RunError`] for the full taxonomy of failures.
+#[doc(hidden)]
+pub fn run(input: &RunInput) -> Result<RunOutcome, RunError> {
+    let content = fs::read_to_string(&input.path).map_err(RunError::Io)?;
+
+    let (rewritten, outcome) = freeze_document(&content)?;
+
+    let output_path = input.output.as_ref().unwrap_or(&input.path);
+    fs::write(output_path, rewritten).map_err(RunError::Io)?;
+
+    Ok(outcome)
+}

--- a/packages/cargo-freeze-deps/src/main.rs
+++ b/packages/cargo-freeze-deps/src/main.rs
@@ -1,0 +1,79 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! Binary entry point for the cargo-freeze-deps tool.
+//!
+//! This module is excluded from mutation testing and coverage because testing process
+//! entry/exit behavior is impractical — it requires spawning subprocesses and checking
+//! exit codes. The bulk of the logic lives in the library and is tested directly via
+//! `cargo_freeze_deps::run`.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use argh::FromArgs;
+use cargo_freeze_deps::{RunInput, run};
+
+/// A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file
+/// to their literal values.
+#[derive(FromArgs)]
+struct Args {
+    /// path to the Cargo.toml file to freeze. Defaults to ./Cargo.toml in the current
+    /// working directory.
+    #[argh(option, short = 'p')]
+    path: Option<PathBuf>,
+
+    /// path to write the rewritten Cargo.toml to. Defaults to the input path
+    /// (rewriting in place).
+    #[argh(option, short = 'o')]
+    output: Option<PathBuf>,
+}
+
+// Binary entry point — mutations would require subprocess testing which is impractical.
+#[cfg_attr(test, mutants::skip)]
+fn main() -> ExitCode {
+    // When invoked as `cargo freeze-deps`, Cargo passes "freeze-deps" as the first
+    // argument after the program name. We strip it so argh sees a normal CLI invocation.
+    let mut env_args: Vec<String> = std::env::args().collect();
+
+    if env_args.get(1).is_some_and(|arg| arg == "freeze-deps") {
+        env_args.remove(1);
+    }
+
+    let str_args: Vec<&str> = env_args.iter().map(String::as_str).collect();
+
+    let program_name = str_args
+        .first()
+        .expect("std::env::args() always provides at least the program name");
+
+    let args: Args = match Args::from_args(&[program_name], str_args.get(1..).unwrap_or(&[])) {
+        Ok(args) => args,
+        Err(early_exit) => {
+            println!("{}", early_exit.output);
+            return if early_exit.output.contains("help") {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            };
+        }
+    };
+
+    let input = RunInput {
+        path: args.path.unwrap_or_else(|| PathBuf::from("Cargo.toml")),
+        output: args.output,
+    };
+
+    match run(&input) {
+        Ok(outcome) => {
+            println!(
+                "Froze {} dependency version(s); left {} unchanged.",
+                outcome.frozen_count, outcome.skipped_count
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/packages/cargo-freeze-deps/src/run.rs
+++ b/packages/cargo-freeze-deps/src/run.rs
@@ -1,0 +1,25 @@
+use std::fs;
+
+use crate::freeze::freeze_document;
+use crate::{RunError, RunInput, RunOutcome};
+
+/// Core entry point of the tool, extracted for direct testability.
+///
+/// Reads the Cargo.toml file at `input.path`, freezes every floating dependency version
+/// requirement, and writes the result either back to the input path (when `input.output`
+/// is `None`) or to the explicit output path.
+///
+/// # Errors
+///
+/// See [`RunError`] for the full taxonomy of failures.
+#[doc(hidden)]
+pub fn run(input: &RunInput) -> Result<RunOutcome, RunError> {
+    let content = fs::read_to_string(&input.path).map_err(RunError::Io)?;
+
+    let (rewritten, outcome) = freeze_document(&content)?;
+
+    let output_path = input.output.as_ref().unwrap_or(&input.path);
+    fs::write(output_path, rewritten).map_err(RunError::Io)?;
+
+    Ok(outcome)
+}

--- a/packages/cargo-freeze-deps/src/types.rs
+++ b/packages/cargo-freeze-deps/src/types.rs
@@ -1,0 +1,164 @@
+// Public API types for cargo-freeze-deps.
+//
+// These types are used by main.rs and exposed via the crate's public API so that integration
+// tests can exercise the core logic without spawning a subprocess.
+
+use std::path::PathBuf;
+use std::{error, fmt, io};
+
+/// Input parameters for the [`run`](crate::run) function.
+#[doc(hidden)]
+#[derive(Debug)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "Hidden struct for internal/test use only"
+)]
+pub struct RunInput {
+    /// Path to the Cargo.toml file to read.
+    pub path: PathBuf,
+    /// Optional path to write the rewritten Cargo.toml to.
+    ///
+    /// When `None`, the file at `path` is rewritten in place.
+    pub output: Option<PathBuf>,
+}
+
+/// The successful outcome of a run.
+#[doc(hidden)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "Hidden struct for internal/test use only"
+)]
+pub struct RunOutcome {
+    /// Number of dependency version requirements that were rewritten.
+    pub frozen_count: usize,
+    /// Number of dependency version requirements that were left as-is because they
+    /// did not have any freezable component (e.g. `<1.2.3`, bare `*`).
+    pub skipped_count: usize,
+}
+
+/// Errors that can occur during a run.
+#[doc(hidden)]
+#[derive(Debug)]
+#[expect(
+    clippy::exhaustive_enums,
+    reason = "Hidden enum for internal/test use only"
+)]
+pub enum RunError {
+    /// Failed to read or write the Cargo.toml file.
+    Io(io::Error),
+    /// The Cargo.toml file could not be parsed as TOML.
+    Parse(String),
+    /// A dependency's version field had an unexpected non-string type.
+    UnexpectedVersionType {
+        /// Name of the dependency whose version field is malformed.
+        dep: String,
+        /// The actual TOML type encountered, for diagnostics.
+        actual_type: String,
+    },
+    /// A dependency's version requirement could not be parsed as a semver requirement.
+    InvalidVersion {
+        /// Name of the dependency whose version requirement is invalid.
+        dep: String,
+        /// The literal text of the requirement.
+        version: String,
+        /// The semver parse error.
+        source: semver::Error,
+    },
+}
+
+impl fmt::Display for RunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Parse(msg) => write!(f, "Failed to parse Cargo.toml: {msg}"),
+            Self::UnexpectedVersionType { dep, actual_type } => write!(
+                f,
+                "Dependency '{dep}' has a non-string version field of type {actual_type}"
+            ),
+            Self::InvalidVersion {
+                dep,
+                version,
+                source,
+            } => write!(
+                f,
+                "Dependency '{dep}' has invalid version requirement '{version}': {source}"
+            ),
+        }
+    }
+}
+
+impl error::Error for RunError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::InvalidVersion { source, .. } => Some(source),
+            Self::Parse(_) | Self::UnexpectedVersionType { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_error_display_io() {
+        let err = RunError::Io(io::Error::new(io::ErrorKind::NotFound, "missing"));
+        assert!(!format!("{err}").is_empty());
+    }
+
+    #[test]
+    fn run_error_display_parse() {
+        let err = RunError::Parse("bad toml".to_string());
+        assert!(!format!("{err}").is_empty());
+    }
+
+    #[test]
+    fn run_error_display_unexpected_version_type() {
+        let err = RunError::UnexpectedVersionType {
+            dep: "serde".to_string(),
+            actual_type: "integer".to_string(),
+        };
+        let display = format!("{err}");
+        assert!(display.contains("serde"));
+        assert!(display.contains("integer"));
+    }
+
+    #[test]
+    fn run_error_display_invalid_version() {
+        let req_err = "not-a-version".parse::<semver::VersionReq>().unwrap_err();
+        let err = RunError::InvalidVersion {
+            dep: "serde".to_string(),
+            version: "not-a-version".to_string(),
+            source: req_err,
+        };
+        let display = format!("{err}");
+        assert!(display.contains("serde"));
+        assert!(display.contains("not-a-version"));
+    }
+
+    #[test]
+    fn run_error_source_chain() {
+        let err = RunError::Io(io::Error::new(io::ErrorKind::NotFound, "missing"));
+        assert!(error::Error::source(&err).is_some());
+
+        let err = RunError::Parse("bad toml".to_string());
+        assert!(error::Error::source(&err).is_none());
+
+        let err = RunError::UnexpectedVersionType {
+            dep: "x".to_string(),
+            actual_type: "y".to_string(),
+        };
+        assert!(error::Error::source(&err).is_none());
+
+        let req_err = "not-a-version".parse::<semver::VersionReq>().unwrap_err();
+        let err = RunError::InvalidVersion {
+            dep: "x".to_string(),
+            version: "x".to_string(),
+            source: req_err,
+        };
+        assert!(error::Error::source(&err).is_some());
+    }
+}

--- a/packages/cargo-freeze-deps/src/version.rs
+++ b/packages/cargo-freeze-deps/src/version.rs
@@ -1,0 +1,273 @@
+// Version requirement freezing logic.
+//
+// Given a version requirement string in Cargo's `semver`-flavored syntax (e.g. `"1.2.3"`,
+// `"^1.2"`, `">=1.2.3"`), produce a literal `=major.minor.patch[-pre]` string. If the
+// requirement is anything other than a single freezable comparator, return `None` to
+// indicate the requirement should be left unchanged.
+
+use semver::{BuildMetadata, Comparator, Op, Version, VersionReq};
+
+/// Computes the frozen `=X.Y.Z[-pre]` string for the given version requirement.
+///
+/// Returns `Ok(None)` if the requirement has no freezable form and the caller should
+/// leave the original text unchanged.
+///
+/// # Errors
+///
+/// Returns the underlying `semver::Error` if the input is not a valid version requirement
+/// per Cargo's flavor of `SemVer`.
+///
+/// # Scope
+///
+/// Only requirements consisting of a single comparator with an "equals" component
+/// (`=`, `^`, `~`, `>=`, `<=`, or a wildcard with a major number) are freezable. Anything
+/// else — strict inequalities, bare `*`, or multi-comparator requirements like
+/// `">=0.5, <1.0"` — is left unchanged.
+pub(crate) fn freeze_requirement(input: &str) -> Result<Option<String>, semver::Error> {
+    let req: VersionReq = input.parse()?;
+
+    // Multi-comparator requirements (e.g. `">=0.5, <1.0"`) are intentionally out of scope:
+    // picking a single literal that preserves the original constraint would require either
+    // ignoring some of the comparators (non-preserving) or knowing which versions actually
+    // exist on the registry (out of reach for this tool).
+    let [comparator] = req.comparators.as_slice() else {
+        return Ok(None);
+    };
+
+    Ok(equals_version(comparator).as_ref().map(format_frozen))
+}
+
+/// If `c` carries an "equals" component (a specific version that satisfies it), returns the
+/// corresponding fully-expanded `Version`. Otherwise returns `None`.
+fn equals_version(c: &Comparator) -> Option<Version> {
+    match c.op {
+        // All of these allow the specified version itself as a match. We zero-fill missing
+        // minor/patch numbers per the user's specification.
+        Op::Exact | Op::Caret | Op::Tilde | Op::GreaterEq | Op::LessEq | Op::Wildcard => {
+            Some(Version {
+                major: c.major,
+                minor: c.minor.unwrap_or(0),
+                patch: c.patch.unwrap_or(0),
+                pre: c.pre.clone(),
+                // Build metadata is never present on a `Comparator` (semver strips it from
+                // version requirements per the spec), so we always emit empty here.
+                build: BuildMetadata::EMPTY,
+            })
+        }
+        // `Op::Greater` and `Op::Less` carry no equals component. `Op` is also
+        // `#[non_exhaustive]`, so we catch any future unknown operators with a wildcard
+        // and skip them conservatively rather than risk freezing them to a wrong value.
+        _ => None,
+    }
+}
+
+fn format_frozen(v: &Version) -> String {
+    if v.pre.is_empty() {
+        format!("={}.{}.{}", v.major, v.minor, v.patch)
+    } else {
+        format!("={}.{}.{}-{}", v.major, v.minor, v.patch, v.pre)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn freeze(input: &str) -> Option<String> {
+        freeze_requirement(input).unwrap()
+    }
+
+    // -- Basic three-component versions and defaults --------------------------------------
+
+    #[test]
+    fn three_components_default() {
+        assert_eq!(freeze("1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    #[test]
+    fn single_component_zero_fills() {
+        assert_eq!(freeze("1").as_deref(), Some("=1.0.0"));
+    }
+
+    #[test]
+    fn two_components_zero_fills() {
+        assert_eq!(freeze("1.2").as_deref(), Some("=1.2.0"));
+    }
+
+    #[test]
+    fn zero_major_three_components() {
+        assert_eq!(freeze("0.5.10").as_deref(), Some("=0.5.10"));
+    }
+
+    // -- Exact (= operator) ---------------------------------------------------------------
+
+    #[test]
+    fn exact_three_components() {
+        assert_eq!(freeze("=1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    #[test]
+    fn exact_two_components_zero_fills() {
+        assert_eq!(freeze("=1.2").as_deref(), Some("=1.2.0"));
+    }
+
+    #[test]
+    fn exact_one_component_zero_fills() {
+        assert_eq!(freeze("=1").as_deref(), Some("=1.0.0"));
+    }
+
+    #[test]
+    fn idempotent_already_frozen() {
+        // Freezing an already-frozen value yields the same text.
+        let frozen = freeze("=1.2.3").unwrap();
+        assert_eq!(freeze(&frozen).as_deref(), Some("=1.2.3"));
+    }
+
+    // -- Caret (^) and tilde (~) ----------------------------------------------------------
+
+    #[test]
+    fn caret_three_components() {
+        assert_eq!(freeze("^1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    #[test]
+    fn caret_two_components() {
+        assert_eq!(freeze("^1.2").as_deref(), Some("=1.2.0"));
+    }
+
+    #[test]
+    fn tilde_three_components() {
+        assert_eq!(freeze("~1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    // -- GreaterEq and LessEq -------------------------------------------------------------
+
+    #[test]
+    fn greater_eq_three_components() {
+        assert_eq!(freeze(">=1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    #[test]
+    fn greater_eq_with_space() {
+        assert_eq!(freeze(">= 1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    #[test]
+    fn greater_eq_one_component() {
+        assert_eq!(freeze(">=1").as_deref(), Some("=1.0.0"));
+    }
+
+    #[test]
+    fn less_eq_three_components() {
+        assert_eq!(freeze("<=1.2.3").as_deref(), Some("=1.2.3"));
+    }
+
+    #[test]
+    fn less_eq_two_components() {
+        assert_eq!(freeze("<=1.2").as_deref(), Some("=1.2.0"));
+    }
+
+    #[test]
+    fn less_eq_one_component() {
+        assert_eq!(freeze("<=1").as_deref(), Some("=1.0.0"));
+    }
+
+    // -- Wildcards ------------------------------------------------------------------------
+
+    #[test]
+    fn wildcard_with_major() {
+        assert_eq!(freeze("1.*").as_deref(), Some("=1.0.0"));
+    }
+
+    #[test]
+    fn wildcard_with_major_and_minor() {
+        assert_eq!(freeze("1.2.*").as_deref(), Some("=1.2.0"));
+    }
+
+    #[test]
+    fn wildcard_triple_star_form() {
+        // Semver documents `1.*.*` as equivalent to `1.*`.
+        assert_eq!(freeze("1.*.*").as_deref(), Some("=1.0.0"));
+    }
+
+    #[test]
+    fn bare_wildcard_left_unchanged() {
+        // Bare `*` parses to an empty comparator list; there is no concrete version to pick.
+        assert_eq!(freeze("*"), None);
+    }
+
+    // -- Strict inequalities (no equals component) ----------------------------------------
+
+    #[test]
+    fn strict_less_unchanged() {
+        assert_eq!(freeze("<1.2.3"), None);
+    }
+
+    #[test]
+    fn strict_greater_unchanged() {
+        assert_eq!(freeze(">1.2.3"), None);
+    }
+
+    // -- Multi-comparator requirements are out of scope -----------------------------------
+
+    #[test]
+    fn multi_comparator_left_unchanged_even_when_all_freezable() {
+        // Two `=` comparators — both individually freezable — but a multi-comparator
+        // requirement is out of scope and is left unchanged.
+        assert_eq!(freeze("=1.2.3, =1.2.4"), None);
+    }
+
+    #[test]
+    fn multi_comparator_mixed_left_unchanged() {
+        assert_eq!(freeze(">=1.0.0, <2.0.0"), None);
+    }
+
+    #[test]
+    fn multi_comparator_all_strict_left_unchanged() {
+        assert_eq!(freeze(">1.0.0, <2.0.0"), None);
+    }
+
+    // -- Pre-release and build metadata ---------------------------------------------------
+
+    #[test]
+    fn prerelease_three_components_preserved() {
+        assert_eq!(
+            freeze("1.2.3-foobar45-wakawaka").as_deref(),
+            Some("=1.2.3-foobar45-wakawaka")
+        );
+    }
+
+    #[test]
+    fn prerelease_short_form_is_invalid() {
+        // Per the SemVer spec a pre-release suffix is only allowed on a complete
+        // major.minor.patch triple. `1.2-foo` is not valid.
+        freeze_requirement("1.2-foo").unwrap_err();
+    }
+
+    #[test]
+    fn build_metadata_silently_dropped() {
+        // Per the semver crate docs, build metadata is stripped from version requirements.
+        // The frozen output cannot carry build metadata.
+        assert_eq!(freeze("1.2.3+build.42").as_deref(), Some("=1.2.3"));
+    }
+
+    // -- Whitespace tolerance -------------------------------------------------------------
+
+    #[test]
+    fn surrounding_whitespace_tolerated() {
+        assert_eq!(freeze("  ^1.2.3  ").as_deref(), Some("=1.2.3"));
+    }
+
+    // -- Parse errors ---------------------------------------------------------------------
+
+    #[test]
+    fn garbage_input_returns_error() {
+        freeze_requirement("not-a-version").unwrap_err();
+    }
+
+    #[test]
+    fn empty_string_returns_error() {
+        freeze_requirement("").unwrap_err();
+    }
+}

--- a/packages/cargo-freeze-deps/tests/cargo_freeze_deps_integration.rs
+++ b/packages/cargo-freeze-deps/tests/cargo_freeze_deps_integration.rs
@@ -1,0 +1,349 @@
+//! Integration tests for cargo-freeze-deps.
+//!
+//! These tests exercise the public `run()` entry point against temporary on-disk
+//! Cargo.toml files, covering the path arg defaults, the `--output` option, and end-to-end
+//! error reporting.
+//!
+//! Tests that depend on the process current directory are marked `#[serial]` per the
+//! workspace convention. They also use a CWD-guard RAII helper so the current directory
+//! is restored even when an assertion fails mid-test.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use cargo_freeze_deps::{RunError, RunInput, run};
+use serial_test::serial;
+
+/// RAII helper: restores the process current directory when dropped, even on panic.
+struct CurrentDirGuard {
+    original: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(target: &Path) -> Self {
+        let original = std::env::current_dir().expect("current_dir should be readable");
+        std::env::set_current_dir(target).expect("set_current_dir to test target should succeed");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        // Best-effort restoration; if this fails we are likely already unwinding from
+        // another panic and there is nothing useful to do.
+        drop(std::env::set_current_dir(&self.original));
+    }
+}
+
+fn write_cargo_toml(dir: &Path, content: &str) -> PathBuf {
+    let path = dir.join("Cargo.toml");
+    fs::write(&path, content).unwrap();
+    path
+}
+
+// -- Default in-place rewriting -------------------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore)] // OS interactions exceed Miri emulation capabilities.
+fn rewrites_in_place_when_no_output_specified() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = write_cargo_toml(
+        temp_dir.path(),
+        r#"[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.2.3"
+tokio = "^1.48"
+maybe_pinned = "<2.0.0"
+"#,
+    );
+
+    let outcome = run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap();
+
+    assert_eq!(outcome.frozen_count, 2);
+    assert_eq!(outcome.skipped_count, 1);
+
+    let rewritten = fs::read_to_string(&path).unwrap();
+    assert!(rewritten.contains(r#"serde = "=1.2.3""#));
+    assert!(rewritten.contains(r#"tokio = "=1.48.0""#));
+    assert!(rewritten.contains(r#"maybe_pinned = "<2.0.0""#));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn writes_to_separate_output_path_and_leaves_input_untouched() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_content = r#"[dependencies]
+serde = "1.2.3"
+"#;
+    let input_path = write_cargo_toml(temp_dir.path(), input_content);
+    let output_path = temp_dir.path().join("Cargo.frozen.toml");
+
+    let outcome = run(&RunInput {
+        path: input_path.clone(),
+        output: Some(output_path.clone()),
+    })
+    .unwrap();
+
+    assert_eq!(outcome.frozen_count, 1);
+
+    let input_after = fs::read_to_string(&input_path).unwrap();
+    let output_after = fs::read_to_string(&output_path).unwrap();
+    assert_eq!(input_after, input_content);
+    assert!(output_after.contains(r#"serde = "=1.2.3""#));
+}
+
+#[test]
+#[serial] // Reads ./Cargo.toml relative to the process current directory.
+#[cfg_attr(miri, ignore)]
+fn defaults_to_cargo_toml_in_current_directory() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_cargo_toml(
+        temp_dir.path(),
+        r#"[dependencies]
+serde = "1.2.3"
+"#,
+    );
+
+    let _guard = CurrentDirGuard::enter(temp_dir.path());
+
+    let outcome = run(&RunInput {
+        path: PathBuf::from("Cargo.toml"),
+        output: None,
+    })
+    .unwrap();
+
+    assert_eq!(outcome.frozen_count, 1);
+    let rewritten = fs::read_to_string(temp_dir.path().join("Cargo.toml")).unwrap();
+    assert!(rewritten.contains(r#"serde = "=1.2.3""#));
+}
+
+// -- Workspace-level and package-level files --------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn workspace_level_cargo_toml_processed() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = write_cargo_toml(
+        temp_dir.path(),
+        r#"[workspace]
+members = ["pkg"]
+
+[workspace.dependencies]
+serde = "1.2.3"
+tokio = { version = "1.48.0", features = ["full"] }
+"#,
+    );
+
+    let outcome = run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap();
+
+    assert_eq!(outcome.frozen_count, 2);
+    let rewritten = fs::read_to_string(&path).unwrap();
+    assert!(rewritten.contains(r#"serde = "=1.2.3""#));
+    assert!(rewritten.contains(r#"version = "=1.48.0""#));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn combined_workspace_and_package_cargo_toml_processed() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = write_cargo_toml(
+        temp_dir.path(),
+        r#"[workspace]
+members = ["."]
+
+[workspace.dependencies]
+shared = "1.0.0"
+
+[package]
+name = "root_package"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.2.3"
+
+[dev-dependencies]
+mockall = "0.14.0"
+
+[build-dependencies]
+cc = "1.0.0"
+
+[target."cfg(unix)".dependencies]
+libc = "0.2.172"
+"#,
+    );
+
+    let outcome = run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap();
+
+    assert_eq!(outcome.frozen_count, 5);
+    let rewritten = fs::read_to_string(&path).unwrap();
+    assert!(rewritten.contains(r#"shared = "=1.0.0""#));
+    assert!(rewritten.contains(r#"serde = "=1.2.3""#));
+    assert!(rewritten.contains(r#"mockall = "=0.14.0""#));
+    assert!(rewritten.contains(r#"cc = "=1.0.0""#));
+    assert!(rewritten.contains(r#"libc = "=0.2.172""#));
+}
+
+// -- Realistic mixed file ---------------------------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn realistic_file_preserves_comments_and_layout() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input = r#"[package]
+name = "my_app"
+version = "0.2.0"
+edition = "2021"
+
+# Runtime dependencies
+[dependencies]
+# Standard serialization
+serde = { version = "1.2.3", features = ["derive"] }
+serde_json = "1.0.0"            # pretty printing matters
+tokio = "1.48.0"
+# Internal crate, no version freezing needed
+internal = { path = "../internal" }
+# Pinned to a range; we intentionally leave it alone
+custom_range = ">=1.0.0, <2.0.0"
+
+[dev-dependencies]
+mockall = "0.14.0"
+"#;
+    let path = write_cargo_toml(temp_dir.path(), input);
+
+    run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap();
+
+    let rewritten = fs::read_to_string(&path).unwrap();
+
+    assert!(rewritten.contains("# Runtime dependencies"));
+    assert!(rewritten.contains("# Standard serialization"));
+    assert!(rewritten.contains("# pretty printing matters"));
+    assert!(rewritten.contains("# Internal crate, no version freezing needed"));
+    assert!(rewritten.contains("# Pinned to a range; we intentionally leave it alone"));
+
+    assert!(rewritten.contains(r#"version = "=1.2.3""#));
+    assert!(rewritten.contains(r#"serde_json = "=1.0.0""#));
+    assert!(rewritten.contains(r#"tokio = "=1.48.0""#));
+    assert!(rewritten.contains(r#"internal = { path = "../internal" }"#));
+    assert!(rewritten.contains(r#"custom_range = ">=1.0.0, <2.0.0""#));
+    assert!(rewritten.contains(r#"mockall = "=0.14.0""#));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn idempotent_when_run_twice() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = write_cargo_toml(
+        temp_dir.path(),
+        r#"[dependencies]
+serde = "1.2.3"
+tokio = "^1.48"
+"#,
+    );
+
+    run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap();
+    let after_first = fs::read_to_string(&path).unwrap();
+
+    let outcome = run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap();
+    let after_second = fs::read_to_string(&path).unwrap();
+
+    assert_eq!(after_first, after_second);
+    assert_eq!(outcome.frozen_count, 0);
+    assert_eq!(outcome.skipped_count, 0);
+}
+
+// -- Error reporting --------------------------------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn missing_file_returns_io_error() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let missing = temp_dir.path().join("does-not-exist.toml");
+
+    match run(&RunInput {
+        path: missing,
+        output: None,
+    })
+    .unwrap_err()
+    {
+        RunError::Io(_) => {}
+        other => panic!("expected Io error, got {other:?}"),
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn invalid_toml_returns_parse_error() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = write_cargo_toml(temp_dir.path(), "this is = not [valid toml");
+
+    match run(&RunInput { path, output: None }).unwrap_err() {
+        RunError::Parse(_) => {}
+        other => panic!("expected Parse error, got {other:?}"),
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn invalid_version_returns_typed_error_with_dep_name() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = write_cargo_toml(
+        temp_dir.path(),
+        r#"[dependencies]
+serde = "not-a-version"
+"#,
+    );
+
+    match run(&RunInput { path, output: None }).unwrap_err() {
+        RunError::InvalidVersion { dep, version, .. } => {
+            assert_eq!(dep, "serde");
+            assert_eq!(version, "not-a-version");
+        }
+        other => panic!("expected InvalidVersion error, got {other:?}"),
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn error_during_freeze_leaves_input_intact() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input = r#"[dependencies]
+serde = "garbage-version"
+"#;
+    let path = write_cargo_toml(temp_dir.path(), input);
+
+    run(&RunInput {
+        path: path.clone(),
+        output: None,
+    })
+    .unwrap_err();
+
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(after, input, "input file must not be partially rewritten");
+}

--- a/packages/cargo-freeze-deps/tests/cargo_freeze_deps_integration.rs
+++ b/packages/cargo-freeze-deps/tests/cargo_freeze_deps_integration.rs
@@ -31,7 +31,7 @@ impl Drop for CurrentDirGuard {
     fn drop(&mut self) {
         // Best-effort restoration; if this fails we are likely already unwinding from
         // another panic and there is nothing useful to do.
-        drop(std::env::set_current_dir(&self.original));
+        _ = std::env::set_current_dir(&self.original);
     }
 }
 

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -36,7 +36,7 @@ event-listener = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 many_cpus = { path = "../many_cpus" }
 mutants = { workspace = true }
-new_zealand = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 par_bench = { path = "../par_bench", features = ["criterion"] }
 rsevents = { workspace = true }
 static_assertions = { workspace = true }

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -28,9 +28,9 @@ tick = { workspace = true }
 [dev-dependencies]
 alloc_tracker = { path = "../alloc_tracker" }
 criterion = { workspace = true }
-many_cpus = { workspace = true }
+many_cpus = { path = "../many_cpus" }
 mutants = { workspace = true }
-new_zealand = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 nm = { path = "../nm", features = ["test-util"] }
 nm_otel = { path = ".", features = ["test-util"] }
 opentelemetry-stdout = { workspace = true, features = ["metrics"] }

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -31,7 +31,7 @@ mutants = { workspace = true }
 static_assertions = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
-new_zealand = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 
 [lints]
 workspace = true

--- a/packages/ui_tests/Cargo.toml
+++ b/packages/ui_tests/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 development = ["new_zealand"]
 
 [dev-dependencies]
-new_zealand = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 trybuild = { workspace = true }
 
 [lints]


### PR DESCRIPTION
Add cargo-freeze-deps subcommand for pinning floating dependency versions.

## What

New `cargo-freeze-deps` package: a Cargo subcommand that rewrites a `Cargo.toml`
file in place (or to `--output`), freezing every floating dependency version
requirement to its literal `=X.Y.Z[-pre]` form.

```
cargo freeze-deps [--path PATH] [--output PATH]
```

## Freezing rules

| Input              | Output            |
| ------------------ | ----------------- |
| `1`                | `=1.0.0`          |
| `1.2`              | `=1.2.0`          |
| `=1.2`             | `=1.2.0`          |
| `1.2.3-foobar45`   | `=1.2.3-foobar45` |
| `^1.2.3`           | `=1.2.3`          |
| `~1.2.3`           | `=1.2.3`          |
| `>=1.2.3`          | `=1.2.3`          |
| `<=1.2.3`          | `=1.2.3`          |
| `1.*`              | `=1.0.0`          |
| `<1.2.3`           | `<1.2.3` (unchanged) |
| `>1.2.3`           | `>1.2.3` (unchanged) |
| `*`                | unchanged |
| multi-comparator (e.g. `">= 1, < 2"`) | unchanged |

Workspace inheritance (`workspace = true`), git/path deps, and `[patch]`/
`[replace]` tables are left untouched. Both inline-table and detached-table
dependency forms are supported, in `[dependencies]`, `[dev-dependencies]`,
`[build-dependencies]`, `[workspace.dependencies]`, and the corresponding
`[target.*.{deps,dev-deps,build-deps}]` tables.

Comments and layout are preserved via `toml_edit`'s decor-preserving APIs.

## Implementation

Mirrors the existing `cargo-detect-package` pattern:

- `src/version.rs` — single-comparator → frozen-literal mapping via `semver`.
- `src/freeze.rs` — TOML document walker covering every dependency section
  in both workspace and package manifests.
- `src/lib.rs` — `run(&RunInput) -> Result<RunOutcome, RunError>`
- `src/main.rs` — argh CLI binary; strips leading `freeze-deps` arg when
  invoked as `cargo freeze-deps`.
- 82 tests (71 unit + 11 integration); all integration tests are
  `#[cfg_attr(miri, ignore)]` because they touch the filesystem.

## Workspace tidy (pre-existing cleanups picked up by `ss-cargo-deps-tidy`)

Five same-workspace dev-dependencies were using `{ workspace = true }`
instead of path-only references, which is the workspace convention for
correct publishing-order resolution. Converted to `{ path = "../..." }`:

- `packages/events/Cargo.toml`: `new_zealand`
- `packages/nm_otel/Cargo.toml`: `many_cpus`, `new_zealand`
- `packages/testing/Cargo.toml`: `new_zealand`
- `packages/ui_tests/Cargo.toml`: `new_zealand`

Also moved `toml_edit` Cargo features (`parse`, `display`) from the
workspace-level declaration down to the `cargo-freeze-deps` package-level
declaration (the only consumer), per the workspace convention to centralize
versions but specify features per-package.

## Pre-existing warnings noted (filed as separate issues, not blocking)

- folo#235: two `unreachable_pub` warnings in `packages/nm_otel/src/state.rs`
- folo#236: future-incompat warning from transitive `proc-macro-error2 v2.0.1`
  (via `gungraun-macros`)

## Validation

- `just package=cargo-freeze-deps validate-local` on Windows: ✅ 82/82 tests
- `wsl -e bash -l -c "just package=cargo-freeze-deps validate-local"`: ✅
  82/82 tests; 71/71 Miri (11 integration tests correctly skipped)
- Minimum-version build verification: pinned `semver = "=1.0.28"` and
  `toml_edit = "=0.25.12"` and confirmed `cargo check -p cargo-freeze-deps`
  succeeds with the lowest promised compatible versions.
