### PR TITLE
Add machine-readable JSON output to all_the_time and alloc_tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,12 @@ version = "0.4.20"
 dependencies = [
  "cpu-time",
  "criterion",
+ "folo_utils",
  "mutants 0.0.4",
+ "serde",
+ "serde_json",
  "static_assertions",
+ "tempfile",
 ]
 
 [[package]]
@@ -26,9 +30,13 @@ name = "alloc_tracker"
 version = "0.5.25"
 dependencies = [
  "criterion",
+ "folo_utils",
  "mutants 0.0.4",
+ "serde",
+ "serde_json",
  "serial_test",
  "static_assertions",
+ "tempfile",
 ]
 
 [[package]]
@@ -619,6 +627,8 @@ name = "folo_utils"
 version = "0.1.7"
 dependencies = [
  "mutants 0.0.4",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ fake_headers = { version = "0.0.5", default-features = false }
 fast_time = { version = "0.1.23", path = "packages/fast_time", default-features = false }
 foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
 folo_ffi = { version = "0.1.15", path = "packages/folo_ffi", default-features = false }
+folo_utils = { version = "0.1.7", path = "packages/folo_utils", default-features = false }
 frozen-collections = { version = "0.8.0", default-features = false }
 future_deque = { version = "0.1.10", path = "packages/future_deque", default-features = false }
 futures = { version = "0.3.11", default-features = false, features = ["std"] }
@@ -87,6 +88,13 @@ scc = { version = "3.0.2", default-features = false }
 scopeguard = { version = "1.2.0", default-features = false }
 semver = { version = "1.0.28", default-features = false, features = ["std"] }
 seq-macro = { version = "0.3.0", default-features = false }
+serde = { version = "1.0.219", default-features = false, features = [
+    "derive",
+    "std",
+] }
+serde_json = { version = "1.0.140", default-features = false, features = [
+    "std",
+] }
 serial_test = { version = "3.2.0", default-features = false }
 simple-mermaid = { version = "0.2.0", default-features = false }
 smallvec = { version = "1.15.0", default-features = false }

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -15,11 +15,15 @@ all-features = true
 
 [dependencies]
 cpu-time = { workspace = true }
+folo_utils = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
 mutants = { workspace = true }
 static_assertions = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "all_the_time_example"

--- a/packages/all_the_time/README.md
+++ b/packages/all_the_time/README.md
@@ -6,7 +6,7 @@ enabling analysis of processor usage patterns in benchmarks and performance test
 ```rust
 use all_the_time::Session;
 
-fn main() {
+fn main() -> std::io::Result<()> {
     let session = Session::new();
 
     // Track multiple iterations efficiently
@@ -28,6 +28,12 @@ fn main() {
     } // Total time measured once and divided by iteration count for mean
 
     session.print_to_stdout();
+
+    // Also emit machine-readable JSON files (one per operation) into the Cargo
+    // target directory: target/all_the_time/<operation>.json
+    session.write_to_target()?;
+
+    Ok(())
 }
 ```
 

--- a/packages/all_the_time/README.md
+++ b/packages/all_the_time/README.md
@@ -6,7 +6,7 @@ enabling analysis of processor usage patterns in benchmarks and performance test
 ```rust
 use all_the_time::Session;
 
-fn main() -> std::io::Result<()> {
+fn main() {
     let session = Session::new();
 
     // Track multiple iterations efficiently
@@ -31,9 +31,7 @@ fn main() -> std::io::Result<()> {
 
     // Also emit machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/all_the_time/<operation>.json
-    session.write_to_target()?;
-
-    Ok(())
+    session.write_to_target();
 }
 ```
 

--- a/packages/all_the_time/examples/all_the_time_readme.rs
+++ b/packages/all_the_time/examples/all_the_time_readme.rs
@@ -10,7 +10,7 @@
 
 use all_the_time::Session;
 
-fn main() -> std::io::Result<()> {
+fn main() {
     let session = Session::new();
 
     // Track multiple iterations efficiently
@@ -37,7 +37,5 @@ fn main() -> std::io::Result<()> {
 
     // Also emit machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/all_the_time/<operation>.json
-    session.write_to_target()?;
-
-    Ok(())
+    session.write_to_target();
 }

--- a/packages/all_the_time/examples/all_the_time_readme.rs
+++ b/packages/all_the_time/examples/all_the_time_readme.rs
@@ -10,7 +10,7 @@
 
 use all_the_time::Session;
 
-fn main() {
+fn main() -> std::io::Result<()> {
     let session = Session::new();
 
     // Track multiple iterations efficiently
@@ -34,4 +34,10 @@ fn main() {
     } // Total time measured once and divided by iteration count for mean
 
     session.print_to_stdout();
+
+    // Also emit machine-readable JSON files (one per operation) into the Cargo
+    // target directory: target/all_the_time/<operation>.json
+    session.write_to_target()?;
+
+    Ok(())
 }

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -37,6 +37,32 @@
 //! # }
 //! ```
 //!
+//! # Machine-readable output
+//!
+//! In addition to printing to the console, you can emit machine-readable JSON
+//! files (one per operation) into the Cargo target directory for later
+//! analysis. Files are written to `target/all_the_time/<operation>.json`, with
+//! operation names sanitized to be filesystem-safe:
+//!
+//! ```no_run
+//! use all_the_time::Session;
+//!
+//! # fn main() -> std::io::Result<()> {
+//! let session = Session::new();
+//!
+//! {
+//!     let batch_op = session.operation("batch_work");
+//!     let _span = batch_op.measure_thread().iterations(1000);
+//!     for _ in 0..1000 {
+//!         std::hint::black_box(42 * 2);
+//!     }
+//! }
+//!
+//! session.write_to_target()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! # Thread vs process processor time
 //!
 //! You can choose between tracking thread processor time or process processor time:
@@ -114,6 +140,7 @@ mod pal;
 mod process_span;
 mod report;
 mod session;
+mod target_output;
 mod thread_span;
 
 pub(crate) use constants::*;

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -47,7 +47,7 @@
 //! ```no_run
 //! use all_the_time::Session;
 //!
-//! # fn main() -> std::io::Result<()> {
+//! # fn main() {
 //! let session = Session::new();
 //!
 //! {
@@ -58,8 +58,7 @@
 //!     }
 //! }
 //!
-//! session.write_to_target()?;
-//! # Ok(())
+//! session.write_to_target();
 //! # }
 //! ```
 //!

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -1,0 +1,257 @@
+//! Machine-readable JSON output of processor time statistics.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use std::{fs, io};
+
+use serde::Serialize;
+
+use crate::{Report, Session};
+
+/// Subdirectory of the Cargo target directory that receives the JSON files.
+const OUTPUT_SUBDIRECTORY: &str = "all_the_time";
+
+/// Machine-readable processor time statistics for a single operation.
+#[derive(Serialize)]
+struct OperationOutput<'a> {
+    operation: &'a str,
+    total_iterations: u64,
+    total_processor_time_nanos: u64,
+    mean_processor_time_nanos: u64,
+}
+
+impl Report {
+    /// Writes machine-readable JSON statistics into the Cargo target directory.
+    ///
+    /// One file is written per operation, named after the operation, at
+    /// `<target>/all_the_time/<operation>.json`. Operation names are sanitized
+    /// to be filesystem-safe and existing files are overwritten.
+    ///
+    /// The target directory is resolved the same way as Criterion (honoring
+    /// `CARGO_TARGET_DIR`), falling back to a relative `target` directory.
+    ///
+    /// Writes nothing if no operations were captured. This may indicate that the
+    /// session was part of a "list available benchmarks" probe run instead of
+    /// some real activity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use all_the_time::Session;
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let session = Session::new();
+    /// {
+    ///     let operation = session.operation("work");
+    ///     let _span = operation.measure_thread().iterations(100);
+    ///     for _ in 0..100 {
+    ///         std::hint::black_box(42 * 2);
+    ///     }
+    /// }
+    ///
+    /// session.to_report().write_to_target()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_to_target(&self) -> io::Result<()> {
+        let target =
+            folo_utils::cargo_target_directory().unwrap_or_else(|| PathBuf::from("target"));
+        self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY))
+    }
+
+    /// Writes machine-readable JSON statistics into the given directory.
+    ///
+    /// One file is written per operation, named after the operation, as
+    /// `<directory>/<operation>.json`. Operation names are sanitized to be
+    /// filesystem-safe and existing files are overwritten. The directory is
+    /// created if it does not exist.
+    ///
+    /// Writes nothing if no operations were captured.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use all_the_time::Session;
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let session = Session::new();
+    /// {
+    ///     let operation = session.operation("work");
+    ///     let _span = operation.measure_thread().iterations(100);
+    ///     for _ in 0..100 {
+    ///         std::hint::black_box(42 * 2);
+    ///     }
+    /// }
+    ///
+    /// let directory = std::env::temp_dir().join("all_the_time_example");
+    /// session.to_report().write_to_directory(&directory)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let directory = directory.as_ref();
+        fs::create_dir_all(directory)?;
+
+        for (name, operation) in self.operations() {
+            if operation.total_iterations() == 0 {
+                continue;
+            }
+
+            let output = OperationOutput {
+                operation: name,
+                total_iterations: operation.total_iterations(),
+                total_processor_time_nanos: duration_as_nanos(operation.total_processor_time()),
+                mean_processor_time_nanos: duration_as_nanos(operation.mean()),
+            };
+
+            let json = serde_json::to_string_pretty(&output)
+                .expect("serializing fixed primitive fields to JSON cannot fail");
+
+            let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
+            fs::write(directory.join(file_name), json)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Session {
+    /// Writes machine-readable JSON statistics into the Cargo target directory.
+    ///
+    /// This is a convenience method equivalent to
+    /// `self.to_report().write_to_target()`. See
+    /// [`Report::write_to_target`](crate::Report::write_to_target) for details.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    pub fn write_to_target(&self) -> io::Result<()> {
+        self.to_report().write_to_target()
+    }
+
+    /// Writes machine-readable JSON statistics into the given directory.
+    ///
+    /// This is a convenience method equivalent to
+    /// `self.to_report().write_to_directory(directory)`. See
+    /// [`Report::write_to_directory`](crate::Report::write_to_directory) for
+    /// details.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+        self.to_report().write_to_directory(directory)
+    }
+}
+
+/// Converts a [`Duration`] to whole nanoseconds, capped at the `u64` range.
+fn duration_as_nanos(duration: Duration) -> u64 {
+    duration
+        .as_nanos()
+        .try_into()
+        .expect("all realistic processor time values fit in u64 nanoseconds")
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use crate::Session;
+    use crate::pal::{FakePlatform, PlatformFacade};
+
+    fn session_with_recorded_work(name: &str) -> Session {
+        let fake_platform = FakePlatform::new();
+        let platform = PlatformFacade::fake(fake_platform.clone());
+        let session = Session::with_platform(platform);
+
+        fake_platform.set_thread_time(std::time::Duration::from_millis(0));
+        {
+            let operation = session.operation(name);
+            let _span = operation.measure_thread().iterations(4);
+            fake_platform.set_thread_time(std::time::Duration::from_millis(80));
+        }
+
+        session
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn writes_one_json_file_per_operation() {
+        let session = session_with_recorded_work("read_cell");
+        let directory = tempfile::tempdir().unwrap();
+
+        session
+            .write_to_directory(directory.path())
+            .expect("writing to a writable temp directory succeeds");
+
+        let file = directory.path().join("read_cell.json");
+        let contents = std::fs::read_to_string(&file).unwrap();
+
+        assert!(contents.contains("\"operation\": \"read_cell\""));
+        assert!(contents.contains("\"total_iterations\": 4"));
+        assert!(contents.contains("\"total_processor_time_nanos\": 80000000"));
+        assert!(contents.contains("\"mean_processor_time_nanos\": 20000000"));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn sanitizes_operation_name_in_file_name() {
+        let session = session_with_recorded_work("group/case name");
+        let directory = tempfile::tempdir().unwrap();
+
+        session.write_to_directory(directory.path()).unwrap();
+
+        let file = directory.path().join("group_case_name.json");
+        assert!(file.exists());
+
+        let contents = std::fs::read_to_string(&file).unwrap();
+        // The original, unsanitized name is preserved inside the file.
+        assert!(contents.contains("\"operation\": \"group/case name\""));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn empty_session_writes_no_files() {
+        let fake_platform = FakePlatform::new();
+        let platform = PlatformFacade::fake(fake_platform);
+        let session = Session::with_platform(platform);
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("nested");
+
+        session.write_to_directory(&target).unwrap();
+
+        // Nothing is written, so the directory is not even created.
+        assert!(!target.exists());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn overwrites_existing_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("read_cell.json");
+        std::fs::write(&file, "stale contents").unwrap();
+
+        let session = session_with_recorded_work("read_cell");
+        session.write_to_directory(directory.path()).unwrap();
+
+        let contents = std::fs::read_to_string(&file).unwrap();
+        assert!(!contents.contains("stale"));
+        assert!(contents.contains("read_cell"));
+    }
+}

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -160,30 +160,42 @@ impl Session {
     }
 }
 
-/// Converts a [`Duration`] to whole nanoseconds, capped at the `u64` range.
+/// Converts a [`Duration`] to whole nanoseconds, saturating at `u64::MAX`.
 fn duration_as_nanos(duration: Duration) -> u64 {
-    duration
-        .as_nanos()
-        .try_into()
-        .expect("all realistic processor time values fit in u64 nanoseconds")
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::time::Duration;
+
+    use super::duration_as_nanos;
     use crate::Session;
     use crate::pal::{FakePlatform, PlatformFacade};
+
+    #[test]
+    fn duration_as_nanos_converts_whole_nanoseconds() {
+        assert_eq!(duration_as_nanos(Duration::from_millis(5)), 5_000_000);
+    }
+
+    #[test]
+    fn duration_as_nanos_saturates_beyond_u64() {
+        // `Duration::from_secs(u64::MAX)` holds far more nanoseconds than fit in
+        // a `u64`, so the conversion saturates instead of panicking.
+        assert_eq!(duration_as_nanos(Duration::from_secs(u64::MAX)), u64::MAX);
+    }
 
     fn session_with_recorded_work(name: &str) -> Session {
         let fake_platform = FakePlatform::new();
         let platform = PlatformFacade::fake(fake_platform.clone());
         let session = Session::with_platform(platform);
 
-        fake_platform.set_thread_time(std::time::Duration::from_millis(0));
+        fake_platform.set_thread_time(Duration::from_millis(0));
         {
             let operation = session.operation(name);
             let _span = operation.measure_thread().iterations(4);
-            fake_platform.set_thread_time(std::time::Duration::from_millis(80));
+            fake_platform.set_thread_time(Duration::from_millis(80));
         }
 
         session

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -254,6 +254,30 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn skips_operations_without_iterations() {
+        let fake_platform = FakePlatform::new();
+        let platform = PlatformFacade::fake(fake_platform.clone());
+        let session = Session::with_platform(platform);
+
+        fake_platform.set_thread_time(Duration::from_millis(0));
+        {
+            let operation = session.operation("measured");
+            let _span = operation.measure_thread().iterations(4);
+            fake_platform.set_thread_time(Duration::from_millis(80));
+        }
+        // Registered but never measured, so it stays at zero iterations and must
+        // be skipped rather than written.
+        let _unmeasured = session.operation("unmeasured");
+
+        let directory = tempfile::tempdir().unwrap();
+        session.write_to_directory(directory.path()).unwrap();
+
+        assert!(directory.path().join("measured.json").exists());
+        assert!(!directory.path().join("unmeasured.json").exists());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
     fn overwrites_existing_files() {
         let directory = tempfile::tempdir().unwrap();
         let file = directory.path().join("read_cell.json");

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -350,6 +350,34 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    #[should_panic(expected = "failed to create benchmark output directory")]
+    fn panics_when_output_directory_cannot_be_created() {
+        let session = session_with_recorded_work("read_cell");
+        let directory = tempfile::tempdir().unwrap();
+
+        // A regular file where a directory component is expected makes the
+        // recursive directory creation fail.
+        let blocker = directory.path().join("blocker");
+        fs::write(&blocker, "not a directory").unwrap();
+
+        session.write_to_directory(blocker.join("nested"));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    #[should_panic(expected = "failed to write benchmark output file")]
+    fn panics_when_output_file_cannot_be_written() {
+        let session = session_with_recorded_work("read_cell");
+        let directory = tempfile::tempdir().unwrap();
+
+        // A directory occupying the output file's path makes the file write fail.
+        fs::create_dir_all(directory.path().join("read_cell.json")).unwrap();
+
+        session.write_to_directory(directory.path());
+    }
+
+    #[test]
     #[should_panic(expected = "after sanitization")]
     fn panics_when_operation_names_collide_after_sanitization() {
         let fake_platform = FakePlatform::new();

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -1,5 +1,6 @@
 //! Machine-readable JSON output of processor time statistics.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -40,6 +41,9 @@ impl Report {
     /// written. Benchmark results are not useful without the output files they
     /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
+    /// Also panics if two operation names sanitize to the same file name, since
+    /// writing both would silently discard one operation's results.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -77,6 +81,9 @@ impl Report {
     /// written. Benchmark results are not useful without the output files they
     /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
+    /// Also panics if two operation names sanitize to the same file name, since
+    /// writing both would silently discard one operation's results.
+    ///
     /// # Examples
     ///
     /// ```
@@ -95,21 +102,25 @@ impl Report {
     /// session.to_report().write_to_directory(&directory);
     /// ```
     pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
-        if self.is_empty() {
-            return;
-        }
-
         let directory = directory.as_ref();
-        fs::create_dir_all(directory).unwrap_or_else(|error| {
-            panic!(
-                "failed to create benchmark output directory {}: {error}",
-                directory.display()
-            )
-        });
 
+        // Build every output up front, detecting sanitized-name collisions before
+        // touching the filesystem. Two operation names that sanitize to the same
+        // file name would otherwise silently overwrite each other's results.
+        let mut file_names: HashMap<String, &str> = HashMap::new();
+        let mut outputs: Vec<(PathBuf, String)> = Vec::new();
         for (name, operation) in self.operations() {
             if operation.total_iterations() == 0 {
                 continue;
+            }
+
+            let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
+            if let Some(previous) = file_names.insert(file_name.clone(), name) {
+                panic!(
+                    "operations {previous:?} and {name:?} both map to the output file name \
+                     {file_name:?} after sanitization; rename one of them to avoid silently \
+                     overwriting benchmark results"
+                );
             }
 
             let output = OperationOutput {
@@ -122,8 +133,23 @@ impl Report {
             let json = serde_json::to_string_pretty(&output)
                 .expect("serializing fixed primitive fields to JSON cannot fail");
 
-            let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
-            let path = directory.join(file_name);
+            outputs.push((directory.join(file_name), json));
+        }
+
+        // Without any output, no directory is created, so a probe run that captured
+        // no measurable work leaves nothing behind.
+        if outputs.is_empty() {
+            return;
+        }
+
+        fs::create_dir_all(directory).unwrap_or_else(|error| {
+            panic!(
+                "failed to create benchmark output directory {}: {error}",
+                directory.display()
+            )
+        });
+
+        for (path, json) in outputs {
             fs::write(&path, json).unwrap_or_else(|error| {
                 panic!(
                     "failed to write benchmark output file {}: {error}",
@@ -293,5 +319,26 @@ mod tests {
         let contents = fs::read_to_string(&file).unwrap();
         assert!(!contents.contains("stale"));
         assert!(contents.contains("read_cell"));
+    }
+
+    #[test]
+    #[should_panic(expected = "after sanitization")]
+    fn panics_when_operation_names_collide_after_sanitization() {
+        let fake_platform = FakePlatform::new();
+        let platform = PlatformFacade::fake(fake_platform.clone());
+        let session = Session::with_platform(platform);
+
+        // Both names sanitize to `group_case.json`, so writing both would silently
+        // discard one operation's results.
+        for name in ["group/case", "group_case"] {
+            fake_platform.set_thread_time(Duration::from_millis(0));
+            let operation = session.operation(name);
+            let _span = operation.measure_thread().iterations(4);
+            fake_platform.set_thread_time(Duration::from_millis(80));
+        }
+
+        // The collision is detected before anything is written, so this path is
+        // never created.
+        session.write_to_directory("collision_is_detected_before_writing");
     }
 }

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -1,8 +1,8 @@
 //! Machine-readable JSON output of processor time statistics.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::{fs, io};
 
 use serde::Serialize;
 
@@ -34,17 +34,17 @@ impl Report {
     /// session was part of a "list available benchmarks" probe run instead of
     /// some real activity.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written. Benchmark results are not useful without the output files they
+    /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use all_the_time::Session;
     ///
-    /// # fn main() -> std::io::Result<()> {
     /// let session = Session::new();
     /// {
     ///     let operation = session.operation("work");
@@ -54,14 +54,12 @@ impl Report {
     ///     }
     /// }
     ///
-    /// session.to_report().write_to_target()?;
-    /// # Ok(())
-    /// # }
+    /// session.to_report().write_to_target();
     /// ```
-    pub fn write_to_target(&self) -> io::Result<()> {
+    pub fn write_to_target(&self) {
         let target =
             folo_utils::cargo_target_directory().unwrap_or_else(|| PathBuf::from("target"));
-        self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY))
+        self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY));
     }
 
     /// Writes machine-readable JSON statistics into the given directory.
@@ -73,17 +71,17 @@ impl Report {
     ///
     /// Writes nothing if no operations were captured.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written. Benchmark results are not useful without the output files they
+    /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
     /// # Examples
     ///
     /// ```
     /// use all_the_time::Session;
     ///
-    /// # fn main() -> std::io::Result<()> {
     /// let session = Session::new();
     /// {
     ///     let operation = session.operation("work");
@@ -94,17 +92,20 @@ impl Report {
     /// }
     ///
     /// let directory = std::env::temp_dir().join("all_the_time_example");
-    /// session.to_report().write_to_directory(&directory)?;
-    /// # Ok(())
-    /// # }
+    /// session.to_report().write_to_directory(&directory);
     /// ```
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
         if self.is_empty() {
-            return Ok(());
+            return;
         }
 
         let directory = directory.as_ref();
-        fs::create_dir_all(directory)?;
+        fs::create_dir_all(directory).unwrap_or_else(|error| {
+            panic!(
+                "failed to create benchmark output directory {}: {error}",
+                directory.display()
+            )
+        });
 
         for (name, operation) in self.operations() {
             if operation.total_iterations() == 0 {
@@ -122,10 +123,14 @@ impl Report {
                 .expect("serializing fixed primitive fields to JSON cannot fail");
 
             let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
-            fs::write(directory.join(file_name), json)?;
+            let path = directory.join(file_name);
+            fs::write(&path, json).unwrap_or_else(|error| {
+                panic!(
+                    "failed to write benchmark output file {}: {error}",
+                    path.display()
+                )
+            });
         }
-
-        Ok(())
     }
 }
 
@@ -136,12 +141,12 @@ impl Session {
     /// `self.to_report().write_to_target()`. See
     /// [`Report::write_to_target`](crate::Report::write_to_target) for details.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
-    pub fn write_to_target(&self) -> io::Result<()> {
-        self.to_report().write_to_target()
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written.
+    pub fn write_to_target(&self) {
+        self.to_report().write_to_target();
     }
 
     /// Writes machine-readable JSON statistics into the given directory.
@@ -151,12 +156,12 @@ impl Session {
     /// [`Report::write_to_directory`](crate::Report::write_to_directory) for
     /// details.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
-        self.to_report().write_to_directory(directory)
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written.
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
+        self.to_report().write_to_directory(directory);
     }
 }
 
@@ -207,9 +212,7 @@ mod tests {
         let session = session_with_recorded_work("read_cell");
         let directory = tempfile::tempdir().unwrap();
 
-        session
-            .write_to_directory(directory.path())
-            .expect("writing to a writable temp directory succeeds");
+        session.write_to_directory(directory.path());
 
         let file = directory.path().join("read_cell.json");
         let contents = std::fs::read_to_string(&file).unwrap();
@@ -226,7 +229,7 @@ mod tests {
         let session = session_with_recorded_work("group/case name");
         let directory = tempfile::tempdir().unwrap();
 
-        session.write_to_directory(directory.path()).unwrap();
+        session.write_to_directory(directory.path());
 
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
@@ -246,7 +249,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("nested");
 
-        session.write_to_directory(&target).unwrap();
+        session.write_to_directory(&target);
 
         // Nothing is written, so the directory is not even created.
         assert!(!target.exists());
@@ -270,7 +273,7 @@ mod tests {
         let _unmeasured = session.operation("unmeasured");
 
         let directory = tempfile::tempdir().unwrap();
-        session.write_to_directory(directory.path()).unwrap();
+        session.write_to_directory(directory.path());
 
         assert!(directory.path().join("measured.json").exists());
         assert!(!directory.path().join("unmeasured.json").exists());
@@ -284,7 +287,7 @@ mod tests {
         std::fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("read_cell");
-        session.write_to_directory(directory.path()).unwrap();
+        session.write_to_directory(directory.path());
 
         let contents = std::fs::read_to_string(&file).unwrap();
         assert!(!contents.contains("stale"));

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -173,6 +173,7 @@ fn duration_as_nanos(duration: Duration) -> u64 {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::fs;
     use std::time::Duration;
 
     use super::duration_as_nanos;
@@ -208,14 +209,14 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
-    fn writes_one_json_file_per_operation() {
+    fn writes_operation_statistics_as_json() {
         let session = session_with_recorded_work("read_cell");
         let directory = tempfile::tempdir().unwrap();
 
         session.write_to_directory(directory.path());
 
         let file = directory.path().join("read_cell.json");
-        let contents = std::fs::read_to_string(&file).unwrap();
+        let contents = fs::read_to_string(&file).unwrap();
 
         assert!(contents.contains("\"operation\": \"read_cell\""));
         assert!(contents.contains("\"total_iterations\": 4"));
@@ -234,7 +235,7 @@ mod tests {
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
 
-        let contents = std::fs::read_to_string(&file).unwrap();
+        let contents = fs::read_to_string(&file).unwrap();
         // The original, unsanitized name is preserved inside the file.
         assert!(contents.contains("\"operation\": \"group/case name\""));
     }
@@ -284,12 +285,12 @@ mod tests {
     fn overwrites_existing_files() {
         let directory = tempfile::tempdir().unwrap();
         let file = directory.path().join("read_cell.json");
-        std::fs::write(&file, "stale contents").unwrap();
+        fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("read_cell");
         session.write_to_directory(directory.path());
 
-        let contents = std::fs::read_to_string(&file).unwrap();
+        let contents = fs::read_to_string(&file).unwrap();
         assert!(!contents.contains("stale"));
         assert!(contents.contains("read_cell"));
     }

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -200,11 +200,18 @@ fn duration_as_nanos(duration: Duration) -> u64 {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::fs;
+    use std::path::Path;
     use std::time::Duration;
+
+    use serde_json::Value;
 
     use super::duration_as_nanos;
     use crate::Session;
     use crate::pal::{FakePlatform, PlatformFacade};
+
+    fn read_json(path: &Path) -> Value {
+        serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
 
     #[test]
     fn duration_as_nanos_converts_whole_nanoseconds() {
@@ -242,12 +249,28 @@ mod tests {
         session.write_to_directory(directory.path());
 
         let file = directory.path().join("read_cell.json");
-        let contents = fs::read_to_string(&file).unwrap();
+        let value = read_json(&file);
 
-        assert!(contents.contains("\"operation\": \"read_cell\""));
-        assert!(contents.contains("\"total_iterations\": 4"));
-        assert!(contents.contains("\"total_processor_time_nanos\": 80000000"));
-        assert!(contents.contains("\"mean_processor_time_nanos\": 20000000"));
+        assert_eq!(
+            value.get("operation").and_then(Value::as_str),
+            Some("read_cell")
+        );
+        assert_eq!(
+            value.get("total_iterations").and_then(Value::as_u64),
+            Some(4)
+        );
+        assert_eq!(
+            value
+                .get("total_processor_time_nanos")
+                .and_then(Value::as_u64),
+            Some(80_000_000)
+        );
+        assert_eq!(
+            value
+                .get("mean_processor_time_nanos")
+                .and_then(Value::as_u64),
+            Some(20_000_000)
+        );
     }
 
     #[test]
@@ -261,9 +284,11 @@ mod tests {
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
 
-        let contents = fs::read_to_string(&file).unwrap();
         // The original, unsanitized name is preserved inside the file.
-        assert!(contents.contains("\"operation\": \"group/case name\""));
+        assert_eq!(
+            read_json(&file).get("operation").and_then(Value::as_str),
+            Some("group/case name")
+        );
     }
 
     #[test]
@@ -316,9 +341,12 @@ mod tests {
         let session = session_with_recorded_work("read_cell");
         session.write_to_directory(directory.path());
 
-        let contents = fs::read_to_string(&file).unwrap();
-        assert!(!contents.contains("stale"));
-        assert!(contents.contains("read_cell"));
+        // Parsing succeeds only if the stale, non-JSON contents were replaced.
+        let value = read_json(&file);
+        assert_eq!(
+            value.get("operation").and_then(Value::as_str),
+            Some("read_cell")
+        );
     }
 
     #[test]

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -133,3 +133,24 @@ fn write_to_target_writes_into_cargo_target_directory() {
     // Avoid polluting the shared target directory for later runs.
     fs::remove_file(&expected).unwrap();
 }
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform, which is not supported under Miri.
+#[should_panic(expected = "after sanitization")]
+fn panics_when_operation_names_collide_after_sanitization() {
+    let session = Session::new();
+
+    // Both names sanitize to the same file name, which must not silently
+    // overwrite one operation's results.
+    for name in ["group/case", "group_case"] {
+        let operation = session.operation(name);
+        let _span = operation.measure_thread().iterations(4);
+        for _ in 0..4 {
+            black_box(black_box(2_u64) * black_box(3));
+        }
+    }
+
+    // The collision is detected before anything is written, so this path is
+    // never created.
+    session.write_to_directory("collision_is_detected_before_writing");
+}

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -89,3 +89,45 @@ fn empty_session_writes_nothing() {
 
     assert!(!target.exists(), "no directory should be created");
 }
+
+#[test]
+#[cfg_attr(miri, ignore)] // Resolves the Cargo target directory and writes files, neither supported under Miri.
+fn write_to_target_writes_into_cargo_target_directory() {
+    // A distinctive name avoids colliding with output from other operations in
+    // the shared Cargo target directory.
+    const OPERATION: &str = "all_the_time_write_to_target_probe";
+
+    let session = Session::new();
+    {
+        let operation = session.operation(OPERATION);
+        let _span = operation.measure_thread().iterations(8);
+        for _ in 0..8 {
+            black_box(black_box(2_u64) * black_box(3));
+        }
+    }
+
+    let expected = folo_utils::cargo_target_directory()
+        .unwrap_or_else(|| std::path::PathBuf::from("target"))
+        .join("all_the_time")
+        .join(format!("{OPERATION}.json"));
+
+    // Start from a clean slate so the assertion proves this call wrote the file.
+    if expected.exists() {
+        std::fs::remove_file(&expected).unwrap();
+    }
+
+    session.write_to_target().unwrap();
+
+    assert!(
+        expected.exists(),
+        "write_to_target should create {}",
+        expected.display()
+    );
+
+    let contents = std::fs::read_to_string(&expected).unwrap();
+    assert!(contents.contains("\"operation\": \"all_the_time_write_to_target_probe\""));
+    assert!(contents.contains("\"total_iterations\": 8"));
+
+    // Avoid polluting the shared target directory for later runs.
+    std::fs::remove_file(&expected).unwrap();
+}

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -71,11 +71,11 @@ fn report_and_session_write_equivalently() {
     assert!(session_file.exists());
     assert!(report_file.exists());
 
-    // Both entry points capture the same data (iteration count is deterministic).
+    // Both entry points serialize the same recorded data, so the output is identical.
     let session_contents = fs::read_to_string(&session_file).unwrap();
     let report_contents = fs::read_to_string(&report_file).unwrap();
+    assert_eq!(session_contents, report_contents);
     assert!(session_contents.contains("\"total_iterations\": 10"));
-    assert!(report_contents.contains("\"total_iterations\": 10"));
 }
 
 #[test]

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -26,7 +26,7 @@ fn writes_json_files_for_each_operation() {
     }
 
     let directory = tempfile::tempdir().unwrap();
-    session.write_to_directory(directory.path()).unwrap();
+    session.write_to_directory(directory.path());
 
     let first = directory.path().join("first_operation.json");
     let second = directory.path().join("second_operation.json");
@@ -57,11 +57,8 @@ fn report_and_session_write_equivalently() {
     let from_session = tempfile::tempdir().unwrap();
     let from_report = tempfile::tempdir().unwrap();
 
-    session.write_to_directory(from_session.path()).unwrap();
-    session
-        .to_report()
-        .write_to_directory(from_report.path())
-        .unwrap();
+    session.write_to_directory(from_session.path());
+    session.to_report().write_to_directory(from_report.path());
 
     let session_file = from_session.path().join("shared_name.json");
     let report_file = from_report.path().join("shared_name.json");
@@ -85,7 +82,7 @@ fn empty_session_writes_nothing() {
     let directory = tempfile::tempdir().unwrap();
     let target = directory.path().join("output");
 
-    session.write_to_directory(&target).unwrap();
+    session.write_to_directory(&target);
 
     assert!(!target.exists(), "no directory should be created");
 }
@@ -116,7 +113,7 @@ fn write_to_target_writes_into_cargo_target_directory() {
         std::fs::remove_file(&expected).unwrap();
     }
 
-    session.write_to_target().unwrap();
+    session.write_to_target();
 
     assert!(
         expected.exists(),

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -1,0 +1,91 @@
+//! Integration tests for writing machine-readable JSON output to disk.
+
+use std::hint::black_box;
+
+use all_the_time::Session;
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn writes_json_files_for_each_operation() {
+    let session = Session::new();
+
+    {
+        let operation = session.operation("first_operation");
+        let _span = operation.measure_thread().iterations(100);
+        for _ in 0..100 {
+            black_box(black_box(21_u64) * black_box(2));
+        }
+    }
+
+    {
+        let operation = session.operation("second_operation");
+        let _span = operation.measure_thread().iterations(50);
+        for _ in 0..50 {
+            black_box(black_box(3_u64) + black_box(4));
+        }
+    }
+
+    let directory = tempfile::tempdir().unwrap();
+    session.write_to_directory(directory.path()).unwrap();
+
+    let first = directory.path().join("first_operation.json");
+    let second = directory.path().join("second_operation.json");
+
+    assert!(first.exists(), "expected JSON file for first operation");
+    assert!(second.exists(), "expected JSON file for second operation");
+
+    let first_contents = std::fs::read_to_string(&first).unwrap();
+    assert!(first_contents.contains("\"operation\": \"first_operation\""));
+    assert!(first_contents.contains("\"total_iterations\": 100"));
+    assert!(first_contents.contains("\"total_processor_time_nanos\""));
+    assert!(first_contents.contains("\"mean_processor_time_nanos\""));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn report_and_session_write_equivalently() {
+    let session = Session::new();
+
+    {
+        let operation = session.operation("shared_name");
+        let _span = operation.measure_thread().iterations(10);
+        for _ in 0..10 {
+            black_box(black_box(1_u64) + black_box(1));
+        }
+    }
+
+    let from_session = tempfile::tempdir().unwrap();
+    let from_report = tempfile::tempdir().unwrap();
+
+    session.write_to_directory(from_session.path()).unwrap();
+    session
+        .to_report()
+        .write_to_directory(from_report.path())
+        .unwrap();
+
+    let session_file = from_session.path().join("shared_name.json");
+    let report_file = from_report.path().join("shared_name.json");
+
+    assert!(session_file.exists());
+    assert!(report_file.exists());
+
+    // Both entry points capture the same data (iteration count is deterministic).
+    let session_contents = std::fs::read_to_string(&session_file).unwrap();
+    let report_contents = std::fs::read_to_string(&report_file).unwrap();
+    assert!(session_contents.contains("\"total_iterations\": 10"));
+    assert!(report_contents.contains("\"total_iterations\": 10"));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn empty_session_writes_nothing() {
+    let session = Session::new();
+    let _operation = session.operation("never_measured");
+
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("output");
+
+    session.write_to_directory(&target).unwrap();
+
+    assert!(!target.exists(), "no directory should be created");
+}

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -1,5 +1,6 @@
 //! Integration tests for writing machine-readable JSON output to disk.
 
+use std::fs;
 use std::hint::black_box;
 
 use all_the_time::Session;
@@ -34,7 +35,11 @@ fn writes_json_files_for_each_operation() {
     assert!(first.exists(), "expected JSON file for first operation");
     assert!(second.exists(), "expected JSON file for second operation");
 
-    let first_contents = std::fs::read_to_string(&first).unwrap();
+    // Exactly one file per measured operation, and nothing more.
+    let written = fs::read_dir(directory.path()).unwrap().count();
+    assert_eq!(written, 2, "expected one JSON file per operation");
+
+    let first_contents = fs::read_to_string(&first).unwrap();
     assert!(first_contents.contains("\"operation\": \"first_operation\""));
     assert!(first_contents.contains("\"total_iterations\": 100"));
     assert!(first_contents.contains("\"total_processor_time_nanos\""));
@@ -67,8 +72,8 @@ fn report_and_session_write_equivalently() {
     assert!(report_file.exists());
 
     // Both entry points capture the same data (iteration count is deterministic).
-    let session_contents = std::fs::read_to_string(&session_file).unwrap();
-    let report_contents = std::fs::read_to_string(&report_file).unwrap();
+    let session_contents = fs::read_to_string(&session_file).unwrap();
+    let report_contents = fs::read_to_string(&report_file).unwrap();
     assert!(session_contents.contains("\"total_iterations\": 10"));
     assert!(report_contents.contains("\"total_iterations\": 10"));
 }
@@ -110,7 +115,7 @@ fn write_to_target_writes_into_cargo_target_directory() {
 
     // Start from a clean slate so the assertion proves this call wrote the file.
     if expected.exists() {
-        std::fs::remove_file(&expected).unwrap();
+        fs::remove_file(&expected).unwrap();
     }
 
     session.write_to_target();
@@ -121,10 +126,10 @@ fn write_to_target_writes_into_cargo_target_directory() {
         expected.display()
     );
 
-    let contents = std::fs::read_to_string(&expected).unwrap();
+    let contents = fs::read_to_string(&expected).unwrap();
     assert!(contents.contains("\"operation\": \"all_the_time_write_to_target_probe\""));
     assert!(contents.contains("\"total_iterations\": 8"));
 
     // Avoid polluting the shared target directory for later runs.
-    std::fs::remove_file(&expected).unwrap();
+    fs::remove_file(&expected).unwrap();
 }

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -107,7 +107,7 @@ fn write_to_target_writes_into_cargo_target_directory() {
     }
 
     let expected = folo_utils::cargo_target_directory()
-        .unwrap_or_else(|| std::path::PathBuf::from("target"))
+        .unwrap_or_else(|| "target".into())
         .join("all_the_time")
         .join(format!("{OPERATION}.json"));
 

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -2,8 +2,14 @@
 
 use std::fs;
 use std::hint::black_box;
+use std::path::Path;
 
 use all_the_time::Session;
+use serde_json::Value;
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
@@ -39,11 +45,27 @@ fn writes_json_files_for_each_operation() {
     let written = fs::read_dir(directory.path()).unwrap().count();
     assert_eq!(written, 2, "expected one JSON file per operation");
 
-    let first_contents = fs::read_to_string(&first).unwrap();
-    assert!(first_contents.contains("\"operation\": \"first_operation\""));
-    assert!(first_contents.contains("\"total_iterations\": 100"));
-    assert!(first_contents.contains("\"total_processor_time_nanos\""));
-    assert!(first_contents.contains("\"mean_processor_time_nanos\""));
+    let value = read_json(&first);
+    assert_eq!(
+        value.get("operation").and_then(Value::as_str),
+        Some("first_operation")
+    );
+    assert_eq!(
+        value.get("total_iterations").and_then(Value::as_u64),
+        Some(100)
+    );
+    assert!(
+        value
+            .get("total_processor_time_nanos")
+            .and_then(Value::as_u64)
+            .is_some()
+    );
+    assert!(
+        value
+            .get("mean_processor_time_nanos")
+            .and_then(Value::as_u64)
+            .is_some()
+    );
 }
 
 #[test]
@@ -75,7 +97,12 @@ fn report_and_session_write_equivalently() {
     let session_contents = fs::read_to_string(&session_file).unwrap();
     let report_contents = fs::read_to_string(&report_file).unwrap();
     assert_eq!(session_contents, report_contents);
-    assert!(session_contents.contains("\"total_iterations\": 10"));
+    assert_eq!(
+        read_json(&session_file)
+            .get("total_iterations")
+            .and_then(Value::as_u64),
+        Some(10)
+    );
 }
 
 #[test]
@@ -126,9 +153,15 @@ fn write_to_target_writes_into_cargo_target_directory() {
         expected.display()
     );
 
-    let contents = fs::read_to_string(&expected).unwrap();
-    assert!(contents.contains("\"operation\": \"all_the_time_write_to_target_probe\""));
-    assert!(contents.contains("\"total_iterations\": 8"));
+    let value = read_json(&expected);
+    assert_eq!(
+        value.get("operation").and_then(Value::as_str),
+        Some("all_the_time_write_to_target_probe")
+    );
+    assert_eq!(
+        value.get("total_iterations").and_then(Value::as_u64),
+        Some(8)
+    );
 
     // Avoid polluting the shared target directory for later runs.
     fs::remove_file(&expected).unwrap();

--- a/packages/alloc_tracker/Cargo.toml
+++ b/packages/alloc_tracker/Cargo.toml
@@ -22,12 +22,16 @@ default = []
 panic_on_next_alloc = []
 
 [dependencies]
+folo_utils = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
 mutants = { workspace = true }
 serial_test = { workspace = true }
 static_assertions = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "alloc_tracker_example"

--- a/packages/alloc_tracker/README.md
+++ b/packages/alloc_tracker/README.md
@@ -11,7 +11,7 @@ use alloc_tracker::{Allocator, Session};
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
-fn main() {
+fn main() -> std::io::Result<()> {
     let session = Session::new();
 
     // Track a single operation
@@ -24,7 +24,13 @@ fn main() {
     // Print results
     session.print_to_stdout();
 
+    // Also emit machine-readable JSON files (one per operation) into the Cargo
+    // target directory: target/alloc_tracker/<operation>.json
+    session.write_to_target()?;
+
     // Session automatically cleans up when dropped
+
+    Ok(())
 }
 ```
 

--- a/packages/alloc_tracker/README.md
+++ b/packages/alloc_tracker/README.md
@@ -11,7 +11,7 @@ use alloc_tracker::{Allocator, Session};
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
-fn main() -> std::io::Result<()> {
+fn main() {
     let session = Session::new();
 
     // Track a single operation
@@ -26,11 +26,9 @@ fn main() -> std::io::Result<()> {
 
     // Also emit machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/alloc_tracker/<operation>.json
-    session.write_to_target()?;
+    session.write_to_target();
 
     // Session automatically cleans up when dropped
-
-    Ok(())
 }
 ```
 

--- a/packages/alloc_tracker/examples/alloc_tracker_readme.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_readme.rs
@@ -18,7 +18,7 @@ use alloc_tracker::{Allocator, Session, panic_on_next_alloc};
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
 #[expect(clippy::useless_vec, reason = "example needs to show allocation")]
-fn main() {
+fn main() -> std::io::Result<()> {
     // Basic allocation tracking - now shows both bytes and allocation count
     let session = Session::new();
 
@@ -40,6 +40,10 @@ fn main() {
 
     // Print results - now shows both mean bytes and mean allocation count
     session.print_to_stdout();
+
+    // Also emit machine-readable JSON files (one per operation) into the Cargo
+    // target directory: target/alloc_tracker/<operation>.json
+    session.write_to_target()?;
 
     // Session automatically cleans up when dropped
 
@@ -63,4 +67,6 @@ fn main() {
         println!("cargo run --example alloc_tracker_readme --features panic_on_next_alloc");
         let _vec = vec![1, 2, 3]; // Regular allocation without panic functionality
     }
+
+    Ok(())
 }

--- a/packages/alloc_tracker/examples/alloc_tracker_readme.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_readme.rs
@@ -18,7 +18,7 @@ use alloc_tracker::{Allocator, Session, panic_on_next_alloc};
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
 #[expect(clippy::useless_vec, reason = "example needs to show allocation")]
-fn main() -> std::io::Result<()> {
+fn main() {
     // Basic allocation tracking - now shows both bytes and allocation count
     let session = Session::new();
 
@@ -43,7 +43,7 @@ fn main() -> std::io::Result<()> {
 
     // Also emit machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/alloc_tracker/<operation>.json
-    session.write_to_target()?;
+    session.write_to_target();
 
     // Session automatically cleans up when dropped
 
@@ -67,6 +67,4 @@ fn main() -> std::io::Result<()> {
         println!("cargo run --example alloc_tracker_readme --features panic_on_next_alloc");
         let _vec = vec![1, 2, 3]; // Regular allocation without panic functionality
     }
-
-    Ok(())
 }

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -66,6 +66,32 @@
 //! }
 //! ```
 //!
+//! # Machine-readable output
+//!
+//! In addition to printing to the console, you can emit machine-readable JSON
+//! files (one per operation) into the Cargo target directory for later
+//! analysis. Files are written to `target/alloc_tracker/<operation>.json`, with
+//! operation names sanitized to be filesystem-safe:
+//!
+//! ```no_run
+//! use alloc_tracker::{Allocator, Session};
+//!
+//! #[global_allocator]
+//! static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+//!
+//! # fn main() -> std::io::Result<()> {
+//! let session = Session::new();
+//! {
+//!     let operation = session.operation("my_operation");
+//!     let _span = operation.measure_process();
+//!     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
+//! }
+//!
+//! session.write_to_target()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! # Tracking mean allocations
 //!
 //! For benchmarking scenarios, where you run multiple iterations of an operation, use [`Operation`]:
@@ -149,6 +175,7 @@ mod operation_metrics;
 mod process_span;
 mod report;
 mod session;
+mod target_output;
 mod thread_span;
 
 pub use allocator::*;

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -79,7 +79,7 @@
 //! #[global_allocator]
 //! static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 //!
-//! # fn main() -> std::io::Result<()> {
+//! # fn main() {
 //! let session = Session::new();
 //! {
 //!     let operation = session.operation("my_operation");
@@ -87,8 +87,7 @@
 //!     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
 //! }
 //!
-//! session.write_to_target()?;
-//! # Ok(())
+//! session.write_to_target();
 //! # }
 //! ```
 //!

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -173,6 +173,8 @@ impl Session {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::fs;
+
     use crate::Session;
     use crate::allocator::register_fake_allocation;
 
@@ -188,14 +190,14 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
-    fn writes_one_json_file_per_operation() {
+    fn writes_operation_statistics_as_json() {
         let session = session_with_recorded_work("allocate_vec");
         let directory = tempfile::tempdir().unwrap();
 
         session.write_to_directory(directory.path());
 
         let file = directory.path().join("allocate_vec.json");
-        let contents = std::fs::read_to_string(&file).unwrap();
+        let contents = fs::read_to_string(&file).unwrap();
 
         assert!(contents.contains("\"operation\": \"allocate_vec\""));
         assert!(contents.contains("\"total_iterations\": 4"));
@@ -216,7 +218,7 @@ mod tests {
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
 
-        let contents = std::fs::read_to_string(&file).unwrap();
+        let contents = fs::read_to_string(&file).unwrap();
         // The original, unsanitized name is preserved inside the file.
         assert!(contents.contains("\"operation\": \"group/case name\""));
     }
@@ -259,12 +261,12 @@ mod tests {
     fn overwrites_existing_files() {
         let directory = tempfile::tempdir().unwrap();
         let file = directory.path().join("allocate_vec.json");
-        std::fs::write(&file, "stale contents").unwrap();
+        fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("allocate_vec");
         session.write_to_directory(directory.path());
 
-        let contents = std::fs::read_to_string(&file).unwrap();
+        let contents = fs::read_to_string(&file).unwrap();
         assert!(!contents.contains("stale"));
         assert!(contents.contains("allocate_vec"));
     }

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -1,0 +1,248 @@
+//! Machine-readable JSON output of memory allocation statistics.
+
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+use serde::Serialize;
+
+use crate::{Report, Session};
+
+/// Subdirectory of the Cargo target directory that receives the JSON files.
+const OUTPUT_SUBDIRECTORY: &str = "alloc_tracker";
+
+/// Machine-readable allocation statistics for a single operation.
+#[derive(Serialize)]
+struct OperationOutput<'a> {
+    operation: &'a str,
+    total_iterations: u64,
+    total_bytes_allocated: u64,
+    total_allocations_count: u64,
+    mean_bytes_per_iteration: u64,
+    mean_allocations_per_iteration: u64,
+}
+
+impl Report {
+    /// Writes machine-readable JSON statistics into the Cargo target directory.
+    ///
+    /// One file is written per operation, named after the operation, at
+    /// `<target>/alloc_tracker/<operation>.json`. Operation names are sanitized
+    /// to be filesystem-safe and existing files are overwritten.
+    ///
+    /// The target directory is resolved the same way as Criterion (honoring
+    /// `CARGO_TARGET_DIR`), falling back to a relative `target` directory.
+    ///
+    /// Writes nothing if no operations were captured. This may indicate that the
+    /// session was part of a "list available benchmarks" probe run instead of
+    /// some real activity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use alloc_tracker::{Allocator, Session};
+    ///
+    /// #[global_allocator]
+    /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let session = Session::new();
+    /// {
+    ///     let operation = session.operation("work");
+    ///     let _span = operation.measure_process();
+    ///     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
+    /// }
+    ///
+    /// session.to_report().write_to_target()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_to_target(&self) -> io::Result<()> {
+        let target =
+            folo_utils::cargo_target_directory().unwrap_or_else(|| PathBuf::from("target"));
+        self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY))
+    }
+
+    /// Writes machine-readable JSON statistics into the given directory.
+    ///
+    /// One file is written per operation, named after the operation, as
+    /// `<directory>/<operation>.json`. Operation names are sanitized to be
+    /// filesystem-safe and existing files are overwritten. The directory is
+    /// created if it does not exist.
+    ///
+    /// Writes nothing if no operations were captured.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use alloc_tracker::{Allocator, Session};
+    ///
+    /// #[global_allocator]
+    /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let session = Session::new();
+    /// {
+    ///     let operation = session.operation("work");
+    ///     let _span = operation.measure_process();
+    ///     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
+    /// }
+    ///
+    /// let directory = std::env::temp_dir().join("alloc_tracker_example");
+    /// session.to_report().write_to_directory(&directory)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let directory = directory.as_ref();
+        fs::create_dir_all(directory)?;
+
+        for (name, operation) in self.operations() {
+            if operation.total_iterations() == 0 {
+                continue;
+            }
+
+            let output = OperationOutput {
+                operation: name,
+                total_iterations: operation.total_iterations(),
+                total_bytes_allocated: operation.total_bytes_allocated(),
+                total_allocations_count: operation.total_allocations_count(),
+                mean_bytes_per_iteration: operation.mean_bytes(),
+                mean_allocations_per_iteration: operation.mean_allocations(),
+            };
+
+            let json = serde_json::to_string_pretty(&output)
+                .expect("serializing fixed primitive fields to JSON cannot fail");
+
+            let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
+            fs::write(directory.join(file_name), json)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Session {
+    /// Writes machine-readable JSON statistics into the Cargo target directory.
+    ///
+    /// This is a convenience method equivalent to
+    /// `self.to_report().write_to_target()`. See
+    /// [`Report::write_to_target`](crate::Report::write_to_target) for details.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    pub fn write_to_target(&self) -> io::Result<()> {
+        self.to_report().write_to_target()
+    }
+
+    /// Writes machine-readable JSON statistics into the given directory.
+    ///
+    /// This is a convenience method equivalent to
+    /// `self.to_report().write_to_directory(directory)`. See
+    /// [`Report::write_to_directory`](crate::Report::write_to_directory) for
+    /// details.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output directory cannot be created or a file
+    /// cannot be written.
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+        self.to_report().write_to_directory(directory)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use crate::Session;
+    use crate::allocator::register_fake_allocation;
+
+    fn session_with_recorded_work(name: &str) -> Session {
+        let session = Session::new();
+        {
+            let operation = session.operation(name);
+            let _span = operation.measure_thread().iterations(4);
+            register_fake_allocation(800, 8);
+        }
+        session
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn writes_one_json_file_per_operation() {
+        let session = session_with_recorded_work("allocate_vec");
+        let directory = tempfile::tempdir().unwrap();
+
+        session
+            .write_to_directory(directory.path())
+            .expect("writing to a writable temp directory succeeds");
+
+        let file = directory.path().join("allocate_vec.json");
+        let contents = std::fs::read_to_string(&file).unwrap();
+
+        assert!(contents.contains("\"operation\": \"allocate_vec\""));
+        assert!(contents.contains("\"total_iterations\": 4"));
+        assert!(contents.contains("\"total_bytes_allocated\": 800"));
+        assert!(contents.contains("\"total_allocations_count\": 8"));
+        assert!(contents.contains("\"mean_bytes_per_iteration\": 200"));
+        assert!(contents.contains("\"mean_allocations_per_iteration\": 2"));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn sanitizes_operation_name_in_file_name() {
+        let session = session_with_recorded_work("group/case name");
+        let directory = tempfile::tempdir().unwrap();
+
+        session.write_to_directory(directory.path()).unwrap();
+
+        let file = directory.path().join("group_case_name.json");
+        assert!(file.exists());
+
+        let contents = std::fs::read_to_string(&file).unwrap();
+        // The original, unsanitized name is preserved inside the file.
+        assert!(contents.contains("\"operation\": \"group/case name\""));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn empty_session_writes_no_files() {
+        let session = Session::new();
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("nested");
+
+        session.write_to_directory(&target).unwrap();
+
+        // Nothing is written, so the directory is not even created.
+        assert!(!target.exists());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn overwrites_existing_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("allocate_vec.json");
+        std::fs::write(&file, "stale contents").unwrap();
+
+        let session = session_with_recorded_work("allocate_vec");
+        session.write_to_directory(directory.path()).unwrap();
+
+        let contents = std::fs::read_to_string(&file).unwrap();
+        assert!(!contents.contains("stale"));
+        assert!(contents.contains("allocate_vec"));
+    }
+}

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -332,6 +332,34 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    #[should_panic(expected = "failed to create benchmark output directory")]
+    fn panics_when_output_directory_cannot_be_created() {
+        let session = session_with_recorded_work("allocate_vec");
+        let directory = tempfile::tempdir().unwrap();
+
+        // A regular file where a directory component is expected makes the
+        // recursive directory creation fail.
+        let blocker = directory.path().join("blocker");
+        fs::write(&blocker, "not a directory").unwrap();
+
+        session.write_to_directory(blocker.join("nested"));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    #[should_panic(expected = "failed to write benchmark output file")]
+    fn panics_when_output_file_cannot_be_written() {
+        let session = session_with_recorded_work("allocate_vec");
+        let directory = tempfile::tempdir().unwrap();
+
+        // A directory occupying the output file's path makes the file write fail.
+        fs::create_dir_all(directory.path().join("allocate_vec.json")).unwrap();
+
+        session.write_to_directory(directory.path());
+    }
+
+    #[test]
     #[should_panic(expected = "after sanitization")]
     fn panics_when_operation_names_collide_after_sanitization() {
         let session = Session::new();

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -1,5 +1,6 @@
 //! Machine-readable JSON output of memory allocation statistics.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -41,6 +42,9 @@ impl Report {
     /// written. Benchmark results are not useful without the output files they
     /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
+    /// Also panics if two operation names sanitize to the same file name, since
+    /// writing both would silently discard one operation's results.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -79,6 +83,9 @@ impl Report {
     /// written. Benchmark results are not useful without the output files they
     /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
+    /// Also panics if two operation names sanitize to the same file name, since
+    /// writing both would silently discard one operation's results.
+    ///
     /// # Examples
     ///
     /// ```
@@ -98,21 +105,25 @@ impl Report {
     /// session.to_report().write_to_directory(&directory);
     /// ```
     pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
-        if self.is_empty() {
-            return;
-        }
-
         let directory = directory.as_ref();
-        fs::create_dir_all(directory).unwrap_or_else(|error| {
-            panic!(
-                "failed to create benchmark output directory {}: {error}",
-                directory.display()
-            )
-        });
 
+        // Build every output up front, detecting sanitized-name collisions before
+        // touching the filesystem. Two operation names that sanitize to the same
+        // file name would otherwise silently overwrite each other's results.
+        let mut file_names: HashMap<String, &str> = HashMap::new();
+        let mut outputs: Vec<(PathBuf, String)> = Vec::new();
         for (name, operation) in self.operations() {
             if operation.total_iterations() == 0 {
                 continue;
+            }
+
+            let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
+            if let Some(previous) = file_names.insert(file_name.clone(), name) {
+                panic!(
+                    "operations {previous:?} and {name:?} both map to the output file name \
+                     {file_name:?} after sanitization; rename one of them to avoid silently \
+                     overwriting benchmark results"
+                );
             }
 
             let output = OperationOutput {
@@ -127,8 +138,23 @@ impl Report {
             let json = serde_json::to_string_pretty(&output)
                 .expect("serializing fixed primitive fields to JSON cannot fail");
 
-            let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
-            let path = directory.join(file_name);
+            outputs.push((directory.join(file_name), json));
+        }
+
+        // Without any output, no directory is created, so a probe run that captured
+        // no measurable work leaves nothing behind.
+        if outputs.is_empty() {
+            return;
+        }
+
+        fs::create_dir_all(directory).unwrap_or_else(|error| {
+            panic!(
+                "failed to create benchmark output directory {}: {error}",
+                directory.display()
+            )
+        });
+
+        for (path, json) in outputs {
             fs::write(&path, json).unwrap_or_else(|error| {
                 panic!(
                     "failed to write benchmark output file {}: {error}",
@@ -269,5 +295,23 @@ mod tests {
         let contents = fs::read_to_string(&file).unwrap();
         assert!(!contents.contains("stale"));
         assert!(contents.contains("allocate_vec"));
+    }
+
+    #[test]
+    #[should_panic(expected = "after sanitization")]
+    fn panics_when_operation_names_collide_after_sanitization() {
+        let session = Session::new();
+
+        // Both names sanitize to `group_case.json`, so writing both would silently
+        // discard one operation's results.
+        for name in ["group/case", "group_case"] {
+            let operation = session.operation(name);
+            let _span = operation.measure_thread().iterations(4);
+            register_fake_allocation(800, 8);
+        }
+
+        // The collision is detected before anything is written, so this path is
+        // never created.
+        session.write_to_directory("collision_is_detected_before_writing");
     }
 }

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -200,9 +200,16 @@ impl Session {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::fs;
+    use std::path::Path;
+
+    use serde_json::Value;
 
     use crate::Session;
     use crate::allocator::register_fake_allocation;
+
+    fn read_json(path: &Path) -> Value {
+        serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
 
     fn session_with_recorded_work(name: &str) -> Session {
         let session = Session::new();
@@ -223,14 +230,36 @@ mod tests {
         session.write_to_directory(directory.path());
 
         let file = directory.path().join("allocate_vec.json");
-        let contents = fs::read_to_string(&file).unwrap();
+        let value = read_json(&file);
 
-        assert!(contents.contains("\"operation\": \"allocate_vec\""));
-        assert!(contents.contains("\"total_iterations\": 4"));
-        assert!(contents.contains("\"total_bytes_allocated\": 800"));
-        assert!(contents.contains("\"total_allocations_count\": 8"));
-        assert!(contents.contains("\"mean_bytes_per_iteration\": 200"));
-        assert!(contents.contains("\"mean_allocations_per_iteration\": 2"));
+        assert_eq!(
+            value.get("operation").and_then(Value::as_str),
+            Some("allocate_vec")
+        );
+        assert_eq!(
+            value.get("total_iterations").and_then(Value::as_u64),
+            Some(4)
+        );
+        assert_eq!(
+            value.get("total_bytes_allocated").and_then(Value::as_u64),
+            Some(800)
+        );
+        assert_eq!(
+            value.get("total_allocations_count").and_then(Value::as_u64),
+            Some(8)
+        );
+        assert_eq!(
+            value
+                .get("mean_bytes_per_iteration")
+                .and_then(Value::as_u64),
+            Some(200)
+        );
+        assert_eq!(
+            value
+                .get("mean_allocations_per_iteration")
+                .and_then(Value::as_u64),
+            Some(2)
+        );
     }
 
     #[test]
@@ -244,9 +273,11 @@ mod tests {
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
 
-        let contents = fs::read_to_string(&file).unwrap();
         // The original, unsanitized name is preserved inside the file.
-        assert!(contents.contains("\"operation\": \"group/case name\""));
+        assert_eq!(
+            read_json(&file).get("operation").and_then(Value::as_str),
+            Some("group/case name")
+        );
     }
 
     #[test]
@@ -292,9 +323,12 @@ mod tests {
         let session = session_with_recorded_work("allocate_vec");
         session.write_to_directory(directory.path());
 
-        let contents = fs::read_to_string(&file).unwrap();
-        assert!(!contents.contains("stale"));
-        assert!(contents.contains("allocate_vec"));
+        // Parsing succeeds only if the stale, non-JSON contents were replaced.
+        let value = read_json(&file);
+        assert_eq!(
+            value.get("operation").and_then(Value::as_str),
+            Some("allocate_vec")
+        );
     }
 
     #[test]

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -233,6 +233,26 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
+    fn skips_operations_without_iterations() {
+        let session = Session::new();
+        {
+            let operation = session.operation("measured");
+            let _span = operation.measure_thread().iterations(4);
+            register_fake_allocation(800, 8);
+        }
+        // Registered but never measured, so it stays at zero iterations and must
+        // be skipped rather than written.
+        let _unmeasured = session.operation("unmeasured");
+
+        let directory = tempfile::tempdir().unwrap();
+        session.write_to_directory(directory.path()).unwrap();
+
+        assert!(directory.path().join("measured.json").exists());
+        assert!(!directory.path().join("unmeasured.json").exists());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
     fn overwrites_existing_files() {
         let directory = tempfile::tempdir().unwrap();
         let file = directory.path().join("allocate_vec.json");

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -1,7 +1,7 @@
 //! Machine-readable JSON output of memory allocation statistics.
 
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::{fs, io};
 
 use serde::Serialize;
 
@@ -35,10 +35,11 @@ impl Report {
     /// session was part of a "list available benchmarks" probe run instead of
     /// some real activity.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written. Benchmark results are not useful without the output files they
+    /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
     /// # Examples
     ///
@@ -48,7 +49,6 @@ impl Report {
     /// #[global_allocator]
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
-    /// # fn main() -> std::io::Result<()> {
     /// let session = Session::new();
     /// {
     ///     let operation = session.operation("work");
@@ -56,14 +56,12 @@ impl Report {
     ///     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
     /// }
     ///
-    /// session.to_report().write_to_target()?;
-    /// # Ok(())
-    /// # }
+    /// session.to_report().write_to_target();
     /// ```
-    pub fn write_to_target(&self) -> io::Result<()> {
+    pub fn write_to_target(&self) {
         let target =
             folo_utils::cargo_target_directory().unwrap_or_else(|| PathBuf::from("target"));
-        self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY))
+        self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY));
     }
 
     /// Writes machine-readable JSON statistics into the given directory.
@@ -75,10 +73,11 @@ impl Report {
     ///
     /// Writes nothing if no operations were captured.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written. Benchmark results are not useful without the output files they
+    /// produce, so a write failure is treated as fatal rather than recoverable.
     ///
     /// # Examples
     ///
@@ -88,7 +87,6 @@ impl Report {
     /// #[global_allocator]
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
-    /// # fn main() -> std::io::Result<()> {
     /// let session = Session::new();
     /// {
     ///     let operation = session.operation("work");
@@ -97,17 +95,20 @@ impl Report {
     /// }
     ///
     /// let directory = std::env::temp_dir().join("alloc_tracker_example");
-    /// session.to_report().write_to_directory(&directory)?;
-    /// # Ok(())
-    /// # }
+    /// session.to_report().write_to_directory(&directory);
     /// ```
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
         if self.is_empty() {
-            return Ok(());
+            return;
         }
 
         let directory = directory.as_ref();
-        fs::create_dir_all(directory)?;
+        fs::create_dir_all(directory).unwrap_or_else(|error| {
+            panic!(
+                "failed to create benchmark output directory {}: {error}",
+                directory.display()
+            )
+        });
 
         for (name, operation) in self.operations() {
             if operation.total_iterations() == 0 {
@@ -127,10 +128,14 @@ impl Report {
                 .expect("serializing fixed primitive fields to JSON cannot fail");
 
             let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
-            fs::write(directory.join(file_name), json)?;
+            let path = directory.join(file_name);
+            fs::write(&path, json).unwrap_or_else(|error| {
+                panic!(
+                    "failed to write benchmark output file {}: {error}",
+                    path.display()
+                )
+            });
         }
-
-        Ok(())
     }
 }
 
@@ -141,12 +146,12 @@ impl Session {
     /// `self.to_report().write_to_target()`. See
     /// [`Report::write_to_target`](crate::Report::write_to_target) for details.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
-    pub fn write_to_target(&self) -> io::Result<()> {
-        self.to_report().write_to_target()
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written.
+    pub fn write_to_target(&self) {
+        self.to_report().write_to_target();
     }
 
     /// Writes machine-readable JSON statistics into the given directory.
@@ -156,12 +161,12 @@ impl Session {
     /// [`Report::write_to_directory`](crate::Report::write_to_directory) for
     /// details.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the output directory cannot be created or a file
-    /// cannot be written.
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) -> io::Result<()> {
-        self.to_report().write_to_directory(directory)
+    /// Panics if the output directory cannot be created or a file cannot be
+    /// written.
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
+        self.to_report().write_to_directory(directory);
     }
 }
 
@@ -187,9 +192,7 @@ mod tests {
         let session = session_with_recorded_work("allocate_vec");
         let directory = tempfile::tempdir().unwrap();
 
-        session
-            .write_to_directory(directory.path())
-            .expect("writing to a writable temp directory succeeds");
+        session.write_to_directory(directory.path());
 
         let file = directory.path().join("allocate_vec.json");
         let contents = std::fs::read_to_string(&file).unwrap();
@@ -208,7 +211,7 @@ mod tests {
         let session = session_with_recorded_work("group/case name");
         let directory = tempfile::tempdir().unwrap();
 
-        session.write_to_directory(directory.path()).unwrap();
+        session.write_to_directory(directory.path());
 
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
@@ -225,7 +228,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("nested");
 
-        session.write_to_directory(&target).unwrap();
+        session.write_to_directory(&target);
 
         // Nothing is written, so the directory is not even created.
         assert!(!target.exists());
@@ -245,7 +248,7 @@ mod tests {
         let _unmeasured = session.operation("unmeasured");
 
         let directory = tempfile::tempdir().unwrap();
-        session.write_to_directory(directory.path()).unwrap();
+        session.write_to_directory(directory.path());
 
         assert!(directory.path().join("measured.json").exists());
         assert!(!directory.path().join("unmeasured.json").exists());
@@ -259,7 +262,7 @@ mod tests {
         std::fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("allocate_vec");
-        session.write_to_directory(directory.path()).unwrap();
+        session.write_to_directory(directory.path());
 
         let contents = std::fs::read_to_string(&file).unwrap();
         assert!(!contents.contains("stale"));

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -116,3 +116,25 @@ fn write_to_target_writes_into_cargo_target_directory() {
     // Avoid polluting the shared target directory for later runs.
     fs::remove_file(&expected).unwrap();
 }
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the global allocator, which is not supported under Miri.
+#[should_panic(expected = "after sanitization")]
+fn panics_when_operation_names_collide_after_sanitization() {
+    let session = Session::new();
+
+    // Both names sanitize to the same file name, which must not silently
+    // overwrite one operation's results.
+    for name in ["group/case", "group_case"] {
+        let operation = session.operation(name);
+        let _span = operation.measure_thread().iterations(4);
+        for _ in 0..4 {
+            let data: Vec<u8> = black_box(vec![0_u8; 64]);
+            black_box(&data);
+        }
+    }
+
+    // The collision is detected before anything is written, so this path is
+    // never created.
+    session.write_to_directory("collision_is_detected_before_writing");
+}

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -1,5 +1,6 @@
 //! Integration tests for writing machine-readable JSON output to disk.
 
+use std::fs;
 use std::hint::black_box;
 
 use alloc_tracker::{Allocator, Session};
@@ -10,16 +11,27 @@ static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
 fn writes_json_files_for_each_operation() {
-    const BYTES_PER_ITERATION: usize = 128;
-    const ITERATIONS: u64 = 16;
+    const FIRST_BYTES_PER_ITERATION: usize = 128;
+    const FIRST_ITERATIONS: u64 = 16;
+    const SECOND_BYTES_PER_ITERATION: usize = 64;
+    const SECOND_ITERATIONS: u64 = 8;
 
     let session = Session::new();
 
     {
         let operation = session.operation("allocate_buffer");
-        let _span = operation.measure_thread().iterations(ITERATIONS);
-        for _ in 0..ITERATIONS {
-            let data: Vec<u8> = black_box(vec![0_u8; BYTES_PER_ITERATION]);
+        let _span = operation.measure_thread().iterations(FIRST_ITERATIONS);
+        for _ in 0..FIRST_ITERATIONS {
+            let data: Vec<u8> = black_box(vec![0_u8; FIRST_BYTES_PER_ITERATION]);
+            black_box(&data);
+        }
+    }
+
+    {
+        let operation = session.operation("allocate_small_buffer");
+        let _span = operation.measure_thread().iterations(SECOND_ITERATIONS);
+        for _ in 0..SECOND_ITERATIONS {
+            let data: Vec<u8> = black_box(vec![0_u8; SECOND_BYTES_PER_ITERATION]);
             black_box(&data);
         }
     }
@@ -27,10 +39,17 @@ fn writes_json_files_for_each_operation() {
     let directory = tempfile::tempdir().unwrap();
     session.write_to_directory(directory.path());
 
-    let file = directory.path().join("allocate_buffer.json");
-    assert!(file.exists(), "expected JSON file for the operation");
+    let first = directory.path().join("allocate_buffer.json");
+    let second = directory.path().join("allocate_small_buffer.json");
 
-    let contents = std::fs::read_to_string(&file).unwrap();
+    assert!(first.exists(), "expected JSON file for first operation");
+    assert!(second.exists(), "expected JSON file for second operation");
+
+    // Exactly one file per measured operation, and nothing more.
+    let written = fs::read_dir(directory.path()).unwrap().count();
+    assert_eq!(written, 2, "expected one JSON file per operation");
+
+    let contents = fs::read_to_string(&first).unwrap();
     assert!(contents.contains("\"operation\": \"allocate_buffer\""));
     assert!(contents.contains("\"total_iterations\": 16"));
     assert!(contents.contains("\"total_bytes_allocated\""));
@@ -79,7 +98,7 @@ fn write_to_target_writes_into_cargo_target_directory() {
 
     // Start from a clean slate so the assertion proves this call wrote the file.
     if expected.exists() {
-        std::fs::remove_file(&expected).unwrap();
+        fs::remove_file(&expected).unwrap();
     }
 
     session.write_to_target();
@@ -90,10 +109,10 @@ fn write_to_target_writes_into_cargo_target_directory() {
         expected.display()
     );
 
-    let contents = std::fs::read_to_string(&expected).unwrap();
+    let contents = fs::read_to_string(&expected).unwrap();
     assert!(contents.contains("\"operation\": \"alloc_tracker_write_to_target_probe\""));
     assert!(contents.contains("\"total_iterations\": 8"));
 
     // Avoid polluting the shared target directory for later runs.
-    std::fs::remove_file(&expected).unwrap();
+    fs::remove_file(&expected).unwrap();
 }

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -25,7 +25,7 @@ fn writes_json_files_for_each_operation() {
     }
 
     let directory = tempfile::tempdir().unwrap();
-    session.write_to_directory(directory.path()).unwrap();
+    session.write_to_directory(directory.path());
 
     let file = directory.path().join("allocate_buffer.json");
     assert!(file.exists(), "expected JSON file for the operation");
@@ -48,7 +48,7 @@ fn empty_session_writes_nothing() {
     let directory = tempfile::tempdir().unwrap();
     let target = directory.path().join("output");
 
-    session.write_to_directory(&target).unwrap();
+    session.write_to_directory(&target);
 
     assert!(!target.exists(), "no directory should be created");
 }
@@ -82,7 +82,7 @@ fn write_to_target_writes_into_cargo_target_directory() {
         std::fs::remove_file(&expected).unwrap();
     }
 
-    session.write_to_target().unwrap();
+    session.write_to_target();
 
     assert!(
         expected.exists(),

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -73,7 +73,7 @@ fn write_to_target_writes_into_cargo_target_directory() {
     }
 
     let expected = folo_utils::cargo_target_directory()
-        .unwrap_or_else(|| std::path::PathBuf::from("target"))
+        .unwrap_or_else(|| "target".into())
         .join("alloc_tracker")
         .join(format!("{OPERATION}.json"));
 

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -52,3 +52,48 @@ fn empty_session_writes_nothing() {
 
     assert!(!target.exists(), "no directory should be created");
 }
+
+#[test]
+#[cfg_attr(miri, ignore)] // Resolves the Cargo target directory and writes files, neither supported under Miri.
+fn write_to_target_writes_into_cargo_target_directory() {
+    // A distinctive name avoids colliding with output from other operations in
+    // the shared Cargo target directory.
+    const OPERATION: &str = "alloc_tracker_write_to_target_probe";
+    const BYTES_PER_ITERATION: usize = 64;
+    const ITERATIONS: u64 = 8;
+
+    let session = Session::new();
+    {
+        let operation = session.operation(OPERATION);
+        let _span = operation.measure_thread().iterations(ITERATIONS);
+        for _ in 0..ITERATIONS {
+            let data: Vec<u8> = black_box(vec![0_u8; BYTES_PER_ITERATION]);
+            black_box(&data);
+        }
+    }
+
+    let expected = folo_utils::cargo_target_directory()
+        .unwrap_or_else(|| std::path::PathBuf::from("target"))
+        .join("alloc_tracker")
+        .join(format!("{OPERATION}.json"));
+
+    // Start from a clean slate so the assertion proves this call wrote the file.
+    if expected.exists() {
+        std::fs::remove_file(&expected).unwrap();
+    }
+
+    session.write_to_target().unwrap();
+
+    assert!(
+        expected.exists(),
+        "write_to_target should create {}",
+        expected.display()
+    );
+
+    let contents = std::fs::read_to_string(&expected).unwrap();
+    assert!(contents.contains("\"operation\": \"alloc_tracker_write_to_target_probe\""));
+    assert!(contents.contains("\"total_iterations\": 8"));
+
+    // Avoid polluting the shared target directory for later runs.
+    std::fs::remove_file(&expected).unwrap();
+}

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -1,0 +1,54 @@
+//! Integration tests for writing machine-readable JSON output to disk.
+
+use std::hint::black_box;
+
+use alloc_tracker::{Allocator, Session};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
+fn writes_json_files_for_each_operation() {
+    const BYTES_PER_ITERATION: usize = 128;
+    const ITERATIONS: u64 = 16;
+
+    let session = Session::new();
+
+    {
+        let operation = session.operation("allocate_buffer");
+        let _span = operation.measure_thread().iterations(ITERATIONS);
+        for _ in 0..ITERATIONS {
+            let data: Vec<u8> = black_box(vec![0_u8; BYTES_PER_ITERATION]);
+            black_box(&data);
+        }
+    }
+
+    let directory = tempfile::tempdir().unwrap();
+    session.write_to_directory(directory.path()).unwrap();
+
+    let file = directory.path().join("allocate_buffer.json");
+    assert!(file.exists(), "expected JSON file for the operation");
+
+    let contents = std::fs::read_to_string(&file).unwrap();
+    assert!(contents.contains("\"operation\": \"allocate_buffer\""));
+    assert!(contents.contains("\"total_iterations\": 16"));
+    assert!(contents.contains("\"total_bytes_allocated\""));
+    assert!(contents.contains("\"total_allocations_count\""));
+    assert!(contents.contains("\"mean_bytes_per_iteration\""));
+    assert!(contents.contains("\"mean_allocations_per_iteration\""));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
+fn empty_session_writes_nothing() {
+    let session = Session::new();
+    let _operation = session.operation("never_measured");
+
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("output");
+
+    session.write_to_directory(&target).unwrap();
+
+    assert!(!target.exists(), "no directory should be created");
+}

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -2,11 +2,17 @@
 
 use std::fs;
 use std::hint::black_box;
+use std::path::Path;
 
 use alloc_tracker::{Allocator, Session};
+use serde_json::Value;
 
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
@@ -49,13 +55,39 @@ fn writes_json_files_for_each_operation() {
     let written = fs::read_dir(directory.path()).unwrap().count();
     assert_eq!(written, 2, "expected one JSON file per operation");
 
-    let contents = fs::read_to_string(&first).unwrap();
-    assert!(contents.contains("\"operation\": \"allocate_buffer\""));
-    assert!(contents.contains("\"total_iterations\": 16"));
-    assert!(contents.contains("\"total_bytes_allocated\""));
-    assert!(contents.contains("\"total_allocations_count\""));
-    assert!(contents.contains("\"mean_bytes_per_iteration\""));
-    assert!(contents.contains("\"mean_allocations_per_iteration\""));
+    let value = read_json(&first);
+    assert_eq!(
+        value.get("operation").and_then(Value::as_str),
+        Some("allocate_buffer")
+    );
+    assert_eq!(
+        value.get("total_iterations").and_then(Value::as_u64),
+        Some(16)
+    );
+    assert!(
+        value
+            .get("total_bytes_allocated")
+            .and_then(Value::as_u64)
+            .is_some()
+    );
+    assert!(
+        value
+            .get("total_allocations_count")
+            .and_then(Value::as_u64)
+            .is_some()
+    );
+    assert!(
+        value
+            .get("mean_bytes_per_iteration")
+            .and_then(Value::as_u64)
+            .is_some()
+    );
+    assert!(
+        value
+            .get("mean_allocations_per_iteration")
+            .and_then(Value::as_u64)
+            .is_some()
+    );
 }
 
 #[test]
@@ -109,9 +141,15 @@ fn write_to_target_writes_into_cargo_target_directory() {
         expected.display()
     );
 
-    let contents = fs::read_to_string(&expected).unwrap();
-    assert!(contents.contains("\"operation\": \"alloc_tracker_write_to_target_probe\""));
-    assert!(contents.contains("\"total_iterations\": 8"));
+    let value = read_json(&expected);
+    assert_eq!(
+        value.get("operation").and_then(Value::as_str),
+        Some("alloc_tracker_write_to_target_probe")
+    );
+    assert_eq!(
+        value.get("total_iterations").and_then(Value::as_u64),
+        Some(8)
+    );
 
     // Avoid polluting the shared target directory for later runs.
     fs::remove_file(&expected).unwrap();

--- a/packages/folo_utils/Cargo.toml
+++ b/packages/folo_utils/Cargo.toml
@@ -20,6 +20,8 @@ doc = false
 default = []
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 mutants = { workspace = true }

--- a/packages/folo_utils/src/file_name.rs
+++ b/packages/folo_utils/src/file_name.rs
@@ -52,8 +52,10 @@ fn is_windows_reserved(name: &str) -> bool {
         return true;
     }
 
-    // `COM0`..=`COM9` and `LPT0`..=`LPT9` are reserved serial and parallel port
-    // names.
+    // Escape `COM0`..=`COM9` and `LPT0`..=`LPT9`. The canonical reserved set is
+    // `COM1`..=`COM9` and `LPT1`..=`LPT9`, but the `0` variants are escaped too as
+    // a conservative choice: over-escaping a name is harmless, whereas failing to
+    // escape a genuinely reserved name makes the file unwritable on Windows.
     for prefix in ["COM", "LPT"] {
         if let Some(rest) = strip_prefix_ignore_ascii_case(stem, prefix)
             && let [digit] = rest.as_bytes()

--- a/packages/folo_utils/src/file_name.rs
+++ b/packages/folo_utils/src/file_name.rs
@@ -1,0 +1,61 @@
+//! Sanitizing arbitrary strings into filesystem-safe file name components.
+
+/// Converts an arbitrary string into a filesystem-safe file name component.
+///
+/// Every character that is not an ASCII alphanumeric or one of `.`, `_`, `-`
+/// is replaced with `_`. An empty input produces `_`. The result never
+/// contains path separators, so it is always a single path component.
+#[must_use]
+pub fn sanitize_file_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if sanitized.is_empty() {
+        "_".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_safe_characters() {
+        assert_eq!(sanitize_file_name("read_cell"), "read_cell");
+        assert_eq!(sanitize_file_name("op-1.v2_final"), "op-1.v2_final");
+    }
+
+    #[test]
+    fn replaces_path_separators() {
+        assert_eq!(sanitize_file_name("group/case"), "group_case");
+        assert_eq!(sanitize_file_name("a\\b"), "a_b");
+        assert_eq!(sanitize_file_name("../../etc/passwd"), ".._.._etc_passwd");
+    }
+
+    #[test]
+    fn replaces_whitespace_and_symbols() {
+        assert_eq!(sanitize_file_name("a b c"), "a_b_c");
+        assert_eq!(sanitize_file_name("a:b*c?"), "a_b_c_");
+    }
+
+    #[test]
+    fn replaces_non_ascii() {
+        assert_eq!(sanitize_file_name("naïve"), "na_ve");
+    }
+
+    #[test]
+    fn empty_input_yields_underscore() {
+        assert_eq!(sanitize_file_name(""), "_");
+    }
+}

--- a/packages/folo_utils/src/file_name.rs
+++ b/packages/folo_utils/src/file_name.rs
@@ -3,11 +3,18 @@
 /// Converts an arbitrary string into a filesystem-safe file name component.
 ///
 /// Every character that is not an ASCII alphanumeric or one of `.`, `_`, `-`
-/// is replaced with `_`. An empty input produces `_`. The result never
-/// contains path separators, so it is always a single path component.
+/// is replaced with `_`, and trailing dots (which Windows silently strips) are
+/// removed. The result never contains path separators, so it is always a single
+/// path component.
+///
+/// A leading `_` is prepended when the result would otherwise be unusable as a
+/// file name: an empty string (which includes inputs like `.` and `..` once
+/// their dots are stripped) or a name reserved by Windows for a device (such as
+/// `CON`, `NUL`, `COM1`, or `LPT1`, case-insensitively and regardless of any
+/// extension).
 #[must_use]
 pub fn sanitize_file_name(name: &str) -> String {
-    let sanitized: String = name
+    let mut sanitized: String = name
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
@@ -18,11 +25,54 @@ pub fn sanitize_file_name(name: &str) -> String {
         })
         .collect();
 
-    if sanitized.is_empty() {
-        "_".to_string()
-    } else {
-        sanitized
+    // Windows silently strips trailing dots from file names, which would let
+    // distinct operation names collide and produce surprising paths.
+    while sanitized.ends_with('.') {
+        sanitized.pop();
     }
+
+    if sanitized.is_empty() || is_windows_reserved(&sanitized) {
+        sanitized.insert(0, '_');
+    }
+
+    sanitized
+}
+
+/// Returns whether the name (ignoring any extension) is a reserved Windows
+/// device name, which is rejected by the OS even when an extension is appended.
+fn is_windows_reserved(name: &str) -> bool {
+    const RESERVED: [&str; 4] = ["CON", "PRN", "AUX", "NUL"];
+
+    let stem = name.split_once('.').map_or(name, |(stem, _extension)| stem);
+
+    if RESERVED
+        .iter()
+        .any(|reserved| stem.eq_ignore_ascii_case(reserved))
+    {
+        return true;
+    }
+
+    // `COM0`..=`COM9` and `LPT0`..=`LPT9` are reserved serial and parallel port
+    // names.
+    for prefix in ["COM", "LPT"] {
+        if let Some(rest) = strip_prefix_ignore_ascii_case(stem, prefix)
+            && let [digit] = rest.as_bytes()
+            && digit.is_ascii_digit()
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Strips a case-insensitive ASCII prefix, returning the remainder when present.
+fn strip_prefix_ignore_ascii_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let candidate = value.get(..prefix.len())?;
+    candidate
+        .eq_ignore_ascii_case(prefix)
+        .then(|| value.get(prefix.len()..))
+        .flatten()
 }
 
 #[cfg(test)]
@@ -57,5 +107,50 @@ mod tests {
     #[test]
     fn empty_input_yields_underscore() {
         assert_eq!(sanitize_file_name(""), "_");
+    }
+
+    #[test]
+    fn strips_trailing_dots() {
+        assert_eq!(sanitize_file_name("report."), "report");
+        assert_eq!(sanitize_file_name("report..."), "report");
+    }
+
+    #[test]
+    fn dot_and_dotdot_yield_underscore() {
+        assert_eq!(sanitize_file_name("."), "_");
+        assert_eq!(sanitize_file_name(".."), "_");
+    }
+
+    #[test]
+    fn escapes_reserved_device_names() {
+        assert_eq!(sanitize_file_name("CON"), "_CON");
+        assert_eq!(sanitize_file_name("nul"), "_nul");
+        assert_eq!(sanitize_file_name("Aux"), "_Aux");
+        assert_eq!(sanitize_file_name("PRN"), "_PRN");
+    }
+
+    #[test]
+    fn escapes_reserved_device_names_with_extension() {
+        // Windows treats `CON.json` as the `CON` device, so it must be escaped.
+        assert_eq!(sanitize_file_name("CON.json"), "_CON.json");
+        assert_eq!(sanitize_file_name("nul.txt"), "_nul.txt");
+    }
+
+    #[test]
+    fn escapes_reserved_port_names() {
+        assert_eq!(sanitize_file_name("COM1"), "_COM1");
+        assert_eq!(sanitize_file_name("com9"), "_com9");
+        assert_eq!(sanitize_file_name("LPT1"), "_LPT1");
+        assert_eq!(sanitize_file_name("lpt0"), "_lpt0");
+    }
+
+    #[test]
+    fn keeps_names_that_merely_start_like_reserved_names() {
+        // Only exact device names (before the extension) are reserved.
+        assert_eq!(sanitize_file_name("CONFIG"), "CONFIG");
+        assert_eq!(sanitize_file_name("console"), "console");
+        assert_eq!(sanitize_file_name("COM"), "COM");
+        assert_eq!(sanitize_file_name("COM10"), "COM10");
+        assert_eq!(sanitize_file_name("COMA"), "COMA");
     }
 }

--- a/packages/folo_utils/src/lib.rs
+++ b/packages/folo_utils/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Utilities for internal use in Folo packages; no stable API surface.
 
-// All content migrated to other packages for the time being.
+mod file_name;
+mod target_dir;
+
+pub use file_name::*;
+pub use target_dir::*;

--- a/packages/folo_utils/src/target_dir.rs
+++ b/packages/folo_utils/src/target_dir.rs
@@ -10,8 +10,12 @@ use serde::Deserialize;
 ///
 /// Uses the same strategy as Criterion: the `CARGO_TARGET_DIR` environment
 /// variable if set, otherwise the `target_directory` reported by
-/// `cargo metadata`. Returns `None` if neither source is available, in which
-/// case callers should fall back to a relative `target` path.
+/// `cargo metadata`. When the `CARGO` environment variable is not set (so the
+/// path to the `cargo` binary that launched the process is unknown), the
+/// `cargo` binary is resolved from `PATH` instead, because `CARGO` is not
+/// guaranteed to be present in every runtime environment. Returns `None` if the
+/// target directory cannot be determined, in which case callers should fall
+/// back to a relative `target` path.
 #[cfg_attr(test, mutants::skip)]
 // Reads process env and shells out to `cargo metadata`; the JSON parsing is unit-tested separately.
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -21,7 +25,7 @@ pub fn cargo_target_directory() -> Option<PathBuf> {
         return Some(PathBuf::from(dir));
     }
 
-    let cargo = env::var_os("CARGO")?;
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let output = Command::new(cargo)
         .args(["metadata", "--format-version", "1", "--no-deps"])
         .output()

--- a/packages/folo_utils/src/target_dir.rs
+++ b/packages/folo_utils/src/target_dir.rs
@@ -16,8 +16,16 @@ use serde::Deserialize;
 /// guaranteed to be present in every runtime environment. Returns `None` if the
 /// target directory cannot be determined, in which case callers should fall
 /// back to a relative `target` path.
+//
+// The behavior here depends entirely on the ambient environment: which
+// environment variables are set, whether a `cargo` binary is reachable, and the
+// workspace layout that `cargo metadata` reports. None of that can be exercised
+// deterministically across CI environments, so coverage measurement would be
+// flaky and stable tests cannot catch mutations to the env-var names or the
+// subprocess arguments. The only branch-worthy pure logic is parsing the
+// metadata JSON, which lives in `parse_metadata_target_directory` and is
+// unit-tested directly.
 #[cfg_attr(test, mutants::skip)]
-// Reads process env and shells out to `cargo metadata`; the JSON parsing is unit-tested separately.
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[must_use]
 pub fn cargo_target_directory() -> Option<PathBuf> {

--- a/packages/folo_utils/src/target_dir.rs
+++ b/packages/folo_utils/src/target_dir.rs
@@ -1,0 +1,87 @@
+//! Resolving the Cargo `target` directory for benchmark output files.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde::Deserialize;
+
+/// Resolves the Cargo `target` directory.
+///
+/// Uses the same strategy as Criterion: the `CARGO_TARGET_DIR` environment
+/// variable if set, otherwise the `target_directory` reported by
+/// `cargo metadata`. Returns `None` if neither source is available, in which
+/// case callers should fall back to a relative `target` path.
+#[cfg_attr(test, mutants::skip)]
+// Reads process env and shells out to `cargo metadata`; the JSON parsing is unit-tested separately.
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[must_use]
+pub fn cargo_target_directory() -> Option<PathBuf> {
+    if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+
+    let cargo = env::var_os("CARGO")?;
+    let output = Command::new(cargo)
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_metadata_target_directory(&output.stdout)
+}
+
+/// Extracts the `target_directory` field from `cargo metadata` JSON output.
+fn parse_metadata_target_directory(metadata_json: &[u8]) -> Option<PathBuf> {
+    #[derive(Deserialize)]
+    struct Metadata {
+        target_directory: PathBuf,
+    }
+
+    let metadata: Metadata = serde_json::from_slice(metadata_json).ok()?;
+    Some(metadata.target_directory)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_target_directory_from_metadata() {
+        let json = br#"{
+            "packages": [],
+            "workspace_root": "/home/user/project",
+            "target_directory": "/home/user/project/target",
+            "version": 1
+        }"#;
+
+        let result = parse_metadata_target_directory(json);
+        assert_eq!(result, Some(PathBuf::from("/home/user/project/target")));
+    }
+
+    #[test]
+    fn parses_target_directory_ignoring_unknown_fields() {
+        let json = br#"{"target_directory": "/custom/target", "extra": [1, 2, 3]}"#;
+
+        let result = parse_metadata_target_directory(json);
+        assert_eq!(result, Some(PathBuf::from("/custom/target")));
+    }
+
+    #[test]
+    fn returns_none_for_invalid_json() {
+        let result = parse_metadata_target_directory(b"not json at all");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn returns_none_when_target_directory_missing() {
+        let json = br#"{"workspace_root": "/home/user/project"}"#;
+
+        let result = parse_metadata_target_directory(json);
+        assert_eq!(result, None);
+    }
+}


### PR DESCRIPTION
## Summary

`all_the_time` and `alloc_tracker` add value to Criterion benchmarks but until now could only print human-readable reports to the console. This PR closes that gap by also emitting machine-readable JSON files, one per operation, into the Cargo `target` directory — mirroring how Criterion persists its own data.

## What changed

- New `write_to_target()` and `write_to_directory(dir)` methods on `Report` and `Session` in both crates. `write_to_target()` resolves the Cargo target directory and writes to `target/all_the_time/<operation>.json` / `target/alloc_tracker/<operation>.json`.
- Shared, tricky logic is centralized in `folo_utils`: Criterion-style target-directory resolution (`CARGO_TARGET_DIR` → `cargo metadata` → fallback) and filesystem-safe operation-name sanitization.
- Operation names are sanitized for the filename, but the original unsanitized name is preserved inside the JSON `operation` field. Existing files are overwritten on each run.
- Durations are serialized as integer nanoseconds (`u64`) to avoid float precision and large-integer concerns.

## Example output

`target/all_the_time/my_operation.json`:

```json
{
  "operation": "my_operation",
  "total_iterations": 10,
  "total_processor_time_nanos": 46875000,
  "mean_processor_time_nanos": 4687500
}
```

`target/alloc_tracker/multiple_allocations.json`:

```json
{
  "operation": "multiple_allocations",
  "total_iterations": 1,
  "total_bytes_allocated": 25,
  "total_allocations_count": 3,
  "mean_bytes_per_iteration": 25,
  "mean_allocations_per_iteration": 3
}
```

## Notes

- Empty reports (probe runs) write nothing; zero-iteration operations are skipped.
- `serde` + `serde_json` are introduced as workspace dependencies (default-features disabled).
- Crate docs, READMEs, and the readme examples are updated to demonstrate `write_to_target()`.

## Testing

`validate-local` (Windows) and `validate-linux` (WSL) both pass end-to-end: format-check, check, clippy, test, test-docs, docs, docs-default-features, miri, machete, default-features-check, and release check/clippy/build. Filesystem/subprocess test paths are gated off under Miri (CI runs Miri with isolation).
