### PR TITLE
Auto-emit benchmark session output on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,6 @@ dependencies = [
  "mutants 0.0.4",
  "serde",
  "serde_json",
- "serial_test",
  "static_assertions",
  "tempfile",
 ]

--- a/packages/all_the_time/README.md
+++ b/packages/all_the_time/README.md
@@ -27,11 +27,11 @@ fn main() {
         }
     } // Total time measured once and divided by iteration count for mean
 
-    session.print_to_stdout();
-
-    // Also emit machine-readable JSON files (one per operation) into the Cargo
-    // target directory: target/all_the_time/<operation>.json
-    session.write_to_target();
+    // When `session` is dropped it prints a human-readable summary to stdout and
+    // writes machine-readable JSON files (one per operation) into the Cargo
+    // target directory: target/all_the_time/<operation>.json.
+    //
+    // Use `Session::new().no_stdout()` or `.no_file()` to suppress either output.
 }
 ```
 

--- a/packages/all_the_time/benches/all_the_time_example.rs
+++ b/packages/all_the_time/benches/all_the_time_example.rs
@@ -87,7 +87,9 @@ fn entrypoint(c: &mut Criterion) {
     });
 
     group.finish();
-    cpu_time.print_to_stdout();
+
+    // `cpu_time` prints its summary and writes JSON to the Cargo target
+    // directory when it is dropped at the end of this function.
 }
 
 criterion_group!(benches, entrypoint);

--- a/packages/all_the_time/benches/all_the_time_tracking_overhead.rs
+++ b/packages/all_the_time/benches/all_the_time_tracking_overhead.rs
@@ -30,7 +30,9 @@ fn entrypoint(c: &mut Criterion) {
 
     // all_the_time overhead measurements
     {
-        let time_session = Session::new();
+        // This bench measures tracking overhead itself, so the session suppresses
+        // its own stdout and file output on drop.
+        let time_session = Session::new().no_stdout().no_file();
 
         let thread_op = time_session.operation("empty_thread_span");
         group.bench_function("thread_span_empty", |b| {

--- a/packages/all_the_time/examples/all_the_time_basic.rs
+++ b/packages/all_the_time/examples/all_the_time_basic.rs
@@ -88,7 +88,7 @@ fn main() {
         }
     }
 
-    session.print_to_stdout();
     println!();
-    println!("Session automatically cleaned up when dropped.");
+    println!("When the session is dropped, its results are printed to stdout and");
+    println!("written to target/all_the_time/ as machine-readable JSON.");
 }

--- a/packages/all_the_time/examples/all_the_time_basic.rs
+++ b/packages/all_the_time/examples/all_the_time_basic.rs
@@ -88,7 +88,11 @@ fn main() {
         }
     }
 
+    // Dropping the session prints its results to stdout and writes the JSON
+    // output files.
+    drop(session);
+
     println!();
-    println!("When the session is dropped, its results are printed to stdout and");
-    println!("written to target/all_the_time/ as machine-readable JSON.");
+    println!("The session's results were printed above and written to");
+    println!("target/all_the_time/ as machine-readable JSON.");
 }

--- a/packages/all_the_time/examples/all_the_time_batching_overhead.rs
+++ b/packages/all_the_time/examples/all_the_time_batching_overhead.rs
@@ -12,53 +12,59 @@ fn main() {
     println!("=== processor time Batching Overhead Demonstration ===");
     println!();
 
-    let session = Session::new();
+    // The session is dropped at the end of this scope, printing its recorded
+    // processor-time statistics before the wall-clock comparison below.
+    let (unbatched_wall_time, batched_wall_time) = {
+        let session = Session::new();
 
-    // Test: Many individual measurements (high overhead)
-    println!("Testing unbatched measurements (1000 individual spans)...");
+        // Test: Many individual measurements (high overhead)
+        println!("Testing unbatched measurements (1000 individual spans)...");
 
-    let start_wall_time = Instant::now();
-    let unbatched_op = session.operation("unbatched_measurements");
+        let start_wall_time = Instant::now();
+        let unbatched_op = session.operation("unbatched_measurements");
 
-    for _ in 0..1000 {
-        let _span = unbatched_op.measure_thread();
-        // Simple operation
-        black_box(42_u64.wrapping_mul(73));
-    }
-
-    let unbatched_wall_time = start_wall_time.elapsed();
-
-    // Test: Single batched measurement (low overhead)
-    println!("Testing batched measurements (1 span covering 1000 iterations)...");
-
-    let start_wall_time = Instant::now();
-    let batched_op = session.operation("batched_measurements");
-
-    {
-        let _span = batched_op.measure_thread().iterations(1000);
         for _ in 0..1000 {
-            // Same simple operation
+            let _span = unbatched_op.measure_thread();
+            // Simple operation
             black_box(42_u64.wrapping_mul(73));
         }
-    }
 
-    let batched_wall_time = start_wall_time.elapsed();
+        let unbatched_wall_time = start_wall_time.elapsed();
 
-    // Test: More substantial work for comparison
-    let substantial_op = session.operation("substantial_work");
+        // Test: Single batched measurement (low overhead)
+        println!("Testing batched measurements (1 span covering 1000 iterations)...");
 
-    {
-        let _span = substantial_op.measure_thread().iterations(5);
-        for _ in 0..5 {
-            let mut sum = 0_u64;
-            for i in 0..50000_u64 {
-                sum = sum.wrapping_add(i.wrapping_mul(i).wrapping_add(i));
+        let start_wall_time = Instant::now();
+        let batched_op = session.operation("batched_measurements");
+
+        {
+            let _span = batched_op.measure_thread().iterations(1000);
+            for _ in 0..1000 {
+                // Same simple operation
+                black_box(42_u64.wrapping_mul(73));
             }
-            black_box(sum);
         }
-    }
 
-    println!();
+        let batched_wall_time = start_wall_time.elapsed();
+
+        // Test: More substantial work for comparison
+        let substantial_op = session.operation("substantial_work");
+
+        {
+            let _span = substantial_op.measure_thread().iterations(5);
+            for _ in 0..5 {
+                let mut sum = 0_u64;
+                for i in 0..50000_u64 {
+                    sum = sum.wrapping_add(i.wrapping_mul(i).wrapping_add(i));
+                }
+                black_box(sum);
+            }
+        }
+
+        println!();
+
+        (unbatched_wall_time, batched_wall_time)
+    };
 
     println!("Wall clock times (includes measurement overhead):");
     println!("  Unbatched approach: {unbatched_wall_time:?}");

--- a/packages/all_the_time/examples/all_the_time_batching_overhead.rs
+++ b/packages/all_the_time/examples/all_the_time_batching_overhead.rs
@@ -59,8 +59,6 @@ fn main() {
     }
 
     println!();
-    session.print_to_stdout();
-    println!();
 
     println!("Wall clock times (includes measurement overhead):");
     println!("  Unbatched approach: {unbatched_wall_time:?}");

--- a/packages/all_the_time/examples/all_the_time_measurement_types.rs
+++ b/packages/all_the_time/examples/all_the_time_measurement_types.rs
@@ -55,10 +55,14 @@ fn main() {
     println!("=== Processor Time Measurement Types Example ===");
     println!();
 
-    let session = Session::new();
+    // The session is dropped at the end of this scope, which prints the recorded
+    // statistics and writes the JSON output files before the note below.
+    {
+        let session = Session::new();
 
-    measure_thread_time(&session);
-    measure_process_time(&session);
+        measure_thread_time(&session);
+        measure_process_time(&session);
+    }
 
     println!();
     println!("Note: measure_thread should show much lower times than measure_process.");

--- a/packages/all_the_time/examples/all_the_time_measurement_types.rs
+++ b/packages/all_the_time/examples/all_the_time_measurement_types.rs
@@ -60,8 +60,6 @@ fn main() {
     measure_thread_time(&session);
     measure_process_time(&session);
 
-    session.print_to_stdout();
-
     println!();
     println!("Note: measure_thread should show much lower times than measure_process.");
     println!("This is because measure_thread only measures the main thread's processor time,");

--- a/packages/all_the_time/examples/all_the_time_readme.rs
+++ b/packages/all_the_time/examples/all_the_time_readme.rs
@@ -33,9 +33,7 @@ fn main() {
         }
     } // Total time measured once and divided by iteration count for mean
 
-    session.print_to_stdout();
-
-    // Also emit machine-readable JSON files (one per operation) into the Cargo
+    // When `session` is dropped it prints a human-readable summary to stdout and
+    // writes machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/all_the_time/<operation>.json
-    session.write_to_target();
 }

--- a/packages/all_the_time/examples/all_the_time_threaded_reports.rs
+++ b/packages/all_the_time/examples/all_the_time_threaded_reports.rs
@@ -64,7 +64,9 @@ fn main() {
 fn worker_thread(thread_name: &str) -> Report {
     println!("🧵 {thread_name} starting work...");
 
-    let session = Session::new();
+    // The caller prints the returned report, so this session opts out of
+    // emitting on drop to avoid duplicate output.
+    let session = Session::new().no_stdout().no_file();
 
     // Each thread does some "common work" that will be merged
     // Using measure_thread() to track per-thread CPU time (avoids double-counting in multithreaded scenarios)

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -22,6 +22,7 @@
 //!
 //! # fn main() {
 //! let session = Session::new();
+//! # let session = session.no_stdout().no_file();
 //!
 //! {
 //!     let batch_op = session.operation("batch_work");
@@ -32,33 +33,33 @@
 //!     }
 //! }
 //!
-//! // Output statistics of all operations to console
-//! session.print_to_stdout();
+//! // When `session` is dropped, the recorded statistics are printed to stdout
+//! // and written to the Cargo target directory. No explicit call is required.
 //! # }
 //! ```
 //!
 //! # Machine-readable output
 //!
-//! In addition to printing to the console, you can emit machine-readable JSON
-//! files (one per operation) into the Cargo target directory for later
-//! analysis. Files are written to `target/all_the_time/<operation>.json`, with
-//! operation names sanitized to be filesystem-safe:
+//! Dropping a [`Session`] writes machine-readable JSON files (one per operation)
+//! into the Cargo target directory at `target/all_the_time/<operation>.json`,
+//! with operation names sanitized to be filesystem-safe. A human-readable
+//! summary is also printed to stdout.
 //!
-//! ```no_run
+//! These outputs are produced automatically, so a typical benchmark only needs
+//! to create a session and record work. Either output can be suppressed:
+//!
+//! ```rust
 //! use all_the_time::Session;
 //!
 //! # fn main() {
-//! let session = Session::new();
+//! // Print to stdout but do not write JSON files.
+//! let session = Session::new().no_file();
 //!
-//! {
-//!     let batch_op = session.operation("batch_work");
-//!     let _span = batch_op.measure_thread().iterations(1000);
-//!     for _ in 0..1000 {
-//!         std::hint::black_box(42 * 2);
-//!     }
-//! }
+//! // Or write JSON files but do not print to stdout.
+//! let quiet_session = Session::new().no_stdout();
 //!
-//! session.write_to_target();
+//! // Or suppress both.
+//! let silent_session = Session::new().no_stdout().no_file();
 //! # }
 //! ```
 //!
@@ -71,6 +72,7 @@
 //!
 //! # fn main() {
 //! let session = Session::new();
+//! # let session = session.no_stdout().no_file();
 //!
 //! // Track thread processor time
 //! {
@@ -110,6 +112,7 @@
 //!
 //! # fn main() {
 //! let session = Session::new();
+//! # let session = session.no_stdout().no_file();
 //! let operation = session.operation("work");
 //! let _span = operation.measure_thread();
 //! // Some work happens here

--- a/packages/all_the_time/src/operation.rs
+++ b/packages/all_the_time/src/operation.rs
@@ -22,6 +22,7 @@ use crate::{ERR_POISONED_LOCK, OperationMetrics, ProcessSpan, ThreadSpan};
 /// use all_the_time::Session;
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let operation = session.operation("processor_intensive_work");
 ///
 /// // Simulate multiple operations - note explicit iteration count
@@ -85,6 +86,7 @@ impl Operation {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("thread_work");
     /// {
     ///     let _span = operation.measure_thread();
@@ -101,6 +103,7 @@ impl Operation {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_ops");
     /// {
     ///     let _span = operation.measure_thread().iterations(10000);
@@ -128,6 +131,7 @@ impl Operation {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("process_work");
     /// {
     ///     let _span = operation.measure_process();
@@ -144,6 +148,7 @@ impl Operation {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_process().iterations(1000);

--- a/packages/all_the_time/src/process_span.rs
+++ b/packages/all_the_time/src/process_span.rs
@@ -21,6 +21,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics};
 /// use all_the_time::Session;
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let operation = session.operation("test");
 /// {
 ///     let _span = operation.measure_process();
@@ -38,6 +39,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics};
 /// use all_the_time::Session;
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let operation = session.operation("benchmark");
 /// {
 ///     let _span = operation.measure_process().iterations(1000);
@@ -98,6 +100,7 @@ impl ProcessSpan {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_process().iterations(1000);
@@ -113,6 +116,7 @@ impl ProcessSpan {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("dynamic_work");
     /// {
     ///     let span = operation.measure_process();

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 ///
 /// # fn main() {
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let operation = session.operation("test_work");
 /// let _span = operation.measure_thread().iterations(100);
 /// for _ in 0..100 {
@@ -38,7 +39,9 @@ use std::time::Duration;
 /// # fn main() {
 /// // Create two separate sessions
 /// let session1 = Session::new();
+/// # let session1 = session1.no_stdout().no_file();
 /// let session2 = Session::new();
+/// # let session2 = session2.no_stdout().no_file();
 ///
 /// // Record some work in each
 /// let op1 = session1.operation("work");
@@ -115,7 +118,9 @@ impl Report {
     ///
     /// # fn main() {
     /// let session1 = Session::new();
+    /// # let session1 = session1.no_stdout().no_file();
     /// let session2 = Session::new();
+    /// # let session2 = session2.no_stdout().no_file();
     ///
     /// // Both sessions record the same operation name
     /// let op1 = session1.operation("common_work");
@@ -196,6 +201,7 @@ impl Report {
     ///
     /// # fn main() {
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("test_work");
     /// let _span = operation.measure_thread().iterations(100);
     /// for _ in 0..100 {

--- a/packages/all_the_time/src/session.rs
+++ b/packages/all_the_time/src/session.rs
@@ -10,12 +10,26 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics, Report};
 /// This type serves as a container for tracking operations and provides
 /// methods to analyze processor time usage patterns across different operations.
 ///
+/// # Output on drop
+///
+/// When a session is dropped it automatically emits its results:
+///
+/// * a human-readable summary is printed to stdout, and
+/// * machine-readable JSON files (one per operation) are written into the Cargo
+///   target directory at `target/all_the_time/<operation>.json`.
+///
+/// A session that recorded no measurable work emits nothing, so a "list
+/// available benchmarks" probe run leaves no output behind. Either output can be
+/// suppressed with [`no_stdout()`](Self::no_stdout) and
+/// [`no_file()`](Self::no_file).
+///
 /// # Examples
 ///
 /// ```
 /// use all_the_time::Session;
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let processor_op = session.operation("processor_intensive_work");
 ///
 /// for _ in 0..3 {
@@ -27,16 +41,21 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics, Report};
 ///     }
 /// }
 ///
-/// // Output statistics of all operations to console.
-/// // Using print_to_stdout() here is important in benchmarks because it will
-/// // print nothing if no spans were recorded, not even an empty line, which can
-/// // be functionally critical for benchmark harness behavior.
-/// session.print_to_stdout();
+/// // When `session` is dropped, the recorded statistics are printed to stdout
+/// // and written to `target/all_the_time/` as machine-readable JSON.
 /// ```
+///
+/// # Panics
+///
+/// Dropping a session panics if writing the JSON output files fails, since a
+/// benchmark that cannot persist its results is not useful. To avoid masking an
+/// in-flight panic, no output is emitted while the thread is already panicking.
 #[derive(Debug)]
 pub struct Session {
     operations: Arc<Mutex<HashMap<String, Arc<Mutex<OperationMetrics>>>>>,
     platform: PlatformFacade,
+    emit_stdout: bool,
+    emit_file: bool,
 }
 
 impl Session {
@@ -48,8 +67,8 @@ impl Session {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
-    /// // Processor time tracking is enabled
-    /// // Session will disable tracking when dropped
+    /// // Processor time tracking is enabled. When the session is dropped, its
+    /// // results are printed to stdout and written to the Cargo target directory.
     /// ```
     #[expect(
         clippy::new_without_default,
@@ -60,19 +79,47 @@ impl Session {
         Self {
             operations: Arc::new(Mutex::new(HashMap::new())),
             platform: PlatformFacade::real(),
+            emit_stdout: true,
+            emit_file: true,
         }
     }
 
     /// Creates a new processor time tracking session with a specific platform.
     ///
     /// This method is primarily used for testing purposes to inject a fake platform
-    /// that does not rely on actual system calls.
+    /// that does not rely on actual system calls. Automatic output on drop is
+    /// disabled so that tests do not print to stdout or write to the target
+    /// directory unless they opt back in.
     #[cfg(test)]
     pub(crate) fn with_platform(platform: PlatformFacade) -> Self {
         Self {
             operations: Arc::new(Mutex::new(HashMap::new())),
             platform,
+            emit_stdout: false,
+            emit_file: false,
         }
+    }
+
+    /// Disables printing a human-readable summary to stdout when the session is
+    /// dropped.
+    ///
+    /// JSON files are still written to the Cargo target directory unless
+    /// [`no_file()`](Self::no_file) is also used.
+    #[must_use]
+    pub fn no_stdout(mut self) -> Self {
+        self.emit_stdout = false;
+        self
+    }
+
+    /// Disables writing machine-readable JSON files to the Cargo target
+    /// directory when the session is dropped.
+    ///
+    /// A human-readable summary is still printed to stdout unless
+    /// [`no_stdout()`](Self::no_stdout) is also used.
+    #[must_use]
+    pub fn no_file(mut self) -> Self {
+        self.emit_file = false;
+        self
     }
 
     /// Creates or retrieves an operation with the given name.
@@ -87,6 +134,7 @@ impl Session {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let processor_op = session.operation("processor_operations");
     ///
     /// for _ in 0..3 {
@@ -125,6 +173,7 @@ impl Session {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("test_work");
     /// let _span = operation.measure_thread();
     /// // Work happens here
@@ -152,17 +201,6 @@ impl Session {
         Report::from_operation_data(&operations_snapshot)
     }
 
-    /// Prints the processor time statistics of all operations to stdout.
-    ///
-    /// This is a convenience method equivalent to `self.to_report().print_to_stdout()`.
-    /// Prints nothing if no spans were captured. This may indicate that the session
-    /// was part of a "list available benchmarks" probe run instead of some real activity,
-    /// in which case printing anything might violate the output protocol the tool is speaking.
-    #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
-    pub fn print_to_stdout(&self) {
-        self.to_report().print_to_stdout();
-    }
-
     /// Whether there is any recorded activity in this session.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -171,6 +209,36 @@ impl Session {
             || operations
                 .values()
                 .all(|data| data.lock().expect(ERR_POISONED_LOCK).total_iterations == 0)
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        // Emitting output while the thread is already unwinding would risk a
+        // double panic (which aborts the process) and would obscure the original
+        // failure. See docs/error-handling.md.
+        if std::thread::panicking() {
+            return;
+        }
+
+        if !self.emit_stdout && !self.emit_file {
+            return;
+        }
+
+        // A session that recorded no measurable work emits nothing. Returning
+        // early also avoids resolving the Cargo target directory (which may shell
+        // out to `cargo metadata`) during "list available benchmarks" probe runs.
+        if self.is_empty() {
+            return;
+        }
+
+        let report = self.to_report();
+        if self.emit_stdout {
+            report.print_to_stdout();
+        }
+        if self.emit_file {
+            report.write_to_target();
+        }
     }
 }
 

--- a/packages/all_the_time/src/session.rs
+++ b/packages/all_the_time/src/session.rs
@@ -221,7 +221,9 @@ impl Drop for Session {
             return;
         }
 
-        if !self.emit_stdout && !self.emit_file {
+        // With neither output enabled there is nothing to emit, so skip building
+        // a report entirely.
+        if !(self.emit_stdout || self.emit_file) {
             return;
         }
 

--- a/packages/all_the_time/src/session.rs
+++ b/packages/all_the_time/src/session.rs
@@ -89,7 +89,7 @@ impl Session {
     /// This method is primarily used for testing purposes to inject a fake platform
     /// that does not rely on actual system calls. Automatic output on drop is
     /// disabled so that tests do not print to stdout or write to the target
-    /// directory unless they opt back in.
+    /// directory.
     #[cfg(test)]
     pub(crate) fn with_platform(platform: PlatformFacade) -> Self {
         Self {

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use serde::Serialize;
 
-use crate::{Report, Session};
+use crate::Report;
 
 /// Subdirectory of the Cargo target directory that receives the JSON files.
 const OUTPUT_SUBDIRECTORY: &str = "all_the_time";
@@ -43,24 +43,7 @@ impl Report {
     ///
     /// Also panics if two operation names sanitize to the same file name, since
     /// writing both would silently discard one operation's results.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use all_the_time::Session;
-    ///
-    /// let session = Session::new();
-    /// {
-    ///     let operation = session.operation("work");
-    ///     let _span = operation.measure_thread().iterations(100);
-    ///     for _ in 0..100 {
-    ///         std::hint::black_box(42 * 2);
-    ///     }
-    /// }
-    ///
-    /// session.to_report().write_to_target();
-    /// ```
-    pub fn write_to_target(&self) {
+    pub(crate) fn write_to_target(&self) {
         let target =
             folo_utils::cargo_target_directory().unwrap_or_else(|| PathBuf::from("target"));
         self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY));
@@ -83,25 +66,7 @@ impl Report {
     ///
     /// Also panics if two operation names sanitize to the same file name, since
     /// writing both would silently discard one operation's results.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use all_the_time::Session;
-    ///
-    /// let session = Session::new();
-    /// {
-    ///     let operation = session.operation("work");
-    ///     let _span = operation.measure_thread().iterations(100);
-    ///     for _ in 0..100 {
-    ///         std::hint::black_box(42 * 2);
-    ///     }
-    /// }
-    ///
-    /// let directory = std::env::temp_dir().join("all_the_time_example");
-    /// session.to_report().write_to_directory(&directory);
-    /// ```
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
+    pub(crate) fn write_to_directory(&self, directory: impl AsRef<Path>) {
         let directory = directory.as_ref();
 
         // Build every output up front, detecting sanitized-name collisions before
@@ -160,37 +125,6 @@ impl Report {
     }
 }
 
-impl Session {
-    /// Writes machine-readable JSON statistics into the Cargo target directory.
-    ///
-    /// This is a convenience method equivalent to
-    /// `self.to_report().write_to_target()`. See
-    /// [`Report::write_to_target`](crate::Report::write_to_target) for details.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the output directory cannot be created or a file cannot be
-    /// written.
-    pub fn write_to_target(&self) {
-        self.to_report().write_to_target();
-    }
-
-    /// Writes machine-readable JSON statistics into the given directory.
-    ///
-    /// This is a convenience method equivalent to
-    /// `self.to_report().write_to_directory(directory)`. See
-    /// [`Report::write_to_directory`](crate::Report::write_to_directory) for
-    /// details.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the output directory cannot be created or a file cannot be
-    /// written.
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
-        self.to_report().write_to_directory(directory);
-    }
-}
-
 /// Converts a [`Duration`] to whole nanoseconds, saturating at `u64::MAX`.
 fn duration_as_nanos(duration: Duration) -> u64 {
     u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
@@ -246,7 +180,7 @@ mod tests {
         let session = session_with_recorded_work("read_cell");
         let directory = tempfile::tempdir().unwrap();
 
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         let file = directory.path().join("read_cell.json");
         let value = read_json(&file);
@@ -279,7 +213,7 @@ mod tests {
         let session = session_with_recorded_work("group/case name");
         let directory = tempfile::tempdir().unwrap();
 
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
@@ -301,7 +235,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("nested");
 
-        session.write_to_directory(&target);
+        session.to_report().write_to_directory(&target);
 
         // Nothing is written, so the directory is not even created.
         assert!(!target.exists());
@@ -325,7 +259,7 @@ mod tests {
         let _unmeasured = session.operation("unmeasured");
 
         let directory = tempfile::tempdir().unwrap();
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         assert!(directory.path().join("measured.json").exists());
         assert!(!directory.path().join("unmeasured.json").exists());
@@ -339,7 +273,7 @@ mod tests {
         fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("read_cell");
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         // Parsing succeeds only if the stale, non-JSON contents were replaced.
         let value = read_json(&file);
@@ -361,7 +295,9 @@ mod tests {
         let blocker = directory.path().join("blocker");
         fs::write(&blocker, "not a directory").unwrap();
 
-        session.write_to_directory(blocker.join("nested"));
+        session
+            .to_report()
+            .write_to_directory(blocker.join("nested"));
     }
 
     #[test]
@@ -374,7 +310,7 @@ mod tests {
         // A directory occupying the output file's path makes the file write fail.
         fs::create_dir_all(directory.path().join("read_cell.json")).unwrap();
 
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
     }
 
     #[test]
@@ -395,6 +331,8 @@ mod tests {
 
         // The collision is detected before anything is written, so this path is
         // never created.
-        session.write_to_directory("collision_is_detected_before_writing");
+        session
+            .to_report()
+            .write_to_directory("collision_is_detected_before_writing");
     }
 }

--- a/packages/all_the_time/src/thread_span.rs
+++ b/packages/all_the_time/src/thread_span.rs
@@ -17,6 +17,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics};
 /// use all_the_time::Session;
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let operation = session.operation("test");
 /// {
 ///     let _span = operation.measure_thread();
@@ -34,6 +35,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics};
 /// use all_the_time::Session;
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let operation = session.operation("test");
 /// {
 ///     let _span = operation.measure_thread().iterations(1000);
@@ -87,6 +89,7 @@ impl ThreadSpan {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_thread().iterations(1000);
@@ -102,6 +105,7 @@ impl ThreadSpan {
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("dynamic_work");
     /// {
     ///     let span = operation.measure_thread();

--- a/packages/all_the_time/tests/all_the_time_integration.rs
+++ b/packages/all_the_time/tests/all_the_time_integration.rs
@@ -51,7 +51,7 @@ fn perform_measurable_cpu_work() -> u64 {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri cannot use the real operating system APIs.
 fn real_platform_thread_span_measures_nonzero_time() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     let operation = session.operation("thread_work");
 
     // Perform significant CPU work and measure it with a thread span
@@ -89,7 +89,7 @@ fn real_platform_thread_span_measures_nonzero_time() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri cannot use the real operating system APIs.
 fn real_platform_process_span_measures_nonzero_time() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     let operation = session.operation("process_work");
 
     // Perform significant CPU work and measure it with a process span
@@ -127,7 +127,7 @@ fn real_platform_process_span_measures_nonzero_time() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri cannot use the real operating system APIs.
 fn real_platform_session_not_empty_after_work() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     // Session should start empty
     assert!(session.is_empty());

--- a/packages/all_the_time/tests/all_the_time_report_api.rs
+++ b/packages/all_the_time/tests/all_the_time_report_api.rs
@@ -7,7 +7,7 @@ use all_the_time::Session as TimeSession;
 #[test]
 #[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
 fn all_the_time_report_api() {
-    let session = TimeSession::new();
+    let session = TimeSession::new().no_stdout().no_file();
 
     {
         let op = session.operation("test_work");

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -6,6 +6,7 @@
 
 use std::fs::{read_to_string, remove_file};
 use std::hint::black_box;
+use std::io;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
@@ -28,8 +29,12 @@ fn read_json(path: &Path) -> Value {
 
 /// Removes `path` if it exists, leaving a clean slate for an assertion.
 fn remove_if_present(path: &Path) {
-    if path.exists() {
-        remove_file(path).unwrap();
+    // Attempt the removal unconditionally and tolerate a missing file rather than
+    // checking `exists()` first, which would race with parallel test processes.
+    match remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => panic!("failed to remove {}: {error}", path.display()),
     }
 }
 

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -88,6 +88,36 @@ fn dropping_session_writes_json_into_cargo_target_directory() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn no_stdout_session_still_writes_json() {
+    const OPERATION: &str = "all_the_time_no_stdout_writes_probe";
+
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
+
+    {
+        // Suppressing stdout must not suppress the JSON file output.
+        let session = Session::new().no_stdout();
+        record_work(&session, OPERATION);
+    }
+
+    assert!(
+        expected.exists(),
+        "no_stdout() should still write {}",
+        expected.display()
+    );
+
+    let value = read_json(&expected);
+    assert_eq!(
+        value.get("operation").and_then(Value::as_str),
+        Some(OPERATION)
+    );
+
+    // Avoid polluting the shared target directory for later runs.
+    remove_file(&expected).unwrap();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
 fn no_file_suppresses_json_output() {
     const OPERATION: &str = "all_the_time_no_file_probe";
 

--- a/packages/all_the_time/tests/all_the_time_target_output.rs
+++ b/packages/all_the_time/tests/all_the_time_target_output.rs
@@ -1,58 +1,79 @@
-//! Integration tests for writing machine-readable JSON output to disk.
+//! Integration tests for the machine-readable JSON output written on drop.
+//!
+//! These exercise the public behavior end to end: dropping a [`Session`] writes
+//! one JSON file per operation into the Cargo target directory unless that output
+//! is suppressed.
 
-use std::fs;
+use std::fs::{read_to_string, remove_file};
 use std::hint::black_box;
-use std::path::Path;
+use std::panic::{self, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
 
 use all_the_time::Session;
 use serde_json::Value;
 
+const ITERATIONS: u64 = 100;
+
+/// Resolves the JSON output path that dropping a session writes for `operation`.
+fn output_path(operation: &str) -> PathBuf {
+    folo_utils::cargo_target_directory()
+        .unwrap_or_else(|| "target".into())
+        .join("all_the_time")
+        .join(format!("{operation}.json"))
+}
+
 fn read_json(path: &Path) -> Value {
-    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    serde_json::from_str(&read_to_string(path).unwrap()).unwrap()
+}
+
+/// Removes `path` if it exists, leaving a clean slate for an assertion.
+fn remove_if_present(path: &Path) {
+    if path.exists() {
+        remove_file(path).unwrap();
+    }
+}
+
+/// Records a fixed amount of processor-time work under `operation` in `session`.
+fn record_work(session: &Session, operation: &str) {
+    let operation = session.operation(operation);
+    let _span = operation.measure_thread().iterations(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        black_box(black_box(21_u64).wrapping_mul(black_box(2)));
+    }
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
-fn writes_json_files_for_each_operation() {
-    let session = Session::new();
+fn dropping_session_writes_json_into_cargo_target_directory() {
+    // A distinctive name avoids colliding with output from other operations in
+    // the shared Cargo target directory.
+    const OPERATION: &str = "all_the_time_drop_writes_probe";
+
+    let expected = output_path(OPERATION);
+    // Start from a clean slate so the assertion proves the drop wrote the file.
+    remove_if_present(&expected);
 
     {
-        let operation = session.operation("first_operation");
-        let _span = operation.measure_thread().iterations(100);
-        for _ in 0..100 {
-            black_box(black_box(21_u64) * black_box(2));
-        }
+        // Both stdout and file output are enabled; the harness captures the
+        // printed summary while the assertion below checks the JSON file.
+        let session = Session::new();
+        record_work(&session, OPERATION);
     }
 
-    {
-        let operation = session.operation("second_operation");
-        let _span = operation.measure_thread().iterations(50);
-        for _ in 0..50 {
-            black_box(black_box(3_u64) + black_box(4));
-        }
-    }
+    assert!(
+        expected.exists(),
+        "dropping the session should create {}",
+        expected.display()
+    );
 
-    let directory = tempfile::tempdir().unwrap();
-    session.write_to_directory(directory.path());
-
-    let first = directory.path().join("first_operation.json");
-    let second = directory.path().join("second_operation.json");
-
-    assert!(first.exists(), "expected JSON file for first operation");
-    assert!(second.exists(), "expected JSON file for second operation");
-
-    // Exactly one file per measured operation, and nothing more.
-    let written = fs::read_dir(directory.path()).unwrap().count();
-    assert_eq!(written, 2, "expected one JSON file per operation");
-
-    let value = read_json(&first);
+    let value = read_json(&expected);
     assert_eq!(
         value.get("operation").and_then(Value::as_str),
-        Some("first_operation")
+        Some(OPERATION)
     );
     assert_eq!(
         value.get("total_iterations").and_then(Value::as_u64),
-        Some(100)
+        Some(ITERATIONS)
     );
     assert!(
         value
@@ -60,130 +81,73 @@ fn writes_json_files_for_each_operation() {
             .and_then(Value::as_u64)
             .is_some()
     );
-    assert!(
-        value
-            .get("mean_processor_time_nanos")
-            .and_then(Value::as_u64)
-            .is_some()
-    );
-}
-
-#[test]
-#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
-fn report_and_session_write_equivalently() {
-    let session = Session::new();
-
-    {
-        let operation = session.operation("shared_name");
-        let _span = operation.measure_thread().iterations(10);
-        for _ in 0..10 {
-            black_box(black_box(1_u64) + black_box(1));
-        }
-    }
-
-    let from_session = tempfile::tempdir().unwrap();
-    let from_report = tempfile::tempdir().unwrap();
-
-    session.write_to_directory(from_session.path());
-    session.to_report().write_to_directory(from_report.path());
-
-    let session_file = from_session.path().join("shared_name.json");
-    let report_file = from_report.path().join("shared_name.json");
-
-    assert!(session_file.exists());
-    assert!(report_file.exists());
-
-    // Both entry points serialize the same recorded data, so the output is identical.
-    let session_contents = fs::read_to_string(&session_file).unwrap();
-    let report_contents = fs::read_to_string(&report_file).unwrap();
-    assert_eq!(session_contents, report_contents);
-    assert_eq!(
-        read_json(&session_file)
-            .get("total_iterations")
-            .and_then(Value::as_u64),
-        Some(10)
-    );
-}
-
-#[test]
-#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
-fn empty_session_writes_nothing() {
-    let session = Session::new();
-    let _operation = session.operation("never_measured");
-
-    let directory = tempfile::tempdir().unwrap();
-    let target = directory.path().join("output");
-
-    session.write_to_directory(&target);
-
-    assert!(!target.exists(), "no directory should be created");
-}
-
-#[test]
-#[cfg_attr(miri, ignore)] // Resolves the Cargo target directory and writes files, neither supported under Miri.
-fn write_to_target_writes_into_cargo_target_directory() {
-    // A distinctive name avoids colliding with output from other operations in
-    // the shared Cargo target directory.
-    const OPERATION: &str = "all_the_time_write_to_target_probe";
-
-    let session = Session::new();
-    {
-        let operation = session.operation(OPERATION);
-        let _span = operation.measure_thread().iterations(8);
-        for _ in 0..8 {
-            black_box(black_box(2_u64) * black_box(3));
-        }
-    }
-
-    let expected = folo_utils::cargo_target_directory()
-        .unwrap_or_else(|| "target".into())
-        .join("all_the_time")
-        .join(format!("{OPERATION}.json"));
-
-    // Start from a clean slate so the assertion proves this call wrote the file.
-    if expected.exists() {
-        fs::remove_file(&expected).unwrap();
-    }
-
-    session.write_to_target();
-
-    assert!(
-        expected.exists(),
-        "write_to_target should create {}",
-        expected.display()
-    );
-
-    let value = read_json(&expected);
-    assert_eq!(
-        value.get("operation").and_then(Value::as_str),
-        Some("all_the_time_write_to_target_probe")
-    );
-    assert_eq!(
-        value.get("total_iterations").and_then(Value::as_u64),
-        Some(8)
-    );
 
     // Avoid polluting the shared target directory for later runs.
-    fs::remove_file(&expected).unwrap();
+    remove_file(&expected).unwrap();
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Uses the real platform, which is not supported under Miri.
-#[should_panic(expected = "after sanitization")]
-fn panics_when_operation_names_collide_after_sanitization() {
-    let session = Session::new();
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn no_file_suppresses_json_output() {
+    const OPERATION: &str = "all_the_time_no_file_probe";
 
-    // Both names sanitize to the same file name, which must not silently
-    // overwrite one operation's results.
-    for name in ["group/case", "group_case"] {
-        let operation = session.operation(name);
-        let _span = operation.measure_thread().iterations(4);
-        for _ in 0..4 {
-            black_box(black_box(2_u64) * black_box(3));
-        }
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
+
+    {
+        let session = Session::new().no_stdout().no_file();
+        record_work(&session, OPERATION);
     }
 
-    // The collision is detected before anything is written, so this path is
-    // never created.
-    session.write_to_directory("collision_is_detected_before_writing");
+    assert!(
+        !expected.exists(),
+        "no_file() should suppress writing {}",
+        expected.display()
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn empty_session_writes_nothing_on_drop() {
+    const OPERATION: &str = "all_the_time_empty_drop_probe";
+
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
+
+    {
+        // File output stays enabled, but the session records no measurable work,
+        // so dropping it must still write nothing.
+        let session = Session::new().no_stdout();
+        let _operation = session.operation(OPERATION);
+    }
+
+    assert!(
+        !expected.exists(),
+        "an empty session should not write {}",
+        expected.display()
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the real platform and the filesystem, neither supported under Miri.
+fn panicking_thread_does_not_write_json() {
+    const OPERATION: &str = "all_the_time_panic_guard_probe";
+
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
+
+    // The session is dropped while the thread unwinds from the panic, so its
+    // output must be suppressed to avoid masking the original failure.
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        let session = Session::new().no_stdout();
+        record_work(&session, OPERATION);
+        panic!("intentional panic to exercise the drop guard");
+    }));
+
+    assert!(result.is_err(), "the closure should have panicked");
+    assert!(
+        !expected.exists(),
+        "a panicking thread should not write {}",
+        expected.display()
+    );
 }

--- a/packages/all_the_time/tests/all_the_time_thread_safety.rs
+++ b/packages/all_the_time/tests/all_the_time_thread_safety.rs
@@ -10,7 +10,7 @@ use all_the_time::{Report, Session};
 #[test]
 #[cfg_attr(miri, ignore)] // The real platform functionality cannot be accessed under Miri.
 fn session_can_be_moved_between_threads() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     // Move session to another thread
     let handle = thread::spawn(move || {
@@ -36,7 +36,7 @@ fn session_can_be_moved_between_threads() {
 #[test]
 #[cfg_attr(miri, ignore)] // The real platform functionality cannot be accessed under Miri.
 fn operation_can_be_moved_between_threads() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     let operation = session.operation("test_op");
 
     // Move operation to another thread
@@ -60,7 +60,7 @@ fn operation_can_be_moved_between_threads() {
 #[test]
 #[cfg_attr(miri, ignore)] // The real platform functionality cannot be accessed under Miri.
 fn report_can_be_shared_across_threads() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     {
         let operation = session.operation("shared_work");
         let _span = operation.measure_thread();
@@ -88,8 +88,8 @@ fn report_can_be_shared_across_threads() {
 #[test]
 #[cfg_attr(miri, ignore)] // The real platform functionality cannot be accessed under Miri.
 fn reports_can_be_merged_across_threads() {
-    let session1 = Session::new();
-    let session2 = Session::new();
+    let session1 = Session::new().no_stdout().no_file();
+    let session2 = Session::new().no_stdout().no_file();
 
     // Create reports in different threads
     let handle1 = thread::spawn(move || {

--- a/packages/alloc_tracker/Cargo.toml
+++ b/packages/alloc_tracker/Cargo.toml
@@ -10,10 +10,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[package.metadata.cargo-udeps.ignore]
-# Depends on enabled features and dev-dependencies cannot be optional.
-development = ["serial_test"]
-
 [package.metadata.docs.rs]
 all-features = true
 
@@ -29,7 +25,6 @@ serde_json = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 mutants = { workspace = true }
-serial_test = { workspace = true }
 static_assertions = { workspace = true }
 tempfile = { workspace = true }
 

--- a/packages/alloc_tracker/README.md
+++ b/packages/alloc_tracker/README.md
@@ -21,14 +21,11 @@ fn main() {
         let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
     }
 
-    // Print results
-    session.print_to_stdout();
-
-    // Also emit machine-readable JSON files (one per operation) into the Cargo
-    // target directory: target/alloc_tracker/<operation>.json
-    session.write_to_target();
-
-    // Session automatically cleans up when dropped
+    // When `session` is dropped it prints a human-readable summary to stdout and
+    // writes machine-readable JSON files (one per operation) into the Cargo
+    // target directory: target/alloc_tracker/<operation>.json.
+    //
+    // Use `Session::new().no_stdout()` or `.no_file()` to suppress either output.
 }
 ```
 

--- a/packages/alloc_tracker/benches/alloc_tracker_example.rs
+++ b/packages/alloc_tracker/benches/alloc_tracker_example.rs
@@ -45,7 +45,8 @@ fn entrypoint(c: &mut Criterion) {
 
     group.finish();
 
-    allocs.print_to_stdout();
+    // `allocs` prints its summary and writes JSON to the Cargo target directory
+    // when it is dropped at the end of this function.
 }
 
 criterion_group!(benches, entrypoint);

--- a/packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs
+++ b/packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs
@@ -33,7 +33,9 @@ fn entrypoint(c: &mut Criterion) {
 
     // alloc_tracker overhead measurements
     {
-        let alloc_session = Session::new();
+        // This bench measures tracking overhead itself, so the session suppresses
+        // its own stdout and file output on drop.
+        let alloc_session = Session::new().no_stdout().no_file();
 
         let process_op = alloc_session.operation("empty_process_span");
         group.bench_function("process_span_empty", |b| {

--- a/packages/alloc_tracker/examples/alloc_tracker_basic.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_basic.rs
@@ -52,8 +52,7 @@ fn main() {
         }
     }
 
-    session.print_to_stdout();
-
     println!();
-    println!("Session automatically cleaned up when dropped.");
+    println!("When the session is dropped, its results are printed to stdout and");
+    println!("written to target/alloc_tracker/ as machine-readable JSON.");
 }

--- a/packages/alloc_tracker/examples/alloc_tracker_basic.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_basic.rs
@@ -52,7 +52,11 @@ fn main() {
         }
     }
 
+    // Dropping the session prints its results to stdout and writes the JSON
+    // output files.
+    drop(session);
+
     println!();
-    println!("When the session is dropped, its results are printed to stdout and");
-    println!("written to target/alloc_tracker/ as machine-readable JSON.");
+    println!("The session's results were printed above and written to");
+    println!("target/alloc_tracker/ as machine-readable JSON.");
 }

--- a/packages/alloc_tracker/examples/alloc_tracker_readme.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_readme.rs
@@ -38,14 +38,10 @@ fn main() {
         let _string = String::from("Hello"); // Third allocation
     }
 
-    // Print results - now shows both mean bytes and mean allocation count
-    session.print_to_stdout();
-
-    // Also emit machine-readable JSON files (one per operation) into the Cargo
-    // target directory: target/alloc_tracker/<operation>.json
-    session.write_to_target();
-
-    // Session automatically cleans up when dropped
+    // When `session` is dropped it prints a human-readable summary (mean bytes
+    // and mean allocation count) to stdout and writes machine-readable JSON files
+    // (one per operation) into the Cargo target directory:
+    // target/alloc_tracker/<operation>.json
 
     // Debugging unexpected allocations (only with feature enabled)
     #[cfg(feature = "panic_on_next_alloc")]

--- a/packages/alloc_tracker/examples/alloc_tracker_thread_vs_process.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_thread_vs_process.rs
@@ -57,10 +57,14 @@ fn main() {
     println!("=== Thread vs Process Allocation Tracking ===");
     println!();
 
-    let session = Session::new();
+    // The session is dropped at the end of this scope, which prints the recorded
+    // statistics and writes the JSON output files before the note below.
+    {
+        let session = Session::new();
 
-    track_thread_local_allocations(&session);
-    track_process_wide_allocations(&session);
+        track_thread_local_allocations(&session);
+        track_process_wide_allocations(&session);
+    }
 
     println!();
     println!("Note: measure_thread should show much lower allocation counts than measure_process.");

--- a/packages/alloc_tracker/examples/alloc_tracker_thread_vs_process.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_thread_vs_process.rs
@@ -62,8 +62,6 @@ fn main() {
     track_thread_local_allocations(&session);
     track_process_wide_allocations(&session);
 
-    session.print_to_stdout();
-
     println!();
     println!("Note: measure_thread should show much lower allocation counts than measure_process.");
     println!("This is because measure_thread only measures the main thread's allocations,");

--- a/packages/alloc_tracker/examples/alloc_tracker_threaded_reports.rs
+++ b/packages/alloc_tracker/examples/alloc_tracker_threaded_reports.rs
@@ -60,7 +60,9 @@ fn main() {
 fn worker_thread(thread_name: &str) -> Report {
     println!("🧵 {thread_name} starting work...");
 
-    let session = Session::new();
+    // The caller prints the returned report, so this session opts out of
+    // emitting on drop to avoid duplicate output.
+    let session = Session::new().no_stdout().no_file();
 
     // Each thread does some "common work" that will be merged
     // Using measure_thread() to track per-thread allocation (avoids double-counting in multithreaded scenarios)

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -51,6 +51,7 @@
 //!
 //! fn main() {
 //!     let session = Session::new();
+//! #   let session = session.no_stdout().no_file();
 //!
 //!     // Track a single operation
 //!     {
@@ -59,35 +60,36 @@
 //!         let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
 //!     }
 //!
-//!     // Print results
-//!     session.print_to_stdout();
-//!
-//!     // Session automatically cleans up when dropped
+//!     // When `session` is dropped, the recorded statistics are printed to
+//!     // stdout and written to the Cargo target directory as JSON.
 //! }
 //! ```
 //!
 //! # Machine-readable output
 //!
-//! In addition to printing to the console, you can emit machine-readable JSON
-//! files (one per operation) into the Cargo target directory for later
-//! analysis. Files are written to `target/alloc_tracker/<operation>.json`, with
-//! operation names sanitized to be filesystem-safe:
+//! Dropping a [`Session`] writes machine-readable JSON files (one per operation)
+//! into the Cargo target directory at `target/alloc_tracker/<operation>.json`,
+//! with operation names sanitized to be filesystem-safe. A human-readable
+//! summary is also printed to stdout.
 //!
-//! ```no_run
+//! These outputs are produced automatically, so a typical benchmark only needs
+//! to create a session and record work. Either output can be suppressed:
+//!
+//! ```
 //! use alloc_tracker::{Allocator, Session};
 //!
 //! #[global_allocator]
 //! static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 //!
 //! # fn main() {
-//! let session = Session::new();
-//! {
-//!     let operation = session.operation("my_operation");
-//!     let _span = operation.measure_process();
-//!     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
-//! }
+//! // Print to stdout but do not write JSON files.
+//! let session = Session::new().no_file();
 //!
-//! session.write_to_target();
+//! // Or write JSON files but do not print to stdout.
+//! let quiet_session = Session::new().no_stdout();
+//!
+//! // Or suppress both.
+//! let silent_session = Session::new().no_stdout().no_file();
 //! # }
 //! ```
 //!
@@ -103,6 +105,7 @@
 //!
 //! fn main() {
 //!     let session = Session::new();
+//! #   let session = session.no_stdout().no_file();
 //!
 //!     // Track mean over multiple operations (batched for efficiency)
 //!     {
@@ -113,8 +116,7 @@
 //!         }
 //!     }
 //!
-//!     // Output statistics of all operations to console
-//!     session.print_to_stdout();
+//!     // Statistics are emitted automatically when `session` is dropped.
 //! }
 //! ```
 //!
@@ -145,6 +147,7 @@
 //!
 //! # fn main() {
 //! let session = Session::new();
+//! # let session = session.no_stdout().no_file();
 //! {
 //!     let operation = session.operation("work");
 //!     let _span = operation.measure_process();

--- a/packages/alloc_tracker/src/operation.rs
+++ b/packages/alloc_tracker/src/operation.rs
@@ -24,6 +24,7 @@ use crate::{ERR_POISONED_LOCK, OperationMetrics, ProcessSpan, ThreadSpan};
 /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let mean_calc = session.operation("string_allocations");
 ///
 /// // Simulate multiple operations
@@ -71,6 +72,7 @@ impl Operation {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("thread_work");
     /// {
     ///     let _span = operation.measure_thread();
@@ -87,6 +89,7 @@ impl Operation {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_thread().iterations(1000);
@@ -117,6 +120,7 @@ impl Operation {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("process_work");
     /// {
     ///     let _span = operation.measure_process();
@@ -133,6 +137,7 @@ impl Operation {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_process().iterations(1000);
@@ -189,7 +194,7 @@ mod tests {
     use crate::allocator::register_fake_allocation;
 
     fn create_test_operation() -> Operation {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         session.operation("test")
     }
 
@@ -347,7 +352,7 @@ mod tests {
 
     #[test]
     fn operation_drop_merges_data() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
 
         // Create and use operation
         {
@@ -373,7 +378,7 @@ mod tests {
 
     #[test]
     fn multiple_operations_concurrent() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
 
         let op1 = session.operation("test");
         let op2 = session.operation("test");

--- a/packages/alloc_tracker/src/process_span.rs
+++ b/packages/alloc_tracker/src/process_span.rs
@@ -21,6 +21,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics};
 /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let mean_calc = session.operation("test");
 /// {
 ///     let _span = mean_calc.measure_process();
@@ -78,6 +79,7 @@ impl ProcessSpan {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_process().iterations(1000);

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -19,6 +19,7 @@ use std::fmt;
 ///
 /// # fn main() {
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// {
 ///     let operation = session.operation("test_work");
 ///     let _span = operation.measure_process();
@@ -41,7 +42,9 @@ use std::fmt;
 /// # fn main() {
 /// // Create two separate sessions
 /// let session1 = Session::new();
+/// # let session1 = session1.no_stdout().no_file();
 /// let session2 = Session::new();
+/// # let session2 = session2.no_stdout().no_file();
 ///
 /// // Record some work in each
 /// {
@@ -131,7 +134,9 @@ impl Report {
     ///
     /// # fn main() {
     /// let session1 = Session::new();
+    /// # let session1 = session1.no_stdout().no_file();
     /// let session2 = Session::new();
+    /// # let session2 = session2.no_stdout().no_file();
     ///
     /// // Both sessions record the same operation name
     /// {
@@ -218,6 +223,7 @@ impl Report {
     ///
     /// # fn main() {
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// {
     ///     let operation = session.operation("test_work");
     ///     let _span = operation.measure_process();
@@ -395,14 +401,14 @@ mod tests {
 
     #[test]
     fn report_from_empty_session_is_empty() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         let report = session.to_report();
         assert!(report.is_empty());
     }
 
     #[test]
     fn report_from_session_with_operations_is_not_empty() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         {
             let operation = session.operation("test");
             let _span = operation.measure_thread();
@@ -423,7 +429,7 @@ mod tests {
 
     #[test]
     fn merge_empty_with_non_empty() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         {
             let operation = session.operation("test");
             let _span = operation.measure_thread();
@@ -442,8 +448,8 @@ mod tests {
 
     #[test]
     fn merge_different_operations() {
-        let session1 = Session::new();
-        let session2 = Session::new();
+        let session1 = Session::new().no_stdout().no_file();
+        let session2 = Session::new().no_stdout().no_file();
 
         {
             let op1 = session1.operation("test1");
@@ -468,8 +474,8 @@ mod tests {
 
     #[test]
     fn merge_same_operations() {
-        let session1 = Session::new();
-        let session2 = Session::new();
+        let session1 = Session::new().no_stdout().no_file();
+        let session2 = Session::new().no_stdout().no_file();
 
         {
             let op1 = session1.operation("test");
@@ -496,7 +502,7 @@ mod tests {
 
     #[test]
     fn report_clone() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         {
             let operation = session.operation("test");
             let _span = operation.measure_thread();
@@ -533,7 +539,7 @@ mod tests {
 
     #[test]
     fn report_operation_total_allocations_count_consistency_with_session() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         {
             let operation = session.operation("test_consistency");
             let _span = operation.measure_thread();

--- a/packages/alloc_tracker/src/session.rs
+++ b/packages/alloc_tracker/src/session.rs
@@ -6,6 +6,19 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics, Report};
 
 /// Manages allocation tracking session state and contains operations.
 ///
+/// # Output on drop
+///
+/// When a session is dropped it automatically emits its results:
+///
+/// * a human-readable summary is printed to stdout, and
+/// * machine-readable JSON files (one per operation) are written into the Cargo
+///   target directory at `target/alloc_tracker/<operation>.json`.
+///
+/// A session that recorded no measurable work emits nothing, so a "list
+/// available benchmarks" probe run leaves no output behind. Either output can be
+/// suppressed with [`no_stdout()`](Self::no_stdout) and
+/// [`no_file()`](Self::no_file).
+///
 /// # Examples
 ///
 /// ```rust
@@ -15,6 +28,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics, Report};
 /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let string_op = session.operation("do_stuff_with_strings");
 ///
 /// {
@@ -24,15 +38,20 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics, Report};
 ///     }
 /// }
 ///
-/// // Output statistics of all operations to console.
-/// // Using print_to_stdout() here is important in benchmarks because it will
-/// // print nothing if no spans were recorded, not even an empty line, which can
-/// // be functionally critical for benchmark harness behavior.
-/// session.print_to_stdout();
+/// // When `session` is dropped, the recorded statistics are printed to stdout
+/// // and written to `target/alloc_tracker/` as machine-readable JSON.
 /// ```
+///
+/// # Panics
+///
+/// Dropping a session panics if writing the JSON output files fails, since a
+/// benchmark that cannot persist its results is not useful. To avoid masking an
+/// in-flight panic, no output is emitted while the thread is already panicking.
 #[derive(Debug)]
 pub struct Session {
     operations: Arc<Mutex<HashMap<String, Arc<Mutex<OperationMetrics>>>>>,
+    emit_stdout: bool,
+    emit_file: bool,
 }
 
 impl Session {
@@ -47,8 +66,8 @@ impl Session {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
-    /// // Allocation tracking is now enabled
-    /// // Session will disable tracking when dropped
+    /// // Allocation tracking is enabled. When the session is dropped, its
+    /// // results are printed to stdout and written to the Cargo target directory.
     /// ```
     #[expect(
         clippy::new_without_default,
@@ -58,7 +77,31 @@ impl Session {
     pub fn new() -> Self {
         Self {
             operations: Arc::new(Mutex::new(HashMap::new())),
+            emit_stdout: true,
+            emit_file: true,
         }
+    }
+
+    /// Disables printing a human-readable summary to stdout when the session is
+    /// dropped.
+    ///
+    /// JSON files are still written to the Cargo target directory unless
+    /// [`no_file()`](Self::no_file) is also used.
+    #[must_use]
+    pub fn no_stdout(mut self) -> Self {
+        self.emit_stdout = false;
+        self
+    }
+
+    /// Disables writing machine-readable JSON files to the Cargo target
+    /// directory when the session is dropped.
+    ///
+    /// A human-readable summary is still printed to stdout unless
+    /// [`no_stdout()`](Self::no_stdout) is also used.
+    #[must_use]
+    pub fn no_file(mut self) -> Self {
+        self.emit_file = false;
+        self
     }
 
     /// Creates or retrieves an operation with the given name.
@@ -76,6 +119,7 @@ impl Session {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let string_op = session.operation("string_operations");
     ///
     /// {
@@ -114,6 +158,7 @@ impl Session {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("test_work");
     /// {
     ///     let _span = operation.measure_process();
@@ -139,17 +184,6 @@ impl Session {
         Report::from_operation_data(&operation_data)
     }
 
-    /// Prints the allocation statistics of all operations to stdout.
-    ///
-    /// This is a convenience method equivalent to `self.to_report().print_to_stdout()`.
-    /// Prints nothing if no spans were captured. This may indicate that the session
-    /// was part of a "list available benchmarks" probe run instead of some real activity,
-    /// in which case printing anything might violate the output protocol the tool is speaking.
-    #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
-    pub fn print_to_stdout(&self) {
-        self.to_report().print_to_stdout();
-    }
-
     /// Whether there is any recorded activity in this session.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -158,6 +192,36 @@ impl Session {
             || operations
                 .values()
                 .all(|op| op.lock().expect(ERR_POISONED_LOCK).total_iterations == 0)
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        // Emitting output while the thread is already unwinding would risk a
+        // double panic (which aborts the process) and would obscure the original
+        // failure. See docs/error-handling.md.
+        if std::thread::panicking() {
+            return;
+        }
+
+        if !self.emit_stdout && !self.emit_file {
+            return;
+        }
+
+        // A session that recorded no measurable work emits nothing. Returning
+        // early also avoids resolving the Cargo target directory (which may shell
+        // out to `cargo metadata`) during "list available benchmarks" probe runs.
+        if self.is_empty() {
+            return;
+        }
+
+        let report = self.to_report();
+        if self.emit_stdout {
+            report.print_to_stdout();
+        }
+        if self.emit_file {
+            report.write_to_target();
+        }
     }
 }
 

--- a/packages/alloc_tracker/src/session.rs
+++ b/packages/alloc_tracker/src/session.rs
@@ -204,7 +204,9 @@ impl Drop for Session {
             return;
         }
 
-        if !self.emit_stdout && !self.emit_file {
+        // With neither output enabled there is nothing to emit, so skip building
+        // a report entirely.
+        if !(self.emit_stdout || self.emit_file) {
             return;
         }
 

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::{Report, Session};
+use crate::Report;
 
 /// Subdirectory of the Cargo target directory that receives the JSON files.
 const OUTPUT_SUBDIRECTORY: &str = "alloc_tracker";
@@ -44,25 +44,7 @@ impl Report {
     ///
     /// Also panics if two operation names sanitize to the same file name, since
     /// writing both would silently discard one operation's results.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use alloc_tracker::{Allocator, Session};
-    ///
-    /// #[global_allocator]
-    /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
-    ///
-    /// let session = Session::new();
-    /// {
-    ///     let operation = session.operation("work");
-    ///     let _span = operation.measure_process();
-    ///     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
-    /// }
-    ///
-    /// session.to_report().write_to_target();
-    /// ```
-    pub fn write_to_target(&self) {
+    pub(crate) fn write_to_target(&self) {
         let target =
             folo_utils::cargo_target_directory().unwrap_or_else(|| PathBuf::from("target"));
         self.write_to_directory(target.join(OUTPUT_SUBDIRECTORY));
@@ -85,26 +67,7 @@ impl Report {
     ///
     /// Also panics if two operation names sanitize to the same file name, since
     /// writing both would silently discard one operation's results.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use alloc_tracker::{Allocator, Session};
-    ///
-    /// #[global_allocator]
-    /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
-    ///
-    /// let session = Session::new();
-    /// {
-    ///     let operation = session.operation("work");
-    ///     let _span = operation.measure_process();
-    ///     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
-    /// }
-    ///
-    /// let directory = std::env::temp_dir().join("alloc_tracker_example");
-    /// session.to_report().write_to_directory(&directory);
-    /// ```
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
+    pub(crate) fn write_to_directory(&self, directory: impl AsRef<Path>) {
         let directory = directory.as_ref();
 
         // Build every output up front, detecting sanitized-name collisions before
@@ -165,37 +128,6 @@ impl Report {
     }
 }
 
-impl Session {
-    /// Writes machine-readable JSON statistics into the Cargo target directory.
-    ///
-    /// This is a convenience method equivalent to
-    /// `self.to_report().write_to_target()`. See
-    /// [`Report::write_to_target`](crate::Report::write_to_target) for details.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the output directory cannot be created or a file cannot be
-    /// written.
-    pub fn write_to_target(&self) {
-        self.to_report().write_to_target();
-    }
-
-    /// Writes machine-readable JSON statistics into the given directory.
-    ///
-    /// This is a convenience method equivalent to
-    /// `self.to_report().write_to_directory(directory)`. See
-    /// [`Report::write_to_directory`](crate::Report::write_to_directory) for
-    /// details.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the output directory cannot be created or a file cannot be
-    /// written.
-    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
-        self.to_report().write_to_directory(directory);
-    }
-}
-
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -212,7 +144,7 @@ mod tests {
     }
 
     fn session_with_recorded_work(name: &str) -> Session {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         {
             let operation = session.operation(name);
             let _span = operation.measure_thread().iterations(4);
@@ -227,7 +159,7 @@ mod tests {
         let session = session_with_recorded_work("allocate_vec");
         let directory = tempfile::tempdir().unwrap();
 
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         let file = directory.path().join("allocate_vec.json");
         let value = read_json(&file);
@@ -268,7 +200,7 @@ mod tests {
         let session = session_with_recorded_work("group/case name");
         let directory = tempfile::tempdir().unwrap();
 
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
@@ -283,11 +215,11 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
     fn empty_session_writes_no_files() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("nested");
 
-        session.write_to_directory(&target);
+        session.to_report().write_to_directory(&target);
 
         // Nothing is written, so the directory is not even created.
         assert!(!target.exists());
@@ -296,7 +228,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // Writes files, which is not supported under Miri isolation.
     fn skips_operations_without_iterations() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
         {
             let operation = session.operation("measured");
             let _span = operation.measure_thread().iterations(4);
@@ -307,7 +239,7 @@ mod tests {
         let _unmeasured = session.operation("unmeasured");
 
         let directory = tempfile::tempdir().unwrap();
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         assert!(directory.path().join("measured.json").exists());
         assert!(!directory.path().join("unmeasured.json").exists());
@@ -321,7 +253,7 @@ mod tests {
         fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("allocate_vec");
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
 
         // Parsing succeeds only if the stale, non-JSON contents were replaced.
         let value = read_json(&file);
@@ -343,7 +275,9 @@ mod tests {
         let blocker = directory.path().join("blocker");
         fs::write(&blocker, "not a directory").unwrap();
 
-        session.write_to_directory(blocker.join("nested"));
+        session
+            .to_report()
+            .write_to_directory(blocker.join("nested"));
     }
 
     #[test]
@@ -356,13 +290,13 @@ mod tests {
         // A directory occupying the output file's path makes the file write fail.
         fs::create_dir_all(directory.path().join("allocate_vec.json")).unwrap();
 
-        session.write_to_directory(directory.path());
+        session.to_report().write_to_directory(directory.path());
     }
 
     #[test]
     #[should_panic(expected = "after sanitization")]
     fn panics_when_operation_names_collide_after_sanitization() {
-        let session = Session::new();
+        let session = Session::new().no_stdout().no_file();
 
         // Both names sanitize to `group_case.json`, so writing both would silently
         // discard one operation's results.
@@ -374,6 +308,8 @@ mod tests {
 
         // The collision is detected before anything is written, so this path is
         // never created.
-        session.write_to_directory("collision_is_detected_before_writing");
+        session
+            .to_report()
+            .write_to_directory("collision_is_detected_before_writing");
     }
 }

--- a/packages/alloc_tracker/src/thread_span.rs
+++ b/packages/alloc_tracker/src/thread_span.rs
@@ -19,6 +19,7 @@ use crate::{ERR_POISONED_LOCK, Operation, OperationMetrics};
 /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 ///
 /// let session = Session::new();
+/// # let session = session.no_stdout().no_file();
 /// let mean_calc = session.operation("test");
 /// {
 ///     let _span = mean_calc.measure_thread();
@@ -68,6 +69,7 @@ impl ThreadSpan {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
     /// let operation = session.operation("batch_work");
     /// {
     ///     let _span = operation.measure_thread().iterations(1000);

--- a/packages/alloc_tracker/tests/alloc_tracker_integration.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_integration.rs
@@ -14,7 +14,7 @@ static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 #[test]
 #[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
 fn no_span_is_empty_session() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     let _op = session.operation("test_no_span");
 
@@ -24,7 +24,7 @@ fn no_span_is_empty_session() {
 #[test]
 #[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
 fn span_with_no_allocation_is_not_empty_session() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     {
         let op = session.operation("test_no_allocation");
@@ -43,7 +43,7 @@ fn single_thread_allocations() {
     const BYTES_PER_ITERATION: usize = 100;
     const TEST_ITERATIONS: usize = 5;
 
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     // Test process span in single-threaded context
     let process_total = {
@@ -82,7 +82,7 @@ fn multithreaded_allocations_show_span_differences() {
     const MAIN_THREAD_ALLOCATIONS: u32 = 10;
     const TEST_ITERATIONS: usize = 3;
 
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     // Helper function to spawn worker threads that allocate memory
     let spawn_workers = || {
@@ -150,7 +150,7 @@ fn multithreaded_allocations_show_span_differences() {
 fn mixed_span_types_in_multithreaded_context() {
     const ITERATIONS: usize = 3;
 
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     let mixed_op = session.operation("mixed_multithreaded");
 
     for iteration in 1..=ITERATIONS {
@@ -187,7 +187,7 @@ fn mixed_span_types_in_multithreaded_context() {
 #[test]
 #[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
 fn report_is_empty_matches_session_is_empty() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     // Test 1: Both empty initially
     let report = session.to_report();
@@ -220,7 +220,7 @@ fn report_is_empty_matches_session_is_empty() {
 fn report_mean_with_known_allocations() {
     const NUM_ITERATIONS: u64 = 5;
 
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     {
         let operation = session.operation("known_allocation");
@@ -271,7 +271,7 @@ fn process_report_includes_allocations_from_multiple_threads() {
     const SIZE_A: usize = 128; // bytes per allocation in thread A
     const SIZE_B: usize = 256; // bytes per allocation in thread B
 
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     {
         let op = session.operation("two_thread_process");
         let _span = op.measure_process();

--- a/packages/alloc_tracker/tests/alloc_tracker_panic_on_next_alloc_controlled.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_panic_on_next_alloc_controlled.rs
@@ -1,16 +1,19 @@
-//! Tests for the `panic_on_next_alloc` feature of the `alloc_tracker` crate.
+//! Verifies that `panic_on_next_alloc` can be toggled on and off without panicking.
+//!
+//! This lives in its own test binary because `panic_on_next_alloc` flips a
+//! process-global flag in the global allocator: any allocation on any thread in the
+//! process consumes it. Running it as the only test in its process guarantees no other
+//! test thread can trip the flag while this test holds it.
 
 #![cfg(feature = "panic_on_next_alloc")]
 
 use alloc_tracker::{Allocator, panic_on_next_alloc};
-use serial_test::serial;
 
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
 #[test]
 #[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
-#[serial]
 fn panic_on_next_alloc_can_be_controlled() {
     // This test verifies the API works but does not test the panic behavior
     // as that would terminate the test process
@@ -34,31 +37,4 @@ fn panic_on_next_alloc_can_be_controlled() {
         reason = "we need actual allocation to test the feature"
     )]
     let _another_allowed_allocation = vec![4, 5, 6];
-}
-
-#[test]
-#[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
-#[serial]
-fn panic_on_next_alloc_resets_automatically() {
-    use std::panic;
-
-    // Enable panic on next allocation
-    panic_on_next_alloc(true);
-
-    // First allocation should panic
-    let result = panic::catch_unwind(|| {
-        #[expect(
-            clippy::useless_vec,
-            reason = "we need actual allocation to test the feature"
-        )]
-        let _vec = vec![1, 2, 3];
-    });
-    assert!(result.is_err());
-
-    // Second allocation should work because flag was reset
-    #[expect(
-        clippy::useless_vec,
-        reason = "we need actual allocation to test the feature"
-    )]
-    let _allowed_allocation = vec![4, 5, 6];
 }

--- a/packages/alloc_tracker/tests/alloc_tracker_panic_on_next_alloc_resets.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_panic_on_next_alloc_resets.rs
@@ -1,0 +1,39 @@
+//! Verifies that `panic_on_next_alloc` panics on the next allocation and then resets.
+//!
+//! This lives in its own test binary because `panic_on_next_alloc` flips a
+//! process-global flag in the global allocator: any allocation on any thread in the
+//! process consumes it. Running it as the only test in its process guarantees that the
+//! allocation which trips the flag is this test's own, not another test thread's.
+
+#![cfg(feature = "panic_on_next_alloc")]
+
+use std::panic;
+
+use alloc_tracker::{Allocator, panic_on_next_alloc};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+#[test]
+#[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
+fn panic_on_next_alloc_resets_automatically() {
+    // Enable panic on next allocation
+    panic_on_next_alloc(true);
+
+    // First allocation should panic
+    let result = panic::catch_unwind(|| {
+        #[expect(
+            clippy::useless_vec,
+            reason = "we need actual allocation to test the feature"
+        )]
+        let _vec = vec![1, 2, 3];
+    });
+    assert!(result.is_err());
+
+    // Second allocation should work because flag was reset
+    #[expect(
+        clippy::useless_vec,
+        reason = "we need actual allocation to test the feature"
+    )]
+    let _allowed_allocation = vec![4, 5, 6];
+}

--- a/packages/alloc_tracker/tests/alloc_tracker_report_api.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_report_api.rs
@@ -8,7 +8,7 @@ static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 #[test]
 #[cfg_attr(miri, ignore)] // Test uses the real platform which cannot be executed under Miri.
 fn alloc_tracker_report_api() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     {
         let op = session.operation("test_alloc");

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -93,6 +93,36 @@ fn dropping_session_writes_json_into_cargo_target_directory() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
+fn no_stdout_session_still_writes_json() {
+    const OPERATION: &str = "alloc_tracker_no_stdout_writes_probe";
+
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
+
+    {
+        // Suppressing stdout must not suppress the JSON file output.
+        let session = Session::new().no_stdout();
+        record_work(&session, OPERATION);
+    }
+
+    assert!(
+        expected.exists(),
+        "no_stdout() should still write {}",
+        expected.display()
+    );
+
+    let value = read_json(&expected);
+    assert_eq!(
+        value.get("operation").and_then(Value::as_str),
+        Some(OPERATION)
+    );
+
+    // Avoid polluting the shared target directory for later runs.
+    remove_file(&expected).unwrap();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
 fn no_file_suppresses_json_output() {
     const OPERATION: &str = "alloc_tracker_no_file_probe";
 

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -6,6 +6,7 @@
 
 use std::fs::{read_to_string, remove_file};
 use std::hint::black_box;
+use std::io;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
@@ -32,8 +33,12 @@ fn read_json(path: &Path) -> Value {
 
 /// Removes `path` if it exists, leaving a clean slate for an assertion.
 fn remove_if_present(path: &Path) {
-    if path.exists() {
-        remove_file(path).unwrap();
+    // Attempt the removal unconditionally and tolerate a missing file rather than
+    // checking `exists()` first, which would race with parallel test processes.
+    match remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => panic!("failed to remove {}: {error}", path.display()),
     }
 }
 

--- a/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_target_output.rs
@@ -1,8 +1,13 @@
-//! Integration tests for writing machine-readable JSON output to disk.
+//! Integration tests for the machine-readable JSON output written on drop.
+//!
+//! These exercise the public behavior end to end: dropping a [`Session`] writes
+//! one JSON file per operation into the Cargo target directory unless that output
+//! is suppressed.
 
-use std::fs;
+use std::fs::{read_to_string, remove_file};
 use std::hint::black_box;
-use std::path::Path;
+use std::panic::{self, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
 
 use alloc_tracker::{Allocator, Session};
 use serde_json::Value;
@@ -10,59 +15,70 @@ use serde_json::Value;
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
+const BYTES_PER_ITERATION: usize = 64;
+const ITERATIONS: u64 = 8;
+
+/// Resolves the JSON output path that dropping a session writes for `operation`.
+fn output_path(operation: &str) -> PathBuf {
+    folo_utils::cargo_target_directory()
+        .unwrap_or_else(|| "target".into())
+        .join("alloc_tracker")
+        .join(format!("{operation}.json"))
+}
+
 fn read_json(path: &Path) -> Value {
-    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    serde_json::from_str(&read_to_string(path).unwrap()).unwrap()
+}
+
+/// Removes `path` if it exists, leaving a clean slate for an assertion.
+fn remove_if_present(path: &Path) {
+    if path.exists() {
+        remove_file(path).unwrap();
+    }
+}
+
+/// Records a fixed amount of allocation work under `operation` in `session`.
+fn record_work(session: &Session, operation: &str) {
+    let operation = session.operation(operation);
+    let _span = operation.measure_thread().iterations(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let data: Vec<u8> = black_box(vec![0_u8; BYTES_PER_ITERATION]);
+        black_box(&data);
+    }
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
-fn writes_json_files_for_each_operation() {
-    const FIRST_BYTES_PER_ITERATION: usize = 128;
-    const FIRST_ITERATIONS: u64 = 16;
-    const SECOND_BYTES_PER_ITERATION: usize = 64;
-    const SECOND_ITERATIONS: u64 = 8;
+fn dropping_session_writes_json_into_cargo_target_directory() {
+    // A distinctive name avoids colliding with output from other operations in
+    // the shared Cargo target directory.
+    const OPERATION: &str = "alloc_tracker_drop_writes_probe";
 
-    let session = Session::new();
-
-    {
-        let operation = session.operation("allocate_buffer");
-        let _span = operation.measure_thread().iterations(FIRST_ITERATIONS);
-        for _ in 0..FIRST_ITERATIONS {
-            let data: Vec<u8> = black_box(vec![0_u8; FIRST_BYTES_PER_ITERATION]);
-            black_box(&data);
-        }
-    }
+    let expected = output_path(OPERATION);
+    // Start from a clean slate so the assertion proves the drop wrote the file.
+    remove_if_present(&expected);
 
     {
-        let operation = session.operation("allocate_small_buffer");
-        let _span = operation.measure_thread().iterations(SECOND_ITERATIONS);
-        for _ in 0..SECOND_ITERATIONS {
-            let data: Vec<u8> = black_box(vec![0_u8; SECOND_BYTES_PER_ITERATION]);
-            black_box(&data);
-        }
+        // Both stdout and file output are enabled; the harness captures the
+        // printed summary while the assertion below checks the JSON file.
+        let session = Session::new();
+        record_work(&session, OPERATION);
     }
 
-    let directory = tempfile::tempdir().unwrap();
-    session.write_to_directory(directory.path());
+    assert!(
+        expected.exists(),
+        "dropping the session should create {}",
+        expected.display()
+    );
 
-    let first = directory.path().join("allocate_buffer.json");
-    let second = directory.path().join("allocate_small_buffer.json");
-
-    assert!(first.exists(), "expected JSON file for first operation");
-    assert!(second.exists(), "expected JSON file for second operation");
-
-    // Exactly one file per measured operation, and nothing more.
-    let written = fs::read_dir(directory.path()).unwrap().count();
-    assert_eq!(written, 2, "expected one JSON file per operation");
-
-    let value = read_json(&first);
+    let value = read_json(&expected);
     assert_eq!(
         value.get("operation").and_then(Value::as_str),
-        Some("allocate_buffer")
+        Some(OPERATION)
     );
     assert_eq!(
         value.get("total_iterations").and_then(Value::as_u64),
-        Some(16)
+        Some(ITERATIONS)
     );
     assert!(
         value
@@ -70,109 +86,73 @@ fn writes_json_files_for_each_operation() {
             .and_then(Value::as_u64)
             .is_some()
     );
+
+    // Avoid polluting the shared target directory for later runs.
+    remove_file(&expected).unwrap();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
+fn no_file_suppresses_json_output() {
+    const OPERATION: &str = "alloc_tracker_no_file_probe";
+
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
+
+    {
+        let session = Session::new().no_stdout().no_file();
+        record_work(&session, OPERATION);
+    }
+
     assert!(
-        value
-            .get("total_allocations_count")
-            .and_then(Value::as_u64)
-            .is_some()
-    );
-    assert!(
-        value
-            .get("mean_bytes_per_iteration")
-            .and_then(Value::as_u64)
-            .is_some()
-    );
-    assert!(
-        value
-            .get("mean_allocations_per_iteration")
-            .and_then(Value::as_u64)
-            .is_some()
+        !expected.exists(),
+        "no_file() should suppress writing {}",
+        expected.display()
     );
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
-fn empty_session_writes_nothing() {
-    let session = Session::new();
-    let _operation = session.operation("never_measured");
+fn empty_session_writes_nothing_on_drop() {
+    const OPERATION: &str = "alloc_tracker_empty_drop_probe";
 
-    let directory = tempfile::tempdir().unwrap();
-    let target = directory.path().join("output");
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
 
-    session.write_to_directory(&target);
-
-    assert!(!target.exists(), "no directory should be created");
-}
-
-#[test]
-#[cfg_attr(miri, ignore)] // Resolves the Cargo target directory and writes files, neither supported under Miri.
-fn write_to_target_writes_into_cargo_target_directory() {
-    // A distinctive name avoids colliding with output from other operations in
-    // the shared Cargo target directory.
-    const OPERATION: &str = "alloc_tracker_write_to_target_probe";
-    const BYTES_PER_ITERATION: usize = 64;
-    const ITERATIONS: u64 = 8;
-
-    let session = Session::new();
     {
-        let operation = session.operation(OPERATION);
-        let _span = operation.measure_thread().iterations(ITERATIONS);
-        for _ in 0..ITERATIONS {
-            let data: Vec<u8> = black_box(vec![0_u8; BYTES_PER_ITERATION]);
-            black_box(&data);
-        }
+        // File output stays enabled, but the session records no measurable work,
+        // so dropping it must still write nothing.
+        let session = Session::new().no_stdout();
+        let _operation = session.operation(OPERATION);
     }
-
-    let expected = folo_utils::cargo_target_directory()
-        .unwrap_or_else(|| "target".into())
-        .join("alloc_tracker")
-        .join(format!("{OPERATION}.json"));
-
-    // Start from a clean slate so the assertion proves this call wrote the file.
-    if expected.exists() {
-        fs::remove_file(&expected).unwrap();
-    }
-
-    session.write_to_target();
 
     assert!(
-        expected.exists(),
-        "write_to_target should create {}",
+        !expected.exists(),
+        "an empty session should not write {}",
         expected.display()
     );
-
-    let value = read_json(&expected);
-    assert_eq!(
-        value.get("operation").and_then(Value::as_str),
-        Some("alloc_tracker_write_to_target_probe")
-    );
-    assert_eq!(
-        value.get("total_iterations").and_then(Value::as_u64),
-        Some(8)
-    );
-
-    // Avoid polluting the shared target directory for later runs.
-    fs::remove_file(&expected).unwrap();
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Uses the global allocator, which is not supported under Miri.
-#[should_panic(expected = "after sanitization")]
-fn panics_when_operation_names_collide_after_sanitization() {
-    let session = Session::new();
+#[cfg_attr(miri, ignore)] // Uses the global allocator and the filesystem, neither supported under Miri.
+fn panicking_thread_does_not_write_json() {
+    const OPERATION: &str = "alloc_tracker_panic_guard_probe";
 
-    // Both names sanitize to the same file name, which must not silently
-    // overwrite one operation's results.
-    for name in ["group/case", "group_case"] {
-        let operation = session.operation(name);
-        let _span = operation.measure_thread().iterations(4);
-        for _ in 0..4 {
-            let data: Vec<u8> = black_box(vec![0_u8; 64]);
-            black_box(&data);
-        }
-    }
+    let expected = output_path(OPERATION);
+    remove_if_present(&expected);
 
-    // The collision is detected before anything is written, so this path is
-    // never created.
-    session.write_to_directory("collision_is_detected_before_writing");
+    // The session is dropped while the thread unwinds from the panic, so its
+    // output must be suppressed to avoid masking the original failure.
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        let session = Session::new().no_stdout();
+        record_work(&session, OPERATION);
+        panic!("intentional panic to exercise the drop guard");
+    }));
+
+    assert!(result.is_err(), "the closure should have panicked");
+    assert!(
+        !expected.exists(),
+        "a panicking thread should not write {}",
+        expected.display()
+    );
 }

--- a/packages/alloc_tracker/tests/alloc_tracker_thread_safety.rs
+++ b/packages/alloc_tracker/tests/alloc_tracker_thread_safety.rs
@@ -14,7 +14,7 @@ thread_local! {
 
 #[test]
 fn session_can_be_moved_between_threads() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
 
     // Move session to another thread
     let handle = thread::spawn(move || {
@@ -36,7 +36,7 @@ fn session_can_be_moved_between_threads() {
 
 #[test]
 fn operation_can_be_moved_between_threads() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     let operation = session.operation("test_op");
 
     // Move operation to another thread
@@ -54,7 +54,7 @@ fn operation_can_be_moved_between_threads() {
 
 #[test]
 fn report_can_be_shared_across_threads() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     // Create an empty report for testing
     let report = session.to_report();
 
@@ -70,8 +70,8 @@ fn report_can_be_shared_across_threads() {
 
 #[test]
 fn reports_can_be_merged_across_threads() {
-    let session1 = Session::new();
-    let session2 = Session::new();
+    let session1 = Session::new().no_stdout().no_file();
+    let session2 = Session::new().no_stdout().no_file();
 
     // Create reports in different threads
     let handle1 = thread::spawn(move || {

--- a/packages/events/benches/events_uncontended.rs
+++ b/packages/events/benches/events_uncontended.rs
@@ -59,7 +59,8 @@ fn entrypoint(c: &mut Criterion) {
     async_poll_ready(c, &allocs);
     many_waiters(c, &allocs);
 
-    allocs.print_to_stdout();
+    // `allocs` prints its summary and writes JSON to the Cargo target directory
+    // when it is dropped at the end of this function.
 }
 
 /// Measures the overhead of creating a heap-allocated event object.

--- a/packages/infinity_pool/benches/infinity_pool_vs_std.rs
+++ b/packages/infinity_pool/benches/infinity_pool_vs_std.rs
@@ -598,7 +598,8 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
 
     group.finish();
 
-    allocs.print_to_stdout();
+    // `allocs` prints its summary and writes JSON to the Cargo target directory
+    // when it is dropped at the end of this function.
 }
 
 criterion_group!(benches, churn_insertion_benchmark);

--- a/packages/nm_otel_impl/benches/nm_otel_export.rs
+++ b/packages/nm_otel_impl/benches/nm_otel_export.rs
@@ -69,7 +69,8 @@ fn entrypoint(c: &mut Criterion) {
 
     group.finish();
 
-    allocs.print_to_stdout();
+    // `allocs` prints its summary and writes JSON to the Cargo target directory
+    // when it is dropped at the end of this function.
 }
 
 fn build_publisher() -> Publisher {

--- a/packages/nm_otel_impl/tests/nm_otel_histogram_deltas_alloc.rs
+++ b/packages/nm_otel_impl/tests/nm_otel_histogram_deltas_alloc.rs
@@ -19,7 +19,7 @@ const BUCKETS: [i64; 4] = [10, 50, 100, 500];
               conflicts with the alloc_tracker probe"
 )]
 fn histogram_deltas_does_not_allocate_on_steady_state() {
-    let session = Session::new();
+    let session = Session::new().no_stdout().no_file();
     let op = session.operation("histogram_deltas_steady_state");
 
     let mut state = EventState::default();

--- a/packages/par_bench/examples/par_bench_measure_wrapper_tracking.rs
+++ b/packages/par_bench/examples/par_bench_measure_wrapper_tracking.rs
@@ -103,8 +103,10 @@ fn run_benchmark_with_tracking(pool: &mut ThreadPool) -> par_bench::RunSummary<M
         .measure_wrapper(
             // Wrapper begin function: creates tracking sessions and spans before the timed execution.
             |args| {
-                let alloc_session = AllocSession::new();
-                let time_session = TimeSession::new();
+                // The merged reports are printed by the caller, so these
+                // per-thread sessions opt out of emitting on drop.
+                let alloc_session = AllocSession::new().no_stdout().no_file();
+                let time_session = TimeSession::new().no_stdout().no_file();
 
                 // Create operations and start spans that will be active during all iterations.
                 let alloc_operation = alloc_session.operation("benchmark_work");

--- a/packages/par_bench/examples/par_bench_resource_usage_ext.rs
+++ b/packages/par_bench/examples/par_bench_resource_usage_ext.rs
@@ -68,8 +68,12 @@ fn main() {
         results.mean_duration()
     );
 
-    // When `allocs` and `processor_time` are dropped at the end of `main`, each
-    // prints its summary and writes JSON into the Cargo target directory.
+    // When `allocs` and `processor_time` are dropped here, each prints its
+    // summary and writes JSON into the Cargo target directory.
+    #[cfg(feature = "alloc_tracker")]
+    drop(allocs);
+    #[cfg(feature = "all_the_time")]
+    drop(processor_time);
 
     // Access measurement outputs
     let measure_count = results.measure_outputs().count();

--- a/packages/par_bench/examples/par_bench_resource_usage_ext.rs
+++ b/packages/par_bench/examples/par_bench_resource_usage_ext.rs
@@ -68,16 +68,8 @@ fn main() {
         results.mean_duration()
     );
 
-    // Print resource usage statistics
-    #[cfg(feature = "alloc_tracker")]
-    {
-        allocs.print_to_stdout();
-    }
-
-    #[cfg(feature = "all_the_time")]
-    {
-        processor_time.print_to_stdout();
-    }
+    // When `allocs` and `processor_time` are dropped at the end of `main`, each
+    // prints its summary and writes JSON into the Cargo target directory.
 
     // Access measurement outputs
     let measure_count = results.measure_outputs().count();

--- a/packages/par_bench/src/resource_usage_ext.rs
+++ b/packages/par_bench/src/resource_usage_ext.rs
@@ -25,6 +25,8 @@
 ///
 /// let allocs = AllocSession::new();
 /// let processor_time = TimeSession::new();
+/// # let allocs = allocs.no_stdout().no_file();
+/// # let processor_time = processor_time.no_stdout().no_file();
 /// let mut pool = ThreadPool::new(&SystemHardware::current().processors());
 ///
 /// let run = Run::new()
@@ -83,6 +85,7 @@ pub trait ResourceUsageExt<'a, ThreadState> {
     /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
     ///
     /// let allocs = Session::new();
+    /// # let allocs = allocs.no_stdout().no_file();
     /// let mut pool = ThreadPool::new(&SystemHardware::current().processors());
     ///
     /// let run = Run::new()
@@ -106,6 +109,7 @@ pub trait ResourceUsageExt<'a, ThreadState> {
     /// use par_bench::{ResourceUsageExt, Run, ThreadPool};
     ///
     /// let processor_time = Session::new();
+    /// # let processor_time = processor_time.no_stdout().no_file();
     /// let mut pool = ThreadPool::new(&SystemHardware::current().processors());
     ///
     /// let run = Run::new()
@@ -433,7 +437,7 @@ mod tests {
     #[test]
     #[cfg(all(not(miri), feature = "alloc_tracker"))] // Uses ThreadPool which requires OS threading functions that Miri cannot emulate.
     fn measure_resource_usage_allocs_only() {
-        let allocs = alloc_tracker::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
         let mut pool = ThreadPool::new(
             SystemHardware::current()
                 .processors()
@@ -466,7 +470,7 @@ mod tests {
     #[test]
     #[cfg(all(not(miri), feature = "all_the_time"))] // Uses ThreadPool which requires OS threading functions that Miri cannot emulate.
     fn measure_resource_usage_processor_time_only() {
-        let processor_time = all_the_time::Session::new();
+        let processor_time = all_the_time::Session::new().no_stdout().no_file();
         let mut pool = ThreadPool::new(
             SystemHardware::current()
                 .processors()
@@ -505,8 +509,8 @@ mod tests {
     #[test]
     #[cfg(all(not(miri), feature = "alloc_tracker", feature = "all_the_time"))] // Uses ThreadPool which requires OS threading functions that Miri cannot emulate.
     fn measure_resource_usage_combined() {
-        let allocs = alloc_tracker::Session::new();
-        let processor_time = all_the_time::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
+        let processor_time = all_the_time::Session::new().no_stdout().no_file();
         let mut pool = ThreadPool::new(
             SystemHardware::current()
                 .processors()
@@ -557,8 +561,8 @@ mod tests {
 
         let mut pool = ThreadPool::new(processors.clone());
 
-        let allocs = alloc_tracker::Session::new();
-        let processor_time = all_the_time::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
+        let processor_time = all_the_time::Session::new().no_stdout().no_file();
 
         // Test 1: .measure_resource_usage() before .groups()
         let results1 = Run::new()
@@ -610,7 +614,7 @@ mod tests {
 
         let mut pool = ThreadPool::new(processors.clone());
 
-        let allocs = alloc_tracker::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
 
         // Test pattern: Run::new().groups().measure_resource_usage()
         let results = Run::new()
@@ -634,7 +638,7 @@ mod tests {
 
         let mut pool = ThreadPool::new(processors.clone());
 
-        let allocs = alloc_tracker::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
 
         // Test original pattern: Run::new().groups().prepare_iter().measure_resource_usage()
         let results = Run::new()
@@ -652,7 +656,7 @@ mod tests {
     #[test]
     #[cfg(all(not(miri), feature = "alloc_tracker"))] // Uses ThreadPool which requires OS threading functions that Miri cannot emulate.
     fn measure_resource_usage_with_thread_state() {
-        let allocs = alloc_tracker::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
         let mut pool = ThreadPool::new(
             SystemHardware::current()
                 .processors()
@@ -694,7 +698,7 @@ mod tests {
             return;
         };
 
-        let allocs = alloc_tracker::Session::new();
+        let allocs = alloc_tracker::Session::new().no_stdout().no_file();
         let mut pool = ThreadPool::new(processors);
 
         // Each thread will execute 1000 iterations, but the allocation tracker should

--- a/packages/par_bench/tests/par_bench_resource_usage_output.rs
+++ b/packages/par_bench/tests/par_bench_resource_usage_output.rs
@@ -17,7 +17,7 @@ static ALLOCATOR: alloc_tracker::Allocator<std::alloc::System> = alloc_tracker::
 
 #[test]
 fn resource_usage_output_provides_meaningful_allocation_data() {
-    let allocs = alloc_tracker::Session::new();
+    let allocs = alloc_tracker::Session::new().no_stdout().no_file();
     let mut pool = ThreadPool::new(
         SystemHardware::current()
             .processors()
@@ -85,7 +85,7 @@ fn resource_usage_output_provides_meaningful_allocation_data() {
 
 #[test]
 fn resource_usage_output_provides_meaningful_processor_time_data() {
-    let processor_time = all_the_time::Session::new();
+    let processor_time = all_the_time::Session::new().no_stdout().no_file();
     let mut pool = ThreadPool::new(
         SystemHardware::current()
             .processors()
@@ -167,8 +167,8 @@ fn resource_usage_output_provides_meaningful_processor_time_data() {
 
 #[test]
 fn resource_usage_output_provides_meaningful_combined_data() {
-    let allocs = alloc_tracker::Session::new();
-    let processor_time = all_the_time::Session::new();
+    let allocs = alloc_tracker::Session::new().no_stdout().no_file();
+    let processor_time = all_the_time::Session::new().no_stdout().no_file();
     let mut pool = ThreadPool::new(
         SystemHardware::current()
             .processors()
@@ -271,7 +271,7 @@ fn resource_usage_output_provides_meaningful_combined_data() {
 
 #[test]
 fn resource_usage_output_handles_no_allocations_gracefully() {
-    let allocs = alloc_tracker::Session::new();
+    let allocs = alloc_tracker::Session::new().no_stdout().no_file();
     let mut pool = ThreadPool::new(
         SystemHardware::current()
             .processors()
@@ -319,7 +319,7 @@ fn resource_usage_output_handles_no_allocations_gracefully() {
 
 #[test]
 fn resource_usage_output_tracks_multiple_operations() {
-    let allocs = alloc_tracker::Session::new();
+    let allocs = alloc_tracker::Session::new().no_stdout().no_file();
     let mut pool = ThreadPool::new(
         SystemHardware::current()
             .processors()

--- a/packages/vicinal/benches/vicinal.rs
+++ b/packages/vicinal/benches/vicinal.rs
@@ -448,8 +448,8 @@ fn entrypoint(c: &mut Criterion) {
 
     g.finish();
 
-    allocs.print_to_stdout();
-    times.print_to_stdout();
+    // `allocs` and `times` print their summaries and write JSON to the Cargo
+    // target directory when they are dropped at the end of this function.
 }
 
 criterion_group!(benches, entrypoint);


### PR DESCRIPTION
## Summary

This flips `all_the_time` and `alloc_tracker` so that dropping a `Session` always emits its results — printing a human-readable summary to stdout and writing machine-readable JSON files (one per operation) into the Cargo target directory. A typical benchmark now needs only `Session::new()` to get full terminal and on-disk output; no explicit `print_to_stdout()` / `write_to_target()` call is required.

This is an **intentional breaking change** — there is no backward compatibility.

## What changed

- `Session` always emits on drop: a stdout summary plus `target/<crate>/<operation>.json` files.
- New consuming builders `Session::no_stdout()` and `Session::no_file()` opt out of either output independently.
- `Drop` is panic-safe: it emits nothing while the thread is already unwinding (so it never masks an in-flight panic), and an empty "probe" session emits nothing (which also avoids spawning `cargo metadata`).
- Removed `Session::print_to_stdout()`, `Session::write_to_target()`, and `Session::write_to_directory()`. The `Report` write helpers are now crate-internal and routed through `Drop`. `Report::print_to_stdout` stays public for merged multi-thread reports.

## Fan-out

Examples, benches, doctests, and tests across the affected packages (`par_bench`, `events`, `vicinal`, `infinity_pool`, `nm_otel_impl`) are updated. Real benchmarks rely on drop to emit; per-thread / merge-pattern sessions and all tests opt out via `.no_stdout().no_file()` to avoid duplicate output and target pollution. `par_bench` production code is unchanged because it borrows user sessions rather than owning them, so it has no session to drop.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean across all affected packages.
- All unit, integration, and doctests pass; examples verified to print and write JSON on drop.
- `cargo +nightly fmt --all` clean.
- Coverage: the `Session::drop` paths are fully line-covered by new integration tests (write-on-drop, `no_file` suppression, empty-session, and the panicking-thread guard).
- Miri (`cargo +nightly miri nextest`) passes for `all_the_time`.
