### PR TITLE
Remove the `azure` feature flag from cargo-bench-history

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -69,14 +69,14 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
   - Tests all feature combinations with `cargo hack --feature-powerset`
 
 - **test-azurite** — single-platform (Linux) by choice, package-gated to `cargo-bench-history`
-  - Runs the `azure`-feature tests against a live Azurite blob emulator and also
+  - Runs the Azure storage backend tests against a live Azurite blob emulator and also
     collects coverage so the `azure.rs` network paths reach Codecov.
   - Named for the Azurite emulator it targets; its sibling `test-azure` runs the
     same backend against a real Azure account. Single-platform by choice, not
     limitation: the Azure Blob backend is OS-agnostic network I/O, so one platform
     fully covers it and Linux is the cheapest runner.
-  - The `azure` feature is off by default and its network paths **self-skip** when
-    no emulator is reachable, so the multi-platform `--all-features` jobs
+  - The Azure backend's network paths **self-skip** when
+    no emulator is reachable, so the multi-platform test jobs
     (`test-more`, `coverage`) stay green without one. They run for real only in
     this job: Azurite is provisioned on the runner host (via the `start-azurite`
     composite action) and `BENCH_HISTORY_REQUIRE_AZURITE=1` turns an unreachable
@@ -90,7 +90,7 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     cannot override the command), so the host-process approach is used instead.
 
 - **test-azure** — single-platform (Linux) by choice, package-gated to `cargo-bench-history`
-  - Additive sibling of `test-azurite`: runs the same `azure`-feature backend
+  - Additive sibling of `test-azurite`: runs the same Azure storage backend
     tests against a **real Azure Storage account** to exercise the **Microsoft
     Entra ID** authentication path that the emulator (account-key/SAS) never
     touches — a real account with shared-key access disabled, reached over HTTPS.
@@ -206,5 +206,5 @@ its args to `gungraun-runner`. Without `gungraun-runner` on `$PATH` the call fai
 The `start-azurite` composite action (`.github/actions/start-azurite`) installs the Azurite
 blob emulator via `npm install -g azurite` and starts it on the runner host at
 `127.0.0.1:10000`, blocking until the port accepts connections. It is Linux-only (uses bash and
-`/dev/tcp`) and is used only by the `test-azurite` job to back the `cargo-bench-history` `azure`
-feature tests. Node.js/npm are preinstalled on the GitHub-hosted Ubuntu runners.
+`/dev/tcp`) and is used only by the `test-azurite` job to back the `cargo-bench-history` Azure
+storage backend tests. Node.js/npm are preinstalled on the GitHub-hosted Ubuntu runners.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -600,8 +600,8 @@ jobs:
 
   # Azure Blob storage backend tests against the Azurite emulator.
   #
-  # The `azure` feature is off by default, and its network paths self-skip when no
-  # emulator is reachable (so the multi-platform `--all-features` jobs stay green
+  # The Azure backend's network paths self-skip when no
+  # emulator is reachable (so the multi-platform test jobs stay green
   # without one). They run for real only here: Azurite is provisioned on the host
   # and BENCH_HISTORY_REQUIRE_AZURITE turns an unreachable emulator into a hard
   # failure, so a misconfigured emulator can never silently degrade into skipping

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,8 +76,8 @@ Validation:
 
 # Testing Azure functionality
 
-The `cargo-bench-history` package has an optional `azure` feature with an Azure Blob storage
-backend. Its tests are special: they are **not** exercised by `just test`, because they need
+The `cargo-bench-history` package has an Azure Blob storage backend. Its tests are
+special: they are **not** exercised by `just test`, because they need
 either a local storage emulator or a real cloud account that an ordinary test run cannot assume
 is present. Under `just test` these tests self-skip (no emulator is started), so they never break
 a normal test run. To actually exercise them, use one of the dedicated recipes below.

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -51,7 +51,7 @@ install-tools:
     }
 
     # Azurite is the Azure Blob storage emulator that backs the cargo-bench-history
-    # `azure` feature tests, exercised locally via `just test-azurite`. It is a Node
+    # Azure backend tests, exercised locally via `just test-azurite`. It is a Node
     # package, so npm is a prerequisite (see DEVELOPMENT.md). We install it on every
     # platform because the emulator and those tests are cross-platform. If npm is not
     # present we warn and continue rather than fail, so the rest of the toolchain still

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -248,7 +248,7 @@ test-azurite:
         # would then start/reuse one emulator while the tests hit another — non-hermetic).
         $env:AZURITE_BLOB_ENDPOINT = "http://${blobHost}:${blobPort}/devstoreaccount1"
         Write-Host "Running Azurite-backed tests against ${blobHost}:${blobPort}."
-        cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --features azure --locked --no-fail-fast azure azurite
+        cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --locked --no-fail-fast azure azurite
     } finally {
         if ($startedByUs) {
             Write-Host "Stopping the Azurite emulator we started."
@@ -290,7 +290,7 @@ test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_AZURE_ACCOUNT', ''):
     $env:ENABLE_AZURE = "1"
 
     Write-Host "Running real-Azure tests against account '$account' (Microsoft Entra ID; requires az login)."
-    cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --features azure real_azure --locked --no-fail-fast
+    cargo +$env:RUST_MSRV nextest run -p cargo-bench-history real_azure --locked --no-fail-fast
 
 # Runs regular tests as well as doing one iteration of benchmarks.
 # We separate it from "test" because benchmarks are quite slow,

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -26,8 +26,8 @@ driven in tests by fakes, never by real IO:
   one-file-per-operation trees, scanned by `collect_flat`) — all `mtime`-scoped to
   the run. Fake `FakeOutput` is engine-aware and returns in-memory `RawSummary`,
   `RawCriterionCase` or `RawOperationFile` values.
-* `storage::Storage` — real `LocalStorage` and (behind the `azure` feature)
-  `AzureBlobStorage`, selected at runtime by the `StorageFacade` enum that
+* `storage::Storage` — real `LocalStorage` and `AzureBlobStorage`, selected at
+  runtime by the `StorageFacade` enum that
   `build_storage` returns; fake `MemoryStorage`. `put` is **write-once** (an
   existing key yields `StorageError::AlreadyExists`); `put_overwrite` is the
   replacing escape hatch used only by `run --overwrite` (and, later, `backfill
@@ -690,13 +690,15 @@ make a test pass — regenerate the Callgrind fixtures from `just bench-cg` (and
 Criterion / `alloc_tracker` / `all_the_time` fixtures from a `cargo bench` run) if
 the upstream schema genuinely changes, and update the parser/tests to match.
 
-## Azure Blob storage (`azure` feature)
+## Azure Blob storage
 
-The `azure` feature adds `AzureBlobStorage`, a `Storage` backed by an Azure Blob
-container. It is **off by default** so the common build stays light; enabling it
-pulls in the Azure SDK and the RustCrypto `hmac`/`sha2` crates used to self-sign
-SAS tokens. Object keys map 1:1 to `/`-separated blob names, so the key model is
-identical to `LocalStorage` (write-once, list-by-prefix).
+`AzureBlobStorage` is a `Storage` backed by an Azure Blob container. It is
+**always compiled in** — `cargo-bench-history` is a CLI tool that users install
+without choosing feature flags, so gating the backend behind a build feature
+would only ever hide a backend the user explicitly configured. It pulls in the
+Azure SDK and the RustCrypto `hmac`/`sha2` crates used to self-sign SAS tokens.
+Object keys map 1:1 to `/`-separated blob names, so the key model is identical to
+`LocalStorage` (write-once, list-by-prefix).
 
 Authentication is resolved once in `AzureBlobStorage::from_config`, in priority
 order: a self-signed account SAS (`account_key`), a verbatim `sas_token`, or
@@ -710,9 +712,8 @@ golden signature — do not "fix" that test by editing the expected value.
 
 The network tests (`storage::azure::tests` and the `cbh_azure`
 integration file) talk to a live [Azurite](https://github.com/Azure/Azurite)
-blob emulator. They **self-skip** when no emulator is reachable, so a normal
-`--all-features` run stays green without one; they run for real once Azurite is
-up.
+blob emulator. They **self-skip** when no emulator is reachable, so a normal test
+run stays green without one; they run for real once Azurite is up.
 
 The `just test-azurite` recipe wraps the whole flow. Install the emulator once with
 `just install-tools` (or manually with `npm install -g azurite`), then:
@@ -732,7 +733,7 @@ instead, start the emulator and point `cargo` at it:
 # On Windows azurite-blob is a .cmd, so launch it through cmd:
 cmd /c azurite-blob --blobHost 127.0.0.1 --blobPort 10000 --inMemoryPersistence --skipApiVersionCheck --silent --loose
 # then, in another shell:
-cargo test -p cargo-bench-history --features azure
+cargo test -p cargo-bench-history
 ```
 
 * `AZURITE_BLOB_ENDPOINT` overrides the default
@@ -773,7 +774,7 @@ just test-azure
 `just test-azure` reads the account from `BENCH_HISTORY_AZURE_ACCOUNT` (committed in
 `constants.env`); pass a name to target a different account
 (`just test-azure <storage-account-name>`). The equivalent raw command is
-`cargo test -p cargo-bench-history --features azure real_azure` with `ENABLE_AZURE`
+`cargo test -p cargo-bench-history real_azure` with `ENABLE_AZURE`
 and `BENCH_HISTORY_AZURE_ACCOUNT` set.
 
 * `BENCH_HISTORY_AZURE_ENDPOINT` overrides the default

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -11,24 +11,8 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[package.metadata.docs.rs]
-all-features = true
-
-[features]
-# Azure Blob Storage backend. Off by default so the common build stays light;
-# enabling it pulls in the Azure SDK and the crypto crates used to self-sign SAS
-# tokens (for Azurite in CI and for SAS-authenticated production access).
-azure = [
-    "dep:azure_core",
-    "dep:azure_identity",
-    "dep:azure_storage_blob",
-    "dep:base64",
-    "dep:futures",
-    "dep:hmac",
-]
-
 [dependencies]
-azure_core = { workspace = true, optional = true }
+azure_core = { workspace = true }
 # The `default` feature on these two crates is load-bearing, not gratuitous: it
 # transitively enables `azure_core/default`, which selects the reqwest + rustls
 # HTTP transport. Without it the SDK still compiles, but `new_http_client()`
@@ -37,13 +21,13 @@ azure_core = { workspace = true, optional = true }
 # the same "defaults pick a backend" situation that keeps `clap` on its
 # defaults. The workspace declarations keep `default-features = false`, so the
 # defaults are scoped to this package alone.
-azure_identity = { workspace = true, optional = true, features = ["default"] }
-azure_storage_blob = { workspace = true, optional = true, features = ["default"] }
-base64 = { workspace = true, optional = true }
+azure_identity = { workspace = true, features = ["default"] }
+azure_storage_blob = { workspace = true, features = ["default"] }
+base64 = { workspace = true }
 cargo-bench-history-core = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-futures = { workspace = true, optional = true }
-hmac = { workspace = true, optional = true }
+futures = { workspace = true }
+hmac = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 many_cpus = { workspace = true }
 nonempty = { workspace = true }

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -1271,15 +1271,6 @@ the process CWD (see `cargo-detect-package/AGENTS.md`); no `parking_lot`; no
 real-time sleeps (inject `tick::Clock`); proptest with bounded cases + Miri-safe
 regression twins; zero warnings; alphabetical no-default-features deps.
 
-Dependency sketch: `clap` (derive; `default` feature on per the workspace CLI
-exception), `serde`, `serde_json`, `toml`, `jiff` (timestamps +
-`--since`/`--until`), `tokio` (rt-multi-thread, macros, process, fs, io-util),
-`tick` (clock; `tokio` feature in prod, `test-util` in dev), and `many_cpus` and
-`sha2` (the machine key). The **Azure backend** pulls in `azure_core`,
-`azure_identity`, `azure_storage_blob`, `base64`, `hmac` (SAS signing pairs `hmac`
-with the always-on `sha2`), and `futures` (the stream combinators it uses at
-runtime; the `executor` feature is added in dev for the Miri-safe `block_on`).
-
 ## 11. Cross-platform notes
 
 * `analyze`, `install`, and the harvest/store half of `run` are platform-neutral

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -1274,11 +1274,11 @@ regression twins; zero warnings; alphabetical no-default-features deps.
 Dependency sketch: `clap` (derive; `default` feature on per the workspace CLI
 exception), `serde`, `serde_json`, `toml`, `jiff` (timestamps +
 `--since`/`--until`), `tokio` (rt-multi-thread, macros, process, fs, io-util),
-`tick` (clock; `tokio` feature in prod, `test-util` in dev), `many_cpus` and `sha2`
-(the machine key), and `futures` (`executor`, dev-only) for the Miri-safe
-`block_on`. The **Azure backend** pulls in `azure_core`, `azure_identity`,
-`azure_storage_blob`, `base64`, `hmac` (SAS signing pairs `hmac` with the
-always-on `sha2`), and `futures` at runtime.
+`tick` (clock; `tokio` feature in prod, `test-util` in dev), and `many_cpus` and
+`sha2` (the machine key). The **Azure backend** pulls in `azure_core`,
+`azure_identity`, `azure_storage_blob`, `base64`, `hmac` (SAS signing pairs `hmac`
+with the always-on `sha2`), and `futures` (the stream combinators it uses at
+runtime; the `executor` feature is added in dev for the Miri-safe `block_on`).
 
 ## 11. Cross-platform notes
 

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -439,9 +439,10 @@ no `async_trait` dependency, and `run`/`analyze` stay backend-agnostic by holdin
 * **LocalStorage** (iteration 1): root from config; create dirs; write/read/walk
   via `tokio::fs` (iterative directory walk — no boxed async recursion).
 * **AzureBlobStorage** (iteration 4): `azure_storage_blob` (+ `azure_identity`),
-  behind an **optional `azure` Cargo feature** so default builds and Miri stay
-  light and dependency-free; the feature compiles on Windows, Linux **and
-  macOS**. Auth is resolved once in `from_config`, in priority order:
+  always compiled in — `cargo-bench-history` is a CLI tool installed without
+  feature flags, so a build-time gate would only ever hide a backend the user
+  explicitly configured. It compiles on Windows, Linux **and macOS**. Auth is
+  resolved once in `from_config`, in priority order:
   1. **self-signed account SAS** (`account_key`) — the signing math lives in
      `storage::sas` (HMAC-SHA256 via the pure-Rust RustCrypto `hmac`/`sha2`
      crates) and is the path used for **Azurite** in CI and for SAS-based
@@ -1207,8 +1208,8 @@ src/
     mod.rs                # Storage trait (async) + in-memory fake
     local.rs              # tokio::fs backend
     facade.rs             # StorageFacade enum (Local | Azure), static dispatch
-    azure.rs              # AzureBlobStorage           [feature = "azure"]
-    sas.rs                # self-signed account-SAS signer [feature = "azure"]
+    azure.rs              # AzureBlobStorage
+    sas.rs                # self-signed account-SAS signer
   analyze/
     mod.rs                # query orchestration (shared selection pipeline)
     discriminant.rs       # parse v1 keys; DiscriminantSet/DiscriminantSetQuery
@@ -1275,9 +1276,9 @@ exception), `serde`, `serde_json`, `toml`, `jiff` (timestamps +
 `--since`/`--until`), `tokio` (rt-multi-thread, macros, process, fs, io-util),
 `tick` (clock; `tokio` feature in prod, `test-util` in dev), `many_cpus` and `sha2`
 (the machine key), and `futures` (`executor`, dev-only) for the Miri-safe
-`block_on`. The optional **`azure`** feature pulls in `azure_core`,
-`azure_identity`, `azure_storage_blob`, `base64`, `hmac` (SAS signing pairs `hmac`
-with the always-on `sha2`), and `futures` at runtime.
+`block_on`. The **Azure backend** pulls in `azure_core`, `azure_identity`,
+`azure_storage_blob`, `base64`, `hmac` (SAS signing pairs `hmac` with the
+always-on `sha2`), and `futures` at runtime.
 
 ## 11. Cross-platform notes
 
@@ -1317,9 +1318,9 @@ adds macOS; mapped to the original request's numbering:
    regression over local Callgrind history; text report (+ `--fail-on`).
 3. ✅ **`install`** (your 4) — generate `.cargo/bench_history.toml`, point the user
    to it.
-4. ✅ **Azure blob** (your 5) — `azure` feature, `AzureBlobStorage`, self-signed
+4. ✅ **Azure blob** (your 5) — `AzureBlobStorage`, self-signed
    account SAS (Azurite/CI + SAS production) / verbatim SAS / Entra ID;
-   `run`/`analyze` become storage-agnostic; verify the feature builds and runs on
+   `run`/`analyze` become storage-agnostic; verify it builds and runs on
    Windows, Linux and macOS.
 5. ✅ **Criterion** (your 6) — adapter parses `target/criterion/**/new/{benchmark,
    estimates}.json` into `WallTime` records (slope estimate when present, else the
@@ -1464,7 +1465,7 @@ Each iteration ships with tests and docs and leaves the tool runnable.
     emulator runs directly on the runner host (started by the `start-azurite` composite
     action) in a Linux-only, package-gated job rather than as a service container,
     which cannot reliably bind Azurite to a reachable address. The network tests
-    **self-skip** when no emulator is reachable so the multi-platform `--all-features`
+    **self-skip** when no emulator is reachable so the multi-platform test
     jobs stay green; `BENCH_HISTORY_REQUIRE_AZURITE=1` (set only in `test-azurite`)
     turns an unreachable emulator into a hard failure so it can never silently skip.
     That job also collects coverage so the `azure.rs` network paths reach Codecov.

--- a/packages/cargo-bench-history/README.md
+++ b/packages/cargo-bench-history/README.md
@@ -8,7 +8,7 @@ data".
 
 Most benchmark tooling only reports the current run, or at best compares against
 the previous local run. `cargo-bench-history` instead stores **every** run as an
-immutable record — on the local filesystem or, with the `azure` feature, in an
+immutable record — on the local filesystem or in an
 Azure Blob container — and reconstructs per-benchmark series in git first-parent
 commit order, so historical trends become analyzable.
 

--- a/packages/cargo-bench-history/src/config.rs
+++ b/packages/cargo-bench-history/src/config.rs
@@ -21,12 +21,11 @@ const DEFAULT_TEMPLATE: &str = "\
 path = \"./bench-history\"
 
 # To store results in Azure Blob Storage instead, replace the [storage.local]
-# section above with a [storage.azure] section. The `azure` build feature must
-# be enabled. Authentication is, in priority order: a self-signed account SAS
-# (set `account_key`), a pre-made SAS token (set `sas_token`), or Microsoft Entra
-# ID (set neither; requires an HTTPS endpoint). Entra ID is the recommended mode
-# for CI, where GitHub Actions can federate into Azure without a stored secret;
-# for setup, see
+# section above with a [storage.azure] section. Authentication is, in priority
+# order: a self-signed account SAS (set `account_key`), a pre-made SAS token (set
+# `sas_token`), or Microsoft Entra ID (set neither; requires an HTTPS endpoint).
+# Entra ID is the recommended mode for CI, where GitHub Actions can federate into
+# Azure without a stored secret; for setup, see
 # https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-azure
 #
 # [storage.azure]
@@ -72,10 +71,6 @@ pub(crate) enum StorageConfig {
         path: PathBuf,
     },
     /// Store result sets in an Azure Blob Storage container.
-    ///
-    /// Available only when the crate is built with the `azure` feature; the
-    /// variant always parses so configuration is portable, but building the
-    /// backend without the feature is an error.
     Azure {
         /// The storage account name (e.g. `devstoreaccount1` for Azurite).
         account: String,

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -14,8 +14,8 @@
 //!
 //! Most benchmark tooling only reports the current run, or at best compares
 //! against the previous local run. `cargo-bench-history` instead stores *every*
-//! run as an immutable result set — on the local filesystem or, with the `azure`
-//! feature, in an Azure Blob container — and reconstructs each benchmark's series
+//! run as an immutable result set — on the local filesystem or in an Azure Blob
+//! container — and reconstructs each benchmark's series
 //! in git first-parent commit order, so historical trends become analyzable
 //! ("benchmark X has been getting incrementally slower over the past 12 months",
 //! "scenario Y regressed after commit Z, visible only in hindsight against noisy
@@ -191,7 +191,7 @@
 //! `install` writes a starter `.cargo/bench_history.toml`. It carries an optional
 //! `[project]` id (used to namespace stored data; defaults to the workspace
 //! directory name) and a `[storage]` section selecting either the local filesystem
-//! or, behind the `azure` feature, an Azure Blob container:
+//! or an Azure Blob container:
 //!
 //! ```toml
 //! # [project]

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -672,8 +672,8 @@ mod tests {
     //
     // These exercise the real put/get/list paths and the error classification
     // that pure tests cannot reach. They require an Azurite blob endpoint (the
-    // CI `azure` job provides one; see the package AGENTS.md for running them
-    // locally) and so are network-bound: ignored under Miri and serialized.
+    // CI `test-azurite` job provides one; see the package AGENTS.md for running
+    // them locally) and so are network-bound: ignored under Miri and serialized.
     // Each test uses a freshly named container, so they never share state even
     // against a shared emulator.
     // =======================================================================
@@ -700,9 +700,9 @@ mod tests {
 
     /// Whether an Azurite blob endpoint is reachable via a short TCP connect.
     ///
-    /// The `azure` feature enables these tests under `--all-features`, where the
-    /// runner usually has no emulator. A reachability probe lets the test self-skip
-    /// there while still running for real wherever Azurite is provided.
+    /// These tests are always compiled, but the runner usually has no emulator. A
+    /// reachability probe lets the test self-skip there while still running for
+    /// real wherever Azurite is provided.
     fn azurite_reachable() -> bool {
         let endpoint = azurite_endpoint();
         let Ok(url) = Url::parse(&endpoint) else {

--- a/packages/cargo-bench-history/src/storage/facade.rs
+++ b/packages/cargo-bench-history/src/storage/facade.rs
@@ -10,11 +10,9 @@ use std::path::Path;
 use crate::config::{Config, StorageConfig};
 use crate::wiring::rebase;
 
+use super::azure::AzureBlobStorage;
 use super::local::LocalStorage;
 use super::{Storage, StorageError};
-
-#[cfg(feature = "azure")]
-use super::azure::AzureBlobStorage;
 
 /// A [`Storage`] backend selected at configuration time.
 #[derive(Debug)]
@@ -22,7 +20,6 @@ pub(crate) enum StorageFacade {
     /// A local filesystem backend.
     Local(LocalStorage),
     /// An Azure Blob Storage backend.
-    #[cfg(feature = "azure")]
     Azure(AzureBlobStorage),
 }
 
@@ -30,7 +27,6 @@ impl Storage for StorageFacade {
     async fn put(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
         match self {
             Self::Local(storage) => storage.put(key, bytes).await,
-            #[cfg(feature = "azure")]
             Self::Azure(storage) => storage.put(key, bytes).await,
         }
     }
@@ -38,7 +34,6 @@ impl Storage for StorageFacade {
     async fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
         match self {
             Self::Local(storage) => storage.put_overwrite(key, bytes).await,
-            #[cfg(feature = "azure")]
             Self::Azure(storage) => storage.put_overwrite(key, bytes).await,
         }
     }
@@ -46,7 +41,6 @@ impl Storage for StorageFacade {
     async fn get(&self, key: &str) -> Result<Vec<u8>, StorageError> {
         match self {
             Self::Local(storage) => storage.get(key).await,
-            #[cfg(feature = "azure")]
             Self::Azure(storage) => storage.get(key).await,
         }
     }
@@ -54,7 +48,6 @@ impl Storage for StorageFacade {
     async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
         match self {
             Self::Local(storage) => storage.list(prefix).await,
-            #[cfg(feature = "azure")]
             Self::Azure(storage) => storage.list(prefix).await,
         }
     }
@@ -62,7 +55,6 @@ impl Storage for StorageFacade {
     async fn delete(&self, key: &str) -> Result<(), StorageError> {
         match self {
             Self::Local(storage) => storage.delete(key).await,
-            #[cfg(feature = "azure")]
             Self::Azure(storage) => storage.delete(key).await,
         }
     }
@@ -77,8 +69,7 @@ impl Storage for StorageFacade {
 /// # Errors
 ///
 /// Returns [`StorageError::Config`] if the selected backend cannot be built —
-/// for example an Azure backend with conflicting authentication settings, or an
-/// Azure backend when the crate was built without the `azure` feature.
+/// for example an Azure backend with conflicting authentication settings.
 pub(crate) fn build_storage(
     config: &Config,
     workspace_dir: &Path,
@@ -88,7 +79,6 @@ pub(crate) fn build_storage(
             workspace_dir,
             path.clone(),
         )))),
-        #[cfg(feature = "azure")]
         StorageConfig::Azure {
             account,
             container,
@@ -102,11 +92,6 @@ pub(crate) fn build_storage(
             account_key.clone(),
             sas_token.clone(),
         )?)),
-        #[cfg(not(feature = "azure"))]
-        StorageConfig::Azure { .. } => Err(StorageError::Config {
-            message: "Azure storage requires building cargo-bench-history with the `azure` feature"
-                .to_owned(),
-        }),
     }
 }
 
@@ -160,23 +145,9 @@ mod tests {
         assert!(format!("{storage:?}").contains("data"), "{storage:?}");
     }
 
-    #[cfg(not(feature = "azure"))]
-    #[test]
-    fn build_storage_for_azure_without_feature_is_a_config_error() {
-        let config = config_with_storage("[storage.azure]\naccount = \"a\"\ncontainer = \"c\"\n");
-        let error = build_storage(&config, Path::new("/work")).unwrap_err();
-        match error {
-            StorageError::Config { message } => {
-                assert!(message.contains("azure"), "{message}");
-            }
-            other => panic!("unexpected error: {other:?}"),
-        }
-    }
-
-    #[cfg(feature = "azure")]
     #[test]
     #[cfg_attr(miri, ignore = "reads the wall clock to compute the SAS expiry")]
-    fn build_storage_for_azure_with_feature_yields_an_azure_backend() {
+    fn build_storage_for_azure_with_account_key_yields_an_azure_backend() {
         let config = config_with_storage(
             "[storage.azure]\naccount = \"devstoreaccount1\"\ncontainer = \"bench-history\"\n\
              endpoint = \"http://127.0.0.1:10000/devstoreaccount1\"\n\
@@ -186,7 +157,6 @@ mod tests {
         assert!(matches!(storage, StorageFacade::Azure(_)));
     }
 
-    #[cfg(feature = "azure")]
     #[test]
     fn build_storage_for_azure_with_conflicting_auth_is_a_config_error() {
         let config = config_with_storage(

--- a/packages/cargo-bench-history/src/storage/mod.rs
+++ b/packages/cargo-bench-history/src/storage/mod.rs
@@ -1,12 +1,9 @@
 //! The storage abstraction: an immutable, list-by-prefix object store that both a
-//! local filesystem and an Azure Blob container (behind the `azure` feature)
-//! implement identically.
+//! local filesystem and an Azure Blob container implement identically.
 
-#[cfg(feature = "azure")]
 mod azure;
 mod facade;
 mod local;
-#[cfg(feature = "azure")]
 mod sas;
 
 pub(crate) use facade::build_storage;
@@ -99,7 +96,7 @@ pub enum StorageError {
         key: String,
     },
     /// The storage backend is misconfigured (e.g. conflicting Azure
-    /// authentication settings, or a backend the build does not support).
+    /// authentication settings).
     Config {
         /// Human-readable description of the misconfiguration.
         message: String,
@@ -151,13 +148,6 @@ pub(crate) fn is_plain_segment(segment: &str) -> bool {
 ///
 /// Returns [`StorageError::InvalidKey`] if any segment of `key` is not a single
 /// ordinary path component.
-#[cfg_attr(
-    not(any(test, feature = "azure")),
-    expect(
-        dead_code,
-        reason = "outside the azure feature the only caller, MemoryStorage, is test-only"
-    )
-)]
 pub(crate) fn validate_key(key: &str) -> Result<(), StorageError> {
     for segment in key.split('/') {
         if !is_plain_segment(segment) {

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -8,8 +8,8 @@
 //!
 //! * **Azurite** (`*_in_azurite`) — against a local Azurite emulator using the
 //!   self-signed account-SAS path. They **self-skip** when no emulator is reachable
-//!   (so a normal `--all-features` run stays green) and run for real once Azurite is
-//!   up; CI provides one in the `test-azurite` job.
+//!   (so a normal test run stays green) and run for real once Azurite is up; CI
+//!   provides one in the `test-azurite` job.
 //! * **Real Azure** (`*_in_real_azure`) — against a real Storage account using the
 //!   **Microsoft Entra ID** path (no account key). They self-skip unless
 //!   `ENABLE_AZURE` is set (an explicit opt-in, so the account name living in
@@ -20,10 +20,8 @@
 //!   comes from `BENCH_HISTORY_AZURE_ACCOUNT`. Each test uses a fresh container
 //!   that is deleted when the test finishes, even on panic.
 //!
-//! They compile only with the `azure` feature, each scenario uses its own container
-//! so they never share state, and they are ignored under Miri (real network and
-//! process I/O).
-#![cfg(feature = "azure")]
+//! Each scenario uses its own container so they never share state, and they are
+//! ignored under Miri (real network and process I/O).
 #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
 use std::net::{TcpStream, ToSocketAddrs as _};
@@ -61,9 +59,9 @@ fn azurite_endpoint() -> String {
 
 /// Whether an Azurite blob endpoint is reachable via a short TCP connect.
 ///
-/// The `azure` feature builds these tests under `--all-features`, where the
-/// runner usually has no emulator. A reachability probe lets each test self-skip
-/// there while still running for real wherever Azurite is provided.
+/// These tests are always compiled, but the runner usually has no emulator. A
+/// reachability probe lets each test self-skip there while still running for real
+/// wherever Azurite is provided.
 ///
 /// Setting `BENCH_HISTORY_REQUIRE_AZURITE` turns an unreachable emulator into a
 /// hard failure, so the dedicated CI job that provisions Azurite cannot silently
@@ -135,12 +133,12 @@ fn real_azure_endpoint(account: &str) -> String {
 
 /// Whether the real-Azure tests are enabled.
 ///
-/// They run only when `ENABLE_AZURE` is set, so a plain test run (and the
-/// `--all-features` jobs) self-skips them even though `BENCH_HISTORY_AZURE_ACCOUNT`
-/// may be in scope. `ENABLE_AZURE` is an explicit opt-in — set by the `just
-/// test-azure` recipe and the CI `test-azure` job — that says "really run these",
-/// so a then-missing `BENCH_HISTORY_AZURE_ACCOUNT` is a hard failure rather than a
-/// silent skip, mirroring how `BENCH_HISTORY_REQUIRE_AZURITE` guards Azurite.
+/// They run only when `ENABLE_AZURE` is set, so a plain test run self-skips them
+/// even though `BENCH_HISTORY_AZURE_ACCOUNT` may be in scope. `ENABLE_AZURE` is an
+/// explicit opt-in — set by the `just test-azure` recipe and the CI `test-azure`
+/// job — that says "really run these", so a then-missing
+/// `BENCH_HISTORY_AZURE_ACCOUNT` is a hard failure rather than a silent skip,
+/// mirroring how `BENCH_HISTORY_REQUIRE_AZURITE` guards Azurite.
 fn real_azure_enabled() -> bool {
     if std::env::var_os("ENABLE_AZURE").is_none_or(|value| value.is_empty()) {
         eprintln!("skipping real Azure integration test: ENABLE_AZURE not set");


### PR DESCRIPTION
## What

Removes the `azure` Cargo feature from `cargo-bench-history` and makes the Azure Blob storage backend always compiled in.

## Why

`cargo-bench-history` is a CLI tool that users install (`cargo install`) without choosing Cargo feature flags. Gating the Azure backend behind an off-by-default `azure` feature therefore only ever hid a backend the user explicitly configured in `bench_history.toml` — building without the feature turned a valid config into a runtime "Azure storage requires building with the `azure` feature" error nobody could reasonably hit. The gate added complexity (cfg-splattered storage module, a feature-absent error arm, dead-code expectations, `--features azure` in every recipe and doc) for no real benefit.

## Changes

- **Cargo.toml** — delete the `[features]` block; make `azure_core`, `azure_identity`, `azure_storage_blob`, `base64`, `futures`, `hmac` non-optional. Drop the now-empty `[package.metadata.docs.rs]`.
- **src/storage/{mod,facade}.rs** — remove every `#[cfg(feature = "azure")]` / `#[cfg(not(feature = "azure"))]`, the build arm that errored when the feature was absent (and its test), and the stale `validate_key` dead-code `expect`.
- **src/{config,lib}.rs, tests/cbh_azure.rs, src/storage/azure.rs** — drop feature wording from comments and the `#![cfg(feature = "azure")]` test gate.
- **justfiles/just_testing.just** — drop `--features azure` from `test-azurite` / `test-azure`.
- **Docs** — package AGENTS.md, DESIGN.md, README.md, DEVELOPMENT.md, just_setup.just, and `.github/workflows/{AGENTS.md,validation.yml}` now describe the Azure backend as always built in.

No behavior change for storage at runtime; the Azure tests still self-skip when no emulator/account is reachable, and CI's `test-azurite` / `test-azure` jobs are unaffected (they drive the `just` recipes, and the Azure code is simply always present now).

## Validation

`cargo check --all-targets`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, `cargo nextest run -p cargo-bench-history` (568 passed; Azure tests self-skip), doctests, `cargo +nightly fmt --check`, `cargo machete`, and `cargo doc -D warnings` all pass. `Cargo.lock` is unchanged.
