### PR TITLE
Add check-frozen job validating minimum dependency versions

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -51,6 +51,15 @@ Split from the monolithic `just validate-local` into individual jobs:
   - check-release
   - clippy-release
   - build-release
+  - **check-frozen** — verifies the workspace compiles at the minimum dependency versions
+    declared in `Cargo.toml` (our published minimum-version promises) rather than the
+    higher versions pinned in `Cargo.lock`. Runs the `check-frozen` just recipe, which
+    uses the `cargo-freeze-deps` subcommand to rewrite every workspace dependency
+    requirement to its declared minimum (`=X.Y.Z`), regenerates the lockfile so the
+    resolver selects those minimums, and then runs `check`. A failure means a declared
+    minimum is too low to actually compile. Multi-platform because target-specific
+    dependencies and conditional compilation can make minimum-version resolution differ
+    per platform.
   - careful
 
 Split from the monolithic `just validate-extra-local` into individual jobs, all multi-platform:
@@ -151,6 +160,9 @@ for manual cache warming after toolchain updates.
    - `clippy-release` depends on `clippy-dev`
    - `build-release` depends on `check-dev` (no point linking a release binary if the
      dev `cargo check` already failed)
+   - `check-frozen` depends on `check-dev` (checking the frozen minimum dependency
+     versions is pointless if the code does not even build with the normal lockfile
+     versions)
    - `miri-x64` and `miri-arm` depend on `check-dev` (Miri is much slower than `cargo check`;
      if the code does not even compile in dev mode, there is nothing for Miri to interpret)
    - `miri-x64` also depends on `test-more-x64`, and `miri-arm` also depends on

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -485,6 +485,32 @@ jobs:
       - name: Run build release on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" build release
 
+  # Verifies the workspace still compiles at the minimum dependency versions declared in
+  # Cargo.toml (our published minimum-version promises), rather than the higher versions
+  # pinned in Cargo.lock. The `check-frozen` recipe freezes every workspace dependency to
+  # its declared minimum, regenerates the lockfile, and runs `check`. Gated behind check-dev
+  # because checking the frozen minimums is pointless if the code does not even build with
+  # the normal lockfile versions.
+  check-frozen:
+    needs: [delta, check-dev]
+    if: needs.delta.outputs.skip_all != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Run check-frozen on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" check-frozen
+
   mutants:
     needs: [delta, test-more-x64]
     if: needs.delta.outputs.skip_all != 'true'

--- a/justfiles/just_basics.just
+++ b/justfiles/just_basics.just
@@ -6,6 +6,18 @@ build PROFILE='dev':
 check PROFILE='dev':
     cargo +{{ env_var('RUST_MSRV') }} check {{ target_package }} --profile {{ PROFILE }} --all-features --all-targets --locked
 
+# Verify the workspace compiles at the minimum dependency versions our manifests promise.
+[group('basics')]
+check-frozen:
+    # `cargo freeze-deps` rewrites every workspace dependency requirement in Cargo.toml to
+    # its declared minimum (`=X.Y.Z`) in place. Regenerating Cargo.lock then makes the
+    # resolver select those minimums, and `check` compiles against them — a failure means a
+    # published minimum-version promise is too low to actually compile. This rewrites
+    # Cargo.toml and Cargo.lock in place, so run it on a throwaway checkout (e.g. CI).
+    cargo freeze-deps
+    cargo +{{ env_var('RUST_MSRV') }} generate-lockfile
+    just package="{{ package }}" check
+
 [group('basics')]
 clean:
     cargo clean

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -15,7 +15,7 @@ install-tools:
     rustup toolchain install $env:RUST_MSRV
     rustup toolchain install $env:RUST_NIGHTLY --component miri --component rustfmt --component rust-src --component llvm-tools-preview
 
-    cargo install cargo-machete cargo-nextest release-plz cargo-semver-checks cargo-audit cargo-hack cargo-llvm-cov cargo-sort cargo-sort-derives cargo-udeps cargo-careful cargo-ensure-no-default-features cargo-delta --locked
+    cargo install cargo-machete cargo-nextest release-plz cargo-semver-checks cargo-audit cargo-hack cargo-llvm-cov cargo-sort cargo-sort-derives cargo-udeps cargo-careful cargo-ensure-no-default-features cargo-delta cargo-freeze-deps --locked
 
     # cargo-mutants transitively depends on `winapi 0.2.8`, which only defines its
     # types for `target_arch = "x86"` / `"x86_64"` and fails to compile on aarch64


### PR DESCRIPTION
## What

Adds a `check-frozen` validation job that verifies our packages still compile at the **minimum** dependency versions declared in `Cargo.toml` — our published minimum-version promises — rather than the higher versions pinned in `Cargo.lock`.

## Why

`Cargo.lock` records the latest compatible versions, so normal CI never exercises the version *floors* we advertise to downstream consumers. A dependency requirement like `clap = "4.6.1"` claims everything from 4.6.1 upward works, but nothing checks that 4.6.1 actually builds. This job closes that gap so we catch under-declared minimums (a floor that is too low to compile, or that does not resolve at all).

## How

A new `check-frozen` just recipe drives the check:

- `cargo freeze-deps` rewrites every `[workspace.dependencies]` requirement to its declared minimum (`=X.Y.Z`) in place.
- `cargo +<MSRV> generate-lockfile` regenerates `Cargo.lock` so the resolver selects those minimums (the regeneration is required because `just check` passes `--locked`, which would otherwise reject the now-stale lockfile).
- `just check` compiles against the frozen lockfile at the MSRV toolchain.

A failure means a declared minimum is too low to actually compile or resolve — exactly the promise violation we want to surface.

The `cargo-freeze-deps` subcommand is added to `install-tools` so it is available in CI (via `setup-environment`) and local setups. The CI job is multi-platform (ubuntu/macos/windows, since target-specific dependencies and conditional compilation can make minimum-version resolution differ per platform) and is gated behind `check-dev`, mirroring how the other check/build variants are gated.

## Validation

Verified end-to-end locally (manifests backed up and restored): `cargo freeze-deps` froze 88 dependency versions, `generate-lockfile` resolved the minimum-version graph at MSRV (e.g. `ohno 0.3.0`, `tokio 1.49.0`, `trybuild 1.0.0`), and `just package="new_zealand" check-frozen` compiled cleanly at MSRV with `--locked`.
