### PR TITLE
Align cbh report formats: lean JSON, mirror text in markdown

### DIFF
--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -192,14 +192,13 @@ pub enum Direction {
     Improvement,
 }
 
-/// One point of a finding's underlying series, exposed in the JSON output.
+/// One point of a finding's underlying series, retained for charting.
 ///
 /// Carries, for charting and provenance, the commit it was measured against, the
 /// value, and whether it came from a dirty (uncommitted-tree) snapshot.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub struct SeriesValue {
     /// Abbreviated commit the point was measured against, if known.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub commit: Option<String>,
     /// The measured value.
     pub value: f64,
@@ -208,13 +207,11 @@ pub struct SeriesValue {
 }
 
 /// One flagged change: where it is, what moved, by how much, and how sure we are.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub struct Finding {
     /// The comparable discriminant set the series belongs to.
-    #[serde(flatten)]
     pub set: DiscriminantSet,
     /// The benchmark identity.
-    #[serde(flatten)]
     pub id: BenchmarkId,
     /// The category of the metric that moved (governs unit and polarity).
     pub kind: MetricKind,
@@ -234,14 +231,12 @@ pub struct Finding {
     /// deterministic step).
     pub confidence: f64,
     /// Abbreviated commit the change is attributed to, if known.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub commit: Option<String>,
     /// Where, within a feature branch, the latest regime began — set only in
     /// branch mode when a within-branch flip is located, naming the commit the
     /// move starts at, so a "got worse late in the branch" finding can point at it.
     /// In history mode, an inactive (recovered) finding sets this to the commit at
     /// which the level returned to baseline.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub flipped_at: Option<String>,
     /// Whether the change is still reflected in the latest measured state. An active
     /// finding's current level still differs from baseline; an inactive one has
@@ -251,25 +246,13 @@ pub struct Finding {
     /// Index into `series` at which the active (post-blessing) window begins; points
     /// before it are pre-blessing history, retained for charting but excluded from
     /// detection. `0` when the series is unblessed.
-    #[serde(skip_serializing_if = "is_zero")]
     pub active_from: usize,
     /// Abbreviated commit of the blessing that re-baselined this series, if any.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub blessed_at: Option<String>,
     /// Effective (committer) time of the blessed commit, RFC 3339, if blessed.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub blessed_commit_time: Option<String>,
     /// The full underlying series, oldest-first, so a consumer can draw a chart.
     pub series: Vec<SeriesValue>,
-}
-
-/// Whether a count is zero, for `#[serde(skip_serializing_if)]`.
-#[expect(
-    clippy::trivially_copy_pass_by_ref,
-    reason = "serde skip predicate signature"
-)]
-fn is_zero(value: &usize) -> bool {
-    *value == 0
 }
 
 impl Finding {
@@ -2156,16 +2139,11 @@ mod tests {
             finding.blessed_commit_time.as_deref(),
             Some("1970-01-01T00:00:03Z")
         );
-        // A non-zero active window survives serialization (the `is_zero` skip
-        // predicate must keep it); an unblessed finding omits the field.
-        let json = serde_json::to_string(&finding).unwrap();
-        assert!(json.contains("\"active_from\":3"), "{json}");
+        // An unblessed finding has a zero active window.
         let unblessed = only(changes(&[series_of(&[
             10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 20.0,
         ])]));
         assert_eq!(unblessed.active_from, 0);
-        let json = serde_json::to_string(&unblessed).unwrap();
-        assert!(!json.contains("active_from"), "{json}");
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -251,7 +251,9 @@ pub struct Finding {
     pub blessed_at: Option<String>,
     /// Effective (committer) time of the blessed commit, RFC 3339, if blessed.
     pub blessed_commit_time: Option<String>,
-    /// The full underlying series, oldest-first, so a consumer can draw a chart.
+    /// The full underlying series, oldest-first. Retained internally so the text and
+    /// Markdown reports can draw a chart; it is not part of the machine-readable JSON
+    /// contract.
     pub series: Vec<SeriesValue>,
 }
 

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -256,11 +256,31 @@ fn set_label(set: &DiscriminantSet) -> String {
     set.to_string()
 }
 
+/// Forces `colored`'s process-global override to `value` until dropped, then
+/// restores ambient auto-detection. Bundling the set with the matching restore keeps
+/// the override scoped to a single render call so it can never leak into later output,
+/// even on an early return or panic.
+struct ColorOverride;
+
+impl ColorOverride {
+    #[must_use]
+    fn force(value: bool) -> Self {
+        colored::control::set_override(value);
+        Self
+    }
+}
+
+impl Drop for ColorOverride {
+    fn drop(&mut self) {
+        colored::control::unset_override();
+    }
+}
+
 fn render_text(input: &ReportInput<'_>, color: bool) -> String {
-    // Force `colored` and `rasciigraph` to honor this explicit decision rather
-    // than their own ambient terminal auto-detection, so tests and pipes are
-    // deterministic regardless of how the process is run.
-    colored::control::set_override(color);
+    // Force `colored` and `rasciigraph` to honor this explicit decision rather than
+    // their own ambient terminal auto-detection, so tests and pipes are deterministic
+    // regardless of how the process is run. The guard restores auto-detection on return.
+    let _color = ColorOverride::force(color);
 
     let regressions = count_top(input.findings, Direction::Regression);
     let improvements = count_top(input.findings, Direction::Improvement);
@@ -465,15 +485,10 @@ fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) ->
 fn render_markdown(input: &ReportInput<'_>) -> String {
     // Charts embed ANSI color when `colored` is active; force it off while rendering
     // so the fenced code blocks carry plain characters that render in any Markdown
-    // viewer, then return `colored` to its ambient auto-detection so this override
+    // viewer. The guard restores ambient auto-detection on return so this override
     // never leaks into later output in the same process.
-    colored::control::set_override(false);
-    let report = render_markdown_body(input);
-    colored::control::unset_override();
-    report
-}
+    let _color = ColorOverride::force(false);
 
-fn render_markdown_body(input: &ReportInput<'_>) -> String {
     let regressions = count_top(input.findings, Direction::Regression);
     let improvements = count_top(input.findings, Direction::Improvement);
 
@@ -1177,7 +1192,7 @@ mod tests {
     #[test]
     fn chart_of_needs_at_least_two_points() {
         // Deterministic, Miri-safe color state for the rasciigraph plot.
-        colored::control::set_override(false);
+        let _color = ColorOverride::force(false);
         let point = |value: f64| SeriesValue {
             commit: None,
             value,
@@ -1193,7 +1208,7 @@ mod tests {
     #[test]
     fn chart_of_plots_improvements_and_overlays_a_partial_active_window() {
         // Deterministic, Miri-safe color state for the rasciigraph plot.
-        colored::control::set_override(false);
+        let _color = ColorOverride::force(false);
         let point = |value: f64| SeriesValue {
             commit: None,
             value,

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -271,6 +271,12 @@ impl ColorOverride {
 }
 
 impl Drop for ColorOverride {
+    // Restoring `colored`'s process-global override is exercised by every render test
+    // (each builds and drops a guard), but asserting it requires observing that global
+    // state, which races with the rest of the parallel test suite and which `colored`
+    // exposes no override-state getter to read deterministically. Skipped for mutation
+    // only; the restore itself is covered behaviourally.
+    #[cfg_attr(test, mutants::skip)]
     fn drop(&mut self) {
         colored::control::unset_override();
     }
@@ -845,6 +851,39 @@ mod tests {
     }
 
     #[test]
+    fn text_report_shows_per_set_counts_distinct_from_totals() {
+        // Give the set tallies that differ from the top-level aggregate so the per-set
+        // counts line is identifiable on its own — a blanked-out line would no longer
+        // match, unlike when the set and total counts coincide.
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let summaries = vec![SetSummary {
+            set: &set,
+            runs: 7,
+            series: 5,
+            findings: findings.iter().collect(),
+        }];
+        let input = ReportInput {
+            project: "folo",
+            mode: "history",
+            notable: true,
+            runs: 99,
+            series: 88,
+            findings: &findings,
+            sets: &summaries,
+            hint: None,
+            warning: None,
+        };
+        let report = render(&input, ReportFormat::Text, false);
+        // The per-set counts line carries the set's own tallies, distinct from the
+        // top-level totals (`runs: 99  series: 88`).
+        assert!(
+            report.contains("  runs: 7  series: 5  regressions: 1  improvements: 0"),
+            "{report}"
+        );
+    }
+
+    #[test]
     fn report_renders_direction_labels() {
         let set = discriminant_set();
         let mut improvement = regression();
@@ -954,8 +993,45 @@ mod tests {
             report.contains("**+30.00%** — `nm/nm::observe/pull` · instruction_count"),
             "{report}"
         );
+        // An active finding carries no recovered suffix.
+        assert!(!report.contains("_(recovered)_"), "{report}");
         assert!(
             report.contains("regression via change point · 100% confidence · 100 → 130"),
+            "{report}"
+        );
+    }
+
+    #[test]
+    fn markdown_report_marks_an_inactive_recovered_finding() {
+        let set = discriminant_set();
+        let mut recovered = regression();
+        recovered.active = false;
+        recovered.flipped_at = Some("c4".to_owned());
+        let findings = vec![recovered];
+        let mut summaries = Vec::new();
+        let input = single_set_input("folo", &set, &findings, &mut summaries);
+        let report = render(&input, ReportFormat::Markdown, false);
+        // The headline suffix flags a recovered finding; the shared detail line names
+        // the recovery commit.
+        assert!(
+            report.contains("· instruction_count _(recovered)_"),
+            "{report}"
+        );
+        assert!(report.contains("recovers at c4"), "{report}");
+    }
+
+    #[test]
+    fn markdown_report_annotates_a_blessed_finding() {
+        let set = discriminant_set();
+        let mut blessed = regression();
+        blessed.blessed_at = Some("c3".to_owned());
+        blessed.blessed_commit_time = Some("2024-01-01T00:00:00Z".to_owned());
+        let findings = vec![blessed];
+        let mut summaries = Vec::new();
+        let input = single_set_input("folo", &set, &findings, &mut summaries);
+        let report = render(&input, ReportFormat::Markdown, false);
+        assert!(
+            report.contains("blessed at c3 (2024-01-01T00:00:00Z)"),
             "{report}"
         );
     }

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -29,7 +29,7 @@ pub enum ReportFormat {
     Text,
     /// A machine-readable JSON document.
     Json,
-    /// A Markdown summary with a findings table per set.
+    /// A Markdown summary mirroring the text report, with charts as fenced blocks.
     Markdown,
 }
 
@@ -86,6 +86,11 @@ pub struct ReportInput<'a> {
 }
 
 /// The JSON shape of a per-set slice.
+///
+/// Carries only the partition identity and its tallies — the cheap metadata that
+/// mirrors the per-set header the text and Markdown reports print. The findings
+/// themselves live once in the top-level [`JsonReport::findings`] list (each names
+/// its own set), so the document never duplicates a finding per set.
 #[derive(Serialize)]
 struct JsonSet<'a> {
     /// Engine identifier.
@@ -102,8 +107,75 @@ struct JsonSet<'a> {
     regressions: usize,
     /// Flagged improvements in this set.
     improvements: usize,
-    /// This set's findings, ranked most-notable first.
-    findings: Vec<&'a Finding>,
+}
+
+/// The JSON shape of one finding: the machine-readable form of a text-report
+/// finding paragraph.
+///
+/// It carries exactly the data the text and Markdown reports show — the partition,
+/// the benchmark identity, the metric, the detected move, and the provenance — with
+/// no underlying series (the text chart is a presentation concern, not data a
+/// consumer reconstructs) and full `f64` precision (the human reports round).
+#[derive(Serialize)]
+struct JsonFinding<'a> {
+    /// The comparable discriminant set, inlined as `engine`/`target_triple`/
+    /// `machine_key` so the flat list is self-describing.
+    #[serde(flatten)]
+    set: &'a DiscriminantSet,
+    /// The benchmark identity, inlined as `segments`.
+    #[serde(flatten)]
+    id: &'a BenchmarkId,
+    /// The metric kind that moved (its `snake_case` wire name).
+    kind: &'static str,
+    /// Which detector produced the finding.
+    method: FindingMethod,
+    /// Whether the move is a regression or an improvement.
+    direction: Direction,
+    /// The before-regime representative value.
+    baseline: f64,
+    /// The after-regime representative value.
+    latest: f64,
+    /// The change relative to the baseline (`(latest - baseline) / baseline`).
+    relative_delta: f64,
+    /// The detector's confidence (`1 - p_value`; `1.0` for an exact step).
+    confidence: f64,
+    /// Abbreviated commit the change is attributed to, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit: Option<&'a str>,
+    /// Whether the change is still reflected in the latest measured state.
+    active: bool,
+    /// Where, within a branch, the latest regime began (branch mode) or where the
+    /// level recovered (history + inactive). Present only when located.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flipped_at: Option<&'a str>,
+    /// Abbreviated commit of the blessing that re-baselined the series, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blessed_at: Option<&'a str>,
+    /// Effective (committer) time of the blessed commit, RFC 3339, if blessed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blessed_commit_time: Option<&'a str>,
+}
+
+impl<'a> JsonFinding<'a> {
+    /// Projects a [`Finding`] onto its cheap, series-free JSON shape.
+    fn from_finding(finding: &'a Finding) -> Self {
+        Self {
+            set: &finding.set,
+            id: &finding.id,
+            kind: finding.kind.as_str(),
+            method: finding.method,
+            direction: finding.direction,
+            baseline: finding.baseline,
+            latest: finding.latest,
+            relative_delta: finding.relative_delta,
+            confidence: finding.confidence,
+            commit: finding.commit.as_deref(),
+            active: finding.active,
+            flipped_at: finding.flipped_at.as_deref(),
+            blessed_at: finding.blessed_at.as_deref(),
+            blessed_commit_time: finding.blessed_commit_time.as_deref(),
+        }
+    }
 }
 
 /// The JSON shape of a rendered report.
@@ -129,9 +201,9 @@ struct JsonReport<'a> {
     /// A warning when dirty base-branch-tip runs were admitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     warning: Option<&'a str>,
-    /// Every set's findings, globally ranked.
-    findings: &'a [Finding],
-    /// The per-set breakdown.
+    /// Every finding, globally ranked most-notable first; each names its own set.
+    findings: Vec<JsonFinding<'a>>,
+    /// The per-set breakdown (partition identity and tallies only).
     sets: Vec<JsonSet<'a>>,
 }
 
@@ -220,6 +292,7 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
         }
         lines.push(String::new());
         lines.push(format!("Set {}", set_label(summary.set)));
+        lines.push(set_counts_line(summary));
         for finding in &summary.findings {
             push_finding_block(&mut lines, finding, chart_enabled);
         }
@@ -250,8 +323,40 @@ fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled:
         finding.kind.as_str()
     ));
 
+    lines.push(format!("    {}", detail_text(finding)).dimmed().to_string());
+
+    // Name the blessing that re-baselined the series, so the reader knows the
+    // history before it is intentionally excluded from detection.
+    if let Some(blessing) = blessing_text(finding) {
+        lines.push(format!("    {blessing}").dimmed().to_string());
+    }
+
+    if chart_enabled
+        && let Some(chart) = chart_of(&finding.series, finding.direction, finding.active_from)
+    {
+        lines.push(chart);
+    }
+}
+
+/// The per-set summary line — the cheap tally the JSON `sets` block carries, shown
+/// under each set header so the text and Markdown reports surface it too.
+fn set_counts_line(summary: &SetSummary<'_>) -> String {
+    format!(
+        "  runs: {}  series: {}  regressions: {}  improvements: {}",
+        summary.runs,
+        summary.series,
+        count_direction(&summary.findings, Direction::Regression),
+        count_direction(&summary.findings, Direction::Improvement),
+    )
+}
+
+/// The plain-text detail body shared by the text and Markdown reports: the
+/// direction, detector, confidence, the `baseline → latest` move, the attributed
+/// commit, and — when located — the flip/recovery commit. Carries no styling and no
+/// leading indent; each format applies its own.
+fn detail_text(finding: &Finding) -> String {
     let mut detail = format!(
-        "    {} via {} · {} confidence · {} → {} · @ {}",
+        "{} via {} · {} confidence · {} → {} · @ {}",
         direction_label(finding.direction),
         method_label(finding.method),
         format_confidence(finding.confidence),
@@ -268,27 +373,18 @@ fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled:
         };
         write!(detail, " · {verb} {flipped_at}").expect("writing to a String is infallible");
     }
-    lines.push(detail.dimmed().to_string());
+    detail
+}
 
-    // Name the blessing that re-baselined the series, so the reader knows the
-    // history before it is intentionally excluded from detection.
-    if let Some(blessed_at) = &finding.blessed_at {
-        let date = finding
-            .blessed_commit_time
-            .as_deref()
-            .map_or_else(String::new, |effective| format!(" ({effective})"));
-        lines.push(
-            format!("    blessed at {blessed_at}{date}")
-                .dimmed()
-                .to_string(),
-        );
-    }
-
-    if chart_enabled
-        && let Some(chart) = chart_of(&finding.series, finding.direction, finding.active_from)
-    {
-        lines.push(chart);
-    }
+/// The plain-text blessing/recovery note, when the series was re-baselined by a
+/// blessing. Carries no styling and no leading indent.
+fn blessing_text(finding: &Finding) -> Option<String> {
+    let blessed_at = finding.blessed_at.as_deref()?;
+    let date = finding
+        .blessed_commit_time
+        .as_deref()
+        .map_or_else(String::new, |effective| format!(" ({effective})"));
+    Some(format!("blessed at {blessed_at}{date}"))
 }
 
 /// Whether the active window spans the whole series, so no greyed prefix is drawn.
@@ -367,6 +463,10 @@ fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) ->
 }
 
 fn render_markdown(input: &ReportInput<'_>) -> String {
+    // Charts embed ANSI color when `colored` is active; force it off so the fenced
+    // code blocks carry plain characters that render in any Markdown viewer.
+    colored::control::set_override(false);
+
     let regressions = count_top(input.findings, Direction::Regression);
     let improvements = count_top(input.findings, Direction::Improvement);
 
@@ -391,35 +491,69 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
         return finish(&lines);
     }
 
+    // A per-commit chart is meaningful only for a history timeline, matching the
+    // text report; branch/tip modes compare against a baseline.
+    let chart_enabled = input.mode == "history";
     for summary in input.sets {
         if summary.findings.is_empty() {
             continue;
         }
         lines.push(String::new());
-        lines.push(format!("## {}", summary.set));
+        lines.push(format!("## Set {}", set_label(summary.set)));
         lines.push(String::new());
-        lines.push(
-            "| Change | Direction | Method | Confidence | Engine | Benchmark | Metric | Baseline | Latest |"
-                .to_owned(),
-        );
-        lines.push("| --- | --- | --- | --- | --- | --- | --- | --- | --- |".to_owned());
+        lines.push(format!("- Runs: {}", summary.runs));
+        lines.push(format!("- Series: {}", summary.series));
+        lines.push(format!(
+            "- Regressions: {}",
+            count_direction(&summary.findings, Direction::Regression)
+        ));
+        lines.push(format!(
+            "- Improvements: {}",
+            count_direction(&summary.findings, Direction::Improvement)
+        ));
         for finding in &summary.findings {
-            lines.push(format!(
-                "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
-                format_percent(finding.relative_delta),
-                direction_label(finding.direction),
-                method_label(finding.method),
-                format_confidence(finding.confidence),
-                finding.set.engine,
-                describe_id(&finding.id),
-                finding.kind.as_str(),
-                format_value(finding.baseline),
-                format_value(finding.latest),
-            ));
+            push_finding_markdown(&mut lines, finding, chart_enabled);
         }
     }
     push_warning(&mut lines, input.warning);
     finish(&lines)
+}
+
+/// Appends one finding as a Markdown block mirroring the text report: a bold
+/// percentage headline naming the benchmark and metric, the shared detail line, an
+/// optional blessing note, and — in history mode — the metric chart in a fenced
+/// `text` block so it survives Markdown rendering.
+fn push_finding_markdown(lines: &mut Vec<String>, finding: &Finding, chart_enabled: bool) {
+    lines.push(String::new());
+
+    let status = if finding.active {
+        String::new()
+    } else {
+        " _(recovered)_".to_owned()
+    };
+    lines.push(format!(
+        "**{}** — `{}` · {}{status}",
+        format_percent(finding.relative_delta),
+        describe_id(&finding.id),
+        finding.kind.as_str(),
+    ));
+
+    lines.push(String::new());
+    lines.push(detail_text(finding));
+
+    if let Some(blessing) = blessing_text(finding) {
+        lines.push(String::new());
+        lines.push(blessing);
+    }
+
+    if chart_enabled
+        && let Some(chart) = chart_of(&finding.series, finding.direction, finding.active_from)
+    {
+        lines.push(String::new());
+        lines.push("```text".to_owned());
+        lines.push(chart);
+        lines.push("```".to_owned());
+    }
 }
 
 // Pure serialization glue, fully exercised by `json_report_is_structured` and
@@ -439,7 +573,6 @@ fn render_json(input: &ReportInput<'_>) -> String {
             series: summary.series,
             regressions: count_direction(&summary.findings, Direction::Regression),
             improvements: count_direction(&summary.findings, Direction::Improvement),
-            findings: summary.findings.clone(),
         })
         .collect();
 
@@ -453,7 +586,11 @@ fn render_json(input: &ReportInput<'_>) -> String {
         improvements: count_top(input.findings, Direction::Improvement),
         hint: input.hint,
         warning: input.warning,
-        findings: input.findings,
+        findings: input
+            .findings
+            .iter()
+            .map(JsonFinding::from_finding)
+            .collect(),
         sets,
     };
     // The report is built from plain structs whose only numbers are finite (or
@@ -701,8 +838,16 @@ mod tests {
         assert!(text.contains("improvement via change point"), "{text}");
 
         let markdown = render(&input, ReportFormat::Markdown, false);
-        assert!(markdown.contains("| +30.00% | regression |"), "{markdown}");
-        assert!(markdown.contains("| -5.00% | improvement |"), "{markdown}");
+        assert!(
+            markdown.contains("regression via change point"),
+            "{markdown}"
+        );
+        assert!(
+            markdown.contains("improvement via change point"),
+            "{markdown}"
+        );
+        assert!(markdown.contains("**+30.00%**"), "{markdown}");
+        assert!(markdown.contains("**-5.00%**"), "{markdown}");
 
         // The per-set JSON tallies count each direction independently: this set
         // holds one regression and one improvement.
@@ -765,7 +910,7 @@ mod tests {
     }
 
     #[test]
-    fn markdown_report_renders_a_table_per_set() {
+    fn markdown_report_renders_a_block_per_set() {
         let set = discriminant_set();
         let findings = vec![regression()];
         let mut summaries = Vec::new();
@@ -776,11 +921,35 @@ mod tests {
             "{report}"
         );
         assert!(
-            report.contains("## callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            report.contains("## Set callgrind/x86_64-unknown-linux-gnu/synthetic"),
             "{report}"
         );
-        assert!(report.contains("| Change | Direction |"), "{report}");
-        assert!(report.contains("| +30.00% | regression |"), "{report}");
+        // The per-set tally mirrors the JSON metadata and the text header.
+        assert!(report.contains("- Regressions: 1"), "{report}");
+        // Findings render as bold-headline blocks, not a table.
+        assert!(!report.contains("| Change | Direction |"), "{report}");
+        assert!(
+            report.contains("**+30.00%** — `nm/nm::observe/pull` · instruction_count"),
+            "{report}"
+        );
+        assert!(
+            report.contains("regression via change point · 100% confidence · 100 → 130"),
+            "{report}"
+        );
+    }
+
+    #[test]
+    fn markdown_history_mode_draws_a_fenced_chart() {
+        let set = discriminant_set();
+        let findings = vec![regression_with_series()];
+        let mut summaries = Vec::new();
+        let mut input = single_set_input("folo", &set, &findings, &mut summaries);
+        input.mode = "history";
+        let report = render(&input, ReportFormat::Markdown, false);
+        // The chart sits inside a fenced `text` block and carries no ANSI escapes.
+        assert!(report.contains("```text"), "{report}");
+        assert!(report.contains('┤') || report.contains('┼'), "{report}");
+        assert!(!report.contains('\u{1b}'), "{report}");
     }
 
     #[test]
@@ -900,11 +1069,17 @@ mod tests {
         assert_eq!(finding["segments"][0], "nm");
         assert_eq!(finding["segments"][1], "nm::observe");
         assert_eq!(finding["direction"], "regression");
-        // The per-set breakdown carries the partition triple.
+        assert_eq!(finding["kind"], "instruction_count");
+        // The bulky per-commit series is no longer carried: JSON mirrors the text
+        // data, not the chart it draws from.
+        assert!(finding.get("series").is_none(), "{report}");
+        // The per-set breakdown carries the partition triple and tallies only — no
+        // duplicated findings array.
         let set_json = &parsed["sets"][0];
         assert_eq!(set_json["engine"], "callgrind");
         assert_eq!(set_json["target_triple"], "x86_64-unknown-linux-gnu");
         assert_eq!(set_json["regressions"], 1);
+        assert!(set_json.get("findings").is_none(), "{report}");
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -463,10 +463,17 @@ fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) ->
 }
 
 fn render_markdown(input: &ReportInput<'_>) -> String {
-    // Charts embed ANSI color when `colored` is active; force it off so the fenced
-    // code blocks carry plain characters that render in any Markdown viewer.
+    // Charts embed ANSI color when `colored` is active; force it off while rendering
+    // so the fenced code blocks carry plain characters that render in any Markdown
+    // viewer, then return `colored` to its ambient auto-detection so this override
+    // never leaks into later output in the same process.
     colored::control::set_override(false);
+    let report = render_markdown_body(input);
+    colored::control::unset_override();
+    report
+}
 
+fn render_markdown_body(input: &ReportInput<'_>) -> String {
     let regressions = count_top(input.findings, Direction::Regression);
     let improvements = count_top(input.findings, Direction::Improvement);
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -311,9 +311,10 @@ being analyzed:
   detail line; in **history mode only** a colored `rasciigraph` line chart of the
   series). `analyze_with` receives an explicit `color: bool` (production computes
   `stdout().is_terminal() && NO_COLOR unset`; tests pass `false`) and `render_text`
-  calls `colored::control::set_override(color)` so both `colored` styling and the
-  chart honor it deterministically (and stay Miri-safe — no isatty syscall). Text
-  and Markdown values are rounded to four significant figures via `format_value`
+  installs a scoped `colored` override (a `ColorOverride` RAII guard) so both
+  `colored` styling and the chart honor it deterministically (and stay Miri-safe — no
+  isatty syscall); the guard restores ambient auto-detection when rendering returns.
+  Text and Markdown values are rounded to four significant figures via `format_value`
   (the integer part is never truncated); the JSON keeps full `f64` precision.
 
 The read-only `git_history::GitHistory` port (`resolve`, `default_branch`,

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1214,8 +1214,8 @@ benchmark identifier + metric, a dimmed detail line (`direction via method ·
 confidence · baseline → latest · @ commit`, plus `· flips at <commit>` in branch
 mode), and — in **history mode only** — a small colored line chart of the series
 over commits drawn with `rasciigraph` (regressions red, improvements green). Each set
-header is followed by a one-line tally (`runs · series · regressions ·
-improvements`). The chart is omitted for branch/tip mode. Color (ANSI styling and
+header is followed by a one-line tally (`runs: <n>  series: <n>  regressions: <n>
+improvements: <n>`). The chart is omitted for branch/tip mode. Color (ANSI styling and
 chart hue) is enabled only when stdout is a terminal and `NO_COLOR` is unset, so
 piped output and tests stay plain.
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1117,7 +1117,10 @@ established level (a bounded window of preceding points) using the same engine g
 and reports regressions only.
 
 **JSON signal (downstream contract).** Because findings never gate the exit code
-(§8.3), the `json` report is the machine-readable output:
+(§8.3), the `json` report is the machine-readable output. It carries exactly the data
+the text and Markdown reports show — no underlying per-commit series (a presentation
+concern the human reports draw a chart from, not data a consumer reconstructs) — at
+full `f64` precision:
 
 ```json
 {
@@ -1135,35 +1138,54 @@ and reports regressions only.
       "kind": "instruction_count",
       "method": "change_point", "direction": "regression",
       "baseline": 100.0, "latest": 130.0,
-      "delta": 30.0, "relative_delta": 0.30, "confidence": 1.0,
+      "relative_delta": 0.30, "confidence": 1.0,
+      "commit": "deadbee",       // commit the change is attributed to, if known
+      "active": true,            // false for a resolved/blessed finding (§9.7)
       "flipped_at": "a1b2c3d",   // branch: where the latest regime began;
                                  // history+inactive: where the level recovered
-      "active": true,            // false for a resolved/blessed finding (§9.7)
       "blessed_at": "9f8e7d6",   // history only: the blessing that re-baselined this series
-      "blessed_commit_time": "2024-03-01T00:00:00Z",
-      "series": [ { "commit": "…", "value": 100.0, "dirty": false }, … ]
+      "blessed_commit_time": "2024-03-01T00:00:00Z"
     }
   ],
-  "sets": [ … ]              // per-discriminant-set breakdown
+  "sets": [                  // per-discriminant-set breakdown: identity + tallies only
+    {
+      "engine": "callgrind",
+      "target_triple": "x86_64-unknown-linux-gnu",
+      "machine_key": "synthetic",
+      "runs": 7, "series": 3,
+      "regressions": 1, "improvements": 0
+    }
+  ]
 }
 ```
 
-A consumer keys off `notable` (post or stay silent), reads each finding's
-`direction`/`relative_delta`/`flipped_at`/`active`, and can render the embedded
-`series` as a chart. `blessed_at`/`blessed_commit_time` are present only when the
-series was re-baselined by a blessing (§9.7); `active_from` (omitted when zero) marks
-where the active window begins. JSON values keep full `f64` precision; only the
-human-readable text and Markdown reports round to four significant figures.
+Each finding is self-describing: it inlines its discriminant set
+(`engine`/`target_triple`/`machine_key`) and benchmark `segments`, so the flat,
+globally-ranked `findings` list is the single source of truth — findings are never
+duplicated under `sets`. A consumer keys off `notable` (post or stay silent), reads
+each finding's `direction`/`relative_delta`/`flipped_at`/`active`, and tallies per
+partition from `sets`. `commit`, `flipped_at`, `blessed_at`, and
+`blessed_commit_time` are present only when known (§9.7). JSON values keep full `f64`
+precision; only the human-readable text and Markdown reports round to four
+significant figures.
 
 **Text report layout.** The text report renders one paragraph per finding: a bold,
 direction-colored headline leading with the relative-change percent and the
 benchmark identifier + metric, a dimmed detail line (`direction via method ·
 confidence · baseline → latest · @ commit`, plus `· flips at <commit>` in branch
 mode), and — in **history mode only** — a small colored line chart of the series
-over commits drawn with `rasciigraph` (regressions red, improvements green). The
-chart is omitted for branch/tip mode and for non-text formats. Color (ANSI styling
-and chart hue) is enabled only when stdout is a terminal and `NO_COLOR` is unset, so
+over commits drawn with `rasciigraph` (regressions red, improvements green). Each set
+header is followed by a one-line tally (`runs · series · regressions ·
+improvements`). The chart is omitted for branch/tip mode. Color (ANSI styling and
+chart hue) is enabled only when stdout is a terminal and `NO_COLOR` is unset, so
 piped output and tests stay plain.
+
+**Markdown report layout.** The Markdown report carries the same data as the text
+report with Markdown formatting: a top-level metadata list, an `## Set …` heading per
+partition with its tally as a bullet list, and one block per finding — a bold
+percentage headline (`` **+30.00%** — `pkg/group/case` · kind ``), the same detail
+line, an optional blessing note, and — in history mode — the chart inside a fenced
+` ```text ` block (rendered without ANSI so it survives Markdown viewers).
 
 ### 9.7 Re-baselining: blessings, resolved spikes, and active/inactive segments
 
@@ -1836,3 +1858,19 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      changes the output, so `worker_count` carries `#[mutants::skip]` while the real detection
      logic in `detect_one` stays under mutation testing. The serial `find_changes` survives
      only as the test-only oracle that pins the chunked path to a non-chunked reference.
+34. **Report formats mirror the text output** — *Decided:* the three report formats
+     carry the **same data**, differing only in presentation. The `text` format is the
+     canonical layout; `markdown` is that data with Markdown formatting (per-finding blocks,
+     not a table; charts as fenced ` ```text ` code blocks rendered without ANSI); and
+     `json` is the machine-readable form of the same fields. The JSON `findings` list is
+     flat and globally ranked, each finding self-describing (inlining its discriminant set
+     and benchmark `segments`), and the `sets` array carries only per-partition identity and
+     tallies (`runs`/`series`/`regressions`/`improvements`) — findings are never duplicated
+     under `sets`. JSON omits the per-commit `series` (a charting/presentation concern the
+     text and Markdown reports draw from internally, not data a consumer reconstructs) and
+     the redundant absolute `delta` (derivable from `baseline`/`latest`). The per-set tally
+     is surfaced in all three formats (a set-counts line in text, a bullet list in Markdown,
+     the `sets` objects in JSON). *(Superseded: the earlier JSON embedded each finding's full
+     per-commit series and serialized every finding twice — once at the top level and once
+     under its set — which on a large history inflated the document to hundreds of MiB; the
+     earlier Markdown rendered a wide findings table per set with no charts.)*

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -127,7 +127,9 @@ async fn analyze_markdown_format_renders_blocks() {
     );
     // A bold percentage headline leads each finding block; there is no table.
     assert!(!report.contains("| Change | Direction |"), "{report}");
-    assert!(report.contains("**"), "{report}");
+    // The headline format is a bold signed percentage joined to the benchmark id —
+    // far more specific than a bare `**` that any unrelated bold text would match.
+    assert!(report.contains("%** — `"), "{report}");
     assert!(report.contains("via change point"), "{report}");
 }
 

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -107,10 +107,10 @@ async fn analyze_json_format_is_structured() {
     assert_eq!(parsed["findings"][0]["direction"], "regression");
 }
 
-/// `--format markdown` renders a findings table.
+/// `--format markdown` renders per-finding blocks mirroring the text report.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_markdown_format_renders_table() {
+async fn analyze_markdown_format_renders_blocks() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.seed_rising_callgrind_history();
 
@@ -125,7 +125,10 @@ async fn analyze_markdown_format_renders_table() {
         report.contains("# Benchmark history analysis: testproj"),
         "{report}"
     );
-    assert!(report.contains("| Change | Direction |"), "{report}");
+    // A bold percentage headline leads each finding block; there is no table.
+    assert!(!report.contains("| Change | Direction |"), "{report}");
+    assert!(report.contains("**"), "{report}");
+    assert!(report.contains("via change point"), "{report}");
 }
 
 /// `--since` excludes points before the cutoff, so an early spike is dropped and
@@ -391,7 +394,7 @@ async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
     assert_eq!(findings[0]["segments"][1], "alpha::bench", "{report}");
     assert_eq!(findings[1]["segments"][0], "beta", "{report}");
 
-    // The Markdown rendering preserves the same ranked order in its table rows.
+    // The Markdown rendering preserves the same ranked order in its finding blocks.
     let RunOutcome::Analyzed {
         report: markdown, ..
     } = workspace
@@ -1264,8 +1267,8 @@ async fn analyze_branch_mode_reports_the_latest_regime_with_a_flip() {
         "the flip should name the commit the latest regime began at: {report}"
     );
     assert!(
-        finding["series"].as_array().is_some_and(|s| !s.is_empty()),
-        "the finding should carry the underlying series for charting: {report}"
+        finding.get("series").is_none(),
+        "the JSON finding mirrors the text data and omits the charting series: {report}"
     );
 }
 


### PR DESCRIPTION
## Problem

`analyze::report::render_json()` was absurdly slow in `just bench-history-stress`. Each JSON `Finding` embedded its **entire per-commit series**, and the whole findings list was serialized **twice** — once at the top level and again duplicated under every `sets[]` entry — then pretty-printed. On the stress dataset a 19 MiB input produced a **154 MiB** `history.json` (branch 84 MiB, tip 42 MiB), and that serialization dominated the stress wall clock.

## Redesign

The JSON was a full data dump rather than a machine-readable form of the report. All three formats now carry the **same data**, differing only in presentation, with the **text report as the canonical layout**.

- **JSON findings** are flat, globally ranked, and self-describing (each inlines its discriminant set and benchmark `segments`). Dropped the per-commit `series` (a charting/presentation concern, not data a consumer reconstructs) and the redundant absolute `delta` (derivable from `baseline`/`latest`).
- **JSON `sets`** carry per-partition identity and tallies only (`runs`/`series`/`regressions`/`improvements`), so findings are never duplicated.
- The per-set tally — the one genuinely cheap "bright idea" from the old JSON — is now surfaced in **all three** formats: a counts line in text, a bullet list in Markdown, and the `sets` objects in JSON.
- **Markdown** drops the wide findings table for per-finding blocks mirroring the text report (bold percentage headline, shared detail line, optional blessing note), with history charts rendered into fenced `text` code blocks (ANSI forced off so they survive Markdown viewers).
- Removed `Serialize` from `Finding`/`SeriesValue`; report serialization now goes through dedicated `JsonFinding`/`JsonSet` view structs, and the text/Markdown renderers share `detail_text`/`blessing_text`/`set_counts_line` helpers.

No backward compatibility was kept — the old JSON and Markdown shapes are gone.

## Verification

Re-ran the stress dump (moderate scenario, `--benchmarks 200 --commits 400`):

| file | before | after |
|---|---|---|
| history.json | 154 MB | **1.48 MB** |
| branch.json | 84 MB | **0.80 MB** |
| tip.json | 42 MB | **0.41 MB** |

~100x smaller. A sample finding is now `{engine, target_triple, machine_key, segments, kind, method, direction, baseline, latest, relative_delta, confidence, commit, active}` — no series, no delta.

`just package="cargo-bench-history cargo-bench-history-core cargo-bench-history-stress" validate-local` passes (format-check, check, clippy, test, test-docs, docs, miri, machete, default-features).

DESIGN.md is updated: section 9.6 (JSON contract + text/Markdown layouts) and a new decision 35. Integration and unit tests are updated for the new shapes.
