### PR TITLE
Rename internal-only `test-util` feature to `private-test-util`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1040,15 +1040,22 @@ reach internal types, constructors, or invariants, the preferred pattern is to s
 the crate into a thin public shell (`foo`) plus an implementation crate (`foo_impl`)
 that hosts everything. The shell re-exports a narrow, explicit list of items; the
 impl crate uses plain `pub` for anything benches/tests need to reach. This replaces
-the `test-util` Cargo feature anti-pattern (which leaks private surface into the
-documented public API).
+the public-feature anti-pattern of leaking private surface into a crate's documented
+API just so in-workspace consumers can reach it.
+
+Cargo features on `foo_impl` follow a strict naming rule: features named without a
+`private-` prefix (e.g. `test-util`, `tokio`, `metrics`) are part of the public API
+surface and are forwarded 1:1 from `foo` (`feature = ["foo_impl/feature"]`).
+Features named with the `private-` prefix (e.g. `private-test-util`) are
+internal-only, are never forwarded by `foo`, and are activated only by
+in-workspace dev-dependencies. The two kinds may coexist on the same impl crate.
 
 The canonical example is `packages/nm` (shell) + `packages/nm_impl` (implementation),
 with `packages/nm_otel` + `packages/nm_otel_impl` as a second worked example. For full
-details — when to apply the split, the optional `test-util` Cargo feature on the impl
-crate (for `*::fake(...)` fabrication constructors, when needed), the doctest-cycle
-dev-dependency, lockstep versioning, and the distinction from the in-crate `__private`
-module convention above — see [docs/impl-crate-split.md](docs/impl-crate-split.md).
+details — when to apply the split, the `private-test-util` Cargo feature for internal
+fabrication constructors, the doctest-cycle dev-dependency, lockstep versioning, and
+the distinction from the in-crate `__private` module convention above — see
+[docs/impl-crate-split.md](docs/impl-crate-split.md).
 
 # UI tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1045,7 +1045,7 @@ API just so in-workspace consumers can reach it.
 
 Cargo features on `foo_impl` follow a strict naming rule: features named without a
 `private-` prefix (e.g. `test-util`, `tokio`, `metrics`) are part of the public API
-surface and are forwarded 1:1 from `foo` (`feature = ["foo_impl/feature"]`).
+surface and are forwarded 1:1 from `foo` (e.g. `tokio = ["foo_impl/tokio"]`).
 Features named with the `private-` prefix (e.g. `private-test-util`) are
 internal-only, are never forwarded by `foo`, and are activated only by
 in-workspace dev-dependencies. The two kinds may coexist on the same impl crate.
@@ -1053,8 +1053,8 @@ in-workspace dev-dependencies. The two kinds may coexist on the same impl crate.
 The canonical example is `packages/nm` (shell) + `packages/nm_impl` (implementation),
 with `packages/nm_otel` + `packages/nm_otel_impl` as a second worked example. For full
 details — when to apply the split, the `private-test-util` Cargo feature for internal
-fabrication constructors, the doctest-cycle dev-dependency, lockstep versioning, and
-the distinction from the in-crate `__private` module convention above — see
+API surface, the doctest-cycle dev-dependency, lockstep versioning, and the
+distinction from the in-crate `__private` module convention above — see
 [docs/impl-crate-split.md](docs/impl-crate-split.md).
 
 # UI tests

--- a/docs/impl-crate-split.md
+++ b/docs/impl-crate-split.md
@@ -123,8 +123,9 @@ Apply this split when at least one of these holds:
 - The crate has (or wants) benchmarks or external tests that need access to
   internal types, constructors, or invariants that should not be part of the
   public API.
-- The crate currently uses a `test-util` Cargo feature (or equivalent) on its
-  public API purely to expose internal items for in-workspace consumers.
+- The crate currently uses a Cargo feature on its public API purely to
+  expose internal items for in-workspace consumers (the historical
+  workaround for the same problem).
 - Another crate in the workspace needs to construct internal data structures
   for testing or benchmarking purposes.
 
@@ -148,7 +149,7 @@ happens to need today.
 | --------------------------------- | ---------- | --------- |
 | `src/**` (implementation)         | `foo_impl` | The whole point of the split. |
 | Unit tests (`#[cfg(test)] mod tests` inside `src/**`) | `foo_impl` | They follow the code they test. |
-| `benches/**`                      | `foo_impl` | Benches are a maintainer tool; whoever runs them already knows the impl crate exists. Hosting them in `foo_impl` means a future bench can reach for `test-util` fabrication constructors or other internal `pub` items without having to be relocated first. |
+| `benches/**`                      | `foo_impl` | Benches are a maintainer tool; whoever runs them already knows the impl crate exists. Hosting them in `foo_impl` means a future bench can reach for `private-test-util` fabrication constructors or other internal `pub` items without having to be relocated first. |
 | `tests/**` (integration tests)    | `foo_impl` | Same reasoning as benches: they are for maintainers, and proximity to `foo_impl` internals is occasionally needed. |
 | `examples/**` (user-facing)       | `foo`      | Examples are a form of end-user documentation. They must compile against the same public API a user gets from `cargo add foo`. Keeping them in the public crate is what enforces that they cannot accidentally reach for internals. |
 | Maintainer-only demo/dev binaries | `foo_impl/examples/` (optional) | If you do want a runnable internal demo (e.g. a load-generator, a profiling harness, a "wire up the internals to see what they do" app), put it under `foo_impl/examples/`. Treat it explicitly as "examples and dev apps for maintainers", a different category from end-user examples. |
@@ -161,27 +162,45 @@ Two principles fall out of the table:
    documentation, so they stay with the users. Benches and integration tests
    are maintainer tooling, so they stay with the maintainers.
 2. **Benches and integration tests living in `foo_impl` should still prefer
-   the public API.** Reach for `test-util` fabrication constructors or other
-   `foo_impl`-internal items only when there is a specific reason —
+   the public API.** Reach for `private-test-util` fabrication constructors or
+   other `foo_impl`-internal items only when there is a specific reason —
    fabricating internal state for a contract that the public API cannot
    express, or measuring a hot path that the public API gates behind a slower
    entry point. When a bench uses only `use foo::Event;` it is still measuring
    what the user pays; the impl crate is just a convenient host.
 
-## Test-only fabrication constructors
+## Cargo features on the impl crate
 
-Some internal items only make sense in a test or benchmark context: constructors
-that fabricate data structures bypassing the real-world entry path (e.g.
-building a `Report` from a hand-assembled `Vec<EventMetrics>` without observing
-real events). Two competing concerns apply:
+Two distinct kinds of Cargo feature may live on `foo_impl`, and they are named
+differently so they do not collide.
+
+| Feature kind          | Naming             | Forwarded by `foo`? | Audience |
+| --------------------- | ------------------ | ------------------- | -------- |
+| Public functional or testing feature | `test-util`, `metrics`, `tokio`, etc. (whatever the public-API name is) | Yes, 1:1. `foo` declares `feature-name = ["foo_impl/feature-name"]`. | End users of `foo`. |
+| Internal-only helpers | `private-test-util` (`private-*` prefix in general) | **No.** Never forwarded by `foo`. | In-workspace dev-dependencies only. |
+
+The `private-*` prefix mirrors the workspace's existing `__private` /
+`__private_*` "logically private but mechanically public" naming convention.
+
+A package may have either kind, both, or neither. The rule is just that the
+internal-only feature must be distinguishable by name from any public-API
+feature so the shell crate can forward the right things without accidentally
+exposing the wrong ones.
+
+## Internal-only test/bench helpers (`private-test-util`)
+
+Some internal items only make sense in a test or benchmark context:
+constructors that fabricate data structures bypassing the real-world entry
+path (e.g. building a `Report` from a hand-assembled `Vec<EventMetrics>`
+without observing real events). Two competing concerns apply:
 
 1. They must be reachable from external benches/tests in other workspace
    crates, which requires them to be `pub` in `foo_impl`.
 2. They are pure dead weight in production builds and should not bloat the
    binary that real users ship.
 
-The convention is to put them directly on the type they fabricate, gated behind
-a `test-util` Cargo feature on `foo_impl`:
+The convention is to put them directly on the type they fabricate, gated
+behind a `private-test-util` Cargo feature on `foo_impl`:
 
 ```rust
 // in foo_impl/src/reports.rs
@@ -191,7 +210,7 @@ impl Report {
     /// global event registry.
     ///
     /// Intended for in-workspace tests and benchmarks.
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     #[must_use]
     pub fn fake(events: Vec<EventMetrics>) -> Self {
@@ -205,39 +224,39 @@ impl Report {
 ```toml
 # foo_impl/Cargo.toml
 [features]
-# Enables fabrication constructors for testing and benchmarking. The `foo`
-# shell crate does not activate this feature, so end-user builds never see
+# Internal-only fabrication constructors for in-workspace tests and benchmarks.
+# Never forwarded by the `foo` shell crate, so end-user builds never see
 # these items.
-test-util = []
+private-test-util = []
 ```
 
-The `test-util` feature lives on `foo_impl`, not on `foo`. `foo_impl` is
-`[lib] doc = false`, `#![doc(hidden)]`, and documented as "do not depend on
-this directly", so the feature flag is invisible to docs.rs. The `foo` shell
-crate's `Cargo.toml` declares `foo_impl = { workspace = true }` without
-activating the feature, so end users running `cargo add foo` never get
-fabrication constructors compiled into their build. In-workspace consumers
-(`foo_otel` etc.) activate the feature on their own `foo_impl` dev-dependency:
+The `private-test-util` feature lives on `foo_impl` and is never declared on
+`foo`. The `foo` shell crate's `Cargo.toml` declares
+`foo_impl = { workspace = true }` without forwarding any private feature, so
+end users running `cargo add foo` never get fabrication constructors compiled
+into their build. In-workspace consumers (`foo_otel` etc.) activate the
+feature on their own `foo_impl` dev-dependency:
 
 ```toml
 [dev-dependencies]
-foo_impl = { path = "../foo_impl", features = ["test-util"] }
+foo_impl = { path = "../foo_impl", features = ["private-test-util"] }
 ```
 
 Cargo's feature unification then makes `Report::fake` available across the
-workspace's test/bench build graph. The `cfg(any(test, feature = "test-util"))`
-form means `foo_impl`'s own unit tests automatically see the constructors
-without anyone needing to opt the workspace into the feature.
+workspace's test/bench build graph. The
+`cfg(any(test, feature = "private-test-util"))` form means `foo_impl`'s own
+unit tests automatically see the constructors without anyone needing to opt
+the workspace into the feature.
 
 If `foo_impl`'s own benches use the feature-gated items, add
-`required-features = ["test-util"]` to those bench entries so Cargo skips
-them when the feature is off:
+`required-features = ["private-test-util"]` to those bench entries so Cargo
+skips them when the feature is off:
 
 ```toml
 [[bench]]
 name = "foo_internals"
 harness = false
-required-features = ["test-util"]
+required-features = ["private-test-util"]
 ```
 
 Call sites become natural and symmetric with the rest of the public API:
@@ -253,10 +272,39 @@ let report = Report::fake(vec![
 
 Call sites name the types through `foo` (the public crate), not through
 `foo_impl`. The `fake` constructors are inherent methods on the type, so they
-are reachable via any path that names the type — and `foo`'s re-exports expose
-the type, even though they do not advertise the `fake` constructor. The
-`foo_impl` dev-dependency exists only to activate the `test-util` feature; no
-`use foo_impl::*;` import is required in test code.
+are reachable via any path that names the type — and `foo`'s re-exports
+expose the type, even though they do not advertise the `fake` constructor.
+The `foo_impl` dev-dependency exists only to activate the `private-test-util`
+feature; no `use foo_impl::*;` import is required in test code.
+
+## Public testing APIs that the shell crate exposes (`test-util`)
+
+A separate, larger pattern applies when a crate has a *documented* testing
+aid intended for end users — for example, `many_cpus::fake::FakeHardware`,
+which downstream crates use to write tests against `many_cpus`. This is a
+public-API feature, gated by `test-util` (or whatever the public name is),
+and it must be reachable when users enable it:
+
+```toml
+# foo/Cargo.toml
+[features]
+test-util = ["foo_impl/test-util"]   # forward 1:1
+
+[dependencies]
+foo_impl = { workspace = true }
+```
+
+```toml
+# foo_impl/Cargo.toml
+[features]
+test-util         = []   # forwarded from `foo`
+private-test-util = []   # internal only
+```
+
+A crate may have *both* features simultaneously. They are independent: the
+public `test-util` items are advertised by `foo`'s documentation and become
+part of `foo`'s SemVer surface, while `private-test-util` items remain
+unreachable from `foo` and stay in the impl crate's internal scope.
 
 ## How to do the split
 
@@ -317,17 +365,26 @@ the type, even though they do not advertise the `fake` constructor. The
    - Declare modules and re-export items just as the original `foo` lib.rs
      did.
 
-8. Convert any `#[cfg(any(test, feature = "test-util"))] pub fn fake(...)`
-   constructors that already existed in `foo` so they live in `foo_impl`
-   instead. Add a `test-util = []` feature to `foo_impl/Cargo.toml`. Keep the
-   `cfg(any(test, feature = "test-util"))` gate, the `#[doc(hidden)]`
-   attribute, and the `pub fn fake(...)` signature directly on the type. See
-   "Test-only fabrication constructors" above for the full rationale. If
-   `foo_impl`'s own benches consume these items, set
-   `required-features = ["test-util"]` on the affected `[[bench]]` entries.
+8. Convert any internal-only fabrication constructors that already existed
+   in `foo` (typically gated behind a workspace-internal `test-util` feature)
+   so they live in `foo_impl` instead. Add a `private-test-util = []` feature
+   to `foo_impl/Cargo.toml`. Keep the `cfg(any(test, feature = "private-test-util"))`
+   gate, the `#[doc(hidden)]` attribute, and the `pub fn fake(...)` signature
+   directly on the type. See "Internal-only test/bench helpers
+   (`private-test-util`)" above for the full rationale. If `foo_impl`'s own
+   benches consume these items, set
+   `required-features = ["private-test-util"]` on the affected `[[bench]]`
+   entries.
 
-9. Update in-workspace consumers (dev-dependencies that were using `test-util`
-   on `foo`) to declare `foo_impl = { path = "../foo_impl", features = ["test-util"] }`
+   If `foo` *also* has a public-API testing feature (e.g. `many_cpus`'s
+   `test-util` exposing `fake::FakeHardware` for downstream user tests),
+   declare it on `foo_impl` under its own name and forward it 1:1 from `foo`
+   — see "Public testing APIs that the shell crate exposes (`test-util`)"
+   above.
+
+9. Update in-workspace consumers (dev-dependencies that previously activated
+   an internal feature on `foo` to reach these items) to instead declare
+   `foo_impl = { path = "../foo_impl", features = ["private-test-util"] }`
    as a dev-dependency. Call sites continue to name types through `foo`
    (e.g. `use foo::Report; Report::fake(...)`); no `use foo_impl::*;` import
    is needed because `fake` is an inherent method on the type that `foo`
@@ -372,12 +429,12 @@ The original worked example. Concrete files to study:
 - `packages/nm/src/lib.rs` — preserved crate docs + explicit re-export list.
 - `packages/nm/tests/nm_reexports.rs` — re-export smoke test.
 - `packages/nm_impl/Cargo.toml` — impl manifest with `[lib] doc = false`, the
-  `test-util` feature for fabrication constructors, and the `nm` dev-dep for
-  the doctest cycle.
+  `private-test-util` feature for fabrication constructors, and the `nm`
+  dev-dep for the doctest cycle.
 - `packages/nm_impl/src/lib.rs` — `#![doc(hidden)]` root.
-- `packages/nm_impl/src/reports.rs` — `#[cfg(any(test, feature = "test-util"))]
-  #[doc(hidden)] pub fn fake(...)` constructors on `Report`, `EventMetrics`,
-  and `Histogram`.
+- `packages/nm_impl/src/reports.rs` —
+  `#[cfg(any(test, feature = "private-test-util"))] #[doc(hidden)] pub fn fake(...)`
+  constructors on `Report`, `EventMetrics`, and `Histogram`.
 - `packages/nm_impl/README.md` — "do not depend on this directly" notice.
 - `release-plz.toml` — `version_group = "nm"` entries for `nm` and `nm_impl`.
 
@@ -391,11 +448,12 @@ The second worked example. Concrete files to study:
   explicit `pub use nm_otel_impl::{Publisher, PublisherBuilder};`.
 - `packages/nm_otel/tests/nm_otel_reexports.rs` — re-export smoke test.
 - `packages/nm_otel_impl/Cargo.toml` — impl manifest with `[lib] doc = false`,
-  the `test-util` feature gating `Publisher::run_one_iteration_with_report`,
-  the `nm_otel` dev-dep for the doctest cycle, and the `nm_impl` dev-dep with
-  `features = ["test-util"]` so the impl-hosted benches can fabricate input
-  reports via `Report::fake`. Both `[[bench]]` entries declare
-  `required-features = ["test-util"]`.
+  the `private-test-util` feature gating
+  `Publisher::run_one_iteration_with_report`, the `nm_otel` dev-dep for the
+  doctest cycle, and the `nm_impl` dev-dep with
+  `features = ["private-test-util"]` so the impl-hosted benches can fabricate
+  input reports via `Report::fake`. Both `[[bench]]` entries declare
+  `required-features = ["private-test-util"]`.
 - `packages/nm_otel_impl/src/lib.rs` — `#![doc(hidden)]` root that re-exports
   the public-API subset for the shell crate plus `EventState` for the
   alloc-tracking integration test.

--- a/docs/impl-crate-split.md
+++ b/docs/impl-crate-split.md
@@ -14,9 +14,9 @@ crates that ship benchmarks or integration tests as separate compilation units:
 - A benchmark in `packages/foo/benches/foo_internals.rs` is its own compilation
   unit outside the `foo` crate. It can only call into `pub` items.
 - An integration test in `packages/foo/tests/` is also outside the crate.
-- An external bench/test in a *different* package (e.g. `foo_otel` benchmarking
-  the export path with fabricated reports) cannot reach `pub(crate)` items
-  either.
+- An external bench/test in a *different* package (e.g. `foo_otel` reaching
+  into `foo`'s internals to drive a hot path directly) cannot reach
+  `pub(crate)` items either.
 
 The `_impl` crate split solves this by moving the implementation behind a
 crate boundary that benches and tests can cross without making the same items
@@ -42,8 +42,9 @@ The visibility model becomes:
   outside the crate boundary, without `#[cfg]` gates and without a Cargo
   feature to expose internal API for testing. Items that genuinely only need
   to be visible within the impl crate stay `pub(crate)` as usual.
-- The narrow exception is **test-only fabrication constructors**: see
-  "Test-only fabrication constructors" below.
+- The narrow exception is the **internal-only test/bench API surface** that
+  some crates expose behind a `private-test-util` Cargo feature: see
+  "Internal-only test/bench helpers (`private-test-util`)" below.
 
 `foo_impl` is published and reachable on crates.io, but documented as
 off-limits via:
@@ -149,7 +150,7 @@ happens to need today.
 | --------------------------------- | ---------- | --------- |
 | `src/**` (implementation)         | `foo_impl` | The whole point of the split. |
 | Unit tests (`#[cfg(test)] mod tests` inside `src/**`) | `foo_impl` | They follow the code they test. |
-| `benches/**`                      | `foo_impl` | Benches are a maintainer tool; whoever runs them already knows the impl crate exists. Hosting them in `foo_impl` means a future bench can reach for `private-test-util` fabrication constructors or other internal `pub` items without having to be relocated first. |
+| `benches/**`                      | `foo_impl` | Benches are a maintainer tool; whoever runs them already knows the impl crate exists. Hosting them in `foo_impl` means a future bench can reach for `private-test-util` items or any other `foo_impl`-internal `pub` item without having to be relocated first. |
 | `tests/**` (integration tests)    | `foo_impl` | Same reasoning as benches: they are for maintainers, and proximity to `foo_impl` internals is occasionally needed. |
 | `examples/**` (user-facing)       | `foo`      | Examples are a form of end-user documentation. They must compile against the same public API a user gets from `cargo add foo`. Keeping them in the public crate is what enforces that they cannot accidentally reach for internals. |
 | Maintainer-only demo/dev binaries | `foo_impl/examples/` (optional) | If you do want a runnable internal demo (e.g. a load-generator, a profiling harness, a "wire up the internals to see what they do" app), put it under `foo_impl/examples/`. Treat it explicitly as "examples and dev apps for maintainers", a different category from end-user examples. |
@@ -162,12 +163,12 @@ Two principles fall out of the table:
    documentation, so they stay with the users. Benches and integration tests
    are maintainer tooling, so they stay with the maintainers.
 2. **Benches and integration tests living in `foo_impl` should still prefer
-   the public API.** Reach for `private-test-util` fabrication constructors or
-   other `foo_impl`-internal items only when there is a specific reason —
-   fabricating internal state for a contract that the public API cannot
-   express, or measuring a hot path that the public API gates behind a slower
-   entry point. When a bench uses only `use foo::Event;` it is still measuring
-   what the user pays; the impl crate is just a convenient host.
+   the public API.** Reach for `private-test-util` items or other
+   `foo_impl`-internal items only when there is a specific reason —
+   exercising a contract that the public API cannot express, or measuring a
+   hot path that the public API gates behind a slower entry point. When a
+   bench uses only `use foo::Event;` it is still measuring what the user
+   pays; the impl crate is just a convenient host.
 
 ## Cargo features on the impl crate
 
@@ -189,18 +190,19 @@ exposing the wrong ones.
 
 ## Internal-only test/bench helpers (`private-test-util`)
 
-Some internal items only make sense in a test or benchmark context:
-constructors that fabricate data structures bypassing the real-world entry
-path (e.g. building a `Report` from a hand-assembled `Vec<EventMetrics>`
-without observing real events). Two competing concerns apply:
+Some items only make sense in a test or benchmark context — for example,
+constructors that build a data structure from pre-assembled parts without
+going through the normal entry path, accessors that expose internal state
+for assertion, or methods that bypass an outer layer to drive a hot path
+directly. Two competing concerns apply:
 
 1. They must be reachable from external benches/tests in other workspace
    crates, which requires them to be `pub` in `foo_impl`.
 2. They are pure dead weight in production builds and should not bloat the
    binary that real users ship.
 
-The convention is to put them directly on the type they fabricate, gated
-behind a `private-test-util` Cargo feature on `foo_impl`:
+The convention is to put these items directly on the type they relate to,
+gated behind a `private-test-util` Cargo feature on `foo_impl`:
 
 ```rust
 // in foo_impl/src/reports.rs
@@ -224,29 +226,29 @@ impl Report {
 ```toml
 # foo_impl/Cargo.toml
 [features]
-# Internal-only fabrication constructors for in-workspace tests and benchmarks.
-# Never forwarded by the `foo` shell crate, so end-user builds never see
-# these items.
+# Internal-only API surface for in-workspace tests and benchmarks. Never
+# forwarded by the `foo` shell crate, so end-user builds never see these
+# items.
 private-test-util = []
 ```
 
 The `private-test-util` feature lives on `foo_impl` and is never declared on
 `foo`. The `foo` shell crate's `Cargo.toml` declares
 `foo_impl = { workspace = true }` without forwarding any private feature, so
-end users running `cargo add foo` never get fabrication constructors compiled
-into their build. In-workspace consumers (`foo_otel` etc.) activate the
-feature on their own `foo_impl` dev-dependency:
+end users running `cargo add foo` never get these items compiled into their
+build. In-workspace consumers (`foo_otel` etc.) activate the feature on
+their own `foo_impl` dev-dependency:
 
 ```toml
 [dev-dependencies]
 foo_impl = { path = "../foo_impl", features = ["private-test-util"] }
 ```
 
-Cargo's feature unification then makes `Report::fake` available across the
+Cargo's feature unification then makes the gated items available across the
 workspace's test/bench build graph. The
 `cfg(any(test, feature = "private-test-util"))` form means `foo_impl`'s own
-unit tests automatically see the constructors without anyone needing to opt
-the workspace into the feature.
+unit tests automatically see the items without anyone needing to opt the
+workspace into the feature.
 
 If `foo_impl`'s own benches use the feature-gated items, add
 `required-features = ["private-test-util"]` to those bench entries so Cargo
@@ -271,11 +273,11 @@ let report = Report::fake(vec![
 ```
 
 Call sites name the types through `foo` (the public crate), not through
-`foo_impl`. The `fake` constructors are inherent methods on the type, so they
-are reachable via any path that names the type — and `foo`'s re-exports
-expose the type, even though they do not advertise the `fake` constructor.
-The `foo_impl` dev-dependency exists only to activate the `private-test-util`
-feature; no `use foo_impl::*;` import is required in test code.
+`foo_impl`. Gated items declared as inherent methods on a type are reachable
+via any path that names the type — and `foo`'s re-exports expose the type,
+even though `foo` does not advertise the gated method itself. The `foo_impl`
+dev-dependency exists only to activate the `private-test-util` feature; no
+`use foo_impl::*;` import is required in test code.
 
 ## Public testing APIs that the shell crate exposes (`test-util`)
 
@@ -365,14 +367,14 @@ unreachable from `foo` and stay in the impl crate's internal scope.
    - Declare modules and re-export items just as the original `foo` lib.rs
      did.
 
-8. Convert any internal-only fabrication constructors that already existed
-   in `foo` (typically gated behind a workspace-internal `test-util` feature)
-   so they live in `foo_impl` instead. Add a `private-test-util = []` feature
-   to `foo_impl/Cargo.toml`. Keep the `cfg(any(test, feature = "private-test-util"))`
-   gate, the `#[doc(hidden)]` attribute, and the `pub fn fake(...)` signature
-   directly on the type. See "Internal-only test/bench helpers
-   (`private-test-util`)" above for the full rationale. If `foo_impl`'s own
-   benches consume these items, set
+8. Convert any internal-only API surface that already existed in `foo`
+   (typically gated behind a workspace-internal `test-util` feature) so it
+   lives in `foo_impl` instead. Add a `private-test-util = []` feature to
+   `foo_impl/Cargo.toml`. Keep the
+   `cfg(any(test, feature = "private-test-util"))` gate and the
+   `#[doc(hidden)]` attribute on each item. See "Internal-only test/bench
+   helpers (`private-test-util`)" above for the full rationale. If
+   `foo_impl`'s own benches consume these items, set
    `required-features = ["private-test-util"]` on the affected `[[bench]]`
    entries.
 
@@ -387,8 +389,8 @@ unreachable from `foo` and stay in the impl crate's internal scope.
    `foo_impl = { path = "../foo_impl", features = ["private-test-util"] }`
    as a dev-dependency. Call sites continue to name types through `foo`
    (e.g. `use foo::Report; Report::fake(...)`); no `use foo_impl::*;` import
-   is needed because `fake` is an inherent method on the type that `foo`
-   re-exports.
+   is needed because gated inherent methods are reachable via any path that
+   names the type, and `foo` re-exports the type.
 
 10. Add `foo` itself as a dev-dependency of `foo_impl` so doctests written
     from the user's perspective (`use foo::Event;`) compile in
@@ -429,8 +431,8 @@ The original worked example. Concrete files to study:
 - `packages/nm/src/lib.rs` — preserved crate docs + explicit re-export list.
 - `packages/nm/tests/nm_reexports.rs` — re-export smoke test.
 - `packages/nm_impl/Cargo.toml` — impl manifest with `[lib] doc = false`, the
-  `private-test-util` feature for fabrication constructors, and the `nm`
-  dev-dep for the doctest cycle.
+  `private-test-util` feature for internal helpers, and the `nm` dev-dep for
+  the doctest cycle.
 - `packages/nm_impl/src/lib.rs` — `#![doc(hidden)]` root.
 - `packages/nm_impl/src/reports.rs` —
   `#[cfg(any(test, feature = "private-test-util"))] #[doc(hidden)] pub fn fake(...)`
@@ -451,7 +453,7 @@ The second worked example. Concrete files to study:
   the `private-test-util` feature gating
   `Publisher::run_one_iteration_with_report`, the `nm_otel` dev-dep for the
   doctest cycle, and the `nm_impl` dev-dep with
-  `features = ["private-test-util"]` so the impl-hosted benches can fabricate
+  `features = ["private-test-util"]` so the impl-hosted benches can build
   input reports via `Report::fake`. Both `[[bench]]` entries declare
   `required-features = ["private-test-util"]`.
 - `packages/nm_otel_impl/src/lib.rs` — `#![doc(hidden)]` root that re-exports

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -19,9 +19,9 @@ all-features = true
 doc = false
 
 [features]
-# Internal-only fabrication constructors for in-workspace tests and benchmarks.
-# Never forwarded by the `nm` shell crate, so end-user builds never see these
-# items. See docs/impl-crate-split.md for the `test-util` vs `private-test-util`
+# Internal-only API surface for in-workspace tests and benchmarks. Never
+# forwarded by the `nm` shell crate, so end-user builds never see these items.
+# See docs/impl-crate-split.md for the `test-util` vs `private-test-util`
 # distinction.
 private-test-util = []
 

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -19,10 +19,11 @@ all-features = true
 doc = false
 
 [features]
-# Enables fabrication constructors for testing and benchmarking. The `nm`
-# shell crate does not activate this feature, so end-user builds never see
-# these items.
-test-util = []
+# Internal-only fabrication constructors for in-workspace tests and benchmarks.
+# Never forwarded by the `nm` shell crate, so end-user builds never see these
+# items. See docs/impl-crate-split.md for the `test-util` vs `private-test-util`
+# distinction.
+private-test-util = []
 
 [dependencies]
 fast_time = { workspace = true }

--- a/packages/nm_impl/src/reports.rs
+++ b/packages/nm_impl/src/reports.rs
@@ -108,7 +108,7 @@ impl Report {
     ///
     /// Intended for in-workspace tests and benchmarks that need to drive code paths
     /// expecting a [`Report`] without observing real events.
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     #[must_use]
     pub fn fake(events: Vec<EventMetrics>) -> Self {
@@ -341,7 +341,7 @@ impl EventMetrics {
     ///
     /// Intended for in-workspace tests and benchmarks that need to fabricate
     /// metric snapshots.
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     #[must_use]
     pub fn fake(
@@ -487,7 +487,7 @@ impl Histogram {
     /// # Panics
     ///
     /// Panics if any of the above preconditions are violated.
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     #[must_use]
     pub fn fake(

--- a/packages/nm_impl/src/reports.rs
+++ b/packages/nm_impl/src/reports.rs
@@ -339,8 +339,8 @@ impl EventMetrics {
     /// global event registry. The mean is calculated as `sum / count` (rounded
     /// down); when `count` is zero, the mean is zero.
     ///
-    /// Intended for in-workspace tests and benchmarks that need to fabricate
-    /// metric snapshots.
+    /// Intended for in-workspace tests and benchmarks that need to build metric
+    /// snapshots without observing real events.
     #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     #[must_use]

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -27,9 +27,9 @@ development = ["criterion", "gungraun", "many_cpus", "par_bench"]
 doc = false
 
 [features]
-# Internal-only fabrication helpers for in-workspace tests and benchmarks.
-# Never forwarded by the `nm_otel` shell crate, so end-user builds never see
-# these items. See docs/impl-crate-split.md for the `test-util` vs
+# Internal-only API surface for in-workspace tests and benchmarks. Never
+# forwarded by the `nm_otel` shell crate, so end-user builds never see these
+# items. See docs/impl-crate-split.md for the `test-util` vs
 # `private-test-util` distinction.
 private-test-util = []
 

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -14,9 +14,9 @@ rust-version.workspace = true
 all-features = true
 
 # These dev-dependencies are consumed only by `[[bench]]` entries that declare
-# `required-features = ["test-util"]`. When udeps runs without `--all-features`,
-# the benches are skipped, so the dev-deps appear unused. Ignore them here to
-# silence false positives.
+# `required-features = ["private-test-util"]`. When udeps runs without
+# `--all-features`, the benches are skipped, so the dev-deps appear unused.
+# Ignore them here to silence false positives.
 [package.metadata.cargo-udeps.ignore]
 development = ["criterion", "gungraun", "many_cpus", "par_bench"]
 
@@ -27,10 +27,11 @@ development = ["criterion", "gungraun", "many_cpus", "par_bench"]
 doc = false
 
 [features]
-# Enables fabrication helpers for testing and benchmarking. The `nm_otel`
-# shell crate does not activate this feature, so end-user builds never see
-# these items.
-test-util = []
+# Internal-only fabrication helpers for in-workspace tests and benchmarks.
+# Never forwarded by the `nm_otel` shell crate, so end-user builds never see
+# these items. See docs/impl-crate-split.md for the `test-util` vs
+# `private-test-util` distinction.
+private-test-util = []
 
 [dependencies]
 foldhash = { workspace = true }
@@ -46,7 +47,7 @@ criterion = { workspace = true }
 many_cpus = { path = "../many_cpus" }
 mutants = { workspace = true }
 new_zealand = { path = "../new_zealand" }
-nm_impl = { path = "../nm_impl", features = ["test-util"] }
+nm_impl = { path = "../nm_impl", features = ["private-test-util"] }
 # `nm_otel` is a dev-dep so doctests, examples, and benches can write
 # `use nm_otel::Publisher;` exactly as user code would, matching the documentation
 # rendered for `nm_otel`. This forms an allowed dev-dependency-only cycle.
@@ -65,12 +66,12 @@ gungraun = { workspace = true, features = ["default"] }
 [[bench]]
 name = "nm_otel_export"
 harness = false
-required-features = ["test-util"]
+required-features = ["private-test-util"]
 
 [[bench]]
 name = "nm_otel_export_cg"
 harness = false
-required-features = ["test-util"]
+required-features = ["private-test-util"]
 
 [lints]
 workspace = true

--- a/packages/nm_otel_impl/benches/nm_otel_export_cg.rs
+++ b/packages/nm_otel_impl/benches/nm_otel_export_cg.rs
@@ -5,8 +5,8 @@
 //! the per-bucket delta from this optimization is on the order of tens of instructions
 //! per bucket and would be invisible under Criterion noise on a shared machine.
 //!
-//! All scenarios drive [`Publisher::run_one_iteration_with_report`] on a fabricated
-//! [`Report`] (built via [`Report::fake`] + [`Histogram::fake`] +
+//! All scenarios drive [`Publisher::run_one_iteration_with_report`] on a pre-built
+//! [`Report`] (assembled via [`Report::fake`] + [`Histogram::fake`] +
 //! [`EventMetrics::fake`]) so the measurement is decoupled from the global nm
 //! registry and reproducible run-to-run.
 //!

--- a/packages/nm_otel_impl/src/publisher.rs
+++ b/packages/nm_otel_impl/src/publisher.rs
@@ -231,7 +231,7 @@ impl Publisher {
     ///
     /// This bypasses [`Report::collect`] so callers can drive the export pipeline with
     /// fabricated reports built via `Report::fake`.
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     pub fn run_one_iteration_with_report(&mut self, report: &Report) {
         self.export(report);

--- a/packages/nm_otel_impl/src/publisher.rs
+++ b/packages/nm_otel_impl/src/publisher.rs
@@ -230,7 +230,8 @@ impl Publisher {
     /// Runs a single export iteration using the supplied report.
     ///
     /// This bypasses [`Report::collect`] so callers can drive the export pipeline with
-    /// fabricated reports built via `Report::fake`.
+    /// a pre-built [`Report`] (typically constructed via `Report::fake` in tests and
+    /// benchmarks).
     #[cfg(any(test, feature = "private-test-util"))]
     #[doc(hidden)]
     pub fn run_one_iteration_with_report(&mut self, report: &Report) {


### PR DESCRIPTION
Rename the workspace-internal `test-util` feature on `nm_impl` and
`nm_otel_impl` to `private-test-util`, and codify this naming convention in
`docs/impl-crate-split.md` + `AGENTS.md`.

## Why

The `_impl` crate split pattern needs to distinguish between two different
kinds of Cargo feature that may live on the implementation crate:

* **Public-API testing features** (e.g. `many_cpus`'s `test-util` exposing
  `fake::FakeHardware`), which must be forwarded 1:1 by the shell crate so
  end users can opt in via `cargo add foo --features test-util`.
* **Internal-only fabrication helpers**, which must **never** be forwarded
  by the shell crate so they cannot leak into the public API surface — but
  are activated by in-workspace dev-dependencies that need to fabricate
  internal data structures for tests and benchmarks.

A single feature name (`test-util`) cannot serve both purposes: there is
no way for `foo` to forward "the public bits but not the internal bits"
when both live under the same name on `foo_impl`. The distinction must
therefore be encoded in the name.

The convention is to prefix internal-only features with `private-` (e.g.
`private-test-util`), mirroring the existing `__private` / `__private_*`
"logically private but mechanically public" naming for items elsewhere in
the workspace. Public-API features keep their natural names.

## What changes

Neither `nm_impl` nor `nm_otel_impl` has a public-API testing feature
today, so each now exposes only `private-test-util`. Both crates may later
grow a public `test-util` alongside without name conflict.

Concretely:

* `packages/nm_impl/Cargo.toml` — `[features] test-util = []` →
  `private-test-util = []`, with an explanatory comment.
* `packages/nm_otel_impl/Cargo.toml` — same rename; both `[[bench]]`
  entries' `required-features` updated; the `nm_impl` dev-dep activation
  switched from `["test-util"]` to `["private-test-util"]`; the
  `cargo-udeps.ignore` comment updated.
* `packages/nm_impl/src/reports.rs` — three `cfg(any(test, feature = "test-util"))`
  gates (on `Report::fake`, `EventMetrics::fake`, `Histogram::fake`)
  renamed.
* `packages/nm_otel_impl/src/publisher.rs` — one `cfg` gate (on
  `Publisher::run_one_iteration_with_report`) renamed.
* `docs/impl-crate-split.md` — restructured. New "Cargo features on the
  impl crate" section spells out the two-feature distinction in a table.
  The former "Test-only fabrication constructors" section is now
  "Internal-only test/bench helpers (`private-test-util`)", with a
  companion "Public testing APIs that the shell crate exposes
  (`test-util`)" section that walks through the public-forwarding case.
  Step 8 of "How to do the split" is split to cover both cases.
* `AGENTS.md` — summary paragraph for the `_impl` crate split section now
  mentions both feature kinds.

## Validation

Ran `just package=<pkg> validate-local` for `nm`, `nm_impl`, `nm_otel`,
`nm_otel_impl` on both Windows and Linux (via WSL). All green.

## Follow-ups

This rename is the prerequisite for splitting `many_cpus` into
`many_cpus` + `many_cpus_impl`. `many_cpus` already has *both* kinds of
exposure today (a documented `test-util` for `fake::FakeHardware`, plus
`__private_*` PAL helpers consumed by an internal bench), so the
two-feature convention must be in place before that work lands. After
`many_cpus`, the same pattern can be applied to `linked` (which has
`__private_clear_linked_variables_*` helpers consumed by an internal
bench).
