### PR TITLE
Self-mint GitHub OIDC assertions for long bench-history runs

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -129,6 +129,30 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     account, identity and federated credentials are scripted/Bicep'd in
     `infra/azure-bench-history-test/` (see its README to deploy or re-create).
 
+- **test-azure-gh** — single-platform (Linux) by choice, package-gated to `cargo-bench-history`
+  - Variant of `test-azure` that exercises cargo-bench-history's **self-minting GitHub
+    OIDC credential** — the credential the nightly prod collection (`bench-history.yml`)
+    depends on — against the real test account. The `storage/github_oidc.rs` unit tests
+    stub the HTTP exchange and `test-azure` takes the local-`az`
+    `DeveloperToolsCredential` fallback, so without this job nothing proves the
+    self-minting path actually round-trips real GitHub OIDC → Entra → Blob until the
+    post-merge nightly run.
+  - **Only difference from `test-azure`**: an extra step exports `AZURE_CLIENT_ID`
+    (= `AZURE_TEST_CLIENT_ID`). Setting `AZURE_CLIENT_ID` is the switch that makes
+    `from_config` build a `ClientAssertionCredential` (which GETs a fresh OIDC JWT,
+    audience `api://AzureADTokenExchange`, per Entra token exchange) instead of the
+    `DeveloperToolsCredential` it uses otherwise. `permissions: { id-token: write }`
+    injects the `ACTIONS_ID_TOKEN_REQUEST_URL`/`TOKEN` values the tool reads to mint
+    those assertions, and the test identity's `pull_request` federated credential lets
+    same-repo PR runs federate in.
+  - `azure/login@v2` is **retained only for harness cleanup**: the per-test
+    `delete_container` and the `if: always()` backstop both shell out to `az`, so they
+    need a session. The code under test ignores the `az` session entirely once
+    `AZURE_CLIENT_ID` is set, so the login does not undermine what the job proves.
+  - **Same double-gating** as `test-azure` (package-gated + same-repo only); collects no
+    coverage. Together the two jobs cover both credential branches: `test-azure` the
+    local-`az` fallback, `test-azure-gh` the CI self-minting path.
+
 ### cache-warmup.yml
 
 A scheduled workflow that keeps GitHub Actions caches warm. GitHub evicts caches after

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -123,7 +123,10 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     reads the account from the job's `BENCH_HISTORY_TEST_AZURE_ACCOUNT` env and runs the
     `*_in_real_azure` tests). Each test deletes its own container, even on panic; a
     final `if: always()` step runs `infra/azure-bench-history-test/cleanup-containers.ps1`
-    as a backstop for a container a crashed run might leave.
+    as a backstop for a container a crashed run might leave. Because `test-azure` and
+    `test-azure-gh` run concurrently against this one account, that backstop passes
+    `-MinAgeMinutes 180` so it only sweeps older, genuinely leaked containers and never
+    deletes a container the sibling job is still writing to.
   - Collects **no coverage** (`test-azurite` already covers `azure.rs`); its value
     is proving the real Entra + real Blob endpoint round-trip end to end. The
     account, identity and federated credentials are scripted/Bicep'd in

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -37,12 +37,14 @@ jobs:
     # run rather than the expected duration.
     timeout-minutes: 360
 
-    # `id-token: write` lets the job mint a short-lived GitHub OIDC token (a signed JWT
-    # proving "this run is repo folo-rs/folo on ref refs/heads/main"). `azure/login@v2`
-    # hands it to Azure, which matches it against the dedicated prod managed identity's
-    # `main`-branch federated credential (created by infra/azure-bench-history-prod/) and
-    # issues an access token — so CI authenticates with no stored secret. `contents: read`
-    # is the minimum the checkout needs.
+    # `id-token: write` lets cargo-bench-history mint short-lived GitHub OIDC tokens
+    # (each a signed JWT proving "this run is repo folo-rs/folo on ref refs/heads/main").
+    # The tool exchanges them directly with Entra, which matches each against the
+    # dedicated prod managed identity's `main`-branch federated credential (created by
+    # infra/azure-bench-history-prod/) and issues an access token — so CI authenticates
+    # with no stored secret. Minting on demand (rather than once up front via
+    # `azure/login`) is what keeps a multi-hour run authenticated past the ~1h
+    # access-token lifetime. `contents: read` is the minimum the checkout needs.
     permissions:
       id-token: write
       contents: read
@@ -54,21 +56,22 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      # Surface the non-secret AZURE_* identity values from constants.env as job env vars
-      # so the azure/login inputs can reference them without duplicating values in repo
-      # Variables. The data store account name is NOT needed here: it is baked into the
-      # committed .cargo/bench_history.toml that cargo-bench-history reads. Each line is
-      # `KEY=value`.
-      - name: Load Azure identifiers from constants.env
+      # cargo-bench-history self-federates with GitHub OIDC: given the managed identity's
+      # client id and tenant — plus the ACTIONS_ID_TOKEN_* values GitHub injects because
+      # of id-token: write — it mints a fresh OIDC assertion each time Entra needs a new
+      # access token, so a long run never re-submits an expired assertion. Export those
+      # two identifiers from constants.env under the standard names the tool reads
+      # (AZURE_PROD_CLIENT_ID is the prod identity's client id). The data store account
+      # name is NOT needed here: it is baked into the committed .cargo/bench_history.toml.
+      - name: Configure Azure federation identity from constants.env
         shell: bash
-        run: grep -E '^(AZURE_PROD_CLIENT_ID|AZURE_TENANT_ID|AZURE_SUBSCRIPTION_ID)=' constants.env >> "$GITHUB_ENV"
-
-      - name: Sign in to Azure (OIDC workload identity federation)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ env.AZURE_PROD_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          source constants.env
+          {
+            echo "AZURE_CLIENT_ID=$AZURE_PROD_CLIENT_ID"
+            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
+          } >> "$GITHUB_ENV"
 
       # The deterministic engines (Callgrind, allocation/time counters) are
       # hardware-independent; the wall-clock engines auto-detect a per-machine partition.
@@ -87,8 +90,8 @@ jobs:
     # far faster than benchmarking.
     timeout-minutes: 60
 
-    # id-token for OIDC sign-in (read history), contents for checkout, issues to file
-    # the rolling regression issue.
+    # id-token to self-federate with Entra (reads the history; see collect's note),
+    # contents for checkout, issues to file the rolling regression issue.
     permissions:
       id-token: write
       contents: read
@@ -105,16 +108,18 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Load Azure identifiers from constants.env
+      # Same self-federation as collect: export the prod identity's client id and tenant
+      # under the standard names cargo-bench-history reads, then let the tool mint OIDC
+      # assertions on demand (no azure/login). The account name is baked into config.
+      - name: Configure Azure federation identity from constants.env
         shell: bash
-        run: grep -E '^(AZURE_PROD_CLIENT_ID|AZURE_TENANT_ID|AZURE_SUBSCRIPTION_ID)=' constants.env >> "$GITHUB_ENV"
-
-      - name: Sign in to Azure (OIDC workload identity federation)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ env.AZURE_PROD_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          source constants.env
+          {
+            echo "AZURE_CLIENT_ID=$AZURE_PROD_CLIENT_ID"
+            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
+          } >> "$GITHUB_ENV"
 
       # Renders bench-history-report.md and bench-history-notable.txt. Findings never
       # fail the recipe (the tool always exits 0); the issue is advisory, not a gate.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -749,12 +749,17 @@ jobs:
       - name: Run real-Azure storage tests
         run: just test-azure
 
-      - name: Delete any leftover test containers
+      - name: Delete leaked test containers
         if: always()
         shell: pwsh
         # cleanup-containers.ps1 defaults its account to BENCH_HISTORY_TEST_AZURE_ACCOUNT,
-        # which the load step above put into the job env.
-        run: ./infra/azure-bench-history-test/cleanup-containers.ps1
+        # which the load step above put into the job env. Each test already deletes its
+        # own container when it finishes, so this backstop only needs to sweep containers
+        # leaked by a crashed or timed-out run. test-azure and test-azure-gh run
+        # concurrently against the same account, so -MinAgeMinutes keeps this sweep from
+        # deleting the sibling job's still-in-use (freshly written) containers; a genuine
+        # leak is older than the cutoff and gets swept here or on a later run.
+        run: ./infra/azure-bench-history-test/cleanup-containers.ps1 -MinAgeMinutes 180
 
   # Variant of test-azure that exercises cargo-bench-history's SELF-MINTING GitHub
   # OIDC credential — the exact credential the nightly prod collection (bench-history.yml)
@@ -815,9 +820,14 @@ jobs:
       - name: Run real-Azure storage tests via the self-minting OIDC credential
         run: just test-azure
 
-      - name: Delete any leftover test containers
+      - name: Delete leaked test containers
         if: always()
         shell: pwsh
         # cleanup-containers.ps1 defaults its account to BENCH_HISTORY_TEST_AZURE_ACCOUNT,
-        # which the load step above put into the job env.
-        run: ./infra/azure-bench-history-test/cleanup-containers.ps1
+        # which the load step above put into the job env. Each test already deletes its
+        # own container when it finishes, so this backstop only needs to sweep containers
+        # leaked by a crashed or timed-out run. test-azure and test-azure-gh run
+        # concurrently against the same account, so -MinAgeMinutes keeps this sweep from
+        # deleting the sibling job's still-in-use (freshly written) containers; a genuine
+        # leak is older than the cutoff and gets swept here or on a later run.
+        run: ./infra/azure-bench-history-test/cleanup-containers.ps1 -MinAgeMinutes 180

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -755,3 +755,69 @@ jobs:
         # cleanup-containers.ps1 defaults its account to BENCH_HISTORY_TEST_AZURE_ACCOUNT,
         # which the load step above put into the job env.
         run: ./infra/azure-bench-history-test/cleanup-containers.ps1
+
+  # Variant of test-azure that exercises cargo-bench-history's SELF-MINTING GitHub
+  # OIDC credential — the exact credential the nightly prod collection (bench-history.yml)
+  # depends on — against the real test account. The unit tests in storage/github_oidc.rs
+  # stub the HTTP exchange, and test-azure above takes the local-az DeveloperToolsCredential
+  # fallback, so without this job nothing would prove the self-minting path actually
+  # round-trips real GitHub OIDC -> Entra -> Blob until the post-merge nightly run.
+  #
+  # The only difference from test-azure is exporting AZURE_CLIENT_ID: setting it is the
+  # switch that makes from_config build a ClientAssertionCredential (which mints a fresh
+  # OIDC JWT per token exchange) instead of the DeveloperToolsCredential it would use
+  # otherwise. azure/login is retained ONLY so the test harness's container cleanup
+  # (which shells out to `az`) works; the code under test ignores the az session once
+  # AZURE_CLIENT_ID is set.
+  test-azure-gh:
+    needs: [delta]
+    if: >-
+      needs.delta.outputs.skip_all != 'true'
+      && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'cargo-bench-history'))
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    # `id-token: write` injects the ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN values that the
+    # tool itself reads to mint OIDC assertions on demand (the prod-critical path), and
+    # the test identity's `pull_request` federated credential lets same-repo PR runs
+    # federate in. Fork PRs cannot get an OIDC token for our tenant, hence the same-repo
+    # gate above. `contents: read` is the minimum the checkout needs.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Load Azure identifiers from constants.env
+        shell: bash
+        run: grep -E '^(AZURE_TEST_CLIENT_ID|AZURE_TENANT_ID|AZURE_SUBSCRIPTION_ID|BENCH_HISTORY_TEST_AZURE_ACCOUNT)=' constants.env >> "$GITHUB_ENV"
+
+      # Setting AZURE_CLIENT_ID (to the test identity's client id) is what makes
+      # cargo-bench-history take its self-minting OIDC path. AZURE_TEST_CLIENT_ID was
+      # placed in the job env by the previous step, so it is readable here.
+      - name: Select the self-minting OIDC credential
+        shell: bash
+        run: echo "AZURE_CLIENT_ID=$AZURE_TEST_CLIENT_ID" >> "$GITHUB_ENV"
+
+      # The tool self-mints regardless of this login; it exists only so the test
+      # harness's `az`-based container cleanup has a session to use.
+      - name: Sign in to Azure (for harness container cleanup only)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_TEST_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run real-Azure storage tests via the self-minting OIDC credential
+        run: just test-azure
+
+      - name: Delete any leftover test containers
+        if: always()
+        shell: pwsh
+        # cleanup-containers.ps1 defaults its account to BENCH_HISTORY_TEST_AZURE_ACCOUNT,
+        # which the load step above put into the job env.
+        run: ./infra/azure-bench-history-test/cleanup-containers.ps1

--- a/infra/azure-bench-history-prod/README.md
+++ b/infra/azure-bench-history-prod/README.md
@@ -17,8 +17,10 @@ the environment can be deleted and re-created with one command.
   disabled** (Entra ID only, so there is no account key to leak). Container and blob
   soft-delete are disabled, matching the test account.
 - A **dedicated user-assigned managed identity** (`id-folo-bench-history-prod`) with a
-  **GitHub OIDC federated credential** for `main`. The nightly workflow signs in with
-  no stored secret. Only `main` is trusted — there is no pull-request credential —
+  **GitHub OIDC federated credential** for `main`. The nightly workflow federates into
+  it with no stored secret: `cargo-bench-history` mints a fresh GitHub OIDC token on
+  demand and exchanges it with Entra for each access token (so a multi-hour run stays
+  authenticated). Only `main` is trusted — there is no pull-request credential —
   because collection only ever runs on `main` (schedule + gated dispatch).
 - **`Storage Blob Data Contributor`** role assignments on the account for that managed
   identity and (optionally) a local developer principal. That single role covers

--- a/infra/azure-bench-history-test/cleanup-containers.ps1
+++ b/infra/azure-bench-history-test/cleanup-containers.ps1
@@ -8,7 +8,12 @@
     Each real-Azure test creates a uniquely-named container (prefix `bh-it-`) and
     deletes it when it finishes. A crashed or timed-out test can leave one behind;
     this script sweeps them up. It is used both locally (manual cleanup) and as the
-    CI `test-azure` job's `if: always()` backstop.
+    `if: always()` backstop of the concurrent CI jobs `test-azure` and
+    `test-azure-gh`, which share one storage account.
+
+    Because those two jobs run at the same time, pass a non-zero -MinAgeMinutes in
+    CI so the backstop never deletes a container the sibling job is still writing to;
+    only older, genuinely leaked containers are swept.
 
     Authenticates with Microsoft Entra ID (`--auth-mode login`), matching the
     Entra-only storage account, so it works with the same `az login` / federated

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -850,7 +850,7 @@ Microsoft Entra ID. SAS modes carry the token in the endpoint URL's query and pa
 no credential, so the emulator's plain-HTTP endpoint is accepted; Entra mode passes
 a token credential and requires HTTPS. The Entra credential is chosen by the
 `entra_credential` helper: in a GitHub Actions job configured for Azure federation
-(detected by `github_oidc::from_env` finding `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`
+(detected by `github_oidc::credential_from` finding `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`
 and the `ACTIONS_ID_TOKEN_REQUEST_*` pair) it builds a `ClientAssertionCredential`
 whose assertion (`storage::github_oidc::GithubOidcAssertion`) mints a **fresh**
 GitHub OIDC JWT on demand for each Entra token exchange; everywhere else (local

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -846,16 +846,27 @@ Object keys map 1:1 to `/`-separated blob names, so the key model is identical t
 
 Authentication is resolved once in `AzureBlobStorage::from_config`, in priority
 order: a self-signed account SAS (`account_key`), a verbatim `sas_token`, or
-Microsoft Entra ID (`DeveloperToolsCredential`). SAS modes carry the token in the
-endpoint URL's query and pass no credential, so the emulator's plain-HTTP
-endpoint is accepted; Entra mode passes a token credential and requires HTTPS.
-The Entra credential is wrapped in a `CachingCredential` decorator that holds a
-cache lock across the inner acquisition, so a concurrent read burst collapses to
-one `az account get-access-token` call rather than racing the Windows MSAL
-token-cache lockfile (which fails the read with a permission error).
-`CachingCredential` implements the azure SDK's `#[async_trait]` `TokenCredential`
-trait, so it is the one place the crate pulls in `async_trait` — the crate's own
-IO ports still use RPITIT (`impl Future`), as the external trait leaves no choice.
+Microsoft Entra ID. SAS modes carry the token in the endpoint URL's query and pass
+no credential, so the emulator's plain-HTTP endpoint is accepted; Entra mode passes
+a token credential and requires HTTPS. The Entra credential is chosen by the
+`entra_credential` helper: in a GitHub Actions job configured for Azure federation
+(detected by `github_oidc::from_env` finding `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`
+and the `ACTIONS_ID_TOKEN_REQUEST_*` pair) it builds a `ClientAssertionCredential`
+whose assertion (`storage::github_oidc::GithubOidcAssertion`) mints a **fresh**
+GitHub OIDC JWT on demand for each Entra token exchange; everywhere else (local
+`az login`, the `test-azure` CI job) it falls back to `DeveloperToolsCredential`.
+Self-minting is what keeps a multi-hour collection run authenticated: a single
+`azure/login` session caches one OIDC assertion that expires within minutes, so the
+first access-token refresh after it lapses re-submits a dead assertion and Entra
+rejects it (`AADSTS700024`).
+The chosen Entra credential is then wrapped in a `CachingCredential` decorator that
+holds a cache lock across the inner acquisition, so a concurrent read burst collapses
+to one token acquisition rather than racing the Windows MSAL token-cache lockfile
+(which fails the read with a permission error).
+`CachingCredential` and `GithubOidcAssertion` implement the azure SDK's
+`#[async_trait]` `TokenCredential`/`ClientAssertion` traits, so they are where the
+crate pulls in `async_trait` — the crate's own IO ports still use RPITIT
+(`impl Future`), as the external traits leave no choice.
 The account-SAS signer lives in `storage::sas` and is verified against a pinned
 golden signature — do not "fix" that test by editing the expected value.
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -454,14 +454,18 @@ backend-agnostic by holding a `StorageFacade`.
      client passes **no credential** and Azurite's plain-HTTP endpoint is
      accepted.
   2. **verbatim `sas_token`** — a pre-signed SAS supplied in config, used as-is.
-  3. **Microsoft Entra ID** (`DeveloperToolsCredential`) — the secret-free
-     production default (CI managed identity / workload-identity federation,
-     local `az login`, env service principals); requires an **HTTPS** endpoint.
-     The credential is wrapped in a `CachingCredential` decorator that serializes
-     token acquisition and caches the token per scope, so `analyze`'s concurrent
-     object-load burst shares one acquisition instead of driving that many
-     simultaneous `az account get-access-token` calls — which on Windows collide
-     on the exclusive MSAL token-cache lockfile and fail the whole read.
+  3. **Microsoft Entra ID** — the secret-free production default (CI managed
+     identity / workload-identity federation, local `az login`, env service
+     principals); requires an **HTTPS** endpoint. The concrete credential is picked
+     by `entra_credential`: in a GitHub Actions job configured for federation it is a
+     `ClientAssertionCredential` whose assertion self-mints a fresh GitHub OIDC JWT on
+     demand (`storage::github_oidc`); otherwise it is `DeveloperToolsCredential`
+     (which discovers the local `az login` session). Either way it is wrapped in a
+     `CachingCredential` decorator that serializes token acquisition and caches the
+     token per scope, so `analyze`'s concurrent object-load burst shares one
+     acquisition instead of driving that many simultaneous token fetches — which on
+     Windows collide on the exclusive MSAL token-cache lockfile and fail the whole
+     read.
 
   The shipped azure-sdk-for-rust v1.0.0 removed connection-string parsing,
   `StorageSharedKeyCredential`, and `DefaultAzureCredential`, which is why the
@@ -1523,9 +1527,10 @@ Each iteration ships with tests and docs and leaves the tool runnable.
    change-point and drift plug in afterward.
 6. **Azure auth** — *Decided:* resolved in priority order — self-signed account
    SAS (`account_key`, the Azurite/CI and SAS-production path, HMAC-signed by
-   `storage::sas`), verbatim `sas_token`, then Microsoft Entra ID
-   (`DeveloperToolsCredential`, the secret-free production default). The account
-   SAS is self-signed because azure-sdk-for-rust v1.0.0 dropped connection
+   `storage::sas`), verbatim `sas_token`, then Microsoft Entra ID (the secret-free
+   production default; a self-minting GitHub OIDC `ClientAssertionCredential` in a
+   federated CI job, otherwise `DeveloperToolsCredential` — see decision 38). The
+   account SAS is self-signed because azure-sdk-for-rust v1.0.0 dropped connection
    strings, `StorageSharedKeyCredential`, and `DefaultAzureCredential` (§7).
 7. **Date/time dependency** — *Decided:* `jiff` for timestamps and `--since`
    parsing.
@@ -1623,7 +1628,11 @@ Each iteration ships with tests and docs and leaves the tool runnable.
     `AZURE_SUBSCRIPTION_ID`) are committed, non-secret, in the repository-root
     `constants.env` (the same source `just test-azure` reads), so local and CI target
     the same account; a `grep` step surfaces them into `$GITHUB_ENV` for the
-    `azure/login` inputs. It collects no coverage — `test-azurite` already covers
+    `azure/login` inputs. Because that job exports the client id as
+    `AZURE_TEST_CLIENT_ID` (not `AZURE_CLIENT_ID`), it does **not** trip the
+    self-minting OIDC path (decision 38) and stays on `DeveloperToolsCredential` via
+    the `azure/login` CLI session — exactly what this job exists to exercise. It
+    collects no coverage — `test-azurite` already covers
     `azure.rs`; its value is the real Entra + real Blob round-trip. The account,
     identity and federated credentials are scripted/Bicep'd in
     `infra/azure-bench-history-test/` (decision 31).
@@ -1997,3 +2006,27 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      (e.g. the blessing `blessed_at`, which still calls a `short_commit` render helper on the
      full SHA) is a separate, deferred concern — display abbreviation is questionable but not a
      priority, so it is left as-is for now.
+38. **Self-minting GitHub OIDC credential for long CI runs** — *Decided:* in a
+     GitHub Actions job configured for Azure federation, the Entra path resolves to a
+     `ClientAssertionCredential` whose assertion (`storage::github_oidc::GithubOidcAssertion`)
+     fetches a **fresh** GitHub OIDC JWT on demand — `GET`ting
+     `${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange` with the
+     `ACTIONS_ID_TOKEN_REQUEST_TOKEN` bearer — for each Entra token exchange. The
+     `entra_credential` helper activates it only when `from_env` finds all four of
+     `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, `AZURE_CLIENT_ID`
+     and `AZURE_TENANT_ID` non-empty; otherwise it falls back to
+     `DeveloperToolsCredential` (local `az login`; the `test-azure` job, which exports
+     `AZURE_TEST_CLIENT_ID` rather than `AZURE_CLIENT_ID`, decision 17). *Why:* a
+     federated `azure/login` session yields a ~1h access token but caches a single OIDC
+     assertion that lives only minutes; a multi-hour collection run outlives the access
+     token, and the first refresh re-submits the long-dead assertion, which Entra
+     rejects (`AADSTS700024`). `ClientAssertionCredential` has its own `TokenCache`, so
+     it calls the assertion only when its access token is stale (~hourly) — and the
+     job-lifetime request token always yields a still-valid assertion, so the run never
+     re-submits an expired one. This needs `permissions: { id-token: write }`, no
+     `azure/login` step, and no stored secret. `GithubOidcAssertion` reuses the
+     backend's shared `HttpClient` for the token `GET`, redacts the request token in
+     `Debug`, and maps every failure to `ErrorKind::Credential`; it is unit-tested with
+     a stub `HttpClient` (no network, Miri-safe) covering success, HTTP-error status,
+     malformed/empty JSON, the audience-append and bearer header, `Debug` redaction, the
+     four-var env detection, and credential construction.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1636,6 +1636,22 @@ Each iteration ships with tests and docs and leaves the tool runnable.
     `azure.rs`; its value is the real Entra + real Blob round-trip. The account,
     identity and federated credentials are scripted/Bicep'd in
     `infra/azure-bench-history-test/` (decision 31).
+
+    **Real Azure account via self-minting OIDC** (`test-azure-gh` job): a second
+    additive job, identical to `test-azure` except it also exports `AZURE_CLIENT_ID`
+    (= `AZURE_TEST_CLIENT_ID`). That single switch routes `from_config` through the
+    **self-minting `ClientAssertionCredential`** (decision 38) — the exact credential
+    the nightly prod collection depends on — so PR-time CI proves the real GitHub OIDC →
+    Entra → Blob round-trip works, instead of only discovering a regression after merge
+    on the next nightly run. `permissions: id-token: write` provides the
+    `ACTIONS_ID_TOKEN_REQUEST_*` values the tool reads to mint assertions, and the test
+    identity's `pull_request` federated credential lets same-repo PR runs federate in.
+    `azure/login@v2` is retained **only** so the harness's `az`-based container cleanup
+    has a session; the code under test ignores that session once `AZURE_CLIENT_ID` is
+    set. Together the pair covers both branches of `entra_credential`: `test-azure` the
+    local-`az` `DeveloperToolsCredential` fallback, `test-azure-gh` the CI self-minting
+    path.
+
 18. **Integration testing** — *Decided:* integration tests invoke the **library
     entry** (`Cli::from_args(argv).into_command()` → `run()`), matching the
     workspace pattern (no `assert_cmd`); a table-driven CLI-flag matrix runs over

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -2028,7 +2028,7 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      fetches a **fresh** GitHub OIDC JWT on demand — `GET`ting
      `${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange` with the
      `ACTIONS_ID_TOKEN_REQUEST_TOKEN` bearer — for each Entra token exchange. The
-     `entra_credential` helper activates it only when `from_env` finds all four of
+     `entra_credential` helper activates it only when `credential_from` finds all of
      `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, `AZURE_CLIENT_ID`
      and `AZURE_TENANT_ID` non-empty; otherwise it falls back to
      `DeveloperToolsCredential` (local `az login`; the `test-azure` job, which exports
@@ -2042,7 +2042,12 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      re-submits an expired one. This needs `permissions: { id-token: write }`, no
      `azure/login` step, and no stored secret. `GithubOidcAssertion` reuses the
      backend's shared `HttpClient` for the token `GET`, redacts the request token in
-     `Debug`, and maps every failure to `ErrorKind::Credential`; it is unit-tested with
-     a stub `HttpClient` (no network, Miri-safe) covering success, HTTP-error status,
-     malformed/empty JSON, the audience-append and bearer header, `Debug` redaction, the
-     four-var env detection, and credential construction.
+     `Debug`, and maps its own failures (a malformed request URL, a non-success HTTP
+     status, malformed/empty JSON) to `ErrorKind::Credential`, while a transport error
+     from the `GET` itself propagates unchanged (it stays `ErrorKind::Io`). It is
+     unit-tested with a stub `HttpClient` (no network, Miri-safe) covering success,
+     HTTP-error status, malformed/empty JSON, transport-error passthrough, the
+     audience-append and bearer header, `Debug` redaction, the federation-variable
+     detection, and credential construction; `entra_credential_from` (the getter-seam
+     under `entra_credential`) is unit-tested for both the self-minting and fallback
+     branches.

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -247,10 +247,17 @@
 //! 3. **For CI, authenticate with GitHub OIDC workload identity federation** instead
 //!    of a stored secret: create a user-assigned managed identity, add a federated
 //!    credential whose subject matches the workflow's OIDC token (for a scheduled run
-//!    on the default branch that is `repo:<owner>/<repo>:ref:refs/heads/main`), grant
-//!    it the role from step 2, then sign in with `azure/login@v2` from a job that has
-//!    `permissions: { id-token: write }`. The signed-in Azure CLI session is what the
-//!    tool's Entra credential picks up.
+//!    on the default branch that is `repo:<owner>/<repo>:ref:refs/heads/main`) and
+//!    whose audience is `api://AzureADTokenExchange`, then grant it the role from
+//!    step 2. Run the tool from a job that has `permissions: { id-token: write }`,
+//!    with the managed identity's client ID and your Entra tenant ID exported as the
+//!    `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` environment variables. The tool then
+//!    mints a fresh OIDC assertion straight from GitHub's per-job token endpoint for
+//!    each Entra token exchange, so it stays authenticated even across the hourly
+//!    access-token refresh of a multi-hour benchmark run — no `azure/login` step and
+//!    no stored secret are involved. (When those variables are absent — locally, or in
+//!    a short job that runs `azure/login` — the tool instead picks up the ambient
+//!    Azure CLI session.)
 //!
 //! Worked, runnable examples of all of the above live in the folo repository as Bicep
 //! templates with PowerShell deploy wrappers: the long-lived store with its own

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -38,7 +38,7 @@ use jiff::tz::TimeZone;
 use jiff::{Timestamp, ToSpan as _};
 
 use super::sas::{AccountSasParams, account_sas_query};
-use super::{Storage, StorageError, validate_key};
+use super::{Storage, StorageError, github_oidc, validate_key};
 
 /// The SAS permissions a self-signed token grants: read, write, delete, list,
 /// add, create — everything the backend needs to create the container on demand
@@ -125,6 +125,33 @@ impl AzureBlobStorage {
             .pop_if_empty()
             .push(container);
 
+        // Reject Entra-over-HTTP before building anything else, so this validation
+        // error never depends on first constructing the HTTP client (which would pull
+        // in `reqwest` and make the check un-runnable under Miri). The SAS modes set a
+        // credential-bearing query and so accept the emulator's plain-HTTP endpoint;
+        // only the Entra path (neither key nor token) demands HTTPS.
+        let is_entra = account_key.is_none() && sas_token.is_none();
+        if is_entra && container_endpoint.scheme() != "https" {
+            return Err(config_error(
+                "Azure Entra ID authentication requires an https endpoint",
+            ));
+        }
+
+        // Build one HTTP client up front and share it across every per-object blob
+        // and container client (via the transport seam in `shared_client_options`),
+        // so all operations reuse a single connection pool and keep TCP+TLS
+        // connections alive instead of paying a fresh handshake per object.
+        // `automatic_decompression` is left off to match the SDK's own per-client
+        // default: the storage layer stores gzip and inflates it itself in `get`, so
+        // the transport must hand back the raw compressed bytes (turning
+        // auto-decompression on would double-inflate). The Entra OIDC credential
+        // reuses the same client for its token `GET`; that endpoint is never gzipped
+        // (the request advertises no `Accept-Encoding`), so decompression staying off
+        // is correct there too.
+        let http_client = new_http_client(Some(HttpClientOptions {
+            automatic_decompression: false,
+        }));
+
         let credential = if let Some(account_key) = account_key {
             let query = account_sas_query(&AccountSasParams {
                 account,
@@ -141,33 +168,14 @@ impl AzureBlobStorage {
             container_endpoint.set_query(Some(sas_token.trim_start_matches('?')));
             None
         } else {
-            if container_endpoint.scheme() != "https" {
-                return Err(config_error(
-                    "Azure Entra ID authentication requires an https endpoint",
-                ));
-            }
-            let credential: Arc<dyn TokenCredential> = DeveloperToolsCredential::new(None)
-                .map_err(|error| {
-                    config_error(format!("could not initialize Entra ID credential: {error}"))
-                })?;
+            // The endpoint was already confirmed to be HTTPS above.
+            let credential = entra_credential(&http_client)?;
             // Wrap the credential so a burst of concurrent reads shares one token
-            // instead of each driving its own Azure CLI token acquisition (see
+            // instead of each driving its own token acquisition (see
             // `CachingCredential`).
             let caching: Arc<dyn TokenCredential> = Arc::new(CachingCredential::new(credential));
             Some(caching)
         };
-
-        // Build one HTTP client up front and share it across every per-object
-        // blob and container client (via the transport seam in
-        // `shared_client_options`), so all operations reuse a single connection
-        // pool and keep TCP+TLS connections alive instead of paying a fresh
-        // handshake per object. `automatic_decompression` is left off to match
-        // the SDK's own per-client default: the storage layer stores gzip and
-        // inflates it itself in `get`, so the transport must hand back the raw
-        // compressed bytes (turning auto-decompression on would double-inflate).
-        let http_client = new_http_client(Some(HttpClientOptions {
-            automatic_decompression: false,
-        }));
 
         Ok(Self {
             container_endpoint,
@@ -354,6 +362,28 @@ impl Storage for AzureBlobStorage {
             Err(error) => Err(azure_io(&error)),
         }
     }
+}
+
+/// Resolves the Entra ID token credential used against the HTTPS Blob endpoint.
+///
+/// In a GitHub Actions job configured for Azure federation it self-mints fresh OIDC
+/// assertions (see [`github_oidc`]), which keeps a long collection run authenticated
+/// past the first hourly access-token refresh — a single `azure/login` session
+/// cannot, because the assertion it caches expires within minutes. Everywhere else
+/// (local development, and the `test-azure` CI job that signs in with `azure/login`)
+/// it falls back to [`DeveloperToolsCredential`], which discovers the existing
+/// Azure CLI session.
+fn entra_credential(
+    http_client: &Arc<dyn HttpClient>,
+) -> Result<Arc<dyn TokenCredential>, StorageError> {
+    if let Some(result) = github_oidc::from_env(http_client) {
+        return result;
+    }
+    let credential: Arc<dyn TokenCredential> =
+        DeveloperToolsCredential::new(None).map_err(|error| {
+            config_error(format!("could not initialize Entra ID credential: {error}"))
+        })?;
+    Ok(credential)
 }
 
 /// How long before a cached token's stated expiry it is treated as stale and

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -14,6 +14,7 @@
 //! Entra mode passes a token credential and requires HTTPS.
 
 use std::collections::HashMap;
+use std::env;
 use std::fmt;
 use std::io;
 use std::sync::Arc;
@@ -373,12 +374,44 @@ impl Storage for AzureBlobStorage {
 /// (local development, and the `test-azure` CI job that signs in with `azure/login`)
 /// it falls back to [`DeveloperToolsCredential`], which discovers the existing
 /// Azure CLI session.
+///
+/// This thin wrapper only supplies the live process environment to the testable
+/// [`entra_credential_from`] seam; it is coverage- and mutation-excluded because its
+/// sole behavior — reading ambient OS environment variables — cannot be driven from a
+/// unit test without mutating the global process environment (which this crate's tests
+/// avoid). The `test-azure-gh` job exercises it end to end in a real federated job.
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(test, mutants::skip)]
 fn entra_credential(
     http_client: &Arc<dyn HttpClient>,
 ) -> Result<Arc<dyn TokenCredential>, StorageError> {
-    if let Some(result) = github_oidc::from_env(http_client) {
+    entra_credential_from(|key| env::var(key).ok(), http_client)
+}
+
+/// Resolves the Entra credential from an arbitrary environment getter, so both the
+/// self-minting and fallback branches are unit-testable without mutating the global
+/// process environment. With all GitHub OIDC federation variables present it returns
+/// the self-minting assertion credential; otherwise it falls back to the developer
+/// credential.
+fn entra_credential_from(
+    get: impl Fn(&str) -> Option<String>,
+    http_client: &Arc<dyn HttpClient>,
+) -> Result<Arc<dyn TokenCredential>, StorageError> {
+    if let Some(result) = github_oidc::credential_from(get, http_client) {
         return result;
     }
+    developer_tools_credential()
+}
+
+/// Discovers the ambient Azure CLI / developer credential.
+///
+/// Coverage-excluded because both of its outcomes depend on the host: it succeeds only
+/// where a developer or CI Azure session exists and reports an error only where the
+/// developer-tooling discovery itself fails, neither of which a unit test can stage. It
+/// is isolated to a single call so the surrounding [`entra_credential_from`] resolution
+/// logic stays testable.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn developer_tools_credential() -> Result<Arc<dyn TokenCredential>, StorageError> {
     let credential: Arc<dyn TokenCredential> =
         DeveloperToolsCredential::new(None).map_err(|error| {
             config_error(format!("could not initialize Entra ID credential: {error}"))
@@ -1137,7 +1170,7 @@ mod tests {
 
     /// The Azurite blob endpoint, overridable for a non-default emulator.
     fn azurite_endpoint() -> String {
-        std::env::var("AZURITE_BLOB_ENDPOINT")
+        env::var("AZURITE_BLOB_ENDPOINT")
             .unwrap_or_else(|_| "http://127.0.0.1:10000/devstoreaccount1".to_owned())
     }
 
@@ -1178,7 +1211,7 @@ mod tests {
     fn azurite_storage_or_skip() -> Option<AzureBlobStorage> {
         if !azurite_reachable() {
             assert!(
-                std::env::var_os("BENCH_HISTORY_REQUIRE_AZURITE").is_none(),
+                env::var_os("BENCH_HISTORY_REQUIRE_AZURITE").is_none(),
                 "BENCH_HISTORY_REQUIRE_AZURITE is set but no Azurite emulator is reachable at {}",
                 azurite_endpoint()
             );
@@ -1425,5 +1458,42 @@ mod tests {
         };
         storage.put("v1/proj/a.json", b"x").await.unwrap();
         assert!(storage.list("v1/other/").await.unwrap().is_empty());
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds a real HTTP pipeline (reqwest) that Miri cannot run"
+    )]
+    fn entra_credential_uses_the_self_minting_oidc_path_when_all_vars_present() {
+        let http_client = new_http_client(None);
+        // With every GitHub OIDC federation variable present the self-minting branch
+        // builds and returns the assertion credential without falling through to the
+        // developer credential. Construction performs no network I/O; the tenant and
+        // client IDs must be legal GUIDs so the assertion credential constructs. The
+        // names are GitHub's and Azure's fixed federation-variable contract.
+        let get = |key: &str| match key {
+            "ACTIONS_ID_TOKEN_REQUEST_URL" => Some("https://example.test/token".to_owned()),
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN" => Some("request-token".to_owned()),
+            "AZURE_CLIENT_ID" => Some("11111111-1111-1111-1111-111111111111".to_owned()),
+            "AZURE_TENANT_ID" => Some("22222222-2222-2222-2222-222222222222".to_owned()),
+            _ => None,
+        };
+        entra_credential_from(get, &http_client).expect("self-minting OIDC credential builds");
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "constructs the developer credential chain (reqwest) that Miri cannot run"
+    )]
+    fn entra_credential_falls_back_to_the_developer_credential_without_oidc_vars() {
+        let http_client = new_http_client(None);
+        // Absent the federation variables the self-minting branch is skipped and
+        // resolution falls back to the ambient developer/CLI credential. Constructing
+        // it assembles the discovery chain without authenticating, so the fallback
+        // wiring is exercised whether or not an Azure session exists on the host.
+        entra_credential_from(|_| None, &http_client)
+            .expect("developer credential chain constructs");
     }
 }

--- a/packages/cargo-bench-history/src/storage/github_oidc.rs
+++ b/packages/cargo-bench-history/src/storage/github_oidc.rs
@@ -225,6 +225,9 @@ mod tests {
     struct StubHttpClient {
         status: StatusCode,
         body: Vec<u8>,
+        /// When set, `execute_request` returns this as an `Io`-kind transport error
+        /// instead of a response, exercising `secret`'s request-failure branch.
+        fail: Option<String>,
         seen: Mutex<Option<SeenRequest>>,
     }
 
@@ -233,6 +236,18 @@ mod tests {
             Self {
                 status,
                 body: body.into(),
+                fail: None,
+                seen: Mutex::new(None),
+            }
+        }
+
+        /// A client whose `execute_request` fails with a transport error carrying
+        /// `message`, so a test can assert that `secret` surfaces it unchanged.
+        fn failing(message: impl Into<String>) -> Self {
+            Self {
+                status: StatusCode::Ok,
+                body: Vec::new(),
+                fail: Some(message.into()),
                 seen: Mutex::new(None),
             }
         }
@@ -257,6 +272,9 @@ mod tests {
                 url: request.url().to_string(),
                 authorization,
             });
+            if let Some(message) = &self.fail {
+                return Err(Error::with_message(ErrorKind::Io, message.clone()));
+            }
             Ok(AsyncRawResponse::from_bytes(
                 self.status,
                 Headers::default(),
@@ -304,6 +322,16 @@ mod tests {
         let client = Arc::new(StubHttpClient::new(StatusCode::Forbidden, b"nope".to_vec()));
         let error = block_on(assertion(client).secret(None)).expect_err("error");
         assert!(matches!(error.kind(), ErrorKind::Credential), "{error:?}");
+    }
+
+    #[test]
+    fn secret_propagates_a_transport_error_unchanged() {
+        let client = Arc::new(StubHttpClient::failing("connection reset by peer"));
+        let error = block_on(assertion(client).secret(None)).expect_err("error");
+        // A failure to even send the request is surfaced as-is (an `Io` transport
+        // error), not remapped to a credential error like the HTTP-status, JSON, and
+        // empty-value branches are.
+        assert!(matches!(error.kind(), ErrorKind::Io), "{error:?}");
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/storage/github_oidc.rs
+++ b/packages/cargo-bench-history/src/storage/github_oidc.rs
@@ -23,7 +23,6 @@
 //! sidesteps that entirely, and needs neither an `azure/login` step nor a stored
 //! secret.
 
-use std::env;
 use std::fmt;
 use std::sync::Arc;
 
@@ -59,27 +58,7 @@ const ENV_CLIENT_ID: &str = "AZURE_CLIENT_ID";
 /// authenticate against.
 const ENV_TENANT_ID: &str = "AZURE_TENANT_ID";
 
-/// Builds a self-refreshing GitHub OIDC credential when the process is running in a
-/// GitHub Actions job configured for Azure federation, or returns `None` otherwise
-/// so the caller falls back to the Azure CLI / developer credential.
-///
-/// `http_client` is reused for the on-demand OIDC token `GET`, sharing the backend's
-/// connection pool. A `Some(Err(..))` result means the job *is* in the federation
-/// context but the credential could not be constructed (for example an invalid
-/// tenant ID), which the caller surfaces rather than silently falling back.
-// Thin adapter: its only behavior is injecting the real process environment into
-// `credential_from` (unit-tested with an injected getter). Returning `None` here is
-// observable only in a live GitHub Actions job, which the `test-azure-gh` integration
-// job verifies but unit tests cannot reproduce without mutating the global process
-// environment (which this crate's tests avoid).
-#[cfg_attr(test, mutants::skip)]
-pub(crate) fn from_env(
-    http_client: &Arc<dyn HttpClient>,
-) -> Option<Result<Arc<dyn TokenCredential>, StorageError>> {
-    credential_from(|key| env::var(key).ok(), http_client)
-}
-
-/// The four values that together opt a job into GitHub OIDC federation.
+/// The values that together opt a job into GitHub OIDC federation.
 struct GithubOidcParams {
     request_url: String,
     request_token: String,
@@ -87,12 +66,19 @@ struct GithubOidcParams {
     tenant_id: String,
 }
 
-/// Resolves a self-minting credential from an arbitrary env getter, so the wiring
-/// from detected parameters to a built credential is testable without mutating the
-/// global process environment. Returns `None` when the job is not in the federation
-/// context (the caller then falls back to the developer credential), mirroring
-/// [`from_env`] which delegates here with the real process environment.
-fn credential_from(
+/// Builds a self-refreshing GitHub OIDC credential when the process is running in a
+/// GitHub Actions job configured for Azure federation, or returns `None` otherwise so
+/// the caller falls back to the Azure CLI / developer credential.
+///
+/// The federation parameters are read through `get`; the caller passes a real
+/// process-environment lookup, while tests pass a getter over an explicit set, so the
+/// wiring from detected parameters to a built credential is exercised without mutating
+/// the global process environment. A `Some(Err(..))` result means the job *is* in the
+/// federation context but the credential could not be constructed (for example an
+/// invalid tenant ID), which the caller surfaces rather than silently falling back.
+/// `http_client` is reused for the on-demand OIDC token `GET`, sharing the backend's
+/// connection pool.
+pub(crate) fn credential_from(
     get: impl Fn(&str) -> Option<String>,
     http_client: &Arc<dyn HttpClient>,
 ) -> Option<Result<Arc<dyn TokenCredential>, StorageError>> {

--- a/packages/cargo-bench-history/src/storage/github_oidc.rs
+++ b/packages/cargo-bench-history/src/storage/github_oidc.rs
@@ -70,8 +70,7 @@ const ENV_TENANT_ID: &str = "AZURE_TENANT_ID";
 pub(crate) fn from_env(
     http_client: &Arc<dyn HttpClient>,
 ) -> Option<Result<Arc<dyn TokenCredential>, StorageError>> {
-    let params = params_from_env()?;
-    Some(build_credential(params, Arc::clone(http_client)))
+    credential_from(|key| env::var(key).ok(), http_client)
 }
 
 /// The four values that together opt a job into GitHub OIDC federation.
@@ -82,9 +81,17 @@ struct GithubOidcParams {
     tenant_id: String,
 }
 
-/// Reads the GitHub OIDC parameters from the process environment.
-fn params_from_env() -> Option<GithubOidcParams> {
-    params_from(|key| env::var(key).ok())
+/// Resolves a self-minting credential from an arbitrary env getter, so the wiring
+/// from detected parameters to a built credential is testable without mutating the
+/// global process environment. Returns `None` when the job is not in the federation
+/// context (the caller then falls back to the developer credential), mirroring
+/// [`from_env`] which delegates here with the real process environment.
+fn credential_from(
+    get: impl Fn(&str) -> Option<String>,
+    http_client: &Arc<dyn HttpClient>,
+) -> Option<Result<Arc<dyn TokenCredential>, StorageError>> {
+    let params = params_from(get)?;
+    Some(build_credential(params, Arc::clone(http_client)))
 }
 
 /// Resolves the parameters from an arbitrary getter, so the detection rule is
@@ -464,5 +471,33 @@ mod tests {
         };
         let error = build_credential(params, http_client).expect_err("error");
         assert!(matches!(error, StorageError::Config { .. }), "{error:?}");
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds a real HTTP pipeline (reqwest) that Miri cannot run"
+    )]
+    fn credential_from_builds_a_credential_when_all_params_present() {
+        let http_client: Arc<dyn HttpClient> =
+            Arc::new(StubHttpClient::new(StatusCode::Ok, b"{}".to_vec()));
+        // The tenant and client IDs must be legal GUIDs so the assertion credential
+        // actually constructs (the env getter's strings flow straight through).
+        let present = vec![
+            (ENV_REQUEST_URL, "https://example.test/token"),
+            (ENV_REQUEST_TOKEN, "secret"),
+            (ENV_CLIENT_ID, "11111111-1111-1111-1111-111111111111"),
+            (ENV_TENANT_ID, "22222222-2222-2222-2222-222222222222"),
+        ];
+        let result =
+            credential_from(getter(present), &http_client).expect("params present yields Some");
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn credential_from_absent_when_a_var_is_missing() {
+        let http_client: Arc<dyn HttpClient> =
+            Arc::new(StubHttpClient::new(StatusCode::Ok, b"{}".to_vec()));
+        assert!(credential_from(getter(Vec::new()), &http_client).is_none());
     }
 }

--- a/packages/cargo-bench-history/src/storage/github_oidc.rs
+++ b/packages/cargo-bench-history/src/storage/github_oidc.rs
@@ -67,6 +67,12 @@ const ENV_TENANT_ID: &str = "AZURE_TENANT_ID";
 /// connection pool. A `Some(Err(..))` result means the job *is* in the federation
 /// context but the credential could not be constructed (for example an invalid
 /// tenant ID), which the caller surfaces rather than silently falling back.
+// Thin adapter: its only behavior is injecting the real process environment into
+// `credential_from` (unit-tested with an injected getter). Returning `None` here is
+// observable only in a live GitHub Actions job, which the `test-azure-gh` integration
+// job verifies but unit tests cannot reproduce without mutating the global process
+// environment (which this crate's tests avoid).
+#[cfg_attr(test, mutants::skip)]
 pub(crate) fn from_env(
     http_client: &Arc<dyn HttpClient>,
 ) -> Option<Result<Arc<dyn TokenCredential>, StorageError>> {

--- a/packages/cargo-bench-history/src/storage/github_oidc.rs
+++ b/packages/cargo-bench-history/src/storage/github_oidc.rs
@@ -1,0 +1,440 @@
+//! A self-refreshing GitHub Actions OIDC client-assertion credential for Entra ID.
+//!
+//! On a GitHub-hosted runner the workflow authenticates to Azure through GitHub's
+//! OIDC workload identity federation. A benchmark collection run can take longer
+//! than an hour — longer than a single Entra access token lives — so the run must be
+//! able to acquire a *new* access token partway through. This credential makes that
+//! work by minting a fresh GitHub OIDC assertion on demand, rather than reusing one
+//! assertion captured at job start.
+//!
+//! GitHub exposes two per-job values for this: a token-request URL
+//! (`ACTIONS_ID_TOKEN_REQUEST_URL`) and a bearer request token
+//! (`ACTIONS_ID_TOKEN_REQUEST_TOKEN`). The request token stays valid for the whole
+//! job, so a `GET` against the request URL returns a brand-new, still-valid OIDC JWT
+//! at any point during the run. [`ClientAssertionCredential`] calls
+//! [`GithubOidcAssertion::secret`] only when its cached access token has gone stale
+//! (roughly hourly), so every token exchange presents an assertion minted moments
+//! earlier rather than one that has already expired.
+//!
+//! The alternative — leaning on the Azure CLI session that `azure/login` leaves
+//! behind — fails on long runs: that session caches a single OIDC assertion that
+//! lives only a few minutes, so the first access-token refresh after it expires
+//! re-submits a dead assertion and Entra rejects it (AADSTS700024). Self-minting
+//! sidesteps that entirely, and needs neither an `azure/login` step nor a stored
+//! secret.
+
+use std::env;
+use std::fmt;
+use std::sync::Arc;
+
+use azure_core::Error;
+use azure_core::credentials::TokenCredential;
+use azure_core::error::ErrorKind;
+use azure_core::http::headers;
+use azure_core::http::{ClientMethodOptions, HttpClient, Method, Request, Url};
+use azure_identity::{ClientAssertion, ClientAssertionCredential};
+use serde::Deserialize;
+
+use super::StorageError;
+
+/// The audience every GitHub OIDC token minted for Azure federation must carry. It
+/// is the fixed value Entra assigns to its token-exchange endpoint and must match
+/// the `audience` on the managed identity's federated credential.
+const FEDERATION_AUDIENCE: &str = "api://AzureADTokenExchange";
+
+/// The environment variable GitHub sets to the URL that issues an OIDC token for the
+/// running job.
+const ENV_REQUEST_URL: &str = "ACTIONS_ID_TOKEN_REQUEST_URL";
+
+/// The environment variable GitHub sets to the bearer token authorizing a request
+/// against [`ENV_REQUEST_URL`]. It is valid for the whole job; treat it as a secret.
+const ENV_REQUEST_TOKEN: &str = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
+
+/// The environment variable the workflow sets to the client (application) ID of the
+/// managed identity to federate into. Its presence is what opts a job into this
+/// credential.
+const ENV_CLIENT_ID: &str = "AZURE_CLIENT_ID";
+
+/// The environment variable the workflow sets to the Entra tenant (directory) ID to
+/// authenticate against.
+const ENV_TENANT_ID: &str = "AZURE_TENANT_ID";
+
+/// Builds a self-refreshing GitHub OIDC credential when the process is running in a
+/// GitHub Actions job configured for Azure federation, or returns `None` otherwise
+/// so the caller falls back to the Azure CLI / developer credential.
+///
+/// `http_client` is reused for the on-demand OIDC token `GET`, sharing the backend's
+/// connection pool. A `Some(Err(..))` result means the job *is* in the federation
+/// context but the credential could not be constructed (for example an invalid
+/// tenant ID), which the caller surfaces rather than silently falling back.
+pub(crate) fn from_env(
+    http_client: &Arc<dyn HttpClient>,
+) -> Option<Result<Arc<dyn TokenCredential>, StorageError>> {
+    let params = params_from_env()?;
+    Some(build_credential(params, Arc::clone(http_client)))
+}
+
+/// The four values that together opt a job into GitHub OIDC federation.
+struct GithubOidcParams {
+    request_url: String,
+    request_token: String,
+    client_id: String,
+    tenant_id: String,
+}
+
+/// Reads the GitHub OIDC parameters from the process environment.
+fn params_from_env() -> Option<GithubOidcParams> {
+    params_from(|key| env::var(key).ok())
+}
+
+/// Resolves the parameters from an arbitrary getter, so the detection rule is
+/// testable without mutating the global process environment. An empty value counts
+/// as absent: GitHub leaves an unset request variable as the empty string rather
+/// than removing it.
+fn params_from(get: impl Fn(&str) -> Option<String>) -> Option<GithubOidcParams> {
+    let non_empty = |key| get(key).filter(|value| !value.is_empty());
+    Some(GithubOidcParams {
+        request_url: non_empty(ENV_REQUEST_URL)?,
+        request_token: non_empty(ENV_REQUEST_TOKEN)?,
+        client_id: non_empty(ENV_CLIENT_ID)?,
+        tenant_id: non_empty(ENV_TENANT_ID)?,
+    })
+}
+
+/// Constructs the [`ClientAssertionCredential`] wrapping a [`GithubOidcAssertion`].
+fn build_credential(
+    params: GithubOidcParams,
+    http_client: Arc<dyn HttpClient>,
+) -> Result<Arc<dyn TokenCredential>, StorageError> {
+    let assertion = GithubOidcAssertion {
+        request_url: params.request_url,
+        request_token: params.request_token,
+        http_client,
+    };
+    let credential: Arc<dyn TokenCredential> =
+        ClientAssertionCredential::new(params.tenant_id, params.client_id, assertion, None)
+            .map_err(|error| StorageError::Config {
+                message: format!("could not initialize GitHub OIDC credential: {error}"),
+            })?;
+    Ok(credential)
+}
+
+/// A [`ClientAssertion`] that fetches a fresh GitHub Actions OIDC token on demand.
+struct GithubOidcAssertion {
+    /// The per-job GitHub token-request URL (`ACTIONS_ID_TOKEN_REQUEST_URL`).
+    request_url: String,
+    /// The per-job bearer token authorizing the request (a secret; redacted in
+    /// `Debug`).
+    request_token: String,
+    /// The HTTP client used for the token `GET`, shared with the storage backend.
+    http_client: Arc<dyn HttpClient>,
+}
+
+impl fmt::Debug for GithubOidcAssertion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redact the request token: it authorizes minting OIDC tokens for this job
+        // and must never reach logs.
+        f.debug_struct("GithubOidcAssertion")
+            .field("request_url", &self.request_url)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The body GitHub returns from a successful OIDC token request: `{"value":"<jwt>"}`.
+#[derive(Deserialize)]
+struct OidcTokenResponse {
+    value: String,
+}
+
+#[async_trait::async_trait]
+impl ClientAssertion for GithubOidcAssertion {
+    async fn secret(
+        &self,
+        _options: Option<ClientMethodOptions<'_>>,
+    ) -> azure_core::Result<String> {
+        let mut url = Url::parse(&self.request_url).map_err(|error| {
+            Error::with_message(
+                ErrorKind::Credential,
+                format!(
+                    "invalid GitHub OIDC request URL {:?}: {error}",
+                    self.request_url
+                ),
+            )
+        })?;
+        // Append rather than replace: the request URL already carries an
+        // `api-version` query that must be preserved.
+        url.query_pairs_mut()
+            .append_pair("audience", FEDERATION_AUDIENCE);
+
+        let mut request = Request::new(url, Method::Get);
+        request.insert_header(
+            headers::AUTHORIZATION,
+            format!("Bearer {}", self.request_token),
+        );
+        request.insert_header(headers::ACCEPT, "application/json");
+
+        let response = self.http_client.execute_request(&request).await?;
+        let status = response.status();
+        let body = response.into_body().collect().await?;
+        if !status.is_success() {
+            return Err(Error::with_message(
+                ErrorKind::Credential,
+                format!("GitHub OIDC token request failed with HTTP status {status}"),
+            ));
+        }
+
+        let parsed: OidcTokenResponse = serde_json::from_slice(&body).map_err(|error| {
+            Error::with_message(
+                ErrorKind::Credential,
+                format!("could not parse GitHub OIDC token response: {error}"),
+            )
+        })?;
+        if parsed.value.is_empty() {
+            return Err(Error::with_message(
+                ErrorKind::Credential,
+                "GitHub OIDC token response carried an empty token value",
+            ));
+        }
+        Ok(parsed.value)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+
+    use azure_core::http::headers::Headers;
+    use azure_core::http::{AsyncRawResponse, StatusCode};
+    use futures::executor::block_on;
+
+    /// Records the request a [`StubHttpClient`] saw, so a test can assert on the URL
+    /// and bearer header the assertion built.
+    #[derive(Clone, Debug, Default)]
+    struct SeenRequest {
+        url: String,
+        authorization: Option<String>,
+    }
+
+    /// A minimal [`HttpClient`] that records the request and replies with a fixed
+    /// status and body, exercising the assertion's `GET`/parse logic with no real
+    /// network (so the tests stay Miri-safe).
+    #[derive(Debug)]
+    struct StubHttpClient {
+        status: StatusCode,
+        body: Vec<u8>,
+        seen: Mutex<Option<SeenRequest>>,
+    }
+
+    impl StubHttpClient {
+        fn new(status: StatusCode, body: impl Into<Vec<u8>>) -> Self {
+            Self {
+                status,
+                body: body.into(),
+                seen: Mutex::new(None),
+            }
+        }
+
+        fn seen(&self) -> SeenRequest {
+            self.seen
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("a request should have been sent")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HttpClient for StubHttpClient {
+        async fn execute_request(&self, request: &Request) -> azure_core::Result<AsyncRawResponse> {
+            let authorization = request
+                .headers()
+                .get_optional_str(&headers::AUTHORIZATION)
+                .map(ToOwned::to_owned);
+            *self.seen.lock().unwrap() = Some(SeenRequest {
+                url: request.url().to_string(),
+                authorization,
+            });
+            Ok(AsyncRawResponse::from_bytes(
+                self.status,
+                Headers::default(),
+                self.body.clone(),
+            ))
+        }
+    }
+
+    /// Builds an assertion over `client` with a request URL that already carries a
+    /// query, so the audience-append behaviour is observable.
+    fn assertion(client: Arc<dyn HttpClient>) -> GithubOidcAssertion {
+        GithubOidcAssertion {
+            request_url: "https://example.test/token?api-version=2.0".to_owned(),
+            request_token: "request-secret".to_owned(),
+            http_client: client,
+        }
+    }
+
+    #[test]
+    fn secret_returns_token_value_and_sends_audience_and_bearer() {
+        let client = Arc::new(StubHttpClient::new(
+            StatusCode::Ok,
+            br#"{"value":"the-jwt"}"#.to_vec(),
+        ));
+        let client_for_assertion = Arc::clone(&client);
+        let assertion = assertion(client_for_assertion);
+
+        let token = block_on(assertion.secret(None)).expect("token");
+        assert_eq!(token, "the-jwt");
+
+        let seen = client.seen();
+        // The pre-existing query is preserved and the fixed audience is appended.
+        assert!(seen.url.contains("api-version=2.0"), "{}", seen.url);
+        assert!(
+            seen.url
+                .contains("audience=api%3A%2F%2FAzureADTokenExchange"),
+            "{}",
+            seen.url
+        );
+        assert_eq!(seen.authorization.as_deref(), Some("Bearer request-secret"));
+    }
+
+    #[test]
+    fn secret_maps_http_error_status_to_credential_error() {
+        let client = Arc::new(StubHttpClient::new(StatusCode::Forbidden, b"nope".to_vec()));
+        let error = block_on(assertion(client).secret(None)).expect_err("error");
+        assert!(matches!(error.kind(), ErrorKind::Credential), "{error:?}");
+    }
+
+    #[test]
+    fn secret_maps_malformed_json_to_credential_error() {
+        let client = Arc::new(StubHttpClient::new(StatusCode::Ok, b"not json".to_vec()));
+        let error = block_on(assertion(client).secret(None)).expect_err("error");
+        assert!(matches!(error.kind(), ErrorKind::Credential), "{error:?}");
+    }
+
+    #[test]
+    fn secret_rejects_an_empty_token_value() {
+        let client = Arc::new(StubHttpClient::new(
+            StatusCode::Ok,
+            br#"{"value":""}"#.to_vec(),
+        ));
+        let error = block_on(assertion(client).secret(None)).expect_err("error");
+        assert!(matches!(error.kind(), ErrorKind::Credential), "{error:?}");
+    }
+
+    #[test]
+    fn secret_rejects_an_invalid_request_url() {
+        let client = Arc::new(StubHttpClient::new(
+            StatusCode::Ok,
+            br#"{"value":"x"}"#.to_vec(),
+        ));
+        let mut assertion = assertion(client);
+        assertion.request_url = "not a url".to_owned();
+        let error = block_on(assertion.secret(None)).expect_err("error");
+        assert!(matches!(error.kind(), ErrorKind::Credential), "{error:?}");
+    }
+
+    #[test]
+    fn debug_redacts_the_request_token() {
+        let client = Arc::new(StubHttpClient::new(StatusCode::Ok, b"{}".to_vec()));
+        let rendered = format!("{:?}", assertion(client));
+        assert!(!rendered.contains("request-secret"), "{rendered}");
+        assert!(rendered.contains("example.test"), "{rendered}");
+    }
+
+    /// The full set of GitHub OIDC variables, all present and non-empty.
+    fn full_env() -> Vec<(&'static str, &'static str)> {
+        vec![
+            (ENV_REQUEST_URL, "https://example.test/token"),
+            (ENV_REQUEST_TOKEN, "secret"),
+            (ENV_CLIENT_ID, "client"),
+            (ENV_TENANT_ID, "tenant"),
+        ]
+    }
+
+    /// A getter over an explicit set of variables, so detection is tested without
+    /// touching the global process environment.
+    fn getter(pairs: Vec<(&'static str, &'static str)>) -> impl Fn(&str) -> Option<String> {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| (*value).to_owned())
+        }
+    }
+
+    #[test]
+    fn params_present_when_all_four_set() {
+        let params = params_from(getter(full_env())).expect("params");
+        assert_eq!(params.request_url, "https://example.test/token");
+        assert_eq!(params.request_token, "secret");
+        assert_eq!(params.client_id, "client");
+        assert_eq!(params.tenant_id, "tenant");
+    }
+
+    #[test]
+    fn params_absent_when_any_var_missing() {
+        for missing in [
+            ENV_REQUEST_URL,
+            ENV_REQUEST_TOKEN,
+            ENV_CLIENT_ID,
+            ENV_TENANT_ID,
+        ] {
+            let pairs: Vec<_> = full_env()
+                .into_iter()
+                .filter(|(name, _)| *name != missing)
+                .collect();
+            assert!(params_from(getter(pairs)).is_none(), "missing {missing}");
+        }
+    }
+
+    #[test]
+    fn params_absent_when_a_var_is_empty() {
+        let pairs: Vec<_> = full_env()
+            .into_iter()
+            .map(|(name, value)| {
+                if name == ENV_CLIENT_ID {
+                    (name, "")
+                } else {
+                    (name, value)
+                }
+            })
+            .collect();
+        assert!(params_from(getter(pairs)).is_none());
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds a real HTTP pipeline (reqwest) that Miri cannot run"
+    )]
+    fn build_credential_succeeds_with_valid_params() {
+        let http_client: Arc<dyn HttpClient> =
+            Arc::new(StubHttpClient::new(StatusCode::Ok, b"{}".to_vec()));
+        let params = GithubOidcParams {
+            request_url: "https://example.test/token".to_owned(),
+            request_token: "secret".to_owned(),
+            client_id: "11111111-1111-1111-1111-111111111111".to_owned(),
+            tenant_id: "22222222-2222-2222-2222-222222222222".to_owned(),
+        };
+        let credential = build_credential(params, http_client);
+        assert!(credential.is_ok(), "{credential:?}");
+    }
+
+    #[test]
+    fn build_credential_rejects_an_invalid_tenant_id() {
+        let http_client: Arc<dyn HttpClient> =
+            Arc::new(StubHttpClient::new(StatusCode::Ok, b"{}".to_vec()));
+        let params = GithubOidcParams {
+            request_url: "https://example.test/token".to_owned(),
+            request_token: "secret".to_owned(),
+            client_id: "client".to_owned(),
+            // A space is not a legal tenant-ID character; this is rejected before any
+            // network pipeline is built.
+            tenant_id: "not a valid tenant".to_owned(),
+        };
+        let error = build_credential(params, http_client).expect_err("error");
+        assert!(matches!(error, StorageError::Config { .. }), "{error:?}");
+    }
+}

--- a/packages/cargo-bench-history/src/storage/mod.rs
+++ b/packages/cargo-bench-history/src/storage/mod.rs
@@ -3,6 +3,7 @@
 
 mod azure;
 mod facade;
+mod github_oidc;
 mod local;
 mod sas;
 

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -300,13 +300,24 @@ async fn delete_container(endpoint: &str, container: &str) {
 struct AzureWorkspace {
     dir: tempfile::TempDir,
     bench: Vec<String>,
+    /// The synthetic UTC second stamped on the next commit. It starts a few minutes
+    /// before construction and advances one second per commit, so consecutive commits
+    /// never share a wall-clock second (git's commit-date resolution). Sharing a
+    /// second would make `analyze`'s first-parent, date-ordered window resolution
+    /// non-deterministic in fast CI; starting only minutes back keeps every commit
+    /// inside the default (six-month) analyze window.
+    next_second: std::cell::Cell<i64>,
 }
 
 impl AzureWorkspace {
     fn new(config: &str) -> Self {
+        // Start a few minutes back so every pinned commit date stays inside the
+        // default analyze window while remaining strictly in the past.
+        let base_second = jiff::Timestamp::now().as_second().saturating_sub(300);
         let workspace = Self {
             dir: tempfile::tempdir().unwrap(),
             bench: Vec::new(),
+            next_second: std::cell::Cell::new(base_second),
         };
         let cargo_dir = workspace.dir.path().join(".cargo");
         std::fs::create_dir_all(&cargo_dir).unwrap();
@@ -318,7 +329,7 @@ impl AzureWorkspace {
         .unwrap();
         workspace.git(&["init", "-b", "master"]);
         workspace.git(&["add", ".gitignore"]);
-        workspace.git(&["commit", "-m", "root"]);
+        workspace.git_commit(&["commit", "-m", "root"]);
         workspace
     }
 
@@ -336,6 +347,12 @@ impl AzureWorkspace {
     /// background repack fires; this keeps a throwaway repository to `init`/`add`/
     /// `commit` rather than several extra `git config` spawns.
     fn git(&self, args: &[&str]) -> std::process::Output {
+        self.git_with_env(args, &[])
+    }
+
+    /// Like [`git`](Self::git) but also exports `env` to the `git` process, used to
+    /// pin commit dates via `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`.
+    fn git_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
         let root = self.dir.path().to_string_lossy().into_owned();
         let mut full: Vec<&str> = vec![
             "-c",
@@ -356,6 +373,7 @@ impl AzureWorkspace {
         full.extend_from_slice(args);
         let output = std::process::Command::new("git")
             .args(&full)
+            .envs(env.iter().copied())
             .output()
             .unwrap();
         assert!(
@@ -367,11 +385,29 @@ impl AzureWorkspace {
         output
     }
 
+    /// Runs a `git` sub-command that creates a commit, pinning its author and
+    /// committer dates to a distinct, monotonically increasing synthetic second so
+    /// consecutive commits never share a wall-clock second. Sharing a second would
+    /// make `analyze`'s first-parent, date-ordered window resolution non-deterministic
+    /// when commits are created in quick succession (as they are in CI).
+    fn git_commit(&self, args: &[&str]) -> std::process::Output {
+        let second = self.next_second.get();
+        self.next_second.set(second.saturating_add(1));
+        let when = format!("@{second} +0000");
+        self.git_with_env(
+            args,
+            &[
+                ("GIT_AUTHOR_DATE", when.as_str()),
+                ("GIT_COMMITTER_DATE", when.as_str()),
+            ],
+        )
+    }
+
     /// Creates an empty commit so a subsequent clean run lands on a fresh commit
     /// directory (a clean run is keyed solely by its commit, so each point in a
     /// history needs its own commit).
     fn commit(&self, message: &str) {
-        self.git(&["commit", "--allow-empty", "-m", message]);
+        self.git_commit(&["commit", "--allow-empty", "-m", message]);
     }
 
     /// Creates and checks out a new branch off the current `HEAD`.


### PR DESCRIPTION
## What

Make `cargo-bench-history` self-mint GitHub OIDC client assertions so the nightly benchmark-history workflow stays authenticated to Azure across multi-hour runs. Follow-up to #283.

## Why

The first real nightly `collect` run failed at the upload stage with:

```
AADSTS700024: Client assertion is not within its valid time range.
Current time: 2026-06-29T17:33:23Z, assertion valid from 16:29:15Z, expiry 16:34:15Z
```

Root cause: `azure/login@v2` establishes an `az` CLI session whose Entra **access token** lives ~1 hour, but the **GitHub OIDC assertion** it caches lives only a few minutes. The benchmark run took ~64 minutes — longer than the access token — so when the storage upload at the end of the job triggered an access-token refresh, `az` re-submitted the long-dead OIDC assertion and Entra rejected it. With a 6-hour job timeout this would only get more likely as the suite grows.

This is **not** a bug in the tool's `CachingCredential`: that decorator correctly tried to refresh; the underlying federated `az` session simply has no way to mint a fresh assertion.

## How

When a job is configured for Azure federation (all of `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN` present), the Entra path now builds a `ClientAssertionCredential` whose assertion (`storage::github_oidc::GithubOidcAssertion`) `GET`s `${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange` with the request token as bearer and returns the fresh JWT. `ClientAssertionCredential` has its own token cache, so it calls the assertion only when its access token is stale (~hourly) — and GitHub's request token is valid for the whole job, so a still-valid assertion is always available. No `azure/login` step and no stored secret.

Everywhere else — local `az login`, and the `test-azure` CI job (which exports `AZURE_TEST_CLIENT_ID`, not `AZURE_CLIENT_ID`) — it falls back to `DeveloperToolsCredential` exactly as before. The chosen credential is still wrapped in `CachingCredential` so `analyze`'s concurrent read burst shares one acquisition.

## Changes

- New module `storage/github_oidc.rs`: the assertion, the four-variable env detection (empty counts as absent), and the credential builder. Unit-tested with a stub `HttpClient` (no network, Miri-safe) covering success, HTTP-error status, malformed/empty JSON, audience-append + bearer header, `Debug` redaction of the request token, env detection, and credential construction.
- `storage/azure.rs`: new `entra_credential` helper selects OIDC vs DeveloperTools; the Entra-over-HTTP rejection now happens before the HTTP client is built (keeps that validation Miri-runnable).
- `.github/workflows/bench-history.yml`: `collect` and `analyze` export `AZURE_CLIENT_ID`/`AZURE_TENANT_ID` from `constants.env` and drop `azure/login`; `id-token: write` retained.
- Docs updated to describe the self-minting credential (lib.rs Azure guide, DESIGN.md decisions 6/17/38, AGENTS.md auth section, prod infra README).

## Validation

`just package="cargo-bench-history" validate-local` passes (format-check, check, clippy `-D warnings`, test, test-docs, docs, miri — 439 tests, machete, default-features-check dev+release). The end-to-end fix can be exercised via the workflow's `workflow_dispatch` on `main`.
