### PR TITLE
cargo-bench-history: store BenchmarkResult metrics inline via SmallVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "rasciigraph",
  "serde",
  "serde_json",
+ "smallvec",
 ]
 
 [[package]]
@@ -3037,6 +3038,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/packages/cargo-bench-history-core/Cargo.toml
+++ b/packages/cargo-bench-history-core/Cargo.toml
@@ -19,6 +19,7 @@ nonempty = { workspace = true, features = ["serialize"] }
 rasciigraph = { workspace = true, features = ["color"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+smallvec = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 alloc_tracker = { path = "../alloc_tracker" }

--- a/packages/cargo-bench-history-core/src/model/mod.rs
+++ b/packages/cargo-bench-history-core/src/model/mod.rs
@@ -24,4 +24,4 @@ pub use context::{
     EnvironmentInfo, EnvironmentProvider, GitInfo, RunContext, ToolchainInfo, detect_environment,
 };
 pub use metric::{Metric, MetricKind};
-pub use run::{BenchmarkResult, Run, SCHEMA_VERSION};
+pub use run::{BenchmarkResult, MetricList, Run, SCHEMA_VERSION};

--- a/packages/cargo-bench-history-core/src/model/run.rs
+++ b/packages/cargo-bench-history-core/src/model/run.rs
@@ -1,6 +1,7 @@
 //! The benchmark run: the immutable unit of storage, one file per invocation.
 
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use crate::model::{BenchmarkId, Metric, RunContext};
 
@@ -53,20 +54,38 @@ impl Run {
     }
 }
 
+/// The metrics carried by a [`BenchmarkResult`].
+///
+/// A result holds at most one metric per [`MetricKind`], and the noisy
+/// single-metric engines (Criterion wall time, `all_the_time` processor time) are
+/// the common case, so a small result is kept inline rather than heap allocated.
+/// This drops an allocation per result on the deserialization-heavy `analyze`
+/// path, where every stored run's results are reconstructed in bulk. Larger
+/// (Callgrind) results spill to the heap as usual.
+///
+/// Its on-disk form is a plain JSON array, identical to a `Vec<Metric>`, so the
+/// change is wire-compatible and needs no [`SCHEMA_VERSION`] bump.
+///
+/// [`MetricKind`]: crate::model::MetricKind
+pub type MetricList = SmallVec<[Metric; 2]>;
+
 /// A single benchmark case: a stable identity plus its measured metrics.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct BenchmarkResult {
     /// Stable identity of the benchmark case (its series key).
     pub id: BenchmarkId,
     /// Metrics captured for this case in this run.
-    pub metrics: Vec<Metric>,
+    pub metrics: MetricList,
 }
 
 impl BenchmarkResult {
     /// Creates a result for `id` carrying `metrics`.
     #[must_use]
-    pub fn new(id: BenchmarkId, metrics: Vec<Metric>) -> Self {
-        Self { id, metrics }
+    pub fn new(id: BenchmarkId, metrics: impl Into<MetricList>) -> Self {
+        Self {
+            id,
+            metrics: metrics.into(),
+        }
     }
 }
 
@@ -111,5 +130,47 @@ mod tests {
         let parsed = Run::from_json(&json).unwrap();
 
         assert_eq!(parsed, run);
+    }
+
+    #[test]
+    fn metrics_serialize_as_a_plain_json_array() {
+        // The on-disk form must stay a JSON array, identical to a `Vec<Metric>`,
+        // so objects written before the field became a `SmallVec` keep
+        // deserializing unchanged.
+        let result = BenchmarkResult::new(
+            BenchmarkId::new(nonempty!["pkg".to_owned(), "case".to_owned()]),
+            vec![
+                Metric::new(MetricKind::InstructionCount, 10.0),
+                Metric::new(MetricKind::L1CacheHits, 20.0),
+            ],
+        );
+
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(
+            json.contains("\"metrics\":[{"),
+            "metrics must serialize as a JSON array: {json}"
+        );
+
+        let parsed: BenchmarkResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, result);
+    }
+
+    #[test]
+    fn result_roundtrips_across_the_inline_capacity_boundary() {
+        // One and two metrics stay inline; three spill to the heap. Serde must
+        // treat all three identically.
+        for count in [1_usize, 2, 3] {
+            let metrics = vec![Metric::new(MetricKind::InstructionCount, 1.0); count];
+            let result = BenchmarkResult::new(
+                BenchmarkId::new(nonempty!["pkg".to_owned(), "case".to_owned()]),
+                metrics,
+            );
+
+            let json = serde_json::to_string(&result).unwrap();
+            let parsed: BenchmarkResult = serde_json::from_str(&json).unwrap();
+
+            assert_eq!(parsed, result);
+            assert_eq!(parsed.metrics.len(), count);
+        }
     }
 }

--- a/packages/cargo-bench-history-core/src/model/run.rs
+++ b/packages/cargo-bench-history-core/src/model/run.rs
@@ -146,10 +146,13 @@ mod tests {
         );
 
         let json = serde_json::to_string(&result).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let metrics = value.get("metrics").expect("the metrics field is present");
         assert!(
-            json.contains("\"metrics\":[{"),
+            metrics.is_array(),
             "metrics must serialize as a JSON array: {json}"
         );
+        assert_eq!(metrics.as_array().unwrap().len(), 2);
 
         let parsed: BenchmarkResult = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, result);
@@ -158,9 +161,19 @@ mod tests {
     #[test]
     fn result_roundtrips_across_the_inline_capacity_boundary() {
         // One and two metrics stay inline; three spill to the heap. Serde must
-        // treat all three identically.
+        // treat all three identically. Each metric uses a distinct kind, as a
+        // result carries at most one metric per `MetricKind`.
+        const KINDS: [MetricKind; 3] = [
+            MetricKind::InstructionCount,
+            MetricKind::L1CacheHits,
+            MetricKind::EstimatedCycles,
+        ];
         for count in [1_usize, 2, 3] {
-            let metrics = vec![Metric::new(MetricKind::InstructionCount, 1.0); count];
+            let metrics: Vec<Metric> = KINDS
+                .iter()
+                .take(count)
+                .map(|&kind| Metric::new(kind, 1.0))
+                .collect();
             let result = BenchmarkResult::new(
                 BenchmarkId::new(nonempty!["pkg".to_owned(), "case".to_owned()]),
                 metrics,


### PR DESCRIPTION
## Summary

Each `BenchmarkResult` carries at most one metric per `MetricKind`, and the common case (Criterion wall time, `all_the_time` processor time) is a single metric. Heap-allocating that tiny per-result `Vec<Metric>` adds up on the deserialization-heavy `analyze` path, where every stored run's results are reconstructed in bulk.

This backs the field with `SmallVec<[Metric; 2]>` (exposed as a new `MetricList` type alias) so small results stay inline. `smallvec`'s serde impl serializes and deserializes as a plain sequence, so the on-disk JSON is byte-identical to a `Vec<Metric>` — the change is wire-compatible and needs no `SCHEMA_VERSION` bump. Larger (Callgrind, 9-metric) results spill to the heap exactly as before. The inline capacity of 2 captures the single-metric engines plus `alloc_tracker` (2 metrics).

## Measured effect

A/B allocation probe over a 200-result, single-metric payload (release build):

| | allocations / `Run::from_json` | time / deser |
|---|---|---|
| `Vec` baseline | 1008 | 136.0 µs |
| `SmallVec<[Metric; 2]>` | 808 | 132.1 µs |

Exactly one heap allocation eliminated per single-metric result (−200, i.e. −19.8% of all allocations during deserialize). The ~3% time delta is real but noisy; the allocation reduction is the clean, deterministic signal.

## Compatibility

- On-disk JSON form is unchanged (a plain array), so existing stored objects keep deserializing; no `SCHEMA_VERSION` bump.
- `BenchmarkResult::new` now takes `impl Into<MetricList>`, so every existing `vec![…]` / `Vec` caller compiles unchanged.

## Tests

- Added a wire-format test (metrics serialize as a JSON array) and an inline/spill roundtrip test covering 1, 2, and 3 metrics.
- Full `cargo-bench-history-core` (222) and `cargo-bench-history` lib (470) test suites pass; clippy `--all-targets` and rustfmt are clean.
