### PR TITLE
Add `just mutants-careful` for serialized mutation testing

### DIFF
--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -1,8 +1,10 @@
 [group('quality')]
 [script]
-mutants:
+mutants CAREFUL='false':
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
+
+    $careful = '{{ CAREFUL }}' -eq 'true'
 
     function Escape-Wildcards ($s) {
         if ($IsWindows) {
@@ -85,8 +87,15 @@ mutants:
     }
 
     $args += "--jobs"
-    # Experimentally determined heuristics.
-    $args += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
+    if ($careful) {
+        # In careful mode, only one mutation is tested at a time. Combined with
+        # `RUST_TEST_THREADS=1` set below, this ensures that exactly one test runs at any
+        # given moment across the entire mutation testing run.
+        $args += "1"
+    } else {
+        # Experimentally determined heuristics.
+        $args += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
+    }
 
     # We must use Invoke-Expression to preserve the quotes around the wildcarded arguments on Linux.
     $expanded_args = [String]::join(" ", $args)
@@ -117,6 +126,18 @@ mutants:
     # This allows mutations that cause infinite loops to hang as expected.
     $env:MUTATION_TESTING = "1"
 
+    if ($careful) {
+        # Force libtest to run a single test at a time within each `cargo test` invocation.
+        # Combined with `--jobs 1` above, this ensures that exactly one test runs at any
+        # given moment, which helps diagnose tests that are sensitive to concurrent
+        # execution or otherwise interact in unexpected ways.
+        $env:RUST_TEST_THREADS = "1"
+    }
+
+    # In careful mode tests run serially, so a single mutation's test pass takes much longer
+    # than the parallel default. Bump the per-mutation timeout accordingly.
+    $timeout = if ($careful) { 600 } else { 60 }
+
     # --baseline=skip - We assume that regular tests have already been executed
     #     and are not failing, for mutation speedup.
     # --no-shuffle - We do not care about shuffling, that is something rarely useful.
@@ -127,5 +148,9 @@ mutants:
     #     but short enough to call a timeout and timeout and avoid things going on forever.
     #     This should only be reached if a mutation causes a serious issue (and may need to be
     #     skipped or the test improved).
-    Invoke-Expression "cargo mutants {{ target_package }} --baseline=skip --timeout=60 --no-shuffle --caught --unviable $expanded_args"
+    Invoke-Expression "cargo mutants {{ target_package }} --baseline=skip --timeout=$timeout --no-shuffle --caught --unviable $expanded_args"
     exit $LASTEXITCODE
+
+# Run mutation tests with no parallelism: one mutation at a time, one test at a time within each mutation. Slow but useful for investigating flaky or concurrency-sensitive tests.
+[group('quality')]
+mutants-careful: (mutants "true")

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -134,10 +134,6 @@ mutants CAREFUL='false':
         $env:RUST_TEST_THREADS = "1"
     }
 
-    # In careful mode tests run serially, so a single mutation's test pass takes much longer
-    # than the parallel default. Bump the per-mutation timeout accordingly.
-    $timeout = if ($careful) { 600 } else { 60 }
-
     # --baseline=skip - We assume that regular tests have already been executed
     #     and are not failing, for mutation speedup.
     # --no-shuffle - We do not care about shuffling, that is something rarely useful.
@@ -148,7 +144,7 @@ mutants CAREFUL='false':
     #     but short enough to call a timeout and timeout and avoid things going on forever.
     #     This should only be reached if a mutation causes a serious issue (and may need to be
     #     skipped or the test improved).
-    Invoke-Expression "cargo mutants {{ target_package }} --baseline=skip --timeout=$timeout --no-shuffle --caught --unviable $expanded_args"
+    Invoke-Expression "cargo mutants {{ target_package }} --baseline=skip --timeout=60 --no-shuffle --caught --unviable $expanded_args"
     exit $LASTEXITCODE
 
 # Run mutation tests with no parallelism: one mutation at a time, one test at a time within each mutation. Slow but useful for investigating flaky or concurrency-sensitive tests.


### PR DESCRIPTION
Adds a new recipe `just mutants-careful` that runs cargo-mutants with no parallelism at all: only one mutation tested at a time, and within each mutation only one test runs at a time. Useful for investigating flaky tests or tests that are sensitive to concurrent execution.

## Mechanism

- `--jobs 1` (one cargo invocation at a time) instead of the `NCPUS/6 + 1` heuristic used by the default `just mutants`.
- `RUST_TEST_THREADS=1` env var so libtest serializes within each `cargo test` invocation. (`--test-threads=1` could not be plumbed through cargo-mutants without disturbing the existing `additional_cargo_test_args = ["--tests"]` config in `.cargo/mutants.toml` — see note below.)
- `--timeout=60` is unchanged from the regular `mutants` recipe. Even with serialized execution, individual tests are expected to complete well within 60s; that limit is an extreme threshold for resource-constrained scenarios, not a normal-case budget.

## Implementation

Parameterizes the existing `mutants` recipe with a `CAREFUL='false'` argument; `mutants-careful` is a thin wrapper:

```
mutants-careful: (mutants `"true"`)
```

Default `just mutants` behavior is unchanged.

## Why `RUST_TEST_THREADS` instead of `--test-threads=1`

cargo-mutants assembles `additional_cargo_test_args` (currently `["--tests"]` from `.cargo/mutants.toml`) at the **end** of the cargo command, after any CLI-supplied `--` separator. Injecting `-- --test-threads=1` from the recipe would land *before* the config's `--tests`, turning `--tests` into a test-binary argument and breaking the build. The `RUST_TEST_THREADS` env var is honored by libtest as a default for `--test-threads` and side-steps the ordering problem cleanly.

## Env-var scoping

` = "1"` is scoped to the `pwsh` child process spawned for the `[script]` recipe and does not leak back into the invoking shell — consistent with the existing ``, ``, and `C:\Users\Sander\AppData\Local\Temp` assignments in the same recipe.

## Verification

Smoke-tested locally with `just package=cpulist mutants-careful`: 22 mutants generated, all caught, run completed cleanly under serial execution.
