### PR TITLE
Make verbose analyze notes lazy via ReporterExt::note_with

### DIFF
--- a/packages/cargo-bench-history/src/analyze/bless.rs
+++ b/packages/cargo-bench-history/src/analyze/bless.rs
@@ -25,7 +25,7 @@ use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
 use crate::model::BlessingRecord;
 use crate::model::Run;
-use crate::report::{Reporter, StderrReporter};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, build_storage};
 use crate::text::count_noun;
 use crate::wiring::{resolve_config_path, resolve_project_id, resolve_repo};
@@ -221,7 +221,7 @@ where
             .put_overwrite(&bless_key, json.as_bytes())
             .await
             .map_err(RunError::Storage)?;
-        reporter.note(&format!("blessed set {} at {bless_key}", parsed.set));
+        reporter.note_with(|| format!("blessed set {} at {bless_key}", parsed.set));
         sets = sets.saturating_add(1);
     }
 
@@ -276,7 +276,7 @@ where
     let mut removed = 0_usize;
     for key in &blessings_at_head {
         storage.delete(key).await.map_err(RunError::Storage)?;
-        reporter.note(&format!("removed blessing {key}"));
+        reporter.note_with(|| format!("removed blessing {key}"));
         removed = removed.saturating_add(1);
     }
 

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
-use crate::report::{Reporter, StderrReporter};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, build_storage};
 use crate::text::count_noun;
 use crate::wiring::{resolve_config_path, resolve_project_id, resolve_repo};
@@ -599,7 +599,7 @@ where
         let record = BlessingRecord::from_json(&text).map_err(|error| RunError::Analyze {
             message: format!("stored object {key} is not a valid blessing: {error}"),
         })?;
-        reporter.note(&format!("blessing {key}"));
+        reporter.note_with(|| format!("blessing {key}"));
         entries.push(BlessingEntry {
             set: parsed.set,
             benchmark: None,

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -39,7 +39,7 @@ use crate::model::BlessingRecord;
 use crate::model::Run;
 use crate::model::{DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment};
 use crate::probe::{EnvironmentProbe, SystemProbe};
-use crate::report::{Reporter, StderrReporter};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, build_storage};
 use crate::text::count_noun;
 use crate::wiring::{resolve_config_path, resolve_project_id, resolve_repo};
@@ -435,9 +435,7 @@ async fn facet_filtered_candidates<S: Storage>(
         "project id: {project_id} (storage segment: {project})"
     ));
     reporter.note(&format!("listing stored objects under prefix {prefix}"));
-    if reporter.enabled() {
-        reporter.note(&format!("facet filters: {}", describe_facets(facets)));
-    }
+    reporter.note_with(|| format!("facet filters: {}", describe_facets(facets)));
 
     let keys = storage.list(&prefix).await.map_err(RunError::Storage)?;
     reporter.note(&format!(
@@ -448,20 +446,22 @@ async fn facet_filtered_candidates<S: Storage>(
     let mut candidates: Vec<(String, StorageKey)> = Vec::new();
     for key in keys {
         if !key.ends_with(".json") {
-            reporter.note(&format!("skipping {key}: not a .json object"));
+            reporter.note_with(|| format!("skipping {key}: not a .json object"));
             continue;
         }
         let Some(parsed) = parse_key(&key) else {
-            reporter.note(&format!(
-                "skipping {key}: not a recognized {STORAGE_VERSION} storage key"
-            ));
+            reporter.note_with(|| {
+                format!("skipping {key}: not a recognized {STORAGE_VERSION} storage key")
+            });
             continue;
         };
         if !facets.matches(&parsed.set) {
-            reporter.note(&format!(
-                "skipping {key}: discriminant {} does not match the facet filters",
-                parsed.set
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "skipping {key}: discriminant {} does not match the facet filters",
+                    parsed.set
+                )
+            });
             continue;
         }
         candidates.push((key, parsed));
@@ -598,10 +598,12 @@ where
     for (key, parsed) in candidates {
         if !order.contains_key(&parsed.commit) {
             excluded_outside_history = excluded_outside_history.saturating_add(1);
-            reporter.note(&format!(
-                "excluding {key}: commit {} is not on {target_ref}'s analyzed history",
-                parsed.commit
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "excluding {key}: commit {} is not on {target_ref}'s analyzed history",
+                    parsed.commit
+                )
+            });
             continue;
         }
         if parsed.is_dirty()
@@ -611,11 +613,13 @@ where
                 .unwrap_or(false)
         {
             excluded_dirty_base = excluded_dirty_base.saturating_add(1);
-            reporter.note(&format!(
-                "excluding {key}: dirty snapshot on a base-side commit ({} \
-                 only admits clean runs); dirty runs count only on the target side",
-                parsed.commit
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "excluding {key}: dirty snapshot on a base-side commit ({} \
+                     only admits clean runs); dirty runs count only on the target side",
+                    parsed.commit
+                )
+            });
             continue;
         }
         let bytes = storage.get(&key).await.map_err(RunError::Storage)?;
@@ -627,16 +631,14 @@ where
         })?;
         if since.is_some_and(|since| result.context.commit < since) {
             excluded_since = excluded_since.saturating_add(1);
-            reporter.note(&format!(
-                "excluding {key}: commit time is before the --since cutoff"
-            ));
+            reporter
+                .note_with(|| format!("excluding {key}: commit time is before the --since cutoff"));
             continue;
         }
         if until.is_some_and(|until| result.context.commit > until) {
             excluded_until = excluded_until.saturating_add(1);
-            reporter.note(&format!(
-                "excluding {key}: commit time is after the --until cutoff"
-            ));
+            reporter
+                .note_with(|| format!("excluding {key}: commit time is after the --until cutoff"));
             continue;
         }
         if parsed.is_dirty()
@@ -646,12 +648,14 @@ where
                 .unwrap_or(false)
         {
             included_dirty_base_exception = true;
-            reporter.note(&format!(
-                "including {key}: dirty snapshot on the base-branch tip, admitted \
-                 because the working tree is dirty (ephemeral — see the warning)"
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "including {key}: dirty snapshot on the base-branch tip, admitted \
+                     because the working tree is dirty (ephemeral — see the warning)"
+                )
+            });
         } else {
-            reporter.note(&format!("including {key}"));
+            reporter.note_with(|| format!("including {key}"));
         }
         loaded.push(LoadedObject {
             key: parsed,
@@ -674,7 +678,7 @@ where
     if mode == AnalysisMode::History {
         for (key, parsed) in bless_candidates {
             let Some(&topo_index) = order.get(&parsed.commit) else {
-                reporter.note(&format!(
+                reporter.note_with(|| format!(
                     "skipping blessing {key}: commit {} is not on {target_ref}'s analyzed history",
                     parsed.commit
                 ));
@@ -687,11 +691,13 @@ where
             let record = BlessingRecord::from_json(&text).map_err(|error| RunError::Analyze {
                 message: format!("stored blessing {key} is not a valid blessing record: {error}"),
             })?;
-            reporter.note(&format!(
-                "loaded blessing {key} ({} accepted at {})",
-                count_noun(record.prefixes.len(), "prefix filter"),
-                parsed.commit
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "loaded blessing {key} ({} accepted at {})",
+                    count_noun(record.prefixes.len(), "prefix filter"),
+                    parsed.commit
+                )
+            });
             blessings
                 .entry(parsed.set.clone())
                 .or_default()

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
 use crate::model::Run;
-use crate::report::{Reporter, StderrReporter};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, build_storage};
 use crate::text::count_noun;
 use crate::wiring::{resolve_config_path, resolve_project_id, resolve_repo};
@@ -174,28 +174,34 @@ where
 
     for (key, parsed) in runs {
         let Some(&index) = order.get(&parsed.commit) else {
-            reporter.note(&format!(
-                "skipping {key}: commit {} is not on {target_ref}'s history",
-                parsed.commit
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "skipping {key}: commit {} is not on {target_ref}'s history",
+                    parsed.commit
+                )
+            });
             continue;
         };
         // Preserve base-branch history: unless this is a base-branch prune, only
         // the commits after the merge-base (the context branch's own commits) are
         // eligible for removal.
         if !commit_is_eligible(index, merge_base_index, tip_is_merge_base) {
-            reporter.note(&format!(
-                "skipping {key}: commit {} is on the base branch (preserved; prune from \
-                 the base branch with --prune-base to remove it)",
-                parsed.commit
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "skipping {key}: commit {} is on the base branch (preserved; prune from \
+                     the base branch with --prune-base to remove it)",
+                    parsed.commit
+                )
+            });
             continue;
         }
         if !commit_matches(&parsed.commit, &options.commit) {
-            reporter.note(&format!(
-                "skipping {key}: commit {} does not match the requested <commit> arguments",
-                parsed.commit
-            ));
+            reporter.note_with(|| {
+                format!(
+                    "skipping {key}: commit {} does not match the requested <commit> arguments",
+                    parsed.commit
+                )
+            });
             continue;
         }
 
@@ -208,7 +214,8 @@ where
         match kind {
             RunKind::Dirty => {
                 if !scope.touches_dirty() {
-                    reporter.note(&format!("skipping {key}: --clean removes only clean runs"));
+                    reporter
+                        .note_with(|| format!("skipping {key}: --clean removes only clean runs"));
                     continue;
                 }
                 // `--dirty` reproduces `clean`: a dirty snapshot is removed only on
@@ -220,17 +227,20 @@ where
                         .copied()
                         .unwrap_or(false)
                 {
-                    reporter.note(&format!(
-                        "skipping {key}: dirty snapshot on a base-side commit ({} admits \
-                         only clean runs)",
-                        parsed.commit
-                    ));
+                    reporter.note_with(|| {
+                        format!(
+                            "skipping {key}: dirty snapshot on a base-side commit ({} admits \
+                             only clean runs)",
+                            parsed.commit
+                        )
+                    });
                     continue;
                 }
             }
             RunKind::Clean => {
                 if !scope.touches_clean() {
-                    reporter.note(&format!("skipping {key}: --dirty removes only dirty runs"));
+                    reporter
+                        .note_with(|| format!("skipping {key}: --dirty removes only dirty runs"));
                     continue;
                 }
             }
@@ -244,17 +254,17 @@ where
             if let Some(since) = since
                 && committed < since
             {
-                reporter.note(&format!(
-                    "skipping {key}: its commit predates the --since cutoff"
-                ));
+                reporter.note_with(|| {
+                    format!("skipping {key}: its commit predates the --since cutoff")
+                });
                 continue;
             }
             if let Some(until) = until
                 && committed > until
             {
-                reporter.note(&format!(
-                    "skipping {key}: its commit is after the --until cutoff"
-                ));
+                reporter.note_with(|| {
+                    format!("skipping {key}: its commit is after the --until cutoff")
+                });
                 continue;
             }
         }
@@ -262,7 +272,7 @@ where
         if kind == RunKind::Clean {
             clean_removed.insert((parsed.set.clone(), parsed.commit.clone()));
         }
-        reporter.note(&format!("selected {key} for removal"));
+        reporter.note_with(|| format!("selected {key} for removal"));
         items.push(RemovalItem {
             index,
             set: parsed.set,
@@ -281,12 +291,11 @@ where
                 continue;
             };
             if !clean_removed.contains(&(parsed.set.clone(), parsed.commit.clone())) {
-                reporter.note(&format!(
-                    "skipping {key}: its clean run is not being removed"
-                ));
+                reporter
+                    .note_with(|| format!("skipping {key}: its clean run is not being removed"));
                 continue;
             }
-            reporter.note(&format!("selected {key} for removal (blessing sidecar)"));
+            reporter.note_with(|| format!("selected {key} for removal (blessing sidecar)"));
             items.push(RemovalItem {
                 index,
                 set: parsed.set,
@@ -303,7 +312,7 @@ where
         for set in &plan.sets {
             for commit in &set.commits {
                 for key in &commit.keys {
-                    reporter.note(&format!("deleting {key}"));
+                    reporter.note_with(|| format!("deleting {key}"));
                     storage.delete(key).await.map_err(RunError::Storage)?;
                 }
             }

--- a/packages/cargo-bench-history/src/bench_output.rs
+++ b/packages/cargo-bench-history/src/bench_output.rs
@@ -17,7 +17,7 @@ use crate::bench::{
     CRITERION_ESTIMATES_FILE, CRITERION_NEW_DIR, GUNGRAUN_DIR, SUMMARY_FILE,
 };
 use crate::model::Engine;
-use crate::report::Reporter;
+use crate::report::{Reporter, ReporterExt};
 use crate::text::count_noun;
 
 /// Tolerance subtracted from the run-start boundary before comparing file
@@ -140,13 +140,11 @@ impl FsBenchOutputSource {
                 } else if path.file_name() == Some(summary_name) {
                     let modified = entry.metadata().await?.modified()?;
                     if modified >= threshold {
-                        if reporter.enabled() {
-                            reporter.note(&format!("callgrind: including {}", path.display()));
-                        }
+                        reporter.note_with(|| format!("callgrind: including {}", path.display()));
                         let content = tokio::fs::read_to_string(&path).await?;
                         summaries.push(RawSummary { path, content });
-                    } else if reporter.enabled() {
-                        reporter.note(&format!(
+                    } else {
+                        reporter.note_with(|| format!(
                             "callgrind: excluding {} (modified {}, older than the run boundary)",
                             path.display(),
                             format_mtime(modified)
@@ -223,19 +221,17 @@ impl FsBenchOutputSource {
                 continue;
             }
             let Some(modified) = estimates_mtime.filter(|_| has_benchmark) else {
-                if reporter.enabled() {
-                    reporter.note(&format!(
+                reporter.note_with(|| {
+                    format!(
                         "criterion: skipping {} (missing {CRITERION_BENCHMARK_FILE} or \
                          {CRITERION_ESTIMATES_FILE})",
                         dir.display()
-                    ));
-                }
+                    )
+                });
                 continue;
             };
             if modified >= threshold {
-                if reporter.enabled() {
-                    reporter.note(&format!("criterion: including {}", dir.display()));
-                }
+                reporter.note_with(|| format!("criterion: including {}", dir.display()));
                 let benchmark =
                     tokio::fs::read_to_string(dir.join(CRITERION_BENCHMARK_FILE)).await?;
                 let estimates =
@@ -245,12 +241,14 @@ impl FsBenchOutputSource {
                     benchmark,
                     estimates,
                 });
-            } else if reporter.enabled() {
-                reporter.note(&format!(
-                    "criterion: excluding {} (modified {}, older than the run boundary)",
-                    dir.display(),
-                    format_mtime(modified)
-                ));
+            } else {
+                reporter.note_with(|| {
+                    format!(
+                        "criterion: excluding {} (modified {}, older than the run boundary)",
+                        dir.display(),
+                        format_mtime(modified)
+                    )
+                });
             }
         }
 
@@ -303,17 +301,17 @@ impl FsBenchOutputSource {
             }
             let modified = entry.metadata().await?.modified()?;
             if modified >= threshold {
-                if reporter.enabled() {
-                    reporter.note(&format!("{label}: including {}", path.display()));
-                }
+                reporter.note_with(|| format!("{label}: including {}", path.display()));
                 let content = tokio::fs::read_to_string(&path).await?;
                 files.push(RawOperationFile { path, content });
-            } else if reporter.enabled() {
-                reporter.note(&format!(
-                    "{label}: excluding {} (modified {}, older than the run boundary)",
-                    path.display(),
-                    format_mtime(modified)
-                ));
+            } else {
+                reporter.note_with(|| {
+                    format!(
+                        "{label}: excluding {} (modified {}, older than the run boundary)",
+                        path.display(),
+                        format_mtime(modified)
+                    )
+                });
             }
         }
 
@@ -370,11 +368,13 @@ fn note_missing_dir(reporter: &dyn Reporter, engine: &str, dir: &Path, root: &Pa
             "{engine}: directory {} does not exist; no output was produced here",
             dir.display()
         ));
-    } else if reporter.enabled() {
-        reporter.note(&format!(
-            "{engine}: directory {} disappeared during the scan; skipping",
-            dir.display()
-        ));
+    } else {
+        reporter.note_with(|| {
+            format!(
+                "{engine}: directory {} disappeared during the scan; skipping",
+                dir.display()
+            )
+        });
     }
 }
 

--- a/packages/cargo-bench-history/src/commands/run.rs
+++ b/packages/cargo-bench-history/src/commands/run.rs
@@ -25,7 +25,7 @@ use crate::model::{DiscriminantSet, Engine};
 use crate::model::{EnvironmentInfo, RunContext, ToolchainInfo, detect_environment};
 use crate::probe::{EnvironmentProbe, SystemProbe};
 use crate::process::{BenchRunner, TokioBenchRunner};
-use crate::report::{Reporter, StderrReporter};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, StorageError, build_storage};
 use crate::text::count_noun;
 use crate::wiring::{resolve_config_path, resolve_project_id, resolve_repo};
@@ -245,17 +245,16 @@ where
         deps.target_root.to_string_lossy().into_owned(),
     ));
 
-    if deps.reporter.enabled() {
-        deps.reporter
-            .note(&format!("running benchmark command: {}", argv.join(" ")));
+    deps.reporter
+        .note_with(|| format!("running benchmark command: {}", argv.join(" ")));
+    deps.reporter.note_with(|| {
         let rendered_env = env
             .iter()
             .map(|(name, value)| format!("{name}={value}"))
             .collect::<Vec<_>>()
             .join(", ");
-        deps.reporter
-            .note(&format!("injected environment: {rendered_env}"));
-    }
+        format!("injected environment: {rendered_env}")
+    });
 
     let run_start = deps.clock.system_time();
     let status = deps.runner.run_benches(&argv, &env).await?;

--- a/packages/cargo-bench-history/src/report.rs
+++ b/packages/cargo-bench-history/src/report.rs
@@ -19,6 +19,33 @@ pub(crate) trait Reporter {
     fn note(&self, message: &str);
 }
 
+/// Lazy-formatting helpers available on every [`Reporter`], including
+/// `&dyn Reporter`.
+///
+/// These live on a separate trait rather than on [`Reporter`] itself so the base
+/// trait stays dyn-compatible: a method taking a generic closure cannot be
+/// dispatched through `&dyn Reporter`. A blanket impl makes the helpers available
+/// on every reporter regardless.
+pub(crate) trait ReporterExt {
+    /// Records a diagnostic note whose formatting runs only when notes are
+    /// consumed.
+    ///
+    /// The `build` closure — typically an allocating `format!` — is invoked only
+    /// when [`enabled`](Reporter::enabled) is true. On a hot path that emits one
+    /// note per scanned object this avoids building (and immediately discarding) a
+    /// string for every object when `--verbose` is off, without sprinkling an
+    /// `if reporter.enabled()` guard around each call site.
+    fn note_with(&self, build: impl FnOnce() -> String);
+}
+
+impl<R: Reporter + ?Sized> ReporterExt for R {
+    fn note_with(&self, build: impl FnOnce() -> String) {
+        if self.enabled() {
+            self.note(&build());
+        }
+    }
+}
+
 /// A [`Reporter`] that writes notes to standard error when verbose mode is on,
 /// and discards them otherwise.
 #[derive(Clone, Copy, Debug)]
@@ -123,5 +150,28 @@ mod tests {
         );
         assert!(reporter.contains("stale"));
         assert!(!reporter.contains("missing"));
+    }
+
+    #[test]
+    fn note_with_skips_formatting_when_disabled() {
+        use std::cell::Cell;
+
+        // A disabled reporter must never run the formatting closure, so a per-object
+        // note costs nothing when nothing will consume it.
+        let built = Cell::new(0_u32);
+        StderrReporter::new(false).note_with(|| {
+            built.set(built.get() + 1);
+            "discarded".to_owned()
+        });
+        assert_eq!(built.get(), 0);
+
+        // An enabled reporter runs the closure and records the resulting note.
+        let recording = RecordingReporter::new();
+        recording.note_with(|| {
+            built.set(built.get() + 1);
+            "lazy note".to_owned()
+        });
+        assert_eq!(built.get(), 1);
+        assert!(recording.contains("lazy note"));
     }
 }


### PR DESCRIPTION
Closes #259.

The analyze object-selection loop built verbose diagnostic strings eagerly with `reporter.note(&format!(...))` even when `--verbose` was off, wasting one `format!` allocation per scanned object — thousands of discarded strings at scale.

This adds a closure-based lazy note helper and converts the hot-loop call sites to it:

- `ReporterExt::note_with(|| format!(...))` formats and emits a note only when the reporter is enabled. It lives on a separate `ReporterExt` trait with a blanket impl over `R: Reporter + ?Sized`, so the base `Reporter` trait stays dyn-compatible (it is always used as `&dyn Reporter`).
- All per-object/per-key hot-loop notes in the analyze pipeline (`analyze/mod.rs`, `prune.rs`, `list.rs`, `bless.rs`) now use `note_with`.
- The file-scan guards in `bench_output.rs` and the multi-statement guard in `commands/run.rs` are unified onto the same idiom, so no scattered `if reporter.enabled()` guards remain.

The closure is monomorphized and inlined, captures by reference (never boxed), and only runs `format!` when enabled, so this is effectively zero-overhead — equivalent codegen to a manual `enabled()` guard, without the boilerplate. We deliberately kept the injected `&dyn Reporter` port rather than adopting `tracing`: a global subscriber would undermine the in-memory `RecordingReporter` test strategy and the `!Send`/Miri design.

Note text and format strings are unchanged, so existing `RecordingReporter`-based assertions still hold; the only observable difference is laziness when verbose is off. A new Miri-safe unit test verifies the closure is not invoked when disabled and is recorded when enabled.

Validation: `cargo +nightly fmt --all --check`, `cargo clippy -p cargo-bench-history --all-targets --all-features --locked -- -D warnings`, `cargo test -p cargo-bench-history --lib` (456) and `--tests` (all green), and `cargo +nightly miri test -p cargo-bench-history --lib report::` all pass.
