### PR TITLE
perf(cbh-analyze): parallelize object load with per-worker fold + mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "hmac",
  "jiff",
  "many_cpus",
+ "mimalloc",
  "mutants",
  "nonempty",
  "serde",
@@ -480,6 +481,7 @@ dependencies = [
  "clap",
  "futures",
  "jiff",
+ "mimalloc",
  "nonempty",
  "serde",
  "serde_json",
@@ -1793,6 +1795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked"
 version = "1.0.14"
 dependencies = [
@@ -1923,6 +1934,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ linked_macros = { version = "=1.0.14", path = "packages/linked_macros", default-
 linked_macros_impl = { version = "=1.0.14", path = "packages/linked_macros_impl", default-features = false }
 many_cpus = { version = "2.4.9", path = "packages/many_cpus", default-features = false }
 many_cpus_impl = { version = "=2.4.9", path = "packages/many_cpus_impl", default-features = false }
+mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.14.0", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
 negative-impl = { version = "0.1.0", default-features = false }

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -81,6 +81,14 @@ mutants SHARD="" CAREFUL='false':
         "-e"
         (Escape-Wildcards "packages/cargo-bench-history/src/bin/**")
 
+        # `testing.rs` is an in-workspace test utility (gated behind the `private-test-util`
+        # feature, consumed only by the shell crate's tests). It is scaffolding with no public
+        # API contract, so mutating it yields no production coverage signal. A source-level
+        # `mutants::skip` cannot apply to a file module (inner/file-module proc-macro attributes
+        # are unstable Rust), so it is excluded here instead.
+        "-e"
+        (Escape-Wildcards "packages/cargo-bench-history-core/src/testing.rs")
+
         # Some of our systems are single-processor, yet the code may only be meaningfully testable
         # on multi-processor systems. As a "good enough" approximation, we skip mutation testing
         # of code that is only testable in a multi-processor system.

--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -9,11 +9,26 @@ here, alongside the workspace-wide rules in `docs/` (especially
 
 ## Performance principles for the analysis pipeline
 
-* **Stream, don't accumulate.** Fold each fetched run into compact series points
-  and drop the parsed run immediately (`analyze::series::SeriesBuilder`); never
-  hold the whole parsed data set resident at once. A new loader stage must keep
-  this property — peak memory is bounded by the points kept, not the objects
-  seen.
+* **Keep the fold compact; each worker folds its own chunk.** The series fold
+  (`analyze::series::SeriesBuilder`) extracts each run's compact points and drops the
+  parsed run immediately, so the points kept — not the run's full JSON shape — bound
+  what the fold retains. The shell loader fans the per-object decompress + JSON parse +
+  fold across cores (see the distribution bullet below): each worker folds its chunk
+  into its *own* `SeriesBuilder`, dropping each parsed run as it goes, and the main
+  thread merges the per-worker builders (`SeriesBuilder::merge`). No worker buffers its
+  chunk's parsed runs. Each object is parsed into the lean
+  [`RunPoints`](src/analyze/run_points.rs) projection — only the fields
+  `SeriesBuilder::push` reads (the abbreviated commit and, per result, the id and the
+  metric value/interval), dropping the run context and per-metric standard deviation —
+  and `push` consumes that projection rather than a full `Run`. Keep that projection in
+  lockstep with what the fold reads. **Note on memory:** folding in the worker did *not*
+  lower peak — at merge time every worker's finished builder is resident alongside the
+  growing combined builder (~2× the compact point output transiently), which measured
+  ~5% above a buffered-parallel variant; it is kept for the ~10% wall-time and CPU win.
+  The lean `RunPoints` element likewise trims peak only ~1%. The repeated benchmark ids
+  and merge coexistence dominate peak, so the open memory levers are bounded
+  merge-as-complete waves and id interning, not a leaner element — see
+  `docs/DESIGN.md` decision 34.
 * **Operate in place; avoid hidden allocations.** Prefer
   [`sort_unstable_by`](slice::sort_unstable_by) over `sort_by` for the statistics
   primitives: the stable sort allocates a scratch buffer of up to `len`
@@ -28,9 +43,13 @@ here, alongside the workspace-wide rules in `docs/` (especially
   each thread allocates the working state once and repeated calls — including from
   worker threads — stay allocation-free; keep this reuse intact.
 * **Distribute independent compute through an injected `Spawner`, not ad-hoc
-  threads.** The detection step (`find_changes_spawned`) is the one compute pass that
-  fans out across cores: it splits the series into one balanced contiguous chunk per
-  worker — sizes from [`analyze::parallel`](src/analyze/parallel.rs)
+  threads.** Two passes fan out across cores this way. The shell's object loader
+  (`cargo-bench-history`'s `analyze::fold_runs_chunked`) splits the storage-key-sorted
+  survivors into balanced contiguous chunks and parses + folds each chunk into a
+  per-worker `SeriesBuilder` on a spawned task, then merges the partials. The detection
+  step (`find_changes_spawned`) likewise splits the series into one
+  balanced contiguous chunk per worker — sizes from
+  [`analyze::parallel`](src/analyze/parallel.rs)
   (`worker_count` + `balanced_chunk_sizes`) — and dispatches each chunk to a blocking
   task on an injected `anyspawn::Spawner`, then awaits and concatenates in series order
   so the output equals a sequential pass. Production injects a Tokio spawner (sharing
@@ -41,9 +60,11 @@ here, alongside the workspace-wide rules in `docs/` (especially
   one chunk, one task over every series — not a separate serial branch. New per-series
   logic must stay
   side-effect-free so it can run on any worker; do not introduce shared mutable state
-  into a distributed pass. The series fold (`SeriesBuilder::push`) and per-series point
-  sort (`SeriesBuilder::finish`) stay **serial** — their work is dominated by task
-  overhead, and the fold already overlaps the shell loader's concurrent fetch.
+  into a distributed pass. The per-worker builder merge (`SeriesBuilder::merge`) and
+  per-series point sort (`SeriesBuilder::finish`) stay **serial** — their work is
+  dominated by task overhead — and run after the parallel loader's per-worker folds are
+  awaited; the merge is associative and `finish` sorts globally, so the result equals a
+  single-threaded fold in storage-key order.
 
 When you add a hot-path optimization, justify any deviation from a standard
 ecosystem pattern (see `docs/performance.md`) and cover the numeric boundaries

--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -18,9 +18,11 @@ here, alongside the workspace-wide rules in `docs/` (especially
   thread merges the per-worker builders (`SeriesBuilder::merge`). No worker buffers its
   chunk's parsed runs. Each object is parsed into the lean
   [`RunPoints`](src/analyze/run_points.rs) projection — only the fields
-  `SeriesBuilder::push` reads (the abbreviated commit and, per result, the id and the
+  `SeriesBuilder::push` reads (per result, the id and the
   metric value/interval), dropping the run context and per-metric standard deviation —
-  and `push` consumes that projection rather than a full `Run`. Keep that projection in
+  and `push` consumes that projection rather than a full `Run`. The full commit SHA a
+  point is labelled with comes from the storage key, not the run payload, so the
+  projection carries no git fields. Keep that projection in
   lockstep with what the fold reads. **Note on memory:** folding in the worker did *not*
   lower peak — at merge time every worker's finished builder is resident alongside the
   growing combined builder (~2× the compact point output transiently), which measured

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -198,7 +198,7 @@ pub enum Direction {
 /// value, and whether it came from a dirty (uncommitted-tree) snapshot.
 #[derive(Clone, Debug)]
 pub struct SeriesValue {
-    /// Abbreviated commit the point was measured against, if known.
+    /// Commit the point was measured against, if known.
     pub commit: Option<String>,
     /// The measured value.
     pub value: f64,
@@ -230,7 +230,7 @@ pub struct Finding {
     /// How confident the detector is (`1 - p_value`; `1.0` for an exact
     /// deterministic step).
     pub confidence: f64,
-    /// Abbreviated commit the change is attributed to, if known.
+    /// Commit the change is attributed to, if known.
     pub commit: Option<String>,
     /// Where, within a feature branch, the latest regime began — set only in
     /// branch mode when a within-branch flip is located, naming the commit the
@@ -309,7 +309,7 @@ fn series_values(series: &Series) -> Vec<SeriesValue> {
         .collect()
 }
 
-/// The abbreviated commit of a point as an owned `String`, for the JSON output.
+/// The commit of a point as an owned `String`, for the JSON output.
 ///
 /// Points intern their commit as a shared `Arc<str>`; the public finding fields are
 /// plain owned strings, so a surviving finding pays one allocation here rather than

--- a/packages/cargo-bench-history-core/src/analyze/mod.rs
+++ b/packages/cargo-bench-history-core/src/analyze/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod discriminant;
 pub(crate) mod findings;
 pub(crate) mod parallel;
 pub(crate) mod report;
+pub(crate) mod run_points;
 pub(crate) mod selection;
 pub(crate) mod series;
 pub(crate) mod stats;
@@ -21,7 +22,9 @@ pub use findings::{
     AnalysisConfig, AnalysisContext, AnalysisMode, Direction, Finding, FindingMethod, SeriesValue,
     find_changes_spawned,
 };
+pub use parallel::{balanced_chunk_sizes, worker_count};
 pub use report::{ReportFormat, ReportInput, SetSummary, render};
+pub use run_points::{MetricPoint, ResultPoints, RunPoints};
 pub use selection::{SelectedCommit, select_commits};
 pub use series::{
     Blessing, BlessingPlacement, LoadedObject, Series, SeriesBuilder, SeriesFilter, SeriesPoint,

--- a/packages/cargo-bench-history-core/src/analyze/parallel.rs
+++ b/packages/cargo-bench-history-core/src/analyze/parallel.rs
@@ -1,12 +1,14 @@
 //! Chunk-partition math for the spawner-distributed analysis passes.
 //!
 //! Some analysis passes walk a slice whose elements are independent — detecting
-//! each series, for instance — and distribute it across worker tasks dispatched
-//! through an [`anyspawn::Spawner`]. The partition is always the same shape: split
-//! the slice into one balanced, contiguous chunk per worker, process each chunk on
-//! its own blocking task, and recombine in input order. The arithmetic that decides
-//! how many workers to use and how large each chunk is lives here, separate from the
-//! dispatch itself.
+//! each series, or fetching + parsing each stored object, for instance — and
+//! distribute it across worker tasks dispatched through an [`anyspawn::Spawner`].
+//! The partition is always the same shape: split the slice into one balanced,
+//! contiguous chunk per worker, process each chunk on its own blocking task, and
+//! recombine in input order. The arithmetic that decides how many workers to use and
+//! how large each chunk is lives here, separate from the dispatch itself, so the
+//! detection pass (in this crate) and the shell's object loader share one
+//! implementation rather than drifting apart.
 //!
 //! The worker count is the available parallelism capped at the slice length, so a
 //! single available CPU (Miri reports one by default) yields a single worker: one
@@ -18,30 +20,33 @@
 use std::num::NonZero;
 use std::thread;
 
-/// How many worker tasks to split `len` items across: the available parallelism
-/// capped at `len`, so no worker is handed an empty chunk. This is `0` only when `len`
-/// is `0` (nothing to do) and otherwise at least `1` — a single available CPU, or a
-/// single-element slice, yields one worker, i.e. one chunk covering everything.
+/// How many worker tasks to split `len` items across.
+///
+/// The available parallelism capped at `len`, so no worker is handed an empty chunk.
+/// This is `0` only when `len` is `0` (nothing to do) and otherwise at least `1` — a
+/// single available CPU, or a single-element slice, yields one worker, i.e. one chunk
+/// covering everything.
 //
 // Mutation-skipped: the return value only selects how the work is partitioned across
 // workers, never the result. Every worker count yields the same order-preserving
 // output, so no behavioral test can distinguish one partitioning from another.
 #[cfg_attr(test, mutants::skip)]
-pub(crate) fn worker_count(len: usize) -> usize {
+pub fn worker_count(len: usize) -> usize {
     thread::available_parallelism()
         .map_or(1, NonZero::get)
         .min(len)
 }
 
 /// The lengths of exactly `workers` contiguous chunks that partition `len` items as
-/// evenly as possible: the first `len % workers` chunks hold one extra item, the
-/// rest hold `len / workers`.
+/// evenly as possible.
+///
+/// The first `len % workers` chunks hold one extra item, the rest hold `len / workers`.
 ///
 /// For `1 <= workers <= len` every chunk is non-empty and the sizes differ by at most
 /// one, with `workers == 1` yielding a single chunk of all `len` items. The degenerate
 /// `workers == 0` (only ever paired with `len == 0`, the empty slice) yields no chunks.
 /// The unit test covers both.
-pub(crate) fn balanced_chunk_sizes(len: usize, workers: usize) -> impl Iterator<Item = usize> {
+pub fn balanced_chunk_sizes(len: usize, workers: usize) -> impl Iterator<Item = usize> {
     // `workers` may be `0` (the empty-slice case), so the checked divide and remainder
     // fall back to `0`; for `workers >= 1` the division is exact and `base + 1 <= len`
     // cannot overflow. The checked operators keep the workspace's arithmetic lint

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -139,7 +139,7 @@ struct JsonFinding<'a> {
     relative_delta: f64,
     /// The detector's confidence (`1 - p_value`; `1.0` for an exact step).
     confidence: f64,
-    /// Abbreviated commit the change is attributed to, if known.
+    /// Commit the change is attributed to, if known.
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<&'a str>,
     /// Whether the change is still reflected in the latest measured state.

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -1,0 +1,220 @@
+//! A stored run reduced to exactly the data the series fold reads.
+//!
+//! The parallel object loader fans the per-object parse + fold across cores: each
+//! worker parses one object at a time into [`RunPoints`] and folds it straight into
+//! its own `SeriesBuilder`, dropping the parsed run before the next. Deserializing
+//! into [`RunPoints`] instead of the full [`Run`](crate::model::Run) shrinks that
+//! transient per-object footprint: it keeps only the abbreviated commit and, per
+//! result, the benchmark id and the metric fields
+//! [`SeriesBuilder::push`](crate::analyze::SeriesBuilder::push) actually folds
+//! into points — dropping the run context (environment, toolchain, timestamps)
+//! and each metric's standard deviation. Serde ignores the unmentioned JSON
+//! fields, so a run still parses unchanged; only the discarded parts are never
+//! materialized. (The leaner element trims overall peak only marginally — peak is
+//! set by the per-worker builders coexisting during the merge — but the lighter
+//! parse is still worth keeping; see `cargo-bench-history`'s `docs/DESIGN.md`
+//! decision 34.)
+
+use serde::Deserialize;
+use smallvec::SmallVec;
+
+use crate::model::{BenchmarkId, MetricKind, Run};
+
+/// A stored run reduced to the data the series fold reads.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct RunPoints {
+    /// Only carried to reach the abbreviated commit; every other context field is
+    /// ignored during deserialization.
+    #[serde(default)]
+    context: RunPointsContext,
+    /// One entry per benchmark result in the run.
+    results: Vec<ResultPoints>,
+}
+
+impl RunPoints {
+    /// Deserializes the fold-relevant projection of a run from its JSON form.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `json` is not a valid serialized run.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    /// The benchmark results carried by the run, one entry per measured case.
+    #[must_use]
+    pub fn results(&self) -> &[ResultPoints] {
+        &self.results
+    }
+
+    /// The abbreviated commit the run was measured against, if known.
+    #[must_use]
+    pub fn short_commit(&self) -> Option<&str> {
+        self.context.git.short_commit.as_deref()
+    }
+}
+
+impl From<&Run> for RunPoints {
+    fn from(run: &Run) -> Self {
+        Self {
+            context: RunPointsContext {
+                git: RunPointsGit {
+                    short_commit: run.context.git.short_commit.clone(),
+                },
+            },
+            results: run
+                .results
+                .iter()
+                .map(|result| ResultPoints {
+                    id: result.id.clone(),
+                    metrics: result
+                        .metrics
+                        .iter()
+                        .map(|metric| MetricPoint {
+                            kind: metric.kind,
+                            value: metric.value,
+                            interval_low: metric.interval_low,
+                            interval_high: metric.interval_high,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// The slice of a run context the fold needs: just the git commit.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+struct RunPointsContext {
+    #[serde(default)]
+    git: RunPointsGit,
+}
+
+/// The slice of git info the fold needs: just the abbreviated commit.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+struct RunPointsGit {
+    #[serde(default)]
+    short_commit: Option<String>,
+}
+
+/// A benchmark result reduced to its identity and fold-relevant metrics.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ResultPoints {
+    /// Stable identity of the benchmark case (its series key).
+    pub id: BenchmarkId,
+    /// The fold-relevant projection of each captured metric. Inline up to two, as
+    /// the noisy single-metric engines are the common case, matching
+    /// [`MetricList`](crate::model::MetricList).
+    pub metrics: SmallVec<[MetricPoint; 2]>,
+}
+
+/// A metric reduced to the fields the series fold reads.
+///
+/// Drops the standard deviation the fold never consults; the point estimate and
+/// confidence-interval bounds are all it carries into a [`SeriesPoint`].
+///
+/// [`SeriesPoint`]: crate::analyze::SeriesPoint
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub struct MetricPoint {
+    /// What kind of quantity this is (governs unit and comparison semantics).
+    pub kind: MetricKind,
+    /// The per-iteration point estimate, in the unit implied by `kind`.
+    pub value: f64,
+    /// Lower bound of the value's confidence interval, when reported.
+    pub interval_low: Option<f64>,
+    /// Upper bound of the value's confidence interval, when reported.
+    pub interval_high: Option<f64>,
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    #![allow(
+        clippy::float_cmp,
+        reason = "metric values round-trip exactly through serde_json"
+    )]
+    #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
+
+    use nonempty::nonempty;
+    use smallvec::smallvec;
+
+    use super::*;
+    use crate::model::{
+        BenchmarkResult, EnvironmentInfo, GitInfo, Metric, RunContext, ToolchainInfo,
+    };
+
+    fn sample_run() -> Run {
+        let context = RunContext::new(
+            "2024-01-01T00:00:00Z".parse().unwrap(),
+            GitInfo {
+                commit: Some("0123456789abcdef".to_owned()),
+                short_commit: Some("0123456789ab".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo {
+                target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+                rustc_version: Some("1.80.0".to_owned()),
+            },
+            "9.9.9".to_owned(),
+        );
+        let result = BenchmarkResult::new(
+            BenchmarkId::new(nonempty![
+                "pkg".to_owned(),
+                "group".to_owned(),
+                "case".to_owned()
+            ]),
+            smallvec![
+                Metric::new(MetricKind::WallTime, 26.9).with_dispersion(
+                    Some(0.47),
+                    Some(26.6),
+                    Some(27.2),
+                ),
+                Metric::new(MetricKind::InstructionCount, 1234.0),
+            ],
+        );
+        Run::new(context, vec![result])
+    }
+
+    #[test]
+    fn from_json_matches_from_run() {
+        // Parsing the lean projection straight from JSON must agree with converting
+        // a fully parsed `Run`, guarding against drift between the JSON field names
+        // and the lean structs.
+        let run = sample_run();
+        let json = run.to_json().unwrap();
+
+        let from_json = RunPoints::from_json(&json).unwrap();
+        let from_run = RunPoints::from(&run);
+
+        assert_eq!(from_json, from_run);
+    }
+
+    #[test]
+    fn projection_keeps_only_fold_relevant_fields() {
+        let run = sample_run();
+        let points = RunPoints::from(&run);
+
+        assert_eq!(points.short_commit(), Some("0123456789ab"));
+        assert_eq!(points.results().len(), 1);
+        let result = &points.results()[0];
+        assert_eq!(result.id, run.results[0].id);
+        assert_eq!(result.metrics.len(), 2);
+        assert_eq!(result.metrics[0].kind, MetricKind::WallTime);
+        assert_eq!(result.metrics[0].value, 26.9);
+        assert_eq!(result.metrics[0].interval_low, Some(26.6));
+        assert_eq!(result.metrics[0].interval_high, Some(27.2));
+    }
+
+    #[test]
+    fn short_commit_absent_when_unknown() {
+        let mut run = sample_run();
+        run.context.git.short_commit = None;
+        let points = RunPoints::from(&run);
+        assert_eq!(points.short_commit(), None);
+
+        let json = run.to_json().unwrap();
+        assert_eq!(RunPoints::from_json(&json).unwrap().short_commit(), None);
+    }
+}

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -4,12 +4,15 @@
 //! worker parses one object at a time into [`RunPoints`] and folds it straight into
 //! its own `SeriesBuilder`, dropping the parsed run before the next. Deserializing
 //! into [`RunPoints`] instead of the full [`Run`](crate::model::Run) shrinks that
-//! transient per-object footprint: it keeps only the abbreviated commit and, per
-//! result, the benchmark id and the metric fields
+//! transient per-object footprint: it keeps only, per result, the benchmark id and
+//! the metric fields that
 //! [`SeriesBuilder::push`](crate::analyze::SeriesBuilder::push) actually folds
-//! into points — dropping the run context (environment, toolchain, timestamps)
-//! and each metric's standard deviation. Serde ignores the unmentioned JSON
-//! fields, so a run still parses unchanged; only the discarded parts are never
+//! into points — dropping the run context (environment, toolchain, commit,
+//! timestamps) and each metric's standard deviation. The commit a point is
+//! labelled with comes from the storage key (its commit directory segment), not
+//! the run payload, so the projection carries no git fields at all. Serde ignores
+//! the unmentioned JSON fields, so a run still parses unchanged; only the discarded
+//! parts are never
 //! materialized. (The leaner element trims overall peak only marginally — peak is
 //! set by the per-worker builders coexisting during the merge — but the lighter
 //! parse is still worth keeping; see `cargo-bench-history`'s `docs/DESIGN.md`
@@ -23,10 +26,6 @@ use crate::model::{BenchmarkId, MetricKind, Run};
 /// A stored run reduced to the data the series fold reads.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct RunPoints {
-    /// Only carried to reach the abbreviated commit; every other context field is
-    /// ignored during deserialization.
-    #[serde(default)]
-    context: RunPointsContext,
     /// One entry per benchmark result in the run.
     results: Vec<ResultPoints>,
 }
@@ -46,22 +45,11 @@ impl RunPoints {
     pub fn results(&self) -> &[ResultPoints] {
         &self.results
     }
-
-    /// The abbreviated commit the run was measured against, if known.
-    #[must_use]
-    pub fn short_commit(&self) -> Option<&str> {
-        self.context.git.short_commit.as_deref()
-    }
 }
 
 impl From<&Run> for RunPoints {
     fn from(run: &Run) -> Self {
         Self {
-            context: RunPointsContext {
-                git: RunPointsGit {
-                    short_commit: run.context.git.short_commit.clone(),
-                },
-            },
             results: run
                 .results
                 .iter()
@@ -81,20 +69,6 @@ impl From<&Run> for RunPoints {
                 .collect(),
         }
     }
-}
-
-/// The slice of a run context the fold needs: just the git commit.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-struct RunPointsContext {
-    #[serde(default)]
-    git: RunPointsGit,
-}
-
-/// The slice of git info the fold needs: just the abbreviated commit.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-struct RunPointsGit {
-    #[serde(default)]
-    short_commit: Option<String>,
 }
 
 /// A benchmark result reduced to its identity and fold-relevant metrics.
@@ -148,7 +122,6 @@ mod tests {
             "2024-01-01T00:00:00Z".parse().unwrap(),
             GitInfo {
                 commit: Some("0123456789abcdef".to_owned()),
-                short_commit: Some("0123456789ab".to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -196,7 +169,6 @@ mod tests {
         let run = sample_run();
         let points = RunPoints::from(&run);
 
-        assert_eq!(points.short_commit(), Some("0123456789ab"));
         assert_eq!(points.results().len(), 1);
         let result = &points.results()[0];
         assert_eq!(result.id, run.results[0].id);
@@ -208,13 +180,100 @@ mod tests {
     }
 
     #[test]
-    fn short_commit_absent_when_unknown() {
-        let mut run = sample_run();
-        run.context.git.short_commit = None;
-        let points = RunPoints::from(&run);
-        assert_eq!(points.short_commit(), None);
+    fn projection_keeps_metric_without_interval_bounds() {
+        // The second metric of `sample_run` (instruction count) carries no
+        // dispersion, so its confidence-interval bounds must project as absent
+        // rather than defaulting to a fabricated value.
+        let points = RunPoints::from(&sample_run());
+        let metric = points.results()[0].metrics[1];
 
-        let json = run.to_json().unwrap();
-        assert_eq!(RunPoints::from_json(&json).unwrap().short_commit(), None);
+        assert_eq!(metric.kind, MetricKind::InstructionCount);
+        assert_eq!(metric.value, 1234.0);
+        assert_eq!(metric.interval_low, None);
+        assert_eq!(metric.interval_high, None);
+    }
+
+    #[test]
+    fn from_json_rejects_invalid_json() {
+        // A payload that is not a serialized run must surface a parse error rather
+        // than silently yielding an empty or partial projection.
+        RunPoints::from_json("not valid json").unwrap_err();
+    }
+
+    #[test]
+    fn projection_handles_a_run_with_no_results() {
+        // An empty run (no benchmark results) projects to an empty point set and
+        // still round-trips through JSON, so the fold simply contributes nothing.
+        let context = RunContext::new(
+            "2024-01-01T00:00:00Z".parse().unwrap(),
+            GitInfo {
+                commit: Some("0123456789abcdef".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "9.9.9".to_owned(),
+        );
+        let run = Run::new(context, Vec::new());
+
+        let from_run = RunPoints::from(&run);
+        assert!(from_run.results().is_empty());
+        assert_eq!(
+            RunPoints::from_json(&run.to_json().unwrap()).unwrap(),
+            from_run
+        );
+    }
+
+    #[test]
+    fn projection_preserves_multiple_results_and_spilled_metrics() {
+        // A run with several results, one of which carries more metrics than the
+        // inline SmallVec capacity, must project every result and every metric
+        // (the spilled tail included) and agree with the from-JSON parse.
+        let context = RunContext::new(
+            "2024-01-01T00:00:00Z".parse().unwrap(),
+            GitInfo {
+                commit: Some("0123456789abcdef".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "9.9.9".to_owned(),
+        );
+        let many_metrics = BenchmarkResult::new(
+            BenchmarkId::new(nonempty!["pkg".to_owned(), "wide".to_owned()]),
+            smallvec![
+                Metric::new(MetricKind::WallTime, 1.0).with_dispersion(
+                    Some(0.1),
+                    Some(0.9),
+                    Some(1.1),
+                ),
+                Metric::new(MetricKind::InstructionCount, 2.0),
+                Metric::new(MetricKind::EstimatedCycles, 3.0),
+                Metric::new(MetricKind::RamHits, 4.0),
+            ],
+        );
+        let single_metric = BenchmarkResult::new(
+            BenchmarkId::new(nonempty!["pkg".to_owned(), "narrow".to_owned()]),
+            smallvec![Metric::new(MetricKind::WallTime, 5.0)],
+        );
+        let run = Run::new(context, vec![many_metrics, single_metric]);
+
+        let from_run = RunPoints::from(&run);
+        assert_eq!(from_run.results().len(), 2);
+        assert_eq!(
+            from_run.results()[0].metrics.len(),
+            4,
+            "the metric list spilled past inline capacity must survive projection"
+        );
+        assert_eq!(from_run.results()[0].metrics[3].kind, MetricKind::RamHits);
+        assert_eq!(from_run.results()[0].metrics[3].value, 4.0);
+        assert_eq!(from_run.results()[1].metrics.len(), 1);
+
+        assert_eq!(
+            RunPoints::from_json(&run.to_json().unwrap()).unwrap(),
+            from_run
+        );
     }
 }

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -35,9 +35,9 @@ use crate::model::{BenchmarkId, BenchmarkIdPrefix, MetricKind, Run};
 ///
 /// Kept compact because a large history materializes tens of millions of these at
 /// once: the provenance storage key is reduced to [`object_ordinal`] (the key's
-/// rank in sorted storage-key order, the final tie-break) and the abbreviated
-/// commit is an interned [`Arc<str>`] shared across every point measured against
-/// the same commit.
+/// rank in sorted storage-key order, the final tie-break) and the commit is an
+/// interned [`Arc<str>`] shared across every point measured against the same
+/// commit.
 ///
 /// [`object_ordinal`]: SeriesPoint::object_ordinal
 #[derive(Clone, Debug)]
@@ -49,8 +49,9 @@ pub struct SeriesPoint {
     /// The object's rank in sorted storage-key order (the final tie-break),
     /// standing in for the full storage key to keep the point small.
     pub object_ordinal: u32,
-    /// Abbreviated commit the run was measured against, if known. Interned so all
-    /// points on one commit share a single allocation.
+    /// Commit the run was measured against — the storage key's commit directory
+    /// segment (a full SHA, or `unknown`). Interned so all points on one commit
+    /// share a single allocation.
     pub commit: Option<Arc<str>>,
     /// The measured value.
     pub value: f64,
@@ -191,6 +192,7 @@ pub fn build_series<S: BuildHasher>(
             topo_index,
             object.key.is_dirty(),
             ordinal,
+            &object.key.commit,
             &RunPoints::from(&object.result),
         );
     }
@@ -224,8 +226,8 @@ fn ordinal_of(rank: usize) -> u32 {
 /// of the objects into its own builder and hand it back, and [`merge`] folds the
 /// per-worker builders into one before a single [`finish`](SeriesBuilder::finish).
 ///
-/// The abbreviated commit of each run is interned, so all points measured against
-/// one commit share a single [`Arc<str>`] instead of cloning the string per point.
+/// The commit of each run is interned, so all points measured against one commit
+/// share a single [`Arc<str>`] instead of cloning the string per point.
 ///
 /// [`merge`]: SeriesBuilder::merge
 #[derive(Debug)]
@@ -285,21 +287,23 @@ impl SeriesBuilder {
 
     /// Folds one stored run into the accumulating series.
     ///
-    /// `topo_index` is the run commit's first-parent position and `object_ordinal`
-    /// its rank in sorted storage-key order (the final point tie-break); the caller
-    /// supplies both because they come from the storage key and git topology, not
-    /// the run payload. `run` is the fold-relevant projection of the run (see
-    /// [`RunPoints`]); only the matching metrics are retained — it can be dropped as
-    /// soon as this returns.
+    /// `topo_index` is the run commit's first-parent position, `object_ordinal` its
+    /// rank in sorted storage-key order (the final point tie-break), and `commit`
+    /// the storage key's commit directory segment (a full SHA, or `unknown`); the
+    /// caller supplies all three because they come from the storage key and git
+    /// topology, not the run payload. `run` is the fold-relevant projection of the
+    /// run (see [`RunPoints`]); only the matching metrics are retained — it can be
+    /// dropped as soon as this returns.
     pub fn push(
         &mut self,
         set: &DiscriminantSet,
         topo_index: usize,
         dirty: bool,
         object_ordinal: u32,
+        commit: &str,
         run: &RunPoints,
     ) {
-        let commit = run.short_commit().map(|commit| self.intern(commit));
+        let commit = Some(self.intern(commit));
 
         // The discriminant set is constant for the whole run, so resolve its
         // subtree once and clone the set key only when the set is first seen — not
@@ -546,7 +550,6 @@ mod tests {
             observation,
             GitInfo {
                 commit: Some(format!("{commit}full")),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -599,8 +602,9 @@ mod tests {
     }
 
     /// One folded object: its discriminant set, the commit's topological index, the
-    /// dirty flag, the storage-key ordinal, and the lean run projection to push.
-    type FoldInput = (DiscriminantSet, usize, bool, u32, RunPoints);
+    /// dirty flag, the storage-key ordinal, the storage-key commit, and the lean run
+    /// projection to push.
+    type FoldInput = (DiscriminantSet, usize, bool, u32, String, RunPoints);
 
     /// Builds the fold inputs for a small data set spanning two benchmark ids
     /// (packages) across three commits, including a clean/dirty pair on one commit,
@@ -620,14 +624,21 @@ mod tests {
                     "v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
                 );
                 let key = parse_key(&object_key).unwrap();
-                (key.set, topo_index, dirty, ordinal, RunPoints::from(&run))
+                (
+                    key.set,
+                    topo_index,
+                    dirty,
+                    ordinal,
+                    key.commit,
+                    RunPoints::from(&run),
+                )
             })
             .collect()
     }
 
     fn fold_all(builder: &mut SeriesBuilder, inputs: &[FoldInput]) {
-        for (set, topo_index, dirty, ordinal, run) in inputs {
-            builder.push(set, *topo_index, *dirty, *ordinal, run);
+        for (set, topo_index, dirty, ordinal, commit, run) in inputs {
+            builder.push(set, *topo_index, *dirty, *ordinal, commit, run);
         }
     }
 
@@ -905,5 +916,122 @@ mod tests {
 
         assert_eq!(series[0].active_start, 3);
         assert_eq!(series[0].blessing.as_ref().unwrap().commit, "c3full");
+    }
+
+    #[test]
+    fn apply_blessings_leaves_a_series_whose_set_has_no_blessings() {
+        // The blessings map is keyed by discriminant set; a series whose set is
+        // absent from the map must be left fully active rather than re-baselined.
+        let mut series = four_commit_series();
+        // A blessing recorded only for a *different* set (a different target triple),
+        // so the lookup for this series' set misses.
+        let other_set =
+            parse_key("v1/proj/callgrind/aarch64-unknown-linux-gnu/synthetic/c0/clean.json")
+                .unwrap()
+                .set;
+        let mut map = HashMap::new();
+        map.insert(
+            other_set,
+            vec![(2_usize, Some(ts(300)), blessing(&["group"], "c2full", 301))],
+        );
+
+        apply_blessings(&mut series, &map);
+
+        assert_eq!(
+            series[0].active_start, 0,
+            "an unrelated set leaves the series active from the start"
+        );
+        assert!(series[0].blessing.is_none(), "no blessing recorded");
+    }
+
+    #[test]
+    fn push_and_merge_grow_the_id_table_across_resizes() {
+        // Folding many distinct benchmark ids into one discriminant set forces the
+        // per-set id table to grow and rehash its existing entries; merging a second
+        // builder full of further distinct ids grows it again. A wrong hash in either
+        // rehash closure would silently drop or conflate series, so check that every
+        // distinct id survives as its own series across both resize paths.
+        let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(Vec::new());
+        let key = parse_key("v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json")
+            .unwrap();
+
+        let mut first = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
+        for index in 0_u32..64 {
+            let package = format!("pkg{index:03}");
+            let run = run_for_package(ts(1), "c0", f64::from(index), Some(&package));
+            first.push(
+                &key.set,
+                0,
+                false,
+                index,
+                &key.commit,
+                &RunPoints::from(&run),
+            );
+        }
+
+        let mut second = SeriesBuilder::with_prefixes(prefixes);
+        for index in 64_u32..128 {
+            let package = format!("pkg{index:03}");
+            let run = run_for_package(ts(1), "c0", f64::from(index), Some(&package));
+            second.push(
+                &key.set,
+                0,
+                false,
+                index,
+                &key.commit,
+                &RunPoints::from(&run),
+            );
+        }
+
+        first.merge(second);
+        let series = first.finish();
+
+        assert_eq!(
+            series.len(),
+            128,
+            "every distinct id is its own series, none lost to a botched rehash"
+        );
+    }
+
+    #[test]
+    fn finish_orders_two_metric_kinds_of_one_benchmark_by_kind() {
+        // One benchmark measured with two metric kinds yields two series that share
+        // set and id and differ only by kind. finish must fall through to the kind
+        // tie-break (the innermost series comparator) and order them deterministically.
+        let context = RunContext::new(
+            ts(1),
+            GitInfo {
+                commit: Some("c0full".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let record = BenchmarkResult::new(
+            BenchmarkId::new(
+                NonEmpty::from_vec(vec!["group".to_owned(), "case".to_owned()]).unwrap(),
+            ),
+            vec![
+                Metric::new(MetricKind::InstructionCount, 100.0),
+                Metric::new(MetricKind::WallTime, 5.0),
+            ],
+        );
+        let run = Run::new(context, vec![record]);
+        let key = parse_key("v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json")
+            .unwrap();
+
+        let mut builder = SeriesBuilder::new(SeriesFilter::default());
+        builder.push(&key.set, 0, false, 0, &key.commit, &RunPoints::from(&run));
+        let series = builder.finish();
+
+        assert_eq!(series.len(), 2, "two metric kinds of one id are two series");
+        assert_eq!(series[0].id, series[1].id, "same benchmark id");
+        assert_eq!(series[0].set, series[1].set, "same discriminant set");
+        assert!(
+            series[0].kind < series[1].kind,
+            "series sharing set and id are ordered by the kind tie-break"
+        );
     }
 }

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -14,6 +14,7 @@
 //! per-point commit string is interned to a shared `Arc<str>` rather than cloned.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry as MapEntry;
 use std::hash::BuildHasher;
 use std::sync::Arc;
 
@@ -25,6 +26,7 @@ use hashbrown::hash_table::Entry;
 use jiff::Timestamp;
 
 use crate::analyze::StorageKey;
+use crate::analyze::run_points::RunPoints;
 use crate::model::BlessingRecord;
 use crate::model::DiscriminantSet;
 use crate::model::{BenchmarkId, BenchmarkIdPrefix, MetricKind, Run};
@@ -189,7 +191,7 @@ pub fn build_series<S: BuildHasher>(
             topo_index,
             object.key.is_dirty(),
             ordinal,
-            &object.result,
+            &RunPoints::from(&object.result),
         );
     }
     builder.finish()
@@ -217,11 +219,18 @@ fn ordinal_of(rank: usize) -> u32 {
 /// fold each fetched run and drop it immediately, keeping only the (compact) points
 /// resident rather than the whole parsed data set.
 ///
+/// The builder owns its prefix filter (an `Arc<[BenchmarkIdPrefix]>`) and holds no
+/// borrows, so it is `Send + 'static`: a spawned worker can fold a disjoint subset
+/// of the objects into its own builder and hand it back, and [`merge`] folds the
+/// per-worker builders into one before a single [`finish`](SeriesBuilder::finish).
+///
 /// The abbreviated commit of each run is interned, so all points measured against
 /// one commit share a single [`Arc<str>`] instead of cloning the string per point.
+///
+/// [`merge`]: SeriesBuilder::merge
 #[derive(Debug)]
-pub struct SeriesBuilder<'a> {
-    filter: SeriesFilter<'a>,
+pub struct SeriesBuilder {
+    prefixes: Arc<[BenchmarkIdPrefix]>,
     groups: GroupTree,
     commits: HashMap<Box<str>, Arc<str>>,
     /// Hashes benchmark ids for the [`HashTable`] id level. One fixed instance so
@@ -251,12 +260,23 @@ type IdGroups = HashTable<(BenchmarkId, KindGroups)>;
 /// series costs one key clone, not one clone per metric point folded into it.
 type GroupTree = FoldHashMap<DiscriminantSet, IdGroups>;
 
-impl<'a> SeriesBuilder<'a> {
+impl SeriesBuilder {
     /// Starts an empty builder that keeps only series matching `filter`.
     #[must_use]
-    pub fn new(filter: SeriesFilter<'a>) -> Self {
+    pub fn new(filter: SeriesFilter<'_>) -> Self {
+        Self::with_prefixes(Arc::from(filter.prefixes))
+    }
+
+    /// Starts an empty builder that keeps only series whose benchmark id starts
+    /// with one of `prefixes` (an empty list keeps every series).
+    ///
+    /// Takes the prefixes as an owned `Arc<[BenchmarkIdPrefix]>` so the builder
+    /// borrows nothing and stays `Send + 'static`, letting a spawned worker own one
+    /// and a caller share the prefix list across workers with a cheap clone.
+    #[must_use]
+    pub fn with_prefixes(prefixes: Arc<[BenchmarkIdPrefix]>) -> Self {
         Self {
-            filter,
+            prefixes,
             groups: FoldHashMap::new(),
             commits: HashMap::new(),
             hasher: RandomState::default(),
@@ -268,29 +288,25 @@ impl<'a> SeriesBuilder<'a> {
     /// `topo_index` is the run commit's first-parent position and `object_ordinal`
     /// its rank in sorted storage-key order (the final point tie-break); the caller
     /// supplies both because they come from the storage key and git topology, not
-    /// the run payload. Only the matching metrics are retained — the run itself can
-    /// be dropped as soon as this returns.
+    /// the run payload. `run` is the fold-relevant projection of the run (see
+    /// [`RunPoints`]); only the matching metrics are retained — it can be dropped as
+    /// soon as this returns.
     pub fn push(
         &mut self,
         set: &DiscriminantSet,
         topo_index: usize,
         dirty: bool,
         object_ordinal: u32,
-        run: &Run,
+        run: &RunPoints,
     ) {
-        let commit = run
-            .context
-            .git
-            .short_commit
-            .as_deref()
-            .map(|commit| self.intern(commit));
+        let commit = run.short_commit().map(|commit| self.intern(commit));
 
         // The discriminant set is constant for the whole run, so resolve its
         // subtree once and clone the set key only when the set is first seen — not
-        // per record or per metric. Copying the prefix slice and borrowing the
-        // hasher out first keeps the `self.groups` borrow below from entangling
-        // with the other fields.
-        let prefixes = self.filter.prefixes;
+        // per record or per metric. Borrowing the prefix slice and the hasher out
+        // first keeps the `self.groups` borrow below from entangling with the other
+        // fields.
+        let prefixes: &[BenchmarkIdPrefix] = &self.prefixes;
         let hasher = &self.hasher;
         if !self.groups.contains_key(set) {
             self.groups.insert(set.clone(), HashTable::new());
@@ -300,7 +316,7 @@ impl<'a> SeriesBuilder<'a> {
             .get_mut(set)
             .expect("the set's subtree was just inserted when absent");
 
-        for record in &run.results {
+        for record in run.results() {
             if !prefixes_accept(prefixes, &record.id) {
                 continue;
             }
@@ -334,6 +350,58 @@ impl<'a> SeriesBuilder<'a> {
                     interval_high: metric.interval_high,
                 };
                 kind_groups.entry(metric.kind).or_default().push(point);
+            }
+        }
+    }
+
+    /// Folds another builder's accumulated series into this one.
+    ///
+    /// Each `(set, id, kind)` series from `other` is merged into `self`,
+    /// concatenating the points of any series both hold. This is the recombination
+    /// step of the parallel fold: each worker folds a disjoint subset of the objects
+    /// into its own builder, and the main thread merges the per-worker builders
+    /// before a single [`finish`](Self::finish) sorts the combined series. Because
+    /// the partitions are disjoint, the union of their points is exactly the set a
+    /// single-threaded fold would have produced.
+    ///
+    /// The points keep the interned commit [`Arc<str>`] they were folded with in
+    /// `other` (so a commit seen by several workers ends up with one `Arc` per
+    /// worker rather than one overall — a negligible cost). The benchmark ids are
+    /// re-hashed into `self`'s table with `self`'s hasher, so the two builders'
+    /// independent hash seeds need not agree.
+    pub fn merge(&mut self, other: Self) {
+        let hasher = &self.hasher;
+        for (set, other_ids) in other.groups {
+            let id_groups = self.groups.entry(set).or_default();
+            for (id, other_kinds) in other_ids {
+                // Re-probe the id in this builder's table, cloning the id only when
+                // the series is first seen here — mirrors `push`'s single-probe
+                // insert so a hash collision never merges two distinct benchmarks.
+                let hash = hasher.hash_one(&id);
+                let kind_groups = match id_groups.entry(
+                    hash,
+                    |(existing, _)| existing == &id,
+                    |(existing, _)| hasher.hash_one(existing),
+                ) {
+                    Entry::Occupied(occupied) => &mut occupied.into_mut().1,
+                    Entry::Vacant(vacant) => {
+                        &mut vacant.insert((id, FoldHashMap::new())).into_mut().1
+                    }
+                };
+                for (kind, points) in other_kinds {
+                    // Move the whole point vector on first sight of the kind and
+                    // append (a single buffer copy) only when both builders already
+                    // hold points for it, never reallocating per point.
+                    match kind_groups.entry(kind) {
+                        MapEntry::Occupied(mut occupied) => {
+                            let mut points = points;
+                            occupied.get_mut().append(&mut points);
+                        }
+                        MapEntry::Vacant(vacant) => {
+                            vacant.insert(points);
+                        }
+                    }
+                }
             }
         }
     }
@@ -528,6 +596,116 @@ mod tests {
             .enumerate()
             .map(|(index, commit)| ((*commit).to_owned(), index))
             .collect()
+    }
+
+    /// One folded object: its discriminant set, the commit's topological index, the
+    /// dirty flag, the storage-key ordinal, and the lean run projection to push.
+    type FoldInput = (DiscriminantSet, usize, bool, u32, RunPoints);
+
+    /// Builds the fold inputs for a small data set spanning two benchmark ids
+    /// (packages) across three commits, including a clean/dirty pair on one commit,
+    /// so a merge has to combine like series whose points come from both partitions.
+    fn merge_inputs() -> Vec<FoldInput> {
+        let rows = [
+            ("pkga", "c0", 0_usize, false, 0_u32, 10.0),
+            ("pkgb", "c0", 0, false, 1, 20.0),
+            ("pkga", "c1", 1, false, 2, 11.0),
+            ("pkga", "c1", 1, true, 3, 12.0),
+            ("pkgb", "c2", 2, false, 4, 21.0),
+        ];
+        rows.into_iter()
+            .map(|(package, commit, topo_index, dirty, ordinal, value)| {
+                let run = run_for_package(ts(1), commit, value, Some(package));
+                let object_key = format!(
+                    "v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
+                );
+                let key = parse_key(&object_key).unwrap();
+                (key.set, topo_index, dirty, ordinal, RunPoints::from(&run))
+            })
+            .collect()
+    }
+
+    fn fold_all(builder: &mut SeriesBuilder, inputs: &[FoldInput]) {
+        for (set, topo_index, dirty, ordinal, run) in inputs {
+            builder.push(set, *topo_index, *dirty, *ordinal, run);
+        }
+    }
+
+    /// A comparable projection of one finished series: identity plus each point's
+    /// sort key and value, so two series sets can be checked for byte-for-byte
+    /// agreement.
+    type SeriesSummary = (
+        DiscriminantSet,
+        BenchmarkId,
+        MetricKind,
+        Vec<(usize, bool, u32, f64)>,
+    );
+
+    fn series_summary(series: &[Series]) -> Vec<SeriesSummary> {
+        series
+            .iter()
+            .map(|one| {
+                let points = one
+                    .points
+                    .iter()
+                    .map(|point| {
+                        (
+                            point.topo_index,
+                            point.dirty,
+                            point.object_ordinal,
+                            point.value,
+                        )
+                    })
+                    .collect();
+                (one.set.clone(), one.id.clone(), one.kind, points)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn merge_combines_disjoint_folds_into_one() {
+        // Folding the whole data set into one builder must equal folding two disjoint
+        // halves into separate builders and merging them: the parallel fold partitions
+        // the objects across workers, so the union of the per-worker series has to
+        // reproduce the single-threaded result exactly.
+        let inputs = merge_inputs();
+        let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(Vec::new());
+
+        let mut reference = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
+        fold_all(&mut reference, &inputs);
+        let reference = reference.finish();
+
+        let (left, right) = inputs.split_at(2);
+        let mut first = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
+        fold_all(&mut first, left);
+        let mut second = SeriesBuilder::with_prefixes(prefixes);
+        fold_all(&mut second, right);
+        first.merge(second);
+        let merged = first.finish();
+
+        // The data really spans more than one series, so the id-level merge is exercised.
+        assert!(reference.len() >= 2);
+        assert_eq!(series_summary(&reference), series_summary(&merged));
+    }
+
+    #[test]
+    fn merge_into_empty_builder_yields_the_other() {
+        // Merging a folded builder into a fresh one (the degenerate single-worker
+        // case, where the main thread merges one partial) reproduces a direct fold.
+        let inputs = merge_inputs();
+        let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(Vec::new());
+
+        let mut reference = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
+        fold_all(&mut reference, &inputs);
+        let reference = reference.finish();
+
+        let mut only = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
+        fold_all(&mut only, &inputs);
+        let mut empty = SeriesBuilder::with_prefixes(prefixes);
+        empty.merge(only);
+        let merged = empty.finish();
+
+        assert_eq!(series_summary(&reference), series_summary(&merged));
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/model/context.rs
+++ b/packages/cargo-bench-history-core/src/model/context.rs
@@ -57,8 +57,6 @@ impl RunContext {
 pub struct GitInfo {
     /// Full commit hash, if known.
     pub commit: Option<String>,
-    /// Abbreviated commit hash, if known.
-    pub short_commit: Option<String>,
     /// Branch name, if known.
     pub branch: Option<String>,
     /// Whether the working tree had uncommitted changes.

--- a/packages/cargo-bench-history-core/src/model/run.rs
+++ b/packages/cargo-bench-history-core/src/model/run.rs
@@ -10,8 +10,10 @@ use crate::model::{BenchmarkId, Metric, RunContext};
 /// Records which on-disk format a file was written with. Reads are not gated on
 /// it: version 2 dropped the redundant per-object `commit` timestamp (a run's
 /// timeline position is resolved from git topology, keyed by its commit SHA), and
-/// older records still deserialize because the removed field is simply ignored.
-pub const SCHEMA_VERSION: u32 = 2;
+/// version 3 dropped the redundant `short_commit` (an abbreviation of the full
+/// commit SHA the analysis already has from the storage key). Older records still
+/// deserialize because the removed fields are simply ignored.
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// A complete benchmark run: the unit of storage (one immutable file per run).
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/packages/cargo-bench-history-core/src/testing.rs
+++ b/packages/cargo-bench-history-core/src/testing.rs
@@ -4,29 +4,44 @@
 
 #![cfg_attr(coverage_nightly, coverage(off))]
 
+use std::task::{Context, Poll, Waker};
+
 use anyspawn::{BoxedBlockingTask, BoxedFuture, SpawnCustom, Spawner, ThreadAwareAsyncFnOnce};
 use thread_aware::ThreadAware;
 
-/// A [`Spawner`] that runs every dispatched blocking task inline on the calling
-/// thread rather than on a runtime's blocking pool.
+/// A [`Spawner`] that runs every dispatched task inline on the calling thread
+/// rather than on a runtime's worker or blocking pool.
 ///
-/// The analysis distributes its detection work through [`Spawner::spawn_blocking`];
-/// production injects a Tokio spawner, but tests and Miri inject this one so they
-/// need no async runtime and stay deterministic. Each task runs to completion the
-/// moment it is spawned, so the returned join handle resolves immediately and a
-/// panic in a task propagates straight to the caller.
+/// The analysis distributes its detection work through [`Spawner::spawn_blocking`]
+/// and its object-load work through [`Spawner::spawn`]; production injects a Tokio
+/// spawner, but tests and Miri inject this one so they need no async runtime and
+/// stay deterministic. Each task runs to completion the moment it is spawned, so
+/// the returned join handle resolves immediately and a panic in a task propagates
+/// straight to the caller.
 #[derive(Clone, ThreadAware)]
 struct SynchronousSpawner;
 
 impl SpawnCustom for SynchronousSpawner {
-    #[cfg_attr(test, mutants::skip)] // Unreachable: the analysis distributes only blocking work.
-    fn spawn(&self, _task: BoxedFuture) {
-        unreachable!("the analysis distributes only blocking work")
+    fn spawn(&self, mut task: BoxedFuture) {
+        // The analysis's spawned load tasks await only the injected in-memory
+        // storage, which is always immediately ready, so a single poll with a
+        // no-op waker drives the future to completion. Running it inline keeps the
+        // tests free of an async runtime (and Miri-safe), exactly like
+        // `spawn_blocking`, and avoids nesting an executor inside the test's own
+        // `block_on`.
+        let mut context = Context::from_waker(Waker::noop());
+        match task.as_mut().poll(&mut context) {
+            Poll::Ready(()) => {}
+            Poll::Pending => unreachable!(
+                "the synchronous spawner drives only immediately-ready in-memory \
+                 futures, which never yield Pending"
+            ),
+        }
     }
 
-    #[cfg_attr(test, mutants::skip)] // Unreachable: the analysis distributes only blocking work.
+    #[cfg_attr(test, mutants::skip)] // Unreachable: the analysis never spawns relocatable async tasks.
     fn spawn_anywhere(&self, _task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
-        unreachable!("the analysis distributes only blocking work")
+        unreachable!("the analysis never spawns relocatable async tasks")
     }
 
     fn spawn_blocking(&self, task: BoxedBlockingTask) {
@@ -34,7 +49,7 @@ impl SpawnCustom for SynchronousSpawner {
     }
 }
 
-/// Builds a [`Spawner`] that runs blocking tasks inline on the calling thread.
+/// Builds a [`Spawner`] that runs tasks inline on the calling thread.
 ///
 /// Tests and Miri inject this where production injects a Tokio-backed
 /// `Spawner::new_tokio`, so the spawner-distributed analysis runs without a Tokio

--- a/packages/cargo-bench-history-core/src/testing.rs
+++ b/packages/cargo-bench-history-core/src/testing.rs
@@ -39,7 +39,6 @@ impl SpawnCustom for SynchronousSpawner {
         }
     }
 
-    #[cfg_attr(test, mutants::skip)] // Unreachable: the analysis never spawns relocatable async tasks.
     fn spawn_anywhere(&self, _task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
         unreachable!("the analysis never spawns relocatable async tasks")
     }

--- a/packages/cargo-bench-history-stress/Cargo.toml
+++ b/packages/cargo-bench-history-stress/Cargo.toml
@@ -17,6 +17,7 @@ cargo-bench-history = { path = "../cargo-bench-history", default-features = fals
 cargo-bench-history-core = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 jiff = { workspace = true, features = ["serde"] }
+mimalloc = { workspace = true }
 nonempty = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/packages/cargo-bench-history-stress/src/main.rs
+++ b/packages/cargo-bench-history-stress/src/main.rs
@@ -9,6 +9,14 @@
 
 use std::process::ExitCode;
 
+// The harness must measure the same allocator the production binary ships, so its
+// `analyze`-path numbers stay representative: the chunked parallel parse only scales
+// with a per-thread-heap allocator (see `cargo-bench-history`'s `main`). Miri cannot
+// call mimalloc's FFI, so under Miri the default allocator stands in.
+#[cfg(not(miri))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> ExitCode {
     cargo_bench_history_stress::run()
 }

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -314,7 +314,6 @@ fn run_context(
 ) -> RunContext {
     let git = GitInfo {
         commit: Some(sha.to_owned()),
-        short_commit: Some(sha.get(..12).unwrap_or(sha).to_owned()),
         branch: Some(branch.to_owned()),
         dirty,
     };

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -168,8 +168,9 @@ the gzip magic never collides with JSON's first byte.
 > canonical map of the `analyze` load and detection path — what loads where, in what
 > order, what is computed/sorted, and exactly where I/O concurrency vs. CPU
 > parallelism happens (with Mermaid diagrams). Keep it in sync whenever you change the
-> concurrent fetch/fold, the detection distribution (`find_changes_spawned` + the
-> `analyze::parallel` chunk math), or the Azure transport.
+> chunked parallel fetch+parse+fold (`fold_runs_chunked`), the per-worker builder merge,
+> the detection distribution (`find_changes_spawned` + the `analyze::parallel` chunk
+> math), or the Azure transport.
 
 `analyze::execute` builds the real `SystemGitHistory` (rooted at `--repo` or the
 current directory) and the storage from `build_storage`, then delegates to
@@ -178,15 +179,37 @@ ports so tests drive it with `FakeGitHistory` + `MemoryStorage` +
 `futures::executor::block_on` (Miri-safe, no Tokio). Everything below the IO ports
 is pure and synchronous.
 
-The one compute pass that fans out across cores is detection: `analyze_with` takes a
-`&anyspawn::Spawner` and calls `find_changes_spawned`, which dispatches per-series
-detection chunks to blocking tasks. `execute` injects `Spawner::new_tokio()` (the
-runtime's blocking pool); tests inject `cargo_bench_history_core::testing::
-synchronous_spawner()` (the shell takes core as a dev-dependency with its
-`private-test-util` feature) so `block_on`/Miri runs need no Tokio runtime. The fold
-and point sort stay serial. Do **not** spawn ad-hoc threads (`std::thread::scope`,
-`map_parallel`-style helpers) for compute — route fan-out through the injected
-`Spawner` so it shares the runtime's threads and stays legible in a profiler.
+Two compute passes fan out across cores. The object load (`fold_runs_chunked`) splits
+the storage-key-sorted survivors into balanced contiguous chunks; each spawned task
+fetches, decompresses, JSON-parses **and folds** its chunk into its *own* `SeriesBuilder`
+/ `RunIndex`, dropping each parsed run as it goes, and the driver awaits the tasks in
+spawn order and merges the per-worker builders (`SeriesBuilder::merge`). Each object is
+parsed into the lean `cargo_bench_history_core::analyze::RunPoints` projection — only the
+fields the fold reads (the abbreviated commit and, per result, the id and the metric
+value/interval) — not a full `Run`. Detection (`find_changes_spawned`) then dispatches
+per-series detection chunks to blocking tasks the same way. Both take the
+`&anyspawn::Spawner` `analyze_with` threads through; `execute` injects
+`Spawner::new_tokio()` (the runtime's blocking pool), while tests inject
+`cargo_bench_history_core::testing::synchronous_spawner()` (the shell takes core as a
+dev-dependency with its `private-test-util` feature) so `block_on`/Miri runs need no
+Tokio runtime. The per-worker builder merge and point sort stay serial (the merge is
+associative and `finish` sorts globally, so output equals a single-threaded fold). Do
+**not** spawn ad-hoc threads (`std::thread::scope`, `map_parallel`-style helpers) for
+compute — route fan-out through the injected `Spawner` so it shares the runtime's threads
+and stays legible in a profiler.
+
+Folding in the worker (instead of buffering each chunk's parsed runs and folding serially)
+parallelizes the fold for a ~10% wall-time and CPU win, but it did **not** lower peak
+memory: at merge time every worker's finished builder is resident alongside the growing
+combined builder (~2× the compact point output transiently), which measured ~5% above a
+buffered-parallel variant. The parallel parse is only a net win with a scalable global
+allocator: serde_json's many small allocations contend on the system allocator's
+cross-thread lock (acute on the Windows process heap) and otherwise erase the parallel
+speedup, so the `cargo-bench-history` binary installs `mimalloc` as its
+`#[global_allocator]` (the stress harness does the same for representative numbers). The
+lean `RunPoints` projection only trims peak ~1%; the repeated benchmark ids and the merge
+coexistence dominate peak, so the open memory levers are bounded merge-as-complete waves
+and id interning — see `docs/DESIGN.md` decision 34.
 
 `analyze` assembles a series by **resolving git topology at query time** rather
 than reading a flat storage prefix — the storage layout cannot pre-assemble a

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -229,8 +229,9 @@ fetches, decompresses, JSON-parses **and folds** its chunk into its *own* `Serie
 / `RunIndex`, dropping each parsed run as it goes, and the driver awaits the tasks in
 spawn order and merges the per-worker builders (`SeriesBuilder::merge`). Each object is
 parsed into the lean `cargo_bench_history_core::analyze::RunPoints` projection — only the
-fields the fold reads (the abbreviated commit and, per result, the id and the metric
-value/interval) — not a full `Run`. Detection (`find_changes_spawned`) then dispatches
+fields the fold reads (per result, the id and the metric
+value/interval) — not a full `Run`; the full commit SHA a point is labelled with comes
+from the storage key, not the run payload. Detection (`find_changes_spawned`) then dispatches
 per-series detection chunks to blocking tasks the same way. Both take the
 `&anyspawn::Spawner` `analyze_with` threads through; `execute` injects
 `Spawner::new_tokio()` (the runtime's blocking pool), while tests inject

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -32,6 +32,7 @@ futures = { workspace = true }
 hmac = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 many_cpus = { workspace = true }
+mimalloc = { workspace = true }
 nonempty = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1797,12 +1797,14 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      dataset. *Finding (full-scale run, default sizes, ~20000 objects / ~5.7 GiB on
      local FS):* `history` ~240 s, `tip` ~126 s, `branch` ~81 s. All three modes shared
      a multi-second floor spent loading and deserializing the ~20000 stored objects one
-     at a time; `analyze`/`list` now fetch and deserialize them with **bounded
+     at a time; `analyze`/`list` fetch and deserialize them with **bounded
      concurrency** (`analyze/mod.rs`'s `load_objects_concurrently` drives the survivors
      through `futures::stream::…buffer_unordered`, completing out of order then re-sorting
      by storage key for deterministic diagnostics), so the per-mode load floor is roughly
      its slowest fetch rather than the sum — critically so for Azure, where the serial
-     loads were serial network round-trips. The `--since`/`--until` window is applied
+     loads were serial network round-trips. *(The run load was later moved off this path to
+     a chunked parallel fetch+parse+fold — decision 34; `load_objects_concurrently` now
+     serves only the blessing-sidecar load.)* The `--since`/`--until` window is applied
      earlier still: each commit's committer time rides along its SHA on the first-parent
      topology, so out-of-window commits are dropped during selection and their objects are
      never fetched at all (issue #265). The per-series detection that each mode runs
@@ -1836,3 +1838,48 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      changes the output, so `worker_count` carries `#[mutants::skip]` while the real detection
      logic in `detect_one` stays under mutation testing. The serial `find_changes` survives
      only as the test-only oracle that pins the chunked path to a non-chunked reference.
+
+34. **Parallel object load + fold-in-worker + scalable allocator** — *Decided:*
+     `select_dataset`'s survivor load is distributed across worker tasks the same way the
+     detection is (decision 33). `analyze::fold_runs_chunked` splits the storage-key-sorted
+     survivors into one balanced contiguous chunk per worker (`worker_count` from
+     `analyze::parallel` = `thread::available_parallelism` capped at the survivor count) and
+     dispatches each chunk to a task via the injected `Spawner::spawn`. Each task fetches +
+     gzip-inflates + JSON-parses its slice — one object at a time into the lean
+     `analyze::run_points::RunPoints` projection (only what the fold reads: the abbreviated
+     commit and, per result, the id and metric value/interval, not a full `Run`) — and
+     **folds each parsed run into its own `SeriesBuilder` / `RunIndex`, dropping the run the
+     moment its compact points are extracted**, so no worker ever buffers its chunk's parsed
+     runs. The driver awaits the tasks **in spawn order** and merges their per-worker
+     builders (`SeriesBuilder::merge`), run tallies (`RunIndex::merge`) and admission lists
+     into one `WorkerFold`; a single `SeriesBuilder::finish` then sorts the combined series.
+     Ordinals are assigned before chunking and the final sort is global, so the merge is
+     associative and the output stays byte-identical to a deterministic single-threaded fold
+     in storage-key order. This supersedes the streaming `buffer_unordered` fold
+     (decision 32) for the run load. *Speed (measured):* the gzip-inflate + JSON parse **and**
+     the fold now both fan across cores — phase 2/3 went ~18.8 → ~4.0 s and overall `analyze`
+     ~40 → ~21 s on a 32-core box. *Allocator is load-bearing:* serde_json's many small
+     allocations contend on the system allocator's cross-thread lock (acute on the Windows
+     process heap), which made the naive parallel parse *slower* than serial (negative scaling
+     even 1→2 threads); the `cargo-bench-history` binary therefore installs `mimalloc` as its
+     `#[global_allocator]` (the stress harness mirrors it), without which this decision is a
+     regression. *Memory (measured, accepted — fold-in-worker did **not** lower peak):*
+     fold-in-worker was adopted specifically to claw back the peak that parallelizing cost,
+     by never buffering the parsed runs. It did not: against an intermediate buffered-parallel
+     variant (each chunk parsed to a `Vec<RunPoints>` then folded serially on the main
+     thread), back-to-back on the ~20000-object local-FS history, fold-in-worker measured
+     ~19.0 s / ~47% CPU at **~7210 MiB** peak versus buffered-parallel's ~21.1 s / ~40% at
+     **~6880 MiB** — i.e. ~10% *faster* with better core use but ~5% (~330 MiB) *more* peak.
+     The reason: at merge time every worker's finished builder is resident at once alongside
+     the growing combined builder (~2× the compact point output transiently), plus one
+     mimalloc arena per worker thread — which outweighs the single `RunPoints` buffer the
+     buffered variant carried. So the buffered runs were never the dominant peak term; the
+     lean `RunPoints` projection likewise trimmed peak only ~1% in isolation (the repeated
+     ~1000 benchmark ids re-materialized per object, and mimalloc's retention of freed pages,
+     dominate). Fold-in-worker is kept for the wall-time and CPU-efficiency win, accepting the
+     ~5% higher peak; the remaining structural memory levers (bounded merge-as-complete waves
+     so fewer partials coexist, and id interning/dedup) are deferred. *Caveat (Azure):* each
+     worker awaits its chunk's `Storage::get`s sequentially, so the run load's I/O concurrency
+     drops from the `LOAD_CONCURRENCY`-wide streaming pipeline to ≈ the worker count; the win
+     is on the CPU-bound parse, not remote I/O, and the low-volume blessing-sidecar load keeps
+     the `buffer_unordered` path.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -392,7 +392,7 @@ Captured once per stored run and attached to the `Run`:
   the timeline is its committer date, read from the git graph at analyze time
   (§8.3) and never copied onto the run, so a rebase or an amended date can never
   leave a stale timestamp behind.
-* **Git:** commit SHA + short SHA, branch, dirty flag (`git`).
+* **Git:** commit SHA, branch, dirty flag (`git`).
   Branch is metadata only — query-time topology, not this field, decides series
   membership (§8.3). Parent lineage and committer date are **not** recorded:
   `analyze` resolves topology *and* each commit's committer date from a live repo
@@ -1365,7 +1365,7 @@ adapter plus an in-lib `#[cfg(test)]` in-memory fake:
   injected env; return exit status. Real = `tokio::process::Command`; fake records
   the invocation and can drop fixture `summary.json` files to simulate a bench run.
 * `EnvProbe` (async, `probe.rs`) — discover the run-time git facts
-  (commit/short/branch/dirty) and toolchain facts; the real adapter
+  (commit/branch/dirty) and toolchain facts; the real adapter
   shells `git` and `rustc` (PARSE pure in `git.rs`/`host.rs`), the fake returns
   canned facts.
 * `GitHistory` (async, `git_history.rs`) — the read-only history query
@@ -1943,8 +1943,9 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      `analyze::parallel` = `thread::available_parallelism` capped at the survivor count) and
      dispatches each chunk to a task via the injected `Spawner::spawn`. Each task fetches +
      gzip-inflates + JSON-parses its slice — one object at a time into the lean
-     `analyze::run_points::RunPoints` projection (only what the fold reads: the abbreviated
-     commit and, per result, the id and metric value/interval, not a full `Run`) — and
+     `analyze::run_points::RunPoints` projection (only what the fold reads: per result, the
+     id and metric value/interval, not a full `Run`; the full commit SHA a point is labelled
+     with comes from the storage key, not the run payload) — and
      **folds each parsed run into its own `SeriesBuilder` / `RunIndex`, dropping the run the
      moment its compact points are extracted**, so no worker ever buffers its chunk's parsed
      runs. The driver awaits the tasks **in spawn order** and merges their per-worker
@@ -1980,3 +1981,19 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      drops from the `LOAD_CONCURRENCY`-wide streaming pipeline to ≈ the worker count; the win
      is on the CPU-bound parse, not remote I/O, and the low-volume blessing-sidecar load keeps
      the `buffer_unordered` path.
+
+37. **Full commit SHA only — no recorded abbreviation** — *Decided:* a run records only the
+     full commit SHA (`GitInfo.commit`); the previously stored `GitInfo.short_commit` is
+     removed from the data model entirely (and its `git rev-parse --short HEAD` capture
+     dropped). The analysis already has the full SHA in hand for every object — it is the
+     storage-key commit directory segment (`{…}/{commit}/{file}`) that drives topology and
+     ordinals — so the run payload's abbreviation was redundant *and* carried a (small) 48-bit
+     collision risk the full SHA does not. `analyze::SeriesBuilder::push` now labels each
+     `SeriesPoint` from the storage key's full SHA rather than the payload, and `RunPoints`
+     drops its git projection (it carries only `results`). This is a `SCHEMA_VERSION` 2 → 3
+     bump on the same backward-compatible footing as the v2 commit-timestamp removal: reads
+     are not gated on it, so older objects still deserialize (the removed field is ignored).
+     *Display:* a point's commit is now shown as the full SHA. Abbreviating purely for display
+     (e.g. the blessing `blessed_at`, which still calls a `short_commit` render helper on the
+     full SHA) is a separate, deferred concern — display abbreviation is questionable but not a
+     priority, so it is left as-is for now.

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -22,17 +22,18 @@ The single most important distinction:
 
 | Mechanism | What it is | Where | Threads |
 |---|---|---|---|
-| **I/O concurrency** | `buffer_unordered(LOAD_CONCURRENCY)` multiplexes in-flight `Storage::get` futures on **one** `!Send` task | the fetch loop in `select_dataset` | cooperative on a single task — **not** OS-thread parallelism |
-| **CPU parallelism** | one balanced contiguous chunk per worker is dispatched to a blocking task through an injected `anyspawn::Spawner` (`spawn_blocking`); chunk math in `analyze::parallel` | `find_changes_spawned` (the detection step) | runtime worker threads, not freshly spawned per call |
+| **CPU parallelism (load)** | the storage-key-sorted survivors are split into one balanced contiguous chunk per worker; each chunk is fetched + decompressed + JSON-parsed **and folded** into that worker's own `SeriesBuilder` on a blocking task through an injected `anyspawn::Spawner` (`spawn`) | `fold_runs_chunked` in `select_dataset` | runtime worker threads, not freshly spawned per call |
+| **CPU parallelism (detect)** | one balanced contiguous chunk of series per worker is dispatched to a blocking task through the same `Spawner` (`spawn_blocking`); chunk math in `analyze::parallel` | `find_changes_spawned` (the detection step) | runtime worker threads |
+| **I/O concurrency** | `buffer_unordered(LOAD_CONCURRENCY)` multiplexes in-flight `Storage::get` futures on **one** `!Send` task | the blessing-sidecar load (`load_objects_concurrently`) | cooperative on a single task — **not** OS-thread parallelism |
 
-"Fetching N at once" and "detecting across cores" are *different machines*. The fetch
-is latency-hiding I/O on one logical task; the **detection** stage is the only place
-that fans compute out across cores, and it does so through a `Spawner` so the work
-runs on the runtime's shared blocking pool (production) — or inline on the calling
-thread (tests/Miri) — rather than on anonymous per-call OS threads. The load future
-is `!Send` and reactor-free, so it runs unchanged under the Miri-driven
-`futures::executor::block_on` tests; the production binary runs it under
-`#[tokio::main]`, and that same runtime backs the detection spawner.
+"Folding across cores" and "detecting across cores" are the two stages that fan compute
+out across cores, and both do so through a `Spawner` so the work runs on the runtime's
+shared blocking pool (production) — or inline on the calling thread (tests/Miri) — rather
+than on anonymous per-call OS threads. The low-volume blessing-sidecar load still uses
+the older single-task `buffer_unordered` I/O concurrency. Production runs all of this
+under `#[tokio::main]`; tests drive `select_dataset` through the
+`synchronous_spawner` and `futures::executor::block_on`, so the load stays reactor-free
+and runs unchanged under Miri.
 
 ---
 
@@ -70,13 +71,12 @@ flowchart TD
     WF --> TF["to_fetch: Vec<(key, StorageKey)>"]
     TF --> SK["sort by storage key\n→ each object's rank = object_ordinal"]
   end
-  SK --> LOOP
-  subgraph P23["Phase 2/3 — fetch + fold, streaming"]
-    LOOP["buffer_unordered(LOAD_CONCURRENCY)\nfetch_one_ranked → Storage::get → JSON → Run"] -->|"Run, OUT of order"| FOLD["serial fold: SeriesBuilder.push per run\nintern commit, hash id, group points"]
-    FOLD --> DROP["drop parsed Run\nkeep only compact SeriesPoints"]
-    DROP --> LOOP
+  SK --> LOAD
+  subgraph P23["Phase 2/3 — chunked parallel fetch+parse+fold, then merge"]
+    LOAD["fold_runs_chunked: split survivors into\none balanced contiguous chunk per worker"] -->|"spawn(chunk) ★ BLOCKING TASKS ★"| WORK["each worker: for key in chunk →\nStorage::get → gzip inflate → JSON → RunPoints\n→ push into its OWN SeriesBuilder, drop RunPoints"]
+    WORK -->|"await in spawn order"| MERGE["merge per-worker SeriesBuilders\n+ RunIndexes into one"]
   end
-  DROP --> FIN["SeriesBuilder.finish()"]
+  MERGE --> FIN["SeriesBuilder.finish()"]
 ```
 
 Key properties:
@@ -84,26 +84,54 @@ Key properties:
 - **Phase 1 never fetches a payload.** History-membership, base-side dirty admission
   and the `--since`/`--until` window are all decided from the *key* and git topology
   (`window_excludes`), so an excluded object costs zero round-trips.
-- **Ordinals are assigned up front** by sorting `to_fetch` by key, because
-  `buffer_unordered` completes out of order; this makes the result independent of
-  fetch arrival order. `object_ordinal` is the final point tie-break and stands in for
-  the full storage key to keep points small.
-- **Streaming memory.** Only the objects currently in flight (raw bytes + the one
-  parsed `Run` being folded) are resident; each `Run` is dropped right after its
-  points are extracted. On a large history this is the difference between hundreds of
-  MB and tens of GB.
-- **Fetch is concurrent, parse + fold are serial.** Each completed fetch is parsed
-  (JSON → `Run`) and folded (`SeriesBuilder::push`) inline on the single load task as
-  it arrives, overlapped with the still-in-flight fetches. The fold is a sequential
-  section, but it overlaps the concurrent fetch pipeline, so on the remote backend it
-  hides under fetch latency rather than gating it; an earlier per-batch parallel-parse
-  scheme was dropped because its chunks were too small to beat the fork/join overhead
-  (see §6).
+- **Ordinals are assigned up front** by sorting `to_fetch` by key. Each survivor's rank
+  in that order is its `object_ordinal`, captured before chunking so the result is
+  independent of which worker finishes first. `object_ordinal` is the final point
+  tie-break and stands in for the full storage key to keep points small.
+- **The parse and the fold both run across cores; a serial merge follows.**
+  `fold_runs_chunked` splits the key-sorted survivors into one balanced contiguous chunk
+  per worker (sizes differ by at most one) and spawns one blocking task per chunk; each
+  task fetches, inflates, and JSON-parses each object into a lean `RunPoints` (the
+  projection below) and **folds it straight into that worker's own `SeriesBuilder` /
+  `RunIndex`, dropping the `RunPoints` immediately** — so a worker never buffers its
+  chunk's parsed runs. The driver awaits the tasks **in spawn order** and merges their
+  builders (`SeriesBuilder::merge`), run tallies (`RunIndex::merge`) and admission lists
+  into one. Because ordinals are global and the final `finish()` sort is global, the
+  merge is associative and the result is byte-identical to a single-threaded fold in
+  storage-key order. Both the parse and the fold — the local-backend load's dominant
+  costs — now scale with cores; only the merge and the final sort stay serial.
+- **The parsed element is lean (`RunPoints`).** Each object is parsed into `RunPoints`
+  (`analyze::run_points`), which carries only what `SeriesBuilder::push` reads — the
+  abbreviated commit and, per result, the benchmark id and each metric's
+  `kind`/`value`/`interval_low`/`interval_high` — and `push` consumes that projection
+  rather than a full `Run`. Serde ignores the rest of the run JSON, so the discarded run
+  context (environment, toolchain, timestamps) and per-metric standard deviation are
+  never materialized.
+- **Memory: fold-in-worker did not lower peak (the accepted tradeoff).** Folding in the
+  worker means no chunk's parsed runs are ever buffered — yet this is *not* a memory win.
+  At merge time every worker's finished `SeriesBuilder` is resident at once alongside the
+  growing combined builder (~2× the compact point output transiently), plus one mimalloc
+  arena per worker thread. Measured back-to-back on the ~20000-object local-FS history,
+  fold-in-worker ran ~19.0 s / ~47% CPU at **~7210 MiB** peak versus an intermediate
+  buffered-parallel variant (parse a chunk to `Vec<RunPoints>`, fold serially on the main
+  thread) at ~21.1 s / ~40% / **~6880 MiB** — i.e. ~10% faster with better core use but
+  ~5% (~330 MiB) *more* peak. So the buffered runs were never the dominant peak term, and
+  the lean `RunPoints` projection trims peak only ~1% in isolation (the repeated ~1000
+  benchmark ids re-materialized per object, plus mimalloc's page retention, dominate).
+  Fold-in-worker is kept for the wall-time and CPU win; the remaining memory levers
+  (bounded merge-as-complete waves, id interning) are deferred — see `DESIGN.md`
+  decision 34.
+- **The parallel parse needs a scalable allocator.** serde_json makes many small
+  allocations; on the system allocator their cross-thread contention (acute on the
+  Windows process heap) serializes the worker threads and erases the parallel win — the
+  naive change measured *slower* than serial. The `cargo-bench-history` binary therefore
+  installs `mimalloc` as its `#[global_allocator]` (so does the stress harness, for
+  representative numbers); with it the parse scales cleanly across cores.
 
 ### `SeriesBuilder::push` — what the fold does (`analyze::series`)
 
-Per parsed `Run`: intern the short commit into an `Arc<str>` shared by every point on
-that commit (`intern`); resolve the benchmark id's bucket in a `HashTable` with a
+Per parsed `RunPoints`: intern the short commit into an `Arc<str>` shared by every point
+on that commit (`intern`); resolve the benchmark id's bucket in a `HashTable` with a
 single `entry` probe — hashing `BenchmarkId` with the builder's one fixed hasher
 instance and **cloning the id only on a true cache miss** (one id-clone per distinct
 series, never per point); push a compact `SeriesPoint` (`topo_index`, `dirty`,
@@ -113,10 +141,16 @@ hence the compactness and interning.
 
 ### Tuning constants (`analyze::mod`)
 
-- `LOAD_CONCURRENCY` — how many `Storage::get` round-trips overlap. Hides per-object
-  latency (critical on the remote backend); set near the knee where in-flight fetches
-  saturate the network path, past which extra concurrency only subdivides the fixed
-  path bandwidth and lengthens each request without lifting throughput.
+- **Load worker count** (`worker_count`, from `analyze::parallel`) — how many blocking
+  tasks the run load fans across: `thread::available_parallelism()`, capped at the
+  survivor count so a small data set does not spawn idle workers. This bounds both the
+  parallel parse+fold width and (on the run-load path) the number of concurrent in-flight
+  `Storage::get`s, since each worker awaits its chunk's gets sequentially.
+- `LOAD_CONCURRENCY` — how many `Storage::get` round-trips the **blessing-sidecar** load
+  overlaps on its single `buffer_unordered` task. Hides per-object latency (critical on
+  the remote backend); set near the knee where in-flight fetches saturate the network
+  path, past which extra concurrency only subdivides the fixed path bandwidth and
+  lengthens each request without lifting throughput.
 
 ---
 
@@ -170,38 +204,51 @@ reordering them cannot change the median.
 |---|---|---|---|
 | `storage.list` | single async request | the whole prefix | — |
 | Phase-1 filtering | serial | per candidate key | — |
-| **fetch** | **I/O-concurrent (one task)** | per object, bounded in flight | `buffer_unordered(LOAD_CONCURRENCY)` |
-| parse | **serial** (on the load task) | per object, as it arrives | — |
-| fold (`push`) | **serial** | per `Run` | overlaps the concurrent fetch |
+| **fetch + parse + fold (runs)** | **CPU-parallel (spawned blocking tasks)** | one chunk of survivors per worker | `fold_runs_chunked`: split once, each worker folds its own builder, await + merge in spawn order |
+| merge (`SeriesBuilder::merge`) | **serial** | per worker partial | runs after the parallel load completes |
 | series sort | serial | the `Vec<Series>` | — |
 | point sort | serial | per series | — |
 | **detect** | **CPU-parallel (spawned blocking tasks)** | one chunk of series per worker | split once over all series, await + concat |
+| blessing-sidecar fetch | **I/O-concurrent (one task)** | per object, bounded in flight | `buffer_unordered(LOAD_CONCURRENCY)` |
 | BH filter + finding sort + render | serial | the candidate/finding list | — |
 
-`find_changes_spawned` splits the series into **exactly one balanced chunk per
-worker** (sizes differ by at most one, so a slice just above the worker count still
-uses every worker rather than collapsing to fewer chunks), dispatches each chunk to a
-blocking task through the injected `Spawner`, then awaits and concatenates them in
-series order — identical output to a sequential pass. A single available CPU (Miri
-reports one) yields a single worker: one chunk, one task over every series.
+Both `fold_runs_chunked` and `find_changes_spawned` split their input into **exactly one
+balanced chunk per worker** (sizes differ by at most one, so a slice just above the worker
+count still uses every worker rather than collapsing to fewer chunks), dispatch each chunk
+to a blocking task through the injected `Spawner`, then await them in spawn order —
+`fold_runs_chunked` merges the per-worker partials, `find_changes_spawned` concatenates the
+per-worker results — for output identical to a sequential pass. A single available CPU
+(Miri reports one) yields a single worker: one chunk, one task over the whole input.
 
 ---
 
 ## 6. Where the bottlenecks live (to steer optimization)
 
-- **Local-filesystem backend:** the load is **fetch + serial parse/fold** bound. The
-  fold runs inline as each object arrives, overlapped with the concurrent fetch, so
-  the ceiling is fetch arrival plus the serial fold throughput. Levers: shrink the
-  serial section (cheaper `push`), fewer/larger objects. A previous per-batch
-  parallel-parse scheme was reverted: its chunks were too small to beat the fork/join
-  overhead, and the fold already overlapped the fetch pipeline, so it added complexity
-  for no measurable win.
-- **Azure backend:** network-bound. With the shared connection pool (§7) the per-object
-  TCP+TLS handshake is amortised across a keep-alive pool, leaving two ceilings: the
-  path bandwidth between the client and the storage region, and — for small objects — a
-  per-request round-trip rate, since each object costs one round-trip. Concurrency past
-  the knee (`LOAD_CONCURRENCY`) only subdivides the fixed bandwidth and inflates latency
-  tails, so fewer-larger blobs (and fewer bytes) help more than more concurrency.
+- **Local-filesystem backend:** the load is **parse-bound**, and both the parse and the
+  fold now fan across cores. `fold_runs_chunked` spreads the gzip-inflate + JSON-parse +
+  fold over one blocking task per CPU, so the ceiling is the slowest chunk's parse+fold
+  plus the serial merge throughput. Levers: cheaper `push`, parse into a leaner shape
+  (`RunPoints` already drops the run context and per-metric std-dev — less to
+  allocate/parse), fewer/larger objects. Note folding inside the workers did **not** lower
+  peak memory (every worker's partial builder coexists with the merged builder during the
+  merge — see §3 and `DESIGN.md` decision 34); the open memory levers are bounded
+  merge-as-complete waves and id interning, not a leaner buffered element. This parallel
+  parse only pays off with a scalable global allocator (see the mimalloc note below).
+- **Azure backend:** network-bound, and the run load now drives **at most one in-flight
+  `Storage::get` per worker** (≈ CPU count), because each worker awaits its chunk's gets
+  sequentially. That is well below the `LOAD_CONCURRENCY`-wide pipeline the streaming load
+  used, so on a latency-bound remote path the run load can be *less* I/O-concurrent than
+  before; the win from this change is on the CPU-bound parse+fold, not on remote I/O. With
+  the shared connection pool (§7) the per-object TCP+TLS handshake is amortised across a
+  keep-alive pool, leaving two ceilings: the path bandwidth and — for small objects — a
+  per-request round-trip rate. Fewer-larger blobs (and fewer bytes) help more than more
+  concurrency. (The blessing-sidecar load keeps the `LOAD_CONCURRENCY`-wide path.)
+- **The global allocator is load-bearing for the parallel parse.** serde_json's many
+  small allocations contend on the system allocator's cross-thread lock; on the Windows
+  process heap that contention made the naive parallel parse *slower* than serial
+  (negative scaling even 1→2 threads). The binary installs `mimalloc` as its
+  `#[global_allocator]` so the per-thread heaps eliminate the contention and the parse
+  scales. Do not remove it without re-measuring the parallel load.
 - **Data-structure hot spots:** `SeriesPoint` compactness, `Arc<str>` commit interning
   and single-probe `HashTable` id lookups (clone-on-miss) keep the
   tens-of-millions-of-points fold affordable. Preserve these; do not regress them.
@@ -293,7 +340,7 @@ specific stage of the diagrams above without reading the code. Each line reads
 | `git topology resolution`      | §2/§3 `resolve_history` (commit order + times)    |
 | `git.first_parent ancestry …`  | §3 the first-parent ancestry walk alone (scales with history) |
 | `phase 1 — key-only …`         | §3 Phase 1 filtering loop (no fetches)            |
-| `phase 2/3 — concurrent fetch …` | §3 Phase 2/3 concurrent fetch + serial parse + fold |
+| `phase 2/3 — chunked parallel fetch …` | §3 Phase 2/3 chunked parallel fetch + parse + per-worker fold, then merge |
 | `series build finalization`    | §4 `SeriesBuilder::finish()` (+ serial point sort) |
 | `blessing sidecar load`        | §3 history-mode blessing fetch (history only)     |
 | `re-baseline blessed series`   | §2 `apply_blessings`                              |

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -101,12 +101,13 @@ Key properties:
   storage-key order. Both the parse and the fold — the local-backend load's dominant
   costs — now scale with cores; only the merge and the final sort stay serial.
 - **The parsed element is lean (`RunPoints`).** Each object is parsed into `RunPoints`
-  (`analyze::run_points`), which carries only what `SeriesBuilder::push` reads — the
-  abbreviated commit and, per result, the benchmark id and each metric's
+  (`analyze::run_points`), which carries only what `SeriesBuilder::push` reads from the
+  run payload — per result, the benchmark id and each metric's
   `kind`/`value`/`interval_low`/`interval_high` — and `push` consumes that projection
-  rather than a full `Run`. Serde ignores the rest of the run JSON, so the discarded run
-  context (environment, toolchain, timestamps) and per-metric standard deviation are
-  never materialized.
+  rather than a full `Run` (the commit a point is labelled with comes from the storage
+  key, not the payload, so `RunPoints` holds no git fields). Serde ignores the rest of the
+  run JSON, so the discarded run context (environment, toolchain, timestamps) and
+  per-metric standard deviation are never materialized.
 - **Memory: fold-in-worker did not lower peak (the accepted tradeoff).** Folding in the
   worker means no chunk's parsed runs are ever buffered — yet this is *not* a memory win.
   At merge time every worker's finished `SeriesBuilder` is resident at once alongside the
@@ -130,7 +131,8 @@ Key properties:
 
 ### `SeriesBuilder::push` — what the fold does (`analyze::series`)
 
-Per parsed `RunPoints`: intern the short commit into an `Arc<str>` shared by every point
+Per parsed `RunPoints`: intern the commit from the storage key (not the
+run payload) into an `Arc<str>` shared by every point
 on that commit (`intern`); resolve the benchmark id's bucket in a `HashTable` with a
 single `entry` probe — hashing `BenchmarkId` with the builder's one fixed hasher
 instance and **cloning the id only on a true cache miss** (one id-clone per distinct

--- a/packages/cargo-bench-history/src/analyze/bless.rs
+++ b/packages/cargo-bench-history/src/analyze/bless.rs
@@ -345,7 +345,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("master".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -25,6 +25,7 @@ use crate::text::count_noun;
 use crate::wiring::{resolve_config_path, resolve_project_id, resolve_repo};
 use crate::{ListOptions, ListSubject, RunError, RunOutcome};
 
+use anyspawn::Spawner;
 use jiff::Timestamp;
 
 use super::{
@@ -61,6 +62,9 @@ pub(crate) async fn execute(
     let auto = detect_auto_facets().await?;
 
     let now = now_override.unwrap_or_else(Timestamp::now);
+    // The object-load and detection work shares the ambient Tokio worker threads
+    // (mirrors `analyze::execute`).
+    let spawner = Spawner::new_tokio();
     list_with(
         &git,
         &storage,
@@ -70,6 +74,7 @@ pub(crate) async fn execute(
         &auto,
         now,
         &reporter,
+        &spawner,
     )
     .await
 }
@@ -90,10 +95,11 @@ pub(crate) async fn list_with<G, S>(
     auto: &AutoFacets,
     now: Timestamp,
     reporter: &dyn Reporter,
+    spawner: &Spawner,
 ) -> Result<RunOutcome, RunError>
 where
     G: GitHistory,
-    S: Storage,
+    S: Storage + Clone + 'static,
 {
     let format = parse_format(options.format.as_deref())?;
     if options.all && options.subject != ListSubject::Blessings {
@@ -128,7 +134,7 @@ where
         }
         ListSubject::Blessings => {
             let message = list_blessings(
-                git, storage, project_id, config, options, auto, now, reporter,
+                git, storage, project_id, config, options, auto, now, reporter, spawner,
             )
             .await?;
             Ok(RunOutcome::Completed { message })
@@ -136,7 +142,7 @@ where
         ListSubject::Runs => {
             let filter = SeriesFilter::default();
             let dataset = select_dataset(
-                git, storage, project_id, config, &selection, filter, auto, now, reporter,
+                git, storage, project_id, config, &selection, filter, auto, now, reporter, spawner,
             )
             .await?;
             let series = dataset.series;
@@ -507,17 +513,18 @@ async fn list_blessings<G, S>(
     auto: &AutoFacets,
     now: Timestamp,
     reporter: &dyn Reporter,
+    spawner: &Spawner,
 ) -> Result<String, RunError>
 where
     G: GitHistory,
-    S: Storage,
+    S: Storage + Clone + 'static,
 {
     let format = parse_format(options.format.as_deref())?;
     let selection = Selection::from_list(options);
 
     let (head_label, mut entries) = if options.all {
         blessings_across_window(
-            git, storage, project_id, config, &selection, auto, now, reporter,
+            git, storage, project_id, config, &selection, auto, now, reporter, spawner,
         )
         .await?
     } else {
@@ -610,14 +617,15 @@ async fn blessings_across_window<G, S>(
     auto: &AutoFacets,
     now: Timestamp,
     reporter: &dyn Reporter,
+    spawner: &Spawner,
 ) -> Result<(String, Vec<BlessingEntry>), RunError>
 where
     G: GitHistory,
-    S: Storage,
+    S: Storage + Clone + 'static,
 {
     let filter = SeriesFilter::default();
     let dataset = select_dataset(
-        git, storage, project_id, config, selection, filter, auto, now, reporter,
+        git, storage, project_id, config, selection, filter, auto, now, reporter, spawner,
     )
     .await?;
     let mut series = dataset.series;
@@ -868,6 +876,12 @@ mod tests {
 
     fn options() -> ListOptions {
         ListOptions::default()
+    }
+
+    /// An inline spawner that runs the load tasks on the calling thread, so the
+    /// list tests need no Tokio runtime under `block_on` or Miri.
+    fn spawner() -> Spawner {
+        cargo_bench_history_core::testing::synchronous_spawner()
     }
 
     /// A result set with one record carrying two metrics, so its partition
@@ -1139,6 +1153,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &spawner(),
         ))
         .unwrap();
         match outcome {
@@ -1237,6 +1252,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &spawner(),
         ))
         .unwrap_err();
         assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
@@ -1349,6 +1365,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &spawner(),
         ))
         .unwrap_err();
         match error {
@@ -1563,6 +1580,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &spawner(),
         ))
         .unwrap_err()
     }

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -895,7 +895,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -925,7 +924,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -954,7 +952,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -749,10 +749,10 @@ where
             let mut admitted: Vec<(String, bool)> = Vec::with_capacity(chunk.len());
             for (rank, key, parsed) in chunk {
                 let bytes = storage.get(&key).await.map_err(RunError::Storage)?;
-                let text = String::from_utf8(bytes).map_err(|error| RunError::Analyze {
+                let text = str::from_utf8(&bytes).map_err(|error| RunError::Analyze {
                     message: format!("stored object {key} is not valid UTF-8: {error}"),
                 })?;
-                let run = RunPoints::from_json(&text).map_err(|error| RunError::Analyze {
+                let run = RunPoints::from_json(text).map_err(|error| RunError::Analyze {
                     message: format!("stored object {key} is not a valid result set: {error}"),
                 })?;
                 let topo_index = order

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -18,8 +18,9 @@ pub(crate) mod prune;
 
 pub(crate) use cargo_bench_history_core::analyze::{
     AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DiscriminantSetQuery,
-    FacetFilter, ReportFormat, ReportInput, Series, SeriesBuilder, SeriesFilter, SetSummary,
-    StorageKey, apply_blessings, find_changes_spawned, parse_key, render, select_commits,
+    FacetFilter, ReportFormat, ReportInput, RunPoints, Series, SeriesBuilder, SeriesFilter,
+    SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes, find_changes_spawned, parse_key,
+    render, select_commits, worker_count,
 };
 
 use std::collections::{BTreeMap, HashMap};
@@ -39,8 +40,7 @@ use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
 use crate::machine::resolve_machine_key;
 use crate::model::BlessingRecord;
-use crate::model::Run;
-use crate::model::{DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment};
+use crate::model::{BenchmarkIdPrefix, DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment};
 use crate::probe::{EnvironmentProbe, SystemProbe};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, build_storage};
@@ -151,7 +151,7 @@ pub(crate) async fn analyze_with<G, S>(
 ) -> Result<RunOutcome, RunError>
 where
     G: GitHistory,
-    S: Storage,
+    S: Storage + Clone + 'static,
 {
     let format = parse_format(options.format.as_deref())?;
     let selection = Selection::from_analyze(options)?;
@@ -160,7 +160,7 @@ where
     };
     let load_started = Instant::now();
     let dataset = select_dataset(
-        git, storage, project_id, config, &selection, filter, auto, now, reporter,
+        git, storage, project_id, config, &selection, filter, auto, now, reporter, spawner,
     )
     .await?;
     reporter.timing(
@@ -427,6 +427,29 @@ impl RunIndex {
         }
     }
 
+    /// Folds another index's tallies into this one.
+    ///
+    /// The recombination step of the parallel fold: each worker records the runs of
+    /// its disjoint object chunk into its own index, and the main thread merges the
+    /// per-worker indices. Because the chunks are disjoint, summing the totals and
+    /// the per-`(set, commit)` clean/dirty counts reproduces the single-threaded
+    /// tally exactly, independent of the order the workers' indices are merged.
+    fn merge(&mut self, other: Self) {
+        self.total = self.total.saturating_add(other.total);
+        for (set, by_commit) in other.sets {
+            let dest = self.sets.entry(set).or_default();
+            for (topo_index, counts) in by_commit {
+                let entry = dest.entry(topo_index).or_insert_with(|| CommitCounts {
+                    commit: counts.commit.clone(),
+                    clean: 0,
+                    dirty: 0,
+                });
+                entry.clean = entry.clean.saturating_add(counts.clean);
+                entry.dirty = entry.dirty.saturating_add(counts.dirty);
+            }
+        }
+    }
+
     /// Total runs admitted across every set.
     pub(crate) fn total(&self) -> usize {
         self.total
@@ -647,24 +670,118 @@ where
     Ok((key, parsed, value))
 }
 
-/// Like [`fetch_one`], but carries an arbitrary `rank` through the out-of-order
-/// fetch so the caller can recover each object's position (its storage-key
-/// ordinal). Kept as a named `async fn` for the same reason as [`fetch_one`]: the
-/// stream closure then stays a plain `FnMut` returning this future rather than one
-/// wrapping an `async` block.
-async fn fetch_one_ranked<S, F>(
+/// One worker's (or the merged) folded contribution: the series builder it folded
+/// its object chunk into, the run tally it recorded, and the per-object admission
+/// flags for the key-ordered verbose notes.
+///
+/// Returned from each spawned fold task and merged on the main thread; the merged
+/// value carries the same shape so the caller treats one worker and many uniformly.
+struct WorkerFold {
+    /// Series points folded from this worker's objects (compact; the parsed runs
+    /// are dropped inside the worker as each is folded).
+    builder: SeriesBuilder,
+    /// Per-set, per-commit run tally for this worker's objects.
+    run_index: RunIndex,
+    /// `(storage key, admitted-by-dirty-base-exception)` per folded object, for the
+    /// key-ordered verbose notes the caller emits once every worker has folded.
+    admitted: Vec<(String, bool)>,
+}
+
+/// Loads, parses, and **folds** the in-selection survivors across CPU cores.
+///
+/// `ranked` is the storage-key-sorted survivor list, each carrying its
+/// storage-key ordinal (`rank`). It is split into [`worker_count`] balanced
+/// contiguous chunks ([`balanced_chunk_sizes`]); one spawned task per chunk
+/// fetches, decompresses, parses, and folds its slice into its *own*
+/// [`SeriesBuilder`] / [`RunIndex`], dropping each parsed run the moment its
+/// compact points are extracted. The main thread awaits the chunks in spawn order
+/// and merges their builders, run tallies, and admission lists into one
+/// [`WorkerFold`]; a single [`SeriesBuilder::finish`] then sorts the combined
+/// series. The merge is associative and the final sort is global, so the result is
+/// identical to a single-threaded fold in storage-key order.
+///
+/// Folding inside each worker (rather than buffering every chunk's parsed runs and
+/// folding serially on the main thread) parallelizes the fold as well as the parse:
+/// a worker drops each parsed run the moment its compact points are extracted, so it
+/// never buffers its chunk's parsed runs. This does **not** lower peak memory — at
+/// merge time every worker's finished builder is resident at once alongside the
+/// growing combined builder (~2x the compact point output transiently), which measured
+/// ~5% above the buffered-parallel variant; the win it buys is the ~10% faster wall
+/// time and better core use from moving the fold off the main thread. The decompress +
+/// JSON parse — the CPU-dominated cost — is spread across the runtime's worker threads.
+/// See `docs/DESIGN.md` decision 34.
+async fn fold_runs_chunked<S>(
     storage: &S,
-    rank: usize,
-    key: String,
-    parsed: StorageKey,
-    parse: &F,
-) -> Result<(usize, String, StorageKey, Run), RunError>
+    spawner: &Spawner,
+    ranked: Vec<(usize, String, StorageKey)>,
+    order: &Arc<HashMap<String, usize>>,
+    dirty_base_exception: &Arc<HashMap<String, bool>>,
+    prefixes: Arc<[BenchmarkIdPrefix]>,
+) -> Result<WorkerFold, RunError>
 where
-    S: Storage,
-    F: Fn(&str, Vec<u8>) -> Result<Run, RunError>,
+    S: Storage + Clone + 'static,
 {
-    let (key, parsed, run) = fetch_one(storage, key, parsed, parse).await?;
-    Ok((rank, key, parsed, run))
+    let total = ranked.len();
+    let mut combined = WorkerFold {
+        builder: SeriesBuilder::with_prefixes(Arc::clone(&prefixes)),
+        run_index: RunIndex::new(),
+        admitted: Vec::with_capacity(total),
+    };
+    if total == 0 {
+        return Ok(combined);
+    }
+    let workers = worker_count(total);
+
+    let mut items = ranked.into_iter();
+    let mut handles = Vec::with_capacity(workers);
+    for chunk_len in balanced_chunk_sizes(total, workers) {
+        let chunk: Vec<(usize, String, StorageKey)> = items.by_ref().take(chunk_len).collect();
+        let storage = storage.clone();
+        let order = Arc::clone(order);
+        let dirty_base_exception = Arc::clone(dirty_base_exception);
+        let prefixes = Arc::clone(&prefixes);
+        handles.push(spawner.spawn(async move {
+            let mut builder = SeriesBuilder::with_prefixes(prefixes);
+            let mut run_index = RunIndex::new();
+            let mut admitted: Vec<(String, bool)> = Vec::with_capacity(chunk.len());
+            for (rank, key, parsed) in chunk {
+                let bytes = storage.get(&key).await.map_err(RunError::Storage)?;
+                let text = String::from_utf8(bytes).map_err(|error| RunError::Analyze {
+                    message: format!("stored object {key} is not valid UTF-8: {error}"),
+                })?;
+                let run = RunPoints::from_json(&text).map_err(|error| RunError::Analyze {
+                    message: format!("stored object {key} is not a valid result set: {error}"),
+                })?;
+                let topo_index = order
+                    .get(&parsed.commit)
+                    .copied()
+                    .expect("phase 1 admitted only commits on the analyzed history");
+                let dirty = parsed.is_dirty();
+                let is_exception = dirty
+                    && dirty_base_exception
+                        .get(parsed.commit.as_str())
+                        .copied()
+                        .unwrap_or(false);
+                run_index.record(&parsed.set, topo_index, &parsed.commit, dirty);
+                builder.push(&parsed.set, topo_index, dirty, ordinal_of(rank), &run);
+                admitted.push((key, is_exception));
+                // `run` is dropped here; only the extracted (compact) points are kept.
+            }
+            Ok::<WorkerFold, RunError>(WorkerFold {
+                builder,
+                run_index,
+                admitted,
+            })
+        }));
+    }
+
+    for handle in handles {
+        let fold = handle.await?;
+        combined.builder.merge(fold.builder);
+        combined.run_index.merge(fold.run_index);
+        combined.admitted.extend(fold.admitted);
+    }
+    Ok(combined)
 }
 
 /// Resolves the git topology, selects the comparable commits, and loads the
@@ -684,10 +801,11 @@ async fn select_dataset<G, S>(
     auto: &AutoFacets,
     now: Timestamp,
     reporter: &dyn Reporter,
+    spawner: &Spawner,
 ) -> Result<SelectedDataSet, RunError>
 where
     G: GitHistory,
-    S: Storage,
+    S: Storage + Clone + 'static,
 {
     let facets = resolve_facets(selection, Some(auto))?;
     let listing_started = Instant::now();
@@ -731,6 +849,13 @@ where
         "git topology resolution (resolve_history)",
         topology_started.elapsed(),
     );
+
+    // The topology lookups the parallel fold needs — the commit -> first-parent
+    // index map and the base-branch dirty-tree exceptions — are shared read-only
+    // across every worker, so wrap them in `Arc` once and hand each worker a cheap
+    // clone. Downstream main-thread reads still go through `Deref`.
+    let order = Arc::new(order);
+    let dirty_base_exception = Arc::new(dirty_base_exception);
 
     // Mode auto-detection keys off the *recorded data set*, not the on-disk
     // repository state. The branch view exists to compare a feature branch's runs
@@ -793,9 +918,6 @@ where
     let mut excluded_dirty_base = 0_usize;
     let mut excluded_since = 0_usize;
     let mut excluded_until = 0_usize;
-    // Whether at least one dirty run was admitted solely by the base-branch
-    // dirty-tree exception, so the report can warn that it is ephemeral.
-    let mut included_dirty_base_exception = false;
 
     // Phase 1 — key-only filtering, in candidate order. Every exclusion that does
     // not need the object's payload runs here, before anything is fetched, so an
@@ -861,59 +983,49 @@ where
         phase1_started.elapsed(),
     );
 
-    // Phase 2/3 — fetch the survivors concurrently and fold each into the series as
-    // it arrives, dropping the parsed run immediately so the whole parsed data set
-    // is never resident at once (the peak that drove analysis into tens of
-    // gigabytes). Each object's ordinal — the final point tie-break — is its rank
-    // in storage-key order, assigned up front because `buffer_unordered` completes
-    // out of order. The per-object verbose notes and the run tally are collected
-    // during the fold and emitted in storage-key order afterwards, so the
-    // diagnostics stay byte-identical to a deterministic in-order pass.
+    // Phase 2/3 — fetch the survivors and fold each into the series. The fetch +
+    // decompress + JSON parse (the CPU-dominated cost) is spread across the
+    // runtime's worker threads: the storage-key-sorted survivors are split into
+    // balanced contiguous chunks, and one spawned task fetches, parses, *and folds*
+    // each chunk into its own series builder — dropping each parsed run the instant
+    // its compact points are extracted. The main thread then merges the per-worker
+    // builders, run tallies, and admission lists into one. Each object's ordinal —
+    // the final point tie-break — is its rank in storage-key order, assigned up
+    // front, so the single `builder.finish()` sort reproduces the in-order result.
+    // The per-object verbose notes are collected during the fold and emitted in
+    // storage-key order afterwards, so the diagnostics stay byte-identical to a
+    // deterministic in-order pass.
+    //
+    // Folding inside each worker keeps only the compact per-worker points resident
+    // between fetch and merge — never the whole parsed data set — so the parallel
+    // parse does not buy its throughput with the full-buffer memory peak.
     to_fetch.sort_by(|left, right| left.0.cmp(&right.0));
 
     let fetch_fold_started = Instant::now();
-    let mut builder = SeriesBuilder::new(filter);
-    let mut run_index = RunIndex::new();
-    // (storage key, admitted-by-dirty-base-exception) per folded object, for the
-    // key-ordered verbose notes emitted once the fold completes.
-    let mut admitted: Vec<(String, bool)> = Vec::new();
-    {
-        let parse = |key: &str, bytes: Vec<u8>| -> Result<Run, RunError> {
-            let text = String::from_utf8(bytes).map_err(|error| RunError::Analyze {
-                message: format!("stored object {key} is not valid UTF-8: {error}"),
-            })?;
-            Run::from_json(&text).map_err(|error| RunError::Analyze {
-                message: format!("stored object {key} is not a valid result set: {error}"),
-            })
-        };
-        let parse = &parse;
-        let mut fetches = futures::stream::iter(to_fetch.into_iter().enumerate())
-            .map(move |(rank, (key, parsed))| fetch_one_ranked(storage, rank, key, parsed, parse))
-            .buffer_unordered(LOAD_CONCURRENCY);
-
-        while let Some(fetched) = fetches.next().await {
-            let (rank, key, parsed, run) = fetched?;
-            let topo_index = order
-                .get(&parsed.commit)
-                .copied()
-                .expect("phase 1 admitted only commits on the analyzed history");
-            let dirty = parsed.is_dirty();
-            let is_exception = dirty
-                && dirty_base_exception
-                    .get(parsed.commit.as_str())
-                    .copied()
-                    .unwrap_or(false);
-            if is_exception {
-                included_dirty_base_exception = true;
-            }
-            run_index.record(&parsed.set, topo_index, &parsed.commit, dirty);
-            builder.push(&parsed.set, topo_index, dirty, ordinal_of(rank), &run);
-            admitted.push((key, is_exception));
-            // `run` is dropped here; only the extracted (compact) points are kept.
-        }
-    }
+    let ranked: Vec<(usize, String, StorageKey)> = to_fetch
+        .into_iter()
+        .enumerate()
+        .map(|(rank, (key, parsed))| (rank, key, parsed))
+        .collect();
+    let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(filter.prefixes);
+    let WorkerFold {
+        builder,
+        run_index,
+        mut admitted,
+    } = fold_runs_chunked(
+        storage,
+        spawner,
+        ranked,
+        &order,
+        &dirty_base_exception,
+        prefixes,
+    )
+    .await?;
+    // Whether at least one dirty run was admitted solely by the base-branch
+    // dirty-tree exception, so the report can warn that it is ephemeral.
+    let included_dirty_base_exception = admitted.iter().any(|(_, is_exception)| *is_exception);
     reporter.timing(
-        "phase 2/3 — concurrent fetch + serial parse + fold into series",
+        "phase 2/3 — chunked parallel fetch + parse + per-worker fold, then merge",
         fetch_fold_started.elapsed(),
     );
 
@@ -1574,7 +1686,7 @@ mod tests {
     use crate::config::{Config, parse_config};
     use crate::git_history::FakeGitHistory;
     use crate::model::{BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, Metric, MetricKind};
-    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
+    use crate::model::{EnvironmentInfo, GitInfo, Run, RunContext, ToolchainInfo};
     use crate::report::RecordingReporter;
     use crate::storage::{MemoryStorage, Storage};
 
@@ -3381,6 +3493,64 @@ mod tests {
             3,
             "clean and dirty runs both count toward the set tally"
         );
+    }
+
+    #[test]
+    fn run_index_merge_sums_totals_and_per_commit_counts() {
+        // Each worker records its disjoint object chunk into its own index; merging
+        // the per-worker indices must reproduce the single-threaded tally exactly,
+        // summing the totals and the per-(set, commit) clean/dirty counts.
+        let set = DiscriminantSet {
+            engine: "criterion".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        };
+        let other_set = DiscriminantSet {
+            engine: "callgrind".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        };
+
+        // The reference index folds every run in one pass.
+        let mut reference = RunIndex::new();
+        reference.record(&set, 0, "c0", false);
+        reference.record(&set, 0, "c0", true);
+        reference.record(&set, 1, "c1", false);
+        reference.record(&other_set, 0, "c0", false);
+
+        // Two workers split the same runs; c0/set is touched by both so the merge has
+        // to sum the per-commit counts rather than overwrite them.
+        let mut first = RunIndex::new();
+        first.record(&set, 0, "c0", false);
+        first.record(&other_set, 0, "c0", false);
+        let mut second = RunIndex::new();
+        second.record(&set, 0, "c0", true);
+        second.record(&set, 1, "c1", false);
+
+        first.merge(second);
+
+        assert_eq!(first.total(), reference.total());
+        assert_eq!(first.runs_in_set(&set), reference.runs_in_set(&set));
+        assert_eq!(
+            first.runs_in_set(&other_set),
+            reference.runs_in_set(&other_set)
+        );
+
+        let summarize = |index: &RunIndex| {
+            index
+                .sets()
+                .map(|(set, by_commit)| {
+                    let counts: Vec<(usize, String, usize, usize)> = by_commit
+                        .iter()
+                        .map(|(topo, counts)| {
+                            (*topo, counts.commit.clone(), counts.clean, counts.dirty)
+                        })
+                        .collect();
+                    (set.clone(), counts)
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(summarize(&first), summarize(&reference));
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -766,7 +766,14 @@ where
                         .copied()
                         .unwrap_or(false);
                 run_index.record(&parsed.set, topo_index, &parsed.commit, dirty);
-                builder.push(&parsed.set, topo_index, dirty, ordinal_of(rank), &run);
+                builder.push(
+                    &parsed.set,
+                    topo_index,
+                    dirty,
+                    ordinal_of(rank),
+                    &parsed.commit,
+                    &run,
+                );
                 admitted.push((key, is_exception));
                 // `run` is dropped here; only the extracted (compact) points are kept.
             }
@@ -1713,7 +1720,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -1750,7 +1756,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -699,7 +699,6 @@ mod tests {
             Timestamp::from_second(0).unwrap(),
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/commands/run.rs
+++ b/packages/cargo-bench-history/src/commands/run.rs
@@ -985,12 +985,7 @@ mod tests {
 
         fn with_status(status: &str) -> Self {
             Self {
-                git: parse_git_info(
-                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                    "deadbee",
-                    "main",
-                    status,
-                ),
+                git: parse_git_info("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "main", status),
                 rustc: RustcInfo {
                     version: Some("1.91.0".to_owned()),
                     host: Some("x86_64-pc-windows-msvc".to_owned()),

--- a/packages/cargo-bench-history/src/git.rs
+++ b/packages/cargo-bench-history/src/git.rs
@@ -6,13 +6,11 @@ use crate::model::GitInfo;
 /// Builds the recorded git facts from raw git command outputs (pure).
 ///
 /// * `commit` — output of `git rev-parse HEAD`.
-/// * `short` — output of `git rev-parse --short HEAD`.
 /// * `branch` — output of `git rev-parse --abbrev-ref HEAD`.
 /// * `status` — output of `git status --porcelain` (non-empty ⇒ dirty).
-pub(crate) fn parse_git_info(commit: &str, short: &str, branch: &str, status: &str) -> GitInfo {
+pub(crate) fn parse_git_info(commit: &str, branch: &str, status: &str) -> GitInfo {
     GitInfo {
         commit: non_empty(commit),
-        short_commit: non_empty(short),
         branch: non_empty(branch).filter(|branch| branch != "HEAD"),
         dirty: !status.trim().is_empty(),
     }
@@ -35,37 +33,31 @@ mod tests {
 
     #[test]
     fn builds_clean_info() {
-        let info = parse_git_info(
-            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n",
-            "deadbee\n",
-            "main\n",
-            "",
-        );
+        let info = parse_git_info("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n", "main\n", "");
 
         assert_eq!(
             info.commit.as_deref(),
             Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
         );
-        assert_eq!(info.short_commit.as_deref(), Some("deadbee"));
         assert_eq!(info.branch.as_deref(), Some("main"));
         assert!(!info.dirty);
     }
 
     #[test]
     fn detects_dirty_tree() {
-        let info = parse_git_info("c", "c", "main", " M src/lib.rs\n");
+        let info = parse_git_info("c", "main", " M src/lib.rs\n");
         assert!(info.dirty);
     }
 
     #[test]
     fn detached_head_branch_is_dropped() {
-        let info = parse_git_info("c", "c", "HEAD\n", "");
+        let info = parse_git_info("c", "HEAD\n", "");
         assert_eq!(info.branch, None);
     }
 
     #[test]
     fn empty_outputs_yield_defaults() {
-        let info = parse_git_info("", "", "", "");
+        let info = parse_git_info("", "", "");
         assert_eq!(info, GitInfo::default());
     }
 }

--- a/packages/cargo-bench-history/src/main.rs
+++ b/packages/cargo-bench-history/src/main.rs
@@ -10,6 +10,16 @@ use std::process::ExitCode;
 
 use cargo_bench_history::{Cli, RunOutcome, run};
 
+// The analyze pipeline fans the per-object gzip-decompress + JSON parse out across
+// worker threads. serde_json makes many small allocations, and the system
+// allocator's cross-thread contention (acute on the Windows process heap) otherwise
+// serializes those threads and erases the parallel win, so the binary installs a
+// scalable allocator process-wide. Miri cannot call mimalloc's FFI, so under Miri the
+// default allocator stands in (Miri runs single-threaded, so the contention is moot).
+#[cfg(not(miri))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[cfg_attr(test, mutants::skip)]
 #[tokio::main]
 async fn main() -> ExitCode {

--- a/packages/cargo-bench-history/src/probe.rs
+++ b/packages/cargo-bench-history/src/probe.rs
@@ -80,11 +80,10 @@ impl EnvironmentProbe for SystemProbe {
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; the parsing it delegates to is tested.
     async fn git(&self) -> io::Result<GitInfo> {
         let commit = self.git_field(&["rev-parse", "HEAD"]).await;
-        let short = self.git_field(&["rev-parse", "--short", "HEAD"]).await;
         let branch = self.git_field(&["rev-parse", "--abbrev-ref", "HEAD"]).await;
         let status = self.git_field(&["status", "--porcelain"]).await;
 
-        Ok(parse_git_info(&commit, &short, &branch, &status))
+        Ok(parse_git_info(&commit, &branch, &status))
     }
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `rustc`; the parsing it delegates to is tested.

--- a/packages/cargo-bench-history/src/storage/facade.rs
+++ b/packages/cargo-bench-history/src/storage/facade.rs
@@ -15,7 +15,7 @@ use super::local::LocalStorage;
 use super::{Storage, StorageError};
 
 /// A [`Storage`] backend selected at configuration time.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum StorageFacade {
     /// A local filesystem backend.
     Local(LocalStorage),

--- a/packages/cargo-bench-history/src/storage/mod.rs
+++ b/packages/cargo-bench-history/src/storage/mod.rs
@@ -50,12 +50,15 @@ pub(crate) trait Storage: fmt::Debug + Send + Sync {
 
     /// Reads the object stored at `key`.
     ///
+    /// The returned future is `Send` so loads can run on spawned worker tasks
+    /// (the analyze pipeline fans object decompress + parse out across cores).
+    ///
     /// # Errors
     ///
     /// Returns [`StorageError::InvalidKey`] if `key` is malformed,
     /// [`StorageError::NotFound`] if no object exists at `key`, or
     /// [`StorageError::Io`] if it cannot be read.
-    fn get(&self, key: &str) -> impl Future<Output = Result<Vec<u8>, StorageError>>;
+    fn get(&self, key: &str) -> impl Future<Output = Result<Vec<u8>, StorageError>> + Send;
 
     /// Lists the keys of all objects whose key starts with `prefix`.
     ///

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1098,12 +1098,11 @@ pub(crate) fn command_from(args: &[&str]) -> Command {
         .into_command()
 }
 
-/// Builds a [`GitInfo`] for a committed run: the full hash is `<commit>full`, the
-/// short hash is `commit`, and the branch is `main` (clean working tree).
+/// Builds a [`GitInfo`] for a committed run: the full hash is `<commit>full` and
+/// the branch is `main` (clean working tree).
 pub(crate) fn git_info(commit: &str) -> GitInfo {
     GitInfo {
         commit: Some(format!("{commit}full")),
-        short_commit: Some(commit.to_owned()),
         branch: Some("main".to_owned()),
         dirty: false,
     }
@@ -1111,7 +1110,7 @@ pub(crate) fn git_info(commit: &str) -> GitInfo {
 
 /// Builds a Callgrind result set with two records — `alpha::bench/wide` and
 /// `beta::bench/narrow` — each carrying a single `Ir` metric, stamped with the
-/// effective second and abbreviated `commit`.
+/// effective second and `commit`.
 pub(crate) fn two_benchmark_result_set(effective: i64, commit: &str, alpha: f64, beta: f64) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1146,7 +1145,7 @@ pub(crate) fn two_benchmark_result_set(effective: i64, commit: &str, alpha: f64,
 
 /// Builds a Criterion result set for benchmark `time/capture/std_instant`
 /// carrying a single `wall_time` metric at `value` nanoseconds, stamped with the
-/// effective second and abbreviated `commit`.
+/// effective second and `commit`.
 pub(crate) fn criterion_result_set(effective: i64, commit: &str, value: f64) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1169,7 +1168,7 @@ pub(crate) fn criterion_result_set(effective: i64, commit: &str, value: f64) -> 
 
 /// Builds an `alloc_tracker` result set for `operation` carrying an
 /// `allocated_bytes` and an `allocation_count` metric, stamped with the effective
-/// second and abbreviated `commit`.
+/// second and `commit`.
 pub(crate) fn alloc_result_set(
     effective: i64,
     commit: &str,
@@ -1198,7 +1197,7 @@ pub(crate) fn alloc_result_set(
 
 /// Builds an `all_the_time` result set for `operation` carrying a single
 /// `processor_time` metric at `value` nanoseconds, stamped with the effective
-/// second and abbreviated `commit`.
+/// second and `commit`.
 pub(crate) fn time_result_set(effective: i64, commit: &str, operation: &str, value: f64) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1284,7 +1283,7 @@ pub(crate) fn storage_only_config() -> String {
 }
 
 /// Builds a Callgrind result set for benchmark `nm::observe/pull` carrying the
-/// given `metrics`, stamped with the effective second and abbreviated `commit`.
+/// given `metrics`, stamped with the effective second and `commit`.
 pub(crate) fn result_set_with(effective: i64, commit: &str, metrics: Vec<Metric>) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1307,7 +1306,7 @@ pub(crate) fn result_set_with(effective: i64, commit: &str, metrics: Vec<Metric>
 }
 
 /// Builds a Callgrind result set with a single `Ir` metric at `value`, stamped
-/// with the given effective second and abbreviated `commit`.
+/// with the given effective second and `commit`.
 pub(crate) fn ir_result_set(effective: i64, commit: &str, value: f64) -> Run {
     result_set_with(
         effective,


### PR DESCRIPTION
## What

Parallelizes `analyze`/`list`'s stored-object load across CPU cores. `select_dataset` splits the storage-key-sorted survivors into one balanced contiguous chunk per worker and spawns one blocking task per chunk through the injected `anyspawn::Spawner`. Each worker fetches, gzip-inflates and JSON-parses its chunk and folds each run straight into its **own** `SeriesBuilder`/`RunIndex`, dropping the parsed run immediately ("fold-in-worker"); the main thread merges the per-worker partials and a single `finish()` sorts globally. Ordinals are assigned before chunking and the final sort is global, so the output is byte-identical to the previous single-threaded fold.

## Supporting changes

- Parse into the lean `RunPoints` projection (only the fields the fold reads), not a full `Run`.
- Install `mimalloc` as the binary's `#[global_allocator]` (and in the stress harness), gated `#[cfg(not(miri))]`: serde_json's many small allocations otherwise contend on the system allocator's cross-thread lock (acute on the Windows process heap) and make the parallel parse *slower* than serial.
- `SeriesBuilder` is now `Send + 'static`; adds `SeriesBuilder::merge` and `RunIndex::merge`.
- `Storage::get` gains a `Send` bound and `StorageFacade` derives `Clone`, so the backend can move into spawned tasks.
- Threads the injected `Spawner` through the `list` command too; the synchronous test spawner now drives `spawn()` futures inline (Miri-safe, no Tokio).

## Measurements (32-core box, ~20000 objects, local FS, best-of-3)

| variant | wall | CPU eff | peak |
|---|---|---|---|
| buffered-parallel | ~21.1 s | ~40% | ~6.88 GiB |
| **fold-in-worker (this PR)** | ~19.0 s | ~47% | ~7.21 GiB |

Phase 2/3 (fetch+parse+fold) drops ~18.8 → ~4.0 s; overall `analyze` ~40 → ~21 s versus the serial streaming baseline. Fold-in-worker is ~10% faster than the buffered-parallel variant with better core use, at ~5% (~330 MiB) higher peak — every worker's builder is resident during the serial merge. Kept for the speed; the remaining memory levers (bounded merge-as-complete waves, id interning) are deferred. Full rationale and the measured tradeoff are in `docs/DESIGN.md` decision 36; the data-flow map is `docs/analyze.md`.

## Validation

`just package="cargo-bench-history cargo-bench-history-core cargo-bench-history-stress" validate-local` is green: 916 tests, Miri 709, clippy (dev+release), docs, machete, default-features, release build.
