### PR TITLE
Make cargo-bench-history mutation-test skips actually take effect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ variant_size_differences = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(careful)',
     'cfg(coverage_nightly)',
-    'cfg(mutants)', # Set by cargo-mutants; lets tests opt out of mutation runs via `cfg_attr(mutants, ignore)`.
+    'cfg(mutants)', # Set by the `just mutants` recipe via RUSTFLAGS; lets tests opt out of mutation runs via `cfg_attr(mutants, ignore)`.
 ] }
 
 [workspace.lints.rustdoc]

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -22,10 +22,11 @@ mutants SHARD="" CAREFUL='false':
     #   * Path/package exclusions (the `-e` args below) drop whole files cargo-mutants
     #     should never mutate.
     #   * Individual tests that carry no mutation signal opt out at the test site with
-    #     `#[cfg_attr(mutants, ignore = "<why>")]` (cargo-mutants builds with
-    #     `--cfg mutants`). This keeps them running under normal `cargo test`/coverage
-    #     while skipping them under mutation - see packages/cargo-bench-history for
-    #     examples (the Azurite network tests and the real-engine end-to-end test).
+    #     `#[cfg_attr(mutants, ignore = "<why>")]`. This keeps them running under normal
+    #     `cargo test`/coverage while skipping them under mutation - see
+    #     packages/cargo-bench-history for examples (the Azurite network tests and the
+    #     real-engine end-to-end test). cargo-mutants defines no cfg of its own, so this
+    #     recipe exports `RUSTFLAGS=--cfg mutants` below to drive that opt-out.
 
     # Note: while cargo-mutants does theoretically support specifying these via config file, it
     # does not support merging that static set of entries with the dynamic set of entries we
@@ -177,6 +178,16 @@ mutants SHARD="" CAREFUL='false':
     # Set environment variable to disable watchdog during mutation testing.
     # This allows mutations that cause infinite loops to hang as expected.
     $env:MUTATION_TESTING = "1"
+
+    # Enable the `mutants` cfg so tests carrying `#[cfg_attr(mutants, ignore = "<why>")]`
+    # opt out of mutation runs. cargo-mutants defines no cfg of its own, but it preserves
+    # an existing RUSTFLAGS (chaining its own `--cap-lints=warn` onto it), so the flag we
+    # set here reaches rustc in the temporary build. The `cfg(mutants)` name is registered
+    # in the workspace `unexpected_cfgs` check-cfg list, so the zero-warnings policy holds.
+    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
+    if ($existing_rustflags -notlike "*--cfg mutants*") {
+        $env:RUSTFLAGS = ($existing_rustflags, "--cfg mutants" | Where-Object { $_ }) -join " "
+    }
 
     if ($careful) {
         # Force libtest to run a single test at a time within each `cargo test` invocation.

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -26,7 +26,8 @@ mutants SHARD="" CAREFUL='false':
     #     `cargo test`/coverage while skipping them under mutation - see
     #     packages/cargo-bench-history for examples (the Azurite network tests and the
     #     real-engine end-to-end test). cargo-mutants defines no cfg of its own, so this
-    #     recipe exports `RUSTFLAGS=--cfg mutants` below to drive that opt-out.
+    #     recipe ensures `RUSTFLAGS` contains `--cfg mutants` below (preserving any
+    #     existing flags) to drive that opt-out.
 
     # Note: while cargo-mutants does theoretically support specifying these via config file, it
     # does not support merging that static set of entries with the dynamic set of entries we

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -851,8 +851,9 @@ lean on (`classify`, `map_error`, the `storage::sas` signer, and
 so the error-mapping and signing behavior is still mutation-covered.
 
 **Skipping non-discriminating tests under mutation.** The `just mutants` recipe builds
-with `--cfg mutants` set (it exports `RUSTFLAGS=--cfg mutants`; cargo-mutants itself
-defines no such cfg), so a test that carries no mutation signal here can opt out at
+with `--cfg mutants` set (it ensures `RUSTFLAGS` contains `--cfg mutants`, preserving any
+flags you already set; cargo-mutants itself defines no such cfg), so a test that carries
+no mutation signal here can opt out at
 the test site with `#[cfg_attr(mutants, ignore = "<why>")]`. Unlike `mutants::skip`
 on production code, this is self-documenting where the test is defined and leaves
 normal `cargo test`, coverage, and the `test-azurite`/`test-azure` jobs untouched —

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -850,8 +850,9 @@ lean on (`classify`, `map_error`, the `storage::sas` signer, and
 `account_sas_expiry`) has dedicated unit tests and stays under mutation testing,
 so the error-mapping and signing behavior is still mutation-covered.
 
-**Skipping non-discriminating tests under mutation.** cargo-mutants builds with
-`--cfg mutants` set, so a test that carries no mutation signal here can opt out at
+**Skipping non-discriminating tests under mutation.** The `just mutants` recipe builds
+with `--cfg mutants` set (it exports `RUSTFLAGS=--cfg mutants`; cargo-mutants itself
+defines no such cfg), so a test that carries no mutation signal here can opt out at
 the test site with `#[cfg_attr(mutants, ignore = "<why>")]`. Unlike `mutants::skip`
 on production code, this is self-documenting where the test is defined and leaves
 normal `cargo test`, coverage, and the `test-azurite`/`test-azure` jobs untouched —


### PR DESCRIPTION
## Problem

The `#[cfg_attr(mutants, ignore)]` opt-outs added in #274 never actually took effect under `just mutants`. They were predicated on cargo-mutants setting `--cfg mutants`, but cargo-mutants 27.1.0 defines no such cfg, and nothing in the repo exported it. The only RUSTFLAGS change cargo-mutants makes is appending `--cap-lints=warn`.

As a result, the tests those annotations were meant to skip ran under **every mutant**: the `cbh_azure` network tests, the `cbh_real_engine` Criterion end-to-end test, and the `storage::azure` unit tests (which churn through TCP connect timeouts without an emulator). That is a large chunk of the per-mutant wall time that Part 1 of #274 was supposed to eliminate.

## Proof the cfg was never set

- **Source**: cargo-mutants 27.1.0 `src/cargo.rs` (`cargo_argv` + `encoded_rustflags`) only ever adds `--cap-lints=warn`; its own docs tell users to define their own mutation flag.
- **Empirical**: a temporary `#[cfg(mutants)] compile_error!(...)` probe stayed dormant through a real `cargo mutants --check` baseline (build succeeded), and the captured command was `cargo check --tests --profile=mutants --verbose --package=cargo-bench-history --all-features --locked` with no `--cfg` anywhere.

## Fix

Set `RUSTFLAGS=--cfg mutants` in the `just mutants` recipe (alongside the existing `MUTATION_TESTING=1`). cargo-mutants preserves a pre-existing `RUSTFLAGS` (chaining its `--cap-lints=warn`), so the flag reaches rustc in the scratch build and the opt-outs finally fire. The existing-RUSTFLAGS handling is preserved and the addition is idempotent.

## Verification

- With the recipe's RUSTFLAGS, the same `compile_error!` probe **fires** in cargo-mutants' build logs (`error: PROBE: cfg(mutants) IS active during this build`) — confirming `--cfg mutants` now reaches rustc.
- `cargo test -- --list --ignored` under `--cfg mutants`: **19 tests ignored** (11 `storage::azure` unit tests, 7 `cbh_azure`, 1 `cbh_real_engine`).
- Without `--cfg mutants`: **0 ignored** — normal `cargo test`, coverage, and the `test-azurite`/`test-azure` jobs still run everything, so coverage is fully preserved.

## Docs corrected

`Cargo.toml`, the recipe comment, and `packages/cargo-bench-history/AGENTS.md` previously claimed cargo-mutants sets `--cfg mutants`. They now state that the `just mutants` recipe sets it via `RUSTFLAGS`.
