### PR TITLE
cargo-bench-history: gzip-compress stored objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,8 +438,11 @@ dependencies = [
 name = "cargo-bench-history-core"
 version = "0.0.1"
 dependencies = [
+ "alloc_tracker",
  "colored",
  "criterion",
+ "flate2",
+ "gungraun",
  "jiff",
  "mutants",
  "nonempty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ events = { version = "0.7.8", path = "packages/events", default-features = false
 events_once = { version = "0.5.28", path = "packages/events_once", default-features = false }
 fake_headers = { version = "0.0.5", default-features = false }
 fast_time = { version = "0.1.24", path = "packages/fast_time", default-features = false }
+flate2 = { version = "1.1.9", default-features = false, features = ["rust_backend"] }
 foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
 folo_ffi = { version = "0.1.15", path = "packages/folo_ffi", default-features = false }
 folo_utils = { version = "0.1.9", path = "packages/folo_utils", default-features = false }

--- a/packages/cargo-bench-history-core/Cargo.toml
+++ b/packages/cargo-bench-history-core/Cargo.toml
@@ -23,8 +23,11 @@ serde_json = { workspace = true }
 [dev-dependencies]
 alloc_tracker = { path = "../alloc_tracker" }
 criterion = { workspace = true }
-gungraun = { workspace = true, features = ["default"] }
 mutants = { workspace = true }
+
+# Gungraun drives Valgrind-based Callgrind benchmarks; Linux-only.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { workspace = true, features = ["default"] }
 
 [[bench]]
 name = "cbh_core_model"

--- a/packages/cargo-bench-history-core/Cargo.toml
+++ b/packages/cargo-bench-history-core/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 colored = { workspace = true }
+flate2 = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 nonempty = { workspace = true, features = ["serialize"] }
 rasciigraph = { workspace = true, features = ["color"] }
@@ -20,11 +21,21 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+alloc_tracker = { path = "../alloc_tracker" }
 criterion = { workspace = true }
+gungraun = { workspace = true, features = ["default"] }
 mutants = { workspace = true }
 
 [[bench]]
 name = "cbh_core_model"
+harness = false
+
+[[bench]]
+name = "cbh_core_codec"
+harness = false
+
+[[bench]]
+name = "cbh_core_codec_cg"
 harness = false
 
 [lints]

--- a/packages/cargo-bench-history-core/benches/cbh_core_codec.rs
+++ b/packages/cargo-bench-history-core/benches/cbh_core_codec.rs
@@ -1,0 +1,139 @@
+//! Benchmarks for the storage codec: the gzip transform the storage layer
+//! applies to every stored object.
+//!
+//! The codec runs once per stored object on both the write path
+//! (`run`/backfill/stress-seed) and the read path (`analyze`), and it is pure,
+//! single-threaded, syscall-free CPU work, so its cost scales directly with
+//! history size. Benchmarking it now — while the implementation is the simple
+//! high-level `flate2` API — establishes a baseline to measure the documented
+//! future 0-allocation reusable-compressor tuning against.
+//!
+//! Memory allocations are tracked via `alloc_tracker` alongside the wall-clock
+//! timings and printed to stdout (and written to the Cargo target directory)
+//! after all benchmarks complete, so the current high-level API's per-call
+//! allocation churn — the very thing the future tuning targets — is quantified
+//! next to its latency.
+
+#![allow(
+    missing_docs,
+    reason = "No need for API documentation in benchmark code"
+)]
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use alloc_tracker::{Allocator, Session};
+use cargo_bench_history_core::codec;
+use cargo_bench_history_core::model::{
+    BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, MetricKind, Run, RunContext,
+    ToolchainInfo,
+};
+use criterion::{Criterion, criterion_group, criterion_main};
+use nonempty::nonempty;
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+/// Result count of the `small` payload (a serialized `Run` of roughly 9 KB),
+/// representing a modest benchmark suite.
+const SMALL_RESULTS: usize = 20;
+
+/// Result count of the `large` payload (a serialized `Run` of roughly 89 KB),
+/// representing a large suite — so throughput scaling with object size is
+/// visible alongside the small case.
+const LARGE_RESULTS: usize = 200;
+
+criterion_group!(benches, entrypoint);
+criterion_main!(benches);
+
+fn entrypoint(c: &mut Criterion) {
+    let allocs = Session::new();
+
+    compress(c, &allocs);
+    decompress(c, &allocs);
+
+    // `allocs` prints its summary and writes JSON to the Cargo target directory
+    // when it is dropped at the end of this function.
+}
+
+/// Builds a realistic serialized `Run` carrying `result_count` results.
+///
+/// The shape mirrors what the storage layer actually compresses: recurring field
+/// names, a stable id structure, and a handful of metrics per result — the
+/// repetition that makes the JSON compressible.
+fn sample_run_json(result_count: usize) -> Vec<u8> {
+    let epoch = "2024-01-01T00:00:00Z".parse().unwrap();
+    let context = RunContext::new(
+        epoch,
+        epoch,
+        GitInfo::default(),
+        EnvironmentInfo::default(),
+        ToolchainInfo::default(),
+        "0.0.1".to_owned(),
+    );
+    let results = (0..result_count)
+        .map(|i| {
+            let id = BenchmarkId::new(nonempty![
+                "cargo_bench_history".to_owned(),
+                "module::group".to_owned(),
+                format!("case_{i}"),
+                "two_instants".to_owned(),
+            ]);
+            let metrics = vec![
+                Metric::new(MetricKind::InstructionCount, 1_234.0),
+                Metric::new(MetricKind::L1CacheHits, 9_876.0),
+                Metric::new(MetricKind::EstimatedCycles, 4_321.0),
+                Metric::new(MetricKind::WallTime, 26.9).with_dispersion(
+                    Some(0.47),
+                    Some(26.6),
+                    Some(27.2),
+                ),
+            ];
+            BenchmarkResult::new(id, metrics)
+        })
+        .collect();
+    Run::new(context, results)
+        .to_json()
+        .expect("a constructed Run always serializes")
+        .into_bytes()
+}
+
+fn compress(c: &mut Criterion, allocs: &Session) {
+    let mut group = c.benchmark_group("cbh_core_codec/compress");
+    for (name, result_count) in [("small", SMALL_RESULTS), ("large", LARGE_RESULTS)] {
+        let payload = sample_run_json(result_count);
+        let op = allocs.operation(format!("cbh_core_codec/compress/{name}"));
+        group.bench_function(name, |b| {
+            b.iter_custom(|iters| {
+                let _span = op.measure_thread().iterations(iters);
+                let start = Instant::now();
+                for _ in 0..iters {
+                    black_box(codec::compress(black_box(&payload)));
+                }
+                start.elapsed()
+            });
+        });
+    }
+    group.finish();
+}
+
+fn decompress(c: &mut Criterion, allocs: &Session) {
+    let mut group = c.benchmark_group("cbh_core_codec/decompress");
+    for (name, result_count) in [("small", SMALL_RESULTS), ("large", LARGE_RESULTS)] {
+        let compressed = codec::compress(&sample_run_json(result_count));
+        let op = allocs.operation(format!("cbh_core_codec/decompress/{name}"));
+        group.bench_function(name, |b| {
+            b.iter_custom(|iters| {
+                let _span = op.measure_thread().iterations(iters);
+                let start = Instant::now();
+                for _ in 0..iters {
+                    black_box(
+                        codec::decompress(black_box(&compressed)).expect("payload round-trips"),
+                    );
+                }
+                start.elapsed()
+            });
+        });
+    }
+    group.finish();
+}

--- a/packages/cargo-bench-history-core/benches/cbh_core_codec_cg.rs
+++ b/packages/cargo-bench-history-core/benches/cbh_core_codec_cg.rs
@@ -1,0 +1,149 @@
+//! Callgrind benchmarks for the storage codec.
+//!
+//! Paired with `cbh_core_codec.rs` (the Criterion benches for the same two
+//! operations) which measures the codec under wall-clock timing. These benches
+//! isolate the per-call instruction count of `compress` and `decompress` so a
+//! regression — or the future 0-allocation reusable-compressor tuning — can be
+//! tracked at instruction-level granularity.
+//!
+//! # Scope and caveats
+//!
+//! Unlike the `fast_time` clock benches, the codec performs no syscalls and
+//! spawns no threads, and gzip is deterministic, so these instruction counts are
+//! stable run-to-run — there is no flaky-benchmark caveat. Allocator traffic
+//! (the high-level `flate2` API allocates per call) shows up directly in the
+//! counts, which is exactly the quantity the allocation-reuse tuning would move.
+
+#![allow(
+    missing_docs,
+    reason = "no need for API documentation on benchmark code"
+)]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "Triggered by Gungraun macro expansion. Tracking issue drafts live at \
+          c:/Source/gungraun-lint-issues/ pending upstream filing."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Valgrind is Linux-only. On other platforms this bench target compiles
+    // to a no-op so `cargo build --all-targets` still works.
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+
+    use cargo_bench_history_core::codec;
+    use cargo_bench_history_core::model::{
+        BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, MetricKind, Run,
+        RunContext, ToolchainInfo,
+    };
+    use gungraun::prelude::*;
+    use nonempty::nonempty;
+
+    /// Result count of the `small` payload (a serialized `Run` of roughly 9 KB).
+    const SMALL_RESULTS: usize = 20;
+
+    /// Result count of the `large` payload (a serialized `Run` of roughly 89 KB).
+    const LARGE_RESULTS: usize = 200;
+
+    /// Builds a realistic serialized `Run` carrying `result_count` results,
+    /// mirroring the helper in the paired Criterion bench so both views exercise
+    /// the same payload shape.
+    fn sample_run_json(result_count: usize) -> Vec<u8> {
+        let epoch = "2024-01-01T00:00:00Z".parse().unwrap();
+        let context = RunContext::new(
+            epoch,
+            epoch,
+            GitInfo::default(),
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let results = (0..result_count)
+            .map(|i| {
+                let id = BenchmarkId::new(nonempty![
+                    "cargo_bench_history".to_owned(),
+                    "module::group".to_owned(),
+                    format!("case_{i}"),
+                    "two_instants".to_owned(),
+                ]);
+                let metrics = vec![
+                    Metric::new(MetricKind::InstructionCount, 1_234.0),
+                    Metric::new(MetricKind::L1CacheHits, 9_876.0),
+                    Metric::new(MetricKind::EstimatedCycles, 4_321.0),
+                    Metric::new(MetricKind::WallTime, 26.9).with_dispersion(
+                        Some(0.47),
+                        Some(26.6),
+                        Some(27.2),
+                    ),
+                ];
+                BenchmarkResult::new(id, metrics)
+            })
+            .collect();
+        Run::new(context, results)
+            .to_json()
+            .expect("a constructed Run always serializes")
+            .into_bytes()
+    }
+
+    /// Compresses a freshly built payload, for the decompress setup.
+    fn compressed_run_json(result_count: usize) -> Vec<u8> {
+        codec::compress(&sample_run_json(result_count))
+    }
+
+    #[library_benchmark]
+    #[bench::run(sample_run_json(SMALL_RESULTS))]
+    fn compress_small(payload: Vec<u8>) -> Vec<u8> {
+        black_box(codec::compress(black_box(&payload)))
+    }
+
+    #[library_benchmark]
+    #[bench::run(sample_run_json(LARGE_RESULTS))]
+    fn compress_large(payload: Vec<u8>) -> Vec<u8> {
+        black_box(codec::compress(black_box(&payload)))
+    }
+
+    #[library_benchmark]
+    #[bench::run(compressed_run_json(SMALL_RESULTS))]
+    fn decompress_small(compressed: Vec<u8>) -> Vec<u8> {
+        black_box(codec::decompress(black_box(&compressed)).expect("payload round-trips"))
+    }
+
+    #[library_benchmark]
+    #[bench::run(compressed_run_json(LARGE_RESULTS))]
+    fn decompress_large(compressed: Vec<u8>) -> Vec<u8> {
+        black_box(codec::decompress(black_box(&compressed)).expect("payload round-trips"))
+    }
+
+    library_benchmark_group!(
+        name = compress,
+        benchmarks = [compress_small, compress_large]
+    );
+
+    library_benchmark_group!(
+        name = decompress,
+        benchmarks = [decompress_small, decompress_large]
+    );
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig};
+#[cfg(target_os = "linux")]
+pub use linux::{compress, decompress};
+
+#[cfg(target_os = "linux")]
+gungraun::main!(
+    config = LibraryBenchmarkConfig::default().tool(
+        Callgrind::default()
+            .args(["--branch-sim=yes"])
+            .format([CallgrindMetrics::Default, CallgrindMetrics::BranchSim]),
+    );
+    library_benchmark_groups = compress, decompress
+);

--- a/packages/cargo-bench-history-core/benches/cbh_core_codec_cg.rs
+++ b/packages/cargo-bench-history-core/benches/cbh_core_codec_cg.rs
@@ -28,6 +28,15 @@
           c:/Source/gungraun-lint-issues/ pending upstream filing."
     )
 )]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::needless_pass_by_value,
+        reason = "Gungraun's #[bench] setup contract hands the owned setup value to the \
+          benchmark function by value; the measured body only borrows it, but the signature \
+          must own it so the input's construction stays outside the measured region."
+    )
+)]
 
 #[cfg(not(target_os = "linux"))]
 fn main() {

--- a/packages/cargo-bench-history-core/src/codec.rs
+++ b/packages/cargo-bench-history-core/src/codec.rs
@@ -1,0 +1,156 @@
+//! The on-the-wire byte format for stored objects: gzip.
+//!
+//! Stored objects are repetitive JSON (per-object ratios of ~10–30×), and the
+//! Azure backend transfers every stored byte on upload and on every `analyze`
+//! read, so the storage layer compresses object bodies transparently. This module
+//! is the single source of that encoding: the `cargo-bench-history` storage
+//! backends call it on `put`/`get`, and the stress harness calls the *same*
+//! function when it writes its synthetic tree, so the harness can never drift out
+//! of lockstep with production.
+//!
+//! gzip (via the pure-Rust `miniz_oxide` backend) is chosen for three properties
+//! this layer depends on:
+//!
+//! * **Determinism** — the same input always produces byte-identical output (the
+//!   gzip header's mtime is zero and the OS byte is fixed), so a stress seed is
+//!   reproducible and an object's bytes are a pure function of its contents.
+//! * **Self-describing framing** — the gzip magic (`0x1f 0x8b`) never collides
+//!   with a JSON object's first byte (`{` / whitespace), so [`decompress`] returns
+//!   a clean error on a legacy uncompressed object rather than silent garbage.
+//! * **Standard `Content-Encoding`** — `gzip` is a registered HTTP content
+//!   coding, so the Azure backend can declare it and any non-SDK reader can
+//!   inflate the blob with off-the-shelf tooling.
+
+use std::io::{Read as _, Write as _};
+
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+
+/// The deflate level applied to every stored object.
+///
+/// Level 6 (`flate2`'s default) balances ratio against CPU. This data is written
+/// once and read many times, so a higher level (up to 9) would be a defensible
+/// tune if read-side wire volume ever dominated; level 6 already removes the bulk
+/// of the redundancy at a fraction of level 9's compression cost.
+const GZIP_LEVEL: u32 = 6;
+
+/// gzip-compresses `plain` for storage.
+///
+/// Infallible: the encoder writes into an in-memory [`Vec`], and writing to a
+/// `Vec` never fails, so there is no I/O error to surface (an allocation failure
+/// aborts rather than returning).
+#[must_use]
+pub fn compress(plain: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::new(GZIP_LEVEL));
+    encoder
+        .write_all(plain)
+        .expect("writing to an in-memory Vec cannot fail");
+    encoder
+        .finish()
+        .expect("flushing gzip into an in-memory Vec cannot fail")
+}
+
+/// Inflates a gzip-compressed object body produced by [`compress`].
+///
+/// # Errors
+///
+/// Returns an [`std::io::Error`] if `stored` is not a valid gzip stream — a
+/// corrupt or truncated body, or a legacy uncompressed object whose first bytes
+/// are not the gzip magic. Decoding never silently returns partial or wrong data.
+pub fn decompress(stored: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut decoder = GzDecoder::new(stored);
+    let mut plain = Vec::new();
+    decoder.read_to_end(&mut plain)?;
+    Ok(plain)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    /// A representative repetitive object body — the kind of JSON the storage
+    /// layer actually stores, where the same field names recur on every record.
+    fn sample_json() -> Vec<u8> {
+        let record = r#"{"id":["fast_time","capture","two_instants"],"metrics":[{"kind":"WallTime","value":12.5}]},"#;
+        let mut body = String::from(r#"{"schema":1,"results":["#);
+        for _ in 0..64 {
+            body.push_str(record);
+        }
+        body.push_str("]}");
+        body.into_bytes()
+    }
+
+    #[test]
+    fn roundtrips_representative_json() {
+        let plain = sample_json();
+        let restored = decompress(&compress(&plain)).unwrap();
+        assert_eq!(restored, plain);
+    }
+
+    #[test]
+    fn roundtrips_empty_input() {
+        let restored = decompress(&compress(b"")).unwrap();
+        assert_eq!(restored, b"");
+    }
+
+    #[test]
+    fn roundtrips_non_utf8_bytes() {
+        // The codec is byte-oriented; it must not assume its input is text.
+        let plain: Vec<u8> = (0_u8..=255).cycle().take(1000).collect();
+        let restored = decompress(&compress(&plain)).unwrap();
+        assert_eq!(restored, plain);
+    }
+
+    #[test]
+    fn is_deterministic() {
+        let plain = sample_json();
+        // Byte-identical output across calls is what makes a stress seed
+        // reproducible; pin against re-compression rather than a brittle golden.
+        assert_eq!(compress(&plain), compress(&plain));
+    }
+
+    #[test]
+    fn emits_gzip_magic() {
+        let compressed = compress(&sample_json());
+        assert!(
+            compressed.starts_with(&[0x1f, 0x8b]),
+            "a stored body must carry the gzip magic so legacy plaintext is distinguishable"
+        );
+    }
+
+    #[test]
+    fn compresses_repetitive_input() {
+        let plain = sample_json();
+        let compressed = compress(&plain);
+        assert!(
+            compressed.len() < plain.len(),
+            "repetitive JSON must shrink: {} -> {}",
+            plain.len(),
+            compressed.len()
+        );
+    }
+
+    #[test]
+    fn decompress_rejects_plaintext_json() {
+        // A legacy uncompressed object: its first byte is `{`, never the gzip
+        // magic, so decoding fails loudly instead of returning the raw bytes.
+        let error = decompress(br#"{"schema":1}"#).unwrap_err();
+        drop(error);
+    }
+
+    #[test]
+    fn decompress_rejects_truncated_stream() {
+        let mut compressed = compress(&sample_json());
+        compressed.truncate(compressed.len().div_ceil(2));
+        let error = decompress(&compressed).unwrap_err();
+        drop(error);
+    }
+
+    #[test]
+    fn decompress_rejects_empty_input() {
+        let error = decompress(b"").unwrap_err();
+        drop(error);
+    }
+}

--- a/packages/cargo-bench-history-core/src/lib.rs
+++ b/packages/cargo-bench-history-core/src/lib.rs
@@ -22,12 +22,15 @@
 //! fast in-process unit-test suite that is cheap to mutation-test, instead of
 //! re-paying the shell's git-subprocess-heavy integration suite for every mutant.
 //!
-//! The public surface is two namespaces: [`model`] (the data model and
-//! comparability rules) and [`analyze`] (the analysis math and rendering). Within
-//! each, every type is re-exported flat, so consumers write `crate::model::Run`
-//! and `crate::analyze::Finding` rather than reaching into private submodules.
+//! The public surface is three namespaces: [`model`] (the data model and
+//! comparability rules), [`analyze`] (the analysis math and rendering), and
+//! [`codec`] (the gzip byte format the storage layer and the stress harness share
+//! so they encode stored objects identically). Within each, every type is
+//! re-exported flat, so consumers write `crate::model::Run` and
+//! `crate::analyze::Finding` rather than reaching into private submodules.
 //!
 //! [`cargo-bench-history`]: https://github.com/folo-rs/folo
 
 pub mod analyze;
+pub mod codec;
 pub mod model;

--- a/packages/cargo-bench-history-stress/README.md
+++ b/packages/cargo-bench-history-stress/README.md
@@ -33,8 +33,11 @@ By default the harness fabricates:
 * and **blessings** ~75% of the way back for one benchmark family, applied in some
   discriminant sets but not others.
 
-That is roughly 20000 stored objects and ~5.7 GiB of JSON. Sizes are all overridable
-(see flags), so `--commits 100 --benchmarks 100` gives a quick smoke run.
+That is roughly 20000 stored objects whose JSON totals ~5.7 GiB uncompressed.
+The storage layer gzip-compresses every object, so the actual on-disk/wire
+volume — the quantity the harness measures and reports — is roughly an order of
+magnitude smaller. Sizes are all overridable (see flags), so
+`--commits 100 --benchmarks 100` gives a quick smoke run.
 
 It then reads the data back through the real public
 `cargo_bench_history::run_with_overrides` entry point — the exact production path —

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::thread;
 
+use cargo_bench_history_core::codec;
 use cargo_bench_history_core::model::{
     BenchmarkIdPrefix, BenchmarkResult, BlessingRecord, DiscriminantSet, Engine, EnvironmentInfo,
     GitInfo, Run, RunContext, ToolchainInfo,
@@ -274,9 +275,13 @@ fn write_one(
         std::fs::create_dir_all(parent)
             .map_err(|error| fail(format!("failed to create {}: {error}", parent.display())))?;
     }
-    std::fs::write(&path, &body)
+    // Mirror the storage layer's encoding by calling the same codec it uses, so
+    // the seeded tree is byte-for-byte what a real `put` would have written and
+    // the reported volume is the real on-disk/wire size #260 is about.
+    let stored = codec::compress(body.as_bytes());
+    std::fs::write(&path, &stored)
         .map_err(|error| fail(format!("failed to write {}: {error}", path.display())))?;
-    Ok(body.len() as u64)
+    Ok(stored.len() as u64)
 }
 
 /// Builds a [`Run`] whose every benchmark's primary metric comes from `value`.

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -131,6 +131,25 @@ provenance only); there is no "effective timestamp" concept and no `--timestamp`
 override. A dirty key uses the observation second so concurrent snapshots coexist.
 There is no run-id in the key.
 
+### Object byte format (gzip)
+
+Object **keys/filenames are unchanged** (still `…/clean.json` etc.), but the
+**body bytes are gzip**, not plaintext JSON. The storage layer compresses
+transparently at the `Storage` trait boundary: `put`/`put_overwrite` compress the
+caller's plaintext JSON and `get` inflates back to plaintext, so every caller
+(`run`, `backfill`, `analyze`, `prune`, `bless`) keeps handing and receiving plain
+JSON and is unaffected. The single source of the encoding is
+`cargo_bench_history_core::codec` (`compress`/`decompress`, gzip level 6, pure-Rust
+`miniz_oxide`, deterministic, Miri-clean); both the storage backends and the stress
+harness call it, so they cannot drift apart. `AzureBlobStorage` additionally sets
+`Content-Encoding: gzip` on upload so a non-SDK reader can inflate the blob, though
+the backend still inflates on `get` itself rather than relying on the service.
+`MemoryStorage` (the test fake) deliberately stays **plaintext** — its contract is
+the key/value model, no test inspects raw stored bytes, and keeping it uncompressed
+keeps the Miri-driven `analyze` suite fast. This is a breaking storage-format change
+(there is no migration): `get` on a legacy plaintext object errors loudly because
+the gzip magic never collides with JSON's first byte.
+
 ## The `analyze` command
 
 `analyze::execute` builds the real `SystemGitHistory` (rooted at `--repo` or the
@@ -816,8 +835,12 @@ Key facts when touching it:
 
 * **Zero production-code coupling.** The harness only *writes* objects in the same
   key layout the storage backends use (`v1/{project}/{engine}/{triple}/{machine}/
-  {commit}/{file}`), then reads them back through the real public
-  `cargo_bench_history::run_with_overrides` entry point. It deliberately does **not**
+  {commit}/{file}`) and in the same **gzip body encoding** — it calls
+  `cargo_bench_history_core::codec::compress` (the exact function the backends use)
+  rather than reimplementing it, and `seed.rs` reports the *compressed* byte length
+  so the total-bytes figure reflects real on-disk/wire volume. It then reads the
+  objects back through the real public `cargo_bench_history::run_with_overrides`
+  entry point, which inflates them transparently. It deliberately does **not**
   reach into private storage internals, so it needs no `_impl`-crate split and no
   test-only feature on the shell crate. If a refactor changes the on-disk key layout
   or the JSON report's top-level fields, the harness's `seed.rs` / `report.rs` must

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -25,6 +25,7 @@ use azure_storage_blob::models::{
     BlobClientUploadOptions, BlobContainerClientListBlobsOptions, StorageErrorCode,
 };
 use azure_storage_blob::{BlobClient, BlobContainerClient};
+use cargo_bench_history_core::codec;
 use futures::TryStreamExt as _;
 use jiff::tz::TimeZone;
 use jiff::{Timestamp, ToSpan as _};
@@ -39,6 +40,13 @@ const SAS_PERMISSIONS: &str = "rwdlac";
 
 /// The SAS resource types a self-signed token covers: service, container, object.
 const SAS_RESOURCE_TYPES: &str = "sco";
+
+/// The HTTP content coding declared on every uploaded blob. The storage layer
+/// always stores gzip, so this header is unconditionally truthful and lets a
+/// non-SDK reader inflate the blob with standard tooling (the backend still
+/// inflates on [`get`](AzureBlobStorage::get) itself rather than relying on the
+/// service to decode).
+const GZIP_CONTENT_ENCODING: &str = "gzip";
 
 /// A [`Storage`] that persists objects as blobs in an Azure Blob container.
 #[derive(Clone)]
@@ -193,14 +201,16 @@ impl Storage for AzureBlobStorage {
     async fn put(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
         validate_key(key)?;
         let client = self.blob_client(key)?;
-        self.upload_with_retry(&client, bytes, key, true).await
+        self.upload_with_retry(&client, &codec::compress(bytes), key, true)
+            .await
     }
 
     #[cfg_attr(test, mutants::skip)] // Delegates to the Azure SDK; verified by the Azurite round-trip tests, which mutation testing cannot run.
     async fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
         validate_key(key)?;
         let client = self.blob_client(key)?;
-        self.upload_with_retry(&client, bytes, key, false).await
+        self.upload_with_retry(&client, &codec::compress(bytes), key, false)
+            .await
     }
 
     #[cfg_attr(test, mutants::skip)] // Delegates to the Azure SDK; verified by the Azurite round-trip tests, which mutation testing cannot run.
@@ -214,7 +224,7 @@ impl Storage for AzureBlobStorage {
                     .collect()
                     .await
                     .map_err(|error| azure_io(&error))?;
-                Ok(bytes.to_vec())
+                codec::decompress(&bytes).map_err(StorageError::Io)
             }
             Err(error) if matches!(classify(&error), Fault::NotFound | Fault::ContainerMissing) => {
                 Err(StorageError::NotFound {
@@ -277,7 +287,12 @@ impl Storage for AzureBlobStorage {
 /// (failing if the blob already exists); otherwise it replaces any existing blob.
 #[cfg_attr(test, mutants::skip)] // Delegates to the Azure SDK; verified by the Azurite round-trip tests, which mutation testing cannot run.
 async fn upload(client: &BlobClient, bytes: &[u8], if_not_exists: bool) -> azure_core::Result<()> {
-    let mut options = BlobClientUploadOptions::default();
+    let mut options = BlobClientUploadOptions {
+        // The body is always gzip, so declare it: a non-SDK reader can then
+        // inflate the blob with standard tooling.
+        blob_content_encoding: Some(GZIP_CONTENT_ENCODING.to_owned()),
+        ..Default::default()
+    };
     if if_not_exists {
         options = options.if_not_exists();
     }

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -201,7 +201,8 @@ impl Storage for AzureBlobStorage {
     async fn put(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
         validate_key(key)?;
         let client = self.blob_client(key)?;
-        self.upload_with_retry(&client, &codec::compress(bytes), key, true)
+        let compressed = codec::compress(bytes);
+        self.upload_with_retry(&client, &compressed, key, true)
             .await
     }
 
@@ -209,7 +210,8 @@ impl Storage for AzureBlobStorage {
     async fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
         validate_key(key)?;
         let client = self.blob_client(key)?;
-        self.upload_with_retry(&client, &codec::compress(bytes), key, false)
+        let compressed = codec::compress(bytes);
+        self.upload_with_retry(&client, &compressed, key, false)
             .await
     }
 

--- a/packages/cargo-bench-history/src/storage/local.rs
+++ b/packages/cargo-bench-history/src/storage/local.rs
@@ -9,6 +9,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::io::AsyncWriteExt;
 
+use cargo_bench_history_core::codec;
+
 use super::{Storage, StorageError, is_plain_segment};
 
 /// Filename prefix for the transient files an atomic write renames into place.
@@ -78,7 +80,9 @@ impl Storage for LocalStorage {
             Ok(false) => {}
             Err(error) => return Err(StorageError::Io(error)),
         }
-        write_atomic(&path, bytes).await.map_err(StorageError::Io)
+        write_atomic(&path, &codec::compress(bytes))
+            .await
+            .map_err(StorageError::Io)
     }
 
     async fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError> {
@@ -90,13 +94,15 @@ impl Storage for LocalStorage {
         }
         // The atomic rename replaces any existing object in full, the deliberate
         // escape hatch from the write-once contract.
-        write_atomic(&path, bytes).await.map_err(StorageError::Io)
+        write_atomic(&path, &codec::compress(bytes))
+            .await
+            .map_err(StorageError::Io)
     }
 
     async fn get(&self, key: &str) -> Result<Vec<u8>, StorageError> {
         let path = self.key_path(key)?;
         match tokio::fs::read(&path).await {
-            Ok(bytes) => Ok(bytes),
+            Ok(bytes) => codec::decompress(&bytes).map_err(StorageError::Io),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Err(StorageError::NotFound {
                 key: key.to_owned(),
             }),
@@ -251,6 +257,44 @@ mod tests {
         let bytes = storage.get("v1/folo/run.json").await.unwrap();
 
         assert_eq!(bytes, b"payload");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // Touches the real filesystem, which Miri cannot access.
+    async fn put_compresses_the_object_at_rest() {
+        let dir = tempdir().unwrap();
+        let storage = LocalStorage::new(dir.path());
+
+        let plain = br#"{"schema":1,"results":[]}"#;
+        storage.put("v1/folo/run.json", plain).await.unwrap();
+
+        // The file on disk is gzip, not the original plaintext: the bytes #260
+        // transfers are the compressed ones, and `get` inflates them back.
+        let on_disk = std::fs::read(dir.path().join("v1").join("folo").join("run.json")).unwrap();
+        assert!(
+            on_disk.starts_with(&[0x1f, 0x8b]),
+            "stored bytes must be gzip"
+        );
+        assert_ne!(on_disk, plain, "the object is not stored verbatim");
+        assert_eq!(codec::decompress(&on_disk).unwrap(), plain);
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // Touches the real filesystem, which Miri cannot access.
+    async fn get_rejects_a_legacy_plaintext_object() {
+        let dir = tempdir().unwrap();
+        let storage = LocalStorage::new(dir.path());
+
+        // An object written before compression existed is plaintext JSON. Reading
+        // it back must fail loudly (the gzip magic is absent), never return raw
+        // bytes that a later parse would misinterpret.
+        let path = dir.path().join("v1").join("folo").join("run.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, br#"{"schema":1}"#).unwrap();
+
+        let error = storage.get("v1/folo/run.json").await.unwrap_err();
+
+        assert!(matches!(error, StorageError::Io(_)), "{error:?}");
     }
 
     #[tokio::test]

--- a/packages/cargo-bench-history/src/storage/local.rs
+++ b/packages/cargo-bench-history/src/storage/local.rs
@@ -80,7 +80,8 @@ impl Storage for LocalStorage {
             Ok(false) => {}
             Err(error) => return Err(StorageError::Io(error)),
         }
-        write_atomic(&path, &codec::compress(bytes))
+        let compressed = codec::compress(bytes);
+        write_atomic(&path, &compressed)
             .await
             .map_err(StorageError::Io)
     }
@@ -94,7 +95,8 @@ impl Storage for LocalStorage {
         }
         // The atomic rename replaces any existing object in full, the deliberate
         // escape hatch from the write-once contract.
-        write_atomic(&path, &codec::compress(bytes))
+        let compressed = codec::compress(bytes);
+        write_atomic(&path, &compressed)
             .await
             .map_err(StorageError::Io)
     }

--- a/packages/cargo-bench-history/src/storage/mod.rs
+++ b/packages/cargo-bench-history/src/storage/mod.rs
@@ -339,6 +339,14 @@ mod tests {
 ///
 /// Its async methods complete synchronously (no real I/O), so orchestration tests
 /// can drive them with a reactor-free `block_on` and remain Miri-safe.
+///
+/// Unlike the real backends, this fake stores object bodies **uncompressed**. Its
+/// contract is the key/value model — `put X` then `get X` returns `X`, with the
+/// same key validation — which holds identically whether or not bodies are gzip,
+/// and no test inspects a raw stored body (the fake exposes only [`keys`](Self::keys)).
+/// Skipping the codec keeps the Miri-driven orchestration suite fast and free of
+/// gzip on its hot path; the codec itself is exercised by its own unit tests and
+/// by the real backends.
 #[cfg(test)]
 #[derive(Clone, Debug, Default)]
 pub(crate) struct MemoryStorage {

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -104,6 +104,12 @@ fn toml_escape(value: &str) -> String {
 
 /// A config that stores in a fresh Azurite container.
 fn azure_config() -> String {
+    azure_config_for(&unique_container())
+}
+
+/// A config that stores in the named Azurite container, so a test can inspect the
+/// same container directly afterward.
+fn azure_config_for(container: &str) -> String {
     format!(
         "[project]\n\
          id = \"azureproj\"\n\n\
@@ -112,10 +118,54 @@ fn azure_config() -> String {
          container = \"{container}\"\n\
          endpoint = \"{endpoint}\"\n\
          account_key = \"{key}\"\n",
-        container = unique_container(),
         endpoint = toml_escape(&azurite_endpoint()),
         key = AZURITE_KEY,
     )
+}
+
+/// Mints an account SAS query for the Azurite dev account, mirroring the
+/// production minting in `storage::sas` (which is unit-tested there). It is
+/// reproduced here because the Azure SDK exposes no shared-key credential and the
+/// production minting is crate-private, so a test that inspects blobs directly
+/// must sign its own token.
+fn azurite_account_sas() -> String {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use hmac::{Hmac, KeyInit as _, Mac as _};
+    use sha2::Sha256;
+
+    let expiry = "2030-01-01T00:00:00Z";
+    let protocol = "https,http";
+    let string_to_sign =
+        format!("devstoreaccount1\nrwdlac\nb\nsco\n\n{expiry}\n\n{protocol}\n2021-08-06\n\n");
+    let key = BASE64.decode(AZURITE_KEY).unwrap();
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key).unwrap();
+    mac.update(string_to_sign.as_bytes());
+    let signature = BASE64.encode(mac.finalize().into_bytes());
+
+    let mut url = Url::parse("http://sas.invalid/").unwrap();
+    url.query_pairs_mut().extend_pairs([
+        ("sv", "2021-08-06"),
+        ("ss", "b"),
+        ("srt", "sco"),
+        ("sp", "rwdlac"),
+        ("se", expiry),
+        ("spr", protocol),
+        ("sig", signature.as_str()),
+    ]);
+    url.query().unwrap().to_owned()
+}
+
+/// A SAS-authenticated container client for inspecting blobs Azurite stored,
+/// bypassing the production backend (which would transparently inflate them).
+fn azurite_container_client(container: &str) -> BlobContainerClient {
+    let mut url = Url::parse(&azurite_endpoint()).unwrap();
+    url.path_segments_mut()
+        .unwrap()
+        .pop_if_empty()
+        .push(container);
+    url.set_query(Some(&azurite_account_sas()));
+    BlobContainerClient::new(url, None, None).unwrap()
 }
 
 /// The real Storage account name to target, or `None` when none is configured.
@@ -503,6 +553,52 @@ async fn analyze_feature_and_dirty_round_trip_through_azurite() {
         return;
     }
     scenario_feature_and_dirty(&azure_config()).await;
+}
+
+/// A stored blob carries `Content-Encoding: gzip`, so a non-SDK reader knows the
+/// body is compressed. The production round-trip tests cannot prove this — the
+/// backend inflates on `get` regardless of the header — so this inspects the blob
+/// directly through a SAS-authenticated client.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+#[serial]
+async fn stored_blob_declares_gzip_content_encoding_in_azurite() {
+    use azure_storage_blob::models::BlobClientGetPropertiesResultHeaders as _;
+    use futures::TryStreamExt as _;
+
+    if !azurite_available() {
+        return;
+    }
+
+    let container = unique_container();
+    let workspace =
+        AzureWorkspace::new(&azure_config_for(&container)).with_bench(&["--summary", "grp=single"]);
+    workspace.drive(&["run"]).await.unwrap();
+
+    let client = azurite_container_client(&container);
+    let mut pager = client.list_blobs(None).unwrap();
+    let mut names = Vec::new();
+    while let Some(item) = pager.try_next().await.unwrap() {
+        if let Some(name) = item.name {
+            names.push(name);
+        }
+    }
+    assert_eq!(
+        names.len(),
+        1,
+        "the run stored exactly one object: {names:?}"
+    );
+
+    let properties = client
+        .blob_client(&names[0])
+        .get_properties(None)
+        .await
+        .unwrap();
+    assert_eq!(
+        properties.content_encoding().unwrap().as_deref(),
+        Some("gzip"),
+        "the stored blob must declare its gzip encoding"
+    );
 }
 
 // --- Real Azure (Microsoft Entra ID) ---------------------------------------

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -8,6 +8,7 @@ pub(crate) use cargo_bench_history::{
     Overrides, Run, RunContext, RunError, RunOutcome, SCHEMA_VERSION, ToolchainInfo,
     default_template, run, run_with_overrides,
 };
+use cargo_bench_history_core::codec;
 pub(crate) use jiff::Timestamp;
 use nonempty::nonempty;
 pub(crate) use serial_test::serial;
@@ -443,7 +444,9 @@ impl Workspace {
                     .map(|component| component.as_os_str().to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
                     .join("/");
-                let set = Run::from_json(&std::fs::read_to_string(&path).unwrap()).unwrap();
+                let raw = std::fs::read(&path).unwrap();
+                let json = String::from_utf8(codec::decompress(&raw).unwrap()).unwrap();
+                let set = Run::from_json(&json).unwrap();
                 (key, set)
             })
             .collect();
@@ -464,14 +467,15 @@ impl Workspace {
     }
 
     /// Writes `set` to `key` (a `/`-separated object key) under the local store,
-    /// mirroring the layout `run` produces.
+    /// mirroring the layout `run` produces — including the gzip body encoding the
+    /// storage layer applies, so the production read path inflates it correctly.
     pub(crate) fn seed(&self, key: &str, set: &Run) {
         let mut path = self.root().join("store");
         for part in key.split('/') {
             path.push(part);
         }
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, set.to_json().unwrap()).unwrap();
+        std::fs::write(path, codec::compress(set.to_json().unwrap().as_bytes())).unwrap();
     }
 
     /// Seeds one Callgrind result set with an `Ir` value at the given `date`

--- a/packages/cargo-bench-history/tests/cbh_real_engine.rs
+++ b/packages/cargo-bench-history/tests/cbh_real_engine.rs
@@ -27,6 +27,7 @@
 use std::path::{Path, PathBuf};
 
 use cargo_bench_history::{Cli, Command, MetricKind, Run, RunOutcome, run};
+use cargo_bench_history_core::codec;
 use serial_test::serial;
 use testing::CwdGuard;
 
@@ -165,7 +166,9 @@ async fn run_against_real_criterion_bench_stores_wall_time() {
         "expected exactly one stored object, found {files:?}"
     );
 
-    let set = Run::from_json(&std::fs::read_to_string(&files[0]).unwrap()).unwrap();
+    let raw = std::fs::read(&files[0]).unwrap();
+    let json = String::from_utf8(codec::decompress(&raw).unwrap()).unwrap();
+    let set = Run::from_json(&json).unwrap();
     assert_eq!(set.results.len(), 1, "one harvested benchmark case");
     let record = &set.results[0];
     assert_eq!(record.id.qualified(), "e2e/add");


### PR DESCRIPTION
## What

Transparently gzip-compresses every stored object body at the `cargo-bench-history` storage layer. Closes #260.

Benchmark-history objects are repetitive JSON (per-object ratios ~10–30×), and the Azure backend transfers every stored byte on upload and again on every `analyze` read. Compressing at the storage boundary shrinks both the on-disk footprint and the network volume, with the codec living in one place so production and the stress harness can never encode objects differently.

## Changes

- **New `cargo-bench-history-core::codec` module** — the single source of the stored-object byte format: gzip via `flate2`'s pure-Rust `miniz_oxide` backend at level 6. It is deterministic (zeroed mtime / fixed OS byte, so a stress seed stays byte-reproducible) and gzip-magic framed, so a legacy uncompressed object is rejected with a clean error instead of being read as garbage.
- **Local and Azure backends** compress on `put` and inflate on `get`. The Azure backend additionally declares `Content-Encoding: gzip` on every uploaded blob, so any non-SDK reader can inflate it with standard tooling (the backend still inflates itself on read rather than relying on the service to decode).
- **Stress harness** seeds its synthetic tree through the same `codec::compress`, keeping it in lockstep with production storage and making its reported byte volume reflect the real compressed footprint.
- **`MemoryStorage` test fake** deliberately stays uncompressed — its contract is the key/value model, which holds identically with or without gzip, and skipping the codec keeps the Miri-driven orchestration suite fast.
- **Benchmarks** for both `compress` and `decompress`, across a small (~9 KB) and large (~89 KB) serialized `Run`:
  - Criterion wall-clock (`cbh_core_codec`), now also tracking memory allocations via `alloc_tracker` and printing the per-operation allocation table after the run.
  - Callgrind instruction counts (`cbh_core_codec_cg`).
  These establish a baseline to measure the documented future zero-allocation reusable-compressor tuning against.

## Validation

- Full validation was green for the storage/codec/backends/stress work (tests, Miri, clippy, format-check, mutation testing with zero misses across codec/seed/local, and the Azurite Azure-backend suite 43/43).
- The new `alloc_tracker` bench integration is clippy- and format-clean and runs cleanly (results below).

## Benchmark results

Wall-clock (Criterion, this machine):

| case | time (median) |
|---|---|
| compress/small (~9 KB) | 62.4 µs |
| compress/large (~89 KB) | 430.2 µs |
| decompress/small | 10.9 µs |
| decompress/large | 26.6 µs |

Memory allocations (`alloc_tracker`, mean per operation):

| operation | mean bytes | mean count |
|---|---|---|
| compress/small | 353,785 | 11 |
| compress/large | 356,695 | 11 |
| decompress/small | 108,800 | 12 |
| decompress/large | 338,176 | 15 |

The high-level `flate2` API allocates ~350 KB and ~11–15 times per call regardless of input size — exactly the buffer-reuse churn the future zero-allocation tuning targets, now quantified next to the latency.

## Stress before/after (compression impact)

Running the stress harness on this branch vs `main` against local filesystem storage, same deterministic dataset (4223 objects, `--benchmarks 200 --commits 400`):

| metric | main (uncompressed) | this branch (compressed) |
|---|---|---|
| data seeded | 245.07 MiB | 19.10 MiB (12.8× / −92%) |
| generate + write | 2.413 s | 2.781 s |
| analyze history | 4.486 s | 5.244 s |

On a fast local disk the byte savings do not offset the decompress CPU, so compressed reads are marginally slower locally; the payoff lands on network storage, where every saved byte is a byte not transferred.

## Follow-up

The real-Azure leg of that comparison could not complete: the stress harness's `analyze` phase hits a pre-existing, compression-independent credential-concurrency failure on Windows (the 32-wide concurrent read burst contends on the Azure CLI MSAL token-cache lockfile), reproducing identically on `main`. Filed separately as #269.
