### PR TITLE
Upgrade to Rust 1.96 toolchain and bump MSRV to 1.93

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Sander Saares <sander@saares.eu>"]
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/folo-rs/folo"
-rust-version = "1.91"
+rust-version = "1.93"
 
 [workspace.dependencies]
 all_the_time = { version = "0.4.20", path = "packages/all_the_time", default-features = false }

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ links to the relevant code.
 workaround for `std::hint::cold_path()` being unavailable at the workspace MSRV.
 
 The intrinsic stabilized in Rust 1.95. The workspace toolchain
-(`rust-toolchain.toml`) is at 1.95, but the workspace MSRV is 1.91, so
+(`rust-toolchain.toml`) is at 1.96, but the workspace MSRV is 1.93, so
 `std::hint::cold_path()` cannot yet be used without raising `nm`'s MSRV.
 
 Once the workspace MSRV (or just `nm`'s package MSRV) is raised to 1.95 or

--- a/constants.env
+++ b/constants.env
@@ -1,4 +1,4 @@
 # used for testing, ensures the MSRV promise is kept; must match Cargo.toml [workspace.package].rust-version
-RUST_MSRV=1.91
+RUST_MSRV=1.93
 # used for coverage, formatting, miri and extended analysis
 RUST_NIGHTLY=nightly

--- a/packages/all_the_time/src/operation.rs
+++ b/packages/all_the_time/src/operation.rs
@@ -165,14 +165,11 @@ impl Operation {
         if data.total_iterations == 0 {
             Duration::ZERO
         } else {
-            // Use div_ceil for proper division, falling back to manual calculation if needed
-            Duration::from_nanos(
+            Duration::from_nanos_u128(
                 data.total_processor_time
                     .as_nanos()
                     .checked_div(u128::from(data.total_iterations))
-                    .expect("guarded by if condition")
-                    .try_into()
-                    .expect("all realistic values fit in u64"),
+                    .expect("guarded by if condition"),
             )
         }
     }

--- a/packages/all_the_time/src/operation_metrics.rs
+++ b/packages/all_the_time/src/operation_metrics.rs
@@ -18,11 +18,7 @@ impl OperationMetrics {
             .checked_mul(u128::from(iterations))
             .expect("duration multiplied by iterations overflows u128 - this indicates an unrealistic scenario");
 
-        let total_duration = Duration::from_nanos(
-            total_duration_nanos
-                .try_into()
-                .expect("total duration exceeds maximum Duration value - this indicates an unrealistic scenario"),
-        );
+        let total_duration = Duration::from_nanos_u128(total_duration_nanos);
 
         self.total_processor_time = self.total_processor_time.checked_add(total_duration).expect(
             "processor time accumulation overflows Duration - this indicates an unrealistic scenario",

--- a/packages/all_the_time/src/process_span.rs
+++ b/packages/all_the_time/src/process_span.rs
@@ -144,13 +144,11 @@ impl ProcessSpan {
         let total_duration = current_time.saturating_sub(self.start_time);
 
         if self.iterations > 1 {
-            Duration::from_nanos(
+            Duration::from_nanos_u128(
                 total_duration
                     .as_nanos()
                     .checked_div(u128::from(self.iterations))
-                    .expect("guarded by if condition")
-                    .try_into()
-                    .expect("all realistic values fit in u64"),
+                    .expect("guarded by if condition"),
             )
         } else {
             total_duration

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -238,13 +238,11 @@ impl ReportOperation {
         if self.total_iterations == 0 {
             Duration::ZERO
         } else {
-            Duration::from_nanos(
+            Duration::from_nanos_u128(
                 self.total_processor_time
                     .as_nanos()
                     .checked_div(u128::from(self.total_iterations))
-                    .expect("guarded by if condition")
-                    .try_into()
-                    .expect("all realistic values fit in u64"),
+                    .expect("guarded by if condition"),
             )
         }
     }

--- a/packages/all_the_time/src/thread_span.rs
+++ b/packages/all_the_time/src/thread_span.rs
@@ -133,13 +133,11 @@ impl ThreadSpan {
         let total_duration = current_time.saturating_sub(self.start_time);
 
         if self.iterations > 1 {
-            Duration::from_nanos(
+            Duration::from_nanos_u128(
                 total_duration
                     .as_nanos()
                     .checked_div(u128::from(self.iterations))
-                    .expect("guarded by if condition")
-                    .try_into()
-                    .expect("all realistic values fit in u64"),
+                    .expect("guarded by if condition"),
             )
         } else {
             total_duration

--- a/packages/events_once/src/lib.rs
+++ b/packages/events_once/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![expect(clippy::unnecessary_safety_comment, reason = "clippy#16553")]
 
 //! Efficient oneshot events (channels) with support for single-threaded events,
 //! object embedding, event pools and event lakes.

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -114,22 +114,16 @@ impl<T, H> FutureDequeCore<T, H> {
     // making blocking tests hang. Non-blocking tests catch this mutation.
     #[cfg_attr(test, mutants::skip)]
     pub(crate) fn pop_front(&mut self) -> Option<T> {
-        let front_ready = self.slots.front().is_some_and(Slot::is_ready);
-        if front_ready {
-            self.slots.pop_front().and_then(Slot::take_value)
-        } else {
-            None
-        }
+        self.slots
+            .pop_front_if(|slot| slot.is_ready())
+            .and_then(Slot::take_value)
     }
 
     /// Pops the back result if the backmost future has completed.
     pub(crate) fn pop_back(&mut self) -> Option<T> {
-        let back_ready = self.slots.back().is_some_and(Slot::is_ready);
-        if back_ready {
-            self.slots.pop_back().and_then(Slot::take_value)
-        } else {
-            None
-        }
+        self.slots
+            .pop_back_if(|slot| slot.is_ready())
+            .and_then(Slot::take_value)
     }
 }
 

--- a/packages/many_cpus_benchmarking/src/lib.rs
+++ b/packages/many_cpus_benchmarking/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // This is currently impractical to test as we lack the capability to simulate mock processor configurations.
 #![cfg_attr(coverage_nightly, coverage(off))]
-#![expect(clippy::unnecessary_safety_comment, reason = "clippy#16553")]
 
 //! [Criterion][1] benchmark harness designed to compare different modes of distributing work in a
 //! many-processor system with multiple memory regions. This helps highlight the performance impact of

--- a/packages/many_cpus_benchmarking/src/run.rs
+++ b/packages/many_cpus_benchmarking/src/run.rs
@@ -654,11 +654,7 @@ impl BenchmarkBatch {
                 "thread count is asserted as non-zero in ctor, so division by zero is impossible",
             );
 
-        Duration::from_nanos(
-            total_elapsed_nanos_per_thread
-                .try_into()
-                .expect("duration overflow is unfathomable within our spacetime boundaries"),
-        )
+        Duration::from_nanos_u128(total_elapsed_nanos_per_thread)
     }
 
     #[expect(

--- a/packages/par_bench/src/run_configured.rs
+++ b/packages/par_bench/src/run_configured.rs
@@ -170,11 +170,7 @@ fn calculate_mean_duration(thread_count: NonZero<usize>, total_elapsed_nanos: u1
         .checked_div(thread_count.get() as u128)
         .expect("thread count is NonZero, so division by zero is impossible");
 
-    Duration::from_nanos(
-        total_elapsed_nanos_per_thread
-            .try_into()
-            .expect("overflowing u64 is unrealistic when using a real clock"),
-    )
+    Duration::from_nanos_u128(total_elapsed_nanos_per_thread)
 }
 
 /// The result of executing a benchmark run, carrying data suitable for ingestion

--- a/packages/ui_tests/tests/ui/new_zealand/nz_non_const_method_fail.stderr
+++ b/packages/ui_tests/tests/ui/new_zealand/nz_non_const_method_fail.stderr
@@ -4,4 +4,9 @@ error[E0015]: cannot call non-const function `get_value` in constants
 12 |     let _non_const: NonZero<u64> = nz!(get_value());
    |                                        ^^^^^^^^^^^
    |
+note: function `get_value` is not const
+  --> tests/ui/new_zealand/nz_non_const_method_fail.rs:6:1
+   |
+ 6 | fn get_value() -> u64 {
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95"
+channel = "1.96"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Upgrades the workspace to the Rust 1.96 toolchain and bumps the MSRV from 1.91 to 1.93, then adopts the newly-stabilized standard library APIs that this MSRV unlocks. Each adoption is a separate commit for reviewability.

## Toolchain and MSRV

- `rust-toolchain.toml`: pinned toolchain `1.95` -> `1.96`.
- `Cargo.toml`: `rust-version` `1.91` -> `1.93`.
- `constants.env`: `RUST_MSRV` `1.91` -> `1.93`.
- Removed two `#![expect(clippy::unnecessary_safety_comment, reason = "clippy#16553")]` workarounds (`events_once`, `many_cpus_benchmarking`) now that clippy#16553 is fixed in 1.96 — they would otherwise be unfulfilled `expect`s under `-D warnings`.
- Re-blessed one `trybuild` UI snapshot: 1.96 adds a "note: function `...` is not const" pointer to the E0015 diagnostic.

## Newly-stabilized APIs adopted (MSRV 1.93)

- `Duration::from_nanos_u128`: replaces lossy `u128 -> try_into().expect() -> Duration::from_nanos` conversions across `all_the_time`, `many_cpus_benchmarking`, and `par_bench`. The new API takes the full `u128` range directly and only panics at the true `Duration` ceiling, so it is a strict improvement over the truncating fallible conversion.
- `VecDeque::pop_front_if` / `pop_back_if`: simplifies the conditional-pop logic in `future_deque` (replacing `front()/back().is_some_and(...)` followed by a separate `pop`).

Other block-A candidates (`MaybeUninit` slice helpers, `Box/Rc/Arc::new_zeroed`, `into_raw_parts`, `<[T]>::as_array`, `NonZero::div_ceil`, `RwLockWriteGuard::downgrade`, `std::fmt::from_fn`, unchecked arithmetic) were assessed and intentionally not applied: they either conflict with existing workspace policy (checked arithmetic, no lazy-init/`alloc_zeroed` per `infinity_pool/AGENTS.md`) or have no matching call sites.

## New lints

No new allow-by-default lints need enabling. Diffing the `clippy-driver`/`rustc` `-W help` tables between 1.95 and 1.96 shows the only genuinely new clippy lints are `manual_noop_waker`, `manual_option_zip`, and `manual_pop_if` — all warn-by-default, so already enforced under `-D warnings`. The seven new allow-by-default clippy lints that appeared across the wider 1.93..1.96 window are already present in `[workspace.lints.clippy]`. The only new allow-by-default rustc lint is `linker-info`, which suppresses informational linker noise rather than adding strictness.

## Validation

`just validate-local` is green (clippy on 1.96, `cargo +1.93 check` at MSRV, full test suite, format-check).
