### PR TITLE
Speed up cargo-bench-history mutation testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ variant_size_differences = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(careful)',
     'cfg(coverage_nightly)',
+    'cfg(mutants)', # Set by cargo-mutants; lets tests opt out of mutation runs via `cfg_attr(mutants, ignore)`.
 ] }
 
 [workspace.lints.rustdoc]

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -18,6 +18,15 @@ mutants SHARD="" CAREFUL='false':
         "'" + $s + "'"
     }
 
+    # Two mechanisms keep mutation runs fast and meaningful:
+    #   * Path/package exclusions (the `-e` args below) drop whole files cargo-mutants
+    #     should never mutate.
+    #   * Individual tests that carry no mutation signal opt out at the test site with
+    #     `#[cfg_attr(mutants, ignore = "<why>")]` (cargo-mutants builds with
+    #     `--cfg mutants`). This keeps them running under normal `cargo test`/coverage
+    #     while skipping them under mutation - see packages/cargo-bench-history for
+    #     examples (the Azurite network tests and the real-engine end-to-end test).
+
     # Note: while cargo-mutants does theoretically support specifying these via config file, it
     # does not support merging that static set of entries with the dynamic set of entries we
     # determine based on the platform. So we have to specify them all here.

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -515,6 +515,15 @@ marker file is present in the checked-out worktree, so a commit that tracks the
 marker stands in for one that fails to build. Helpers `commit_with_file` /
 `commit_removing_file` / `make_dirty` build the needed histories.
 
+These integration tests are deliberately kept to a small real-adapter smoke
+subset (a clean-object success across a range, a merge-spanning range, and a
+stop-on-failure drive) using **minimal commit ranges**. The planning, skip,
+overwrite, error-handling, and reporting logic is exhaustively covered by the
+fake-driven unit tests in `commands/backfill.rs` (over `FakeBackfillGit` /
+`FakeCommitRunner` / `MemoryStorage`), so do not re-prove that logic with extra
+real-git drives — each one spawns many git subprocesses and is the dominant cost
+under mutation testing. Add coverage at the fake level instead.
+
 ## Engine adapters (Callgrind, Criterion, `alloc_tracker`, `all_the_time`)
 
 Four benchmark engines are supported, each behind a pure parser in `bench/`:

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -705,7 +705,10 @@ Criterion's smallest run (10 samples, sub-second warm-up/measurement) and
 Criterion is taken with `default-features = false` to keep the build quick. When
 touching the run/harvest pipeline, do not let this test's gating tempt you to skip
 it locally — run it with plain `cargo test`/`nextest` (it is not Miri- or
-coverage-gated there).
+coverage-gated there). It is additionally `#[cfg_attr(mutants, ignore)]`: the
+mock-engine integration tests and the `resolve_target_root` unit test cover the same
+pipeline under mutation, so this heavyweight build (it recompiles Criterion on every
+mutant) carries no unique mutation signal — see the Mutation testing section.
 
 ## Fixture-golden canaries
 
@@ -837,6 +840,21 @@ round-trip tests — carry `#[cfg_attr(test, mutants::skip)]`, the same pattern
 lean on (`classify`, `map_error`, the `storage::sas` signer, and
 `account_sas_expiry`) has dedicated unit tests and stays under mutation testing,
 so the error-mapping and signing behavior is still mutation-covered.
+
+**Skipping non-discriminating tests under mutation.** cargo-mutants builds with
+`--cfg mutants` set, so a test that carries no mutation signal here can opt out at
+the test site with `#[cfg_attr(mutants, ignore = "<why>")]`. Unlike `mutants::skip`
+on production code, this is self-documenting where the test is defined and leaves
+normal `cargo test`, coverage, and the `test-azurite`/`test-azure` jobs untouched —
+the test still compiles and runs everywhere except under mutation. The Azurite and
+real-Azure network tests (`storage::azure::tests` round-trips and the whole
+`cbh_azure` suite) use this: without an emulator they only self-skip — slowly,
+through a TCP connect timeout — while the IO they would cover is already
+`mutants::skip`. `tests/cbh_real_engine.rs` uses it too: its run/harvest pipeline is
+also driven by the mock-engine integration tests and the `resolve_target_root` unit
+test, so it adds no unique mutation signal yet would recompile Criterion on every
+mutant. The `cfg(mutants)` name is registered in the workspace `unexpected_cfgs`
+`check-cfg` list so the zero-warnings policy still holds.
 
 ## Stress harness (`cargo-bench-history-stress`)
 

--- a/packages/cargo-bench-history/src/commands/backfill.rs
+++ b/packages/cargo-bench-history/src/commands/backfill.rs
@@ -1041,6 +1041,45 @@ mod tests {
     }
 
     #[test]
+    fn render_lists_a_line_for_every_outcome_section() {
+        let report = BackfillReport {
+            stored: vec![("aaaaaaa".to_owned(), 2)],
+            skipped_existing: vec!["bbbbbbb".to_owned()],
+            skipped_empty: vec!["ccccccc".to_owned()],
+            failed: vec![("ddddddd".to_owned(), "boom".to_owned())],
+            stopped: Some("ddddddd".to_owned()),
+        };
+
+        let rendered = report.render(5);
+
+        assert!(
+            rendered.contains(
+                "Backfill range of 5 commits: 1 stored, 1 skipped (existing), \
+                 1 skipped (empty), 1 failed."
+            ),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("  stored aaaaaaa (2 cases)"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("  skipped bbbbbbb (already stored)"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("  skipped ccccccc (no benchmark cases)"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("  failed ddddddd (boom)"), "{rendered}");
+        assert!(
+            rendered
+                .contains("  stopped at ddddddd (pass --ignore-errors to continue past failures)"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
     fn execute_completes_and_tears_down_on_success() {
         let git = FakeBackfillGit::new(fixture());
         let runner = FakeCommitRunner::new();

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -1093,6 +1093,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn put_creates_the_container_then_get_and_list_round_trip() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1119,6 +1120,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn get_missing_blob_in_existing_container_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1134,6 +1136,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn get_in_missing_container_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1147,6 +1150,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn delete_removes_a_blob_and_leaves_siblings() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1168,6 +1172,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn delete_missing_blob_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1183,6 +1188,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn delete_in_missing_container_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1196,6 +1202,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn put_is_write_once() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1217,6 +1224,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn put_overwrite_replaces_an_existing_blob() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1238,6 +1246,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn put_overwrite_creates_when_absent() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1254,6 +1263,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn list_on_missing_container_is_empty() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1266,6 +1276,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
     #[serial]
     async fn list_with_a_non_matching_prefix_is_empty() {
         let Some(storage) = azurite_storage_or_skip() else {

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -1093,7 +1093,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn put_creates_the_container_then_get_and_list_round_trip() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1120,7 +1123,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn get_missing_blob_in_existing_container_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1136,7 +1142,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn get_in_missing_container_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1150,7 +1159,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn delete_removes_a_blob_and_leaves_siblings() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1172,7 +1184,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn delete_missing_blob_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1188,7 +1203,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn delete_in_missing_container_reports_not_found() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1202,7 +1220,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn put_is_write_once() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1224,7 +1245,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn put_overwrite_replaces_an_existing_blob() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1246,7 +1270,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn put_overwrite_creates_when_absent() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1263,7 +1290,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn list_on_missing_container_is_empty() {
         let Some(storage) = azurite_storage_or_skip() else {
@@ -1276,7 +1306,10 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(mutants, ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip")]
+    #[cfg_attr(
+        mutants,
+        ignore = "Azurite network test: self-skips without an emulator (as under mutation), and the IO it exercises is already mutants::skip"
+    )]
     #[serial]
     async fn list_with_a_non_matching_prefix_is_empty() {
         let Some(storage) = azurite_storage_or_skip() else {

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -525,6 +525,7 @@ async fn scenario_feature_and_dirty(config: &str) {
 /// `run` stores a harvested result set in Azurite.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn run_stores_results_in_azurite() {
     if !azurite_available() {
@@ -536,6 +537,7 @@ async fn run_stores_results_in_azurite() {
 /// A `run` + `analyze` round-trip through Azurite.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn run_then_analyze_round_trips_through_azurite() {
     if !azurite_available() {
@@ -547,6 +549,7 @@ async fn run_then_analyze_round_trips_through_azurite() {
 /// A multi-commit feature/dirty round-trip through Azurite.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn analyze_feature_and_dirty_round_trip_through_azurite() {
     if !azurite_available() {
@@ -561,6 +564,7 @@ async fn analyze_feature_and_dirty_round_trip_through_azurite() {
 /// directly through a SAS-authenticated client.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn stored_blob_declares_gzip_content_encoding_in_azurite() {
     use azure_storage_blob::models::BlobClientGetPropertiesResultHeaders as _;
@@ -606,6 +610,7 @@ async fn stored_blob_declares_gzip_content_encoding_in_azurite() {
 /// `run` stores a harvested result set in a real Azure account via Entra ID.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn run_stores_results_in_real_azure() {
     if !real_azure_enabled() {
@@ -620,6 +625,7 @@ async fn run_stores_results_in_real_azure() {
 /// A `run` + `analyze` round-trip through a real Azure account via Entra ID.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn run_then_analyze_round_trips_through_real_azure() {
     if !real_azure_enabled() {
@@ -634,6 +640,7 @@ async fn run_then_analyze_round_trips_through_real_azure() {
 /// A multi-commit feature/dirty round-trip through a real Azure account via Entra ID.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(mutants, ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip")]
 #[serial]
 async fn analyze_feature_and_dirty_round_trip_through_real_azure() {
     if !real_azure_enabled() {

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -525,7 +525,10 @@ async fn scenario_feature_and_dirty(config: &str) {
 /// `run` stores a harvested result set in Azurite.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn run_stores_results_in_azurite() {
     if !azurite_available() {
@@ -537,7 +540,10 @@ async fn run_stores_results_in_azurite() {
 /// A `run` + `analyze` round-trip through Azurite.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn run_then_analyze_round_trips_through_azurite() {
     if !azurite_available() {
@@ -549,7 +555,10 @@ async fn run_then_analyze_round_trips_through_azurite() {
 /// A multi-commit feature/dirty round-trip through Azurite.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn analyze_feature_and_dirty_round_trip_through_azurite() {
     if !azurite_available() {
@@ -564,7 +573,10 @@ async fn analyze_feature_and_dirty_round_trip_through_azurite() {
 /// directly through a SAS-authenticated client.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Azure network end-to-end test: self-skips without an emulator (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn stored_blob_declares_gzip_content_encoding_in_azurite() {
     use azure_storage_blob::models::BlobClientGetPropertiesResultHeaders as _;
@@ -610,7 +622,10 @@ async fn stored_blob_declares_gzip_content_encoding_in_azurite() {
 /// `run` stores a harvested result set in a real Azure account via Entra ID.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn run_stores_results_in_real_azure() {
     if !real_azure_enabled() {
@@ -625,7 +640,10 @@ async fn run_stores_results_in_real_azure() {
 /// A `run` + `analyze` round-trip through a real Azure account via Entra ID.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn run_then_analyze_round_trips_through_real_azure() {
     if !real_azure_enabled() {
@@ -640,7 +658,10 @@ async fn run_then_analyze_round_trips_through_real_azure() {
 /// A multi-commit feature/dirty round-trip through a real Azure account via Entra ID.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(mutants, ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip")]
+#[cfg_attr(
+    mutants,
+    ignore = "Real-Azure network end-to-end test: self-skips without ENABLE_AZURE (as under mutation), and the azure IO it exercises is already mutants::skip"
+)]
 #[serial]
 async fn analyze_feature_and_dirty_round_trip_through_real_azure() {
     if !real_azure_enabled() {

--- a/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
@@ -10,23 +10,22 @@ async fn backfill_stores_one_clean_object_per_commit_and_restores_checkout() {
         Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
     let c1 = workspace.commit("c1");
     let c2 = workspace.commit("c2");
-    let c3 = workspace.commit("c3");
     let branch_before = workspace.current_branch();
     let head_before = workspace.head();
 
-    let RunOutcome::Completed { message } = workspace.drive(&["backfill", &c1, &c3]).await.unwrap()
+    let RunOutcome::Completed { message } = workspace.drive(&["backfill", &c1, &c2]).await.unwrap()
     else {
         panic!("expected a completed outcome");
     };
-    assert!(message.contains("3 stored"), "{message}");
+    assert!(message.contains("2 stored"), "{message}");
 
     // One clean object per commit, keyed by that commit's full SHA. `backfill`
     // auto-detects the target triple, so derive it from a stored object to keep
     // the key assertions correct on every platform CI runs on.
     let objects = workspace.stored_objects();
-    assert_eq!(objects.len(), 3, "{objects:?}");
+    assert_eq!(objects.len(), 2, "{objects:?}");
     let triple = objects[0].1.context.toolchain.target_triple.clone();
-    for sha in [&c1, &c2, &c3] {
+    for sha in [&c1, &c2] {
         let expected = format!("v1/testproj/callgrind/{triple}/synthetic/{sha}/clean.json");
         assert!(
             objects.iter().any(|(key, _)| key == &expected),
@@ -49,7 +48,7 @@ async fn backfill_stores_one_clean_object_per_commit_and_restores_checkout() {
     };
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        parsed["runs"], 3,
+        parsed["runs"], 2,
         "analyze should see every backfilled commit: {report}"
     );
 }
@@ -100,92 +99,6 @@ async fn backfill_spans_a_merge_commit_along_first_parent() {
     }
 }
 
-/// Re-running an identical backfill skips every commit whose result already
-/// exists (write-once collision), making backfill resumable without duplicating.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn backfill_skips_already_stored_commits_on_rerun() {
-    let workspace =
-        Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
-    let c1 = workspace.commit("c1");
-    let c2 = workspace.commit("c2");
-
-    workspace.drive(&["backfill", &c1, &c2]).await.unwrap();
-    assert_eq!(workspace.stored_objects().len(), 2);
-
-    let RunOutcome::Completed { message } = workspace.drive(&["backfill", &c1, &c2]).await.unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
-    assert!(
-        message.contains("0 stored, 2 skipped (existing)"),
-        "{message}"
-    );
-    // No new objects were written.
-    assert_eq!(workspace.stored_objects().len(), 2);
-}
-
-/// The pre-run existence check skips an already-recorded commit *before* it is
-/// benchmarked: a re-run whose engine would fail if it were invoked still
-/// succeeds, because the recorded commits never reach the (failing) engine.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn backfill_skips_recorded_commits_without_invoking_the_engine() {
-    let workspace =
-        Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
-    let c1 = workspace.commit("c1");
-    let c2 = workspace.commit("c2");
-
-    workspace.drive(&["backfill", &c1, &c2]).await.unwrap();
-    assert_eq!(workspace.stored_objects().len(), 2);
-
-    // Re-run with an engine that exits non-zero whenever it actually runs — the
-    // `.git` marker is present in every worktree, so `--fail-if-exists .git` fails
-    // unconditionally. The pre-run check recognizes both commits as already
-    // recorded and skips them before the engine is invoked, so the command still
-    // succeeds; without the pre-check the failing engine would run and abort.
-    let RunOutcome::Completed { message } = workspace
-        .drive_with_bench(
-            &["--summary", "grp=single", "--fail-if-exists", ".git"],
-            &["backfill", &c1, &c2],
-        )
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
-    assert!(
-        message.contains("0 stored, 2 skipped (existing)"),
-        "{message}"
-    );
-    // Nothing changed: the skip path neither re-ran nor rewrote anything.
-    assert_eq!(workspace.stored_objects().len(), 2);
-}
-
-/// `--overwrite` replaces every already-stored commit in the range rather than
-/// skipping it, leaving exactly one clean object per commit.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn backfill_overwrite_replaces_already_stored_commits() {
-    let workspace =
-        Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
-    let c1 = workspace.commit("c1");
-    let c2 = workspace.commit("c2");
-
-    workspace.drive(&["backfill", &c1, &c2]).await.unwrap();
-
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["backfill", &c1, &c2, "--overwrite"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
-    assert!(message.contains("2 stored"), "{message}");
-    // Each commit still has exactly one object; nothing was duplicated.
-    assert_eq!(workspace.stored_objects().len(), 2);
-}
-
 /// A commit that fails to benchmark stops the backfill by default: earlier commits
 /// are stored, but the loop halts at the failure and reports a non-zero exit.
 #[tokio::test]
@@ -211,81 +124,6 @@ async fn backfill_stops_on_a_failing_commit_by_default() {
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 1, "{objects:?}");
     assert!(objects[0].0.contains(&c1), "{:?}", objects[0].0);
-}
-
-/// `--ignore-errors` continues past a failing commit, storing the healthy commits
-/// on either side and reporting the failure in the summary.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn backfill_ignore_errors_continues_past_a_failing_commit() {
-    let workspace = Workspace::clean_repo(&storage_only_config()).with_bench(&[
-        "--summary",
-        "grp=single",
-        "--fail-if-exists",
-        "BROKEN",
-    ]);
-    let c1 = workspace.commit("c1");
-    workspace.commit_with_file("c2 introduces a broken build", "BROKEN", "boom\n");
-    let c3 = workspace.commit_removing_file("c3 fixes the build", "BROKEN");
-
-    let outcome = workspace
-        .drive(&["backfill", &c1, &c3, "--ignore-errors"])
-        .await
-        .unwrap();
-    // Even though a commit failed to benchmark, `--ignore-errors` makes the
-    // overall command succeed (exit code zero); the failure is reported, not fatal.
-    assert!(
-        outcome.is_success(),
-        "--ignore-errors must yield a successful exit despite the failure: {outcome:?}"
-    );
-    let RunOutcome::Completed { message } = outcome else {
-        panic!("expected a completed outcome");
-    };
-    assert!(message.contains("2 stored"), "{message}");
-    assert!(message.contains("1 failed"), "{message}");
-    // The two healthy commits are stored; the broken one contributed nothing.
-    assert_eq!(workspace.stored_objects().len(), 2);
-}
-
-/// A dirty primary working tree does not block backfill: it runs in an isolated
-/// worktree and benches the requested commit by SHA, so the primary checkout's
-/// state is irrelevant to what gets measured and stored.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn backfill_ignores_a_dirty_primary_working_tree() {
-    let workspace =
-        Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
-    let c1 = workspace.commit("c1");
-    workspace.make_dirty("uncommitted.txt");
-
-    let outcome = workspace.drive(&["backfill", &c1, &c1]).await.unwrap();
-    assert!(
-        outcome.is_success(),
-        "a dirty primary tree must not affect backfill: {outcome:?}"
-    );
-    let RunOutcome::Completed { message } = outcome else {
-        panic!("expected a completed outcome");
-    };
-    assert!(message.contains("1 stored"), "{message}");
-    assert!(!workspace.stored_objects().is_empty());
-}
-
-/// A range whose `--from` is not a first-parent ancestor of `--to` (here, a
-/// reversed range) is rejected before any worktree work, storing nothing.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn backfill_rejects_a_range_outside_the_first_parent_history() {
-    let workspace =
-        Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
-    let c1 = workspace.commit("c1");
-    let c2 = workspace.commit("c2");
-
-    let error = workspace.drive(&["backfill", &c2, &c1]).await.unwrap_err();
-    let RunError::Backfill { message } = error else {
-        panic!("expected a backfill error, got {error:?}");
-    };
-    assert!(message.contains("not a first-parent ancestor"), "{message}");
-    assert!(workspace.stored_objects().is_empty());
 }
 
 /// `backfill --help` is an early exit whose usage text documents the range

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -390,10 +390,9 @@ pub(crate) struct Workspace {
 impl Drop for Workspace {
     fn drop(&mut self) {
         // Close any open `fast-import` stream so the child releases its handles on
-        // the `.git` directory before the tempdir (a later-declared field) is
-        // removed. `finalize` only asserts success when the thread is not already
-        // panicking, so a failing test is reported as itself rather than a double
-        // panic here.
+        // the `.git` directory before `TempDir` cleanup removes the repository.
+        // `finalize` only asserts success when the thread is not already panicking,
+        // so a failing test is reported as itself rather than a double panic here.
         self.flush_git();
     }
 }

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1,6 +1,8 @@
 pub(crate) use std::cell::RefCell;
 pub(crate) use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
 pub(crate) use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Stdio};
 use std::sync::LazyLock;
 
 pub(crate) use cargo_bench_history::{
@@ -136,6 +138,224 @@ fn copy_dir_all(src: &Path, dst: &Path) {
         }
     }
 }
+
+/// The first synthetic committer second handed to an undated commit. Undated
+/// commits exist to express topology (branch tips, merge parents) rather than a
+/// timeline, so any distinct, ordered dates suffice — but they must land inside
+/// `analyze`/`list`'s default six-month look-back window (see [`analysis_now`],
+/// anchored at 2024-06-01 with a 2023-12-01 cutoff), or the default window would
+/// silently drop them. Anchoring at 2024-01-01 and advancing one day per commit
+/// keeps an undated history comfortably inside that window with ample headroom.
+///
+/// [`analysis_now`]: super::harness::analysis_now
+const UNDATED_EPOCH_SECONDS: i64 = 1_704_067_200;
+
+/// One day in seconds, the spacing between successive undated commits.
+const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Builds a workspace's commit history through a single long-lived
+/// `git fast-import` process instead of one `git commit` subprocess per commit.
+///
+/// Process startup — amplified by real-time antivirus on Windows — dominates the
+/// integration suite, and a seed-heavy history pays it once per commit. Streaming
+/// the commits into one `fast-import` collapses an N-commit history into a single
+/// spawn: each commit is one buffered write plus a `get-mark` round-trip that
+/// reports the new SHA, so [`Workspace::commit`] and friends stay synchronous and
+/// their call sites read exactly as they would against real `git commit`.
+///
+/// All commits the harness creates this way carry the base template's empty tree,
+/// so `fast-import` advancing a branch ref without touching the index or working
+/// tree leaves `git status` clean — the property that makes `analyze` pick
+/// `history` mode. Operations that genuinely change the tree or the checkout
+/// (merge, branch switch, file commits) stay on real `git`; the workspace
+/// [`finalize`](Self::finalize)s the open stream first so those refs and objects
+/// are on disk before the next real `git` reads them.
+struct GitGraph {
+    /// The repository root, addressed explicitly so streaming never depends on
+    /// the process current directory.
+    root: PathBuf,
+    /// The branch new commits land on, mirroring the working tree's checked-out
+    /// branch. The workspace's `checkout` helpers keep it in step, so each stream
+    /// roots its first commit at this branch's current tip.
+    current_branch: String,
+    /// The open `fast-import` stream, spawned lazily on the first commit and torn
+    /// down by [`finalize`](Self::finalize) before any real `git` command.
+    session: Option<Session>,
+    /// The next `fast-import` mark, used transiently to read back each commit's
+    /// SHA via `get-mark`.
+    next_mark: u32,
+    /// The committer second handed to the next undated commit (see
+    /// [`UNDATED_EPOCH_SECONDS`]).
+    next_undated_second: i64,
+}
+
+/// An open `git fast-import` stream and the pipes used to drive it.
+struct Session {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    stderr: ChildStderr,
+    /// Whether a commit has already been emitted on this stream. The first commit
+    /// roots the branch with an explicit `from`; later commits append to the tip
+    /// `fast-import` is already tracking.
+    has_commit: bool,
+}
+
+impl GitGraph {
+    fn new(root: PathBuf, current_branch: &str) -> Self {
+        Self {
+            root,
+            current_branch: current_branch.to_owned(),
+            session: None,
+            next_mark: 0,
+            next_undated_second: UNDATED_EPOCH_SECONDS,
+        }
+    }
+
+    /// Records the branch subsequent commits land on, after a real `git checkout`
+    /// has moved the working tree (and created the ref, for a new branch).
+    fn set_current_branch(&mut self, name: &str) {
+        name.clone_into(&mut self.current_branch);
+    }
+
+    /// Streams an empty commit dated `second` (raw committer seconds, UTC) with
+    /// message `message` onto the current branch, returning its full SHA.
+    fn commit(&mut self, message: &str, second: i64) -> String {
+        let mark = self
+            .next_mark
+            .checked_add(1)
+            .expect("mark counter overflow");
+        self.next_mark = mark;
+        let branch = self.current_branch.clone();
+        let session = self.ensure_session();
+
+        let mut stream: Vec<u8> = Vec::new();
+        // `writeln!` emits a bare LF (never CRLF, on any platform), which the stream
+        // requires: `fast-import`'s `data` directive is byte-counted, so a stray CR
+        // would corrupt the following message.
+        writeln!(stream, "commit refs/heads/{branch}").unwrap();
+        writeln!(stream, "mark :{mark}").unwrap();
+        writeln!(
+            stream,
+            "committer Bench History Test <test@example.invalid> {second} +0000"
+        )
+        .unwrap();
+        writeln!(stream, "data {}", message.len()).unwrap();
+        stream.extend_from_slice(message.as_bytes());
+        stream.push(b'\n');
+        if !session.has_commit {
+            // Root this stream at the branch's current on-disk tip. The `^0`
+            // peels the ref to its commit: `from refs/heads/<branch>` (without it)
+            // is rejected as "creating a branch from itself" when the commit
+            // targets that same branch. Later commits append to the tip
+            // `fast-import` tracks, so `from` is implicit for them.
+            writeln!(stream, "from refs/heads/{branch}^0").unwrap();
+            session.has_commit = true;
+        }
+        stream.push(b'\n');
+        writeln!(stream, "get-mark :{mark}").unwrap();
+
+        session.stdin.write_all(&stream).unwrap();
+        session.stdin.flush().unwrap();
+
+        let mut line = String::new();
+        session.stdout.read_line(&mut line).unwrap();
+        let sha = line.trim().to_owned();
+        assert_eq!(
+            sha.len(),
+            40,
+            "git fast-import get-mark returned `{sha}`, not a full SHA"
+        );
+        sha
+    }
+
+    /// Allocates the committer second for the next undated commit, advancing the
+    /// synthetic clock one day so a date-free topology still has distinct, ordered
+    /// timestamps.
+    fn next_undated_second(&mut self) -> i64 {
+        let second = self.next_undated_second;
+        self.next_undated_second = second
+            .checked_add(SECONDS_PER_DAY)
+            .expect("undated commit clock overflow");
+        second
+    }
+
+    /// Returns the open stream, spawning a fresh `fast-import` if none is active.
+    fn ensure_session(&mut self) -> &mut Session {
+        if self.session.is_none() {
+            let mut child = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&self.root)
+                // Match `run_git`'s throughput config: skip the per-object disk
+                // flush and keep a background repack from firing mid-stream.
+                .args([
+                    "-c",
+                    "core.fsync=none",
+                    "-c",
+                    "core.fsyncObjectFiles=false",
+                    "-c",
+                    "gc.auto=0",
+                    "fast-import",
+                    "--quiet",
+                    "--date-format=raw",
+                ])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            let stdin = child.stdin.take().unwrap();
+            let stdout = BufReader::new(child.stdout.take().unwrap());
+            let stderr = child.stderr.take().unwrap();
+            self.session = Some(Session {
+                child,
+                stdin,
+                stdout,
+                stderr,
+                has_commit: false,
+            });
+        }
+        self.session.as_mut().unwrap()
+    }
+
+    /// Closes any open stream so `fast-import` updates the branch refs and writes
+    /// its objects, making them visible to the real `git` commands that follow.
+    fn finalize(&mut self) {
+        let Some(session) = self.session.take() else {
+            return;
+        };
+        let Session {
+            mut child,
+            stdin,
+            stdout,
+            mut stderr,
+            ..
+        } = session;
+        // Closing stdin signals end-of-stream; `fast-import` then finalizes the
+        // pack, updates the refs, and exits. Dropping stdout lets it observe the
+        // read end going away too.
+        drop(stdin);
+        drop(stdout);
+        let mut errors = String::new();
+        // Drain any diagnostics fast-import wrote; they are surfaced only when the
+        // exit status below is non-zero. A read failure just leaves a marker.
+        if let Err(read_error) = stderr.read_to_string(&mut errors) {
+            errors = format!("<failed to read fast-import stderr: {read_error}>");
+        }
+        let status = child.wait();
+        // Always wait above so the child releases its `.git` handles before the
+        // workspace tempdir is removed; only assert success when we are not already
+        // unwinding, so a failing test is not masked by a double panic.
+        if !std::thread::panicking() {
+            let status = status.expect("waiting on git fast-import");
+            assert!(
+                status.success(),
+                "git fast-import exited with {status}: {errors}"
+            );
+        }
+    }
+}
+
 /// A hermetic workspace for driving `run` against the real adapters.
 ///
 /// Writes a configuration and (optionally) fake engine output under a temporary
@@ -160,16 +380,35 @@ pub(crate) struct Workspace {
     /// `--summary` / `--criterion` cases, or an `--exit-code`), so each engine's
     /// output tree is produced by the single benchmark command `run` invokes.
     bench: Vec<String>,
+    /// Streams commit creation through one long-lived `git fast-import` rather than
+    /// a `git commit` subprocess per commit (see [`GitGraph`]). The `&self` commit
+    /// helpers drive it through interior mutability; real `git` operations
+    /// [`finalize`](Self::flush_git) it first so its refs and objects are on disk.
+    graph: RefCell<GitGraph>,
+}
+
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        // Close any open `fast-import` stream so the child releases its handles on
+        // the `.git` directory before the tempdir (a later-declared field) is
+        // removed. `finalize` only asserts success when the thread is not already
+        // panicking, so a failing test is reported as itself rather than a double
+        // panic here.
+        self.flush_git();
+    }
 }
 
 impl Workspace {
     /// Creates a workspace with `config` at the default `.cargo/bench_history.toml`.
     pub(crate) fn new(config: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
         let workspace = Self {
-            dir: tempfile::tempdir().unwrap(),
+            dir,
             commits: RefCell::new(HashMap::new()),
             committer_times: RefCell::new(HashMap::new()),
             bench: Vec::new(),
+            graph: RefCell::new(GitGraph::new(root, "master")),
         };
         let cargo_dir = workspace.root().join(".cargo");
         std::fs::create_dir_all(&cargo_dir).unwrap();
@@ -196,21 +435,27 @@ impl Workspace {
 
     /// Creates an empty workspace with no configuration file written.
     pub(crate) fn empty() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
         Self {
-            dir: tempfile::tempdir().unwrap(),
+            dir,
             commits: RefCell::new(HashMap::new()),
             committer_times: RefCell::new(HashMap::new()),
             bench: Vec::new(),
+            graph: RefCell::new(GitGraph::new(root, "master")),
         }
     }
 
     /// Creates a workspace with `config` at a non-default `relative` path.
     pub(crate) fn with_config_at(relative: &str, config: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
         let workspace = Self {
-            dir: tempfile::tempdir().unwrap(),
+            dir,
             commits: RefCell::new(HashMap::new()),
             committer_times: RefCell::new(HashMap::new()),
             bench: Vec::new(),
+            graph: RefCell::new(GitGraph::new(root, "master")),
         };
         let path = workspace.root().join(relative);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -231,17 +476,35 @@ impl Workspace {
         self.dir.path()
     }
 
+    /// Closes any open [`GitGraph`] stream so its commits' refs and objects are on
+    /// disk before a real `git` command (or a direct `.git` read) observes them.
+    fn flush_git(&self) {
+        self.graph.borrow_mut().finalize();
+    }
+
     /// Runs `git -C <root> <args>` against this workspace, returning its captured
     /// output. Thin wrapper over [`run_git`]; the repository directory is addressed
     /// explicitly so commit creation never depends on the process current directory.
     pub(crate) fn git(&self, args: &[&str]) -> std::process::Output {
+        self.flush_git();
         run_git(self.root(), args)
     }
 
-    /// Like [`git`](Self::git), but sets the given environment variables on the
-    /// invocation — used to pin a commit's author/committer date.
-    pub(crate) fn git_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
-        run_git_with_env(self.root(), args, env)
+    /// Runs a real `git` command that creates a commit, stamping its author and
+    /// committer dates with the synthetic committer `second` (raw UTC seconds) so
+    /// merges and file commits stay on the same monotonic, in-window timeline as the
+    /// empty `fast-import` commits, rather than taking the current wall-clock time.
+    fn git_at(&self, args: &[&str], second: i64) -> std::process::Output {
+        self.flush_git();
+        let when = format!("@{second} +0000");
+        run_git_with_env(
+            self.root(),
+            args,
+            &[
+                ("GIT_AUTHOR_DATE", when.as_str()),
+                ("GIT_COMMITTER_DATE", when.as_str()),
+            ],
+        )
     }
 
     /// Initializes a `master`-branch repository with one empty root commit so `HEAD`
@@ -276,6 +539,7 @@ impl Workspace {
     /// branch ref is always loose; a `git rev-parse` fallback covers the unexpected
     /// (packed refs, detached `HEAD`).
     pub(crate) fn head_sha(&self) -> String {
+        self.flush_git();
         let git_dir = self.root().join(".git");
         if let Ok(head) = std::fs::read_to_string(git_dir.join("HEAD")) {
             let head = head.trim();
@@ -305,8 +569,16 @@ impl Workspace {
         if let Some(sha) = self.commits.borrow().get(label) {
             return sha.clone();
         }
-        self.git(&["commit", "--allow-empty", "-m", label]);
-        let sha = self.head_sha();
+        let second = self.graph.borrow_mut().next_undated_second();
+        let sha = self.graph.borrow_mut().commit(label, second);
+        // Cache the committer time from the synthetic second we just stamped, so an
+        // interleaved seed reading this commit's provenance never has to spawn git
+        // (which would finalize the stream mid-history). Git stays the source of
+        // truth: this matches exactly what `fast-import` wrote.
+        let observed = Timestamp::from_second(second).unwrap();
+        self.committer_times
+            .borrow_mut()
+            .insert(sha.clone(), observed);
         self.commits
             .borrow_mut()
             .insert(label.to_owned(), sha.clone());
@@ -326,15 +598,8 @@ impl Workspace {
             return sha.clone();
         }
         let when = format!("{date}T00:00:00+00:00");
-        self.git_with_env(
-            &["commit", "--allow-empty", "-m", label],
-            &[
-                ("GIT_AUTHOR_DATE", when.as_str()),
-                ("GIT_COMMITTER_DATE", when.as_str()),
-            ],
-        );
-        let sha = self.head_sha();
         let observed: Timestamp = when.parse().unwrap();
+        let sha = self.graph.borrow_mut().commit(label, observed.as_second());
         self.committer_times
             .borrow_mut()
             .insert(sha.clone(), observed);
@@ -380,11 +645,13 @@ impl Workspace {
     }
     pub(crate) fn checkout_new_branch(&self, name: &str) {
         self.git(&["checkout", "-b", name]);
+        self.graph.borrow_mut().set_current_branch(name);
     }
 
     /// Checks out an existing branch.
     pub(crate) fn checkout(&self, name: &str) {
         self.git(&["checkout", name]);
+        self.graph.borrow_mut().set_current_branch(name);
     }
 
     /// Merges `branch` into the current branch with an always-materialized merge
@@ -393,9 +660,22 @@ impl Workspace {
     /// parent and `branch`'s tip as its second, so it sits on the current branch's
     /// first-parent line while the merged-in commits stay off it — the topology the
     /// git-aware `analyze`/`backfill` selection must respect.
+    ///
+    /// The merge commit takes the next synthetic committer date so it stays on the
+    /// same monotonic, in-window timeline as the empty `fast-import` commits around
+    /// it; without that, a real `git merge` would stamp it with the current
+    /// wall-clock time, a future-dated point the default analysis window would treat
+    /// inconsistently with its neighbours.
     pub(crate) fn merge(&self, branch: &str, label: &str) -> String {
-        self.git(&["merge", "--no-ff", "--no-edit", "-m", label, branch]);
+        let second = self.graph.borrow_mut().next_undated_second();
+        self.git_at(
+            &["merge", "--no-ff", "--no-edit", "-m", label, branch],
+            second,
+        );
         let sha = self.head();
+        self.committer_times
+            .borrow_mut()
+            .insert(sha.clone(), Timestamp::from_second(second).unwrap());
         self.commits
             .borrow_mut()
             .insert(label.to_owned(), sha.clone());
@@ -405,20 +685,34 @@ impl Workspace {
     /// Commits a tracked file with `contents` at `relative` on the current branch
     /// and returns the new commit's full SHA. Unlike [`commit`](Self::commit), the
     /// commit changes the tree, so the file appears in any worktree checked out to
-    /// it — used to stand in for a "broken" commit the mock engine reacts to.
+    /// it — used to stand in for a "broken" commit the mock engine reacts to. It
+    /// takes the next synthetic committer date, keeping the timeline monotonic and
+    /// in-window like the surrounding empty commits.
     pub(crate) fn commit_with_file(&self, message: &str, relative: &str, contents: &str) -> String {
         std::fs::write(self.root().join(relative), contents).unwrap();
         self.git(&["add", relative]);
-        self.git(&["commit", "-m", message]);
-        self.head()
+        let second = self.graph.borrow_mut().next_undated_second();
+        self.git_at(&["commit", "-m", message], second);
+        let sha = self.head();
+        self.committer_times
+            .borrow_mut()
+            .insert(sha.clone(), Timestamp::from_second(second).unwrap());
+        sha
     }
 
     /// Removes a previously tracked file at `relative`, commits the removal on the
-    /// current branch, and returns the new commit's full SHA.
+    /// current branch, and returns the new commit's full SHA. As with
+    /// [`commit_with_file`](Self::commit_with_file), the removal commit takes the
+    /// next synthetic committer date.
     pub(crate) fn commit_removing_file(&self, message: &str, relative: &str) -> String {
         self.git(&["rm", relative]);
-        self.git(&["commit", "-m", message]);
-        self.head()
+        let second = self.graph.borrow_mut().next_undated_second();
+        self.git_at(&["commit", "-m", message], second);
+        let sha = self.head();
+        self.committer_times
+            .borrow_mut()
+            .insert(sha.clone(), Timestamp::from_second(second).unwrap());
+        sha
     }
 
     /// The full SHA of the current `HEAD`.
@@ -446,6 +740,7 @@ impl Workspace {
 
     /// Drives a command with `args` against this workspace.
     pub(crate) async fn drive(&self, args: &[&str]) -> Result<RunOutcome, RunError> {
+        self.flush_git();
         // Point the harvest at this workspace's own `target/` explicitly, so a
         // shared ambient `CARGO_TARGET_DIR` (as `cargo llvm-cov` sets during
         // coverage runs) cannot make the harvester pick up summaries written by
@@ -480,6 +775,7 @@ impl Workspace {
         bench: &[&str],
         args: &[&str],
     ) -> Result<RunOutcome, RunError> {
+        self.flush_git();
         let target_root = self.root().join("target");
         let mut bench_command = vec![MOCK_ENGINE.to_owned()];
         bench_command.extend(bench.iter().map(|arg| (*arg).to_owned()));
@@ -501,6 +797,7 @@ impl Workspace {
         &self,
         args: &[&str],
     ) -> Result<RunOutcome, RunError> {
+        self.flush_git();
         let mut bench_command = vec![MOCK_ENGINE.to_owned()];
         bench_command.extend(self.bench.iter().cloned());
 

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -766,31 +766,8 @@ impl Workspace {
         .await
     }
 
-    /// Drives a command with an explicit benchmark command, overriding the
-    /// workspace's configured one for this invocation only. This lets a test make
-    /// the engine behave differently across two drives — for example, succeed on a
-    /// first backfill, then exit non-zero if it is invoked at all on a re-run.
-    pub(crate) async fn drive_with_bench(
-        &self,
-        bench: &[&str],
-        args: &[&str],
-    ) -> Result<RunOutcome, RunError> {
-        self.flush_git();
-        let target_root = self.root().join("target");
-        let mut bench_command = vec![MOCK_ENGINE.to_owned()];
-        bench_command.extend(bench.iter().map(|arg| (*arg).to_owned()));
-
-        run_with_overrides(
-            &command_from(args),
-            Overrides {
-                workspace_dir: Some(self.root().to_path_buf()),
-                target_root: Some(target_root),
-                bench_command: Some(bench_command),
-                now: Some(analysis_now()),
-            },
-        )
-        .await
-    }
+    /// Like [`drive`], but leaves the target root unset so the harvester resolves
+    /// it the default way, exercising the no-override target-root path.
     ///
     /// [`drive`]: Self::drive
     pub(crate) async fn drive_resolving_target_root(

--- a/packages/cargo-bench-history/tests/cbh_real_engine.rs
+++ b/packages/cargo-bench-history/tests/cbh_real_engine.rs
@@ -125,6 +125,10 @@ const FIXTURE_CONFIG: &str = "[project]\nid = \"e2e\"\n\n[storage.local]\npath =
 #[serial]
 #[cfg_attr(miri, ignore)] // Spawns a real `cargo bench`, which Miri cannot run.
 #[cfg_attr(coverage_nightly, ignore)] // Heavy real build; llvm-cov shares one target dir.
+#[cfg_attr(
+    mutants,
+    ignore = "Heavy real `cargo bench` build (compiles Criterion per run); the run/harvest pipeline it covers is also driven by the mock-engine integration tests and the resolve_target_root unit test, so it carries no unique mutation signal"
+)]
 async fn run_against_real_criterion_bench_stores_wall_time() {
     let fixture = tempfile::tempdir().unwrap();
     let root = fixture.path();


### PR DESCRIPTION
## What

Speeds up mutation testing of `cargo-bench-history`, whose runtime was dominated by the git-heavy integration suite. Three independent parts, each validated to preserve mutation coverage (caught set byte-identical, zero new uncaught mutants) and line coverage.

## Part 1 — Skip non-discriminating tests under `--cfg mutants`

cargo-mutants builds with `--cfg mutants` set, so tests that carry no mutation signal can opt out at the test site with `#[cfg_attr(mutants, ignore = "<why>")]`. This marks the skip clearly at the test rather than hiding it in config, and (unlike `#[ignore]` alone) only triggers under mutation runs — normal `cargo test` and Codecov are unaffected.

Annotated the Azurite-network round-trip tests (whose IO methods are already `mutants::skip`'d and which self-skip without an emulator) and `cbh_real_engine` (a real `cargo bench` drive that recompiles Criterion every run, ~12–18s, and is already covered by the mock-engine integration tests + a `resolve_target_root` unit test). Registered `cfg(mutants)` in the workspace `unexpected_cfgs` lint list and documented the convention in the package AGENTS.md and the mutants justfile.

## Part 2 — Batch integration commits via `git fast-import`

The integration harness previously spawned a fresh `git commit` (and friends) per seeded commit, the dominant cost when the suite runs under mutation testing's parallel job contention. A `fast-import`-backed graph builder now streams an entire seeded history into a single long-lived git child process.

The seeding helper signatures are unchanged, so the test bodies still read like ordinary git usage — a contributor without fast-import knowledge sees the same `commit` / `merge` calls as before.

## Part 3 — Demote redundant real-git backfill tests to fakes

The backfill command's planning / running / skip / overwrite / error logic is already exhaustively covered by fake-driven unit tests in `commands/backfill.rs` (over `FakeBackfillGit` / `FakeCommitRunner` / `MemoryStorage`). The integration suite was re-proving that same logic through nine real-git worktree drives, each spawning many git subprocesses.

Reduced the real-git backfill drives from nine to three, keeping only those that uniquely exercise the real adapters and `execute` wiring (which are `mutants::skip`'d and unreachable by fakes): a clean-object success across a range (trimmed 3→2 commits), a merge-spanning range, and a stop-on-failure drive. The six deleted scenarios each had an exact fake equivalent.

To preserve `BackfillReport::render` line coverage (previously reached only via the removed integration tests), added the fake unit test `render_lists_a_line_for_every_outcome_section`, which renders a report containing every outcome category and asserts each line. This also closed a pre-existing skipped-empty gap, so `commands/backfill.rs` line coverage rose from 97.65% to 98.32%; `git_history.rs` is unchanged. Removed the now-unused `drive_with_bench` harness helper and recorded the curated-subset strategy in AGENTS.md so the heavy drives are not re-added.

## Validation

Each part was gated independently before committing:

- Mutation parity: per-part cargo-mutants slices over the touched source produced caught sets byte-identical to the pre-part baseline, with zero new uncaught mutants.
- Coverage parity: `cargo llvm-cov` per-file reports held or improved (backfill.rs 97.65%→98.32%, TOTAL 96.21%→96.25%); no real-git logic path lost coverage.
- Final full package suite green (470 lib + 7 azure + 101 integration + 1 real_engine), `format-check` and `clippy --all-targets --all-features` clean.

## Measured impact

The per-mutant test workload (a full `--cfg mutants` `cargo test`) dropped from ~70.9s to ~8s in isolation: the real_engine Criterion compile and the Azurite-network self-skips no longer run, and the integration binary fell from ~22s to ~7s via the fast-import batching and the curated backfill subset.

Caveat: cargo-mutants' observed per-mutant test phase is ~23s under its six-job parallelism — contention (six jobs × 32 libtest threads all spawning git, AV-serialized) inflates the isolated ~8s by roughly 3×. That overhead is inherent to running parallel jobs, but without Parts 1 and 2 it would be substantially worse, since each of the six jobs would otherwise re-run the Criterion compile and the network self-skips per mutant. A full end-to-end pre/post wall-clock A/B (~50+ min) was not run; the correctness gates carried the validation instead.
