### PR TITLE
Fix Azure analyze credential contention on Windows (#269)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 name = "cargo-bench-history"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "azure_core",
  "azure_identity",
  "azure_storage_blob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.93"
 all_the_time = { version = "0.5.2", path = "packages/all_the_time", default-features = false }
 alloc_tracker = { version = "0.6.2", path = "packages/alloc_tracker", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
+async-trait = { version = "0.1.89", default-features = false }
 awaiter_set = { version = "0.1.7", path = "packages/awaiter_set", default-features = false }
 axum = { version = "0.8.0", default-features = false }
 azure_core = { version = "1.0.0", default-features = false }

--- a/packages/cargo-bench-history-stress/src/lib.rs
+++ b/packages/cargo-bench-history-stress/src/lib.rs
@@ -133,42 +133,55 @@ async fn run_harness() -> Result<(), Error> {
     write_config(workspace_dir.path(), &target, logger).await?;
     target.provision(logger).await?;
 
-    let seed_started = Instant::now();
-    let stats = seed::seed(target.seed_root(), scenario, &sets, &repo, logger)?;
-    let seed_elapsed = seed_started.elapsed();
+    // The target is now provisioned (for Azure, the per-run container exists), so
+    // run the remaining fallible work under a guard that always cleans up
+    // afterward — even if seeding, upload, or a measured mode fails — so a failed
+    // run never orphans its container.
+    let measured = async {
+        let seed_started = Instant::now();
+        let stats = seed::seed(target.seed_root(), scenario, &sets, &repo, logger)?;
+        let seed_elapsed = seed_started.elapsed();
 
-    let upload_started = Instant::now();
-    target.upload(logger).await?;
-    let upload_elapsed = upload_started.elapsed();
+        let upload_started = Instant::now();
+        target.upload(logger).await?;
+        let upload_elapsed = upload_started.elapsed();
 
-    let mut results = Vec::with_capacity(cli.modes.len());
-    for mode in &cli.modes {
-        let result = measure::measure(
-            workspace_dir.path(),
-            repo_dir.path(),
-            *mode,
-            clock,
-            cli.repeat,
-            logger,
-        )
-        .await?;
-        results.push(result);
+        let mut results = Vec::with_capacity(cli.modes.len());
+        for mode in &cli.modes {
+            let result = measure::measure(
+                workspace_dir.path(),
+                repo_dir.path(),
+                *mode,
+                clock,
+                cli.repeat,
+                logger,
+            )
+            .await?;
+            results.push(result);
+        }
+
+        report::print(
+            &target.label(),
+            scenario,
+            sets.len(),
+            stats,
+            Phases {
+                repo: repo_elapsed,
+                seed: seed_elapsed,
+                upload: upload_elapsed,
+            },
+            &results,
+        );
+        Ok::<(), Error>(())
     }
+    .await;
 
-    report::print(
-        &target.label(),
-        scenario,
-        sets.len(),
-        stats,
-        Phases {
-            repo: repo_elapsed,
-            seed: seed_elapsed,
-            upload: upload_elapsed,
-        },
-        &results,
-    );
+    let cleaned = target.cleanup(cli.keep, logger).await;
 
-    target.cleanup(cli.keep, logger).await?;
+    // Surface a measured failure first (it is the root cause); a cleanup failure
+    // is reported only when the run itself otherwise succeeded.
+    measured?;
+    cleaned?;
     Ok(())
 }
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -705,6 +705,10 @@ order: a self-signed account SAS (`account_key`), a verbatim `sas_token`, or
 Microsoft Entra ID (`DeveloperToolsCredential`). SAS modes carry the token in the
 endpoint URL's query and pass no credential, so the emulator's plain-HTTP
 endpoint is accepted; Entra mode passes a token credential and requires HTTPS.
+The Entra credential is wrapped in a `CachingCredential` decorator that holds a
+cache lock across the inner acquisition, so a concurrent read burst collapses to
+one `az account get-access-token` call rather than racing the Windows MSAL
+token-cache lockfile (which fails the read with a permission error).
 The account-SAS signer lives in `storage::sas` and is verified against a pinned
 golden signature — do not "fix" that test by editing the expected value.
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -709,6 +709,9 @@ The Entra credential is wrapped in a `CachingCredential` decorator that holds a
 cache lock across the inner acquisition, so a concurrent read burst collapses to
 one `az account get-access-token` call rather than racing the Windows MSAL
 token-cache lockfile (which fails the read with a permission error).
+`CachingCredential` implements the azure SDK's `#[async_trait]` `TokenCredential`
+trait, so it is the one place the crate pulls in `async_trait` — the crate's own
+IO ports still use RPITIT (`impl Future`), as the external trait leaves no choice.
 The account-SAS signer lives in `storage::sas` and is verified against a pinned
 golden signature — do not "fix" that test by editing the expected value.
 

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 azure_core = { workspace = true }
 # The `default` feature on these two crates is load-bearing, not gratuitous: it
 # transitively enables `azure_core/default`, which selects the reqwest + rustls

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -432,9 +432,9 @@ selected runs.
 
 Storage I/O is **async** (§10): `LocalStorage` over `tokio::fs`, `AzureBlobStorage`
 over async HTTP. `async fn` in a trait is not `dyn`-compatible, so backend
-selection is a `StorageFacade` **enum** (`Local` | `Azure`) with static dispatch —
-no `async_trait` dependency, and `run`/`analyze` stay backend-agnostic by holding a
-`StorageFacade`.
+selection is a `StorageFacade` **enum** (`Local` | `Azure`) with static dispatch
+rather than a boxed-future trait object, and `run`/`analyze` stay
+backend-agnostic by holding a `StorageFacade`.
 
 * **LocalStorage** (iteration 1): root from config; create dirs; write/read/walk
   via `tokio::fs` (iterative directory walk — no boxed async recursion).

--- a/packages/cargo-bench-history/DESIGN.md
+++ b/packages/cargo-bench-history/DESIGN.md
@@ -453,6 +453,11 @@ no `async_trait` dependency, and `run`/`analyze` stay backend-agnostic by holdin
   3. **Microsoft Entra ID** (`DeveloperToolsCredential`) — the secret-free
      production default (CI managed identity / workload-identity federation,
      local `az login`, env service principals); requires an **HTTPS** endpoint.
+     The credential is wrapped in a `CachingCredential` decorator that serializes
+     token acquisition and caches the token per scope, so `analyze`'s concurrent
+     object-load burst shares one acquisition instead of driving that many
+     simultaneous `az account get-access-token` calls — which on Windows collide
+     on the exclusive MSAL token-cache lockfile and fail the whole read.
 
   The shipped azure-sdk-for-rust v1.0.0 removed connection-string parsing,
   `StorageSharedKeyCredential`, and `DefaultAzureCredential`, which is why the

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -13,13 +13,15 @@
 //! and pass no credential (so the emulator's plain-HTTP endpoint is accepted);
 //! Entra mode passes a token credential and requires HTTPS.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::io;
 use std::sync::Arc;
 
-use azure_core::credentials::TokenCredential;
+use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
 use azure_core::error::ErrorKind;
 use azure_core::http::{RequestContent, StatusCode, Url};
+use azure_core::time::{Duration, OffsetDateTime};
 use azure_identity::DeveloperToolsCredential;
 use azure_storage_blob::models::{
     BlobClientUploadOptions, BlobContainerClientListBlobsOptions, StorageErrorCode,
@@ -123,7 +125,11 @@ impl AzureBlobStorage {
                 .map_err(|error| {
                     config_error(format!("could not initialize Entra ID credential: {error}"))
                 })?;
-            Some(credential)
+            // Wrap the credential so a burst of concurrent reads shares one token
+            // instead of each driving its own Azure CLI token acquisition (see
+            // `CachingCredential`).
+            let caching: Arc<dyn TokenCredential> = Arc::new(CachingCredential::new(credential));
+            Some(caching)
         };
 
         Ok(Self {
@@ -272,6 +278,97 @@ impl Storage for AzureBlobStorage {
     }
 }
 
+/// How long before a cached token's stated expiry it is treated as stale and
+/// re-acquired, so a token is never handed out only to expire while the request
+/// that just read it is still in flight.
+const TOKEN_REFRESH_MARGIN: Duration = Duration::minutes(5);
+
+/// A [`TokenCredential`] decorator that serializes token acquisition and caches
+/// each scope's most recent token, so a burst of concurrent reads shares one
+/// token instead of each driving a separate acquisition of the wrapped
+/// credential.
+///
+/// The Entra credential ([`DeveloperToolsCredential`]) shells out to the Azure
+/// CLI on every uncached `get_token`. Without this decorator, `analyze`'s
+/// concurrent object loads fan out into that many simultaneous
+/// `az account get-access-token` invocations; on Windows they collide on the
+/// exclusive MSAL token-cache lockfile and the whole read fails with a permission
+/// error. Holding the cache lock across the inner acquisition means only one
+/// acquisition is ever in flight, so later callers reuse the freshly cached token
+/// rather than racing the CLI.
+struct CachingCredential {
+    /// The wrapped credential that performs the real token acquisition.
+    inner: Arc<dyn TokenCredential>,
+    /// The most recent token per requested scope set. The lock is deliberately
+    /// held across the inner acquisition, so concurrent callers serialize on it
+    /// and share a single fetch rather than stampeding the wrapped credential.
+    cache: futures::lock::Mutex<HashMap<Vec<String>, AccessToken>>,
+    /// The wall-clock source used to decide whether a cached token is still
+    /// fresh. Injected so the freshness logic is deterministic under test.
+    now: fn() -> OffsetDateTime,
+}
+
+impl fmt::Debug for CachingCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CachingCredential")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CachingCredential {
+    /// Wraps `inner`, reading the real wall clock for token-freshness decisions.
+    fn new(inner: Arc<dyn TokenCredential>) -> Self {
+        Self::with_clock(inner, OffsetDateTime::now_utc)
+    }
+
+    /// Wraps `inner` with an explicit clock, so tests pin token freshness
+    /// deterministically instead of reading the wall clock.
+    fn with_clock(inner: Arc<dyn TokenCredential>, now: fn() -> OffsetDateTime) -> Self {
+        Self {
+            inner,
+            cache: futures::lock::Mutex::new(HashMap::new()),
+            now,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for CachingCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        let cache_key: Vec<String> = scopes.iter().map(|scope| (*scope).to_owned()).collect();
+
+        // Holding the lock across the inner acquisition is the whole point: it
+        // collapses a concurrent burst into one acquisition whose result the
+        // other callers then read from the cache.
+        let mut cache = self.cache.lock().await;
+        if let Some(token) = cache.get(&cache_key)
+            && token_is_fresh(token, (self.now)())
+        {
+            return Ok(token.clone());
+        }
+
+        let token = self.inner.get_token(scopes, options).await?;
+        cache.insert(cache_key, token.clone());
+        Ok(token)
+    }
+}
+
+/// Whether `token` is still far enough from its expiry to reuse at `now`,
+/// keeping a [`TOKEN_REFRESH_MARGIN`] safety margin so it cannot expire while a
+/// request that just read it is still in flight.
+///
+/// A `now` so close to the maximum representable date that adding the margin
+/// overflows is treated as not fresh (re-acquire), which is the safe default.
+fn token_is_fresh(token: &AccessToken, now: OffsetDateTime) -> bool {
+    now.checked_add(TOKEN_REFRESH_MARGIN)
+        .is_some_and(|deadline| token.expires_on > deadline)
+}
+
 /// Uploads `bytes` to `client`, creating the container and retrying once if it
 /// does not exist yet. When `if_not_exists` is set the upload is write-once
 /// (failing if the blob already exists); otherwise it replaces any existing blob.
@@ -352,8 +449,14 @@ fn map_error(error: &azure_core::Error, key: &str) -> StorageError {
 }
 
 /// Wraps an Azure error as a generic storage I/O error.
+///
+/// Formats with `Debug` rather than `Display` on purpose: the SDK's retry policy
+/// replaces the `Display` text with an opaque "non-transport error occurred which
+/// will not be retried", masking the real cause (for example a credential
+/// acquisition failure). The `Debug` representation preserves the full error
+/// chain, so the underlying fault is visible in diagnostics.
 fn azure_io(error: &azure_core::Error) -> StorageError {
-    StorageError::Io(io::Error::other(format!("Azure Blob error: {error}")))
+    StorageError::Io(io::Error::other(format!("Azure Blob error: {error:?}")))
 }
 
 /// Builds a generic storage I/O error from a static message.
@@ -665,6 +768,229 @@ mod tests {
         assert!(matches!(put, StorageError::InvalidKey { .. }), "{put:?}");
         let get = block_on(storage.get("../bad")).unwrap_err();
         assert!(matches!(get, StorageError::InvalidKey { .. }), "{get:?}");
+    }
+
+    // =======================================================================
+    // Caching-credential tests.
+    //
+    // These cover the token caching/serialization decorator with a fake inner
+    // credential, so they exercise the dedup, freshness, and per-scope behaviour
+    // without a real Entra credential or any wall-clock read (the clock is
+    // injected). They stay Miri-safe: no IO, no real time.
+    //
+    // `AtomicU64` and `Ordering` are imported by the Azurite section below (one
+    // `tests` module, so module-scoped). `Future` is in the 2024 prelude.
+    // =======================================================================
+
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use futures::future::join_all;
+
+    /// The Unix-second anchor shared by [`fixed_now`] and [`at_offset`].
+    const BASE_UNIX: i64 = 1_000_000_000;
+
+    /// A fixed "now" used by the caching-credential tests so token freshness is
+    /// deterministic and Miri-safe (no wall-clock read).
+    fn fixed_now() -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(BASE_UNIX).unwrap()
+    }
+
+    /// Builds an [`OffsetDateTime`] `offset` seconds from [`fixed_now`].
+    fn at_offset(offset: i64) -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(BASE_UNIX.saturating_add(offset)).unwrap()
+    }
+
+    /// Yields control back to the executor exactly once, so a concurrently-polled
+    /// burst can interleave inside the fake credential's acquisition (and thus be
+    /// observed as concurrent if it were ever allowed to run unserialized).
+    struct YieldOnce(bool);
+
+    impl Future for YieldOnce {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    /// A fake [`TokenCredential`] that records how many times — and how
+    /// concurrently — it is asked to acquire a token, optionally yielding once
+    /// mid-acquisition so a burst can be observed as concurrent if it is not
+    /// serialized by the decorator.
+    #[derive(Debug)]
+    struct CountingCredential {
+        calls: AtomicU64,
+        in_flight: AtomicU64,
+        max_in_flight: AtomicU64,
+        yield_during_acquire: bool,
+        expires_at_unix: i64,
+    }
+
+    impl CountingCredential {
+        fn new(expires_at_unix: i64, yield_during_acquire: bool) -> Self {
+            Self {
+                calls: AtomicU64::new(0),
+                in_flight: AtomicU64::new(0),
+                max_in_flight: AtomicU64::new(0),
+                yield_during_acquire,
+                expires_at_unix,
+            }
+        }
+
+        fn calls(&self) -> u64 {
+            self.calls.load(Ordering::Relaxed)
+        }
+
+        fn max_in_flight(&self) -> u64 {
+            self.max_in_flight.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TokenCredential for CountingCredential {
+        async fn get_token(
+            &self,
+            _scopes: &[&str],
+            _options: Option<TokenRequestOptions<'_>>,
+        ) -> azure_core::Result<AccessToken> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            let now = self.in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+            self.max_in_flight.fetch_max(now, Ordering::Relaxed);
+            if self.yield_during_acquire {
+                YieldOnce(false).await;
+            }
+            self.in_flight.fetch_sub(1, Ordering::Relaxed);
+            Ok(AccessToken::new(
+                "fake-token",
+                OffsetDateTime::from_unix_timestamp(self.expires_at_unix).unwrap(),
+            ))
+        }
+    }
+
+    #[test]
+    fn token_is_fresh_accepts_a_token_beyond_the_refresh_margin() {
+        let margin = TOKEN_REFRESH_MARGIN.whole_seconds();
+        let token = AccessToken::new("t", at_offset(margin + 1));
+        assert!(token_is_fresh(&token, fixed_now()));
+    }
+
+    #[test]
+    fn token_is_fresh_rejects_a_token_within_the_refresh_margin() {
+        let margin = TOKEN_REFRESH_MARGIN.whole_seconds();
+        let token = AccessToken::new("t", at_offset(margin - 1));
+        assert!(!token_is_fresh(&token, fixed_now()));
+    }
+
+    #[test]
+    fn token_is_fresh_rejects_a_token_exactly_at_the_refresh_margin() {
+        let margin = TOKEN_REFRESH_MARGIN.whole_seconds();
+        let token = AccessToken::new("t", at_offset(margin));
+        assert!(!token_is_fresh(&token, fixed_now()));
+    }
+
+    #[test]
+    fn token_is_fresh_rejects_an_expired_token() {
+        let token = AccessToken::new("t", at_offset(-1));
+        assert!(!token_is_fresh(&token, fixed_now()));
+    }
+
+    #[test]
+    fn counting_credential_observes_concurrency_when_unserialized() {
+        // Establishes the discriminating power of the burst test: hit the fake
+        // directly (no decorator) and the yield lets the burst overlap, so the
+        // observed max concurrency exceeds one.
+        let inner = Arc::new(CountingCredential::new(
+            at_offset(3600).unix_timestamp(),
+            true,
+        ));
+        let scopes = ["scope"];
+        let calls = std::iter::repeat_with(|| inner.get_token(&scopes, None)).take(8);
+        for result in block_on(join_all(calls)) {
+            result.unwrap();
+        }
+        assert_eq!(inner.calls(), 8);
+        assert!(inner.max_in_flight() > 1, "{}", inner.max_in_flight());
+    }
+
+    #[test]
+    fn caching_credential_collapses_a_concurrent_burst_into_one_acquisition() {
+        let inner = Arc::new(CountingCredential::new(
+            at_offset(3600).unix_timestamp(),
+            true,
+        ));
+        let cred =
+            CachingCredential::with_clock(Arc::<CountingCredential>::clone(&inner), fixed_now);
+        let scopes = ["scope"];
+        let calls = std::iter::repeat_with(|| cred.get_token(&scopes, None)).take(8);
+        for result in block_on(join_all(calls)) {
+            result.unwrap();
+        }
+        // Serialized through the cache lock: a single acquisition, never overlapping.
+        assert_eq!(inner.calls(), 1);
+        assert_eq!(inner.max_in_flight(), 1);
+    }
+
+    #[test]
+    fn caching_credential_reuses_a_fresh_token() {
+        let inner = Arc::new(CountingCredential::new(
+            at_offset(3600).unix_timestamp(),
+            false,
+        ));
+        let cred =
+            CachingCredential::with_clock(Arc::<CountingCredential>::clone(&inner), fixed_now);
+        let scopes = ["scope"];
+        block_on(cred.get_token(&scopes, None)).unwrap();
+        block_on(cred.get_token(&scopes, None)).unwrap();
+        assert_eq!(inner.calls(), 1);
+    }
+
+    #[test]
+    fn caching_credential_reacquires_an_expired_token() {
+        // The fake hands back an already-stale token, so every call must refresh.
+        let inner = Arc::new(CountingCredential::new(
+            at_offset(-10).unix_timestamp(),
+            false,
+        ));
+        let cred =
+            CachingCredential::with_clock(Arc::<CountingCredential>::clone(&inner), fixed_now);
+        let scopes = ["scope"];
+        block_on(cred.get_token(&scopes, None)).unwrap();
+        block_on(cred.get_token(&scopes, None)).unwrap();
+        assert_eq!(inner.calls(), 2);
+    }
+
+    #[test]
+    fn caching_credential_caches_each_scope_independently() {
+        let inner = Arc::new(CountingCredential::new(
+            at_offset(3600).unix_timestamp(),
+            false,
+        ));
+        let cred =
+            CachingCredential::with_clock(Arc::<CountingCredential>::clone(&inner), fixed_now);
+        block_on(cred.get_token(&["scope-a"], None)).unwrap();
+        block_on(cred.get_token(&["scope-b"], None)).unwrap();
+        // Each new scope acquires once; re-requesting a cached scope does not.
+        assert_eq!(inner.calls(), 2);
+        block_on(cred.get_token(&["scope-a"], None)).unwrap();
+        assert_eq!(inner.calls(), 2);
+    }
+
+    #[test]
+    fn caching_credential_debug_hides_the_cache_and_clock() {
+        let inner: Arc<dyn TokenCredential> = Arc::new(CountingCredential::new(
+            at_offset(3600).unix_timestamp(),
+            false,
+        ));
+        let cred = CachingCredential::with_clock(inner, fixed_now);
+        let rendered = format!("{cred:?}");
+        assert!(rendered.contains("CachingCredential"), "{rendered}");
     }
 
     // =======================================================================


### PR DESCRIPTION
Fixes #269.

## Problem

`analyze` loads history objects with a 32-wide concurrent burst (`LOAD_CONCURRENCY`). On the Entra ID auth path each uncached `get_token` shells out to `az account get-access-token`, so the burst fans out into that many simultaneous Azure CLI invocations. On Windows they collide on the exclusive MSAL token-cache lockfile (`msal_token_cache.bin.lockfile`) and the whole read fails with `[Errno 13] Permission denied`. The real cause was further masked because `azure_io` formatted the error with `Display` only, hiding the boxed source.

## Fix

This addresses all three directions suggested in the issue:

1. **Serializing/caching credential.** A new `CachingCredential` decorator wraps the Entra `DeveloperToolsCredential`. It holds a cache lock across the inner token acquisition, so a concurrent burst collapses into a single acquisition whose result later callers read from the cache. Tokens are cached per scope set and refreshed when within a 5-minute margin of expiry. The clock is injected (`fn() -> OffsetDateTime`) so freshness logic is deterministic and Miri-safe under test.
2. **Error-chain visibility.** `azure_io` now formats with `{error:?}` so the underlying credential cause is surfaced instead of masked behind the generic "Azure Blob error" line.
3. **Cleanup on failure.** In the `cargo-bench-history-stress` harness, `run_harness` now always runs `target.cleanup(...)` after the provisioned work — even when seeding, upload, or a measured mode fails — so a failed Azure run never orphans its per-run container. A measured failure is surfaced first (root cause); a cleanup failure is reported only when the run itself otherwise succeeded.

A new `async-trait` workspace dependency (pinned to `0.1.89`, the resolved version) backs the `TokenCredential` impl on the decorator.

## Verification

- `cargo build` and `cargo clippy --all-targets` clean for both affected packages (zero warnings).
- `cargo +nightly fmt --all --check` clean, with no out-of-scope reformatting.
- Tests: 466 lib + 106 integration tests pass for `cargo-bench-history`; the full `cargo-bench-history-stress` suite passes.
- Miri: the `storage::azure` module is Miri-clean (the new caching/freshness tests run under Miri; network tests stay `#[cfg_attr(miri, ignore)]`).
- Mutation testing: the new caching logic has 0 missed mutants (5 caught, 3 unviable), and `run_harness` has 0 missed mutants.

## Docs

Updated `DESIGN.md` and `AGENTS.md` in `cargo-bench-history` to document the caching decorator on the Entra auth path.
