### PR TITLE
cargo-bench-history: stream analyze data to cut peak memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
 name = "cargo-bench-history-stress"
 version = "0.0.0"
 dependencies = [
+ "all_the_time",
  "cargo-bench-history",
  "cargo-bench-history-core",
  "clap",

--- a/packages/cargo-bench-history-core/benches/cbh_core_codec.rs
+++ b/packages/cargo-bench-history-core/benches/cbh_core_codec.rs
@@ -65,7 +65,6 @@ fn sample_run_json(result_count: usize) -> Vec<u8> {
     let epoch = "2024-01-01T00:00:00Z".parse().unwrap();
     let context = RunContext::new(
         epoch,
-        epoch,
         GitInfo::default(),
         EnvironmentInfo::default(),
         ToolchainInfo::default(),

--- a/packages/cargo-bench-history-core/benches/cbh_core_codec_cg.rs
+++ b/packages/cargo-bench-history-core/benches/cbh_core_codec_cg.rs
@@ -69,7 +69,6 @@ mod linux {
         let epoch = "2024-01-01T00:00:00Z".parse().unwrap();
         let context = RunContext::new(
             epoch,
-            epoch,
             GitInfo::default(),
             EnvironmentInfo::default(),
             ToolchainInfo::default(),

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -284,6 +284,10 @@ impl Finding {
 struct Candidate {
     /// The finding that will be emitted if it survives filtering.
     finding: Finding,
+    /// Index of the source series in the analysed slice. The finding's charting
+    /// points ([`Finding::series`]) are materialised from it only once the
+    /// candidate survives filtering, so a dropped candidate never pays for them.
+    source_index: usize,
     /// The p-value contributed to the false-discovery pool (noisy candidates only).
     bh_p: f64,
     /// Whether the source engine is deterministic (bypasses the FDR filter).
@@ -311,11 +315,20 @@ fn series_values(series: &Series) -> Vec<SeriesValue> {
         .points
         .iter()
         .map(|point| SeriesValue {
-            commit: point.commit.clone(),
+            commit: owned_commit(point),
             value: point.value,
             dirty: point.dirty,
         })
         .collect()
+}
+
+/// The abbreviated commit of a point as an owned `String`, for the JSON output.
+///
+/// Points intern their commit as a shared `Arc<str>`; the public finding fields are
+/// plain owned strings, so a surviving finding pays one allocation here rather than
+/// every point carrying its own copy.
+fn owned_commit(point: &SeriesPoint) -> Option<String> {
+    point.commit.as_deref().map(str::to_owned)
 }
 
 /// The direction of a change, given the signed delta from the baseline and the
@@ -354,17 +367,20 @@ fn relative_delta_of(delta: f64, baseline: f64) -> f64 {
 /// The representative confidence interval of a regime: the median of its points'
 /// lower and upper bounds, available only when the engine reports dispersion.
 fn regime_interval(points: &[&SeriesPoint]) -> Option<(f64, f64)> {
-    let lows: Vec<f64> = points
+    let mut lows: Vec<f64> = points
         .iter()
         .filter_map(|point| point.interval_low)
         .collect();
-    let highs: Vec<f64> = points
+    let mut highs: Vec<f64> = points
         .iter()
         .filter_map(|point| point.interval_high)
         .collect();
-    // `median` yields `None` for an empty side, so a regime missing either bound
-    // short-circuits here without a separate emptiness guard.
-    Some((stats::median(&lows)?, stats::median(&highs)?))
+    // `median_in_place` yields `None` for an empty side, so a regime missing either
+    // bound short-circuits here without a separate emptiness guard.
+    Some((
+        stats::median_in_place(&mut lows)?,
+        stats::median_in_place(&mut highs)?,
+    ))
 }
 
 /// Whether two intervals are disjoint (the after regime sits wholly above or
@@ -376,7 +392,7 @@ fn intervals_disjoint(before: (f64, f64), after: (f64, f64)) -> bool {
 /// The median confidence-interval half-width across `points`, when the engine
 /// reports dispersion. Used as the per-measurement noise floor for noisy drift.
 fn median_half_width(points: &[SeriesPoint]) -> Option<f64> {
-    let halves: Vec<f64> = points
+    let mut halves: Vec<f64> = points
         .iter()
         .filter_map(|point| match (point.interval_low, point.interval_high) {
             (Some(low), Some(high)) => Some((high - low) / 2.0),
@@ -386,7 +402,7 @@ fn median_half_width(points: &[SeriesPoint]) -> Option<f64> {
     if halves.is_empty() {
         return None;
     }
-    stats::median(&halves)
+    stats::median_in_place(&mut halves)
 }
 
 /// The median absolute residual of the two-regime (step) model: each point's
@@ -396,22 +412,22 @@ fn step_model_residual(values: &[f64], tau: usize) -> Option<f64> {
     let after = values.get(tau..)?;
     let before_median = stats::median(before)?;
     let after_median = stats::median(after)?;
-    let residuals: Vec<f64> = before
+    let mut residuals: Vec<f64> = before
         .iter()
         .map(|value| (value - before_median).abs())
         .chain(after.iter().map(|value| (value - after_median).abs()))
         .collect();
-    stats::median(&residuals)
+    stats::median_in_place(&mut residuals)
 }
 
 /// The median absolute residual of the linear (drift) model `intercept + slope·i`.
 fn line_model_residual(values: &[f64], slope: f64, intercept: f64) -> Option<f64> {
-    let residuals: Vec<f64> = values
+    let mut residuals: Vec<f64> = values
         .iter()
         .enumerate()
         .map(|(index, value)| (value - (intercept + slope * count_to_f64(index))).abs())
         .collect();
-    stats::median(&residuals)
+    stats::median_in_place(&mut residuals)
 }
 
 /// Chooses between a change-point and a drift candidate for the same series.
@@ -453,12 +469,15 @@ fn arbitrate(
 /// non-zero step. A noisy engine additionally requires a significant Mann–Whitney
 /// rank-sum difference between the regimes, non-overlapping regime confidence
 /// intervals (when reported), and a practically meaningful relative magnitude.
-fn evaluate_change_point(series: &Series, config: &AnalysisConfig) -> Option<Candidate> {
+fn evaluate_change_point(
+    series: &Series,
+    values: &[f64],
+    config: &AnalysisConfig,
+) -> Option<Candidate> {
     let points = &series.points;
     let n = points.len();
-    let values: Vec<f64> = points.iter().map(|point| point.value).collect();
 
-    let change = stats::pettitt(&values)?;
+    let change = stats::pettitt(values)?;
     let tau = change.index;
     let before_len = tau;
     let after_len = n.checked_sub(tau)?;
@@ -499,7 +518,7 @@ fn evaluate_change_point(series: &Series, config: &AnalysisConfig) -> Option<Can
         mann_whitney
     };
 
-    let commit = points.get(tau).and_then(|point| point.commit.clone());
+    let commit = points.get(tau).and_then(owned_commit);
     Some(Candidate {
         finding: Finding {
             set: series.set.clone(),
@@ -518,8 +537,9 @@ fn evaluate_change_point(series: &Series, config: &AnalysisConfig) -> Option<Can
             active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
-            series: series_values(series),
+            series: Vec::new(),
         },
+        source_index: 0,
         bh_p: effective_p,
         deterministic,
         split: Some(tau),
@@ -535,19 +555,18 @@ fn evaluate_change_point(series: &Series, config: &AnalysisConfig) -> Option<Can
 /// engine the total movement must also exceed the per-measurement noise floor
 /// (twice the median confidence-interval half-width), so jitter does not read as a
 /// trend.
-fn evaluate_drift(series: &Series, config: &AnalysisConfig) -> Option<Candidate> {
+fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> Option<Candidate> {
     let points = &series.points;
     let n = points.len();
     if n < config.drift_min_points {
         return None;
     }
-    let values: Vec<f64> = points.iter().map(|point| point.value).collect();
 
-    let trend = stats::mann_kendall(&values);
+    let trend = stats::mann_kendall(values);
     if trend.p_value >= config.drift_alpha {
         return None;
     }
-    let (slope, intercept) = stats::theil_sen_line(&values)?;
+    let (slope, intercept) = stats::theil_sen_line(values)?;
     let span = count_to_f64(n.checked_sub(1)?);
     let baseline = intercept;
     let latest = intercept + slope * span;
@@ -570,7 +589,7 @@ fn evaluate_drift(series: &Series, config: &AnalysisConfig) -> Option<Candidate>
         return None;
     }
 
-    let commit = points.last().and_then(|point| point.commit.clone());
+    let commit = points.last().and_then(owned_commit);
     Some(Candidate {
         finding: Finding {
             set: series.set.clone(),
@@ -589,8 +608,9 @@ fn evaluate_drift(series: &Series, config: &AnalysisConfig) -> Option<Candidate>
             active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
-            series: series_values(series),
+            series: Vec::new(),
         },
+        source_index: 0,
         bh_p: trend.p_value,
         deterministic,
         split: None,
@@ -671,7 +691,7 @@ fn latest_regime<'a>(
         .get(tau..)
         .map(<[&SeriesPoint]>::to_vec)
         .unwrap_or_default();
-    let flipped_at = branch.get(tau).and_then(|point| point.commit.clone());
+    let flipped_at = branch.get(tau).and_then(|&point| owned_commit(point));
     (after_points, flipped_at)
 }
 
@@ -759,8 +779,9 @@ fn compare_samples(
             active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
-            series: series_values(series),
+            series: Vec::new(),
         },
+        source_index: 0,
         bh_p: effective_p,
         deterministic,
         split: None,
@@ -784,7 +805,7 @@ fn evaluate_branch(
     // either sample's median is absent, so no explicit emptiness guard is needed.
     let base_window = recent(&base, config.compare_window);
     let (latest_points, flipped_at) = latest_regime(&branch, config);
-    let commit = branch.last().and_then(|point| point.commit.clone());
+    let commit = branch.last().and_then(|&point| owned_commit(point));
     compare_samples(
         series,
         &base_window,
@@ -807,7 +828,7 @@ fn evaluate_tip(series: &Series, config: &AnalysisConfig) -> Option<Candidate> {
     let all: Vec<&SeriesPoint> = points.iter().collect();
     let (preceding, tip) = all.split_at(n.saturating_sub(1));
     let before = recent(preceding, config.compare_window);
-    let commit = tip.first().and_then(|point| point.commit.clone());
+    let commit = tip.first().and_then(|&point| owned_commit(point));
     compare_samples(
         series,
         &before,
@@ -844,11 +865,13 @@ fn active_view(series: &Series) -> Series {
     }
 }
 
-/// Restores the full series onto a history-mode finding and records the re-baseline
-/// provenance, so the chart can grey the pre-blessing prefix and the report can name
-/// the blessing.
+/// Records a history-mode finding's re-baseline provenance, so the chart can grey
+/// the pre-blessing prefix and the report can name the blessing.
+///
+/// The finding's charting points ([`Finding::series`]) are filled in later, when
+/// the candidate survives filtering (see [`find_changes`]); a dropped candidate
+/// never builds them.
 fn stamp_history(finding: &mut Finding, series: &Series) {
-    finding.series = series_values(series);
     finding.active_from = series.active_start;
     if let Some(blessing) = &series.blessing {
         finding.blessed_at = Some(short_commit(&blessing.commit));
@@ -874,7 +897,11 @@ const RESOLVED_SPIKE_MAX_POINTS: usize = 200;
 /// and `latest` the spike's own level (its magnitude is what is notable). A
 /// deterministic engine accepts any sustained non-zero plateau; a noisy engine
 /// requires both the rise and the recovery to be Mann–Whitney significant.
-fn evaluate_resolved_spike(series: &Series, config: &AnalysisConfig) -> Option<Candidate> {
+fn evaluate_resolved_spike(
+    series: &Series,
+    values: &[f64],
+    config: &AnalysisConfig,
+) -> Option<Candidate> {
     let points = &series.points;
     let n = points.len();
     if n > RESOLVED_SPIKE_MAX_POINTS {
@@ -885,7 +912,6 @@ fn evaluate_resolved_spike(series: &Series, config: &AnalysisConfig) -> Option<C
     if n < min.checked_mul(3)? {
         return None;
     }
-    let values: Vec<f64> = points.iter().map(|point| point.value).collect();
     let baseline = stats::median(values.get(..min)?)?;
     let current = stats::median(values.get(n.checked_sub(min)?..)?)?;
     // Only a spike that has recovered qualifies; a still-elevated tail is an active
@@ -951,14 +977,15 @@ fn evaluate_resolved_spike(series: &Series, config: &AnalysisConfig) -> Option<C
             delta: deviation,
             relative_delta,
             confidence: (1.0 - effective_p).clamp(0.0, 1.0),
-            commit: points.get(rise).and_then(|point| point.commit.clone()),
-            flipped_at: points.get(recovery).and_then(|point| point.commit.clone()),
+            commit: points.get(rise).and_then(owned_commit),
+            flipped_at: points.get(recovery).and_then(owned_commit),
             active: false,
             active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
-            series: series_values(series),
+            series: Vec::new(),
         },
+        source_index: 0,
         bh_p: effective_p,
         deterministic,
         split: Some(rise),
@@ -998,7 +1025,9 @@ pub fn find_changes(series: &[Series], context: &AnalysisContext) -> Vec<Finding
     let mut keep_iter = keep.into_iter();
 
     // `candidates` and `noisy_p` were built in the same order, so advancing
-    // `keep_iter` exactly for the noisy candidates keeps the mask aligned.
+    // `keep_iter` exactly for the noisy candidates keeps the mask aligned. A
+    // surviving finding that the mode keeps materialises its charting points here —
+    // a dropped candidate never pays for them.
     let mut findings: Vec<Finding> = candidates
         .into_iter()
         .filter_map(|candidate| {
@@ -1007,9 +1036,23 @@ pub fn find_changes(series: &[Series], context: &AnalysisContext) -> Vec<Finding
             } else {
                 keep_iter.next().unwrap_or(false)
             };
-            survive.then_some(candidate.finding)
+            if !survive {
+                return None;
+            }
+            let Candidate {
+                mut finding,
+                source_index,
+                ..
+            } = candidate;
+            if !context.keeps(finding.direction) {
+                return None;
+            }
+            let source = series
+                .get(source_index)
+                .expect("the source index was assigned from this series slice");
+            finding.series = series_values(source);
+            Some(finding)
         })
-        .filter(|finding| context.keeps(finding.direction))
         .collect();
 
     findings.sort_by(|left, right| {
@@ -1045,7 +1088,8 @@ fn detect_all(series: &[Series], context: &AnalysisContext) -> Vec<Candidate> {
     if workers <= 1 {
         return series
             .iter()
-            .filter_map(|one| detect_one(one, context))
+            .enumerate()
+            .filter_map(|(index, one)| detect_one(index, one, context))
             .collect();
     }
 
@@ -1057,6 +1101,10 @@ fn detect_all(series: &[Series], context: &AnalysisContext) -> Vec<Candidate> {
         // yield when `len` only slightly exceeds `workers`). `workers <= series.len()`
         // keeps every chunk non-empty.
         let mut rest = series;
+        // The running offset of `rest` within `series`, so each worker can recover the
+        // global index of every series it evaluates (the chunk-local position plus this
+        // base) and stamp it onto the candidate.
+        let mut base = 0_usize;
         // The eager collect spawns every worker before the first join; a lazy
         // `map`/`flat_map` would instead spawn and join each chunk one at a time,
         // serializing the work.
@@ -1066,10 +1114,20 @@ fn detect_all(series: &[Series], context: &AnalysisContext) -> Vec<Candidate> {
                 let take = rest.len().div_ceil(remaining_workers);
                 let (slice, tail) = rest.split_at(take);
                 rest = tail;
+                let chunk_base = base;
+                base = base
+                    .checked_add(take)
+                    .expect("the total series count fits in usize");
                 scope.spawn(move || {
                     slice
                         .iter()
-                        .filter_map(|one| detect_one(one, context))
+                        .enumerate()
+                        .filter_map(|(offset, one)| {
+                            let index = chunk_base
+                                .checked_add(offset)
+                                .expect("a series index fits in usize");
+                            detect_one(index, one, context)
+                        })
                         .collect::<Vec<_>>()
                 })
             })
@@ -1085,26 +1143,30 @@ fn detect_all(series: &[Series], context: &AnalysisContext) -> Vec<Candidate> {
     })
 }
 
-/// Runs the mode-appropriate detector on a single series and returns its candidate
-/// finding, if one is raised.
+/// Runs the mode-appropriate detector on the series at `index` and returns its
+/// candidate finding, if one is raised.
 ///
 /// This is pure and depends on no other series, so [`find_changes`] evaluates every
 /// series with it in parallel. History mode locates a change-point and a drift and
 /// keeps the better-fitting one (optionally surfacing a recovered spike); branch and
-/// tip modes delegate to their dedicated detectors.
-fn detect_one(one: &Series, context: &AnalysisContext) -> Option<Candidate> {
+/// tip modes delegate to their dedicated detectors. `index` is the series' position
+/// in the analysed slice, stamped onto the candidate so [`find_changes`] can
+/// materialise its charting points only if it survives filtering.
+fn detect_one(index: usize, one: &Series, context: &AnalysisContext) -> Option<Candidate> {
     let config = &context.config;
-    match context.mode {
+    let candidate = match context.mode {
         AnalysisMode::History => {
             let active = active_view(one);
+            // The point values are projected once here and shared by every history
+            // detector, rather than each rebuilding the same `Vec<f64>`.
             let values: Vec<f64> = active.points.iter().map(|point| point.value).collect();
-            let change = evaluate_change_point(&active, config);
-            let drift = evaluate_drift(&active, config);
+            let change = evaluate_change_point(&active, &values, config);
+            let drift = evaluate_drift(&active, &values, config);
             let mut chosen = arbitrate(&values, change, drift);
             // A series with no active change may instead carry a recovered spike;
             // surface it only when inactive findings are requested.
             if chosen.is_none() && context.include_inactive {
-                chosen = evaluate_resolved_spike(&active, config);
+                chosen = evaluate_resolved_spike(&active, &values, config);
             }
             chosen.map(|mut candidate| {
                 stamp_history(&mut candidate.finding, one);
@@ -1113,7 +1175,11 @@ fn detect_one(one: &Series, context: &AnalysisContext) -> Option<Candidate> {
         }
         AnalysisMode::Branch => evaluate_branch(one, config, context.merge_base_index),
         AnalysisMode::Tip => evaluate_tip(one, config),
-    }
+    };
+    candidate.map(|mut candidate| {
+        candidate.source_index = index;
+        candidate
+    })
 }
 
 #[cfg(test)]
@@ -1126,6 +1192,8 @@ mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
     use jiff::Timestamp;
+
+    use std::sync::Arc;
 
     use crate::analyze::{Blessing, SeriesPoint};
     use crate::model::DiscriminantSet;
@@ -1161,8 +1229,8 @@ mod tests {
                 SeriesPoint {
                     topo_index: index,
                     dirty: false,
-                    object_key: format!("v1/p/engine/t/synthetic/commit{index}/clean.json"),
-                    commit: Some(format!("commit{index}")),
+                    object_ordinal: u32::try_from(index).unwrap(),
+                    commit: Some(Arc::from(format!("commit{index}"))),
                     value,
                     interval_low: half.map(|half| value - half),
                     interval_high: half.map(|half| value + half),
@@ -1193,6 +1261,12 @@ mod tests {
     fn only(findings: Vec<Finding>) -> Finding {
         assert_eq!(findings.len(), 1, "expected exactly one finding");
         findings.into_iter().next().unwrap()
+    }
+
+    /// The point values of a series, projected as the history detectors receive
+    /// them (the production path shares one such projection across detectors).
+    fn values_of(series: &Series) -> Vec<f64> {
+        series.points.iter().map(|point| point.value).collect()
     }
 
     /// Builds a minimal [`Candidate`] carrying only the fields [`arbitrate`]
@@ -1226,6 +1300,7 @@ mod tests {
                 blessed_commit_time: None,
                 series: Vec::new(),
             },
+            source_index: 0,
             bh_p: 0.0,
             deterministic: true,
             split,
@@ -1636,7 +1711,7 @@ mod tests {
             practical_relative: 30.0_f64 / 100.0,
             ..AnalysisConfig::default()
         };
-        let candidate = evaluate_change_point(&series, &config).unwrap();
+        let candidate = evaluate_change_point(&series, &values_of(&series), &config).unwrap();
         assert_eq!(candidate.finding.baseline, 100.0);
         assert_eq!(candidate.finding.latest, 130.0);
         assert_eq!(candidate.finding.relative_delta, config.practical_relative);
@@ -1770,8 +1845,8 @@ mod tests {
             .map(|&(topo_index, value, dirty)| SeriesPoint {
                 topo_index,
                 dirty,
-                object_key: format!("v1/p/engine/t/synthetic/commit{topo_index}/clean.json"),
-                commit: Some(format!("commit{topo_index}")),
+                object_ordinal: u32::try_from(topo_index).unwrap(),
+                commit: Some(Arc::from(format!("commit{topo_index}"))),
                 value,
                 interval_low: None,
                 interval_high: None,
@@ -2027,7 +2102,9 @@ mod tests {
         // A sustained interior plateau (20) between baseline regimes (10) that has
         // since recovered: a deterministic engine accepts any non-zero plateau.
         let spike = series_of(&[10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 10.0, 10.0, 10.0, 10.0]);
-        let candidate = evaluate_resolved_spike(&spike, &AnalysisConfig::default()).unwrap();
+        let candidate =
+            evaluate_resolved_spike(&spike, &values_of(&spike), &AnalysisConfig::default())
+                .unwrap();
         assert!(!candidate.finding.active);
         assert_eq!(candidate.finding.baseline, 10.0);
         assert_eq!(candidate.finding.latest, 20.0);
@@ -2065,8 +2142,8 @@ mod tests {
             .map(|(index, &(value, half))| SeriesPoint {
                 topo_index: index,
                 dirty: false,
-                object_key: format!("v1/p/engine/t/synthetic/commit{index}/clean.json"),
-                commit: Some(format!("commit{index}")),
+                object_ordinal: u32::try_from(index).unwrap(),
+                commit: Some(Arc::from(format!("commit{index}"))),
                 value,
                 interval_low: Some(value - half),
                 interval_high: Some(value + half),
@@ -2190,7 +2267,7 @@ mod tests {
             practical_relative: 20.0 / 100.0,
             ..AnalysisConfig::default()
         };
-        let candidate = evaluate_drift(&series, &config).unwrap();
+        let candidate = evaluate_drift(&series, &values_of(&series), &config).unwrap();
         assert_eq!(candidate.finding.method, FindingMethod::Drift);
         assert!(candidate.finding.confidence < 1.0);
     }
@@ -2202,7 +2279,7 @@ mod tests {
         // trend. The `2.0 * half_width` floor must be a product (a `+` mutant lowers
         // the floor to 14 and would flag it).
         let series = wall_series(&[100.0, 104.0, 108.0, 112.0, 116.0, 120.0], 12.0);
-        assert!(evaluate_drift(&series, &AnalysisConfig::default()).is_none());
+        assert!(evaluate_drift(&series, &values_of(&series), &AnalysisConfig::default()).is_none());
     }
 
     #[test]
@@ -2215,9 +2292,9 @@ mod tests {
             ..AnalysisConfig::default()
         };
         let short = series_of(&[100.0, 104.0, 108.0, 112.0, 116.0]);
-        assert!(evaluate_drift(&short, &config).is_none());
+        assert!(evaluate_drift(&short, &values_of(&short), &config).is_none());
         let long = series_of(&[100.0, 104.0, 108.0, 112.0, 116.0, 120.0, 124.0]);
-        assert!(evaluate_drift(&long, &config).is_some());
+        assert!(evaluate_drift(&long, &values_of(&long), &config).is_some());
     }
 
     #[test]
@@ -2258,7 +2335,9 @@ mod tests {
         // baseline (10) by 10 -- the `level - baseline` difference, not a sum or
         // quotient.
         let series = series_of(&[10.0, 10.0, 20.0, 20.0, 10.0, 10.0]);
-        let candidate = evaluate_resolved_spike(&series, &AnalysisConfig::default()).unwrap();
+        let candidate =
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .unwrap();
         assert_eq!(candidate.finding.delta, 10.0);
     }
 
@@ -2276,7 +2355,10 @@ mod tests {
             *value = 20.0;
         }
         let series = series_with(&values, MetricKind::InstructionCount, &[]);
-        assert!(evaluate_resolved_spike(&series, &AnalysisConfig::default()).is_some());
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_some()
+        );
     }
 
     #[test]
@@ -2292,7 +2374,10 @@ mod tests {
             *value = 20.0;
         }
         let series = series_with(&values, MetricKind::InstructionCount, &[]);
-        assert!(evaluate_resolved_spike(&series, &AnalysisConfig::default()).is_none());
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_none()
+        );
     }
 
     #[test]
@@ -2301,7 +2386,10 @@ mod tests {
         // floor. The reject gate is `deviation <= 0 || relative < floor`; an `&&`
         // mutant (needing BOTH) would wrongly surface it.
         let series = series_of(&[1000.0, 1000.0, 1010.0, 1010.0, 1000.0, 1000.0]);
-        assert!(evaluate_resolved_spike(&series, &AnalysisConfig::default()).is_none());
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_none()
+        );
     }
 
     #[test]
@@ -2314,7 +2402,7 @@ mod tests {
             practical_relative: 3.0 / 100.0,
             ..AnalysisConfig::default()
         };
-        assert!(evaluate_resolved_spike(&series, &config).is_some());
+        assert!(evaluate_resolved_spike(&series, &values_of(&series), &config).is_some());
     }
 
     #[test]
@@ -2327,7 +2415,9 @@ mod tests {
             .chain(std::iter::repeat_n(100.0, 8))
             .collect();
         let series = wall_series(&values, 1.0);
-        let candidate = evaluate_resolved_spike(&series, &AnalysisConfig::default()).unwrap();
+        let candidate =
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .unwrap();
         assert!(candidate.finding.confidence < 1.0);
     }
 
@@ -2341,7 +2431,10 @@ mod tests {
             .chain([100.0, 100.0])
             .collect();
         let series = wall_series(&values, 1.0);
-        assert!(evaluate_resolved_spike(&series, &AnalysisConfig::default()).is_none());
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_none()
+        );
     }
 
     #[test]
@@ -2376,7 +2469,10 @@ mod tests {
         // Five points cannot hold a baseline, an elevated middle, and a recovery of
         // at least `min_regime` (2) each, so the `n < min * 3` gate rejects it.
         let series = series_of(&[10.0, 10.0, 20.0, 20.0, 10.0]);
-        assert!(evaluate_resolved_spike(&series, &AnalysisConfig::default()).is_none());
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_none()
+        );
     }
 
     #[test]
@@ -2384,6 +2480,9 @@ mod tests {
         // The recovery tail (30) stays far above the baseline (10), so the series has
         // not recovered; an active change-point handles it instead.
         let series = series_of(&[10.0, 10.0, 20.0, 20.0, 30.0, 30.0]);
-        assert!(evaluate_resolved_spike(&series, &AnalysisConfig::default()).is_none());
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_none()
+        );
     }
 }

--- a/packages/cargo-bench-history-core/src/analyze/mod.rs
+++ b/packages/cargo-bench-history-core/src/analyze/mod.rs
@@ -23,6 +23,6 @@ pub use findings::{
 pub use report::{ReportFormat, ReportInput, SetSummary, render};
 pub use selection::{SelectedCommit, select_commits};
 pub use series::{
-    Blessing, BlessingPlacement, LoadedObject, Series, SeriesFilter, SeriesPoint, apply_blessings,
-    build_series,
+    Blessing, BlessingPlacement, LoadedObject, Series, SeriesBuilder, SeriesFilter, SeriesPoint,
+    apply_blessings, build_series,
 };

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -7,10 +7,15 @@
 //! their commit, supplied as a `commit -> index` map — so the timeline reflects
 //! the history the runs were measured against rather than when they were ingested.
 //! Within a single commit, clean runs precede dirty snapshots, and any remaining
-//! tie breaks by the storage key for determinism.
+//! tie breaks by the object's storage-key order (its ordinal) for determinism.
+//!
+//! Points are kept deliberately small: tens of millions can be resident at once on
+//! a large history, so the storage key is reduced to a 4-byte ordinal and the
+//! per-point commit string is interned to a shared `Arc<str>` rather than cloned.
 
 use std::collections::{BTreeMap, HashMap};
 use std::hash::BuildHasher;
+use std::sync::Arc;
 
 use jiff::Timestamp;
 
@@ -20,16 +25,26 @@ use crate::model::DiscriminantSet;
 use crate::model::{BenchmarkId, BenchmarkIdPrefix, MetricKind, Run};
 
 /// A single observation in a series.
+///
+/// Kept compact because a large history materializes tens of millions of these at
+/// once: the provenance storage key is reduced to [`object_ordinal`] (the key's
+/// rank in sorted storage-key order, the final tie-break) and the abbreviated
+/// commit is an interned [`Arc<str>`] shared across every point measured against
+/// the same commit.
+///
+/// [`object_ordinal`]: SeriesPoint::object_ordinal
 #[derive(Clone, Debug)]
 pub struct SeriesPoint {
     /// First-parent topological position of the run's commit (oldest = 0).
     pub topo_index: usize,
     /// Whether the observation came from a dirty (uncommitted-tree) snapshot.
     pub dirty: bool,
-    /// Storage key the observation came from (final tie-break and provenance).
-    pub object_key: String,
-    /// Abbreviated commit the run was measured against, if known.
-    pub commit: Option<String>,
+    /// The object's rank in sorted storage-key order (the final tie-break),
+    /// standing in for the full storage key to keep the point small.
+    pub object_ordinal: u32,
+    /// Abbreviated commit the run was measured against, if known. Interned so all
+    /// points on one commit share a single allocation.
+    pub commit: Option<Arc<str>>,
     /// The measured value.
     pub value: f64,
     /// Lower confidence-interval bound, when the engine reports one (Criterion).
@@ -72,7 +87,7 @@ pub struct Series {
     pub id: BenchmarkId,
     /// The metric kind all points share (governs unit and comparison semantics).
     pub kind: MetricKind,
-    /// Observations ordered by `(topo_index, dirty, object_key)`.
+    /// Observations ordered by `(topo_index, dirty, object_ordinal)`.
     pub points: Vec<SeriesPoint>,
     /// Index into `points` where the active (post-blessing) window begins; `0`
     /// when the series is unblessed (every point is active). History-mode
@@ -124,66 +139,178 @@ fn prefixes_accept(prefixes: &[BenchmarkIdPrefix], id: &BenchmarkId) -> bool {
 /// metric of each kind, so the kind alone keys the series unambiguously. The
 /// `order` map gives each commit its first-parent topological index; an object
 /// whose commit is not in `order` is outside the analyzed selection and is
-/// skipped. Points are sorted by `(topo_index, dirty, object_key)` so a clean run
-/// precedes a dirty snapshot on the same commit and the timeline follows git
-/// history rather than storage-listing order.
+/// skipped. Points are sorted by `(topo_index, dirty, object_ordinal)` so a clean
+/// run precedes a dirty snapshot on the same commit and the timeline follows git
+/// history rather than storage-listing order; the ordinal is each object's rank in
+/// sorted storage-key order, so the final tie-break matches a sort by storage key.
+///
+/// This is a convenience wrapper over [`SeriesBuilder`]: it assigns each object its
+/// storage-key ordinal up front, then folds every object in. Callers that fetch
+/// objects incrementally (and want to drop each parsed run immediately, never
+/// holding the whole data set in memory) should drive a [`SeriesBuilder`] directly.
 #[must_use]
 pub fn build_series<S: BuildHasher>(
     objects: &[LoadedObject],
     order: &HashMap<String, usize, S>,
     filter: &SeriesFilter<'_>,
 ) -> Vec<Series> {
-    let mut groups: BTreeMap<(DiscriminantSet, BenchmarkId, MetricKind), Vec<SeriesPoint>> =
-        BTreeMap::new();
+    // Assign each in-selection object an ordinal equal to its rank in sorted
+    // storage-key order, so ordering points by `object_ordinal` is identical to
+    // ordering them by the full storage key.
+    let mut keys: Vec<&str> = objects
+        .iter()
+        .filter(|object| order.contains_key(&object.key.commit))
+        .map(|object| object.object_key.as_str())
+        .collect();
+    keys.sort_unstable();
+    keys.dedup();
+    let ordinals: HashMap<&str, u32> = keys
+        .iter()
+        .enumerate()
+        .map(|(index, key)| (*key, ordinal_of(index)))
+        .collect();
 
+    let mut builder = SeriesBuilder::new(*filter);
     for object in objects {
         let Some(&topo_index) = order.get(&object.key.commit) else {
             continue;
         };
-        let dirty = object.key.is_dirty();
-        let commit = object.result.context.git.short_commit.clone();
+        let ordinal = ordinals
+            .get(object.object_key.as_str())
+            .copied()
+            .unwrap_or(u32::MAX);
+        builder.push(
+            &object.key.set,
+            topo_index,
+            object.key.is_dirty(),
+            ordinal,
+            &object.result,
+        );
+    }
+    builder.finish()
+}
 
-        for record in &object.result.results {
-            if !prefixes_accept(filter.prefixes, &record.id) {
+/// Narrows a storage-key rank to the [`SeriesPoint::object_ordinal`] width.
+///
+/// Ordinals are a pure tie-break, so the (practically impossible) overflow past
+/// `u32::MAX` distinct objects merely lets the last ordinals collide — points then
+/// keep their stable insertion order, never a panic.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "saturating: ordinals only tie-break, and >4 billion objects never occur"
+)]
+fn ordinal_of(rank: usize) -> u32 {
+    rank.min(u32::MAX as usize) as u32
+}
+
+/// Folds stored runs into per-`(set, benchmark, metric kind)` series.
+///
+/// Each pushed run contributes one point per metric to the series for its
+/// identity; [`finish`](SeriesBuilder::finish) sorts every series by
+/// `(topo_index, dirty, object_ordinal)`. Unlike [`build_series`], the builder
+/// retains nothing of a run beyond the extracted points, so a streaming loader can
+/// fold each fetched run and drop it immediately, keeping only the (compact) points
+/// resident rather than the whole parsed data set.
+///
+/// The abbreviated commit of each run is interned, so all points measured against
+/// one commit share a single [`Arc<str>`] instead of cloning the string per point.
+#[derive(Debug)]
+pub struct SeriesBuilder<'a> {
+    filter: SeriesFilter<'a>,
+    groups: BTreeMap<(DiscriminantSet, BenchmarkId, MetricKind), Vec<SeriesPoint>>,
+    commits: HashMap<Box<str>, Arc<str>>,
+}
+
+impl<'a> SeriesBuilder<'a> {
+    /// Starts an empty builder that keeps only series matching `filter`.
+    #[must_use]
+    pub fn new(filter: SeriesFilter<'a>) -> Self {
+        Self {
+            filter,
+            groups: BTreeMap::new(),
+            commits: HashMap::new(),
+        }
+    }
+
+    /// Folds one stored run into the accumulating series.
+    ///
+    /// `topo_index` is the run commit's first-parent position and `object_ordinal`
+    /// its rank in sorted storage-key order (the final point tie-break); the caller
+    /// supplies both because they come from the storage key and git topology, not
+    /// the run payload. Only the matching metrics are retained — the run itself can
+    /// be dropped as soon as this returns.
+    pub fn push(
+        &mut self,
+        set: &DiscriminantSet,
+        topo_index: usize,
+        dirty: bool,
+        object_ordinal: u32,
+        run: &Run,
+    ) {
+        let commit = run
+            .context
+            .git
+            .short_commit
+            .as_deref()
+            .map(|commit| self.intern(commit));
+
+        for record in &run.results {
+            if !prefixes_accept(self.filter.prefixes, &record.id) {
                 continue;
             }
             for metric in &record.metrics {
                 let point = SeriesPoint {
                     topo_index,
                     dirty,
-                    object_key: object.object_key.clone(),
+                    object_ordinal,
                     commit: commit.clone(),
                     value: metric.value,
                     interval_low: metric.interval_low,
                     interval_high: metric.interval_high,
                 };
-                groups
-                    .entry((object.key.set.clone(), record.id.clone(), metric.kind))
+                self.groups
+                    .entry((set.clone(), record.id.clone(), metric.kind))
                     .or_default()
                     .push(point);
             }
         }
     }
 
-    groups
-        .into_iter()
-        .map(|((set, id, kind), mut points)| {
-            points.sort_by(|left, right| {
-                left.topo_index
-                    .cmp(&right.topo_index)
-                    .then_with(|| left.dirty.cmp(&right.dirty))
-                    .then_with(|| left.object_key.cmp(&right.object_key))
-            });
-            Series {
-                set,
-                id,
-                kind,
-                points,
-                active_start: 0,
-                blessing: None,
-            }
-        })
-        .collect()
+    /// Returns the interned `Arc<str>` for `commit`, allocating once per distinct
+    /// commit so the millions of points on a commit share one allocation.
+    fn intern(&mut self, commit: &str) -> Arc<str> {
+        if let Some(existing) = self.commits.get(commit) {
+            return Arc::clone(existing);
+        }
+        let interned: Arc<str> = Arc::from(commit);
+        self.commits
+            .insert(Box::from(commit), Arc::clone(&interned));
+        interned
+    }
+
+    /// Finalizes every accumulated series, each sorted into topological order.
+    #[must_use]
+    pub fn finish(self) -> Vec<Series> {
+        self.groups
+            .into_iter()
+            .map(|((set, id, kind), mut points)| {
+                points.sort_by(|left, right| {
+                    left.topo_index
+                        .cmp(&right.topo_index)
+                        .then_with(|| left.dirty.cmp(&right.dirty))
+                        .then_with(|| left.object_ordinal.cmp(&right.object_ordinal))
+                });
+                Series {
+                    set,
+                    id,
+                    kind,
+                    points,
+                    active_start: 0,
+                    blessing: None,
+                }
+            })
+            .collect()
+    }
 }
 
 /// Re-baselines each series to its latest matching blessing (history mode).

--- a/packages/cargo-bench-history-core/src/analyze/stats.rs
+++ b/packages/cargo-bench-history-core/src/analyze/stats.rs
@@ -28,20 +28,36 @@ fn same(left: f64, right: f64) -> bool {
 ///
 /// Uses [`f64::total_cmp`] so `NaN` cannot corrupt the ordering, and computes the
 /// midpoint index with checked integer arithmetic to satisfy the workspace lints.
+///
+/// This copies `values` into a scratch buffer first; a caller that already owns a
+/// buffer it no longer needs in input order should call [`median_in_place`] to
+/// avoid the copy.
 pub(crate) fn median(values: &[f64]) -> Option<f64> {
     if values.is_empty() {
         return None;
     }
     let mut sorted = values.to_vec();
-    sorted.sort_by(f64::total_cmp);
-    let len = sorted.len();
+    median_in_place(&mut sorted)
+}
+
+/// The median of `values`, sorting them in place rather than copying.
+///
+/// The allocation-free core of [`median`]: it sorts `values` with
+/// [`f64::total_cmp`] (so `NaN` cannot corrupt the ordering) and reads the
+/// midpoint, leaving the slice sorted. Returns `None` for an empty slice.
+pub(crate) fn median_in_place(values: &mut [f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(f64::total_cmp);
+    let len = values.len();
     let mid = len.checked_div(2)?;
     if len.checked_rem(2) == Some(1) {
-        sorted.get(mid).copied()
+        values.get(mid).copied()
     } else {
         let lower = mid.checked_sub(1)?;
-        let low = *sorted.get(lower)?;
-        let high = *sorted.get(mid)?;
+        let low = *values.get(lower)?;
+        let high = *values.get(mid)?;
         Some(f64::midpoint(low, high))
     }
 }
@@ -294,14 +310,14 @@ pub(crate) fn theil_sen_line(values: &[f64]) -> Option<(f64, f64)> {
             slopes.push((later - earlier) / span);
         }
     }
-    let slope = median(&slopes)?;
+    let slope = median_in_place(&mut slopes)?;
 
-    let intercepts: Vec<f64> = values
+    let mut intercepts: Vec<f64> = values
         .iter()
         .enumerate()
         .map(|(i, &value)| value - slope * count_to_f64(i))
         .collect();
-    let intercept = median(&intercepts)?;
+    let intercept = median_in_place(&mut intercepts)?;
     Some((slope, intercept))
 }
 

--- a/packages/cargo-bench-history-core/src/codec.rs
+++ b/packages/cargo-bench-history-core/src/codec.rs
@@ -20,12 +20,24 @@
 //! * **Standard `Content-Encoding`** — `gzip` is a registered HTTP content
 //!   coding, so the Azure backend can declare it and any non-SDK reader can
 //!   inflate the blob with off-the-shelf tooling.
+//!
+//! # Allocation reuse
+//!
+//! `analyze` decompresses every stored object and the write paths compress every
+//! one, so the codec runs tens of thousands of times per invocation. The
+//! expensive part of a gzip round-trip is the deflate/inflate working state (the
+//! match-finder hash tables and the sliding window), not the output buffer. That
+//! state is therefore held in a per-thread [`Compress`]/[`Decompress`] and reset
+//! between calls, so a thread allocates it once and reuses it for every object it
+//! handles. The framing (the fixed gzip header, the CRC-32 and length trailer) is
+//! written and parsed directly so the low-level reusable coders — which speak raw
+//! DEFLATE, not gzip — can drive the hot path while the bytes on the wire stay
+//! exactly the standard gzip a stock decoder expects.
 
-use std::io::{Read as _, Write as _};
+use std::cell::RefCell;
+use std::io::{Error, ErrorKind, Result};
 
-use flate2::Compression;
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
+use flate2::{Compress, Compression, Crc, Decompress, FlushCompress, FlushDecompress, Status};
 
 /// The deflate level applied to every stored object.
 ///
@@ -35,6 +47,44 @@ use flate2::write::GzEncoder;
 /// of the redundancy at a fraction of level 9's compression cost.
 const GZIP_LEVEL: u32 = 6;
 
+/// Length of the fixed gzip member header this module writes and expects.
+const HEADER_LEN: usize = 10;
+
+/// Length of the gzip member trailer: a CRC-32 of the plaintext followed by its
+/// length modulo 2³², each a little-endian `u32`.
+const TRAILER_LEN: usize = 8;
+
+/// Output window the coders fill per pass.
+///
+/// Each iteration hands the encoder this many bytes to write into, then copies
+/// what it produced onto the output. A fixed window means progress never depends
+/// on inspecting the output buffer's spare capacity, and 64 KiB clears most
+/// objects in a single pass while bounding the work on the objects that need
+/// several.
+const SCRATCH_CHUNK: usize = 65_536;
+
+/// The fixed 10-byte gzip member header.
+///
+/// The bytes are: magic (`1f 8b`), deflate compression method (`08`), no flags
+/// (`00`), a zero mtime (`00 00 00 00`), no extra-flags (`00`), and an unknown OS
+/// (`ff`). Holding mtime and the OS byte constant is what makes the output a pure
+/// function of the input.
+const GZIP_HEADER: [u8; HEADER_LEN] = [0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff];
+
+thread_local! {
+    /// The reusable raw-DEFLATE compressor for this thread. `zlib_header` is
+    /// `false` because this module writes the gzip framing itself.
+    static DEFLATE: RefCell<Compress> =
+        RefCell::new(Compress::new(Compression::new(GZIP_LEVEL), false));
+
+    /// The reusable raw-INFLATE decompressor for this thread.
+    static INFLATE: RefCell<Decompress> = RefCell::new(Decompress::new(false));
+
+    /// Reusable output window for the coder loops, sized once and refilled each
+    /// pass so neither coder allocates a fresh buffer per object.
+    static SCRATCH: RefCell<Vec<u8>> = RefCell::new(vec![0; SCRATCH_CHUNK]);
+}
+
 /// gzip-compresses `plain` for storage.
 ///
 /// Infallible: the encoder writes into an in-memory [`Vec`], and writing to a
@@ -42,13 +92,27 @@ const GZIP_LEVEL: u32 = 6;
 /// aborts rather than returning).
 #[must_use]
 pub fn compress(plain: &[u8]) -> Vec<u8> {
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::new(GZIP_LEVEL));
-    encoder
-        .write_all(plain)
-        .expect("writing to an in-memory Vec cannot fail");
-    encoder
-        .finish()
-        .expect("flushing gzip into an in-memory Vec cannot fail")
+    DEFLATE.with_borrow_mut(|deflate| {
+        SCRATCH.with_borrow_mut(|scratch| {
+            // Compressed output is rarely larger than the input plus framing;
+            // reserve that up front so the common case writes the whole body
+            // without a regrow.
+            let hint = plain
+                .len()
+                .saturating_add(HEADER_LEN)
+                .saturating_add(TRAILER_LEN)
+                .saturating_add(16);
+            let mut out = Vec::with_capacity(hint);
+            out.extend_from_slice(&GZIP_HEADER);
+            run_deflate(deflate, scratch, plain, &mut out);
+
+            let mut crc = Crc::new();
+            crc.update(plain);
+            out.extend_from_slice(&crc.sum().to_le_bytes());
+            out.extend_from_slice(&plaintext_isize(plain).to_le_bytes());
+            out
+        })
+    })
 }
 
 /// Inflates a gzip-compressed object body produced by [`compress`].
@@ -56,18 +120,216 @@ pub fn compress(plain: &[u8]) -> Vec<u8> {
 /// # Errors
 ///
 /// Returns an [`std::io::Error`] if `stored` is not a valid gzip stream — a
-/// corrupt or truncated body, or a legacy uncompressed object whose first bytes
-/// are not the gzip magic. Decoding never silently returns partial or wrong data.
-pub fn decompress(stored: &[u8]) -> std::io::Result<Vec<u8>> {
-    let mut decoder = GzDecoder::new(stored);
+/// corrupt or truncated body, a CRC-32 or length mismatch, or a legacy
+/// uncompressed object whose first bytes are not the gzip magic. Decoding never
+/// silently returns partial or wrong data.
+pub fn decompress(stored: &[u8]) -> Result<Vec<u8>> {
+    let body = gzip_body(stored)?;
+
     let mut plain = Vec::new();
-    decoder.read_to_end(&mut plain)?;
+    INFLATE.with_borrow_mut(|inflate| {
+        SCRATCH.with_borrow_mut(|scratch| run_inflate(inflate, scratch, body, &mut plain))
+    })?;
+
+    verify_trailer(stored, &plain)?;
     Ok(plain)
+}
+
+/// Validates the fixed gzip header and returns the raw-DEFLATE body slice (the
+/// bytes between the header and the trailer).
+fn gzip_body(stored: &[u8]) -> Result<&[u8]> {
+    let Some(body_end) = stored.len().checked_sub(TRAILER_LEN) else {
+        return Err(Error::new(
+            ErrorKind::UnexpectedEof,
+            "stored object is too short to be a gzip member",
+        ));
+    };
+
+    // The header is matched byte-for-byte: magic, deflate method, then zero flags.
+    // The arms are ordered most-specific first so each failure names its cause.
+    match stored {
+        [0x1f, 0x8b, 0x08, 0x00, ..] => {}
+        [0x1f, 0x8b, 0x08, ..] => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "stored object sets unsupported gzip header flags",
+            ));
+        }
+        [0x1f, 0x8b, ..] => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "stored object uses an unsupported gzip compression method",
+            ));
+        }
+        _ => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "stored object is not gzip (bad magic); it may be a legacy uncompressed object",
+            ));
+        }
+    }
+
+    // A body that ends before the header does is a trailer-only fragment: the
+    // slice bounds reject it, so no separate length guard is needed.
+    stored.get(HEADER_LEN..body_end).ok_or_else(|| {
+        Error::new(
+            ErrorKind::UnexpectedEof,
+            "stored object is too short to be a gzip member",
+        )
+    })
+}
+
+/// Verifies the gzip trailer (CRC-32 then ISIZE) against the inflated plaintext.
+fn verify_trailer(stored: &[u8], plain: &[u8]) -> Result<()> {
+    let trailer_start = stored
+        .len()
+        .checked_sub(TRAILER_LEN)
+        .expect("decompress validated the stored length before inflating");
+    let trailer: [u8; TRAILER_LEN] = stored
+        .get(trailer_start..)
+        .and_then(|tail| <[u8; TRAILER_LEN]>::try_from(tail).ok())
+        .expect("the trailer is exactly eight bytes");
+    let [c0, c1, c2, c3, i0, i1, i2, i3] = trailer;
+    let expected_crc = u32::from_le_bytes([c0, c1, c2, c3]);
+    let expected_isize = u32::from_le_bytes([i0, i1, i2, i3]);
+
+    let mut crc = Crc::new();
+    crc.update(plain);
+    if crc.sum() != expected_crc {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "stored object failed its gzip CRC-32 check",
+        ));
+    }
+    if plaintext_isize(plain) != expected_isize {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "stored object length does not match its gzip ISIZE",
+        ));
+    }
+    Ok(())
+}
+
+/// The gzip ISIZE field: the plaintext length modulo 2³².
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "gzip ISIZE is defined as the input length modulo 2^32"
+)]
+fn plaintext_isize(plain: &[u8]) -> u32 {
+    plain.len() as u32
+}
+
+/// Drives the reusable compressor to raw-DEFLATE all of `input`, appending the
+/// compressed bytes to `out` (after whatever header `out` already holds).
+///
+/// Each pass fills `scratch` with the next slice of compressed output and copies
+/// it onto `out`; `out` therefore grows only by what was actually produced, and
+/// progress never depends on `out`'s spare capacity.
+fn run_deflate(deflate: &mut Compress, scratch: &mut [u8], input: &[u8], out: &mut Vec<u8>) {
+    deflate.reset();
+    loop {
+        let consumed = usize::try_from(deflate.total_in())
+            .expect("a compressed body shorter than usize::MAX was processed");
+        let remaining = input
+            .get(consumed..)
+            .expect("the deflate input cursor never passes the input end");
+        let produced_before = deflate.total_out();
+        let status = deflate
+            .compress(remaining, scratch, FlushCompress::Finish)
+            .expect("deflate into an in-memory buffer cannot fail");
+
+        let produced = usize::try_from(
+            deflate
+                .total_out()
+                .checked_sub(produced_before)
+                .expect("the output counter is monotonic"),
+        )
+        .expect("an output shorter than usize::MAX was produced");
+        out.extend_from_slice(
+            scratch
+                .get(..produced)
+                .expect("a pass never produces more than the scratch window holds"),
+        );
+
+        if matches!(status, Status::StreamEnd) {
+            break;
+        }
+    }
+}
+
+/// Drives the reusable decompressor to raw-INFLATE `body`, appending the
+/// plaintext to `out`.
+///
+/// # Errors
+///
+/// Returns an [`std::io::Error`] if the deflate stream ends before its final
+/// block — a truncated gzip body.
+fn run_inflate(
+    inflate: &mut Decompress,
+    scratch: &mut [u8],
+    body: &[u8],
+    out: &mut Vec<u8>,
+) -> Result<()> {
+    inflate.reset(false);
+    out.reserve(body.len().saturating_mul(4).max(64));
+    loop {
+        let consumed = usize::try_from(inflate.total_in())
+            .expect("a compressed body shorter than usize::MAX was processed");
+        let remaining = body
+            .get(consumed..)
+            .expect("the inflate input cursor never passes the body end");
+        let produced_before = inflate.total_out();
+        // The full body is available from the first call, so intermediate calls
+        // use `None`: the decoder reports `StreamEnd` from the deflate final-block
+        // marker regardless of flush mode, while `Finish` re-invoked across output
+        // grows would have the decoder reject the now-empty input tail.
+        let status = inflate
+            .decompress(remaining, scratch, FlushDecompress::None)
+            .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+
+        let produced = usize::try_from(
+            inflate
+                .total_out()
+                .checked_sub(produced_before)
+                .expect("the output counter is monotonic"),
+        )
+        .expect("an output shorter than usize::MAX was produced");
+        out.extend_from_slice(
+            scratch
+                .get(..produced)
+                .expect("a pass never produces more than the scratch window holds"),
+        );
+
+        if matches!(status, Status::StreamEnd) {
+            return Ok(());
+        }
+
+        // The stream did not end, yet a full output window went unwritten: with
+        // room to spare the decoder produced nothing, so it has run out of input
+        // before the deflate final block — the gzip body is truncated.
+        if produced == 0 {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "gzip body ended before the deflate stream was complete",
+            ));
+        }
+    }
 }
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    #![allow(
+        clippy::arithmetic_side_effects,
+        clippy::indexing_slicing,
+        reason = "panic is fine in tests"
+    )]
+
+    use std::io::{Read as _, Write as _};
+
+    use flate2::read::GzDecoder;
+    use flate2::write::GzEncoder;
+
     use super::*;
 
     /// A representative repetitive object body — the kind of JSON the storage
@@ -80,6 +342,25 @@ mod tests {
         }
         body.push_str("]}");
         body.into_bytes()
+    }
+
+    /// An incompressible payload: random-looking bytes that gzip cannot shrink,
+    /// so both the compress and decompress output buffers must grow past their
+    /// first guess — exercising the grow path in both coder loops.
+    fn incompressible() -> Vec<u8> {
+        incompressible_of(200_000)
+    }
+
+    /// `len` incompressible bytes from a simple LCG, which has no redundancy gzip
+    /// can exploit.
+    fn incompressible_of(len: usize) -> Vec<u8> {
+        let mut state = 0x1234_5678_u32;
+        std::iter::repeat_with(|| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            u8::try_from(state >> 24).expect("a byte-wide shift yields a single byte")
+        })
+        .take(len)
+        .collect()
     }
 
     #[test]
@@ -104,6 +385,26 @@ mod tests {
     }
 
     #[test]
+    fn roundtrips_incompressible_input_growing_both_buffers() {
+        let plain = incompressible();
+        let compressed = compress(&plain);
+        // gzip cannot shrink random data, so the compressed body grew past the
+        // initial `len / 3` guess; decompressing it grows the output buffer too.
+        let restored = decompress(&compressed).unwrap();
+        assert_eq!(restored, plain);
+    }
+
+    #[test]
+    fn reuses_thread_state_across_many_calls() {
+        // Repeated calls on one thread reuse the per-thread coders; each must
+        // still produce an independent, correct round-trip.
+        for seed in 0..50_u32 {
+            let plain: Vec<u8> = (0..1000).map(|i| (i ^ seed).to_le_bytes()[0]).collect();
+            assert_eq!(decompress(&compress(&plain)).unwrap(), plain);
+        }
+    }
+
+    #[test]
     fn is_deterministic() {
         let plain = sample_json();
         // Byte-identical output across calls is what makes a stress seed
@@ -118,6 +419,31 @@ mod tests {
             compressed.starts_with(&[0x1f, 0x8b]),
             "a stored body must carry the gzip magic so legacy plaintext is distinguishable"
         );
+    }
+
+    #[test]
+    fn output_is_standard_gzip_readable_by_a_stock_decoder() {
+        // A stock gzip decoder must inflate our output, proving the framing is
+        // standard and the Azure `Content-Encoding: gzip` promise holds.
+        let plain = sample_json();
+        let compressed = compress(&plain);
+        let mut decoder = GzDecoder::new(&compressed[..]);
+        let mut restored = Vec::new();
+        decoder.read_to_end(&mut restored).unwrap();
+        assert_eq!(restored, plain);
+    }
+
+    #[test]
+    fn decompresses_output_from_a_stock_encoder() {
+        // Conversely, we must read any standard gzip a stock encoder wrote, so
+        // objects stored by other gzip producers round-trip cleanly.
+        let plain = sample_json();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::new(GZIP_LEVEL));
+        encoder.write_all(&plain).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let restored = decompress(&compressed).unwrap();
+        assert_eq!(restored, plain);
     }
 
     #[test]
@@ -136,8 +462,45 @@ mod tests {
     fn decompress_rejects_plaintext_json() {
         // A legacy uncompressed object: its first byte is `{`, never the gzip
         // magic, so decoding fails loudly instead of returning the raw bytes.
-        let error = decompress(br#"{"schema":1}"#).unwrap_err();
+        let error = decompress(br#"{"schema":1,"results":[],"padding":"xxxxxxxxxx"}"#).unwrap_err();
         drop(error);
+    }
+
+    #[test]
+    fn decompress_rejects_unsupported_method_and_flags() {
+        // A well-formed magic but an unexpected compression method or header
+        // flags must be rejected, and each cause must be named distinctly so the
+        // most-specific match arm — not a later catch-all — reports it.
+        let mut bad_method = compress(&sample_json());
+        *bad_method.get_mut(2).expect("header byte present") = 0x07;
+        let error = decompress(&bad_method).unwrap_err();
+        assert!(
+            error.to_string().contains("compression method"),
+            "an unsupported method must be named as such: {error}"
+        );
+
+        let mut bad_flags = compress(&sample_json());
+        *bad_flags.get_mut(3).expect("header byte present") = 0x08;
+        let error = decompress(&bad_flags).unwrap_err();
+        assert!(
+            error.to_string().contains("flags"),
+            "unsupported header flags must be named as such: {error}"
+        );
+    }
+
+    #[test]
+    fn decompress_rejects_a_short_body_with_valid_magic() {
+        // A buffer that carries the gzip magic but is too short to hold a header
+        // and a trailer must fail, not slice out of bounds: the body would end
+        // before the header does.
+        let mut stored = GZIP_HEADER[..4].to_vec();
+        stored.extend_from_slice(&[0_u8; TRAILER_LEN]);
+        assert_eq!(stored.len(), 12, "magic plus a trailer, but no full header");
+        let error = decompress(&stored).unwrap_err();
+        assert!(
+            error.to_string().contains("too short"),
+            "a header-less body must be reported as too short: {error}"
+        );
     }
 
     #[test]
@@ -152,5 +515,65 @@ mod tests {
     fn decompress_rejects_empty_input() {
         let error = decompress(b"").unwrap_err();
         drop(error);
+    }
+
+    #[test]
+    fn decompress_rejects_corrupt_crc() {
+        let mut compressed = compress(&sample_json());
+        // Flip a bit in the CRC-32 word (first of the eight trailer bytes).
+        let crc_index = compressed.len() - TRAILER_LEN;
+        *compressed.get_mut(crc_index).expect("trailer byte present") ^= 0xff;
+        decompress(&compressed).unwrap_err();
+    }
+
+    #[test]
+    fn decompress_rejects_corrupt_length() {
+        let mut compressed = compress(&sample_json());
+        // Flip a bit in the ISIZE word (first of the final four bytes).
+        let isize_index = compressed.len() - 4;
+        *compressed
+            .get_mut(isize_index)
+            .expect("trailer byte present") ^= 0xff;
+        decompress(&compressed).unwrap_err();
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "multi-megabyte round trips are far too slow under Miri"
+    )]
+    fn roundtrips_a_large_compressible_payload_growing_inflate_many_times() {
+        // A highly compressible payload deflates to a tiny body, so inflating it
+        // grows the output buffer many times over — each growth re-reads the
+        // decoder's input cursor, so the cursor must advance correctly every pass.
+        let plain = vec![b'A'; 2_000_000];
+        let compressed = compress(&plain);
+        assert!(
+            compressed.len().saturating_mul(100) < plain.len(),
+            "a run of one byte must compress drastically: {} -> {}",
+            plain.len(),
+            compressed.len()
+        );
+        assert_eq!(decompress(&compressed).unwrap(), plain);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "multi-megabyte round trips are far too slow under Miri"
+    )]
+    fn compress_expands_incompressible_data_forcing_a_deflate_regrow() {
+        // Already-compressed bytes cannot be shrunk, so deflating them produces
+        // *more* output than the up-front capacity guess — forcing the compress
+        // loop to grow its buffer mid-stream — yet must still round-trip exactly.
+        let incompressible = compress(&incompressible_of(1_000_000));
+        let compressed = compress(&incompressible);
+        assert!(
+            compressed.len() > incompressible.len(),
+            "re-compressing gzip output must expand it: {} -> {}",
+            incompressible.len(),
+            compressed.len()
+        );
+        assert_eq!(decompress(&compressed).unwrap(), incompressible);
     }
 }

--- a/packages/cargo-bench-history-core/src/codec.rs
+++ b/packages/cargo-bench-history-core/src/codec.rs
@@ -271,7 +271,10 @@ fn run_inflate(
     out: &mut Vec<u8>,
 ) -> Result<()> {
     inflate.reset(false);
-    out.reserve(body.len().saturating_mul(4).max(64));
+    // The deflate body is a lower bound on the plaintext, so it sizes the output
+    // conservatively: incompressible data lands without an over-reservation while
+    // genuinely compressible data grows the buffer the few extra times it needs.
+    out.reserve(body.len().max(64));
     loop {
         let consumed = usize::try_from(inflate.total_in())
             .expect("a compressed body shorter than usize::MAX was processed");

--- a/packages/cargo-bench-history-stress/Cargo.toml
+++ b/packages/cargo-bench-history-stress/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+all_the_time = { workspace = true }
 cargo-bench-history = { path = "../cargo-bench-history", default-features = false }
 cargo-bench-history-core = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -6,9 +6,12 @@
 //! seeded triples and the `synthetic` machine key never match the host the harness
 //! runs on; without that every object would be filtered out.
 
+use std::num::NonZero;
 use std::path::{Path, PathBuf};
+use std::thread;
 use std::time::{Duration, Instant};
 
+use all_the_time::Session;
 use cargo_bench_history::{AnalyzeOptions, Command, Overrides, RunOutcome, run_with_overrides};
 use jiff::Timestamp;
 use serde::Deserialize;
@@ -29,6 +32,13 @@ pub(crate) struct MeasureResult {
     pub(crate) mode: ModeArg,
     /// The fastest observed wall-clock time across the repeats.
     pub(crate) duration: Duration,
+    /// Process CPU time (summed across every analysis thread) consumed by the
+    /// fastest run — the work the wall time above paid for.
+    pub(crate) processor_time: Duration,
+    /// Fraction of the available cores the fastest run kept busy
+    /// (`processor_time / (duration * cores)`). 1.0 means every core was
+    /// saturated for the whole analysis; lower means cores sat idle.
+    pub(crate) cpu_efficiency: f64,
     /// Stored objects loaded into the analysis.
     pub(crate) runs: usize,
     /// Distinct series compared.
@@ -80,41 +90,100 @@ pub(crate) async fn measure(
     ));
 
     let command = Command::Analyze(options);
-    let mut fastest: Option<Duration> = None;
+
+    // Capture process CPU time (across all analysis threads) over the exact
+    // interval the wall clock times, so we can report how well the analysis
+    // saturates the cores it asked for. A fresh in-process session per attempt
+    // (no stdout table, no JSON file) holds exactly that attempt's one span; the
+    // harness renders the result itself and the tests stay free of target files.
+    let cores = thread::available_parallelism().map_or(1, NonZero::get);
+
+    let mut best: Option<(Duration, Duration)> = None;
     let mut counts: Option<ReportCounts> = None;
     for attempt in 0..repeat.max(1) {
+        let session = Session::new().no_stdout().no_file();
+        let operation = session.operation(format!("analyze-{}", mode.keyword()));
+
         let started = Instant::now();
+        let span = operation.measure_process();
         let outcome = run_with_overrides(&command, overrides(workspace, anchor))
             .await
             .map_err(|error| fail(format!("{} analysis failed: {error}", mode.keyword())))?;
+        drop(span);
         let elapsed = started.elapsed();
+        let attempt_cpu = recorded_cpu(&session);
         let RunOutcome::Analyzed { report, .. } = outcome else {
             return Err(fail("analyze did not return an Analyzed outcome"));
         };
         let parsed: ReportCounts = serde_json::from_str(&report)
             .map_err(|error| fail(format!("failed to parse the analyze report: {error}")))?;
+
         logger.detail(&format!(
-            "attempt {} took {:.3}s ({} objects, {} series)",
+            "attempt {} took {:.3}s wall / {:.3}s CPU = {:.0}% of {cores} cores ({} objects, \
+             {} series)",
             attempt.saturating_add(1),
             elapsed.as_secs_f64(),
+            attempt_cpu.as_secs_f64(),
+            cpu_efficiency(attempt_cpu, elapsed, cores) * 100.0,
             parsed.runs,
             parsed.series,
         ));
-        fastest = Some(fastest.map_or(elapsed, |best| best.min(elapsed)));
+        best = Some(keep_fastest(best, (elapsed, attempt_cpu)));
         counts = Some(parsed);
     }
 
-    let duration = fastest.ok_or_else(|| fail("no analysis attempts ran"))?;
+    let (duration, processor_time) = best.ok_or_else(|| fail("no analysis attempts ran"))?;
     let counts = counts.ok_or_else(|| fail("no analysis attempts ran"))?;
     Ok(MeasureResult {
         mode,
         duration,
+        processor_time,
+        cpu_efficiency: cpu_efficiency(processor_time, duration, cores),
         runs: counts.runs,
         series: counts.series,
         regressions: counts.regressions,
         improvements: counts.improvements,
         notable: counts.notable,
     })
+}
+
+/// The process CPU time recorded by the single span held in `session`, or zero
+/// if the session recorded nothing.
+fn recorded_cpu(session: &Session) -> Duration {
+    session
+        .to_report()
+        .operations()
+        .next()
+        .map_or(Duration::ZERO, |(_, op)| op.total_processor_time())
+}
+
+/// Keeps whichever attempt ran in less wall time, carrying its paired CPU time;
+/// ties keep the incumbent. This is what makes the report show the fastest run.
+fn keep_fastest(
+    best: Option<(Duration, Duration)>,
+    candidate: (Duration, Duration),
+) -> (Duration, Duration) {
+    match best {
+        Some(best) if best.0 <= candidate.0 => best,
+        _ => candidate,
+    }
+}
+
+/// The fraction of the available cores the analysis kept busy: process CPU time
+/// over the wall time times the core count. 1.0 means every core was saturated
+/// for the whole run; values above 1.0 are impossible barring clock skew and are
+/// clamped away by a zero or sub-zero ideal collapsing to 0.0.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "core counts and sub-hour durations are far below 2^53"
+)]
+fn cpu_efficiency(processor_time: Duration, wall: Duration, cores: usize) -> f64 {
+    let ideal = wall.as_secs_f64() * cores as f64;
+    if ideal <= 0.0 {
+        0.0
+    } else {
+        processor_time.as_secs_f64() / ideal
+    }
 }
 
 /// Builds the analyze options for `mode`.
@@ -191,5 +260,66 @@ mod tests {
             "{}",
             path.display()
         );
+    }
+
+    #[test]
+    fn cpu_efficiency_is_cpu_over_wall_times_cores() {
+        // Four cores busy for the whole second == full saturation.
+        let full = cpu_efficiency(Duration::from_secs(4), Duration::from_secs(1), 4);
+        assert!((full - 1.0).abs() < 1e-9, "{full}");
+
+        // Only one of four cores busy == a quarter of the ideal.
+        let quarter = cpu_efficiency(Duration::from_secs(1), Duration::from_secs(1), 4);
+        assert!((quarter - 0.25).abs() < 1e-9, "{quarter}");
+    }
+
+    #[test]
+    fn cpu_efficiency_is_zero_when_there_is_no_wall_time() {
+        // A zero-length (or zero-core) interval has no ideal to divide by, so the
+        // ratio collapses to zero rather than dividing by zero.
+        assert!(cpu_efficiency(Duration::from_secs(1), Duration::ZERO, 4).abs() < 1e-12);
+        assert!(cpu_efficiency(Duration::from_secs(1), Duration::from_secs(1), 0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn keep_fastest_takes_the_smaller_wall_and_carries_its_cpu() {
+        let slow = (Duration::from_secs(5), Duration::from_secs(9));
+        let fast = (Duration::from_secs(3), Duration::from_secs(7));
+
+        // The first attempt is always kept.
+        assert_eq!(keep_fastest(None, slow), slow);
+        // A faster candidate replaces the incumbent, bringing its own CPU time.
+        assert_eq!(keep_fastest(Some(slow), fast), fast);
+        // A slower candidate leaves the incumbent (and its CPU) in place.
+        assert_eq!(keep_fastest(Some(fast), slow), fast);
+        // A tie keeps the incumbent rather than swapping to the newcomer.
+        let tie = (Duration::from_secs(3), Duration::from_secs(1));
+        assert_eq!(keep_fastest(Some(fast), tie), fast);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "all_the_time process timing uses syscalls unsupported under Miri"
+    )]
+    fn recorded_cpu_reflects_a_measured_span() {
+        // A session that recorded nothing has no CPU time to report.
+        let empty = Session::new().no_stdout().no_file();
+        assert_eq!(recorded_cpu(&empty), Duration::ZERO);
+
+        // A span around a CPU burn records a non-zero process time, which is what
+        // the harness pairs with the wall clock to compute efficiency.
+        let session = Session::new().no_stdout().no_file();
+        let operation = session.operation("analyze-history");
+        {
+            let span = operation.measure_process();
+            let mut acc = 0_u64;
+            for value in 0..50_000_000_u64 {
+                acc = acc.wrapping_add(value);
+            }
+            assert_ne!(acc, 0, "the burn must not be optimized away");
+            drop(span);
+        }
+        assert!(recorded_cpu(&session) > Duration::ZERO);
     }
 }

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -170,9 +170,12 @@ fn keep_fastest(
 }
 
 /// The fraction of the available cores the analysis kept busy: process CPU time
-/// over the wall time times the core count. 1.0 means every core was saturated
-/// for the whole run; values above 1.0 are impossible barring clock skew and are
-/// clamped away by a zero or sub-zero ideal collapsing to 0.0.
+/// over the wall time times the core count, clamped to `0.0..=1.0`. 1.0 means
+/// every core was saturated for the whole run; a zero or sub-zero ideal (an
+/// unmeasurably short or zero-core interval) yields 0.0. Measurement skew that
+/// would nudge the raw ratio just past full saturation is clamped back, so the
+/// value always honours the `0.0..=1.0` contract the report renders as a
+/// percentage.
 #[expect(
     clippy::cast_precision_loss,
     reason = "core counts and sub-hour durations are far below 2^53"
@@ -182,7 +185,7 @@ fn cpu_efficiency(processor_time: Duration, wall: Duration, cores: usize) -> f64
     if ideal <= 0.0 {
         0.0
     } else {
-        processor_time.as_secs_f64() / ideal
+        (processor_time.as_secs_f64() / ideal).min(1.0)
     }
 }
 
@@ -271,6 +274,15 @@ mod tests {
         // Only one of four cores busy == a quarter of the ideal.
         let quarter = cpu_efficiency(Duration::from_secs(1), Duration::from_secs(1), 4);
         assert!((quarter - 0.25).abs() < 1e-9, "{quarter}");
+    }
+
+    #[test]
+    fn cpu_efficiency_clamps_above_full_saturation() {
+        // Measurement skew can report more CPU time than the wall-times-cores
+        // ideal; the fraction is clamped to full saturation so it never breaches
+        // the `0.0..=1.0` contract the report renders as a percentage.
+        let over = cpu_efficiency(Duration::from_secs(5), Duration::from_secs(1), 4);
+        assert!((over - 1.0).abs() < 1e-9, "{over}");
     }
 
     #[test]

--- a/packages/cargo-bench-history-stress/src/report.rs
+++ b/packages/cargo-bench-history-stress/src/report.rs
@@ -57,18 +57,36 @@ pub(crate) fn print(
     println!();
 
     println!(
-        "{:<9} {:>10} {:>9} {:>8} {:>12} {:>13} {:>8}",
-        "mode", "duration", "objects", "series", "regressions", "improvements", "notable"
+        "{:<9} {:>10} {:>10} {:>6} {:>9} {:>8} {:>12} {:>13} {:>8}",
+        "mode",
+        "duration",
+        "cpu",
+        "cpu%",
+        "objects",
+        "series",
+        "regressions",
+        "improvements",
+        "notable"
     );
     println!(
-        "{:<9} {:>10} {:>9} {:>8} {:>12} {:>13} {:>8}",
-        "----", "--------", "-------", "------", "-----------", "------------", "-------"
+        "{:<9} {:>10} {:>10} {:>6} {:>9} {:>8} {:>12} {:>13} {:>8}",
+        "----",
+        "--------",
+        "----------",
+        "----",
+        "-------",
+        "------",
+        "-----------",
+        "------------",
+        "-------"
     );
     for result in results {
         println!(
-            "{:<9} {:>10} {:>9} {:>8} {:>12} {:>13} {:>8}",
+            "{:<9} {:>10} {:>10} {:>6} {:>9} {:>8} {:>12} {:>13} {:>8}",
             result.mode.keyword(),
             seconds(result.duration),
+            seconds(result.processor_time),
+            percent(result.cpu_efficiency),
             result.runs,
             result.series,
             result.regressions,
@@ -82,6 +100,11 @@ pub(crate) fn print(
 /// Formats a duration as seconds with millisecond precision.
 fn seconds(duration: Duration) -> String {
     format!("{:.3}s", duration.as_secs_f64())
+}
+
+/// Formats a `0.0..=1.0` ratio as a whole-number percentage.
+fn percent(ratio: f64) -> String {
+    format!("{:.0}%", ratio * 100.0)
 }
 
 /// Formats a byte count in binary units (KiB, MiB, ...).
@@ -122,5 +145,12 @@ mod tests {
     fn seconds_renders_millisecond_precision() {
         assert_eq!(seconds(Duration::from_millis(1500)), "1.500s");
         assert_eq!(seconds(Duration::from_secs(0)), "0.000s");
+    }
+
+    #[test]
+    fn percent_renders_a_whole_number_percentage() {
+        assert_eq!(percent(0.0), "0%");
+        assert_eq!(percent(0.25), "25%");
+        assert_eq!(percent(1.0), "100%");
     }
 }

--- a/packages/cargo-bench-history-stress/tests/stress_smoke.rs
+++ b/packages/cargo-bench-history-stress/tests/stress_smoke.rs
@@ -36,17 +36,18 @@ fn run_stress(extra: &[&str]) -> Output {
         .expect("the stress binary should be runnable")
 }
 
-/// Extracts the per-mode report rows, keyed by mode, with the timing column dropped
-/// so the deterministic columns (objects, series, regressions, improvements,
-/// notable) can be compared across runs.
+/// Extracts the per-mode report rows, keyed by mode, with the non-deterministic
+/// timing columns (duration, cpu, cpu%) dropped so the deterministic columns
+/// (objects, series, regressions, improvements, notable) can be compared across
+/// runs.
 fn deterministic_columns(stdout: &str) -> BTreeMap<String, Vec<String>> {
     stdout
         .lines()
         .filter_map(|line| {
             let columns: Vec<&str> = line.split_whitespace().collect();
-            if columns.len() == 7 && ["history", "branch", "tip"].contains(&columns[0]) {
-                // Skip column 1 (duration); keep the rest.
-                let kept = columns[2..].iter().map(|c| (*c).to_owned()).collect();
+            if columns.len() == 9 && ["history", "branch", "tip"].contains(&columns[0]) {
+                // Skip columns 1-3 (duration, cpu, cpu%); keep the rest.
+                let kept = columns[4..].iter().map(|c| (*c).to_owned()).collect();
                 Some((columns[0].to_owned(), kept))
             } else {
                 None

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -12,7 +12,7 @@
 //! `list discriminants` lists the distinct discriminant sets present in storage
 //! and, like that listing, needs no repository.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use serde::Serialize;
@@ -28,10 +28,10 @@ use crate::{ListOptions, ListSubject, RunError, RunOutcome};
 use jiff::Timestamp;
 
 use super::{
-    AutoFacets, SelectedDataSet, Selection, detect_auto_facets, dirty_base_exception_warning,
-    empty_history_hint, facet_filtered_candidates, parse_format, resolve_facets, select_dataset,
+    AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
+    facet_filtered_candidates, parse_format, resolve_facets, select_dataset,
 };
-use super::{LoadedObject, ReportFormat, Series, SeriesFilter, apply_blessings, build_series};
+use super::{ReportFormat, RunIndex, Series, SeriesFilter, apply_blessings};
 use crate::model::BlessingRecord;
 use crate::model::DiscriminantSet;
 
@@ -134,20 +134,20 @@ where
             Ok(RunOutcome::Completed { message })
         }
         ListSubject::Runs => {
+            let filter = SeriesFilter::default();
             let dataset = select_dataset(
-                git, storage, project_id, config, &selection, auto, now, reporter,
+                git, storage, project_id, config, &selection, filter, auto, now, reporter,
             )
             .await?;
-            let filter = SeriesFilter::default();
-            let series = build_series(&dataset.loaded, &dataset.order, &filter);
-            let listing = build_listing(project_id, &dataset, &series);
+            let series = dataset.series;
+            let listing = build_listing(project_id, &dataset.run_index, &series);
 
             // The same self-explaining diagnostics `analyze` shows: a hint when
             // stored runs matched the facets but none entered the selection, and a
             // warning when a dirty base-branch-tip run was admitted because the
             // working tree is dirty.
             let hint = empty_history_hint(
-                dataset.loaded.is_empty(),
+                dataset.run_index.is_empty(),
                 dataset.candidate_count,
                 &dataset.target_ref,
                 dataset.tally,
@@ -203,53 +203,30 @@ struct Listing {
 
 /// Groups the selected runs by discriminant set and counts each set's runs,
 /// series, and per-commit breakdown (ordered by first-parent topology).
-fn build_listing(project_id: &str, dataset: &SelectedDataSet, series: &[Series]) -> Listing {
-    let mut sets: Vec<DiscriminantSet> = dataset
-        .loaded
-        .iter()
-        .map(|object| object.key.set.clone())
-        .collect();
-    sets.sort();
-    sets.dedup();
-
-    let set_listings: Vec<SetListing> = sets
-        .iter()
-        .map(|set| {
-            let objects: Vec<&LoadedObject> = dataset
-                .loaded
-                .iter()
-                .filter(|object| &object.key.set == set)
-                .collect();
+fn build_listing(project_id: &str, run_index: &RunIndex, series: &[Series]) -> Listing {
+    let set_listings: Vec<SetListing> = run_index
+        .sets()
+        .map(|(set, by_commit)| {
             let series_count = series.iter().filter(|one| &one.set == set).count();
 
-            // Key by first-parent position so commits read oldest-first, matching
-            // the order their series points are compared in.
-            let mut by_commit: BTreeMap<usize, CommitEntry> = BTreeMap::new();
-            for object in &objects {
-                let index = dataset
-                    .order
-                    .get(&object.key.commit)
-                    .copied()
-                    .unwrap_or(usize::MAX);
-                let entry = by_commit.entry(index).or_insert_with(|| CommitEntry {
-                    commit: object.key.commit.clone(),
-                    runs: 0,
-                    clean: 0,
-                    dirty: 0,
-                });
-                entry.runs = entry.runs.saturating_add(1);
-                if object.key.is_dirty() {
-                    entry.dirty = entry.dirty.saturating_add(1);
-                } else {
-                    entry.clean = entry.clean.saturating_add(1);
-                }
-            }
+            // `by_commit` is keyed by first-parent position, so iterating it yields
+            // commits oldest-first, matching the order their series points compare.
+            let commits: Vec<CommitEntry> = by_commit
+                .values()
+                .map(|counts| CommitEntry {
+                    commit: counts.commit.clone(),
+                    runs: counts.clean.saturating_add(counts.dirty),
+                    clean: counts.clean,
+                    dirty: counts.dirty,
+                })
+                .collect();
+            let runs = commits.iter().map(|entry| entry.runs).sum();
 
             SetListing {
                 set: set.clone(),
-                runs: objects.len(),
+                runs,
                 series: series_count,
-                commits: by_commit.into_values().collect(),
+                commits,
             }
         })
         .collect();
@@ -257,7 +234,7 @@ fn build_listing(project_id: &str, dataset: &SelectedDataSet, series: &[Series])
     Listing {
         project: project_id.to_owned(),
         sets: set_listings,
-        total_runs: dataset.loaded.len(),
+        total_runs: run_index.total(),
         total_series: series.len(),
     }
 }
@@ -638,12 +615,12 @@ where
     G: GitHistory,
     S: Storage,
 {
+    let filter = SeriesFilter::default();
     let dataset = select_dataset(
-        git, storage, project_id, config, selection, auto, now, reporter,
+        git, storage, project_id, config, selection, filter, auto, now, reporter,
     )
     .await?;
-    let filter = SeriesFilter::default();
-    let mut series = build_series(&dataset.loaded, &dataset.order, &filter);
+    let mut series = dataset.series;
     apply_blessings(&mut series, &dataset.blessings);
 
     // A benchmark's metrics each form their own series but share a blessing, so the

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -18,11 +18,11 @@ pub(crate) mod prune;
 
 pub(crate) use cargo_bench_history_core::analyze::{
     AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DiscriminantSetQuery,
-    FacetFilter, LoadedObject, ReportFormat, ReportInput, Series, SeriesFilter, SetSummary,
-    StorageKey, apply_blessings, build_series, find_changes, parse_key, render, select_commits,
+    FacetFilter, ReportFormat, ReportInput, Series, SeriesBuilder, SeriesFilter, SetSummary,
+    StorageKey, apply_blessings, find_changes, parse_key, render, select_commits,
 };
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::IsTerminal;
 use std::path::Path;
 
@@ -143,15 +143,15 @@ where
 {
     let format = parse_format(options.format.as_deref())?;
     let selection = Selection::from_analyze(options)?;
-    let dataset = select_dataset(
-        git, storage, project_id, config, &selection, auto, now, reporter,
-    )
-    .await?;
-
     let filter = SeriesFilter {
         prefixes: &options.prefixes,
     };
-    let mut series = build_series(&dataset.loaded, &dataset.order, &filter);
+    let dataset = select_dataset(
+        git, storage, project_id, config, &selection, filter, auto, now, reporter,
+    )
+    .await?;
+
+    let mut series = dataset.series;
     // Re-baseline blessed series before detection (history mode only; branch and
     // tip modes carry an empty blessing map).
     apply_blessings(&mut series, &dataset.blessings);
@@ -177,11 +177,7 @@ where
         .iter()
         .map(|set| SetSummary {
             set,
-            runs: dataset
-                .loaded
-                .iter()
-                .filter(|object| &object.key.set == set)
-                .count(),
+            runs: dataset.run_index.runs_in_set(set),
             series: series.iter().filter(|one| &one.set == set).count(),
             findings: findings
                 .iter()
@@ -194,7 +190,7 @@ where
     // otherwise indistinguishable from "no data". Explain the dominant reasons so
     // the user can act without resorting to `--verbose`.
     let hint = empty_history_hint(
-        dataset.loaded.is_empty(),
+        dataset.run_index.is_empty(),
         dataset.candidate_count,
         &dataset.target_ref,
         dataset.tally,
@@ -211,7 +207,7 @@ where
         project: project_id,
         mode: dataset.mode.as_str(),
         notable,
-        runs: dataset.loaded.len(),
+        runs: dataset.run_index.total(),
         series: series.len(),
         findings: &findings,
         sets: &summaries,
@@ -346,13 +342,98 @@ pub(crate) struct AutoFacets {
     pub(crate) machine_key: String,
 }
 
-/// The objects an analysis (or listing) draws on, plus the bookkeeping needed to
+/// One commit's run tally within a discriminant set, the granularity the report
+/// summaries and the `list runs` breakdown need.
+#[derive(Clone, Debug)]
+pub(crate) struct CommitCounts {
+    /// The commit the runs were measured against (full SHA, or a label in tests).
+    pub(crate) commit: String,
+    /// Clean (committed-tree) runs recorded on the commit.
+    pub(crate) clean: usize,
+    /// Dirty (uncommitted-tree) snapshots recorded on the commit.
+    pub(crate) dirty: usize,
+}
+
+/// Compact per-set, per-commit run tallies kept *in place of* a retained copy of
+/// every loaded object.
+///
+/// A long history holds tens of thousands of run objects, each carrying every
+/// benchmark; keeping them all resident alongside the reconstructed series is what
+/// drove analysis into tens of gigabytes. The analysis only needs the series plus
+/// these aggregate counts (total runs, per-set runs, and the per-commit breakdown
+/// the listing renders), so each parsed run is folded into the series and dropped,
+/// updating this index as it goes.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RunIndex {
+    total: usize,
+    sets: BTreeMap<DiscriminantSet, BTreeMap<usize, CommitCounts>>,
+}
+
+impl RunIndex {
+    /// An empty index.
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records one run on `commit` (first-parent position `topo_index`) in `set`.
+    fn record(&mut self, set: &DiscriminantSet, topo_index: usize, commit: &str, dirty: bool) {
+        self.total = self.total.saturating_add(1);
+        let entry = self
+            .sets
+            .entry(set.clone())
+            .or_default()
+            .entry(topo_index)
+            .or_insert_with(|| CommitCounts {
+                commit: commit.to_owned(),
+                clean: 0,
+                dirty: 0,
+            });
+        if dirty {
+            entry.dirty = entry.dirty.saturating_add(1);
+        } else {
+            entry.clean = entry.clean.saturating_add(1);
+        }
+    }
+
+    /// Total runs admitted across every set.
+    pub(crate) fn total(&self) -> usize {
+        self.total
+    }
+
+    /// Whether no run entered the selection.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.total == 0
+    }
+
+    /// Runs admitted in `set`.
+    pub(crate) fn runs_in_set(&self, set: &DiscriminantSet) -> usize {
+        self.sets.get(set).map_or(0, |by_commit| {
+            by_commit
+                .values()
+                .map(|counts| counts.clean.saturating_add(counts.dirty))
+                .sum()
+        })
+    }
+
+    /// Each set with at least one run, paired with its per-commit tallies in
+    /// first-parent topological order (oldest first).
+    pub(crate) fn sets(
+        &self,
+    ) -> impl Iterator<Item = (&DiscriminantSet, &BTreeMap<usize, CommitCounts>)> {
+        self.sets.iter()
+    }
+}
+
+/// The data an analysis (or listing) draws on, plus the bookkeeping needed to
 /// explain an empty outcome and warn about ephemeral data.
 struct SelectedDataSet {
-    /// The in-selection objects, loaded and parsed, in storage-key order.
-    loaded: Vec<LoadedObject>,
-    /// First-parent position of each selected commit, for series ordering.
-    order: HashMap<String, usize>,
+    /// The reconstructed series for the in-window runs, built with the caller's
+    /// series filter and ordered by git topology. Pre-blessing: the caller applies
+    /// blessings (history mode) or leaves them unapplied (branch/tip, listings).
+    series: Vec<Series>,
+    /// Compact per-set, per-commit run tallies, standing in for a retained copy of
+    /// every loaded object (which a large history cannot afford to keep resident).
+    run_index: RunIndex,
     /// How many facet-matching candidates existed before topology filtering.
     candidate_count: usize,
     /// Why candidates were excluded, for the empty-history hint.
@@ -530,6 +611,26 @@ where
     Ok((key, parsed, value))
 }
 
+/// Like [`fetch_one`], but carries an arbitrary `rank` through the out-of-order
+/// fetch so the caller can recover each object's position (its storage-key
+/// ordinal). Kept as a named `async fn` for the same reason as [`fetch_one`]: the
+/// stream closure then stays a plain `FnMut` returning this future rather than one
+/// wrapping an `async` block.
+async fn fetch_one_ranked<S, F>(
+    storage: &S,
+    rank: usize,
+    key: String,
+    parsed: StorageKey,
+    parse: &F,
+) -> Result<(usize, String, StorageKey, Run), RunError>
+where
+    S: Storage,
+    F: Fn(&str, Vec<u8>) -> Result<Run, RunError>,
+{
+    let (key, parsed, run) = fetch_one(storage, key, parsed, parse).await?;
+    Ok((rank, key, parsed, run))
+}
+
 /// Resolves the git topology, selects the comparable commits, and loads the
 /// in-selection objects into a [`SelectedDataSet`]. Requires a repository: the
 /// timeline is reconstructed from git history, not from stored timestamps.
@@ -543,6 +644,7 @@ async fn select_dataset<G, S>(
     project_id: &str,
     config: &Config,
     selection: &Selection<'_>,
+    filter: SeriesFilter<'_>,
     auto: &AutoFacets,
     now: Timestamp,
     reporter: &dyn Reporter,
@@ -708,34 +810,62 @@ where
         to_fetch.push((key, parsed));
     }
 
-    // Phase 2 — fetch and deserialize the survivors concurrently, then restore a
-    // deterministic (storage-key) order, since `buffer_unordered` completes out of
-    // order.
-    let mut fetched = load_objects_concurrently(storage, to_fetch, |key, bytes| {
-        let text = String::from_utf8(bytes).map_err(|error| RunError::Analyze {
-            message: format!("stored object {key} is not valid UTF-8: {error}"),
-        })?;
-        Run::from_json(&text).map_err(|error| RunError::Analyze {
-            message: format!("stored object {key} is not a valid result set: {error}"),
-        })
-    })
-    .await?;
-    fetched.sort_by(|left, right| left.0.cmp(&right.0));
+    // Phase 2/3 — fetch the survivors concurrently and fold each into the series as
+    // it arrives, dropping the parsed run immediately so the whole parsed data set
+    // is never resident at once (the peak that drove analysis into tens of
+    // gigabytes). Each object's ordinal — the final point tie-break — is its rank
+    // in storage-key order, assigned up front because `buffer_unordered` completes
+    // out of order. The per-object verbose notes and the run tally are collected
+    // during the fold and emitted in storage-key order afterwards, so the
+    // diagnostics stay byte-identical to a deterministic in-order pass.
+    to_fetch.sort_by(|left, right| left.0.cmp(&right.0));
 
-    // Phase 3 — admit each fetched object, in storage-key order so the verbose
-    // diagnostics and the loaded order stay deterministic. Every exclusion already
-    // happened in phase 1 (history membership, base-side dirty admission, and the
-    // `--since`/`--until` window), so a fetched object only needs its
-    // dirty-base-exception flag inspected for the ephemeral-data warning.
-    let mut loaded: Vec<LoadedObject> = Vec::new();
-    for (key, parsed, result) in fetched {
-        if parsed.is_dirty()
-            && dirty_base_exception
-                .get(parsed.commit.as_str())
+    let mut builder = SeriesBuilder::new(filter);
+    let mut run_index = RunIndex::new();
+    // (storage key, admitted-by-dirty-base-exception) per folded object, for the
+    // key-ordered verbose notes emitted once the fold completes.
+    let mut admitted: Vec<(String, bool)> = Vec::new();
+    {
+        let parse = |key: &str, bytes: Vec<u8>| -> Result<Run, RunError> {
+            let text = String::from_utf8(bytes).map_err(|error| RunError::Analyze {
+                message: format!("stored object {key} is not valid UTF-8: {error}"),
+            })?;
+            Run::from_json(&text).map_err(|error| RunError::Analyze {
+                message: format!("stored object {key} is not a valid result set: {error}"),
+            })
+        };
+        let parse = &parse;
+        let mut fetches = futures::stream::iter(to_fetch.into_iter().enumerate())
+            .map(move |(rank, (key, parsed))| fetch_one_ranked(storage, rank, key, parsed, parse))
+            .buffer_unordered(LOAD_CONCURRENCY);
+
+        while let Some(fetched) = fetches.next().await {
+            let (rank, key, parsed, run) = fetched?;
+            let topo_index = order
+                .get(&parsed.commit)
                 .copied()
-                .unwrap_or(false)
-        {
-            included_dirty_base_exception = true;
+                .expect("phase 1 admitted only commits on the analyzed history");
+            let dirty = parsed.is_dirty();
+            let is_exception = dirty
+                && dirty_base_exception
+                    .get(parsed.commit.as_str())
+                    .copied()
+                    .unwrap_or(false);
+            if is_exception {
+                included_dirty_base_exception = true;
+            }
+            run_index.record(&parsed.set, topo_index, &parsed.commit, dirty);
+            builder.push(&parsed.set, topo_index, dirty, ordinal_of(rank), &run);
+            admitted.push((key, is_exception));
+            // `run` is dropped here; only the extracted (compact) points are kept.
+        }
+    }
+
+    // Emit the per-object verbose notes in storage-key order — the deterministic
+    // order objects were previously admitted in — then the summary.
+    admitted.sort_by(|left, right| left.0.cmp(&right.0));
+    for (key, is_exception) in &admitted {
+        if *is_exception {
             reporter.note_with(|| {
                 format!(
                     "including {key}: dirty snapshot on the base-branch tip, admitted \
@@ -745,17 +875,13 @@ where
         } else {
             reporter.note_with(|| format!("including {key}"));
         }
-        loaded.push(LoadedObject {
-            key: parsed,
-            object_key: key,
-            result,
-        });
     }
+    let series = builder.finish();
     reporter.note(&format!(
         "{} entered the analysis ({excluded_outside_history} outside history, \
          {excluded_dirty_base} dirty-on-base, {excluded_since} before --since, \
          {excluded_until} after --until)",
-        count_noun(loaded.len(), "object")
+        count_noun(run_index.total(), "object")
     ));
 
     // Load the blessing sidecars on in-window commits into a per-set map. A
@@ -816,8 +942,8 @@ where
     }
 
     Ok(SelectedDataSet {
-        loaded,
-        order,
+        series,
+        run_index,
         candidate_count,
         tally: ExclusionTally {
             outside_history: excluded_outside_history,
@@ -831,6 +957,19 @@ where
         merge_base_index,
         blessings,
     })
+}
+
+/// Narrows a storage-key rank to the series point ordinal width.
+///
+/// The ordinal is a pure tie-break, so the (practically impossible) overflow past
+/// `u32::MAX` distinct in-window objects merely lets the last ordinals collide —
+/// the affected points then keep their stable fold order rather than panicking.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "saturating: ordinals only tie-break, and >4 billion in-window objects never occur"
+)]
+fn ordinal_of(rank: usize) -> u32 {
+    rank.min(u32::MAX as usize) as u32
 }
 
 /// Auto-detects the analysis mode from the resolved topology and recorded data.
@@ -3062,5 +3201,46 @@ mod tests {
     fn since_rejects_garbage() {
         let error = parse_since(Some("not-a-date")).unwrap_err();
         assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
+    }
+
+    #[test]
+    fn run_index_counts_runs_and_reports_emptiness() {
+        let set = DiscriminantSet {
+            engine: "criterion".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        };
+        let mut index = RunIndex::new();
+        assert!(index.is_empty(), "a fresh index admits no runs");
+        assert_eq!(index.total(), 0);
+        assert_eq!(index.runs_in_set(&set), 0);
+
+        index.record(&set, 0, "c0", false);
+        index.record(&set, 0, "c0", true);
+        index.record(&set, 1, "c1", false);
+
+        assert!(
+            !index.is_empty(),
+            "recording even one run makes the index non-empty"
+        );
+        assert_eq!(index.total(), 3, "every recorded run is counted once");
+        assert_eq!(
+            index.runs_in_set(&set),
+            3,
+            "clean and dirty runs both count toward the set tally"
+        );
+    }
+
+    #[test]
+    fn ordinal_of_passes_small_ranks_through_unchanged() {
+        // The ordinal is the storage-key rank narrowed to the point's `u32` width;
+        // realistic ranks pass through verbatim so the series tie-break stays in
+        // key order.
+        assert_eq!(ordinal_of(0), 0);
+        assert_eq!(ordinal_of(7), 7);
+        assert_eq!(
+            ordinal_of(usize::try_from(u32::MAX).expect("u32 fits in usize")),
+            u32::MAX
+        );
     }
 }


### PR DESCRIPTION
## Problem

A default `cargo-bench-history-stress` run against local storage consumed 10–20 GB of RAM and took an eternity, despite the on-disk data store being a fraction of that size. The `analyze` path materialized the entire data set as a `Vec<LoadedObject>` and then built a *second* full copy while assembling the per-discriminant series, holding both resident at once — and it churned allocations (per-object codec buffers, per-call `sort_by`/`to_vec` in the stats and findings, repeated decompression scratch) all along the hot path.

## Approach

Operate over the data in a streaming fashion with reused allocations instead of holding everything (twice) in memory:

- Stream each loaded object directly into its series as it arrives (`RunIndex`/`CommitCounts`) and drop the retained `Vec<LoadedObject>` entirely.
- Shrink `SeriesPoint` so the one structure we *do* keep is as small as possible.
- Reuse per-thread gzip coders and drive them through a single reusable scratch window, growing the output with `extend_from_slice`; the codec no longer reallocates per object, and progress no longer depends on the output buffer's spare capacity, so small objects stay tightly allocated.
- Compute medians in place and findings with reusable scratch, deferring series-value materialization until a candidate actually needs it.
- Instrument the stress harness's analyze phase with `all_the_time` to surface per-mode CPU time and a CPU-efficiency ratio (`cpu / (wall × cores)`), making it obvious when a mode is I/O-bound rather than CPU-bound. This adds the new `cpu` and `cpu%` columns to the report.

Analysis output is **byte-identical** for a fixed seed (verified by the existing golden integration tests).

## Before / after

Identical inputs on both sides: `--benchmarks 1000 --commits 2000` (the default), default seed, local storage, all three modes. Data store seeded: **423.76 MiB**.

| Metric | Before (`main`) | After | Change |
| --- | --- | --- | --- |
| Peak RSS | 19.76 GB | 6.46 GB | **−67% (3.1× lower)** |
| Total wall | 558 s | 190 s | **−66% (2.9× faster)** |
| `history` analyze | 183.0 s | 69.0 s | 2.7× faster |
| `branch` analyze | 168.9 s | 43.2 s | 3.9× faster |
| `tip` analyze | 178.1 s | 41.6 s | 4.3× faster |

Peak memory dropped from ~48× the data-store size to ~15× — and the reduced allocation churn made the run nearly 3× faster as a bonus.

## Validation

- Full test suites green and byte-identical: core 222 unit, shell 469 lib + 114 integration.
- `codec` is Miri-clean (17 tests, 0 UB) — the reusable thread-local scratch and `extend_from_slice` are sound.
- Mutation tested across the whole diff (core + shell), **0 missed and 0 timeouts**. Rather than let infinite-loop mutants be "caught" by timeout, the coder loops were restructured so the genuinely-equivalent capacity-growth mutant cannot be generated, and the `total_in`/`total_out` narrowing helpers were inlined so their constant-return mutants disappear instead of spinning.
