### PR TITLE
Test cargo-bench-history Azure storage against a real account

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -71,8 +71,8 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
 - **test-azurite** — single-platform (Linux) by choice, package-gated to `cargo-bench-history`
   - Runs the `azure`-feature tests against a live Azurite blob emulator and also
     collects coverage so the `azure.rs` network paths reach Codecov.
-  - Named for the Azurite emulator it targets; `test-azure` is reserved for a future
-    job that runs against a real Azure account. Single-platform by choice, not
+  - Named for the Azurite emulator it targets; its sibling `test-azure` runs the
+    same backend against a real Azure account. Single-platform by choice, not
     limitation: the Azure Blob backend is OS-agnostic network I/O, so one platform
     fully covers it and Linux is the cheapest runner.
   - The `azure` feature is off by default and its network paths **self-skip** when
@@ -88,6 +88,37 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     containers cannot reliably bind the emulator to a reachable address (the
     default image binds `127.0.0.1` inside the container and the service syntax
     cannot override the command), so the host-process approach is used instead.
+
+- **test-azure** — single-platform (Linux) by choice, package-gated to `cargo-bench-history`
+  - Additive sibling of `test-azurite`: runs the same `azure`-feature backend
+    tests against a **real Azure Storage account** to exercise the **Microsoft
+    Entra ID** authentication path that the emulator (account-key/SAS) never
+    touches — a real account with shared-key access disabled, reached over HTTPS.
+  - Authenticates with **GitHub OIDC workload identity federation** (no stored
+    secret): `azure/login@v2` signs in a user-assigned managed identity, leaving
+    the Azure CLI authenticated, which the tests' `DeveloperToolsCredential` picks
+    up unchanged. Requires `permissions: { id-token: write, contents: read }`.
+  - **Double-gated** so it only runs when it can succeed: package-gated to
+    `cargo-bench-history` (same gate as `test-azurite`); and **same-repo only** (a
+    fork PR cannot mint an OIDC token for our tenant, so the `if:` lets fork PRs skip
+    cleanly instead of failing red). The `just test-azure` recipe it invokes sets
+    `ENABLE_AZURE=1`, which both opts the real-Azure tests in and turns a missing
+    account into a hard failure, so a job that does run can never silently skip every
+    test.
+  - Reads its Azure identifiers from the repository-root `constants.env` (the same
+    non-secret `BENCH_HISTORY_AZURE_ACCOUNT`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+    `AZURE_SUBSCRIPTION_ID` that `just test-azure` reads locally, so local and CI
+    target the same account). A `bash` step `grep`s those keys into `$GITHUB_ENV` so
+    the `azure/login` inputs and the cleanup step can reference them. It then runs the
+    tests via the `just test-azure` recipe (the same one developers use locally; it
+    reads the account from the job's `BENCH_HISTORY_AZURE_ACCOUNT` env and runs the
+    `*_in_real_azure` tests). Each test deletes its own container, even on panic; a
+    final `if: always()` step runs `infra/azure-bench-history/cleanup-containers.ps1`
+    as a backstop for a container a crashed run might leave.
+  - Collects **no coverage** (`test-azurite` already covers `azure.rs`); its value
+    is proving the real Entra + real Blob endpoint round-trip end to end. The
+    account, identity and federated credentials are scripted/Bicep'd in
+    `infra/azure-bench-history/` (see its README to deploy or re-create).
 
 ### cache-warmup.yml
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -650,3 +650,82 @@ jobs:
           files: lcov.info
           flags: azure
           fail_ci_if_error: true
+
+  # Azure Blob storage backend tests against a real Azure Storage account.
+  #
+  # Complements `test-azurite` by exercising the Microsoft Entra ID authentication
+  # path that the emulator (account-key/SAS) never touches: a real Storage account
+  # with shared-key access disabled, reached over HTTPS, authenticated through
+  # GitHub OIDC workload identity federation — no stored secret. Each test creates a
+  # fresh blob container and deletes it when it finishes (even on panic); the final
+  # `if: always()` sweep is a backstop for a container a crashed run might leave.
+  #
+  # Gated two ways so it only runs when it can succeed:
+  #   * package-gated to cargo-bench-history (same gate as test-azurite);
+  #   * same-repo only — a fork PR cannot mint an OIDC token for our tenant, so it
+  #     would fail federation; the condition lets fork PRs skip cleanly instead.
+  # The Azure identifiers it needs are committed (non-secret) in constants.env, the
+  # same source `just test-azure` reads locally, so local and CI target the same
+  # account. The `just test-azure` recipe sets ENABLE_AZURE=1, which is what actually
+  # opts the real-Azure tests in (they self-skip without it) and turns a missing
+  # account into a hard failure, so once the job runs it can never silently degrade
+  # into skipping every test.
+  #
+  # Single-platform (Linux) by choice, not limitation: the Azure Blob backend is
+  # OS-agnostic network I/O, so one platform fully covers it and Linux is the
+  # cheapest runner. Unlike test-azurite it collects no coverage (azurite already
+  # covers azure.rs); its value is proving the real Entra + real Blob endpoint
+  # round-trip end to end.
+  #
+  # The account, managed identity and federated credentials are scripted/Bicep'd in
+  # infra/azure-bench-history/ — see that directory's README to deploy or re-create.
+  test-azure:
+    needs: [delta]
+    if: >-
+      needs.delta.outputs.skip_all != 'true'
+      && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'cargo-bench-history'))
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    # `id-token: write` lets the job mint a short-lived GitHub OIDC token (a signed
+    # JWT proving "this run is repo folo-rs/folo on ref X"). `azure/login@v2` hands
+    # that token to Azure, which matches it against the managed identity's federated
+    # credentials (see infra/azure-bench-history/main.bicep) and issues an access
+    # token — so CI authenticates with no stored secret. The default GITHUB_TOKEN
+    # cannot request an OIDC token unless this permission is granted explicitly (and
+    # fork PRs cannot get it at all, hence the same-repo gate above). `contents: read`
+    # is the minimum the checkout needs.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      # Surface the non-secret AZURE_* identity values and the account name from
+      # constants.env (the same source `just test-azure` reads) as job env vars, so
+      # the azure/login inputs and the cleanup step can reference them without
+      # duplicating values in repo Variables. Each line is `KEY=value`; comments skip.
+      - name: Load Azure identifiers from constants.env
+        shell: bash
+        run: grep -E '^(AZURE_CLIENT_ID|AZURE_TENANT_ID|AZURE_SUBSCRIPTION_ID|BENCH_HISTORY_AZURE_ACCOUNT)=' constants.env >> "$GITHUB_ENV"
+
+      - name: Sign in to Azure (OIDC workload identity federation)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run real-Azure storage tests
+        run: just test-azure
+
+      - name: Delete any leftover test containers
+        if: always()
+        shell: pwsh
+        # cleanup-containers.ps1 defaults its account to BENCH_HISTORY_AZURE_ACCOUNT,
+        # which the load step above put into the job env.
+        run: ./infra/azure-bench-history/cleanup-containers.ps1

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,7 @@ Prerequisites:
     * vscode-just
     * WSL
 * PowerShell 7
+* Node.js with npm (used to install and run the Azurite Azure Blob emulator for `just test-azurite`)
 * `rustup toolchain install` to install Rust development tools based on `rust-toolchain.toml`
 * `cargo install just`
 * (Only if publishing releases) GitHub CLI + `gh auth login`
@@ -54,6 +55,7 @@ Prerequisites:
   ```
 * `rustup toolchain install` to install Rust development tools based on `rust-toolchain.toml`
 * `cargo install just`
+* Node.js with npm (used to install and run the Azurite Azure Blob emulator for `just test-azurite`)
 * If first time Git setup, execute `git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"` to setup authentication flow
 
 Setup:
@@ -71,3 +73,24 @@ Validation:
     * `Tasks: Run Build Task`
     * `Tasks: Run Test Task`
 1. Execute `just validate-local` in terminal.
+
+# Testing Azure functionality
+
+The `cargo-bench-history` package has an optional `azure` feature with an Azure Blob storage
+backend. Its tests are special: they are **not** exercised by `just test`, because they need
+either a local storage emulator or a real cloud account that an ordinary test run cannot assume
+is present. Under `just test` these tests self-skip (no emulator is started), so they never break
+a normal test run. To actually exercise them, use one of the dedicated recipes below.
+
+There are two flavours:
+
+* **Azurite (emulator) tests** run against a local [Azurite](https://github.com/Azure/Azurite)
+  Blob emulator. `just install-tools` installs Azurite (via npm), and `just test-azurite` starts
+  the emulator, runs the tests against it, and stops the emulator afterward — including on failure.
+  If an emulator is already running on the default port, the recipe reuses it and leaves it running.
+* **Real-Azure tests** run against a real Azure Storage account to exercise the Microsoft Entra ID
+  authentication path that the emulator does not cover. Run them with `just test-azure` after
+  `az login`. They are opt-in and self-skip unless explicitly enabled.
+
+For account provisioning and the gating environment variables, see `infra/azure-bench-history/` and
+the `packages/cargo-bench-history/AGENTS.md` testing notes.

--- a/constants.env
+++ b/constants.env
@@ -6,3 +6,18 @@ RUST_MSRV=1.93
 # artifacts written by the older one ("contains outdated or invalid JSON; try cargo
 # clean"). Bump this deliberately (and verify the miri component exists for the date).
 RUST_NIGHTLY=nightly-2026-06-19
+
+# Azure identifiers for the cargo-bench-history real-Azure storage tests, shared by
+# local runs (`just test-azure`) and the CI `test-azure` job so both target the same
+# deployed account (infra/azure-bench-history/). These are non-secret identifiers,
+# not credentials — authentication is via Microsoft Entra ID (local `az login` / CI
+# OIDC federation), so there is nothing to leak by committing them.
+#
+# These do NOT by themselves enable the real-Azure tests: those run only when
+# ENABLE_AZURE is set, which the `just test-azure` recipe does. A plain `just test`
+# (and the azurite/coverage jobs) therefore leaves the real-Azure tests self-skipped
+# even though the account name is in scope here via dotenv.
+BENCH_HISTORY_AZURE_ACCOUNT=folovalidate
+AZURE_CLIENT_ID=36cd495b-e66e-4b80-b7d0-478000793523
+AZURE_TENANT_ID=7b8f7512-4d66-425f-bdc3-c24ebef1b03e
+AZURE_SUBSCRIPTION_ID=a94944a5-949a-4cc0-82bf-bf1dc763b137

--- a/infra/azure-bench-history/README.md
+++ b/infra/azure-bench-history/README.md
@@ -76,9 +76,11 @@ just test-azure                # uses BENCH_HISTORY_AZURE_ACCOUNT from constants
 a misconfigured account fail loudly rather than skip) and runs the `real_azure`
 tests. Pass a name to target a different account: `just test-azure <storage-account-name>`.
 
-Without `BENCH_HISTORY_AZURE_ACCOUNT` the real-Azure tests self-skip (the Azurite
-tests are unaffected). Each test creates a unique `bh-it-*` container and deletes it
-when it finishes.
+Without `ENABLE_AZURE` (for example under a plain `just test`) the real-Azure tests
+self-skip regardless of the account, so they never target the cloud unintentionally;
+the Azurite tests are unaffected. With `ENABLE_AZURE` set (as `just test-azure` does)
+a missing `BENCH_HISTORY_AZURE_ACCOUNT` is instead a hard failure, not a skip. Each
+test creates a unique `bh-it-*` container and deletes it when it finishes.
 
 ## Clean up leftover containers
 

--- a/infra/azure-bench-history/README.md
+++ b/infra/azure-bench-history/README.md
@@ -1,0 +1,98 @@
+# Azure infrastructure for cargo-bench-history real-Azure tests
+
+This directory provisions the Azure resources that back the `cargo-bench-history`
+real-Azure storage tests (the `test-azure` CI job and local runs). Everything is
+described in Bicep and driven by idempotent PowerShell scripts, so the environment
+can be deleted and re-created with one command.
+
+## What gets created
+
+`main.bicep` (deployed at resource-group scope) creates:
+
+- A **Storage account** — `StorageV2`, HTTPS-only, TLS 1.2, **shared-key access
+  disabled** (Entra ID only, so there is no account key to leak). Container and blob
+  soft-delete are disabled so a deleted test container is gone immediately.
+- A **user-assigned managed identity** — the CI principal — with **GitHub OIDC
+  federated credentials** (one per trusted branch, plus same-repo pull requests).
+  GitHub Actions signs in with no stored secret.
+- **`Storage Blob Data Contributor`** role assignments on the account for the managed
+  identity and (optionally) a local developer principal. That single role covers
+  container create/delete and blob read/write/delete via the data plane, which is all
+  the tool's `run` and the tests' container cleanup need.
+
+## Prerequisites
+
+- Azure CLI (`az`) and PowerShell 7+.
+- `az login` as an account allowed to create these resources and assign roles
+  (Owner or User Access Administrator on the target scope).
+
+## Deploy
+
+```powershell
+# Your own object id for local data-plane access (optional but recommended):
+$me = az ad signed-in-user show --query id -o tsv
+
+./deploy.ps1 `
+    -SubscriptionId <subscription-guid> `
+    -StorageAccountName <globally-unique-name> `
+    -LocalPrincipalId $me
+```
+
+Key parameters (see `deploy.ps1 -?` for all): `-ResourceGroup` (default
+`rg-folo-bench-history`), `-Location` (default `swedencentral`), `-StorageAccountName`
+(3-24 lowercase alphanumerics, globally unique), `-LocalPrincipalId` /
+`-LocalPrincipalType` (`User` or `Group`).
+
+On success the script prints the identifiers to record in `constants.env`.
+
+## Configure the repository
+
+The Azure identifiers are committed (non-secret) in `constants.env` at the repository
+root, shared by local `just test-azure` runs and the CI `test-azure` job so both
+target the same account. If you re-created the resources, update these lines to match
+the values the deploy script printed:
+
+| Key | Source |
+| --- | --- |
+| `BENCH_HISTORY_AZURE_ACCOUNT` | storage account name |
+| `AZURE_CLIENT_ID` | managed identity client id |
+| `AZURE_TENANT_ID` | tenant id |
+| `AZURE_SUBSCRIPTION_ID` | subscription id |
+
+These are identifiers, not credentials — authentication is via Microsoft Entra ID
+(local `az login` / CI OIDC federation), so there is nothing to leak by committing
+them. They do not by themselves run the real-Azure tests: those run only when
+`ENABLE_AZURE` is set, which the `just test-azure` recipe does. Pull requests from
+forks cannot mint a token for the tenant and so the CI job skips for them.
+
+## Run the tests locally
+
+```powershell
+az login                       # sign in as your Entra user
+just test-azure                # uses BENCH_HISTORY_AZURE_ACCOUNT from constants.env
+```
+
+`just test-azure` sets `ENABLE_AZURE=1` (which opts the real-Azure tests in and makes
+a misconfigured account fail loudly rather than skip) and runs the `real_azure`
+tests. Pass a name to target a different account: `just test-azure <storage-account-name>`.
+
+Without `BENCH_HISTORY_AZURE_ACCOUNT` the real-Azure tests self-skip (the Azurite
+tests are unaffected). Each test creates a unique `bh-it-*` container and deletes it
+when it finishes.
+
+## Clean up leftover containers
+
+A crashed or timed-out test can leave a container behind. Sweep them with:
+
+```powershell
+./cleanup-containers.ps1 -AccountName <storage-account-name>
+```
+
+The CI job runs this automatically (`if: always()`).
+
+## Tear down / re-create
+
+```powershell
+./teardown.ps1 -SubscriptionId <subscription-guid>     # deletes the resource group
+./deploy.ps1 ...                                        # re-create from scratch
+```

--- a/infra/azure-bench-history/cleanup-containers.ps1
+++ b/infra/azure-bench-history/cleanup-containers.ps1
@@ -1,0 +1,85 @@
+#requires -Version 7
+
+<#
+.SYNOPSIS
+    Deletes leftover test containers from the cargo-bench-history storage account.
+
+.DESCRIPTION
+    Each real-Azure test creates a uniquely-named container (prefix `bh-it-`) and
+    deletes it when it finishes. A crashed or timed-out test can leave one behind;
+    this script sweeps them up. It is used both locally (manual cleanup) and as the
+    CI `test-azure` job's `if: always()` backstop.
+
+    Authenticates with Microsoft Entra ID (`--auth-mode login`), matching the
+    Entra-only storage account, so it works with the same `az login` / federated
+    session the tests use.
+
+.PARAMETER AccountName
+    Storage account name. Defaults to the BENCH_HISTORY_AZURE_ACCOUNT env var.
+
+.PARAMETER Prefix
+    Container name prefix to match. Defaults to 'bh-it-'.
+
+.PARAMETER MinAgeMinutes
+    Only delete containers last modified at least this many minutes ago. Defaults
+    to 0 (delete all matching). Raise it locally to avoid disturbing a container an
+    in-progress run is still using.
+
+.EXAMPLE
+    ./cleanup-containers.ps1 -AccountName stfolobenchhist
+#>
+[CmdletBinding()]
+param(
+    [string] $AccountName = $env:BENCH_HISTORY_AZURE_ACCOUNT,
+
+    [string] $Prefix = 'bh-it-',
+
+    [int] $MinAgeMinutes = 0
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+$VerbosePreference = 'Continue'
+
+if ([string]::IsNullOrEmpty($AccountName)) {
+    Write-Error 'No storage account specified. Pass -AccountName or set BENCH_HISTORY_AZURE_ACCOUNT.'
+    exit 1
+}
+
+Write-Verbose "Listing containers in '$AccountName' with prefix '$Prefix'."
+$listJson = az storage container list `
+    --account-name $AccountName `
+    --auth-mode login `
+    --prefix $Prefix `
+    --query '[].{name:name, lastModified:properties.lastModified}' `
+    --output json
+$containers = $listJson | ConvertFrom-Json
+
+if (-not $containers -or $containers.Count -eq 0) {
+    Write-Host "No containers with prefix '$Prefix' found in '$AccountName'." -ForegroundColor Green
+    return
+}
+
+$cutoff = [DateTimeOffset]::UtcNow.AddMinutes(-$MinAgeMinutes)
+$deleted = 0
+$skipped = 0
+
+foreach ($container in $containers) {
+    $lastModified = [DateTimeOffset]::Parse($container.lastModified)
+    if ($lastModified -gt $cutoff) {
+        Write-Verbose "Skipping '$($container.name)' (modified $lastModified, newer than the $MinAgeMinutes-minute cutoff)."
+        $skipped++
+        continue
+    }
+
+    Write-Verbose "Deleting container '$($container.name)' (last modified $lastModified)."
+    az storage container delete `
+        --account-name $AccountName `
+        --auth-mode login `
+        --name $container.name `
+        --output none
+    $deleted++
+}
+
+$deletedNoun = if ($deleted -eq 1) { 'container' } else { 'containers' }
+Write-Host "Deleted $deleted $deletedNoun; skipped $skipped newer than the cutoff." -ForegroundColor Green

--- a/infra/azure-bench-history/deploy.ps1
+++ b/infra/azure-bench-history/deploy.ps1
@@ -1,0 +1,124 @@
+#requires -Version 7
+
+<#
+.SYNOPSIS
+    Deploys (or updates) the Azure resources backing the cargo-bench-history
+    real-Azure storage tests.
+
+.DESCRIPTION
+    Idempotently provisions a resource group, an Entra-only Storage account, a
+    user-assigned managed identity with GitHub OIDC federated credentials, and the
+    `Storage Blob Data Contributor` role assignments needed by CI and (optionally) a
+    local developer principal. Re-running it converges to the same state, so the
+    paired `teardown.ps1` + this script let you delete and re-create everything at
+    will.
+
+    Requires the Azure CLI (`az`) and an authenticated session (`az login`) for an
+    account with rights to create the resources and role assignments.
+
+.PARAMETER SubscriptionId
+    Target subscription id.
+
+.PARAMETER ResourceGroup
+    Resource group to create/use. Defaults to 'rg-folo-bench-history'.
+
+.PARAMETER Location
+    Azure region. Defaults to 'swedencentral'.
+
+.PARAMETER StorageAccountName
+    Globally-unique Storage account name (3-24 lowercase alphanumerics).
+
+.PARAMETER LocalPrincipalId
+    Object id of a local developer principal (user or group) to grant data access.
+    Omit to grant CI access only. Tip: your own user id is
+    `az ad signed-in-user show --query id -o tsv`.
+
+.PARAMETER LocalPrincipalType
+    'User' (default) or 'Group', matching LocalPrincipalId.
+
+.EXAMPLE
+    ./deploy.ps1 -SubscriptionId 00000000-0000-0000-0000-000000000000 `
+        -StorageAccountName stfolobenchhist `
+        -LocalPrincipalId (az ad signed-in-user show --query id -o tsv)
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SubscriptionId,
+
+    [string] $ResourceGroup = 'rg-folo-bench-history',
+
+    [string] $Location = 'swedencentral',
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[a-z0-9]{3,24}$')]
+    [string] $StorageAccountName,
+
+    [string] $ManagedIdentityName = 'id-folo-bench-history-ci',
+
+    [string] $GithubOrg = 'folo-rs',
+
+    [string] $GithubRepo = 'folo',
+
+    [string] $LocalPrincipalId = '',
+
+    [ValidateSet('User', 'Group')]
+    [string] $LocalPrincipalType = 'User'
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+$VerbosePreference = 'Continue'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+Write-Verbose "Selecting subscription $SubscriptionId."
+az account set --subscription $SubscriptionId
+
+Write-Verbose "Ensuring resource group '$ResourceGroup' exists in '$Location'."
+az group create --name $ResourceGroup --location $Location --output none
+
+Write-Verbose 'Exporting parameters for main.bicepparam (readEnvironmentVariable).'
+$env:AZURE_STORAGE_ACCOUNT_NAME = $StorageAccountName
+$env:AZURE_LOCATION = $Location
+$env:AZURE_MANAGED_IDENTITY_NAME = $ManagedIdentityName
+$env:GITHUB_ORG = $GithubOrg
+$env:GITHUB_REPO = $GithubRepo
+$env:AZURE_LOCAL_PRINCIPAL_ID = $LocalPrincipalId
+$env:AZURE_LOCAL_PRINCIPAL_TYPE = $LocalPrincipalType
+
+if ([string]::IsNullOrEmpty($LocalPrincipalId)) {
+    Write-Verbose 'No LocalPrincipalId supplied; granting data access to the CI identity only.'
+}
+else {
+    Write-Verbose "Granting data access to local $LocalPrincipalType '$LocalPrincipalId'."
+}
+
+$bicepFile = Join-Path $scriptDir 'main.bicep'
+$paramFile = Join-Path $scriptDir 'main.bicepparam'
+$deploymentName = "bench-history-$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())"
+
+Write-Verbose "Deploying '$bicepFile' as '$deploymentName'."
+$outputJson = az deployment group create `
+    --resource-group $ResourceGroup `
+    --name $deploymentName `
+    --template-file $bicepFile `
+    --parameters $paramFile `
+    --query properties.outputs `
+    --output json
+$outputs = $outputJson | ConvertFrom-Json
+
+Write-Host ''
+Write-Host 'Deployment complete.' -ForegroundColor Green
+Write-Host ''
+Write-Host 'These identifiers are committed (non-secret) in constants.env, shared by' -ForegroundColor Cyan
+Write-Host 'local `just test-azure` runs and the CI `test-azure` job. If you re-created' -ForegroundColor Cyan
+Write-Host 'the resources, update constants.env to match:' -ForegroundColor Cyan
+Write-Host "  BENCH_HISTORY_AZURE_ACCOUNT=$($outputs.storageAccountName.value)"
+Write-Host "  AZURE_CLIENT_ID=$($outputs.managedIdentityClientId.value)"
+Write-Host "  AZURE_TENANT_ID=$($outputs.tenantId.value)"
+Write-Host "  AZURE_SUBSCRIPTION_ID=$($outputs.subscriptionId.value)"
+Write-Host ''
+Write-Host 'Then run the tests with `az login` followed by `just test-azure`.' -ForegroundColor Cyan
+Write-Host ''
+Write-Host "Blob endpoint: $($outputs.blobEndpoint.value)"

--- a/infra/azure-bench-history/main.bicep
+++ b/infra/azure-bench-history/main.bicep
@@ -1,0 +1,172 @@
+// Azure resources backing the `cargo-bench-history` real-Azure storage tests.
+//
+// Deploy this at resource-group scope (the wrapper `deploy.ps1` creates the
+// resource group first, then runs `az deployment group create`). It provisions:
+//
+//   * a Storage account (Entra-only: shared-key access disabled, HTTPS only);
+//   * a user-assigned managed identity (the CI principal) with GitHub OIDC
+//     federated credentials, so GitHub Actions can sign in without a stored
+//     secret;
+//   * `Storage Blob Data Contributor` role assignments on the account for the
+//     managed identity and (optionally) a local developer principal.
+//
+// Everything is idempotent and fully described here, so the resource group can be
+// torn down (`teardown.ps1`) and re-created at will.
+
+@description('Location for all resources. Defaults to the resource group location.')
+param location string = resourceGroup().location
+
+@description('Globally-unique Storage account name (3-24 lowercase alphanumerics).')
+@minLength(3)
+@maxLength(24)
+param storageAccountName string
+
+@description('Name of the user-assigned managed identity used by CI (GitHub Actions).')
+param managedIdentityName string = 'id-folo-bench-history-ci'
+
+@description('GitHub organisation (or user) that owns the repository.')
+param githubOrg string = 'folo-rs'
+
+@description('GitHub repository name.')
+param githubRepo string = 'folo'
+
+@description('Branches whose workflow runs may federate into Azure (one federated credential each).')
+param githubBranches array = [
+  'main'
+]
+
+@description('Whether to trust pull-request workflow runs from the same repository.')
+param trustPullRequests bool = true
+
+@description('Object id of a local developer principal (user or group) to grant data access. Empty skips the grant.')
+param localPrincipalId string = ''
+
+@description('Type of the local developer principal.')
+@allowed([
+  'User'
+  'Group'
+])
+param localPrincipalType string = 'User'
+
+// `Storage Blob Data Contributor`: read/write/delete blobs AND create/delete
+// containers via the data plane, so the tool's `run` (which creates the
+// container) and the tests' container cleanup both work with this single role.
+var blobDataContributorRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+
+// GitHub's OIDC issuer and the audience Azure expects for the token exchange.
+var githubIssuer = 'https://token.actions.githubusercontent.com'
+var federationAudience = 'api://AzureADTokenExchange'
+
+// One federated credential per trusted branch, plus an optional pull-request one.
+var branchCredentials = [
+  for branch in githubBranches: {
+    name: 'github-branch-${replace(branch, '/', '-')}'
+    subject: 'repo:${githubOrg}/${githubRepo}:ref:refs/heads/${branch}'
+  }
+]
+var pullRequestCredential = trustPullRequests
+  ? [
+      {
+        name: 'github-pull-request'
+        subject: 'repo:${githubOrg}/${githubRepo}:pull_request'
+      }
+    ]
+  : []
+var federatedCredentials = concat(branchCredentials, pullRequestCredential)
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    // Entra-only: no account keys means no shared key to leak. The tests and the
+    // tool authenticate exclusively through Microsoft Entra ID.
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+// Disable container/blob soft delete so a deleted test container is gone
+// immediately and its name can be reused without colliding with a soft-deleted
+// remnant.
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    containerDeleteRetentionPolicy: {
+      enabled: false
+    }
+    deleteRetentionPolicy: {
+      enabled: false
+    }
+  }
+}
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: managedIdentityName
+  location: location
+}
+
+// Federated credentials on the same identity must be created sequentially.
+// A Bicep resource `for` loop deploys its iterations in parallel by default, but
+// Azure rejects concurrent writes to one identity's federated-credentials
+// collection (they conflict). `@batchSize(1)` serialises the loop so each
+// credential is created only after the previous one finishes.
+@batchSize(1)
+resource federation 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = [
+  for credential in federatedCredentials: {
+    parent: managedIdentity
+    name: credential.name
+    properties: {
+      issuer: githubIssuer
+      subject: credential.subject
+      audiences: [
+        federationAudience
+      ]
+    }
+  }
+]
+
+resource managedIdentityBlobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, managedIdentity.id, blobDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', blobDataContributorRoleId)
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource localPrincipalBlobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(localPrincipalId)) {
+  name: guid(storageAccount.id, localPrincipalId, blobDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', blobDataContributorRoleId)
+    principalId: localPrincipalId
+    principalType: localPrincipalType
+  }
+}
+
+@description('Storage account name (record as BENCH_HISTORY_AZURE_ACCOUNT in constants.env).')
+output storageAccountName string = storageAccount.name
+
+@description('Blob service endpoint (https://<account>.blob.core.windows.net/).')
+output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
+
+@description('Client id of the managed identity (record as AZURE_CLIENT_ID in constants.env).')
+output managedIdentityClientId string = managedIdentity.properties.clientId
+
+@description('Principal (object) id of the managed identity.')
+output managedIdentityPrincipalId string = managedIdentity.properties.principalId
+
+@description('Entra tenant id (record as AZURE_TENANT_ID in constants.env).')
+output tenantId string = subscription().tenantId
+
+@description('Subscription id (record as AZURE_SUBSCRIPTION_ID in constants.env).')
+output subscriptionId string = subscription().subscriptionId

--- a/infra/azure-bench-history/main.bicepparam
+++ b/infra/azure-bench-history/main.bicepparam
@@ -1,0 +1,11 @@
+// Parameters for main.bicep, sourced from environment variables so `deploy.ps1`
+// can supply them. Run via: az deployment group create -f main.bicep -p main.bicepparam
+using './main.bicep'
+
+param storageAccountName = readEnvironmentVariable('AZURE_STORAGE_ACCOUNT_NAME')
+param location = readEnvironmentVariable('AZURE_LOCATION', 'swedencentral')
+param managedIdentityName = readEnvironmentVariable('AZURE_MANAGED_IDENTITY_NAME', 'id-folo-bench-history-ci')
+param githubOrg = readEnvironmentVariable('GITHUB_ORG', 'folo-rs')
+param githubRepo = readEnvironmentVariable('GITHUB_REPO', 'folo')
+param localPrincipalId = readEnvironmentVariable('AZURE_LOCAL_PRINCIPAL_ID', '')
+param localPrincipalType = readEnvironmentVariable('AZURE_LOCAL_PRINCIPAL_TYPE', 'User')

--- a/infra/azure-bench-history/teardown.ps1
+++ b/infra/azure-bench-history/teardown.ps1
@@ -1,0 +1,61 @@
+#requires -Version 7
+
+<#
+.SYNOPSIS
+    Deletes the Azure resources backing the cargo-bench-history real-Azure storage
+    tests by removing their resource group.
+
+.DESCRIPTION
+    Deletes the whole resource group (storage account, managed identity, federated
+    credentials, and role assignments) so the environment can be re-created from
+    scratch with `deploy.ps1`. Requires the Azure CLI (`az`) and an authenticated
+    session.
+
+.PARAMETER SubscriptionId
+    Target subscription id.
+
+.PARAMETER ResourceGroup
+    Resource group to delete. Defaults to 'rg-folo-bench-history'.
+
+.PARAMETER Wait
+    Block until the deletion completes instead of returning while it runs.
+
+.EXAMPLE
+    ./teardown.ps1 -SubscriptionId 00000000-0000-0000-0000-000000000000
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SubscriptionId,
+
+    [string] $ResourceGroup = 'rg-folo-bench-history',
+
+    [switch] $Wait
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+$VerbosePreference = 'Continue'
+
+Write-Verbose "Selecting subscription $SubscriptionId."
+az account set --subscription $SubscriptionId
+
+$exists = az group exists --name $ResourceGroup
+if ($exists -ne 'true') {
+    Write-Host "Resource group '$ResourceGroup' does not exist; nothing to delete." -ForegroundColor Yellow
+    return
+}
+
+Write-Verbose "Deleting resource group '$ResourceGroup'."
+$deleteArgs = @('group', 'delete', '--name', $ResourceGroup, '--yes')
+if (-not $Wait) {
+    $deleteArgs += '--no-wait'
+}
+az @deleteArgs
+
+if ($Wait) {
+    Write-Host "Resource group '$ResourceGroup' deleted." -ForegroundColor Green
+}
+else {
+    Write-Host "Deletion of resource group '$ResourceGroup' started (running in the background)." -ForegroundColor Green
+}

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -55,13 +55,18 @@ install-tools:
     # package, so npm is a prerequisite (see DEVELOPMENT.md). We install it on every
     # platform because the emulator and those tests are cross-platform. If npm is not
     # present we warn and continue rather than fail, so the rest of the toolchain still
-    # installs (and so this never hard-fails a CI job on a runner without npm; the CI
-    # `test-azurite` job provisions its own emulator via the start-azurite action).
+    # installs.
     #
     # The version is pinned to match the CI `start-azurite` action
     # (.github/actions/start-azurite/action.yml) so local and CI runs target the same
     # emulator — keep the two in sync when bumping.
-    if (Get-Command npm -ErrorAction SilentlyContinue) {
+    if ($env:CI) {
+        # Skip in CI: `npm install -g azurite` takes ~3 minutes and `install-tools` runs
+        # on every CI job, but only the `test-azurite` job needs the emulator — and that
+        # job provisions its own copy via the start-azurite action. Installing it here too
+        # would add ~3 minutes of uncached work to every other CI job for no benefit.
+        Write-Host "Skipping Azurite install in CI (the test-azurite job provisions its own via the start-azurite action)."
+    } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
         npm install -g azurite@3.35.0
     } else {
         Write-Warning "npm not found; skipping Azurite install. Install Node.js/npm (see DEVELOPMENT.md), then re-run 'just install-tools' to enable 'just test-azurite'."

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -49,3 +49,20 @@ install-tools:
     if ($IsLinux) {
         cargo install gungraun-runner --version 0.19.2 --locked
     }
+
+    # Azurite is the Azure Blob storage emulator that backs the cargo-bench-history
+    # `azure` feature tests, exercised locally via `just test-azurite`. It is a Node
+    # package, so npm is a prerequisite (see DEVELOPMENT.md). We install it on every
+    # platform because the emulator and those tests are cross-platform. If npm is not
+    # present we warn and continue rather than fail, so the rest of the toolchain still
+    # installs (and so this never hard-fails a CI job on a runner without npm; the CI
+    # `test-azurite` job provisions its own emulator via the start-azurite action).
+    #
+    # The version is pinned to match the CI `start-azurite` action
+    # (.github/actions/start-azurite/action.yml) so local and CI runs target the same
+    # emulator — keep the two in sync when bumping.
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        npm install -g azurite@3.35.0
+    } else {
+        Write-Warning "npm not found; skipping Azurite install. Install Node.js/npm (see DEVELOPMENT.md), then re-run 'just install-tools' to enable 'just test-azurite'."
+    }

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -144,9 +144,10 @@ test FILTER="":
     cargo +{{ env_var('RUST_MSRV') }} nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast
 
 # Run the cargo-bench-history Azure storage tests against a REAL Azure account
-# (the Microsoft Entra ID auth path), as opposed to the `test` recipe which runs
-# them against the local Azurite emulator. Mirrors the CI `test-azure` job for
-# local verification.
+# (the Microsoft Entra ID auth path). This is the Azurite emulator path's
+# counterpart: the `test` recipe covers Azurite, but only when an emulator is
+# already reachable (it does not start one) — otherwise those tests self-skip.
+# Mirrors the CI `test-azure` job for local verification.
 #
 # Requires `az login` (the tests authenticate as your Entra user via the Azure
 # CLI) and a deployed storage account that grants your user the `Storage Blob

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -143,11 +143,122 @@ miri-example EXAMPLE:
 test FILTER="":
     cargo +{{ env_var('RUST_MSRV') }} nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast
 
+# Run the cargo-bench-history Azure storage tests against a local Azurite blob
+# emulator (the self-signed account-SAS auth path), as opposed to `test-azure` which
+# targets a REAL account via Microsoft Entra ID. Mirrors the CI `test-azurite` job
+# for local verification.
+#
+# Requires the Azurite emulator (install with `npm install -g azurite`). If an
+# emulator is already listening on 127.0.0.1:10000 this recipe reuses it; otherwise
+# it starts one (in-memory, no persisted state) and stops it again when the tests
+# finish — even on failure. BENCH_HISTORY_REQUIRE_AZURITE is set so an unreachable
+# emulator is a hard error rather than a silent skip, mirroring the CI job. The
+# `azure azurite` test filter selects the Azure-backend tests by the naming
+# convention (the `storage::azure` unit tests and the `*_in_azurite` integration
+# tests); the `*_in_real_azure` tests it also matches self-skip without ENABLE_AZURE.
+[group('testing')]
+[script]
+test-azurite:
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $blobHost = "127.0.0.1"
+    $blobPort = 10000
+
+    # True when something is already accepting connections on the Azurite blob port.
+    function Test-AzuriteReachable {
+        $client = [System.Net.Sockets.TcpClient]::new()
+        try {
+            $client.Connect($blobHost, $blobPort)
+            return $true
+        } catch {
+            return $false
+        } finally {
+            $client.Dispose()
+        }
+    }
+
+    # Stop a process and (on Windows) its descendants. The Windows `.cmd` shim spawns
+    # node as a child, so killing only the shim would orphan the emulator.
+    function Stop-AzuriteProcessTree {
+        param([Parameter(Mandatory)][int] $ProcessId)
+
+        if ($IsWindows) {
+            Get-CimInstance Win32_Process -Filter "ParentProcessId = $ProcessId" -ErrorAction SilentlyContinue |
+                ForEach-Object { Stop-AzuriteProcessTree -ProcessId $_.ProcessId }
+        }
+        Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+    }
+
+    $startedByUs = $false
+    $launcher = $null
+    $emulatorPid = 0
+    try {
+        if (Test-AzuriteReachable) {
+            Write-Host "Azurite already reachable at ${blobHost}:${blobPort}; reusing the running emulator."
+        } else {
+            $shim = if ($IsWindows) { "azurite-blob.cmd" } else { "azurite-blob" }
+            $azurite = Get-Command $shim -ErrorAction SilentlyContinue
+            if (-not $azurite) {
+                throw "Azurite is not installed. Install it with: npm install -g azurite"
+            }
+
+            $azuriteArgs = @(
+                "--blobHost", $blobHost,
+                "--blobPort", "$blobPort",
+                "--inMemoryPersistence",
+                "--skipApiVersionCheck",
+                "--silent",
+                "--loose"
+            )
+
+            Write-Host "Starting Azurite blob emulator on ${blobHost}:${blobPort} (in-memory)."
+            $startParams = @{
+                FilePath     = $azurite.Source
+                ArgumentList = $azuriteArgs
+                PassThru     = $true
+            }
+            if ($IsWindows) { $startParams.WindowStyle = "Hidden" }
+            $launcher = Start-Process @startParams
+            $startedByUs = $true
+
+            $ready = $false
+            foreach ($attempt in 1..30) {
+                if (Test-AzuriteReachable) { $ready = $true; break }
+                Start-Sleep -Seconds 1
+            }
+            if (-not $ready) {
+                throw "Azurite did not become ready on ${blobHost}:${blobPort} within 30 seconds."
+            }
+
+            # The launcher may be a shim that spawns the real emulator as a child, so
+            # resolve the process actually holding the port to stop it directly later.
+            $emulatorPid = $launcher.Id
+            if ($IsWindows) {
+                $listener = Get-NetTCPConnection -LocalPort $blobPort -State Listen -ErrorAction SilentlyContinue |
+                    Select-Object -First 1
+                if ($listener) { $emulatorPid = [int] $listener.OwningProcess }
+            }
+            Write-Host "Azurite is ready (pid $emulatorPid)."
+        }
+
+        $env:BENCH_HISTORY_REQUIRE_AZURITE = "1"
+        Write-Host "Running Azurite-backed tests against ${blobHost}:${blobPort}."
+        cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --features azure --locked --no-fail-fast azure azurite
+    } finally {
+        if ($startedByUs) {
+            Write-Host "Stopping the Azurite emulator we started."
+            if ($emulatorPid -gt 0) { Stop-AzuriteProcessTree -ProcessId $emulatorPid }
+            if ($launcher -and $launcher.Id -ne $emulatorPid) {
+                Stop-AzuriteProcessTree -ProcessId $launcher.Id
+            }
+        }
+    }
+
 # Run the cargo-bench-history Azure storage tests against a REAL Azure account
-# (the Microsoft Entra ID auth path). This is the Azurite emulator path's
-# counterpart: the `test` recipe covers Azurite, but only when an emulator is
-# already reachable (it does not start one) — otherwise those tests self-skip.
-# Mirrors the CI `test-azure` job for local verification.
+# (the Microsoft Entra ID auth path), the counterpart of `test-azurite` which
+# covers the local Azurite emulator path. Mirrors the CI `test-azure` job for
+# local verification.
 #
 # Requires `az login` (the tests authenticate as your Entra user via the Azure
 # CLI) and a deployed storage account that grants your user the `Storage Blob

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -243,6 +243,10 @@ test-azurite:
         }
 
         $env:BENCH_HISTORY_REQUIRE_AZURITE = "1"
+        # Pin the endpoint to the emulator this recipe manages so a developer's pre-existing
+        # AZURITE_BLOB_ENDPOINT cannot redirect the tests to a different target (the recipe
+        # would then start/reuse one emulator while the tests hit another — non-hermetic).
+        $env:AZURITE_BLOB_ENDPOINT = "http://${blobHost}:${blobPort}/devstoreaccount1"
         Write-Host "Running Azurite-backed tests against ${blobHost}:${blobPort}."
         cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --features azure --locked --no-fail-fast azure azurite
     } finally {

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -148,13 +148,13 @@ test FILTER="":
 # targets a REAL account via Microsoft Entra ID. Mirrors the CI `test-azurite` job
 # for local verification.
 #
-# Requires the Azurite emulator (install with `npm install -g azurite`). If an
-# emulator is already listening on 127.0.0.1:10000 this recipe reuses it; otherwise
-# it starts one (in-memory, no persisted state) and stops it again when the tests
-# finish — even on failure. BENCH_HISTORY_REQUIRE_AZURITE is set so an unreachable
-# emulator is a hard error rather than a silent skip, mirroring the CI job. The
-# `azure azurite` test filter selects the Azure-backend tests by the naming
-# convention (the `storage::azure` unit tests and the `*_in_azurite` integration
+# Requires the Azurite emulator (installed by `just install-tools`, or manually via
+# `npm install -g azurite`). If an emulator is already listening on 127.0.0.1:10000
+# this recipe reuses it; otherwise it starts one (in-memory, no persisted state) and
+# stops it again when the tests finish — even on failure. BENCH_HISTORY_REQUIRE_AZURITE
+# is set so an unreachable emulator is a hard error rather than a silent skip, mirroring
+# the CI job. The `azure azurite` test filter selects the Azure-backend tests by the
+# naming convention (the `storage::azure` unit tests and the `*_in_azurite` integration
 # tests); the `*_in_real_azure` tests it also matches self-skip without ENABLE_AZURE.
 [group('testing')]
 [script]

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -143,6 +143,39 @@ miri-example EXAMPLE:
 test FILTER="":
     cargo +{{ env_var('RUST_MSRV') }} nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast
 
+# Run the cargo-bench-history Azure storage tests against a REAL Azure account
+# (the Microsoft Entra ID auth path), as opposed to the `test` recipe which runs
+# them against the local Azurite emulator. Mirrors the CI `test-azure` job for
+# local verification.
+#
+# Requires `az login` (the tests authenticate as your Entra user via the Azure
+# CLI) and a deployed storage account that grants your user the `Storage Blob
+# Data Contributor` role — see infra/azure-bench-history/ to deploy one. The
+# account defaults to BENCH_HISTORY_AZURE_ACCOUNT from constants.env (shared with
+# CI); override it by passing a name: `just test-azure <account>`.
+#
+# Setting ENABLE_AZURE is what actually runs the real-Azure tests: without it they
+# self-skip, so the account name living in constants.env (and thus in every recipe's
+# dotenv environment) does not make a plain `just test` run them. This recipe sets
+# ENABLE_AZURE only here, so the real-Azure tests run for real only through it.
+[group('testing')]
+[script]
+test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_AZURE_ACCOUNT', ''):
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $account = "{{ ACCOUNT }}"
+    if ([string]::IsNullOrEmpty($account)) {
+        Write-Error "No storage account specified. Pass it (just test-azure <account>) or set BENCH_HISTORY_AZURE_ACCOUNT in constants.env. Deploy one with infra/azure-bench-history/deploy.ps1."
+        exit 1
+    }
+
+    $env:BENCH_HISTORY_AZURE_ACCOUNT = $account
+    $env:ENABLE_AZURE = "1"
+
+    Write-Host "Running real-Azure tests against account '$account' (Microsoft Entra ID; requires az login)."
+    cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --features azure real_azure --locked --no-fail-fast
+
 # Runs regular tests as well as doing one iteration of benchmarks.
 # We separate it from "test" because benchmarks are quite slow,
 # so we tend to only run them as part of a full validation pass.

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -712,10 +712,23 @@ The network tests (`storage::azure::tests` and the `cbh_azure`
 integration file) talk to a live [Azurite](https://github.com/Azure/Azurite)
 blob emulator. They **self-skip** when no emulator is reachable, so a normal
 `--all-features` run stays green without one; they run for real once Azurite is
-up. To run them:
+up.
+
+The `just test-azurite` recipe wraps the whole flow — install the emulator once
+with `npm install -g azurite`, then:
 
 ```powershell
-npm install -g azurite
+just test-azurite
+```
+
+It starts an in-memory Azurite on `127.0.0.1:10000` (reusing one already running),
+runs the Azure-backend tests with `BENCH_HISTORY_REQUIRE_AZURITE=1` so an
+unreachable emulator is a hard error rather than a silent skip, and stops the
+emulator it started afterward — even on failure (it never stops one it did not
+start). It is the local counterpart of `just test-azure`. To run the tests by hand
+instead, start the emulator and point `cargo` at it:
+
+```powershell
 # On Windows azurite-blob is a .cmd, so launch it through cmd:
 cmd /c azurite-blob --blobHost 127.0.0.1 --blobPort 10000 --inMemoryPersistence --skipApiVersionCheck --silent --loose
 # then, in another shell:
@@ -725,8 +738,9 @@ cargo test -p cargo-bench-history --features azure
 * `AZURITE_BLOB_ENDPOINT` overrides the default
   `http://127.0.0.1:10000/devstoreaccount1` endpoint.
 * `BENCH_HISTORY_REQUIRE_AZURITE=1` turns an unreachable emulator into a hard
-  failure instead of a skip. CI sets it in the dedicated `test-azurite` job so a
-  misconfigured emulator can never silently degrade into skipping every test.
+  failure instead of a skip. `just test-azurite` sets it for you; CI also sets it
+  in the dedicated `test-azurite` job so a misconfigured emulator can never
+  silently degrade into skipping every test.
 
 In CI these tests run only in the Linux-only `test-azurite` job (see
 `.github/workflows/validation.yml`), which starts Azurite on the runner host via

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -725,14 +725,56 @@ cargo test -p cargo-bench-history --features azure
 * `AZURITE_BLOB_ENDPOINT` overrides the default
   `http://127.0.0.1:10000/devstoreaccount1` endpoint.
 * `BENCH_HISTORY_REQUIRE_AZURITE=1` turns an unreachable emulator into a hard
-  failure instead of a skip. CI sets it in the dedicated `test-azure` job so a
+  failure instead of a skip. CI sets it in the dedicated `test-azurite` job so a
   misconfigured emulator can never silently degrade into skipping every test.
 
-In CI these tests run only in the Linux-only `test-azure` job (see
+In CI these tests run only in the Linux-only `test-azurite` job (see
 `.github/workflows/validation.yml`), which starts Azurite on the runner host via
 the `start-azurite` composite action and also collects coverage so the
 `azure.rs` network paths reach Codecov (the multi-platform `coverage` job runs
 without an emulator and so cannot cover them).
+
+### Running the real-Azure tests locally
+
+The `*_in_real_azure` tests in `cbh_azure` exercise the **Microsoft Entra ID**
+path against a real Storage account (the production default that Azurite's
+account-SAS path never touches). They **self-skip** unless `ENABLE_AZURE` is set —
+an explicit opt-in, so the account name living in `constants.env` does not by itself
+make a plain test run target the cloud. Each test uses a fresh container that is
+deleted when it finishes, even on panic.
+
+One-time: deploy the account, managed identity and federated credentials with the
+Bicep + scripts in [`infra/azure-bench-history/`](../../infra/azure-bench-history/)
+(see its README) and record the identifiers in the repository-root `constants.env`.
+Then, signing in as your own Entra user, the `just test-azure` recipe wraps the run
+(it sets `ENABLE_AZURE` and reads the account from `constants.env` for you):
+
+```powershell
+az login
+just test-azure
+# tidy up any container a crashed run left behind:
+./infra/azure-bench-history/cleanup-containers.ps1
+```
+
+`just test-azure` reads the account from `BENCH_HISTORY_AZURE_ACCOUNT` (committed in
+`constants.env`); pass a name to target a different account
+(`just test-azure <storage-account-name>`). The equivalent raw command is
+`cargo test -p cargo-bench-history --features azure real_azure` with `ENABLE_AZURE`
+and `BENCH_HISTORY_AZURE_ACCOUNT` set.
+
+* `BENCH_HISTORY_AZURE_ENDPOINT` overrides the default
+  `https://<account>.blob.core.windows.net` endpoint.
+* `ENABLE_AZURE` is the gate: when set, the real-Azure tests run, and a then-missing
+  `BENCH_HISTORY_AZURE_ACCOUNT` is a hard failure instead of a skip. `just test-azure`
+  sets it locally; CI sets it (via that recipe) in the dedicated `test-azure` job,
+  which signs in via GitHub OIDC workload identity federation, so it can never
+  silently skip. It is deliberately NOT in `constants.env`, so a plain `just test`
+  leaves the real-Azure tests skipped.
+
+In CI these tests run only in the Linux-only, same-repo-only `test-azure` job (see
+`.github/workflows/validation.yml` and `.github/workflows/AGENTS.md`). It collects
+no coverage — `test-azurite` already covers `azure.rs`; its value is proving the
+real Entra + real Blob endpoint round-trip.
 
 ### Mutation testing
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -714,8 +714,8 @@ blob emulator. They **self-skip** when no emulator is reachable, so a normal
 `--all-features` run stays green without one; they run for real once Azurite is
 up.
 
-The `just test-azurite` recipe wraps the whole flow — install the emulator once
-with `npm install -g azurite`, then:
+The `just test-azurite` recipe wraps the whole flow. Install the emulator once with
+`just install-tools` (or manually with `npm install -g azurite`), then:
 
 ```powershell
 just test-azurite

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -456,8 +456,11 @@ no `async_trait` dependency, and `run`/`analyze` stay backend-agnostic by holdin
   The shipped azure-sdk-for-rust v1.0.0 removed connection-string parsing,
   `StorageSharedKeyCredential`, and `DefaultAzureCredential`, which is why the
   account-SAS path is self-signed rather than delegated to the SDK. Tested in
-  regular CI against the **Azurite emulator** (not real cloud, not `#[ignore]`);
-  the network tests **self-skip** when no emulator is reachable and are
+  regular CI two ways (decision 17): the `test-azurite` job against the **Azurite
+  emulator** (account-SAS path) and the additive `test-azure` job against a **real
+  Storage account** over the **Entra ID** path (signed in via GitHub OIDC, a fresh
+  container per test deleted afterward). Neither is `#[ignore]`; the network tests
+  **self-skip** when their backend is not configured and are
   `#[cfg_attr(miri, ignore)]`. Account-key construction reads the wall clock for
   the SAS expiry, so those pure tests are Miri-ignored too — the signing math is
   still covered under Miri by `storage::sas`'s fixed-expiry golden vector.
@@ -1453,17 +1456,42 @@ Each iteration ships with tests and docs and leaves the tool runnable.
     is removed. `run`/`backfill` invoke `cargo bench` in-process, so to collect
     Callgrind data you run the tool natively on Linux/WSL and no env var has to
     cross a WSL boundary (decision 8).
-17. **Cloud-storage testing** — *Decided:* Azure backend is exercised in regular CI
-    against the **Azurite emulator** (not real cloud, not `#[ignore]`; only
-    `#[cfg_attr(miri, ignore)]` for the network edge). The emulator runs directly
-    on the runner host (started by the `start-azurite` composite action) in a
-    Linux-only, package-gated `test-azure` job rather than as a service container,
+17. **Cloud-storage testing** — *Decided:* the Azure backend is exercised in regular
+    CI two complementary ways.
+
+    **Azurite emulator** (`test-azurite` job): the default, fork-safe path — not real
+    cloud, not `#[ignore]`; only `#[cfg_attr(miri, ignore)]` for the network edge. The
+    emulator runs directly on the runner host (started by the `start-azurite` composite
+    action) in a Linux-only, package-gated job rather than as a service container,
     which cannot reliably bind Azurite to a reachable address. The network tests
-    **self-skip** when no emulator is reachable so the multi-platform
-    `--all-features` jobs stay green; `BENCH_HISTORY_REQUIRE_AZURITE=1` (set only
-    in `test-azure`) turns an unreachable emulator into a hard failure so it can
-    never silently skip. That job also collects coverage so the `azure.rs` network
-    paths reach Codecov.
+    **self-skip** when no emulator is reachable so the multi-platform `--all-features`
+    jobs stay green; `BENCH_HISTORY_REQUIRE_AZURITE=1` (set only in `test-azurite`)
+    turns an unreachable emulator into a hard failure so it can never silently skip.
+    That job also collects coverage so the `azure.rs` network paths reach Codecov.
+
+    **Real Azure account** (`test-azure` job): an additive job that exercises the
+    **Microsoft Entra ID** authentication path the emulator (account-key/SAS) never
+    touches — a real Storage account with shared-key access disabled, reached over
+    HTTPS. No Rust change is needed: `DeveloperToolsCredential` already chains to the
+    Azure CLI, so the same credential works locally (after `az login`) and in CI (after
+    `azure/login@v2` signs in via **GitHub OIDC workload identity federation**, no
+    stored secret). Each test (`*_in_real_azure`) creates a fresh blob container and
+    deletes it when it finishes, even on panic (`catch_unwind` + `resume_unwind`); a
+    final `if: always()` sweep (`cleanup-containers.ps1`) is a backstop for a container
+    a crashed run might leave. The tests **self-skip** unless `ENABLE_AZURE` is set —
+    an explicit opt-in (set by the `just test-azure` recipe the job invokes), so the
+    account name living in `constants.env` does not by itself make a plain test run
+    target the cloud; when set, a then-missing `BENCH_HISTORY_AZURE_ACCOUNT` is a hard
+    failure rather than a silent skip. The job is gated to same-repo runs (fork PRs
+    cannot mint an OIDC token for our tenant). Its Azure identifiers
+    (`BENCH_HISTORY_AZURE_ACCOUNT`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+    `AZURE_SUBSCRIPTION_ID`) are committed, non-secret, in the repository-root
+    `constants.env` (the same source `just test-azure` reads), so local and CI target
+    the same account; a `grep` step surfaces them into `$GITHUB_ENV` for the
+    `azure/login` inputs. It collects no coverage — `test-azurite` already covers
+    `azure.rs`; its value is the real Entra + real Blob round-trip. The account,
+    identity and federated credentials are scripted/Bicep'd in
+    `infra/azure-bench-history/` (decision 31).
 18. **Integration testing** — *Decided:* integration tests invoke the **library
     entry** (`Cli::from_args(argv).into_command()` → `run()`), matching the
     workspace pattern (no `assert_cmd`); a table-driven CLI-flag matrix runs over
@@ -1631,3 +1659,26 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      `list` is an error that names its three subjects. The other workspace cargo tools
      (`cargo-detect-package`/`cargo-freeze-deps`) also use `clap` (issue #252), though
      their flat CLIs need no grouped argument headings.
+31. **Real-Azure test infrastructure (Bicep + UAMI federation)** — *Decided:* the
+     Azure resources backing the `test-azure` job are fully scripted in
+     `infra/azure-bench-history/` so the account and identity can be torn down and
+     re-created with one command. `main.bicep` (resource-group scope) provisions an
+     **Entra-only** Storage account (`allowSharedKeyAccess: false`, HTTPS/TLS1.2,
+     container + blob soft-delete disabled so a deleted test container's name is
+     immediately reusable), a **user-assigned managed identity** with **GitHub OIDC
+     federated credentials** (subjects `repo:folo-rs/folo:ref:refs/heads/main` and
+     `repo:folo-rs/folo:pull_request`; the federation loop is `@batchSize(1)` because
+     Azure rejects concurrent writes to one identity's credentials), and two
+     `Storage Blob Data Contributor` role assignments — for the managed identity (CI)
+     and an optional local developer principal. That single data-plane role covers
+     container create + delete and blob read/write/delete, so production `run`
+     (`ensure_container`) and the test cleanup both work without a control-plane role.
+     A UAMI is chosen over an App Registration because user-assigned identities and
+     their federated credentials are natively Bicep-able (no Graph extension) and
+     `azure/login@v2` accepts a UAMI `client-id` for OIDC sign-in. The Bicep outputs
+     map one-to-one to the Azure identifiers committed (non-secret) in the
+     repository-root `constants.env` (`BENCH_HISTORY_AZURE_ACCOUNT`/`AZURE_CLIENT_ID`/
+     `AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`), the single source both `just
+     test-azure` and the CI `test-azure` job read so local and CI target the same
+     account. `deploy.ps1`/`teardown.ps1`/`cleanup-containers.ps1` wrap deploy,
+     teardown and the leftover-container sweep.

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -1,22 +1,43 @@
 //! End-to-end integration tests for the Azure Blob storage backend.
 //!
-//! These drive the public `run` and `analyze` commands against a live Azurite
-//! emulator, proving the Azure adapter stores result sets (`run`) and reads them
+//! These drive the public `run` and `analyze` commands against a live Azure Blob
+//! endpoint, proving the Azure adapter stores result sets (`run`) and reads them
 //! back (`analyze`) through exactly the same command surface the binary uses.
 //!
-//! They compile only with the `azure` feature and require an Azurite blob
-//! endpoint (the CI `azure` job provides one; see the package AGENTS.md for
-//! running them locally). Each test uses a fresh container, so they never share
-//! state, and they are ignored under Miri (real network and process I/O).
+//! There are two flavours of the same scenarios:
+//!
+//! * **Azurite** (`*_in_azurite`) — against a local Azurite emulator using the
+//!   self-signed account-SAS path. They **self-skip** when no emulator is reachable
+//!   (so a normal `--all-features` run stays green) and run for real once Azurite is
+//!   up; CI provides one in the `test-azurite` job.
+//! * **Real Azure** (`*_in_real_azure`) — against a real Storage account using the
+//!   **Microsoft Entra ID** path (no account key). They self-skip unless
+//!   `ENABLE_AZURE` is set (an explicit opt-in, so the account name living in
+//!   `constants.env` does not by itself make a plain test run target the cloud);
+//!   CI provides one in the `test-azure` job, signing in via GitHub OIDC workload
+//!   identity federation, and locally `just test-azure` sets it after `az login`
+//!   (see the package AGENTS.md and `infra/azure-bench-history/`). The account name
+//!   comes from `BENCH_HISTORY_AZURE_ACCOUNT`. Each test uses a fresh container
+//!   that is deleted when the test finishes, even on panic.
+//!
+//! They compile only with the `azure` feature, each scenario uses its own container
+//! so they never share state, and they are ignored under Miri (real network and
+//! process I/O).
 #![cfg(feature = "azure")]
 #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
 use std::net::{TcpStream, ToSocketAddrs as _};
+use std::panic;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use azure_core::credentials::TokenCredential;
 use azure_core::http::Url;
+use azure_identity::DeveloperToolsCredential;
+use azure_storage_blob::BlobContainerClient;
 use cargo_bench_history::{Cli, Command, Overrides, RunError, RunOutcome, run_with_overrides};
+use futures::FutureExt as _;
 use serial_test::serial;
 
 /// The mock engine binary path, provided by Cargo for the auto-discovered binary target.
@@ -97,6 +118,94 @@ fn azure_config() -> String {
         endpoint = toml_escape(&azurite_endpoint()),
         key = AZURITE_KEY,
     )
+}
+
+/// The real Storage account name to target, or `None` when none is configured.
+fn real_azure_account() -> Option<String> {
+    std::env::var("BENCH_HISTORY_AZURE_ACCOUNT")
+        .ok()
+        .filter(|account| !account.is_empty())
+}
+
+/// The blob endpoint for `account`, overridable via `BENCH_HISTORY_AZURE_ENDPOINT`.
+fn real_azure_endpoint(account: &str) -> String {
+    std::env::var("BENCH_HISTORY_AZURE_ENDPOINT")
+        .unwrap_or_else(|_| format!("https://{account}.blob.core.windows.net"))
+}
+
+/// Whether the real-Azure tests are enabled.
+///
+/// They run only when `ENABLE_AZURE` is set, so a plain test run (and the
+/// `--all-features` jobs) self-skips them even though `BENCH_HISTORY_AZURE_ACCOUNT`
+/// may be in scope. `ENABLE_AZURE` is an explicit opt-in — set by the `just
+/// test-azure` recipe and the CI `test-azure` job — that says "really run these",
+/// so a then-missing `BENCH_HISTORY_AZURE_ACCOUNT` is a hard failure rather than a
+/// silent skip, mirroring how `BENCH_HISTORY_REQUIRE_AZURITE` guards Azurite.
+fn real_azure_enabled() -> bool {
+    if std::env::var_os("ENABLE_AZURE").is_none_or(|value| value.is_empty()) {
+        eprintln!("skipping real Azure integration test: ENABLE_AZURE not set");
+        return false;
+    }
+    assert!(
+        real_azure_account().is_some(),
+        "ENABLE_AZURE is set but BENCH_HISTORY_AZURE_ACCOUNT names no account"
+    );
+    true
+}
+
+/// A config that stores in `container` on the real account via Microsoft Entra ID.
+///
+/// It sets neither `account_key` nor `sas_token`, so `AzureBlobStorage` resolves the
+/// Entra credential path — the production default, which Azurite never exercises.
+fn real_azure_config(container: &str) -> String {
+    let account = real_azure_account().expect("real Azure account is configured");
+    format!(
+        "[project]\n\
+         id = \"azureproj\"\n\n\
+         [storage.azure]\n\
+         account = \"{account}\"\n\
+         container = \"{container}\"\n\
+         endpoint = \"{endpoint}\"\n",
+        endpoint = toml_escape(&real_azure_endpoint(&account)),
+    )
+}
+
+/// Runs `body` against a fresh real-Azure container, deleting the container
+/// afterward even if `body` panics, so a failed test never leaks storage.
+async fn with_real_azure_container<F>(body: F)
+where
+    F: AsyncFnOnce(String),
+{
+    let account = real_azure_account().expect("real Azure account is configured");
+    let endpoint = real_azure_endpoint(&account);
+    let container = unique_container();
+
+    // Capture a panic so the container is always deleted, then re-raise it.
+    let result = panic::AssertUnwindSafe(body(container.clone()))
+        .catch_unwind()
+        .await;
+
+    delete_container(&endpoint, &container).await;
+
+    if let Err(payload) = result {
+        panic::resume_unwind(payload);
+    }
+}
+
+/// Deletes `container` at `endpoint` using the Entra credential, best-effort.
+async fn delete_container(endpoint: &str, container: &str) {
+    let credential: Arc<dyn TokenCredential> =
+        DeveloperToolsCredential::new(None).expect("Entra credential initializes");
+    let mut url = Url::parse(endpoint).expect("endpoint is a valid URL");
+    url.path_segments_mut()
+        .expect("endpoint is a base URL")
+        .pop_if_empty()
+        .push(container);
+    let client =
+        BlobContainerClient::new(url, Some(credential), None).expect("container client builds");
+    if let Err(error) = client.delete(None).await {
+        eprintln!("warning: could not delete test container {container}: {error}");
+    }
 }
 
 /// A hermetic workspace that stores to Azurite rather than the local filesystem.
@@ -215,15 +324,9 @@ impl AzureWorkspace {
     }
 }
 
-/// `run` stores a harvested result set in Azure Blob storage.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-#[serial]
-async fn run_stores_results_in_azurite() {
-    if !azurite_available() {
-        return;
-    }
-    let workspace = AzureWorkspace::new(&azure_config()).with_bench(&["--summary", "grp=single"]);
+/// Scenario: a single `run` stores one harvested result set.
+async fn scenario_run_stores(config: &str) {
+    let workspace = AzureWorkspace::new(config).with_bench(&["--summary", "grp=single"]);
 
     let outcome = workspace.drive(&["run"]).await.unwrap();
     let RunOutcome::Completed { message } = outcome else {
@@ -232,16 +335,10 @@ async fn run_stores_results_in_azurite() {
     assert!(message.contains("Stored 1"), "{message}");
 }
 
-/// A full public round-trip: two `run`s store result sets to Azurite, and
+/// Scenario: a full public round-trip — two `run`s store result sets, and
 /// `analyze` reads them back (list + get) and reports over the history.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-#[serial]
-async fn run_then_analyze_round_trips_through_azurite() {
-    if !azurite_available() {
-        return;
-    }
-    let workspace = AzureWorkspace::new(&azure_config()).with_bench(&["--summary", "grp=single"]);
+async fn scenario_run_then_analyze(config: &str) {
+    let workspace = AzureWorkspace::new(config).with_bench(&["--summary", "grp=single"]);
 
     workspace.drive(&["run"]).await.unwrap();
     // A clean run is keyed by its commit, so the second point needs its own
@@ -270,19 +367,13 @@ async fn run_then_analyze_round_trips_through_azurite() {
     assert_eq!(parsed["regressions"], 0);
 }
 
-/// A non-trivial round-trip through Azurite: a multi-commit master line plus a
-/// feature branch carrying a clean and a dirty snapshot. This proves the Azure
-/// `list(prefix)` enumerates objects across several commit partitions and that
-/// the git-aware feature/official dirty-admission split works end to end against
-/// the real backend (not just a flat two-object listing).
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-#[serial]
-async fn analyze_feature_and_dirty_round_trip_through_azurite() {
-    if !azurite_available() {
-        return;
-    }
-    let workspace = AzureWorkspace::new(&azure_config()).with_bench(&["--summary", "grp=single"]);
+/// Scenario: a non-trivial round-trip — a multi-commit master line plus a feature
+/// branch carrying a clean and a dirty snapshot. This proves `list(prefix)`
+/// enumerates objects across several commit partitions and that the git-aware
+/// feature/official dirty-admission split works end to end against the backend (not
+/// just a flat two-object listing).
+async fn scenario_feature_and_dirty(config: &str) {
+    let workspace = AzureWorkspace::new(config).with_bench(&["--summary", "grp=single"]);
 
     // master: root - c2   (two clean points on the official line).
     workspace.drive(&["run"]).await.unwrap();
@@ -297,7 +388,7 @@ async fn analyze_feature_and_dirty_round_trip_through_azurite() {
     workspace.drive(&["run"]).await.unwrap();
 
     // The feature view admits the dirty snapshot on the target-side commit, so all
-    // four stored objects are loaded from Azurite.
+    // four stored objects are loaded from the backend.
     let RunOutcome::Analyzed { report, .. } = workspace
         .drive(&["analyze", "--format", "json"])
         .await
@@ -344,4 +435,83 @@ async fn analyze_feature_and_dirty_round_trip_through_azurite() {
         parsed["runs"], 2,
         "the official line excludes the feature commit and the dirty snapshot: {report}"
     );
+}
+
+// --- Azurite (self-signed account SAS) -------------------------------------
+
+/// `run` stores a harvested result set in Azurite.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn run_stores_results_in_azurite() {
+    if !azurite_available() {
+        return;
+    }
+    scenario_run_stores(&azure_config()).await;
+}
+
+/// A `run` + `analyze` round-trip through Azurite.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn run_then_analyze_round_trips_through_azurite() {
+    if !azurite_available() {
+        return;
+    }
+    scenario_run_then_analyze(&azure_config()).await;
+}
+
+/// A multi-commit feature/dirty round-trip through Azurite.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn analyze_feature_and_dirty_round_trip_through_azurite() {
+    if !azurite_available() {
+        return;
+    }
+    scenario_feature_and_dirty(&azure_config()).await;
+}
+
+// --- Real Azure (Microsoft Entra ID) ---------------------------------------
+
+/// `run` stores a harvested result set in a real Azure account via Entra ID.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn run_stores_results_in_real_azure() {
+    if !real_azure_enabled() {
+        return;
+    }
+    with_real_azure_container(async |container| {
+        scenario_run_stores(&real_azure_config(&container)).await;
+    })
+    .await;
+}
+
+/// A `run` + `analyze` round-trip through a real Azure account via Entra ID.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn run_then_analyze_round_trips_through_real_azure() {
+    if !real_azure_enabled() {
+        return;
+    }
+    with_real_azure_container(async |container| {
+        scenario_run_then_analyze(&real_azure_config(&container)).await;
+    })
+    .await;
+}
+
+/// A multi-commit feature/dirty round-trip through a real Azure account via Entra ID.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn analyze_feature_and_dirty_round_trip_through_real_azure() {
+    if !real_azure_enabled() {
+        return;
+    }
+    with_real_azure_container(async |container| {
+        scenario_feature_and_dirty(&real_azure_config(&container)).await;
+    })
+    .await;
 }

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -193,16 +193,51 @@ where
 }
 
 /// Deletes `container` at `endpoint` using the Entra credential, best-effort.
+///
+/// Every fallible step logs a warning and returns instead of panicking. This runs
+/// during cleanup between `catch_unwind` and `resume_unwind`, so a panic here would
+/// both leak the container and mask the original test failure being re-raised.
 async fn delete_container(endpoint: &str, container: &str) {
-    let credential: Arc<dyn TokenCredential> =
-        DeveloperToolsCredential::new(None).expect("Entra credential initializes");
-    let mut url = Url::parse(endpoint).expect("endpoint is a valid URL");
-    url.path_segments_mut()
-        .expect("endpoint is a base URL")
-        .pop_if_empty()
-        .push(container);
-    let client =
-        BlobContainerClient::new(url, Some(credential), None).expect("container client builds");
+    let credential: Arc<dyn TokenCredential> = match DeveloperToolsCredential::new(None) {
+        Ok(credential) => credential,
+        Err(error) => {
+            eprintln!(
+                "warning: could not initialize Entra credential to delete test container \
+                 {container}: {error}"
+            );
+            return;
+        }
+    };
+    let mut url = match Url::parse(endpoint) {
+        Ok(url) => url,
+        Err(error) => {
+            eprintln!(
+                "warning: could not parse endpoint {endpoint} to delete test container \
+                 {container}: {error}"
+            );
+            return;
+        }
+    };
+    {
+        let Ok(mut segments) = url.path_segments_mut() else {
+            eprintln!(
+                "warning: endpoint {endpoint} is not a base URL; cannot delete test container \
+                 {container}"
+            );
+            return;
+        };
+        segments.pop_if_empty().push(container);
+    }
+    let client = match BlobContainerClient::new(url, Some(credential), None) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!(
+                "warning: could not build container client to delete test container \
+                 {container}: {error}"
+            );
+            return;
+        }
+    };
     if let Err(error) = client.delete(None).await {
         eprintln!("warning: could not delete test container {container}: {error}");
     }


### PR DESCRIPTION
## What

Adds real-Azure integration tests for the `cargo-bench-history` Azure Blob storage backend, complementing the existing Azurite emulator tests. The emulator uses account-key/SAS auth and so never exercises the Microsoft Entra ID path that production uses; these tests run against a real Storage account (shared-key access disabled, HTTPS, Entra-only) to prove the real Entra + real Blob endpoint round-trip end to end.

## How it authenticates

No Rust change was needed — `DeveloperToolsCredential` already chains to the Azure CLI, so the same credential works locally (after `az login`) and in CI (after `azure/login@v2` signs in via **GitHub OIDC workload identity federation**, no stored secret).

## The ENABLE_AZURE gate

The real-Azure tests run only when `ENABLE_AZURE` is set — an explicit opt-in provided by the `just test-azure` recipe and the CI `test-azure` job. It is deliberately **not** in `constants.env`, so a plain `just test` leaves the tests self-skipped even though the account name is in scope via dotenv. When `ENABLE_AZURE` is set, a missing `BENCH_HISTORY_AZURE_ACCOUNT` is a hard error rather than a silent skip, so a job that runs can never silently degrade into skipping every test. Each test uses a fresh container that is deleted on completion (even on panic), with an `if: always()` CI sweep as a backstop.

## Configuration in constants.env

The non-secret Azure identifiers (account name, client/tenant/subscription id) are committed in `constants.env`, the single source both local runs and CI read, so they always target the same account. They are identifiers, not credentials, so there is nothing to leak by committing them.

## Scripted infrastructure

The Azure resources are fully scripted in `infra/azure-bench-history/` (Bicep + PowerShell) so they can be torn down and re-created with one command:

- Entra-only Storage account (`allowSharedKeyAccess: false`, HTTPS/TLS1.2, soft-delete disabled so a deleted test container's name is immediately reusable)
- User-assigned managed identity with GitHub OIDC federated credentials (subjects for `main` and `pull_request`)
- Two `Storage Blob Data Contributor` role assignments — the CI managed identity and an optional local developer principal
- `deploy.ps1` / `teardown.ps1` / `cleanup-containers.ps1` wrappers

## CI job

A new Linux-only `test-azure` job (package-gated to `cargo-bench-history`, same-repo only since fork PRs cannot mint an OIDC token for the tenant) signs in via OIDC, runs the tests through `just test-azure`, and sweeps leftover containers. It collects no coverage — `test-azurite` already covers `azure.rs`.

## Running locally

```powershell
az login
just test-azure   # uses BENCH_HISTORY_AZURE_ACCOUNT from constants.env
```

See `infra/azure-bench-history/README.md` and the package `AGENTS.md` for details.

## Validation

- `just test-azure` → 3/3 real-Azure tests pass against the deployed account
- Account set but `ENABLE_AZURE` unset → tests correctly self-skip
- `cargo +nightly fmt --all --check`, `just package=cargo-bench-history clippy` (`-D warnings`), `az bicep build`, and YAML parse all clean
- No leftover test containers after runs
