### PR TITLE
De-emphasize Session output controls in docs

### DIFF
--- a/packages/all_the_time/README.md
+++ b/packages/all_the_time/README.md
@@ -30,8 +30,6 @@ fn main() {
     // When `session` is dropped it prints a human-readable summary to stdout and
     // writes machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/all_the_time/<operation>.json.
-    //
-    // Use `Session::new().no_stdout()` or `.no_file()` to suppress either output.
 }
 ```
 

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -46,22 +46,7 @@
 //! summary is also printed to stdout.
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
-//! to create a session and record work. Either output can be suppressed:
-//!
-//! ```rust
-//! use all_the_time::Session;
-//!
-//! # fn main() {
-//! // Print to stdout but do not write JSON files.
-//! let session = Session::new().no_file();
-//!
-//! // Or write JSON files but do not print to stdout.
-//! let quiet_session = Session::new().no_stdout();
-//!
-//! // Or suppress both.
-//! let silent_session = Session::new().no_stdout().no_file();
-//! # }
-//! ```
+//! to create a session and record work.
 //!
 //! # Thread vs process processor time
 //!
@@ -107,8 +92,9 @@
 //!
 //! ```
 //! use std::thread;
+//! use std::time::Duration;
 //!
-//! use all_the_time::{Report, Session};
+//! use all_the_time::Session;
 //!
 //! # fn main() {
 //! let session = Session::new();
@@ -119,12 +105,17 @@
 //!
 //! let report = session.to_report();
 //!
-//! // Report can be sent to another thread
-//! thread::spawn(move || {
-//!     report.print_to_stdout();
+//! // Reports are `Send`, so they can be moved to another thread for processing.
+//! let total_time = thread::spawn(move || {
+//!     report
+//!         .operations()
+//!         .map(|(_, op)| op.total_processor_time())
+//!         .sum::<Duration>()
 //! })
 //! .join()
 //! .unwrap();
+//!
+//! println!("Total processor time: {total_time:?}");
 //! # }
 //! ```
 

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 /// # Examples
 ///
 /// ```
+/// use std::time::Duration;
+///
 /// use all_the_time::Session;
 ///
 /// # fn main() {
@@ -25,14 +27,20 @@ use std::time::Duration;
 /// }
 ///
 /// let report = session.to_report();
-/// report.print_to_stdout();
+///
+/// // A report exposes each operation's statistics for programmatic use.
+/// let total_time: Duration = report
+///     .operations()
+///     .map(|(_, op)| op.total_processor_time())
+///     .sum();
+/// println!("Total processor time: {total_time:?}");
 /// # }
 /// ```
 ///
 /// # Merging reports
 ///
 /// ```
-/// use std::thread;
+/// use std::time::Duration;
 ///
 /// use all_the_time::{Report, Session};
 ///
@@ -57,7 +65,12 @@ use std::time::Duration;
 /// let report2 = session2.to_report();
 /// let merged = Report::merge(&report1, &report2);
 ///
-/// merged.print_to_stdout();
+/// // The merged report exposes the combined statistics for programmatic use.
+/// let total_time: Duration = merged
+///     .operations()
+///     .map(|(_, op)| op.total_processor_time())
+///     .sum();
+/// println!("Merged report total processor time: {total_time:?}");
 /// # }
 /// ```
 #[derive(Clone, Debug, Default)]

--- a/packages/all_the_time/src/session.rs
+++ b/packages/all_the_time/src/session.rs
@@ -170,6 +170,8 @@ impl Session {
     /// # Examples
     ///
     /// ```
+    /// use std::time::Duration;
+    ///
     /// use all_the_time::Session;
     ///
     /// let session = Session::new();
@@ -179,8 +181,13 @@ impl Session {
     /// // Work happens here
     ///
     /// let report = session.to_report();
-    /// // Report can be sent to another thread
-    /// report.print_to_stdout();
+    ///
+    /// // A report exposes each operation's statistics for programmatic use.
+    /// let total_time: Duration = report
+    ///     .operations()
+    ///     .map(|(_, op)| op.total_processor_time())
+    ///     .sum();
+    /// println!("Total processor time: {total_time:?}");
     /// ```
     #[must_use]
     pub fn to_report(&self) -> Report {

--- a/packages/alloc_tracker/README.md
+++ b/packages/alloc_tracker/README.md
@@ -24,8 +24,6 @@ fn main() {
     // When `session` is dropped it prints a human-readable summary to stdout and
     // writes machine-readable JSON files (one per operation) into the Cargo
     // target directory: target/alloc_tracker/<operation>.json.
-    //
-    // Use `Session::new().no_stdout()` or `.no_file()` to suppress either output.
 }
 ```
 

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -73,25 +73,7 @@
 //! summary is also printed to stdout.
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
-//! to create a session and record work. Either output can be suppressed:
-//!
-//! ```
-//! use alloc_tracker::{Allocator, Session};
-//!
-//! #[global_allocator]
-//! static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
-//!
-//! # fn main() {
-//! // Print to stdout but do not write JSON files.
-//! let session = Session::new().no_file();
-//!
-//! // Or write JSON files but do not print to stdout.
-//! let quiet_session = Session::new().no_stdout();
-//!
-//! // Or suppress both.
-//! let silent_session = Session::new().no_stdout().no_file();
-//! # }
-//! ```
+//! to create a session and record work.
 //!
 //! # Tracking mean allocations
 //!
@@ -140,7 +122,7 @@
 //! ```
 //! use std::thread;
 //!
-//! use alloc_tracker::{Allocator, Report, Session};
+//! use alloc_tracker::{Allocator, Session};
 //!
 //! #[global_allocator]
 //! static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
@@ -156,12 +138,17 @@
 //!
 //! let report = session.to_report();
 //!
-//! // Report can be sent to another thread
-//! thread::spawn(move || {
-//!     report.print_to_stdout();
+//! // Reports are `Send`, so they can be moved to another thread for processing.
+//! let total_bytes: u64 = thread::spawn(move || {
+//!     report
+//!         .operations()
+//!         .map(|(_, op)| op.total_bytes_allocated())
+//!         .sum()
 //! })
 //! .join()
 //! .unwrap();
+//!
+//! println!("Captured {total_bytes} bytes across all operations");
 //! # }
 //! ```
 //!

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -27,7 +27,13 @@ use std::fmt;
 /// }
 ///
 /// let report = session.to_report();
-/// report.print_to_stdout();
+///
+/// // A report exposes each operation's statistics for programmatic use.
+/// let total_bytes: u64 = report
+///     .operations()
+///     .map(|(_, op)| op.total_bytes_allocated())
+///     .sum();
+/// println!("Captured {total_bytes} bytes across all operations");
 /// # }
 /// ```
 ///
@@ -64,7 +70,12 @@ use std::fmt;
 /// let report2 = session2.to_report();
 /// let merged = Report::merge(&report1, &report2);
 ///
-/// merged.print_to_stdout();
+/// // The merged report exposes the combined statistics for programmatic use.
+/// let total_bytes: u64 = merged
+///     .operations()
+///     .map(|(_, op)| op.total_bytes_allocated())
+///     .sum();
+/// println!("Merged report captured {total_bytes} bytes across all operations");
 /// # }
 /// ```
 #[derive(Clone, Debug, Default)]

--- a/packages/alloc_tracker/src/session.rs
+++ b/packages/alloc_tracker/src/session.rs
@@ -166,7 +166,13 @@ impl Session {
     /// }
     ///
     /// let report = session.to_report();
-    /// report.print_to_stdout();
+    ///
+    /// // A report exposes each operation's statistics for programmatic use.
+    /// let total_bytes: u64 = report
+    ///     .operations()
+    ///     .map(|(_, op)| op.total_bytes_allocated())
+    ///     .sum();
+    /// println!("Captured {total_bytes} bytes across all operations");
     /// ```
     #[must_use]
     pub fn to_report(&self) -> Report {


### PR DESCRIPTION
## What

De-emphasizes the `Session` output-suppression controls (`.no_stdout()` / `.no_file()`) in the `alloc_tracker` and `all_the_time` documentation, and stops teaching users to manually print a `Report`.

## Why

The suppression methods are special-case functionality. They were presented prominently on each crate's documentation homepage (a dedicated "Either output can be suppressed" example block in `lib.rs` plus a callout in each `README.md`), which over-emphasizes a niche capability. It is fine for users to discover these from the `Session` API docs when they actually need them.

Separately, several doc examples ended by calling `report.print_to_stdout()`, which duplicates what the session already does automatically on drop. We want to encourage relying on the print-on-drop default and discourage hand-rolled printing.

## Changes

- Removed the `.no_stdout()` / `.no_file()` example blocks from both `lib.rs` "Machine-readable output" sections and the suppression callout from both `README.md` files.
- Refactored doc examples that called `report.print_to_stdout()` (the `lib.rs` "Session management" example, the `Report` struct + "Merging reports" examples, and the `Session::to_report` example) to demonstrate programmatic consumption via `Report::operations()` instead.

## Intentionally left as-is

- The `Session` struct-level API docs still document `no_stdout` / `no_file` — that is the appropriate place for users to find them.
- The `print_to_stdout` method itself, the `Drop` mechanism, and the `*_threaded_reports` standalone examples (the canonical "special needs" report-merging case) are unchanged.

## Validation

- Doctests pass for both crates (`cargo test --doc`).
- `cargo clippy --all-targets` is clean.
- `cargo doc --no-deps` builds with `RUSTDOCFLAGS=-D warnings` (no broken intra-doc links).
