### PR TITLE
Shard mutation testing across parallel CI runners

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -55,8 +55,12 @@ Split from the monolithic `just validate-local` into individual jobs:
 
 Split from the monolithic `just validate-extra-local` into individual jobs, all multi-platform:
 
-- **mutants** — `timeout-minutes: 90`
+- **mutants** — `timeout-minutes: 90`, sharded
   - Runs mutation testing (very slow)
+  - Sharded 8 ways per platform via cargo-mutants' native `--shard N/M` support; the
+    just recipe accepts the same 1-based `N/M` format as `miri-harder` and translates
+    to cargo-mutants' 0-based form internally. Without a SHARD argument the recipe
+    runs every mutant in a single job, preserving the local-development experience.
   
 - **run-examples** — `timeout-minutes: 90`
   - Executes all example binaries

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -488,11 +488,12 @@ jobs:
   mutants:
     needs: [delta, test-more-x64]
     if: needs.delta.outputs.skip_all != 'true'
-    timeout-minutes: 240
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest]
+        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
 
     runs-on: ${{ matrix.platform }}
 
@@ -503,8 +504,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run mutants on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" mutants
+      - name: Run mutants on ${{ matrix.platform }} (shard ${{ matrix.shard }})
+        run: just package="${{ needs.delta.outputs.packages }}" mutants ${{ matrix.shard }}
 
   run-examples:
     needs: [delta]

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -1,6 +1,6 @@
 [group('quality')]
 [script]
-mutants:
+mutants SHARD="":
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -87,6 +87,42 @@ mutants:
     $args += "--jobs"
     # Experimentally determined heuristics.
     $args += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
+
+    # Optional sharding lets CI split mutation testing across multiple parallel runners.
+    # We accept the same 1-based "N/M" format as `miri-harder` for consistency with the
+    # existing workspace convention (so `1/8 .. 8/8` for 8 shards), and convert to
+    # cargo-mutants' native 0-based form (`0/N .. (N-1)/N`) before invoking the tool.
+    # Without a SHARD argument, cargo-mutants runs every mutant in a single job (the
+    # original behavior).
+    $shard = "{{ SHARD }}"
+    if ($shard -ne "") {
+        $parts = $shard -split "/"
+
+        if ($parts.Length -ne 2) {
+            Write-Error "Invalid SHARD value '$shard'. Expected format 'N/M'."
+            exit 1
+        }
+
+        $shardIndex = 0
+        $shardCount = 0
+        if (-not [int]::TryParse($parts[0], [ref]$shardIndex) -or -not [int]::TryParse($parts[1], [ref]$shardCount)) {
+            Write-Error "Invalid SHARD value '$shard'. N and M must be integers in 'N/M'."
+            exit 1
+        }
+
+        if ($shardCount -le 0) {
+            Write-Error "Invalid SHARD value '$shard'. M must be a positive integer in 'N/M'."
+            exit 1
+        }
+
+        if ($shardIndex -lt 1 -or $shardIndex -gt $shardCount) {
+            Write-Error "Invalid SHARD value '$shard'. N must satisfy 1 <= N <= M in 'N/M'."
+            exit 1
+        }
+
+        $args += "--shard"
+        $args += ("{0}/{1}" -f ($shardIndex - 1), $shardCount)
+    }
 
     # We must use Invoke-Expression to preserve the quotes around the wildcarded arguments on Linux.
     $expanded_args = [String]::join(" ", $args)


### PR DESCRIPTION
Splits the long-running mutation testing job into 8 parallel shards per platform (16 jobs total) using cargo-mutants' native `--shard` support, mirroring the existing `miri-harder-*` sharding pattern.

## Changes

- **`justfiles/just_quality_mutants.just`** — Add optional `SHARD` parameter to the `mutants` recipe. Accepts the same 1-based `N/M` format as `miri-harder` (e.g. `1/8 .. 8/8`) for consistency with the existing workspace convention, and converts to cargo-mutants' native 0-based form before invocation. Without a SHARD argument, all mutants run in a single job (unchanged local behavior).
- **`.github/workflows/validation.yml`** — Add `shard: [1/8, ..., 8/8]` to the `mutants` matrix. Reduce `timeout-minutes` from 240 to 90 to match the existing `miri-harder-*` jobs.
- **`.github/workflows/AGENTS.md`** — Document the new sharding setup.

## Verification

- Recipe parses correctly (`just --list` shows `mutants SHARD=""`).
- Invalid shard input (`abc`, `5/4`, `0/4`) is rejected with clear errors and exit code 1.
- End-to-end test on `cpulist` (22 mutants) confirms the 8 shards partition perfectly: 3+3+3+3+3+3+3+1 = 22 with no overlap and no gaps.
