### PR TITLE
Upgrade codecov/codecov-action from v6 to v7

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/default/junit.xml
@@ -282,7 +282,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/default/junit.xml
@@ -591,7 +591,7 @@ jobs:
           just coverage-report-ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info


### PR DESCRIPTION
Bumps `codecov/codecov-action` from `v6` to `v7` across all three call sites in `validation.yml`.

## Audit of all GitHub Actions in use

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | `v6` | `v6` | already latest major (v6.0.3) |
| `Swatinem/rust-cache` | `v2` | `v2` | already latest major (v2.9.1) |
| `dtolnay/rust-toolchain` | `@stable` | `@stable` | canonical usage per upstream README — the `@stable` ref selects the stable toolchain; only tag published is `v1` |
| `codecov/codecov-action` | `v6` | **`v7`** | upgraded |

## Why `v7` is safe

The [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0) describe only two changes, neither of which touches user-facing behavior:

- Removed an internal "Enforce License Compliance" CI workflow.
- Rotated the GPG signing key (upstream account migration from `codecovsecurity` to `codecovsecops`).

No input/output schema changes, so the existing `with:` blocks (`token`, `files`, `flags`, `report_type`, `fail_ci_if_error`) work unchanged.
