### PR TITLE
refactor(cbh): drop redundant short_commit, deal in full SHA only (schema v3)

### DIFF
--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -81,6 +81,14 @@ mutants SHARD="" CAREFUL='false':
         "-e"
         (Escape-Wildcards "packages/cargo-bench-history/src/bin/**")
 
+        # `testing.rs` is an in-workspace test utility (gated behind the `private-test-util`
+        # feature, consumed only by the shell crate's tests). It is scaffolding with no public
+        # API contract, so mutating it yields no production coverage signal. A source-level
+        # `mutants::skip` cannot apply to a file module (inner/file-module proc-macro attributes
+        # are unstable Rust), so it is excluded here instead.
+        "-e"
+        (Escape-Wildcards "packages/cargo-bench-history-core/src/testing.rs")
+
         # Some of our systems are single-processor, yet the code may only be meaningfully testable
         # on multi-processor systems. As a "good enough" approximation, we skip mutation testing
         # of code that is only testable in a multi-processor system.

--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -18,9 +18,11 @@ here, alongside the workspace-wide rules in `docs/` (especially
   thread merges the per-worker builders (`SeriesBuilder::merge`). No worker buffers its
   chunk's parsed runs. Each object is parsed into the lean
   [`RunPoints`](src/analyze/run_points.rs) projection — only the fields
-  `SeriesBuilder::push` reads (the abbreviated commit and, per result, the id and the
+  `SeriesBuilder::push` reads (per result, the id and the
   metric value/interval), dropping the run context and per-metric standard deviation —
-  and `push` consumes that projection rather than a full `Run`. Keep that projection in
+  and `push` consumes that projection rather than a full `Run`. The full commit SHA a
+  point is labelled with comes from the storage key, not the run payload, so the
+  projection carries no git fields. Keep that projection in
   lockstep with what the fold reads. **Note on memory:** folding in the worker did *not*
   lower peak — at merge time every worker's finished builder is resident alongside the
   growing combined builder (~2× the compact point output transiently), which measured

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -198,7 +198,7 @@ pub enum Direction {
 /// value, and whether it came from a dirty (uncommitted-tree) snapshot.
 #[derive(Clone, Debug)]
 pub struct SeriesValue {
-    /// Abbreviated commit the point was measured against, if known.
+    /// Commit the point was measured against, if known.
     pub commit: Option<String>,
     /// The measured value.
     pub value: f64,
@@ -230,7 +230,7 @@ pub struct Finding {
     /// How confident the detector is (`1 - p_value`; `1.0` for an exact
     /// deterministic step).
     pub confidence: f64,
-    /// Abbreviated commit the change is attributed to, if known.
+    /// Commit the change is attributed to, if known.
     pub commit: Option<String>,
     /// Where, within a feature branch, the latest regime began — set only in
     /// branch mode when a within-branch flip is located, naming the commit the
@@ -309,7 +309,7 @@ fn series_values(series: &Series) -> Vec<SeriesValue> {
         .collect()
 }
 
-/// The abbreviated commit of a point as an owned `String`, for the JSON output.
+/// The commit of a point as an owned `String`, for the JSON output.
 ///
 /// Points intern their commit as a shared `Arc<str>`; the public finding fields are
 /// plain owned strings, so a surviving finding pays one allocation here rather than

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -139,7 +139,7 @@ struct JsonFinding<'a> {
     relative_delta: f64,
     /// The detector's confidence (`1 - p_value`; `1.0` for an exact step).
     confidence: f64,
-    /// Abbreviated commit the change is attributed to, if known.
+    /// Commit the change is attributed to, if known.
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<&'a str>,
     /// Whether the change is still reflected in the latest measured state.

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -177,4 +177,102 @@ mod tests {
         assert_eq!(result.metrics[0].interval_low, Some(26.6));
         assert_eq!(result.metrics[0].interval_high, Some(27.2));
     }
+
+    #[test]
+    fn projection_keeps_metric_without_interval_bounds() {
+        // The second metric of `sample_run` (instruction count) carries no
+        // dispersion, so its confidence-interval bounds must project as absent
+        // rather than defaulting to a fabricated value.
+        let points = RunPoints::from(&sample_run());
+        let metric = points.results()[0].metrics[1];
+
+        assert_eq!(metric.kind, MetricKind::InstructionCount);
+        assert_eq!(metric.value, 1234.0);
+        assert_eq!(metric.interval_low, None);
+        assert_eq!(metric.interval_high, None);
+    }
+
+    #[test]
+    fn from_json_rejects_invalid_json() {
+        // A payload that is not a serialized run must surface a parse error rather
+        // than silently yielding an empty or partial projection.
+        RunPoints::from_json("not valid json").unwrap_err();
+    }
+
+    #[test]
+    fn projection_handles_a_run_with_no_results() {
+        // An empty run (no benchmark results) projects to an empty point set and
+        // still round-trips through JSON, so the fold simply contributes nothing.
+        let context = RunContext::new(
+            "2024-01-01T00:00:00Z".parse().unwrap(),
+            GitInfo {
+                commit: Some("0123456789abcdef".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "9.9.9".to_owned(),
+        );
+        let run = Run::new(context, Vec::new());
+
+        let from_run = RunPoints::from(&run);
+        assert!(from_run.results().is_empty());
+        assert_eq!(
+            RunPoints::from_json(&run.to_json().unwrap()).unwrap(),
+            from_run
+        );
+    }
+
+    #[test]
+    fn projection_preserves_multiple_results_and_spilled_metrics() {
+        // A run with several results, one of which carries more metrics than the
+        // inline SmallVec capacity, must project every result and every metric
+        // (the spilled tail included) and agree with the from-JSON parse.
+        let context = RunContext::new(
+            "2024-01-01T00:00:00Z".parse().unwrap(),
+            GitInfo {
+                commit: Some("0123456789abcdef".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "9.9.9".to_owned(),
+        );
+        let many_metrics = BenchmarkResult::new(
+            BenchmarkId::new(nonempty!["pkg".to_owned(), "wide".to_owned()]),
+            smallvec![
+                Metric::new(MetricKind::WallTime, 1.0).with_dispersion(
+                    Some(0.1),
+                    Some(0.9),
+                    Some(1.1),
+                ),
+                Metric::new(MetricKind::InstructionCount, 2.0),
+                Metric::new(MetricKind::EstimatedCycles, 3.0),
+                Metric::new(MetricKind::RamHits, 4.0),
+            ],
+        );
+        let single_metric = BenchmarkResult::new(
+            BenchmarkId::new(nonempty!["pkg".to_owned(), "narrow".to_owned()]),
+            smallvec![Metric::new(MetricKind::WallTime, 5.0)],
+        );
+        let run = Run::new(context, vec![many_metrics, single_metric]);
+
+        let from_run = RunPoints::from(&run);
+        assert_eq!(from_run.results().len(), 2);
+        assert_eq!(
+            from_run.results()[0].metrics.len(),
+            4,
+            "the metric list spilled past inline capacity must survive projection"
+        );
+        assert_eq!(from_run.results()[0].metrics[3].kind, MetricKind::RamHits);
+        assert_eq!(from_run.results()[0].metrics[3].value, 4.0);
+        assert_eq!(from_run.results()[1].metrics.len(), 1);
+
+        assert_eq!(
+            RunPoints::from_json(&run.to_json().unwrap()).unwrap(),
+            from_run
+        );
+    }
 }

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -5,7 +5,7 @@
 //! its own `SeriesBuilder`, dropping the parsed run before the next. Deserializing
 //! into [`RunPoints`] instead of the full [`Run`](crate::model::Run) shrinks that
 //! transient per-object footprint: it keeps only, per result, the benchmark id and
-//! the metric fields
+//! the metric fields that
 //! [`SeriesBuilder::push`](crate::analyze::SeriesBuilder::push) actually folds
 //! into points — dropping the run context (environment, toolchain, commit,
 //! timestamps) and each metric's standard deviation. The commit a point is

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -9,9 +9,10 @@
 //! [`SeriesBuilder::push`](crate::analyze::SeriesBuilder::push) actually folds
 //! into points — dropping the run context (environment, toolchain, commit,
 //! timestamps) and each metric's standard deviation. The commit a point is
-//! labelled with comes from the storage key (the full SHA), not the run payload,
-//! so the projection carries no git fields at all. Serde ignores the unmentioned
-//! JSON fields, so a run still parses unchanged; only the discarded parts are never
+//! labelled with comes from the storage key (its commit directory segment), not
+//! the run payload, so the projection carries no git fields at all. Serde ignores
+//! the unmentioned JSON fields, so a run still parses unchanged; only the discarded
+//! parts are never
 //! materialized. (The leaner element trims overall peak only marginally — peak is
 //! set by the per-worker builders coexisting during the merge — but the lighter
 //! parse is still worth keeping; see `cargo-bench-history`'s `docs/DESIGN.md`

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -4,12 +4,14 @@
 //! worker parses one object at a time into [`RunPoints`] and folds it straight into
 //! its own `SeriesBuilder`, dropping the parsed run before the next. Deserializing
 //! into [`RunPoints`] instead of the full [`Run`](crate::model::Run) shrinks that
-//! transient per-object footprint: it keeps only the abbreviated commit and, per
-//! result, the benchmark id and the metric fields
+//! transient per-object footprint: it keeps only, per result, the benchmark id and
+//! the metric fields
 //! [`SeriesBuilder::push`](crate::analyze::SeriesBuilder::push) actually folds
-//! into points — dropping the run context (environment, toolchain, timestamps)
-//! and each metric's standard deviation. Serde ignores the unmentioned JSON
-//! fields, so a run still parses unchanged; only the discarded parts are never
+//! into points — dropping the run context (environment, toolchain, commit,
+//! timestamps) and each metric's standard deviation. The commit a point is
+//! labelled with comes from the storage key (the full SHA), not the run payload,
+//! so the projection carries no git fields at all. Serde ignores the unmentioned
+//! JSON fields, so a run still parses unchanged; only the discarded parts are never
 //! materialized. (The leaner element trims overall peak only marginally — peak is
 //! set by the per-worker builders coexisting during the merge — but the lighter
 //! parse is still worth keeping; see `cargo-bench-history`'s `docs/DESIGN.md`
@@ -23,10 +25,6 @@ use crate::model::{BenchmarkId, MetricKind, Run};
 /// A stored run reduced to the data the series fold reads.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct RunPoints {
-    /// Only carried to reach the abbreviated commit; every other context field is
-    /// ignored during deserialization.
-    #[serde(default)]
-    context: RunPointsContext,
     /// One entry per benchmark result in the run.
     results: Vec<ResultPoints>,
 }
@@ -46,22 +44,11 @@ impl RunPoints {
     pub fn results(&self) -> &[ResultPoints] {
         &self.results
     }
-
-    /// The abbreviated commit the run was measured against, if known.
-    #[must_use]
-    pub fn short_commit(&self) -> Option<&str> {
-        self.context.git.short_commit.as_deref()
-    }
 }
 
 impl From<&Run> for RunPoints {
     fn from(run: &Run) -> Self {
         Self {
-            context: RunPointsContext {
-                git: RunPointsGit {
-                    short_commit: run.context.git.short_commit.clone(),
-                },
-            },
             results: run
                 .results
                 .iter()
@@ -81,20 +68,6 @@ impl From<&Run> for RunPoints {
                 .collect(),
         }
     }
-}
-
-/// The slice of a run context the fold needs: just the git commit.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-struct RunPointsContext {
-    #[serde(default)]
-    git: RunPointsGit,
-}
-
-/// The slice of git info the fold needs: just the abbreviated commit.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-struct RunPointsGit {
-    #[serde(default)]
-    short_commit: Option<String>,
 }
 
 /// A benchmark result reduced to its identity and fold-relevant metrics.
@@ -148,7 +121,6 @@ mod tests {
             "2024-01-01T00:00:00Z".parse().unwrap(),
             GitInfo {
                 commit: Some("0123456789abcdef".to_owned()),
-                short_commit: Some("0123456789ab".to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -196,7 +168,6 @@ mod tests {
         let run = sample_run();
         let points = RunPoints::from(&run);
 
-        assert_eq!(points.short_commit(), Some("0123456789ab"));
         assert_eq!(points.results().len(), 1);
         let result = &points.results()[0];
         assert_eq!(result.id, run.results[0].id);
@@ -205,16 +176,5 @@ mod tests {
         assert_eq!(result.metrics[0].value, 26.9);
         assert_eq!(result.metrics[0].interval_low, Some(26.6));
         assert_eq!(result.metrics[0].interval_high, Some(27.2));
-    }
-
-    #[test]
-    fn short_commit_absent_when_unknown() {
-        let mut run = sample_run();
-        run.context.git.short_commit = None;
-        let points = RunPoints::from(&run);
-        assert_eq!(points.short_commit(), None);
-
-        let json = run.to_json().unwrap();
-        assert_eq!(RunPoints::from_json(&json).unwrap().short_commit(), None);
     }
 }

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -915,4 +915,121 @@ mod tests {
         assert_eq!(series[0].active_start, 3);
         assert_eq!(series[0].blessing.as_ref().unwrap().commit, "c3full");
     }
+
+    #[test]
+    fn apply_blessings_leaves_a_series_whose_set_has_no_blessings() {
+        // The blessings map is keyed by discriminant set; a series whose set is
+        // absent from the map must be left fully active rather than re-baselined.
+        let mut series = four_commit_series();
+        // A blessing recorded only for a *different* set (a different target triple),
+        // so the lookup for this series' set misses.
+        let other_set =
+            parse_key("v1/proj/callgrind/aarch64-unknown-linux-gnu/synthetic/c0/clean.json")
+                .unwrap()
+                .set;
+        let mut map = HashMap::new();
+        map.insert(
+            other_set,
+            vec![(2_usize, Some(ts(300)), blessing(&["group"], "c2full", 301))],
+        );
+
+        apply_blessings(&mut series, &map);
+
+        assert_eq!(
+            series[0].active_start, 0,
+            "an unrelated set leaves the series active from the start"
+        );
+        assert!(series[0].blessing.is_none(), "no blessing recorded");
+    }
+
+    #[test]
+    fn push_and_merge_grow_the_id_table_across_resizes() {
+        // Folding many distinct benchmark ids into one discriminant set forces the
+        // per-set id table to grow and rehash its existing entries; merging a second
+        // builder full of further distinct ids grows it again. A wrong hash in either
+        // rehash closure would silently drop or conflate series, so check that every
+        // distinct id survives as its own series across both resize paths.
+        let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(Vec::new());
+        let key = parse_key("v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json")
+            .unwrap();
+
+        let mut first = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
+        for index in 0_u32..64 {
+            let package = format!("pkg{index:03}");
+            let run = run_for_package(ts(1), "c0", f64::from(index), Some(&package));
+            first.push(
+                &key.set,
+                0,
+                false,
+                index,
+                &key.commit,
+                &RunPoints::from(&run),
+            );
+        }
+
+        let mut second = SeriesBuilder::with_prefixes(prefixes);
+        for index in 64_u32..128 {
+            let package = format!("pkg{index:03}");
+            let run = run_for_package(ts(1), "c0", f64::from(index), Some(&package));
+            second.push(
+                &key.set,
+                0,
+                false,
+                index,
+                &key.commit,
+                &RunPoints::from(&run),
+            );
+        }
+
+        first.merge(second);
+        let series = first.finish();
+
+        assert_eq!(
+            series.len(),
+            128,
+            "every distinct id is its own series, none lost to a botched rehash"
+        );
+    }
+
+    #[test]
+    fn finish_orders_two_metric_kinds_of_one_benchmark_by_kind() {
+        // One benchmark measured with two metric kinds yields two series that share
+        // set and id and differ only by kind. finish must fall through to the kind
+        // tie-break (the innermost series comparator) and order them deterministically.
+        let context = RunContext::new(
+            ts(1),
+            GitInfo {
+                commit: Some("c0full".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let record = BenchmarkResult::new(
+            BenchmarkId::new(
+                NonEmpty::from_vec(vec!["group".to_owned(), "case".to_owned()]).unwrap(),
+            ),
+            vec![
+                Metric::new(MetricKind::InstructionCount, 100.0),
+                Metric::new(MetricKind::WallTime, 5.0),
+            ],
+        );
+        let run = Run::new(context, vec![record]);
+        let key = parse_key("v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json")
+            .unwrap();
+
+        let mut builder = SeriesBuilder::new(SeriesFilter::default());
+        builder.push(&key.set, 0, false, 0, &key.commit, &RunPoints::from(&run));
+        let series = builder.finish();
+
+        assert_eq!(series.len(), 2, "two metric kinds of one id are two series");
+        assert_eq!(series[0].id, series[1].id, "same benchmark id");
+        assert_eq!(series[0].set, series[1].set, "same discriminant set");
+        assert!(
+            series[0].kind < series[1].kind,
+            "series sharing set and id are ordered by the kind tie-break"
+        );
+    }
 }

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -49,8 +49,8 @@ pub struct SeriesPoint {
     /// The object's rank in sorted storage-key order (the final tie-break),
     /// standing in for the full storage key to keep the point small.
     pub object_ordinal: u32,
-    /// Abbreviated commit the run was measured against, if known. Interned so all
-    /// points on one commit share a single allocation.
+    /// Full commit SHA the run was measured against. Interned so all points on one
+    /// commit share a single allocation.
     pub commit: Option<Arc<str>>,
     /// The measured value.
     pub value: f64,
@@ -191,6 +191,7 @@ pub fn build_series<S: BuildHasher>(
             topo_index,
             object.key.is_dirty(),
             ordinal,
+            &object.key.commit,
             &RunPoints::from(&object.result),
         );
     }
@@ -285,21 +286,22 @@ impl SeriesBuilder {
 
     /// Folds one stored run into the accumulating series.
     ///
-    /// `topo_index` is the run commit's first-parent position and `object_ordinal`
-    /// its rank in sorted storage-key order (the final point tie-break); the caller
-    /// supplies both because they come from the storage key and git topology, not
-    /// the run payload. `run` is the fold-relevant projection of the run (see
-    /// [`RunPoints`]); only the matching metrics are retained — it can be dropped as
-    /// soon as this returns.
+    /// `topo_index` is the run commit's first-parent position, `object_ordinal` its
+    /// rank in sorted storage-key order (the final point tie-break), and `commit`
+    /// the full commit SHA; the caller supplies all three because they come from the
+    /// storage key and git topology, not the run payload. `run` is the fold-relevant
+    /// projection of the run (see [`RunPoints`]); only the matching metrics are
+    /// retained — it can be dropped as soon as this returns.
     pub fn push(
         &mut self,
         set: &DiscriminantSet,
         topo_index: usize,
         dirty: bool,
         object_ordinal: u32,
+        commit: &str,
         run: &RunPoints,
     ) {
-        let commit = run.short_commit().map(|commit| self.intern(commit));
+        let commit = Some(self.intern(commit));
 
         // The discriminant set is constant for the whole run, so resolve its
         // subtree once and clone the set key only when the set is first seen — not
@@ -546,7 +548,6 @@ mod tests {
             observation,
             GitInfo {
                 commit: Some(format!("{commit}full")),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -599,8 +600,9 @@ mod tests {
     }
 
     /// One folded object: its discriminant set, the commit's topological index, the
-    /// dirty flag, the storage-key ordinal, and the lean run projection to push.
-    type FoldInput = (DiscriminantSet, usize, bool, u32, RunPoints);
+    /// dirty flag, the storage-key ordinal, the full commit SHA, and the lean run
+    /// projection to push.
+    type FoldInput = (DiscriminantSet, usize, bool, u32, String, RunPoints);
 
     /// Builds the fold inputs for a small data set spanning two benchmark ids
     /// (packages) across three commits, including a clean/dirty pair on one commit,
@@ -620,14 +622,21 @@ mod tests {
                     "v1/proj/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
                 );
                 let key = parse_key(&object_key).unwrap();
-                (key.set, topo_index, dirty, ordinal, RunPoints::from(&run))
+                (
+                    key.set,
+                    topo_index,
+                    dirty,
+                    ordinal,
+                    key.commit,
+                    RunPoints::from(&run),
+                )
             })
             .collect()
     }
 
     fn fold_all(builder: &mut SeriesBuilder, inputs: &[FoldInput]) {
-        for (set, topo_index, dirty, ordinal, run) in inputs {
-            builder.push(set, *topo_index, *dirty, *ordinal, run);
+        for (set, topo_index, dirty, ordinal, commit, run) in inputs {
+            builder.push(set, *topo_index, *dirty, *ordinal, commit, run);
         }
     }
 

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -35,9 +35,9 @@ use crate::model::{BenchmarkId, BenchmarkIdPrefix, MetricKind, Run};
 ///
 /// Kept compact because a large history materializes tens of millions of these at
 /// once: the provenance storage key is reduced to [`object_ordinal`] (the key's
-/// rank in sorted storage-key order, the final tie-break) and the abbreviated
-/// commit is an interned [`Arc<str>`] shared across every point measured against
-/// the same commit.
+/// rank in sorted storage-key order, the final tie-break) and the commit is an
+/// interned [`Arc<str>`] shared across every point measured against the same
+/// commit.
 ///
 /// [`object_ordinal`]: SeriesPoint::object_ordinal
 #[derive(Clone, Debug)]
@@ -49,8 +49,9 @@ pub struct SeriesPoint {
     /// The object's rank in sorted storage-key order (the final tie-break),
     /// standing in for the full storage key to keep the point small.
     pub object_ordinal: u32,
-    /// Full commit SHA the run was measured against. Interned so all points on one
-    /// commit share a single allocation.
+    /// Commit the run was measured against — the storage key's commit directory
+    /// segment (a full SHA, or `unknown`). Interned so all points on one commit
+    /// share a single allocation.
     pub commit: Option<Arc<str>>,
     /// The measured value.
     pub value: f64,
@@ -225,8 +226,8 @@ fn ordinal_of(rank: usize) -> u32 {
 /// of the objects into its own builder and hand it back, and [`merge`] folds the
 /// per-worker builders into one before a single [`finish`](SeriesBuilder::finish).
 ///
-/// The abbreviated commit of each run is interned, so all points measured against
-/// one commit share a single [`Arc<str>`] instead of cloning the string per point.
+/// The commit of each run is interned, so all points measured against one commit
+/// share a single [`Arc<str>`] instead of cloning the string per point.
 ///
 /// [`merge`]: SeriesBuilder::merge
 #[derive(Debug)]
@@ -288,10 +289,11 @@ impl SeriesBuilder {
     ///
     /// `topo_index` is the run commit's first-parent position, `object_ordinal` its
     /// rank in sorted storage-key order (the final point tie-break), and `commit`
-    /// the full commit SHA; the caller supplies all three because they come from the
-    /// storage key and git topology, not the run payload. `run` is the fold-relevant
-    /// projection of the run (see [`RunPoints`]); only the matching metrics are
-    /// retained — it can be dropped as soon as this returns.
+    /// the storage key's commit directory segment (a full SHA, or `unknown`); the
+    /// caller supplies all three because they come from the storage key and git
+    /// topology, not the run payload. `run` is the fold-relevant projection of the
+    /// run (see [`RunPoints`]); only the matching metrics are retained — it can be
+    /// dropped as soon as this returns.
     pub fn push(
         &mut self,
         set: &DiscriminantSet,
@@ -600,7 +602,7 @@ mod tests {
     }
 
     /// One folded object: its discriminant set, the commit's topological index, the
-    /// dirty flag, the storage-key ordinal, the full commit SHA, and the lean run
+    /// dirty flag, the storage-key ordinal, the storage-key commit, and the lean run
     /// projection to push.
     type FoldInput = (DiscriminantSet, usize, bool, u32, String, RunPoints);
 

--- a/packages/cargo-bench-history-core/src/model/context.rs
+++ b/packages/cargo-bench-history-core/src/model/context.rs
@@ -57,8 +57,6 @@ impl RunContext {
 pub struct GitInfo {
     /// Full commit hash, if known.
     pub commit: Option<String>,
-    /// Abbreviated commit hash, if known.
-    pub short_commit: Option<String>,
     /// Branch name, if known.
     pub branch: Option<String>,
     /// Whether the working tree had uncommitted changes.

--- a/packages/cargo-bench-history-core/src/model/run.rs
+++ b/packages/cargo-bench-history-core/src/model/run.rs
@@ -10,8 +10,10 @@ use crate::model::{BenchmarkId, Metric, RunContext};
 /// Records which on-disk format a file was written with. Reads are not gated on
 /// it: version 2 dropped the redundant per-object `commit` timestamp (a run's
 /// timeline position is resolved from git topology, keyed by its commit SHA), and
-/// older records still deserialize because the removed field is simply ignored.
-pub const SCHEMA_VERSION: u32 = 2;
+/// version 3 dropped the redundant `short_commit` (an abbreviation of the full
+/// commit SHA the analysis already has from the storage key). Older records still
+/// deserialize because the removed fields are simply ignored.
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// A complete benchmark run: the unit of storage (one immutable file per run).
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/packages/cargo-bench-history-core/src/testing.rs
+++ b/packages/cargo-bench-history-core/src/testing.rs
@@ -39,7 +39,6 @@ impl SpawnCustom for SynchronousSpawner {
         }
     }
 
-    #[cfg_attr(test, mutants::skip)] // Unreachable: the analysis never spawns relocatable async tasks.
     fn spawn_anywhere(&self, _task: Box<dyn ThreadAwareAsyncFnOnce<()>>) {
         unreachable!("the analysis never spawns relocatable async tasks")
     }

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -314,7 +314,6 @@ fn run_context(
 ) -> RunContext {
     let git = GitInfo {
         commit: Some(sha.to_owned()),
-        short_commit: Some(sha.get(..12).unwrap_or(sha).to_owned()),
         branch: Some(branch.to_owned()),
         dirty,
     };

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -229,8 +229,9 @@ fetches, decompresses, JSON-parses **and folds** its chunk into its *own* `Serie
 / `RunIndex`, dropping each parsed run as it goes, and the driver awaits the tasks in
 spawn order and merges the per-worker builders (`SeriesBuilder::merge`). Each object is
 parsed into the lean `cargo_bench_history_core::analyze::RunPoints` projection — only the
-fields the fold reads (the abbreviated commit and, per result, the id and the metric
-value/interval) — not a full `Run`. Detection (`find_changes_spawned`) then dispatches
+fields the fold reads (per result, the id and the metric
+value/interval) — not a full `Run`; the full commit SHA a point is labelled with comes
+from the storage key, not the run payload. Detection (`find_changes_spawned`) then dispatches
 per-series detection chunks to blocking tasks the same way. Both take the
 `&anyspawn::Spawner` `analyze_with` threads through; `execute` injects
 `Spawner::new_tokio()` (the runtime's blocking pool), while tests inject

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -392,7 +392,7 @@ Captured once per stored run and attached to the `Run`:
   the timeline is its committer date, read from the git graph at analyze time
   (§8.3) and never copied onto the run, so a rebase or an amended date can never
   leave a stale timestamp behind.
-* **Git:** commit SHA + short SHA, branch, dirty flag (`git`).
+* **Git:** commit SHA, branch, dirty flag (`git`).
   Branch is metadata only — query-time topology, not this field, decides series
   membership (§8.3). Parent lineage and committer date are **not** recorded:
   `analyze` resolves topology *and* each commit's committer date from a live repo
@@ -1365,7 +1365,7 @@ adapter plus an in-lib `#[cfg(test)]` in-memory fake:
   injected env; return exit status. Real = `tokio::process::Command`; fake records
   the invocation and can drop fixture `summary.json` files to simulate a bench run.
 * `EnvProbe` (async, `probe.rs`) — discover the run-time git facts
-  (commit/short/branch/dirty) and toolchain facts; the real adapter
+  (commit/branch/dirty) and toolchain facts; the real adapter
   shells `git` and `rustc` (PARSE pure in `git.rs`/`host.rs`), the fake returns
   canned facts.
 * `GitHistory` (async, `git_history.rs`) — the read-only history query
@@ -1943,8 +1943,9 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      `analyze::parallel` = `thread::available_parallelism` capped at the survivor count) and
      dispatches each chunk to a task via the injected `Spawner::spawn`. Each task fetches +
      gzip-inflates + JSON-parses its slice — one object at a time into the lean
-     `analyze::run_points::RunPoints` projection (only what the fold reads: the abbreviated
-     commit and, per result, the id and metric value/interval, not a full `Run`) — and
+     `analyze::run_points::RunPoints` projection (only what the fold reads: per result, the
+     id and metric value/interval, not a full `Run`; the full commit SHA a point is labelled
+     with comes from the storage key, not the run payload) — and
      **folds each parsed run into its own `SeriesBuilder` / `RunIndex`, dropping the run the
      moment its compact points are extracted**, so no worker ever buffers its chunk's parsed
      runs. The driver awaits the tasks **in spawn order** and merges their per-worker
@@ -1980,3 +1981,19 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      drops from the `LOAD_CONCURRENCY`-wide streaming pipeline to ≈ the worker count; the win
      is on the CPU-bound parse, not remote I/O, and the low-volume blessing-sidecar load keeps
      the `buffer_unordered` path.
+
+37. **Full commit SHA only — no recorded abbreviation** — *Decided:* a run records only the
+     full commit SHA (`GitInfo.commit`); the previously stored `GitInfo.short_commit` is
+     removed from the data model entirely (and its `git rev-parse --short HEAD` capture
+     dropped). The analysis already has the full SHA in hand for every object — it is the
+     storage-key commit directory segment (`{…}/{commit}/{file}`) that drives topology and
+     ordinals — so the run payload's abbreviation was redundant *and* carried a (small) 48-bit
+     collision risk the full SHA does not. `analyze::SeriesBuilder::push` now labels each
+     `SeriesPoint` from the storage key's full SHA rather than the payload, and `RunPoints`
+     drops its git projection (it carries only `results`). This is a `SCHEMA_VERSION` 2 → 3
+     bump on the same backward-compatible footing as the v2 commit-timestamp removal: reads
+     are not gated on it, so older objects still deserialize (the removed field is ignored).
+     *Display:* a point's commit is now shown as the full SHA. Abbreviating purely for display
+     (e.g. the blessing `blessed_at`, which still calls a `short_commit` render helper on the
+     full SHA) is a separate, deferred concern — display abbreviation is questionable but not a
+     priority, so it is left as-is for now.

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -101,12 +101,13 @@ Key properties:
   storage-key order. Both the parse and the fold — the local-backend load's dominant
   costs — now scale with cores; only the merge and the final sort stay serial.
 - **The parsed element is lean (`RunPoints`).** Each object is parsed into `RunPoints`
-  (`analyze::run_points`), which carries only what `SeriesBuilder::push` reads — the
-  abbreviated commit and, per result, the benchmark id and each metric's
+  (`analyze::run_points`), which carries only what `SeriesBuilder::push` reads from the
+  run payload — per result, the benchmark id and each metric's
   `kind`/`value`/`interval_low`/`interval_high` — and `push` consumes that projection
-  rather than a full `Run`. Serde ignores the rest of the run JSON, so the discarded run
-  context (environment, toolchain, timestamps) and per-metric standard deviation are
-  never materialized.
+  rather than a full `Run` (the commit a point is labelled with comes from the storage
+  key, not the payload, so `RunPoints` holds no git fields). Serde ignores the rest of the
+  run JSON, so the discarded run context (environment, toolchain, timestamps) and
+  per-metric standard deviation are never materialized.
 - **Memory: fold-in-worker did not lower peak (the accepted tradeoff).** Folding in the
   worker means no chunk's parsed runs are ever buffered — yet this is *not* a memory win.
   At merge time every worker's finished `SeriesBuilder` is resident at once alongside the
@@ -130,7 +131,7 @@ Key properties:
 
 ### `SeriesBuilder::push` — what the fold does (`analyze::series`)
 
-Per parsed `RunPoints`: intern the full commit SHA (taken from the storage key, not the
+Per parsed `RunPoints`: intern the commit from the storage key (not the
 run payload) into an `Arc<str>` shared by every point
 on that commit (`intern`); resolve the benchmark id's bucket in a `HashTable` with a
 single `entry` probe — hashing `BenchmarkId` with the builder's one fixed hasher

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -130,7 +130,8 @@ Key properties:
 
 ### `SeriesBuilder::push` — what the fold does (`analyze::series`)
 
-Per parsed `RunPoints`: intern the short commit into an `Arc<str>` shared by every point
+Per parsed `RunPoints`: intern the full commit SHA (taken from the storage key, not the
+run payload) into an `Arc<str>` shared by every point
 on that commit (`intern`); resolve the benchmark id's bucket in a `HashTable` with a
 single `entry` probe — hashing `BenchmarkId` with the builder's one fixed hasher
 instance and **cloning the id only on a true cache miss** (one id-clone per distinct

--- a/packages/cargo-bench-history/src/analyze/bless.rs
+++ b/packages/cargo-bench-history/src/analyze/bless.rs
@@ -345,7 +345,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("master".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -895,7 +895,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -925,7 +924,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -954,7 +952,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -766,7 +766,14 @@ where
                         .copied()
                         .unwrap_or(false);
                 run_index.record(&parsed.set, topo_index, &parsed.commit, dirty);
-                builder.push(&parsed.set, topo_index, dirty, ordinal_of(rank), &run);
+                builder.push(
+                    &parsed.set,
+                    topo_index,
+                    dirty,
+                    ordinal_of(rank),
+                    &parsed.commit,
+                    &run,
+                );
                 admitted.push((key, is_exception));
                 // `run` is dropped here; only the extracted (compact) points are kept.
             }
@@ -1713,7 +1720,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },
@@ -1750,7 +1756,6 @@ mod tests {
             time,
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -699,7 +699,6 @@ mod tests {
             Timestamp::from_second(0).unwrap(),
             GitInfo {
                 commit: Some(commit.to_owned()),
-                short_commit: Some(commit.to_owned()),
                 branch: Some("main".to_owned()),
                 dirty: false,
             },

--- a/packages/cargo-bench-history/src/commands/run.rs
+++ b/packages/cargo-bench-history/src/commands/run.rs
@@ -985,12 +985,7 @@ mod tests {
 
         fn with_status(status: &str) -> Self {
             Self {
-                git: parse_git_info(
-                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                    "deadbee",
-                    "main",
-                    status,
-                ),
+                git: parse_git_info("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "main", status),
                 rustc: RustcInfo {
                     version: Some("1.91.0".to_owned()),
                     host: Some("x86_64-pc-windows-msvc".to_owned()),

--- a/packages/cargo-bench-history/src/git.rs
+++ b/packages/cargo-bench-history/src/git.rs
@@ -6,13 +6,11 @@ use crate::model::GitInfo;
 /// Builds the recorded git facts from raw git command outputs (pure).
 ///
 /// * `commit` — output of `git rev-parse HEAD`.
-/// * `short` — output of `git rev-parse --short HEAD`.
 /// * `branch` — output of `git rev-parse --abbrev-ref HEAD`.
 /// * `status` — output of `git status --porcelain` (non-empty ⇒ dirty).
-pub(crate) fn parse_git_info(commit: &str, short: &str, branch: &str, status: &str) -> GitInfo {
+pub(crate) fn parse_git_info(commit: &str, branch: &str, status: &str) -> GitInfo {
     GitInfo {
         commit: non_empty(commit),
-        short_commit: non_empty(short),
         branch: non_empty(branch).filter(|branch| branch != "HEAD"),
         dirty: !status.trim().is_empty(),
     }
@@ -35,37 +33,31 @@ mod tests {
 
     #[test]
     fn builds_clean_info() {
-        let info = parse_git_info(
-            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n",
-            "deadbee\n",
-            "main\n",
-            "",
-        );
+        let info = parse_git_info("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n", "main\n", "");
 
         assert_eq!(
             info.commit.as_deref(),
             Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
         );
-        assert_eq!(info.short_commit.as_deref(), Some("deadbee"));
         assert_eq!(info.branch.as_deref(), Some("main"));
         assert!(!info.dirty);
     }
 
     #[test]
     fn detects_dirty_tree() {
-        let info = parse_git_info("c", "c", "main", " M src/lib.rs\n");
+        let info = parse_git_info("c", "main", " M src/lib.rs\n");
         assert!(info.dirty);
     }
 
     #[test]
     fn detached_head_branch_is_dropped() {
-        let info = parse_git_info("c", "c", "HEAD\n", "");
+        let info = parse_git_info("c", "HEAD\n", "");
         assert_eq!(info.branch, None);
     }
 
     #[test]
     fn empty_outputs_yield_defaults() {
-        let info = parse_git_info("", "", "", "");
+        let info = parse_git_info("", "", "");
         assert_eq!(info, GitInfo::default());
     }
 }

--- a/packages/cargo-bench-history/src/probe.rs
+++ b/packages/cargo-bench-history/src/probe.rs
@@ -80,11 +80,10 @@ impl EnvironmentProbe for SystemProbe {
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; the parsing it delegates to is tested.
     async fn git(&self) -> io::Result<GitInfo> {
         let commit = self.git_field(&["rev-parse", "HEAD"]).await;
-        let short = self.git_field(&["rev-parse", "--short", "HEAD"]).await;
         let branch = self.git_field(&["rev-parse", "--abbrev-ref", "HEAD"]).await;
         let status = self.git_field(&["status", "--porcelain"]).await;
 
-        Ok(parse_git_info(&commit, &short, &branch, &status))
+        Ok(parse_git_info(&commit, &branch, &status))
     }
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `rustc`; the parsing it delegates to is tested.

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1098,12 +1098,11 @@ pub(crate) fn command_from(args: &[&str]) -> Command {
         .into_command()
 }
 
-/// Builds a [`GitInfo`] for a committed run: the full hash is `<commit>full`, the
-/// short hash is `commit`, and the branch is `main` (clean working tree).
+/// Builds a [`GitInfo`] for a committed run: the full hash is `<commit>full` and
+/// the branch is `main` (clean working tree).
 pub(crate) fn git_info(commit: &str) -> GitInfo {
     GitInfo {
         commit: Some(format!("{commit}full")),
-        short_commit: Some(commit.to_owned()),
         branch: Some("main".to_owned()),
         dirty: false,
     }
@@ -1111,7 +1110,7 @@ pub(crate) fn git_info(commit: &str) -> GitInfo {
 
 /// Builds a Callgrind result set with two records — `alpha::bench/wide` and
 /// `beta::bench/narrow` — each carrying a single `Ir` metric, stamped with the
-/// effective second and abbreviated `commit`.
+/// effective second and `commit`.
 pub(crate) fn two_benchmark_result_set(effective: i64, commit: &str, alpha: f64, beta: f64) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1146,7 +1145,7 @@ pub(crate) fn two_benchmark_result_set(effective: i64, commit: &str, alpha: f64,
 
 /// Builds a Criterion result set for benchmark `time/capture/std_instant`
 /// carrying a single `wall_time` metric at `value` nanoseconds, stamped with the
-/// effective second and abbreviated `commit`.
+/// effective second and `commit`.
 pub(crate) fn criterion_result_set(effective: i64, commit: &str, value: f64) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1169,7 +1168,7 @@ pub(crate) fn criterion_result_set(effective: i64, commit: &str, value: f64) -> 
 
 /// Builds an `alloc_tracker` result set for `operation` carrying an
 /// `allocated_bytes` and an `allocation_count` metric, stamped with the effective
-/// second and abbreviated `commit`.
+/// second and `commit`.
 pub(crate) fn alloc_result_set(
     effective: i64,
     commit: &str,
@@ -1198,7 +1197,7 @@ pub(crate) fn alloc_result_set(
 
 /// Builds an `all_the_time` result set for `operation` carrying a single
 /// `processor_time` metric at `value` nanoseconds, stamped with the effective
-/// second and abbreviated `commit`.
+/// second and `commit`.
 pub(crate) fn time_result_set(effective: i64, commit: &str, operation: &str, value: f64) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1284,7 +1283,7 @@ pub(crate) fn storage_only_config() -> String {
 }
 
 /// Builds a Callgrind result set for benchmark `nm::observe/pull` carrying the
-/// given `metrics`, stamped with the effective second and abbreviated `commit`.
+/// given `metrics`, stamped with the effective second and `commit`.
 pub(crate) fn result_set_with(effective: i64, commit: &str, metrics: Vec<Metric>) -> Run {
     let time = Timestamp::from_second(effective).unwrap();
     let git = git_info(commit);
@@ -1307,7 +1306,7 @@ pub(crate) fn result_set_with(effective: i64, commit: &str, metrics: Vec<Metric>
 }
 
 /// Builds a Callgrind result set with a single `Ir` metric at `value`, stamped
-/// with the given effective second and abbreviated `commit`.
+/// with the given effective second and `commit`.
 pub(crate) fn ir_result_set(effective: i64, commit: &str, value: f64) -> Run {
     result_set_with(
         effective,


### PR DESCRIPTION
## Summary

Removes the abbreviated git commit (`GitInfo.short_commit`) from the cargo-bench-history data model entirely. The full commit SHA is already in hand for every analyzed object — it is the storage-key directory segment that drives git topology — so recording an abbreviated `git rev-parse --short HEAD` alongside it was redundant and carried a small (48-bit) collision risk. We deal in full SHA-1 only.

## What changed

- `GitInfo.short_commit` is removed: it is no longer captured at run time (`probe.rs` no longer runs `git rev-parse --short HEAD`), no longer stored, and no longer projected into `RunPoints`.
- `SCHEMA_VERSION` 2 → 3. This is read-compatible: reads are not gated on the version, old objects still parse (serde ignores the now-unknown `short_commit`), and new objects simply omit it — same footing as the v1 → v2 commit-timestamp removal.
- `RunPoints` now carries only `results`; the `RunPointsContext` / `RunPointsGit` projection is gone. The fold labels each point from the full SHA in the storage key (`object.key.commit`) via `SeriesBuilder::push`.
- Series points now carry the full 40-char SHA instead of the abbreviation.
- Docs updated: `analyze.md`, `DESIGN.md` (new decision 37), and both `AGENTS.md` files.

## Display note (deferred)

The blessing `blessed_at` field still renders via a `short_commit()` display helper that abbreviates the full SHA. Unifying point display (now full SHA) with blessing display (still abbreviated) is left for a later change — display-time abbreviation is a separate, lower-priority question.

## Validation

`just package="cargo-bench-history cargo-bench-history-core cargo-bench-history-stress" validate-local` is green end to end: format-check, check, clippy, test, test-docs, docs, docs-default-features, miri, machete, default-features-check, and all release builds.

## Stacking

Stacked on #280 (base branch `u/sasaares/parallel-analyze-load`). Rebase onto `main` once #280 merges.
