### PR TITLE
Migrate cargo-detect-package and cargo-freeze-deps from argh to clap (#252)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,37 +120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "argh"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033"
-dependencies = [
- "argh_derive",
- "argh_shared",
-]
-
-[[package]]
-name = "argh_derive"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d"
-dependencies = [
- "argh_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "argh_shared"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,7 +452,7 @@ dependencies = [
 name = "cargo-detect-package"
 version = "1.0.21"
 dependencies = [
- "argh",
+ "clap",
  "mockall",
  "mutants",
  "serial_test",
@@ -495,7 +464,7 @@ dependencies = [
 name = "cargo-freeze-deps"
 version = "0.1.1"
 dependencies = [
- "argh",
+ "clap",
  "mutants",
  "semver",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.93"
 all_the_time = { version = "0.5.2", path = "packages/all_the_time", default-features = false }
 alloc_tracker = { version = "0.6.2", path = "packages/alloc_tracker", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
-argh = { version = "0.1.13", default-features = false, features = ["default"] }
 awaiter_set = { version = "0.1.7", path = "packages/awaiter_set", default-features = false }
 axum = { version = "0.8.0", default-features = false }
 azure_core = { version = "1.0.0", default-features = false }

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -46,8 +46,9 @@ When you add a new IO edge, follow the same pattern: a port trait with an
 The CLI is built with **clap** (derive API). It was chosen over `argh` because the
 command surface is wide and `argh` cannot group flags under named headings; clap's
 `help_heading` lets each command's `--help` present functionally grouped sections.
-The other workspace cargo tools still use `argh` — their migration is tracked in
-GitHub issue #252; do **not** assume they share this crate's CLI conventions.
+The other workspace cargo tools (`cargo-detect-package`/`cargo-freeze-deps`) also use
+clap, but their CLIs are trivial — do **not** assume they share this crate's grouped
+argument conventions.
 
 Flags are organised into functional groups, applied via `#[command(flatten)]` shared
 arg structs so a group looks identical everywhere it appears (and so analyze/list/

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -1169,8 +1169,8 @@ separated from the inactive context that is kept only for continuity.
 ## 10. Crate architecture
 
 `packages/cargo-bench-history/` — binary + library, `clap` (derive) subcommands.
-The other workspace cargo tools (`cargo-detect-package`/`cargo-freeze-deps`) still
-use `argh`; their migration to `clap` is tracked separately (GitHub issue #252).
+The other workspace cargo tools (`cargo-detect-package`/`cargo-freeze-deps`) also use
+`clap`, though their CLIs are trivial enough to need no grouped argument headings.
 
 ```
 src/
@@ -1629,4 +1629,5 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      (commits for `prune`, prefixes for `bless`, and the `runs|discriminants|
      blessings` selector for `list`) are bare positional words, not flags; and a bare
      `list` is an error that names its three subjects. The other workspace cargo tools
-     stay on `argh` for now (GitHub issue #252 tracks their migration).
+     (`cargo-detect-package`/`cargo-freeze-deps`) also use `clap` (issue #252), though
+     their flat CLIs need no grouped argument headings.

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 all-features = true
 
 [dependencies]
-argh = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 toml = { workspace = true, features = ["parse", "serde"] }
 
 [dev-dependencies]

--- a/packages/cargo-detect-package/src/cli.rs
+++ b/packages/cargo-detect-package/src/cli.rs
@@ -1,0 +1,101 @@
+//! Command-line argument parsing for `cargo-detect-package`, built on `clap`.
+//!
+//! The parser lives in the library rather than the binary so its behavior —
+//! argument defaults, help text, and parse errors — can be exercised directly by
+//! integration tests without spawning a subprocess.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use crate::{OutsidePackageAction, RunInput};
+
+/// A Cargo tool to detect the package that a file belongs to, passing the package name
+/// to a subcommand.
+#[derive(Debug, Parser)]
+#[command(
+    name = "cargo-detect-package",
+    about = "Detect the package a file belongs to and pass its name to a subcommand.",
+    disable_version_flag = true
+)]
+pub struct Cli {
+    /// Path to the file to detect the package for.
+    #[arg(long)]
+    path: PathBuf,
+
+    /// Pass the detected package as an environment variable of this name instead of as a
+    /// cargo argument.
+    #[arg(long)]
+    via_env: Option<String>,
+
+    /// Action to take when the path is not in any package: `workspace`, `ignore`, or
+    /// `error`.
+    #[arg(long)]
+    outside_package: Option<OutsidePackageAction>,
+
+    /// The subcommand to execute, with all of its own arguments.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    subcommand: Vec<String>,
+}
+
+/// A parse outcome that should terminate the program before execution.
+///
+/// This is either a help/usage request (success, printed to stdout) or a parse
+/// error (failure, printed to stderr), mirroring the shape the binary entry point
+/// consumes.
+#[derive(Debug)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "handoff struct read directly by the in-crate binary and integration tests"
+)]
+pub struct EarlyExit {
+    /// The rendered message (help text or error) to print.
+    pub output: String,
+    /// `Ok` for a help/usage request (exit success), `Err` for a parse error.
+    pub status: Result<(), ()>,
+}
+
+impl EarlyExit {
+    /// Classifies a `clap` parse error into the success/failure early-exit shape.
+    fn from_clap(error: &clap::Error) -> Self {
+        use clap::error::ErrorKind;
+        let success = matches!(
+            error.kind(),
+            ErrorKind::DisplayHelp
+                | ErrorKind::DisplayVersion
+                | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        );
+        Self {
+            output: error.to_string(),
+            status: if success { Ok(()) } else { Err(()) },
+        }
+    }
+}
+
+impl Cli {
+    /// Parses an argument vector (program name followed by its arguments) into the
+    /// typed CLI, returning an [`EarlyExit`] for a help request or a parse error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EarlyExit`] when the arguments request help/usage or fail to
+    /// parse.
+    pub fn from_args(command_name: &[&str], args: &[&str]) -> Result<Self, EarlyExit> {
+        let argv: Vec<&str> = command_name.iter().chain(args).copied().collect();
+        Self::try_parse_from(argv).map_err(|error| EarlyExit::from_clap(&error))
+    }
+
+    /// Translates the parsed arguments into the [`RunInput`] the core logic consumes,
+    /// defaulting the outside-package action to [`OutsidePackageAction::Workspace`].
+    #[must_use]
+    pub fn into_input(self) -> RunInput {
+        RunInput {
+            path: self.path,
+            via_env: self.via_env,
+            outside_package: self
+                .outside_package
+                .unwrap_or(OutsidePackageAction::Workspace),
+            subcommand: self.subcommand,
+        }
+    }
+}

--- a/packages/cargo-detect-package/src/lib.rs
+++ b/packages/cargo-detect-package/src/lib.rs
@@ -7,12 +7,14 @@
 //! This crate provides the core logic for package detection, exposed via the [`run`] function.
 //! The binary entry point is in `main.rs`.
 
+mod cli;
 mod detection;
 mod execution;
 mod pal;
 mod types;
 mod workspace;
 
+pub use cli::{Cli, EarlyExit};
 use detection::{DetectedPackage, detect_package};
 use execution::{execute_with_cargo_args, execute_with_env_var};
 use pal::{Filesystem, FilesystemFacade};

--- a/packages/cargo-detect-package/src/main.rs
+++ b/packages/cargo-detect-package/src/main.rs
@@ -4,34 +4,13 @@
 //! Binary entry point for the cargo-detect-package tool.
 //!
 //! This module is excluded from mutation testing because testing process entry/exit behavior
-//! is impractical - it requires spawning subprocesses and checking exit codes.
+//! is impractical - it requires spawning subprocesses and checking exit codes. CLI parsing
+//! lives in the library's `cli` module and the core logic lives in `cargo_detect_package::run`,
+//! both tested directly.
 
-use std::path::PathBuf;
 use std::process::ExitCode;
 
-use argh::FromArgs;
-use cargo_detect_package::{OutsidePackageAction, RunInput, RunOutcome, run};
-
-/// A Cargo tool to detect the package that a file belongs to, passing the package name to a
-/// subcommand.
-#[derive(FromArgs)]
-struct Args {
-    /// path to the file to detect package for.
-    #[argh(option)]
-    path: PathBuf,
-
-    /// pass the detected package as an environment variable instead of as a cargo argument.
-    #[argh(option)]
-    via_env: Option<String>,
-
-    /// action to take when path is not in any package (workspace, ignore, error).
-    #[argh(option)]
-    outside_package: Option<OutsidePackageAction>,
-
-    /// the subcommand to execute.
-    #[argh(positional, greedy)]
-    subcommand: Vec<String>,
-}
+use cargo_detect_package::{Cli, RunOutcome, run};
 
 // Binary entry point - mutations would require subprocess testing which is impractical.
 #[cfg_attr(test, mutants::skip)]
@@ -45,35 +24,32 @@ fn main() -> ExitCode {
         env_args.remove(1);
     }
 
-    // Convert to &str for argh.
+    // Convert to &str for the parser.
     let str_args: Vec<&str> = env_args.iter().map(String::as_str).collect();
 
     let program_name = str_args
         .first()
         .expect("std::env::args() always provides at least the program name");
 
-    let args: Args = match Args::from_args(&[program_name], str_args.get(1..).unwrap_or(&[])) {
-        Ok(args) => args,
+    let cli = match Cli::from_args(&[program_name], str_args.get(1..).unwrap_or(&[])) {
+        Ok(cli) => cli,
         Err(early_exit) => {
-            println!("{}", early_exit.output);
-            return if early_exit.output.contains("help") {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::FAILURE
+            // `status` is `Ok` for a `--help`/usage request (print to stdout, exit
+            // success) and `Err` for a parse error (print to stderr, exit failure).
+            return match early_exit.status {
+                Ok(()) => {
+                    println!("{}", early_exit.output);
+                    ExitCode::SUCCESS
+                }
+                Err(()) => {
+                    eprintln!("{}", early_exit.output);
+                    ExitCode::FAILURE
+                }
             };
         }
     };
 
-    let input = RunInput {
-        path: args.path,
-        via_env: args.via_env,
-        outside_package: args
-            .outside_package
-            .unwrap_or(OutsidePackageAction::Workspace),
-        subcommand: args.subcommand,
-    };
-
-    match run(&input) {
+    match run(&cli.into_input()) {
         Ok(outcome) => match outcome {
             RunOutcome::PackageDetected {
                 subcommand_succeeded,

--- a/packages/cargo-detect-package/tests/cli_parsing.rs
+++ b/packages/cargo-detect-package/tests/cli_parsing.rs
@@ -1,0 +1,106 @@
+//! Tests for the `cargo-detect-package` clap argument parser.
+//!
+//! These exercise the library-housed [`Cli`] directly (no subprocess), covering the
+//! required `--path`, the optional `--via-env`/`--outside-package` flags, the
+//! case-insensitive outside-package values, the greedy trailing subcommand capture
+//! (including hyphenated arguments), and the help/error early-exit classification.
+
+use std::path::PathBuf;
+
+use cargo_detect_package::{Cli, EarlyExit, OutsidePackageAction};
+
+fn parse(args: &[&str]) -> Result<Cli, EarlyExit> {
+    Cli::from_args(&["cargo-detect-package"], args)
+}
+
+#[test]
+fn parses_all_options_and_trailing_subcommand() {
+    let input = parse(&[
+        "--path",
+        "src/lib.rs",
+        "--via-env",
+        "DETECTED_PACKAGE",
+        "--outside-package",
+        "error",
+        "clippy",
+        "--fix",
+    ])
+    .unwrap()
+    .into_input();
+
+    assert_eq!(input.path, PathBuf::from("src/lib.rs"));
+    assert_eq!(input.via_env.as_deref(), Some("DETECTED_PACKAGE"));
+    assert_eq!(input.outside_package, OutsidePackageAction::Error);
+    assert_eq!(
+        input.subcommand,
+        vec!["clippy".to_string(), "--fix".to_string()]
+    );
+}
+
+#[test]
+fn outside_package_defaults_to_workspace_when_omitted() {
+    let input = parse(&["--path", "src/lib.rs"]).unwrap().into_input();
+    assert_eq!(input.outside_package, OutsidePackageAction::Workspace);
+    assert_eq!(input.via_env, None);
+    assert!(input.subcommand.is_empty());
+}
+
+#[test]
+fn outside_package_parsing_is_case_insensitive() {
+    let input = parse(&["--path", "x", "--outside-package", "IGNORE"])
+        .unwrap()
+        .into_input();
+    assert_eq!(input.outside_package, OutsidePackageAction::Ignore);
+}
+
+#[test]
+fn trailing_subcommand_captures_double_dash_and_hyphenated_args() {
+    let input = parse(&[
+        "--path",
+        "x",
+        "clippy",
+        "--all-features",
+        "--",
+        "-A",
+        "warnings",
+    ])
+    .unwrap()
+    .into_input();
+    assert_eq!(
+        input.subcommand,
+        vec![
+            "clippy".to_string(),
+            "--all-features".to_string(),
+            "--".to_string(),
+            "-A".to_string(),
+            "warnings".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn missing_required_path_is_a_failure_early_exit() {
+    let early = parse(&[]).unwrap_err();
+    assert!(
+        early.status.is_err(),
+        "missing required arg is a failure exit"
+    );
+}
+
+#[test]
+fn invalid_outside_package_value_is_a_failure_early_exit() {
+    let early = parse(&["--path", "x", "--outside-package", "nope"]).unwrap_err();
+    assert!(early.status.is_err());
+    assert!(
+        early.output.contains("workspace"),
+        "error should name the valid options, got: {}",
+        early.output
+    );
+}
+
+#[test]
+fn help_request_is_a_success_early_exit() {
+    let early = parse(&["--help"]).unwrap_err();
+    assert!(early.status.is_ok(), "help should be a success exit");
+    assert!(early.output.contains("Usage"));
+}

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 all-features = true
 
 [dependencies]
-argh = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 semver = { workspace = true }
 toml_edit = { workspace = true, features = ["parse", "display"] }
 

--- a/packages/cargo-freeze-deps/src/cli.rs
+++ b/packages/cargo-freeze-deps/src/cli.rs
@@ -1,0 +1,89 @@
+//! Command-line argument parsing for `cargo-freeze-deps`, built on `clap`.
+//!
+//! The parser lives in the library rather than the binary so its behavior —
+//! argument defaults, help text, and parse errors — can be exercised directly by
+//! integration tests without spawning a subprocess.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use crate::RunInput;
+
+/// A Cargo subcommand that freezes all floating dependency versions in a `Cargo.toml`
+/// file to their literal values.
+#[derive(Debug, Parser)]
+#[command(
+    name = "cargo-freeze-deps",
+    about = "Freeze every floating dependency version in a Cargo.toml file to its literal value.",
+    disable_version_flag = true
+)]
+pub struct Cli {
+    /// Path to the `Cargo.toml` file to freeze. Defaults to `./Cargo.toml` in the
+    /// current working directory.
+    #[arg(short, long)]
+    path: Option<PathBuf>,
+
+    /// Path to write the rewritten `Cargo.toml` to. Defaults to the input path
+    /// (rewriting in place).
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+}
+
+/// A parse outcome that should terminate the program before execution.
+///
+/// This is either a help/usage request (success, printed to stdout) or a parse
+/// error (failure, printed to stderr), mirroring the shape the binary entry point
+/// consumes.
+#[derive(Debug)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "handoff struct read directly by the in-crate binary and integration tests"
+)]
+pub struct EarlyExit {
+    /// The rendered message (help text or error) to print.
+    pub output: String,
+    /// `Ok` for a help/usage request (exit success), `Err` for a parse error.
+    pub status: Result<(), ()>,
+}
+
+impl EarlyExit {
+    /// Classifies a `clap` parse error into the success/failure early-exit shape.
+    fn from_clap(error: &clap::Error) -> Self {
+        use clap::error::ErrorKind;
+        let success = matches!(
+            error.kind(),
+            ErrorKind::DisplayHelp
+                | ErrorKind::DisplayVersion
+                | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        );
+        Self {
+            output: error.to_string(),
+            status: if success { Ok(()) } else { Err(()) },
+        }
+    }
+}
+
+impl Cli {
+    /// Parses an argument vector (program name followed by its arguments) into the
+    /// typed CLI, returning an [`EarlyExit`] for a help request or a parse error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EarlyExit`] when the arguments request help/usage or fail to
+    /// parse.
+    pub fn from_args(command_name: &[&str], args: &[&str]) -> Result<Self, EarlyExit> {
+        let argv: Vec<&str> = command_name.iter().chain(args).copied().collect();
+        Self::try_parse_from(argv).map_err(|error| EarlyExit::from_clap(&error))
+    }
+
+    /// Translates the parsed arguments into the [`RunInput`] the core logic consumes,
+    /// applying the default input path (`Cargo.toml`) when none was given.
+    #[must_use]
+    pub fn into_input(self) -> RunInput {
+        RunInput {
+            path: self.path.unwrap_or_else(|| PathBuf::from("Cargo.toml")),
+            output: self.output,
+        }
+    }
+}

--- a/packages/cargo-freeze-deps/src/lib.rs
+++ b/packages/cargo-freeze-deps/src/lib.rs
@@ -4,10 +4,12 @@
 //! A Cargo subcommand that freezes every floating dependency version in a Cargo.toml file
 //! to its literal `=X.Y.Z` form.
 
+mod cli;
 mod freeze;
 mod run;
 mod types;
 mod version;
 
+pub use cli::{Cli, EarlyExit};
 pub use run::run;
 pub use types::*;

--- a/packages/cargo-freeze-deps/src/main.rs
+++ b/packages/cargo-freeze-deps/src/main.rs
@@ -5,35 +5,18 @@
 //!
 //! This module is excluded from mutation testing and coverage because testing process
 //! entry/exit behavior is impractical — it requires spawning subprocesses and checking
-//! exit codes. The bulk of the logic lives in the library and is tested directly via
-//! `cargo_freeze_deps::run`.
+//! exit codes. CLI parsing lives in the library's `cli` module and the bulk of the logic
+//! lives in `cargo_freeze_deps::run`, both tested directly.
 
-use std::path::PathBuf;
 use std::process::ExitCode;
 
-use argh::FromArgs;
-use cargo_freeze_deps::{RunInput, run};
-
-/// A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file
-/// to their literal values.
-#[derive(FromArgs)]
-struct Args {
-    /// path to the Cargo.toml file to freeze. Defaults to ./Cargo.toml in the current
-    /// working directory.
-    #[argh(option, short = 'p')]
-    path: Option<PathBuf>,
-
-    /// path to write the rewritten Cargo.toml to. Defaults to the input path
-    /// (rewriting in place).
-    #[argh(option, short = 'o')]
-    output: Option<PathBuf>,
-}
+use cargo_freeze_deps::{Cli, run};
 
 // Binary entry point — mutations would require subprocess testing which is impractical.
 #[cfg_attr(test, mutants::skip)]
 fn main() -> ExitCode {
     // When invoked as `cargo freeze-deps`, Cargo passes "freeze-deps" as the first
-    // argument after the program name. We strip it so argh sees a normal CLI invocation.
+    // argument after the program name. We strip it so clap sees a normal CLI invocation.
     let mut env_args: Vec<String> = std::env::args().collect();
 
     if env_args.get(1).is_some_and(|arg| arg == "freeze-deps") {
@@ -46,27 +29,33 @@ fn main() -> ExitCode {
         .first()
         .expect("std::env::args() always provides at least the program name");
 
-    let args: Args = match Args::from_args(&[program_name], str_args.get(1..).unwrap_or(&[])) {
-        Ok(args) => args,
+    let cli = match Cli::from_args(&[program_name], str_args.get(1..).unwrap_or(&[])) {
+        Ok(cli) => cli,
         Err(early_exit) => {
-            println!("{}", early_exit.output);
-            return if early_exit.output.contains("help") {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::FAILURE
+            // `status` is `Ok` for a `--help`/usage request (print to stdout, exit
+            // success) and `Err` for a parse error (print to stderr, exit failure).
+            return match early_exit.status {
+                Ok(()) => {
+                    println!("{}", early_exit.output);
+                    ExitCode::SUCCESS
+                }
+                Err(()) => {
+                    eprintln!("{}", early_exit.output);
+                    ExitCode::FAILURE
+                }
             };
         }
     };
 
-    let input = RunInput {
-        path: args.path.unwrap_or_else(|| PathBuf::from("Cargo.toml")),
-        output: args.output,
-    };
-
-    match run(&input) {
+    match run(&cli.into_input()) {
         Ok(outcome) => {
+            let noun = if outcome.frozen_count == 1 {
+                "dependency version"
+            } else {
+                "dependency versions"
+            };
             println!(
-                "Froze {} dependency version(s); left {} unchanged.",
+                "Froze {} {noun}; left {} unchanged.",
                 outcome.frozen_count, outcome.skipped_count
             );
             ExitCode::SUCCESS

--- a/packages/cargo-freeze-deps/tests/cli_parsing.rs
+++ b/packages/cargo-freeze-deps/tests/cli_parsing.rs
@@ -1,0 +1,61 @@
+//! Tests for the `cargo-freeze-deps` clap argument parser.
+//!
+//! These exercise the library-housed [`Cli`] directly (no subprocess), covering the
+//! input-path default, the `--path`/`--output` options and their short forms, and the
+//! help/error early-exit classification consumed by the binary entry point.
+
+use std::path::PathBuf;
+
+use cargo_freeze_deps::{Cli, EarlyExit};
+
+fn parse(args: &[&str]) -> Result<Cli, EarlyExit> {
+    Cli::from_args(&["cargo-freeze-deps"], args)
+}
+
+#[test]
+fn defaults_to_cargo_toml_when_no_path_given() {
+    let input = parse(&[]).unwrap().into_input();
+    assert_eq!(input.path, PathBuf::from("Cargo.toml"));
+    assert_eq!(input.output, None);
+}
+
+#[test]
+fn long_options_are_parsed() {
+    let input = parse(&["--path", "a/Cargo.toml", "--output", "b/Cargo.toml"])
+        .unwrap()
+        .into_input();
+    assert_eq!(input.path, PathBuf::from("a/Cargo.toml"));
+    assert_eq!(input.output, Some(PathBuf::from("b/Cargo.toml")));
+}
+
+#[test]
+fn short_options_are_parsed() {
+    let input = parse(&["-p", "a/Cargo.toml", "-o", "b/Cargo.toml"])
+        .unwrap()
+        .into_input();
+    assert_eq!(input.path, PathBuf::from("a/Cargo.toml"));
+    assert_eq!(input.output, Some(PathBuf::from("b/Cargo.toml")));
+}
+
+#[test]
+fn output_is_optional() {
+    let input = parse(&["--path", "a/Cargo.toml"]).unwrap().into_input();
+    assert_eq!(input.path, PathBuf::from("a/Cargo.toml"));
+    assert_eq!(input.output, None);
+}
+
+#[test]
+fn help_request_is_a_success_early_exit() {
+    let early = parse(&["--help"]).unwrap_err();
+    assert!(early.status.is_ok(), "help should be a success exit");
+    assert!(early.output.contains("Usage"));
+}
+
+#[test]
+fn unknown_flag_is_a_failure_early_exit() {
+    let early = parse(&["--definitely-not-a-flag"]).unwrap_err();
+    assert!(
+        early.status.is_err(),
+        "a parse error should be a failure exit"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #252. Migrates the two remaining `argh`-based cargo tools — `cargo-detect-package` and `cargo-freeze-deps` — to `clap` (derive), so every workspace cargo tool now shares one CLI parsing library for uniformity and easier maintenance.

## Approach

To match `cargo-bench-history` (whose clap `Cli` lives in the library and is therefore testable), each tool's parser now lives in its library as a new `src/cli.rs` module exposing a clap `Cli`, an `EarlyExit { output, status }` help/error classifier, `Cli::from_args`, and `into_input()`. `main.rs` is reduced to a thin shell that strips the `cargo <subcommand>` prefix, parses, and runs, with proper stdout/success vs stderr/failure exit handling.

## Behaviour preserved

`cargo-detect-package` keeps its required `--path`, optional `--via-env`/`--outside-package`, and a greedy trailing subcommand. `trailing_var_arg` + `allow_hyphen_values` reproduce argh's `greedy` capture (including `--` and hyphenated arguments), and `OutsidePackageAction`'s case-insensitive `FromStr` still drives parsing while clap surfaces its error message.

`cargo-freeze-deps` keeps `--path`/`-p`, `--output`/`-o`, and the default `Cargo.toml` input path. While rewriting its output line I replaced the banned `version(s)` plural shorthand with a computed singular/plural form.

## Dependencies

Removed `argh` from both package manifests and from `[workspace.dependencies]` (no consumers remain — `cargo machete` confirms). `clap` was already declared at the workspace level with the documented `default`-feature exception; each consumer adds `features = ["derive"]`. Ran the cargo-deps-tidy skill (no issues) and `Cargo.lock` only drops `argh`/`argh_derive`/`argh_shared` with no version churn.

## Tests

Added `tests/cli_parsing.rs` to each package (13 tests total) covering defaults, long/short options, case-insensitive outside-package values, greedy `--` capture, and the help/error early-exit classification. They drive the library-housed `Cli` directly with no I/O, so they also run under Miri.

## Validation

`just package="cargo-detect-package cargo-freeze-deps" validate-local` passes in full: format-check, clippy (dev + release), tests, doctests, docs, docs-default-features, Miri, machete, and default-features-check.

Also updated the now-stale `argh` references in `cargo-bench-history`'s `AGENTS.md` and `DESIGN.md` to reflect that all cargo tools use clap.
