### PR TITLE
Replace --format with per-format output toggles in cargo-bench-history (#285)

### DIFF
--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -19,8 +19,8 @@ gh-collect-bench-history:
 # Markdown report) and bench-history-notable.txt (`true`/`false`, the JSON `notable`
 # flag). Findings never fail the recipe (the tool always exits 0); the workflow files a
 # rolling issue when notable. `auto` mode on a clean `main` checkout resolves to
-# long-range history-trend detection. The double analyze run (markdown + json) collapses
-# to one pass once per-format toggles land (folo-rs/folo#285).
+# long-range history-trend detection. A single analyze pass emits both the Markdown and
+# JSON reports via the per-format output toggles (`--no-text --markdown --json`).
 [group('automation')]
 [script]
 gh-analyze-bench-history:
@@ -28,13 +28,14 @@ gh-analyze-bench-history:
     $PSNativeCommandUseErrorActionPreference = $true
 
     $reportPath = Join-Path (Get-Location) "bench-history-report.md"
+    $jsonPath = Join-Path (Get-Location) "bench-history-report.json"
     $notablePath = Join-Path (Get-Location) "bench-history-notable.txt"
     $common = @('--engine', 'all', '--target-triple', 'all', '--machine-key', 'all')
 
-    Write-Verbose "Rendering Markdown regression report to $reportPath." -Verbose
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --format markdown | Set-Content -Path $reportPath -Encoding utf8
+    Write-Verbose "Analyzing benchmark history in a single pass; writing Markdown to $reportPath and JSON to $jsonPath." -Verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --no-text --markdown $reportPath --json $jsonPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
-    $json = cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --format json | ConvertFrom-Json
+    $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
     $notable = if ($json.notable) { 'true' } else { 'false' }
     Set-Content -Path $notablePath -Value $notable -Encoding utf8
     Write-Verbose "Analysis complete: notable=$notable (report at $reportPath)." -Verbose

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -27,6 +27,12 @@ use crate::scenario::{BRANCH_FEATURE, BRANCH_MAIN};
 /// history-mode analysis (whose default look-back is only six months).
 const FULL_HISTORY_SINCE: &str = "2000-01-01";
 
+/// Where each analysis writes its JSON report inside the seeded workspace. The
+/// harness reads the structured counts back from this file (text output is
+/// suppressed); a relative path resolves against the workspace directory, and
+/// each attempt overwrites the previous one in place.
+const ANALYZE_REPORT_FILE: &str = "stress-analyze-report.json";
+
 /// The timed result of analyzing one mode.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct MeasureResult {
@@ -99,6 +105,14 @@ pub(crate) async fn measure(
     // saturates the cores it asked for. A fresh in-process session per attempt
     // (no stdout table, no JSON file) holds exactly that attempt's one span; the
     // harness renders the result itself and the tests stay free of target files.
+    //
+    // The measured span is the full production `run_with_overrides`, which writes
+    // the JSON report to the workspace as part of producing it. That write stays
+    // inside the span deliberately — it is the production output path being
+    // measured — and is a fixed, sub-percent cost: the lean report is bounded by
+    // the finding count, not the history size. The structured counts are read
+    // back from that file only after the span closes, so the read never distorts
+    // the timing.
     let cores = thread::available_parallelism().map_or(1, NonZero::get);
 
     let mut best: Option<(Duration, Duration)> = None;
@@ -115,9 +129,11 @@ pub(crate) async fn measure(
         drop(span);
         let elapsed = started.elapsed();
         let attempt_cpu = recorded_cpu(&session);
-        let RunOutcome::Analyzed { report, .. } = outcome else {
+        if !matches!(outcome, RunOutcome::Analyzed { .. }) {
             return Err(fail("analyze did not return an Analyzed outcome"));
-        };
+        }
+        let report = std::fs::read_to_string(workspace.join(ANALYZE_REPORT_FILE))
+            .map_err(|error| fail(format!("failed to read the analyze report: {error}")))?;
         let parsed: ReportCounts = serde_json::from_str(&report)
             .map_err(|error| fail(format!("failed to parse the analyze report: {error}")))?;
 
@@ -230,7 +246,9 @@ fn build_options(
         target_triple: vec!["all".to_owned()],
         machine_key: vec!["all".to_owned()],
         prefixes: Vec::new(),
-        format: Some("json".to_owned()),
+        no_text: true,
+        markdown: None,
+        json: Some(PathBuf::from(ANALYZE_REPORT_FILE)),
         mode: Some(mode.keyword().to_owned()),
         include_improvements: true,
         include_inactive: false,

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -65,7 +65,9 @@ arg structs so a group looks identical everywhere it appears (and so analyze/lis
 prune stay in selection lockstep automatically — see those sections):
 
 * **Environment & execution** — `--config`, `--repo`, `--verbose`.
-* **Output** — `--format`.
+* **Output** (reporting commands) — `--no-text` / `--markdown <path>` /
+  `--json <path>`. Text on stdout by default; the file toggles compose and one
+  analysis pass renders every requested format. See `src/output.rs`.
 * **Benchmark scope** (`run`/`backfill`) — `--workspace`, `--package`/`-p`,
   `--exclude` (drops packages from a whole-workspace run; conflicts with
   `--package`), `--bench`.
@@ -456,7 +458,7 @@ requirement — keep them in lockstep). It takes a required **subject** — `run
 `discriminants`, or `blessings` — and a bare `list` is an error that names the
 three. `list runs` and `list blessings` accept the same selection flags
 (`--repo`/`--context`/`--base`/`--engine`/`--target-triple`/`--machine-key`/
-`--no-dirty`/`--since`/`--until`/`--format`/`--config`) but, instead of
+`--no-dirty`/`--since`/`--until`/`--no-text`/`--markdown`/`--json`/`--config`) but, instead of
 analyzing, only *preview* which data set an `analyze` pass would consume: `list
 runs` reports, per discriminant set, the run, series, and per-commit counts of the
 selected runs (each commit's clean/dirty split), ordered oldest-first by git
@@ -482,7 +484,7 @@ with `runs` or `discriminants` rather than silently ignoring it.
 fields, built via `from_analyze`/`from_list`), `parsed_facets`,
 `facet_filtered_candidates` (shared by both the discriminants index and the
 topology query), `select_dataset` (git topology + commit selection + object load),
-and `dirty_base_exception_warning`. `list_with` parses the format and subject, builds a
+and `dirty_base_exception_warning`. `list_with` resolves the output selection and subject, builds a
 `Selection`, then either renders the discriminants index (no repo) or runs
 `select_dataset` → `build_listing` → `render_listing`, returning a
 `RunOutcome::Completed { message }`. `count_noun` (text.rs) appends `s` when the
@@ -492,7 +494,7 @@ count ≠ 1, so list.rs uses a local `series_noun` to avoid "seriess".
 
 **`prune` mirrors `analyze`'s/`list`'s data-set-selection parameters** (the same
 hard lockstep requirement) — it accepts `--repo`/`--context`/`--base`/`--engine`/
-`--target-triple`/`--machine-key`/`--since`/`--until`/`--format`/
+`--target-triple`/`--machine-key`/`--since`/`--until`/`--no-text`/`--markdown`/`--json`/
 `--config`/`--verbose`, plus its own deletion-shaping flags: `--dirty`/`--clean`/
 `--all` (scope, **required** — exactly one kind of run must be named), `--prune-base`
 (base-branch confirmation), `--dry-run`, and `<commit>` subjects (repeatable bare

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -542,7 +542,9 @@ rather than one flat list:
 
 * **Environment and execution** — `--config`, `--repo`, `--verbose`, `--dry-run`
   (on `prune`), and `--help`.
-* **Output** — `--format` (text / json / markdown), on the reporting commands.
+* **Output** — `--no-text` / `--markdown <path>` / `--json <path>`, on the
+  reporting commands (text on stdout by default; the two file toggles add
+  Markdown / JSON files; all rendered from one analysis pass).
 * **Benchmark scope** — `--workspace`, `--package`/`-p`, `--exclude`, `--bench`,
   on the executing commands.
 * **Feature selection** — `--features`, `--all-features`, `--no-default-features`,
@@ -738,7 +740,13 @@ order, runs the finding algorithms (§9), and prints a report.
   (§8.7). Omitting them analyzes every benchmark. There is no `--metric` filter:
   metrics are an internal detail users are not expected to know; scope by benchmark
   prefix instead.
-* `--format text|json|markdown`.
+* **Output toggles** select which renderings a single analysis pass emits. The
+  text report goes to **stdout by default**; `--no-text` suppresses it,
+  `--markdown <path>` also writes the Markdown report to a file, and `--json
+  <path>` also writes the JSON report. The toggles compose — one pass can emit
+  all three — and relative file paths resolve against the workspace directory.
+  Requesting no output at all (`--no-text` with neither file) is an error, since
+  the pass would produce nothing.
 * **Findings never affect the exit code.** The process exits non-zero only when the
   analysis fails to *run* (no repo, storage error, …); a finding is advisory. The
   machine-readable signal lives in the `json` report (§9.6): `mode`, the boolean
@@ -832,7 +840,7 @@ cargo bench-history list <runs|discriminants|blessings> [--all] \
     [--repo PATH] [--context REF] [--base REF] \
     [--engine NAME …] [--target-triple TRIPLE …] [--machine-key KEY …] \
     [--no-dirty] [--since DATE] [--until DATE] \
-    [--format text|json|markdown] [--verbose] [--config PATH]
+    [--no-text] [--markdown PATH] [--json PATH] [--verbose] [--config PATH]
 ```
 
 `list` requires a **subject** — `runs`, `discriminants`, or `blessings`; a bare
@@ -879,7 +887,7 @@ cargo bench-history prune (--clean | --dirty | --all) [<commit> …] \
     [--repo PATH] [--context REF] [--base REF] \
     [--engine NAME …] [--target-triple TRIPLE …] [--machine-key KEY …] \
     [--since DATE] [--until DATE] \
-    [--format text|json|markdown] [--verbose] [--config PATH]
+    [--no-text] [--markdown PATH] [--json PATH] [--verbose] [--config PATH]
 ```
 
 **Deletion scope is required.** The user must say which kinds of run to delete:
@@ -1780,7 +1788,7 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      headings and the command surface is wide enough that an ungrouped flat help
      list is hard to navigate. Flags are organised into functional groups via clap
      `help_heading`s — **Environment and execution** (`--config`/`--repo`/`--verbose`/
-     `--dry-run`), **Output** (`--format`), **Benchmark scope** (`--workspace`/
+     `--dry-run`), **Output** (`--no-text`/`--markdown`/`--json`), **Benchmark scope** (`--workspace`/
      `--package`/`--exclude`/`--bench`), **Feature selection** (`--features`/
      `--all-features`/`--no-default-features`), **Discriminant selection**
      (`--engine`/`--target-triple`/
@@ -1997,3 +2005,24 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      (e.g. the blessing `blessed_at`, which still calls a `short_commit` render helper on the
      full SHA) is a separate, deferred concern — display abbreviation is questionable but not a
      priority, so it is left as-is for now.
+
+38. **Composable per-format output toggles (single pass)** — *Decided:* the reporting
+     commands (`analyze`/`list`/`prune`) replace the single mutually-exclusive
+     `--format text|json|markdown` selector with **composable output toggles** rendered
+     from **one** analysis pass: the text report goes to stdout by default, `--no-text`
+     suppresses it, `--markdown <path>` also writes the Markdown report to a file, and
+     `--json <path>` also writes the JSON report. One invocation can therefore emit every
+     format at once (the automation that wanted both a Markdown report *and* the JSON
+     `notable` flag previously paid for two full analysis passes; it now runs one). The
+     toggles share a flattened `Output` clap group so the three commands stay in selection
+     lockstep, and an `OutputSelection` validates the request up front — `--no-text` with
+     neither file selected is an error (`RunError::Analyze`, "no output selected"), caught
+     before any storage/git work. File writes go through an injected `OutputWriter` IO-port
+     (mirroring the `ConfigWriter` port used by `install`): the real `TokioOutputWriter`
+     rebases relative paths against the workspace directory, creates parent directories, and
+     truncate-overwrites; a `MemoryOutputWriter` fake keeps the orchestrators Miri-drivable
+     in unit tests. The `RunOutcome` text string is unchanged — it is the stdout text, empty
+     when `--no-text`, and `main.rs` skips printing an empty string. *(Breaking change:
+     `--format` is removed entirely; JSON and Markdown reports now go to files rather than
+     stdout. Decision 35 still holds — the three renderings carry the same data — but they
+     are now selected independently rather than one-at-a-time.)*

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -32,11 +32,12 @@ use jiff::Timestamp;
 
 use super::{
     AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
-    facet_filtered_candidates, parse_format, resolve_facets, select_dataset,
+    facet_filtered_candidates, resolve_facets, select_dataset,
 };
 use super::{ReportFormat, RunIndex, Series, SeriesFilter, apply_blessings};
 use crate::model::BlessingRecord;
 use crate::model::DiscriminantSet;
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 
 /// The real `list`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
@@ -68,6 +69,7 @@ pub(crate) async fn execute(
     // The object-load and detection work shares the ambient Tokio worker threads
     // (mirrors `analyze::execute`).
     let spawner = Spawner::new_tokio();
+    let writer = TokioOutputWriter::new(workspace_dir.to_path_buf());
     list_with(
         &git,
         &storage,
@@ -77,6 +79,7 @@ pub(crate) async fn execute(
         &auto,
         now,
         &reporter,
+        &writer,
         &spawner,
     )
     .await
@@ -89,7 +92,7 @@ pub(crate) async fn execute(
     clippy::too_many_arguments,
     reason = "mirrors the analyze selection pipeline, which threads the same injected ports"
 )]
-pub(crate) async fn list_with<G, S>(
+pub(crate) async fn list_with<G, S, W>(
     git: &G,
     storage: &S,
     project_id: &str,
@@ -98,13 +101,19 @@ pub(crate) async fn list_with<G, S>(
     auto: &AutoFacets,
     now: Timestamp,
     reporter: &dyn Reporter,
+    writer: &W,
     spawner: &Spawner,
 ) -> Result<RunOutcome, RunError>
 where
     G: GitHistory,
     S: Storage + Clone + 'static,
+    W: OutputWriter,
 {
-    let format = parse_format(options.format.as_deref())?;
+    let output = OutputSelection::resolve(
+        options.no_text,
+        options.markdown.as_deref(),
+        options.json.as_deref(),
+    )?;
     if options.all && options.subject != ListSubject::Blessings {
         return Err(RunError::Analyze {
             message: "--all applies only to `list blessings`, where it widens the view from \
@@ -131,14 +140,20 @@ where
                 .collect();
             sets.sort();
             sets.dedup();
-            Ok(RunOutcome::Completed {
-                message: render_discriminants(&sets, format),
+            let message = emit(&output, writer, reporter, |format| {
+                render_discriminants(&sets, format)
             })
+            .await?;
+            Ok(RunOutcome::Completed { message })
         }
         ListSubject::Blessings => {
-            let message = list_blessings(
+            let (head_label, entries) = list_blessings(
                 git, storage, project_id, config, options, auto, now, reporter, spawner,
             )
+            .await?;
+            let message = emit(&output, writer, reporter, |format| {
+                render_blessings(project_id, options.all, &head_label, &entries, format)
+            })
             .await?;
             Ok(RunOutcome::Completed { message })
         }
@@ -165,7 +180,10 @@ where
                 .included_dirty_base_exception
                 .then(dirty_base_exception_warning);
 
-            let message = render_listing(&listing, format, hint.as_deref(), warning.as_deref());
+            let message = emit(&output, writer, reporter, |format| {
+                render_listing(&listing, format, hint.as_deref(), warning.as_deref())
+            })
+            .await?;
             Ok(RunOutcome::Completed { message })
         }
     }
@@ -517,12 +535,11 @@ async fn list_blessings<G, S>(
     now: Timestamp,
     reporter: &dyn Reporter,
     spawner: &Spawner,
-) -> Result<String, RunError>
+) -> Result<(String, Vec<BlessingEntry>), RunError>
 where
     G: GitHistory,
     S: Storage + Clone + 'static,
 {
-    let format = parse_format(options.format.as_deref())?;
     let selection = Selection::from_list(options);
 
     let (head_label, mut entries) = if options.all {
@@ -540,13 +557,7 @@ where
             .then_with(|| left.commit.cmp(&right.commit))
     });
 
-    Ok(render_blessings(
-        project_id,
-        options.all,
-        &head_label,
-        &entries,
-        format,
-    ))
+    Ok((head_label, entries))
 }
 
 /// Collects the blessings recorded at the current commit (HEAD) in the
@@ -861,6 +872,9 @@ mod tests {
     use crate::report::RecordingReporter;
     use crate::storage::{MemoryStorage, Storage};
 
+    use crate::output::MemoryOutputWriter;
+    use std::path::PathBuf;
+
     use nonempty::nonempty;
 
     use super::*;
@@ -1142,6 +1156,12 @@ mod tests {
         git
     }
 
+    /// A throwaway in-memory output writer for list tests that assert on the
+    /// returned text message rather than on written files.
+    fn writer() -> MemoryOutputWriter {
+        MemoryOutputWriter::new()
+    }
+
     /// Drives `list_with` and unwraps the rendered message.
     fn list(storage: &MemoryStorage, git: &FakeGitHistory, options: &ListOptions) -> String {
         let outcome = block_on(list_with(
@@ -1153,6 +1173,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -1160,6 +1181,63 @@ mod tests {
             RunOutcome::Completed { message } => message,
             RunOutcome::Analyzed { .. } => panic!("list returns a Completed outcome"),
         }
+    }
+
+    /// Drives `list_with` requesting the JSON report into an in-memory writer and
+    /// returns the JSON text. The text report is suppressed so the JSON file is
+    /// the only rendered output.
+    fn list_json(storage: &MemoryStorage, git: &FakeGitHistory, options: &ListOptions) -> String {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.markdown = None;
+        options.json = Some(PathBuf::from("report.json"));
+        let writer = MemoryOutputWriter::new();
+        block_on(list_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer,
+            &spawner(),
+        ))
+        .unwrap();
+        writer
+            .written(Path::new("report.json"))
+            .expect("the JSON report was written to the requested path")
+    }
+
+    /// Drives `list_with` requesting the Markdown report into an in-memory writer
+    /// and returns the Markdown text.
+    fn list_markdown(
+        storage: &MemoryStorage,
+        git: &FakeGitHistory,
+        options: &ListOptions,
+    ) -> String {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.json = None;
+        options.markdown = Some(PathBuf::from("report.md"));
+        let writer = MemoryOutputWriter::new();
+        block_on(list_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer,
+            &spawner(),
+        ))
+        .unwrap();
+        writer
+            .written(Path::new("report.md"))
+            .expect("the Markdown report was written to the requested path")
     }
 
     #[test]
@@ -1175,11 +1253,7 @@ mod tests {
         }
         let git = linear_git();
 
-        let opts = ListOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
 
         assert_eq!(parsed["totals"]["runs"], 3);
@@ -1225,11 +1299,7 @@ mod tests {
         store(&storage, &clean_key("c0"), &two_metric_set(0, "c0"));
         let git = linear_git();
 
-        let opts = ListOptions {
-            format: Some("markdown".to_owned()),
-            ..options()
-        };
-        let report = list(&storage, &git, &opts);
+        let report = list_markdown(&storage, &git, &options());
         assert!(report.contains("# Data set for folo"), "{report}");
         assert!(
             report.contains("| Commit | Runs | Clean | Dirty |"),
@@ -1252,6 +1322,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -1272,10 +1343,9 @@ mod tests {
 
         let opts = ListOptions {
             engine: vec!["callgrind".to_owned()],
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["totals"]["discriminant_sets"], 1, "{report}");
         assert_eq!(parsed["sets"][0]["engine"], "callgrind");
@@ -1309,10 +1379,9 @@ mod tests {
         // so a user can discover triples and machine keys they do not already know.
         let opts = ListOptions {
             subject: ListSubject::Discriminants,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let sets = parsed.as_array().unwrap();
         assert_eq!(
@@ -1333,10 +1402,9 @@ mod tests {
         let opts = ListOptions {
             subject: ListSubject::Discriminants,
             engine: vec!["criterion".to_owned()],
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let sets = parsed.as_array().unwrap();
         assert_eq!(
@@ -1365,6 +1433,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -1401,10 +1470,9 @@ mod tests {
         let git = FakeGitHistory::new();
         let opts = ListOptions {
             subject: ListSubject::Discriminants,
-            format: Some("markdown".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_markdown(&storage, &git, &opts);
         assert!(report.contains("# Discriminant sets"), "{report}");
         assert!(
             report.contains("| Engine | Target triple | Machine key |"),
@@ -1422,10 +1490,9 @@ mod tests {
         let git = FakeGitHistory::new();
         let opts = ListOptions {
             subject: ListSubject::Discriminants,
-            format: Some("markdown".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_markdown(&storage, &git, &opts);
         assert!(report.contains("# Discriminant sets"), "{report}");
         assert!(report.contains("No discriminant sets found."), "{report}");
         // The empty markdown body has no table.
@@ -1448,11 +1515,7 @@ mod tests {
     fn list_runs_markdown_empty_selection_reports_no_match() {
         let storage = MemoryStorage::new();
         let git = linear_git();
-        let opts = ListOptions {
-            format: Some("markdown".to_owned()),
-            ..options()
-        };
-        let report = list(&storage, &git, &opts);
+        let report = list_markdown(&storage, &git, &options());
         assert!(report.contains("# Data set for folo"), "{report}");
         assert!(
             report.contains("No stored run matches the selection."),
@@ -1488,10 +1551,9 @@ mod tests {
 
         let opts = ListOptions {
             subject: ListSubject::Blessings,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["scope"], "head");
         assert_eq!(parsed["commit"], "c3");
@@ -1535,10 +1597,9 @@ mod tests {
 
         let opts = ListOptions {
             subject: ListSubject::Blessings,
-            format: Some("markdown".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_markdown(&storage, &git, &opts);
         assert!(report.contains("nm/nm::observe"), "{report}");
         assert!(
             report.contains('|'),
@@ -1554,10 +1615,9 @@ mod tests {
 
         let opts = ListOptions {
             subject: ListSubject::Blessings,
-            format: Some("markdown".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_markdown(&storage, &git, &opts);
         assert!(
             report.contains("No blessings recorded at this commit."),
             "{report}"
@@ -1568,7 +1628,6 @@ mod tests {
     fn list_blessings_error(storage: &MemoryStorage, git: &FakeGitHistory) -> RunError {
         let opts = ListOptions {
             subject: ListSubject::Blessings,
-            format: Some("json".to_owned()),
             ..options()
         };
         block_on(list_with(
@@ -1580,6 +1639,7 @@ mod tests {
             &auto(),
             Timestamp::from_second(0).unwrap(),
             &RecordingReporter::new(),
+            &writer(),
             &spawner(),
         ))
         .unwrap_err()
@@ -1649,10 +1709,9 @@ mod tests {
         let opts = ListOptions {
             subject: ListSubject::Blessings,
             all: true,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["scope"], "window");
         // No HEAD anchor in the window view.
@@ -1690,10 +1749,9 @@ mod tests {
         let opts = ListOptions {
             subject: ListSubject::Blessings,
             all: true,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let blessings = parsed["blessings"].as_array().unwrap();
         assert_eq!(blessings.len(), 1, "{report}");
@@ -1719,7 +1777,6 @@ mod tests {
         let opts = ListOptions {
             subject: ListSubject::Blessings,
             all: true,
-            format: Some("text".to_owned()),
             ..options()
         };
         let report = list(&storage, &git, &opts);
@@ -1754,10 +1811,9 @@ mod tests {
         let opts = ListOptions {
             subject: ListSubject::Blessings,
             all: true,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let report = list(&storage, &git, &opts);
+        let report = list_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let blessings = parsed["blessings"].as_array().unwrap();
         assert_eq!(blessings.len(), 2, "{report}");

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -1363,6 +1363,38 @@ mod tests {
     }
 
     #[test]
+    fn list_rejects_when_no_output_is_selected() {
+        // Suppressing the text report without requesting a Markdown or JSON file
+        // leaves nothing to produce, so the selection is rejected up front —
+        // before any data is loaded or the subject is dispatched.
+        let storage = MemoryStorage::new();
+        let git = linear_git();
+        let opts = ListOptions {
+            no_text: true,
+            ..options()
+        };
+        let error = block_on(list_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &opts,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap_err();
+        match error {
+            RunError::Analyze { message } => {
+                assert!(message.contains("no output selected"), "{message}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn list_discriminants_shows_all_sets_by_default_and_facets_narrow() {
         // The discriminants index never requires a repository.
         let storage = MemoryStorage::new();

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -41,6 +41,7 @@ use crate::git_history::{GitHistory, SystemGitHistory};
 use crate::machine::resolve_machine_key;
 use crate::model::BlessingRecord;
 use crate::model::{BenchmarkIdPrefix, DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment};
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 use crate::probe::{EnvironmentProbe, SystemProbe};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, build_storage};
@@ -92,6 +93,9 @@ pub(crate) async fn execute(
     // the analysis shares the ambient Tokio worker threads rather than spawning its
     // own short-lived ones.
     let spawner = Spawner::new_tokio();
+    // Relative `--markdown`/`--json` paths resolve against the workspace directory
+    // (the working directory in production), the same base as `--config`.
+    let writer = TokioOutputWriter::new(workspace_dir.to_path_buf());
     analyze_with(
         &git,
         &storage,
@@ -102,6 +106,7 @@ pub(crate) async fn execute(
         now,
         &reporter,
         color,
+        &writer,
         &spawner,
     )
     .await
@@ -140,7 +145,7 @@ async fn detect_auto_facets() -> Result<AutoFacets, RunError> {
     clippy::too_many_arguments,
     reason = "analyze orchestration wires several injected ports plus the rendering color flag"
 )]
-pub(crate) async fn analyze_with<G, S>(
+pub(crate) async fn analyze_with<G, S, W>(
     git: &G,
     storage: &S,
     project_id: &str,
@@ -150,13 +155,19 @@ pub(crate) async fn analyze_with<G, S>(
     now: Timestamp,
     reporter: &dyn Reporter,
     color: bool,
+    writer: &W,
     spawner: &Spawner,
 ) -> Result<RunOutcome, RunError>
 where
     G: GitHistory,
     S: Storage + Clone + 'static,
+    W: OutputWriter,
 {
-    let format = parse_format(options.format.as_deref())?;
+    let output = OutputSelection::resolve(
+        options.no_text,
+        options.markdown.as_deref(),
+        options.json.as_deref(),
+    )?;
     let selection = Selection::from_analyze(options)?;
     let filter = SeriesFilter {
         prefixes: &options.prefixes,
@@ -248,7 +259,10 @@ where
         warning: warning.as_deref(),
     };
     let render_started = Instant::now();
-    let report = render(&input, format, color);
+    let report = emit(&output, writer, reporter, |format| {
+        render(&input, format, color)
+    })
+    .await?;
     reporter.timing("report render", render_started.elapsed());
 
     Ok(RunOutcome::Analyzed {
@@ -1469,16 +1483,6 @@ async fn resolve_base_name<G: GitHistory>(
     git.default_branch().await.map_err(RunError::Io)
 }
 
-/// Parses the `--format` option, defaulting to text.
-fn parse_format(name: Option<&str>) -> Result<ReportFormat, RunError> {
-    match name {
-        None => Ok(ReportFormat::Text),
-        Some(name) => ReportFormat::from_name(name).ok_or_else(|| RunError::Analyze {
-            message: format!("unknown report format {name:?}; expected text, json, or markdown"),
-        }),
-    }
-}
-
 /// A human-readable summary of the active facet filters, for `--verbose` notes.
 fn describe_facets(facets: &DiscriminantSetQuery) -> String {
     let parts = [
@@ -1697,8 +1701,11 @@ mod tests {
     use crate::git_history::FakeGitHistory;
     use crate::model::{BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, Metric, MetricKind};
     use crate::model::{EnvironmentInfo, GitInfo, Run, RunContext, ToolchainInfo};
+    use crate::output::MemoryOutputWriter;
     use crate::report::RecordingReporter;
     use crate::storage::{MemoryStorage, Storage};
+
+    use std::path::{Path, PathBuf};
 
     use nonempty::nonempty;
 
@@ -1909,6 +1916,53 @@ mod tests {
         cargo_bench_history_core::testing::synchronous_spawner()
     }
 
+    /// A throwaway in-memory output writer for tests that assert on the returned
+    /// text report (or on the verbose trail) rather than on written files.
+    fn writer() -> MemoryOutputWriter {
+        MemoryOutputWriter::new()
+    }
+
+    /// Runs `analyze_with` requesting the JSON report into an in-memory writer,
+    /// returning the JSON text, the regression count, and the recording reporter so
+    /// a test can assert on the machine-readable report and the verbose trail
+    /// together. The text report is suppressed, so the JSON is the only rendered
+    /// output.
+    fn analyze_json(
+        git: &FakeGitHistory,
+        storage: &MemoryStorage,
+        project: &str,
+        options: &AnalyzeOptions,
+    ) -> (String, usize, RecordingReporter) {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.markdown = None;
+        options.json = Some(PathBuf::from("report.json"));
+        let reporter = RecordingReporter::new();
+        let writer = MemoryOutputWriter::new();
+        let outcome = block_on(analyze_with(
+            git,
+            storage,
+            project,
+            &config(),
+            &options,
+            &auto(),
+            now_anchor(),
+            &reporter,
+            false,
+            &writer,
+            &spawner(),
+        ))
+        .unwrap();
+        let regressions = match outcome {
+            RunOutcome::Analyzed { regressions, .. } => regressions,
+            RunOutcome::Completed { .. } => 0,
+        };
+        let report = writer
+            .written(Path::new("report.json"))
+            .expect("the JSON report was written to the requested path");
+        (report, regressions, reporter)
+    }
+
     #[test]
     fn auto_mode_uses_tip_topology_and_recorded_dirty_runs_not_repo_state() {
         // A base branch whose tip is its own merge-base with no dirty run recorded
@@ -2090,6 +2144,7 @@ mod tests {
             now_anchor(),
             &reporter,
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -2168,6 +2223,7 @@ mod tests {
         options: &AnalyzeOptions,
     ) -> (String, usize) {
         let reporter = RecordingReporter::new();
+        let writer = writer();
         let outcome = block_on(analyze_with(
             git,
             storage,
@@ -2178,6 +2234,7 @@ mod tests {
             now_anchor(),
             &reporter,
             false,
+            &writer,
             &spawner(),
         ))
         .unwrap();
@@ -2206,6 +2263,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -2241,17 +2299,14 @@ mod tests {
     fn json_notable_flag_reflects_whether_findings_survived() {
         // The `notable` signal appears only in the JSON report (the text report
         // keys off the finding list directly), so assert it there.
-        let mut json = options();
-        json.format = Some("json".to_owned());
-
         let storage = MemoryStorage::new();
         seed_linear_step(&storage);
-        let (report, regressions) = analyze(&linear6_git(), &storage, "folo", &json);
+        let (report, regressions, _) = analyze_json(&linear6_git(), &storage, "folo", &options());
         assert_eq!(regressions, 1);
         assert!(report.contains("\"notable\": true"), "{report}");
 
         let empty = MemoryStorage::new();
-        let (report, _) = analyze(&linear_git(), &empty, "folo", &json);
+        let (report, _, _) = analyze_json(&linear_git(), &empty, "folo", &options());
         assert!(report.contains("\"notable\": false"), "{report}");
     }
 
@@ -2282,6 +2337,7 @@ mod tests {
             now_anchor(),
             &reporter,
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -2305,6 +2361,7 @@ mod tests {
             now_anchor(),
             &reporter,
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -2343,6 +2400,7 @@ mod tests {
             now_anchor(),
             &reporter,
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -2384,6 +2442,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err()
@@ -2452,6 +2511,7 @@ mod tests {
             now_anchor(),
             &reporter,
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -2490,9 +2550,7 @@ mod tests {
         }
 
         let git = linear_git();
-        let mut options = options();
-        options.format = Some("json".to_owned());
-        let (report, _) = analyze(&git, &storage, "folo", &options);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let sets = parsed["sets"].as_array().unwrap();
@@ -2556,11 +2614,7 @@ mod tests {
         store(&storage, &dirty_key("c3", 500), &ir_set(500, "c3", 999.0));
         let git = linear_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, regressions) = analyze(&git, &storage, "folo", &opts);
+        let (report, regressions, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "the dirty tip run is excluded");
         assert_eq!(regressions, 0);
@@ -2579,11 +2633,7 @@ mod tests {
         store(&storage, &dirty_key("f2", 3), &ir_set(3, "f2", 130.0));
         let git = feature_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, regressions) = analyze(&git, &storage, "folo", &opts);
+        let (report, regressions, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 4, "the dirty f2 snapshot is admitted");
         assert_eq!(regressions, 1, "the admitted dirty f2 completes the step");
@@ -2600,10 +2650,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             no_dirty: true,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "--no-dirty drops the dirty snapshot");
     }
@@ -2619,11 +2668,7 @@ mod tests {
         store(&storage, &clean_key("f1"), &ir_set(2, "f1", 100.0));
         let git = feature_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "the base-side dirty c1 run is excluded");
     }
@@ -2639,27 +2684,7 @@ mod tests {
         store(&storage, &dirty_key("c3", 200), &ir_set(200, "c3", 130.0));
         let git = linear_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let reporter = RecordingReporter::new();
-        let outcome = block_on(analyze_with(
-            &git,
-            &storage,
-            "folo",
-            &config(),
-            &opts,
-            &auto(),
-            now_anchor(),
-            &reporter,
-            false,
-            &spawner(),
-        ))
-        .unwrap();
-        let RunOutcome::Analyzed { report, .. } = outcome else {
-            panic!("expected an analysis outcome");
-        };
+        let (report, _, reporter) = analyze_json(&git, &storage, "folo", &options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(
@@ -2704,32 +2729,7 @@ mod tests {
         let mut git = linear_git();
         git.mark_dirty();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let reporter = RecordingReporter::new();
-        let outcome = block_on(analyze_with(
-            &git,
-            &storage,
-            "folo",
-            &config(),
-            &opts,
-            &auto(),
-            now_anchor(),
-            &reporter,
-            false,
-            &spawner(),
-        ))
-        .unwrap();
-        let RunOutcome::Analyzed {
-            report,
-            regressions,
-            ..
-        } = outcome
-        else {
-            panic!("expected an analysis outcome");
-        };
+        let (report, regressions, reporter) = analyze_json(&git, &storage, "folo", &options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 5, "both dirty tip snapshots are admitted");
@@ -2763,11 +2763,7 @@ mod tests {
         store(&storage, &dirty_key("c3", 300), &ir_set(300, "c3", 999.0));
         let git = linear_git(); // Clean working tree (the default).
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "the dirty tip run stays excluded");
         assert!(
@@ -2789,32 +2785,7 @@ mod tests {
         let mut git = linear6_git();
         git.mark_dirty();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let reporter = RecordingReporter::new();
-        let outcome = block_on(analyze_with(
-            &git,
-            &storage,
-            "folo",
-            &config(),
-            &opts,
-            &auto(),
-            now_anchor(),
-            &reporter,
-            false,
-            &spawner(),
-        ))
-        .unwrap();
-        let RunOutcome::Analyzed {
-            report,
-            regressions,
-            ..
-        } = outcome
-        else {
-            panic!("expected an analysis outcome");
-        };
+        let (report, regressions, reporter) = analyze_json(&git, &storage, "folo", &options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(
@@ -2857,10 +2828,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             no_dirty: true,
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "--no-dirty drops the dirty tip snapshot");
         assert!(parsed["warning"].is_null(), "no warning under --no-dirty");
@@ -2886,27 +2856,7 @@ mod tests {
         let mut git = linear_git();
         git.mark_dirty();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let reporter = RecordingReporter::new();
-        let outcome = block_on(analyze_with(
-            &git,
-            &storage,
-            "folo",
-            &config(),
-            &opts,
-            &auto(),
-            now_anchor(),
-            &reporter,
-            false,
-            &spawner(),
-        ))
-        .unwrap();
-        let RunOutcome::Analyzed { report, .. } = outcome else {
-            panic!("expected an analysis outcome");
-        };
+        let (report, _, reporter) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(
             parsed["runs"], 5,
@@ -2935,11 +2885,7 @@ mod tests {
         store(&storage, &clean_key("f1"), &ir_set(4, "f1", 100.0));
         let git = feature_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "c2 and c3 are off the feature mainline");
     }
@@ -2965,10 +2911,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             context: Some("master".to_owned()),
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, regressions) = analyze(&git, &storage, "folo", &opts);
+        let (report, regressions, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 6, "master's six commits");
         assert_eq!(regressions, 1);
@@ -2988,11 +2933,7 @@ mod tests {
         store(&storage, &dirty_key("f2", 5), &ir_set(5, "f2", 130.0));
         let git = feature_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (_, regressions) = analyze(&git, &storage, "folo", &opts);
+        let (_, regressions, _) = analyze_json(&git, &storage, "folo", &options());
         assert_eq!(regressions, 1, "the dirty f2 values are the latest points");
     }
 
@@ -3011,10 +2952,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             target_triple: vec!["x86_64-pc-windows-msvc".to_owned()],
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 1, "only the windows set is loaded");
         assert_eq!(parsed["sets"].as_array().unwrap().len(), 1, "{report}");
@@ -3038,10 +2978,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             target_triple: vec!["x86_64-unknown-linux-gnu".to_owned()],
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 1, "only the linux-gnu triple is loaded");
         assert_eq!(parsed["sets"].as_array().unwrap().len(), 1, "{report}");
@@ -3062,11 +3001,7 @@ mod tests {
         );
         let git = linear_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["sets"].as_array().unwrap().len(), 2, "{report}");
     }
@@ -3086,10 +3021,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             engine: vec!["callgrind".to_owned()],
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 1, "only the callgrind object is loaded");
     }
@@ -3111,10 +3045,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             since: Some("1970-01-01T00:00:02Z".to_owned()),
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 2, "only c2 and c3 are within the window");
     }
@@ -3136,10 +3069,9 @@ mod tests {
 
         let opts = AnalyzeOptions {
             until: Some("1970-01-01T00:00:01Z".to_owned()),
-            format: Some("json".to_owned()),
             ..options()
         };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 2, "only c0 and c1 are within the window");
     }
@@ -3161,11 +3093,7 @@ mod tests {
             .commit("c5", Some("c4"))
             .branch("master", "c5")
             .head("master"); // No `.mark_default(...)`.
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(
             parsed["runs"], 6,
@@ -3219,6 +3147,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap();
@@ -3231,11 +3160,7 @@ mod tests {
         store(&storage, &clean_key("c0"), &ir_set(0, "c0", 10.0));
         let git = linear_git();
 
-        let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
-            ..options()
-        };
-        let (report, _) = analyze(&git, &storage, "folo", &opts);
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["project"], "folo");
         assert_eq!(parsed["runs"], 1);
@@ -3269,6 +3194,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -3291,6 +3217,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -3298,11 +3225,13 @@ mod tests {
     }
 
     #[test]
-    fn unknown_format_is_rejected() {
+    fn no_output_selected_is_rejected() {
+        // Suppressing the text report without requesting any file output leaves
+        // nothing to produce, which is a usage error rather than a silent no-op.
         let storage = MemoryStorage::new();
         let git = linear_git();
         let opts = AnalyzeOptions {
-            format: Some("yaml".to_owned()),
+            no_text: true,
             ..options()
         };
         let error = block_on(analyze_with(
@@ -3315,10 +3244,12 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
         assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
+        assert!(error.to_string().contains("no output selected"), "{error}");
     }
 
     #[test]
@@ -3339,6 +3270,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -3364,6 +3296,7 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer(),
             &spawner(),
         ))
         .unwrap_err();
@@ -3392,10 +3325,12 @@ mod tests {
         let config = parse_config("[project]\ndefault_branch = \"master\"\n").unwrap();
 
         let opts = AnalyzeOptions {
-            format: Some("json".to_owned()),
+            no_text: true,
+            json: Some(PathBuf::from("report.json")),
             ..options()
         };
-        let outcome = block_on(analyze_with(
+        let writer = writer();
+        block_on(analyze_with(
             &git,
             &storage,
             "folo",
@@ -3405,12 +3340,13 @@ mod tests {
             now_anchor(),
             &RecordingReporter::new(),
             false,
+            &writer,
             &spawner(),
         ))
         .unwrap();
-        let RunOutcome::Analyzed { report, .. } = outcome else {
-            panic!("expected an analyzed outcome");
-        };
+        let report = writer
+            .written(Path::new("report.json"))
+            .expect("the JSON report was written");
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         // c1's dirty run is base-side (excluded); c0, c1 clean and f1 clean load.
         assert_eq!(

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -36,10 +36,11 @@ use crate::{PruneOptions, RunError, RunOutcome};
 use super::ReportFormat;
 use super::{
     AutoFacets, DirtyTipPolicy, ResolvedHistory, Selection, WindowEdge, detect_auto_facets,
-    facet_filtered_candidates, parse_format, parse_since, parse_until, resolve_base_name,
-    resolve_facets, resolve_history, window_excludes,
+    facet_filtered_candidates, parse_since, parse_until, resolve_base_name, resolve_facets,
+    resolve_history, window_excludes,
 };
 use crate::model::DiscriminantSet;
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 
 /// Which objects a prune pass deletes.
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -102,6 +103,7 @@ pub(crate) async fn execute(
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
     let auto = detect_auto_facets().await?;
 
+    let writer = TokioOutputWriter::new(workspace_dir.to_path_buf());
     prune_with(
         &git,
         &storage,
@@ -110,6 +112,7 @@ pub(crate) async fn execute(
         options,
         &auto,
         &reporter,
+        &writer,
     )
     .await
 }
@@ -117,7 +120,11 @@ pub(crate) async fn execute(
 /// Storage- and git-generic `prune`: resolve the selected commit topology, choose
 /// the objects to delete per the scope and filters, then either preview them
 /// (`--dry-run`) or delete them.
-pub(crate) async fn prune_with<G, S>(
+#[expect(
+    clippy::too_many_arguments,
+    reason = "prune orchestration wires several injected ports alongside its options and facets"
+)]
+pub(crate) async fn prune_with<G, S, W>(
     git: &G,
     storage: &S,
     project_id: &str,
@@ -125,12 +132,18 @@ pub(crate) async fn prune_with<G, S>(
     options: &PruneOptions,
     auto: &AutoFacets,
     reporter: &dyn Reporter,
+    writer: &W,
 ) -> Result<RunOutcome, RunError>
 where
     G: GitHistory,
     S: Storage,
+    W: OutputWriter,
 {
-    let format = parse_format(options.format.as_deref())?;
+    let output = OutputSelection::resolve(
+        options.no_text,
+        options.markdown.as_deref(),
+        options.json.as_deref(),
+    )?;
     let since = parse_since(options.since.as_deref())?;
     let until = parse_until(options.until.as_deref())?;
     let scope = Scope::from_options(options)?;
@@ -321,7 +334,10 @@ where
         }
     }
 
-    let message = render_plan(&plan, format, options.dry_run);
+    let message = emit(&output, writer, reporter, |format| {
+        render_plan(&plan, format, options.dry_run)
+    })
+    .await?;
     Ok(RunOutcome::Completed { message })
 }
 
@@ -665,6 +681,9 @@ mod tests {
     use crate::report::RecordingReporter;
     use crate::storage::{MemoryStorage, Storage};
 
+    use crate::output::MemoryOutputWriter;
+    use std::path::PathBuf;
+
     use nonempty::nonempty;
 
     use super::*;
@@ -807,6 +826,12 @@ mod tests {
         git
     }
 
+    /// A throwaway in-memory output writer for prune tests that assert on the
+    /// returned text message rather than on written files.
+    fn writer() -> MemoryOutputWriter {
+        MemoryOutputWriter::new()
+    }
+
     /// Drives `prune_with` and unwraps the rendered message.
     fn prune(storage: &MemoryStorage, git: &FakeGitHistory, options: &PruneOptions) -> String {
         let outcome = block_on(prune_with(
@@ -817,12 +842,66 @@ mod tests {
             options,
             &auto(),
             &RecordingReporter::new(),
+            &writer(),
         ))
         .unwrap();
         match outcome {
             RunOutcome::Completed { message } => message,
             RunOutcome::Analyzed { .. } => panic!("prune returns a Completed outcome"),
         }
+    }
+
+    /// Drives `prune_with` requesting the JSON report into an in-memory writer and
+    /// returns the JSON text. The text report is suppressed so the JSON file is
+    /// the only rendered output.
+    fn prune_json(storage: &MemoryStorage, git: &FakeGitHistory, options: &PruneOptions) -> String {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.markdown = None;
+        options.json = Some(PathBuf::from("report.json"));
+        let writer = MemoryOutputWriter::new();
+        block_on(prune_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            &RecordingReporter::new(),
+            &writer,
+        ))
+        .unwrap();
+        writer
+            .written(Path::new("report.json"))
+            .expect("the JSON report was written to the requested path")
+    }
+
+    /// Drives `prune_with` requesting the Markdown report into an in-memory writer
+    /// and returns the Markdown text.
+    fn prune_markdown(
+        storage: &MemoryStorage,
+        git: &FakeGitHistory,
+        options: &PruneOptions,
+    ) -> String {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.json = None;
+        options.markdown = Some(PathBuf::from("report.md"));
+        let writer = MemoryOutputWriter::new();
+        block_on(prune_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            &RecordingReporter::new(),
+            &writer,
+        ))
+        .unwrap();
+        writer
+            .written(Path::new("report.md"))
+            .expect("the Markdown report was written to the requested path")
     }
 
     #[test]
@@ -839,6 +918,7 @@ mod tests {
             &dirty_options(),
             &auto(),
             &reporter,
+            &writer(),
         ))
         .unwrap();
         assert!(
@@ -863,11 +943,7 @@ mod tests {
         store(&storage, &dirty_key("f2", 300), &set("f2"));
         let git = feature_git();
 
-        let opts = PruneOptions {
-            format: Some("json".to_owned()),
-            ..dirty_options()
-        };
-        let report = prune(&storage, &git, &opts);
+        let report = prune_json(&storage, &git, &dirty_options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(
             parsed["totals"]["runs"], 2,
@@ -933,10 +1009,9 @@ mod tests {
             clean: true,
             dirty: true,
             commit: vec!["f1".to_owned()],
-            format: Some("json".to_owned()),
             ..PruneOptions::default()
         };
-        let report = prune(&storage, &git, &opts);
+        let report = prune_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["totals"]["runs"], 2, "clean + dirty: {report}");
         assert_eq!(parsed["totals"]["blessings"], 1, "{report}");
@@ -1022,6 +1097,7 @@ mod tests {
             &PruneOptions::default(),
             &auto(),
             &RecordingReporter::new(),
+            &writer(),
         ))
         .unwrap_err();
         match error {
@@ -1084,6 +1160,7 @@ mod tests {
             &opts,
             &auto(),
             &RecordingReporter::new(),
+            &writer(),
         ))
         .unwrap_err();
         match error {
@@ -1130,10 +1207,9 @@ mod tests {
         let before = keys(&storage);
         let opts = PruneOptions {
             dry_run: true,
-            format: Some("json".to_owned()),
             ..dirty_options()
         };
-        let report = prune(&storage, &git, &opts);
+        let report = prune_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["dry_run"], true);
         assert_eq!(parsed["totals"]["runs"], 1, "{report}");
@@ -1187,6 +1263,7 @@ mod tests {
             &dirty_options(),
             &auto(),
             &RecordingReporter::new(),
+            &writer(),
         ))
         .unwrap_err();
         match error {
@@ -1320,10 +1397,9 @@ mod tests {
 
         let opts = PruneOptions {
             dry_run: true,
-            format: Some("json".to_owned()),
             ..dirty_options()
         };
-        let report = prune(&storage, &git, &opts);
+        let report = prune_json(&storage, &git, &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let commits = parsed["sets"][0]["commits"].as_array().unwrap();
         assert_eq!(commits[0]["commit"], "f1", "oldest first: {report}");
@@ -1339,10 +1415,9 @@ mod tests {
 
         let opts = PruneOptions {
             dry_run: true,
-            format: Some("markdown".to_owned()),
             ..dirty_options()
         };
-        let report = prune(&storage, &git, &opts);
+        let report = prune_markdown(&storage, &git, &opts);
         assert!(report.contains("# Prune plan for"), "{report}");
         assert!(report.contains("| Commit | Runs | Blessings |"), "{report}");
         assert!(report.contains("| f1 |"), "{report}");
@@ -1357,11 +1432,7 @@ mod tests {
         }
         let git = feature_git();
 
-        let opts = PruneOptions {
-            format: Some("markdown".to_owned()),
-            ..dirty_options()
-        };
-        let report = prune(&storage, &git, &opts);
+        let report = prune_markdown(&storage, &git, &dirty_options());
         assert!(report.contains("# Prune plan for"), "{report}");
         assert!(report.contains("No run matches the selection."), "{report}");
     }

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -1113,6 +1113,41 @@ mod tests {
     }
 
     #[test]
+    fn prune_rejects_when_no_output_is_selected() {
+        // Suppressing the text report without requesting a Markdown or JSON file
+        // leaves nothing to produce, so the selection is rejected before any
+        // pruning work — even with an otherwise-valid scope.
+        let storage = MemoryStorage::new();
+        store(&storage, &clean_key("f1"), &set("f1"));
+        let git = feature_git();
+
+        let opts = PruneOptions {
+            no_text: true,
+            dirty: true,
+            ..PruneOptions::default()
+        };
+        let error = block_on(prune_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &opts,
+            &auto(),
+            &RecordingReporter::new(),
+            &writer(),
+        ))
+        .unwrap_err();
+        match error {
+            RunError::Analyze { message } => {
+                assert!(message.contains("no output selected"), "{message}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        // Nothing was deleted.
+        assert!(keys(&storage).contains(&clean_key("f1")));
+    }
+
+    #[test]
     fn all_scope_keeps_base_side_history_on_a_feature_branch() {
         let storage = MemoryStorage::new();
         for commit in ["c0", "c1", "f1", "f2"] {

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -234,6 +234,31 @@ struct TimelineArgs {
     until: Option<String>,
 }
 
+/// Per-format report output shared by `analyze`/`list`/`prune`.
+///
+/// The text report prints to standard output by default; `--no-text` suppresses
+/// it, while `--markdown` and `--json` each write that format to a file. A single
+/// analysis pass backs every requested format. At least one output must remain
+/// selected, so `--no-text` requires at least one of `--markdown`/`--json`.
+#[derive(Args, Debug)]
+#[command(next_help_heading = HEADING_OUTPUT)]
+struct OutputArgs {
+    /// Suppress the text report on standard output. Pair with `--markdown` and/or
+    /// `--json` to direct the report to files instead.
+    #[arg(long)]
+    no_text: bool,
+
+    /// Also write the Markdown report to this path (a relative path resolves
+    /// against the working directory).
+    #[arg(long, value_name = "PATH")]
+    markdown: Option<PathBuf>,
+
+    /// Also write the JSON report to this path (a relative path resolves against
+    /// the working directory).
+    #[arg(long, value_name = "PATH")]
+    json: Option<PathBuf>,
+}
+
 /// Run the workspace benchmarks (`cargo bench`) and store the results.
 #[derive(Args, Debug)]
 struct RunCommand {
@@ -347,9 +372,8 @@ struct AnalyzeCommand {
     #[command(flatten)]
     env: EnvArgs,
 
-    /// Output format: text, json, or markdown (default: text).
-    #[arg(long, value_name = "FORMAT", help_heading = HEADING_OUTPUT)]
-    format: Option<String>,
+    #[command(flatten)]
+    output: OutputArgs,
 
     #[command(flatten)]
     facets: QueryFacetArgs,
@@ -399,7 +423,9 @@ impl AnalyzeCommand {
             target_triple: self.facets.target_triple,
             machine_key: self.facets.machine_key,
             prefixes: self.prefixes,
-            format: self.format,
+            no_text: self.output.no_text,
+            markdown: self.output.markdown,
+            json: self.output.json,
             mode: self.mode,
             include_improvements: self.include_improvements,
             include_inactive: self.include_inactive,
@@ -443,9 +469,8 @@ struct ListCommand {
     #[command(flatten)]
     env: EnvArgs,
 
-    /// Output format: text, json, or markdown (default: text).
-    #[arg(long, value_name = "FORMAT", help_heading = HEADING_OUTPUT)]
-    format: Option<String>,
+    #[command(flatten)]
+    output: OutputArgs,
 
     #[command(flatten)]
     facets: QueryFacetArgs,
@@ -479,7 +504,9 @@ impl ListCommand {
             engine: self.facets.engine,
             target_triple: self.facets.target_triple,
             machine_key: self.facets.machine_key,
-            format: self.format,
+            no_text: self.output.no_text,
+            markdown: self.output.markdown,
+            json: self.output.json,
             all: self.all,
             verbose: self.env.verbose,
         }
@@ -516,9 +543,8 @@ struct PruneCommand {
     #[arg(long, help_heading = HEADING_ENV)]
     prune_base: bool,
 
-    /// Output format: text, json, or markdown (default: text).
-    #[arg(long, value_name = "FORMAT", help_heading = HEADING_OUTPUT)]
-    format: Option<String>,
+    #[command(flatten)]
+    output: OutputArgs,
 
     #[command(flatten)]
     facets: QueryFacetArgs,
@@ -586,7 +612,9 @@ impl PruneCommand {
             dirty,
             prune_base: self.prune_base,
             dry_run: self.dry_run,
-            format: self.format,
+            no_text: self.output.no_text,
+            markdown: self.output.markdown,
+            json: self.output.json,
             verbose: self.env.verbose,
         }
     }
@@ -1158,6 +1186,33 @@ mod tests {
     }
 
     #[test]
+    fn analyze_output_defaults_to_text_only() {
+        let Command::Analyze(options) = parse(&["analyze"]) else {
+            panic!("expected analyze command");
+        };
+        assert!(!options.no_text);
+        assert!(options.markdown.is_none());
+        assert!(options.json.is_none());
+    }
+
+    #[test]
+    fn analyze_collects_output_toggles() {
+        let Command::Analyze(options) = parse(&[
+            "analyze",
+            "--no-text",
+            "--markdown",
+            "out/report.md",
+            "--json",
+            "out/report.json",
+        ]) else {
+            panic!("expected analyze command");
+        };
+        assert!(options.no_text);
+        assert_eq!(options.markdown, Some(PathBuf::from("out/report.md")));
+        assert_eq!(options.json, Some(PathBuf::from("out/report.json")));
+    }
+
+    #[test]
     fn analyze_parses_include_inactive_switch() {
         let Command::Analyze(options) = parse(&["analyze", "--include-inactive"]) else {
             panic!("expected analyze command");
@@ -1202,8 +1257,11 @@ mod tests {
             "x86_64-unknown-linux-gnu",
             "--machine-key",
             "ci-pool",
-            "--format",
-            "json",
+            "--no-text",
+            "--markdown",
+            "list.md",
+            "--json",
+            "list.json",
             "--verbose",
         ]);
         let Command::List(options) = command else {
@@ -1220,7 +1278,9 @@ mod tests {
             vec!["x86_64-unknown-linux-gnu".to_owned()]
         );
         assert_eq!(options.machine_key, vec!["ci-pool".to_owned()]);
-        assert_eq!(options.format.as_deref(), Some("json"));
+        assert!(options.no_text);
+        assert_eq!(options.markdown, Some(PathBuf::from("list.md")));
+        assert_eq!(options.json, Some(PathBuf::from("list.json")));
         assert!(options.verbose);
     }
 
@@ -1350,8 +1410,9 @@ mod tests {
             "ci-pool",
             "--dirty",
             "--dry-run",
-            "--format",
-            "json",
+            "--no-text",
+            "--json",
+            "prune.json",
             "--verbose",
         ]);
         let Command::Prune(options) = command else {
@@ -1375,7 +1436,8 @@ mod tests {
         assert!(options.dirty);
         assert!(!options.clean);
         assert!(options.dry_run);
-        assert_eq!(options.format.as_deref(), Some("json"));
+        assert!(options.no_text);
+        assert_eq!(options.json, Some(PathBuf::from("prune.json")));
         assert!(options.verbose);
     }
 

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -130,8 +130,14 @@ pub struct AnalyzeOptions {
     /// Restrict analysis to benchmarks whose qualified identity starts with one of
     /// these prefixes (repeatable). Empty means every benchmark.
     pub prefixes: Vec<BenchmarkIdPrefix>,
-    /// Output format selector, if set.
-    pub format: Option<String>,
+    /// Suppress the default text report on standard output (`--no-text`).
+    pub no_text: bool,
+    /// Write the Markdown report to this path, if set (`--markdown <path>`). A
+    /// relative path resolves against the working directory.
+    pub markdown: Option<PathBuf>,
+    /// Write the JSON report to this path, if set (`--json <path>`). A relative
+    /// path resolves against the working directory.
+    pub json: Option<PathBuf>,
     /// Analysis-mode selector (`auto`, `history`, `branch`, or `tip`), if set.
     /// `auto` (the default) infers history vs branch mode from the git topology.
     pub mode: Option<String>,
@@ -214,8 +220,14 @@ pub struct ListOptions {
     /// auto-detects the current machine's fingerprint; `all` matches every
     /// machine.
     pub machine_key: Vec<String>,
-    /// Output format selector, if set.
-    pub format: Option<String>,
+    /// Suppress the default text report on standard output (`--no-text`).
+    pub no_text: bool,
+    /// Write the Markdown report to this path, if set (`--markdown <path>`). A
+    /// relative path resolves against the working directory.
+    pub markdown: Option<PathBuf>,
+    /// Write the JSON report to this path, if set (`--json <path>`). A relative
+    /// path resolves against the working directory.
+    pub json: Option<PathBuf>,
     /// With `blessings`, list the most recent blessing of every benchmark across
     /// the whole analysis window rather than only those at the current commit.
     pub all: bool,
@@ -274,8 +286,14 @@ pub struct PruneOptions {
     pub prune_base: bool,
     /// Preview what would be removed without deleting anything.
     pub dry_run: bool,
-    /// Output format selector, if set.
-    pub format: Option<String>,
+    /// Suppress the default text report on standard output (`--no-text`).
+    pub no_text: bool,
+    /// Write the Markdown report to this path, if set (`--markdown <path>`). A
+    /// relative path resolves against the working directory.
+    pub markdown: Option<PathBuf>,
+    /// Write the JSON report to this path, if set (`--json <path>`). A relative
+    /// path resolves against the working directory.
+    pub json: Option<PathBuf>,
     /// Emit detailed diagnostic notes to standard error describing each step.
     pub verbose: bool,
 }

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -275,6 +275,7 @@ mod git_history;
 mod host;
 mod machine;
 mod outcome;
+mod output;
 mod probe;
 mod process;
 mod report;

--- a/packages/cargo-bench-history/src/main.rs
+++ b/packages/cargo-bench-history/src/main.rs
@@ -8,7 +8,7 @@
 
 use std::process::ExitCode;
 
-use cargo_bench_history::{Cli, RunOutcome, run};
+use cargo_bench_history::{Cli, run};
 
 // The analyze pipeline fans the per-object gzip-decompress + JSON parse out across
 // worker threads. serde_json makes many small allocations, and the system
@@ -72,9 +72,11 @@ async fn main() -> ExitCode {
         }
     };
 
-    match &outcome {
-        RunOutcome::Completed { message } => println!("{message}"),
-        RunOutcome::Analyzed { report, .. } => println!("{report}"),
+    // `--no-text` suppresses the text report, so `stdout_text` is `None`; emit
+    // nothing in that case rather than a blank line (the requested files carry
+    // the result).
+    if let Some(text) = outcome.stdout_text() {
+        println!("{text}");
     }
 
     if outcome.is_success() {

--- a/packages/cargo-bench-history/src/outcome.rs
+++ b/packages/cargo-bench-history/src/outcome.rs
@@ -44,6 +44,22 @@ impl RunOutcome {
             Self::Completed { .. } | Self::Analyzed { .. } => true,
         }
     }
+
+    /// The text to print to standard output, or `None` when there is nothing to
+    /// print.
+    ///
+    /// `--no-text` suppresses the text report, leaving the message/report empty;
+    /// in that case this returns `None` so the caller emits no output at all
+    /// rather than a blank line (the requested Markdown/JSON files carry the
+    /// result instead).
+    #[must_use]
+    pub fn stdout_text(&self) -> Option<&str> {
+        let text = match self {
+            Self::Completed { message } => message,
+            Self::Analyzed { report, .. } => report,
+        };
+        (!text.is_empty()).then_some(text.as_str())
+    }
 }
 
 /// An error from [`run`](crate::run).
@@ -308,6 +324,46 @@ mod tests {
                 regressions: 0,
             }
             .is_success()
+        );
+    }
+
+    #[test]
+    fn stdout_text_returns_nonempty_message_and_report() {
+        assert_eq!(
+            RunOutcome::Completed {
+                message: "done".to_owned(),
+            }
+            .stdout_text(),
+            Some("done")
+        );
+        assert_eq!(
+            RunOutcome::Analyzed {
+                report: "report body".to_owned(),
+                regressions: 2,
+            }
+            .stdout_text(),
+            Some("report body")
+        );
+    }
+
+    #[test]
+    fn stdout_text_is_suppressed_when_the_report_is_empty() {
+        // `--no-text` leaves the message/report empty; the caller must print
+        // nothing rather than a blank line.
+        assert_eq!(
+            RunOutcome::Completed {
+                message: String::new(),
+            }
+            .stdout_text(),
+            None
+        );
+        assert_eq!(
+            RunOutcome::Analyzed {
+                report: String::new(),
+                regressions: 0,
+            }
+            .stdout_text(),
+            None
         );
     }
 }

--- a/packages/cargo-bench-history/src/output.rs
+++ b/packages/cargo-bench-history/src/output.rs
@@ -1,0 +1,373 @@
+//! The per-format output model shared by the reporting commands (`analyze`,
+//! `list`, `prune`): one analysis pass renders any combination of the text,
+//! Markdown, and JSON reports.
+//!
+//! Text is the default and goes to standard output; `--no-text` suppresses it.
+//! `--markdown <path>` and `--json <path>` each write that format to a file. The
+//! file writes go through the [`OutputWriter`] port (mirroring the [`ConfigWriter`]
+//! used by `install`) so the orchestrators stay storage- and filesystem-agnostic:
+//! production uses [`TokioOutputWriter`], while tests drive an in-memory fake.
+//!
+//! A relative `--markdown`/`--json` path resolves against the working directory
+//! (the same base as `--config`), so the resolution happens at the IO edge inside
+//! [`TokioOutputWriter`].
+//!
+//! [`ConfigWriter`]: crate::config_writer::ConfigWriter
+
+use std::future::Future;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use cargo_bench_history_core::analyze::ReportFormat;
+
+use crate::RunError;
+use crate::report::{Reporter, ReporterExt};
+use crate::wiring::rebase;
+
+/// Which report formats a single analysis pass should emit.
+///
+/// Built once, early in each orchestrator, so the "nothing to emit" case (text
+/// suppressed and no file requested) fails before any expensive work.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OutputSelection<'a> {
+    /// Whether the text report to standard output is suppressed (`--no-text`).
+    no_text: bool,
+    /// Where to write the Markdown report, if requested (`--markdown <path>`).
+    markdown: Option<&'a Path>,
+    /// Where to write the JSON report, if requested (`--json <path>`).
+    json: Option<&'a Path>,
+}
+
+impl<'a> OutputSelection<'a> {
+    /// Resolves and validates the requested outputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunError::Analyze`] when nothing would be emitted — `--no-text`
+    /// suppresses the only default output and neither file format was requested —
+    /// so a run that would produce nothing is rejected up front rather than
+    /// completing silently.
+    pub(crate) fn resolve(
+        no_text: bool,
+        markdown: Option<&'a Path>,
+        json: Option<&'a Path>,
+    ) -> Result<Self, RunError> {
+        if no_text && markdown.is_none() && json.is_none() {
+            return Err(RunError::Analyze {
+                message: "no output selected: --no-text suppresses the text report, so request at \
+                          least one of --markdown <path> or --json <path>"
+                    .to_owned(),
+            });
+        }
+        Ok(Self {
+            no_text,
+            markdown,
+            json,
+        })
+    }
+}
+
+/// Writes a rendered report to a destination path, overwriting any existing file.
+///
+/// This is the filesystem edge of the per-format output model: the pure
+/// orchestrators render strings and hand them here, so the report rendering stays
+/// Miri-safe and an in-memory fake can stand in under test.
+pub(crate) trait OutputWriter {
+    /// Writes `contents` to `path`, creating parent directories as needed and
+    /// replacing any existing file (a re-run refreshes the report in place).
+    fn write(&self, path: &Path, contents: &str) -> impl Future<Output = io::Result<()>>;
+}
+
+/// The production [`OutputWriter`], backed by `tokio::fs`.
+///
+/// A relative destination resolves against `base` (the workspace directory, which
+/// is the working directory in production), so `--markdown report.md` lands beside
+/// the other working-directory-relative paths the tool accepts.
+#[derive(Clone, Debug)]
+pub(crate) struct TokioOutputWriter {
+    /// The directory a relative destination path is resolved against.
+    base: PathBuf,
+}
+
+impl TokioOutputWriter {
+    /// Creates a writer that resolves relative paths against `base`.
+    pub(crate) fn new(base: PathBuf) -> Self {
+        Self { base }
+    }
+}
+
+impl OutputWriter for TokioOutputWriter {
+    async fn write(&self, path: &Path, contents: &str) -> io::Result<()> {
+        let resolved = rebase(&self.base, path.to_path_buf());
+        if let Some(parent) = resolved.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        // `write` truncates an existing file, so re-running analysis refreshes the
+        // report in place rather than appending to or failing on a stale one.
+        tokio::fs::write(&resolved, contents.as_bytes()).await
+    }
+}
+
+/// Emits every requested report format from one rendered pass and returns the text
+/// report destined for standard output (empty when `--no-text` suppressed it).
+///
+/// `render` produces the report for a given format; it is invoked once per
+/// requested format (and once more for the text report unless suppressed), so a
+/// single analysis backs all outputs. Each file write is announced on the verbose
+/// trail with its path and size, so a `--verbose` run records exactly what landed
+/// where.
+///
+/// # Errors
+///
+/// Returns [`RunError::Io`] if writing a requested file fails.
+pub(crate) async fn emit<W, F>(
+    selection: &OutputSelection<'_>,
+    writer: &W,
+    reporter: &dyn Reporter,
+    render: F,
+) -> Result<String, RunError>
+where
+    W: OutputWriter,
+    F: Fn(ReportFormat) -> String,
+{
+    if let Some(path) = selection.markdown {
+        let contents = render(ReportFormat::Markdown);
+        write_report(writer, reporter, path, &contents, "Markdown").await?;
+    }
+    if let Some(path) = selection.json {
+        let contents = render(ReportFormat::Json);
+        write_report(writer, reporter, path, &contents, "JSON").await?;
+    }
+    Ok(if selection.no_text {
+        String::new()
+    } else {
+        render(ReportFormat::Text)
+    })
+}
+
+/// Writes one rendered report to `path` and records the result on the verbose
+/// trail.
+async fn write_report<W: OutputWriter>(
+    writer: &W,
+    reporter: &dyn Reporter,
+    path: &Path,
+    contents: &str,
+    label: &str,
+) -> Result<(), RunError> {
+    writer.write(path, contents).await.map_err(RunError::Io)?;
+    reporter.note_with(|| {
+        format!(
+            "wrote the {label} report to {} ({})",
+            path.display(),
+            crate::text::count_noun(contents.len(), "byte")
+        )
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) use fake::MemoryOutputWriter;
+
+#[cfg(test)]
+mod fake {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    use super::{OutputWriter, io};
+
+    /// An in-memory [`OutputWriter`] that records written files without touching
+    /// the filesystem, so orchestration tests run under Miri. A later write to the
+    /// same path overwrites the recorded contents, mirroring the real writer.
+    #[derive(Debug, Default)]
+    pub(crate) struct MemoryOutputWriter {
+        files: Mutex<HashMap<PathBuf, String>>,
+    }
+
+    impl MemoryOutputWriter {
+        /// An empty writer.
+        pub(crate) fn new() -> Self {
+            Self::default()
+        }
+
+        /// The contents recorded for `path`, if any.
+        pub(crate) fn written(&self, path: &Path) -> Option<String> {
+            self.files.lock().unwrap().get(path).cloned()
+        }
+    }
+
+    impl OutputWriter for MemoryOutputWriter {
+        async fn write(&self, path: &Path, contents: &str) -> io::Result<()> {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_path_buf(), contents.to_owned());
+            Ok(())
+        }
+    }
+
+    /// An [`OutputWriter`] whose every write fails, so the emit error path is
+    /// exercised under Miri without touching the filesystem.
+    #[derive(Debug, Default)]
+    pub(crate) struct FailingOutputWriter;
+
+    impl OutputWriter for FailingOutputWriter {
+        async fn write(&self, _path: &Path, _contents: &str) -> io::Result<()> {
+            Err(io::Error::other("write refused"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use futures::executor::block_on;
+
+    use super::fake::FailingOutputWriter;
+    use super::*;
+    use crate::report::RecordingReporter;
+
+    /// A render stub that names the format it was asked for, so a test can tell
+    /// which format backs each written file and the returned text.
+    fn render_label(format: ReportFormat) -> String {
+        format!("{format:?}")
+    }
+
+    #[test]
+    fn resolve_rejects_a_run_that_would_emit_nothing() {
+        let error = OutputSelection::resolve(true, None, None).unwrap_err();
+        match error {
+            RunError::Analyze { message } => {
+                assert!(message.contains("no output selected"), "{message}");
+            }
+            other => panic!("expected an analyze error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_allows_the_default_text_output() {
+        OutputSelection::resolve(false, None, None).unwrap();
+    }
+
+    #[test]
+    fn resolve_allows_no_text_with_a_requested_file() {
+        let json = PathBuf::from("report.json");
+        OutputSelection::resolve(true, None, Some(&json)).unwrap();
+    }
+
+    #[test]
+    fn emit_returns_the_text_report_by_default() {
+        let selection = OutputSelection::resolve(false, None, None).unwrap();
+        let writer = MemoryOutputWriter::new();
+        let reporter = RecordingReporter::new();
+
+        let text = block_on(emit(&selection, &writer, &reporter, render_label)).unwrap();
+
+        assert_eq!(text, "Text");
+    }
+
+    #[test]
+    fn emit_suppresses_the_text_report_under_no_text() {
+        let json = PathBuf::from("report.json");
+        let selection = OutputSelection::resolve(true, None, Some(&json)).unwrap();
+        let writer = MemoryOutputWriter::new();
+        let reporter = RecordingReporter::new();
+
+        let text = block_on(emit(&selection, &writer, &reporter, render_label)).unwrap();
+
+        assert!(text.is_empty(), "{text:?}");
+        assert_eq!(writer.written(&json).as_deref(), Some("Json"));
+    }
+
+    #[test]
+    fn emit_writes_both_files_from_one_pass_and_still_returns_text() {
+        let markdown = PathBuf::from("report.md");
+        let json = PathBuf::from("report.json");
+        let selection = OutputSelection::resolve(false, Some(&markdown), Some(&json)).unwrap();
+        let writer = MemoryOutputWriter::new();
+        let reporter = RecordingReporter::new();
+
+        let text = block_on(emit(&selection, &writer, &reporter, render_label)).unwrap();
+
+        assert_eq!(text, "Text");
+        assert_eq!(writer.written(&markdown).as_deref(), Some("Markdown"));
+        assert_eq!(writer.written(&json).as_deref(), Some("Json"));
+        // Each written file is announced on the verbose trail.
+        assert!(
+            reporter.contains("wrote the Markdown report"),
+            "{:?}",
+            reporter.notes()
+        );
+        assert!(
+            reporter.contains("wrote the JSON report"),
+            "{:?}",
+            reporter.notes()
+        );
+    }
+
+    #[test]
+    fn emit_maps_a_write_failure_to_an_io_error() {
+        let json = PathBuf::from("report.json");
+        let selection = OutputSelection::resolve(true, None, Some(&json)).unwrap();
+        let writer = FailingOutputWriter;
+        let reporter = RecordingReporter::new();
+
+        let error = block_on(emit(&selection, &writer, &reporter, render_label)).unwrap_err();
+
+        assert!(matches!(error, RunError::Io(_)), "{error:?}");
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod real_writer_tests {
+    use tempfile::tempdir;
+
+    use super::{OutputWriter, TokioOutputWriter};
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // Touches the real filesystem, which Miri cannot access.
+    async fn write_creates_missing_parent_directories() {
+        let dir = tempdir().unwrap();
+        let writer = TokioOutputWriter::new(dir.path().to_path_buf());
+
+        writer
+            .write("nested/report.md".as_ref(), "payload")
+            .await
+            .unwrap();
+
+        let written = std::fs::read_to_string(dir.path().join("nested/report.md")).unwrap();
+        assert_eq!(written, "payload");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // Touches the real filesystem, which Miri cannot access.
+    async fn write_overwrites_an_existing_file() {
+        let dir = tempdir().unwrap();
+        let writer = TokioOutputWriter::new(dir.path().to_path_buf());
+        writer.write("report.json".as_ref(), "stale").await.unwrap();
+
+        writer.write("report.json".as_ref(), "fresh").await.unwrap();
+
+        let written = std::fs::read_to_string(dir.path().join("report.json")).unwrap();
+        assert_eq!(written, "fresh");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // Touches the real filesystem, which Miri cannot access.
+    async fn write_resolves_an_absolute_path_without_rebasing() {
+        let base = tempdir().unwrap();
+        let elsewhere = tempdir().unwrap();
+        let writer = TokioOutputWriter::new(base.path().to_path_buf());
+        let absolute = elsewhere.path().join("report.json");
+
+        writer.write(&absolute, "payload").await.unwrap();
+
+        assert_eq!(std::fs::read_to_string(&absolute).unwrap(), "payload");
+        // The base directory is untouched, confirming the absolute path was not
+        // rebased onto it.
+        assert!(!base.path().join("report.json").exists());
+    }
+}

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -405,6 +405,21 @@ impl AzureWorkspace {
         )
         .await
     }
+
+    /// Drives `analyze` requesting the JSON report into a file and returns its contents.
+    async fn drive_json(&self, args: &[&str]) -> String {
+        static OUTPUT_SEQ: AtomicU64 = AtomicU64::new(0);
+
+        let name = format!(
+            "cbh-azure-report-{}.json",
+            OUTPUT_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut full = args.to_vec();
+        full.extend_from_slice(&["--no-text", "--json", &name]);
+        self.drive(&full).await.unwrap();
+        std::fs::read_to_string(self.dir.path().join(&name))
+            .expect("the JSON report was written to the requested path")
+    }
 }
 
 /// Scenario: a single `run` stores one harvested result set.
@@ -429,24 +444,12 @@ async fn scenario_run_then_analyze(config: &str) {
     workspace.commit("second");
     workspace.drive(&["run"]).await.unwrap();
 
-    let outcome = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap();
-    let RunOutcome::Analyzed {
-        report,
-        regressions,
-        ..
-    } = outcome
-    else {
-        panic!("expected an analyzed outcome, got {outcome:?}");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
 
     // The report parsing proves `analyze` listed and fetched both stored objects.
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["project"], "azureproj");
     // A flat two-point series is not a regression.
-    assert_eq!(regressions, 0);
     assert_eq!(parsed["regressions"], 0);
 }
 
@@ -472,13 +475,7 @@ async fn scenario_feature_and_dirty(config: &str) {
 
     // The feature view admits the dirty snapshot on the target-side commit, so all
     // four stored objects are loaded from the backend.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 4,
@@ -494,21 +491,9 @@ async fn scenario_feature_and_dirty(config: &str) {
     // off the data, not the on-disk tree. `--since 2020-01-01` is a generous lower
     // bound that keeps the freshly-committed runs inside the window history mode
     // would otherwise default to (six months back).
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&[
-            "analyze",
-            "--context",
-            "master",
-            "--since",
-            "2020-01-01",
-            "--format",
-            "json",
-        ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--context", "master", "--since", "2020-01-01"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["mode"], "history",

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -87,40 +87,28 @@ async fn analyze_with_regression_is_always_successful() {
     );
 }
 
-/// `--format json` renders a structured, parseable report.
+/// `--json <path>` writes a structured, parseable report.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_json_format_is_structured() {
+async fn analyze_json_output_is_structured() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.seed_rising_callgrind_history();
 
-    let outcome = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap();
-    let RunOutcome::Analyzed { report, .. } = outcome else {
-        panic!("expected an analyzed outcome, got {outcome:?}");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["project"], "testproj");
     assert_eq!(parsed["regressions"], 1);
     assert_eq!(parsed["findings"][0]["direction"], "regression");
 }
 
-/// `--format markdown` renders per-finding blocks mirroring the text report.
+/// `--markdown <path>` writes per-finding blocks mirroring the text report.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_markdown_format_renders_blocks() {
+async fn analyze_markdown_output_renders_blocks() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.seed_rising_callgrind_history();
 
-    let outcome = workspace
-        .drive(&["analyze", "--format", "markdown"])
-        .await
-        .unwrap();
-    let RunOutcome::Analyzed { report, .. } = outcome else {
-        panic!("expected an analyzed outcome, got {outcome:?}");
-    };
+    let report = workspace.drive_markdown(&["analyze"]).await;
     assert!(
         report.contains("# Benchmark history analysis: testproj"),
         "{report}"
@@ -131,6 +119,91 @@ async fn analyze_markdown_format_renders_blocks() {
     // far more specific than a bare `**` that any unrelated bold text would match.
     assert!(report.contains("%** — `"), "{report}");
     assert!(report.contains("via change point"), "{report}");
+}
+
+/// Markdown and JSON files can be rendered from one analysis pass while text is suppressed.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_writes_markdown_and_json_from_one_suppressed_text_pass() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let outcome = workspace
+        .drive(&[
+            "analyze",
+            "--no-text",
+            "--markdown",
+            "report.md",
+            "--json",
+            "report.json",
+        ])
+        .await
+        .unwrap();
+    let RunOutcome::Analyzed { report, .. } = outcome else {
+        panic!("expected an analyzed outcome, got {outcome:?}");
+    };
+    assert!(report.is_empty(), "{report}");
+
+    let markdown = workspace.read("report.md");
+    let json = workspace.read("report.json");
+    assert!(markdown.is_some(), "the Markdown report should be written");
+    assert!(json.is_some(), "the JSON report should be written");
+
+    let markdown = markdown.unwrap();
+    assert!(
+        markdown.contains("# Benchmark history analysis: testproj"),
+        "{markdown}"
+    );
+    let json = json.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["project"], "testproj");
+}
+
+/// `--no-text` suppresses stdout text while still writing a JSON report.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_no_text_suppresses_stdout_alongside_json_file() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let outcome = workspace
+        .drive(&["analyze", "--no-text", "--json", "report.json"])
+        .await
+        .unwrap();
+    let RunOutcome::Analyzed { report, .. } = outcome else {
+        panic!("expected an analyzed outcome, got {outcome:?}");
+    };
+    assert!(report.is_empty(), "{report}");
+
+    let json = workspace
+        .read("report.json")
+        .expect("the JSON report should be written");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["project"], "testproj");
+}
+
+/// Text remains on by default when a JSON file is also requested.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_default_text_coexists_with_json_file() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let outcome = workspace
+        .drive(&["analyze", "--json", "report.json"])
+        .await
+        .unwrap();
+    let RunOutcome::Analyzed { report, .. } = outcome else {
+        panic!("expected an analyzed outcome, got {outcome:?}");
+    };
+    assert!(!report.is_empty(), "text should be rendered by default");
+    assert!(report.contains("regression"), "{report}");
+
+    let json = workspace
+        .read("report.json")
+        .expect("the JSON report should be written");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["project"], "testproj");
 }
 
 /// `--since` excludes points before the cutoff, so an early spike is dropped and
@@ -149,13 +222,9 @@ async fn analyze_since_filters_old_points() {
     workspace.commit_dated("2024-01-03", "c3");
     workspace.seed_callgrind("c3", 100.0);
 
-    let outcome = workspace
-        .drive(&["analyze", "--since", "2024-01-01", "--format", "json"])
-        .await
-        .unwrap();
-    let RunOutcome::Analyzed { report, .. } = outcome else {
-        panic!("expected an analyzed outcome, got {outcome:?}");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--since", "2024-01-01"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 3,
@@ -178,13 +247,9 @@ async fn analyze_engine_filters_partition() {
         &ir_result_set(1, "c1", 100.0),
     );
 
-    let outcome = workspace
-        .drive(&["analyze", "--engine", "callgrind", "--format", "json"])
-        .await
-        .unwrap();
-    let RunOutcome::Analyzed { report, .. } = outcome else {
-        panic!("expected an analyzed outcome, got {outcome:?}");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--engine", "callgrind"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 1,
@@ -192,20 +257,20 @@ async fn analyze_engine_filters_partition() {
     );
 }
 
-/// An unknown `--format` is reported as an analysis error.
+/// Selecting no output for `analyze` is reported as an analysis error.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_rejects_unknown_format() {
+async fn analyze_rejects_no_output_selected() {
     let workspace = Workspace::repo(&storage_only_config());
 
     let error = workspace
-        .drive(&["analyze", "--format", "yaml"])
+        .drive(&["analyze", "--no-text"])
         .await
         .unwrap_err();
     let RunError::Analyze { message } = error else {
         panic!("expected an analyze error, got {error:?}");
     };
-    assert!(message.contains("unknown report format"), "{message}");
+    assert!(message.contains("no output selected"), "{message}");
 }
 
 /// A benchmark-id prefix narrows analysis to the matching benchmarks: a
@@ -265,19 +330,12 @@ async fn analyze_falling_cache_hits_is_a_regression() {
         workspace.seed_metrics(commit, vec![Metric::new(MetricKind::L1CacheHits, hits)]);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 1, "fewer cache hits is a regression: {report}");
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 1,
+        "fewer cache hits is a regression: {report}"
+    );
     assert_eq!(parsed["findings"][0]["direction"], "regression");
     assert_eq!(parsed["findings"][0]["kind"], "l1_cache_hits");
 }
@@ -299,22 +357,14 @@ async fn analyze_rising_l1_cache_hits_is_an_improvement() {
         workspace.seed_metrics(commit, vec![Metric::new(MetricKind::L1CacheHits, hits)]);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json", "--include-improvements"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--include-improvements"])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "more L1 cache hits is not a regression: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["direction"], "improvement");
 }
 
@@ -337,19 +387,12 @@ async fn analyze_rising_ram_hits_is_a_regression() {
         workspace.seed_metrics(commit, vec![Metric::new(MetricKind::RamHits, hits)]);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 1, "more RAM hits is a regression: {report}");
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 1,
+        "more RAM hits is a regression: {report}"
+    );
     assert_eq!(parsed["findings"][0]["direction"], "regression");
     assert_eq!(parsed["findings"][0]["kind"], "ram_hits");
 }
@@ -375,20 +418,13 @@ async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
     workspace.commit_dated("2024-01-06", "c6");
     workspace.seed_two_benchmarks("c6", 200.0, 102.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 2, "both benchmarks regress: {report}");
-
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 2,
+        "both benchmarks regress: {report}"
+    );
+
     let findings = parsed["findings"].as_array().unwrap();
     assert_eq!(findings.len(), 2, "{report}");
     // The larger relative move (alpha, +100%) ranks ahead of the smaller (beta, +2%).
@@ -397,15 +433,7 @@ async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
     assert_eq!(findings[1]["segments"][0], "beta", "{report}");
 
     // The Markdown rendering preserves the same ranked order in its finding blocks.
-    let RunOutcome::Analyzed {
-        report: markdown, ..
-    } = workspace
-        .drive(&["analyze", "--format", "markdown"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let markdown = workspace.drive_markdown(&["analyze"]).await;
     let alpha_row = markdown.find("alpha::bench").unwrap();
     let beta_row = markdown.find("beta::bench").unwrap();
     assert!(
@@ -431,22 +459,14 @@ async fn analyze_reports_improvement_without_regression() {
     workspace.commit_dated("2024-01-06", "c6");
     workspace.seed_callgrind("c6", 70.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json", "--include-improvements"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--include-improvements"])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "a drop in instructions is not a regression: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["direction"], "improvement");
 }
 
@@ -474,30 +494,20 @@ async fn analyze_criterion_jitter_is_not_flagged() {
         workspace.seed_criterion(label, "mk", value);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-pc-windows-msvc",
             "--machine-key",
             "mk",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "jitter must not read as a regression: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert!(
         parsed["findings"].as_array().unwrap().is_empty(),
         "noisy jitter around a flat mean produces no findings at all: {report}"
@@ -528,27 +538,20 @@ async fn analyze_criterion_slow_drift_is_flagged_as_drift() {
         workspace.seed_criterion(label, "mk", value);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-pc-windows-msvc",
             "--machine-key",
             "mk",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 1, "the upward drift is a regression: {report}");
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 1,
+        "the upward drift is a regression: {report}"
+    );
     assert_eq!(parsed["findings"][0]["method"], "drift", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
 }
@@ -575,22 +578,12 @@ async fn analyze_callgrind_tiny_deterministic_step_is_flagged() {
     workspace.commit_dated("2024-01-06", "c6");
     workspace.seed_callgrind("c6", 1001.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "a one-count deterministic step is real and must flag below the noise floor: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
 }
@@ -618,22 +611,12 @@ async fn analyze_alloc_tracker_step_is_flagged_as_change_point() {
     workspace.commit_dated("2024-03-06", "a6");
     workspace.seed_alloc_tracker("a6", "allocate_vec", 201.0, 2.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "a one-byte deterministic step is real and must flag: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
     assert_eq!(parsed["findings"][0]["kind"], "allocated_bytes", "{report}");
@@ -663,24 +646,14 @@ async fn analyze_alloc_tracker_ignores_gaps_in_a_sparse_history() {
     workspace.commit_dated("2024-04-06", "g6");
     workspace.seed_alloc_tracker("g6", "allocate_vec", 260.0, 2.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     // Only `allocate_vec`'s allocated-bytes step is a finding. A gap read as a drop
     // to zero would manufacture wild swings; instead the series is contiguous.
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "the gapped series' real step flags: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
     assert!(report.contains("allocate_vec"), "{report}");
@@ -714,27 +687,20 @@ async fn analyze_all_the_time_slow_drift_is_flagged_as_drift() {
         workspace.seed_all_the_time(label, "mk", "read_cell", value);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-unknown-linux-gnu",
             "--machine-key",
             "mk",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 1, "the upward drift is a regression: {report}");
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 1,
+        "the upward drift is a regression: {report}"
+    );
     assert_eq!(parsed["findings"][0]["method"], "drift", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
     assert_eq!(parsed["findings"][0]["kind"], "processor_time", "{report}");
@@ -762,30 +728,20 @@ async fn analyze_all_the_time_jitter_is_not_flagged() {
         workspace.seed_all_the_time(label, "mk", "read_cell", value);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-unknown-linux-gnu",
             "--machine-key",
             "mk",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "jitter must not read as a regression: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert!(
         parsed["findings"].as_array().unwrap().is_empty(),
         "noisy jitter around a flat mean produces no findings at all: {report}"
@@ -819,30 +775,20 @@ async fn analyze_all_the_time_step_with_disjoint_intervals_is_a_regression() {
         workspace.seed_all_the_time_with_interval(label, "mk", "read_cell", value, 2.0);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-unknown-linux-gnu",
             "--machine-key",
             "mk",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "a sustained step with disjoint intervals is a regression: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
     assert_eq!(parsed["findings"][0]["kind"], "processor_time", "{report}");
@@ -874,30 +820,20 @@ async fn analyze_all_the_time_step_with_overlapping_intervals_is_suppressed() {
         workspace.seed_all_the_time_with_interval(label, "mk", "read_cell", value, 60.0);
     }
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-unknown-linux-gnu",
             "--machine-key",
             "mk",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "an overlapping-interval step is suppressed by the CI gate: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert!(
         parsed["findings"].as_array().unwrap().is_empty(),
         "wide overlapping intervals suppress the step entirely: {report}"
@@ -937,19 +873,12 @@ async fn analyze_official_view_excludes_dirty_runs() {
     // A dirty snapshot on the tip commit that would spike the series if admitted.
     workspace.seed_dirty_callgrind("2024-01-05", "c4", 200.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 0, "the dirty spike must be excluded: {report}");
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 0,
+        "the dirty spike must be excluded: {report}"
+    );
     assert_eq!(
         parsed["runs"], 4,
         "only the four clean runs are loaded, not the dirty snapshot: {report}"
@@ -974,13 +903,7 @@ async fn analyze_hints_when_every_run_is_a_dirty_snapshot_on_the_base() {
     workspace.commit_dated("2024-01-02", "c2");
     workspace.seed_dirty_callgrind("2024-01-02", "c2", 130.0);
 
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 0,
@@ -1021,22 +944,12 @@ async fn analyze_dirty_tree_on_the_base_admits_the_tip_with_a_warning() {
     // matching the "evaluating the tool" / "working on the base branch" scenario.
     workspace.make_dirty("uncommitted.txt");
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "the dirty tip regression is admitted: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 5,
         "the dirty tip snapshots join the three clean runs: {report}"
@@ -1048,13 +961,7 @@ async fn analyze_dirty_tree_on_the_base_admits_the_tip_with_a_warning() {
     );
 
     // `--no-dirty` skips the probe and the exception, so the dirty tip is dropped.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json", "--no-dirty"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze", "--no-dirty"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 3,
@@ -1093,24 +1000,14 @@ async fn analyze_dirty_tree_without_recorded_dirty_runs_stays_history_mode() {
     // Dirty the working tree, even though no dirty run was ever stored.
     workspace.make_dirty("uncommitted.txt");
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["mode"], "history",
         "a dirty tree with only clean runs is still the official history view: {report}"
     );
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "history mode flags the sustained clean step: {report}"
     );
     assert_eq!(
@@ -1191,22 +1088,12 @@ async fn analyze_orders_by_topology_not_commit_time() {
     workspace.commit_dated("2024-04-01", "c6");
     workspace.seed_callgrind("c6", 130.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "topology order must place the 130 step last and flag it: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["baseline"], 100.0, "{report}");
     assert_eq!(parsed["findings"][0]["latest"], 130.0, "{report}");
 }
@@ -1242,22 +1129,12 @@ async fn analyze_branch_mode_reports_the_latest_regime_with_a_flip() {
     workspace.commit_dated("2024-01-09", "f6");
     workspace.seed_callgrind("f6", 130.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "the latest (worse) regime must be reported, not the intermediate improvement: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["mode"], "branch", "{report}");
     assert_eq!(parsed["notable"], true, "{report}");
     let finding = &parsed["findings"][0];
@@ -1295,19 +1172,12 @@ async fn analyze_branch_mode_stays_silent_on_a_flat_branch() {
     workspace.commit_dated("2024-01-06", "f3");
     workspace.seed_callgrind("f3", 100.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 0, "a flat branch must not flag: {report}");
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 0,
+        "a flat branch must not flag: {report}"
+    );
     assert_eq!(parsed["mode"], "branch", "{report}");
     assert_eq!(parsed["notable"], false, "{report}");
     assert!(
@@ -1338,13 +1208,7 @@ async fn analyze_history_mode_suppresses_improvements_by_default() {
     workspace.seed_callgrind("c6", 70.0);
 
     // By default history mode stays silent about the improvement.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["mode"], "history", "{report}");
     assert_eq!(parsed["notable"], false, "{report}");
@@ -1355,13 +1219,9 @@ async fn analyze_history_mode_suppresses_improvements_by_default() {
     );
 
     // Opting in surfaces the very same improvement.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json", "--include-improvements"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--include-improvements"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["improvements"], 1, "{report}");
     assert_eq!(
@@ -1389,19 +1249,12 @@ async fn analyze_tip_mode_flags_only_a_tip_regression() {
     regressing.commit_dated("2024-01-05", "c5");
     regressing.seed_callgrind("c5", 130.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = regressing
-        .drive(&["analyze", "--mode", "tip", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 1, "the tip step up must flag: {report}");
+    let report = regressing.drive_json(&["analyze", "--mode", "tip"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 1,
+        "the tip step up must flag: {report}"
+    );
     assert_eq!(parsed["mode"], "tip", "the override must win: {report}");
 
     let improving = Workspace::repo(&storage_only_config());
@@ -1416,22 +1269,12 @@ async fn analyze_tip_mode_flags_only_a_tip_regression() {
     improving.commit_dated("2024-01-05", "c5");
     improving.seed_callgrind("c5", 70.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = improving
-        .drive(&["analyze", "--mode", "tip", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = improving.drive_json(&["analyze", "--mode", "tip"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "tip mode reports regressions only, so a drop stays silent: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["improvements"], 0, "{report}");
 }
 
@@ -1521,22 +1364,14 @@ async fn analyze_branch_selects_official_line_from_a_feature_checkout() {
     workspace.commit_dated("2024-01-07", "f1");
     workspace.seed_dirty_callgrind("2024-01-07", "f1", 10.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--context", "master", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--context", "master"])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "the master regression is selected, the feature snapshot ignored: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["findings"][0]["latest"], 130.0, "{report}");
 }
 
@@ -1575,17 +1410,7 @@ async fn analyze_official_line_follows_first_parent_across_a_merge() {
     workspace.seed_callgrind("sf1", 999.0);
     workspace.seed_callgrind("sf2", 999.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 6,
@@ -1593,7 +1418,7 @@ async fn analyze_official_line_follows_first_parent_across_a_merge() {
          the side branch: {report}"
     );
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "the regression on the tip commit flags once the merge commit is on the line: {report}"
     );
     assert_eq!(parsed["findings"][0]["latest"], 130.0, "{report}");
@@ -1636,13 +1461,7 @@ async fn analyze_feature_that_merged_master_admits_dirty_off_chain_merge_base() 
     workspace.seed_callgrind("c2", 999.0);
     workspace.seed_callgrind("c3", 999.0);
 
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     // Loaded: c1 clean, c1 dirty, f1 clean, f2 clean = 4. The dirty c1 being
     // counted proves the off-chain merge-base admitted it; c2/c3 being absent
@@ -1674,25 +1493,15 @@ async fn analyze_criterion_machine_keys_stay_isolated() {
     workspace.commit_dated("2024-02-04", "d4");
     workspace.seed_criterion("d4", "mk-flat", 20.0);
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&[
+    let report = workspace
+        .drive_json(&[
             "analyze",
             "--target-triple",
             "x86_64-pc-windows-msvc",
             "--machine-key",
             "all",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     let sets = parsed["sets"].as_array().unwrap();
     assert_eq!(
@@ -1701,7 +1510,7 @@ async fn analyze_criterion_machine_keys_stay_isolated() {
         "the two machine keys form two comparable sets: {report}"
     );
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "only the rising machine regresses; the machines do not cross-compare: {report}"
     );
 }

--- a/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
@@ -39,13 +39,7 @@ async fn backfill_stores_one_clean_object_per_commit_and_restores_checkout() {
     assert_eq!(workspace.head(), head_before);
 
     // The backfilled points are now visible to `analyze` along the master line.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 2,

--- a/packages/cargo-bench-history/tests/cbh_integration/bless.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/bless.rs
@@ -11,14 +11,12 @@ async fn analyze_does_not_reflag_a_blessed_regression() {
     workspace.seed_rising_callgrind_history();
 
     // Before blessing, the sustained upward step is a regression.
-    let RunOutcome::Analyzed { regressions, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 1, "the rising history should flag once");
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 1,
+        "the rising history should flag once"
+    );
 
     // Accept the current level at the base-branch tip.
     let RunOutcome::Completed { message } =
@@ -29,22 +27,12 @@ async fn analyze_does_not_reflag_a_blessed_regression() {
     assert!(message.contains("Blessed"), "{message}");
 
     // The same data is no longer flagged: the blessing re-baselined the series.
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "a blessed regression must not be re-flagged: {report}"
     );
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["notable"], false, "{report}");
     assert!(
         parsed["findings"].as_array().is_some_and(Vec::is_empty),
@@ -74,14 +62,12 @@ async fn bless_on_a_dirty_base_branch_warns_but_succeeds() {
     assert!(message.contains("Blessed"), "{message}");
 
     // The blessing still took effect: the same data is no longer flagged.
-    let RunOutcome::Analyzed { regressions, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
-    assert_eq!(regressions, 0, "the dirty-tree blessing must still apply");
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 0,
+        "the dirty-tree blessing must still apply"
+    );
 }
 
 /// `list blessings` reports the sidecar a `bless` just recorded at the current
@@ -95,13 +81,7 @@ async fn list_blessings_reports_the_blessing_recorded_at_head() {
 
     workspace.drive(&["bless", "nm/nm::observe"]).await.unwrap();
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "blessings", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "blessings"]).await;
     let short_head = head.get(..12).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["scope"], "head", "{message}");
@@ -134,15 +114,10 @@ async fn unbless_restores_a_previously_blessed_regression() {
     workspace.drive(&["bless", "nm/nm::observe"]).await.unwrap();
 
     // The blessing currently suppresses the regression.
-    let RunOutcome::Analyzed { regressions, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 0,
+        parsed["regressions"], 0,
         "the blessing should suppress the regression"
     );
 
@@ -152,19 +127,10 @@ async fn unbless_restores_a_previously_blessed_regression() {
     };
     assert!(message.contains("Removed"), "{message}");
 
-    let RunOutcome::Analyzed {
-        regressions,
-        report,
-        ..
-    } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
-        regressions, 1,
+        parsed["regressions"], 1,
         "the regression returns once the blessing is revoked: {report}"
     );
 }
@@ -227,13 +193,7 @@ async fn analyze_include_inactive_surfaces_a_recovered_spike() {
     workspace.seed_callgrind("c10", 10.0);
 
     // By default, a fully recovered spike is not reported.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["mode"], "history", "{report}");
     assert!(
@@ -242,13 +202,9 @@ async fn analyze_include_inactive_surfaces_a_recovered_spike() {
     );
 
     // Opting in surfaces it as an inactive finding.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json", "--include-inactive"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--include-inactive"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     let finding = &parsed["findings"][0];
     assert_eq!(finding["direction"], "regression", "{report}");

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -4,6 +4,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 pub(crate) use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Stdio};
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) use cargo_bench_history::{
     BenchmarkId, BenchmarkResult, Cli, Command, EnvironmentInfo, GitInfo, Metric, MetricKind,
@@ -34,6 +35,11 @@ pub(crate) const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// and kept alive for the whole test binary (its `TempDir` is never dropped, so the
 /// source `.git` outlives every copy).
 static BASE_TEMPLATE: LazyLock<tempfile::TempDir> = LazyLock::new(build_base_template);
+
+/// A process-global counter handing each `drive_json`/`drive_markdown` call a
+/// unique report filename, so concurrent tests writing into their own workspaces
+/// never collide on a shared name.
+static OUTPUT_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Runs `git -C <root> <args>`, returning its captured output and asserting success.
 ///
@@ -833,6 +839,37 @@ impl Workspace {
             },
         )
         .await
+    }
+
+    /// Drives a reporting command (`analyze`/`list`/`prune`) requesting the JSON
+    /// report into a file and returns its contents. Appends
+    /// `--no-text --json <unique path>`, so the JSON file is the only rendered
+    /// output, and reads it back. Panics if the command fails.
+    pub(crate) async fn drive_json(&self, args: &[&str]) -> String {
+        let name = format!(
+            "cbh-report-{}.json",
+            OUTPUT_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut full: Vec<&str> = args.to_vec();
+        full.extend_from_slice(&["--no-text", "--json", &name]);
+        self.drive(&full).await.unwrap();
+        self.read(&name)
+            .expect("the JSON report was written to the requested path")
+    }
+
+    /// Drives a reporting command requesting the Markdown report into a file and
+    /// returns its contents. Appends `--no-text --markdown <unique path>`, so the
+    /// Markdown file is the only rendered output. Panics if the command fails.
+    pub(crate) async fn drive_markdown(&self, args: &[&str]) -> String {
+        let name = format!(
+            "cbh-report-{}.md",
+            OUTPUT_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut full: Vec<&str> = args.to_vec();
+        full.extend_from_slice(&["--no-text", "--markdown", &name]);
+        self.drive(&full).await.unwrap();
+        self.read(&name)
+            .expect("the Markdown report was written to the requested path")
     }
 
     /// All stored objects as `(object key, parsed result set)` pairs, sorted by key.

--- a/packages/cargo-bench-history/tests/cbh_integration/list.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/list.rs
@@ -11,13 +11,7 @@ async fn list_discriminants_lists_present_sets() {
     workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
     workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 100.0);
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "discriminants", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "discriminants"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     let sets = parsed.as_array().unwrap();
     assert_eq!(sets.len(), 2, "exactly the two present sets: {message}");
@@ -42,13 +36,7 @@ async fn list_previews_the_analyzed_data_set() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.seed_rising_callgrind_history();
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "runs"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 6, "{message}");
     assert_eq!(parsed["totals"]["series"], 1, "{message}");
@@ -81,20 +69,14 @@ async fn list_facet_selection_mirrors_analyze() {
     workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
     workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 50.0);
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
+    let message = workspace
+        .drive_json(&[
             "list",
             "runs",
             "--target-triple",
             "x86_64-unknown-linux-gnu",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["discriminant_sets"], 1, "{message}");
     assert_eq!(
@@ -119,13 +101,7 @@ async fn list_admits_and_excludes_dirty_like_analyze() {
 
     // By default the dirty snapshot on the target side is included: f1 hosts both a
     // clean and a dirty run, for three runs across two commits.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "runs"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 3, "{message}");
     let commits = parsed["sets"][0]["commits"].as_array().unwrap();
@@ -135,13 +111,7 @@ async fn list_admits_and_excludes_dirty_like_analyze() {
     assert_eq!(f1["dirty"], 1, "{message}");
 
     // `--no-dirty` drops the dirty snapshot, leaving only the two clean runs.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--no-dirty", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "runs", "--no-dirty"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 2, "{message}");
 }

--- a/packages/cargo-bench-history/tests/cbh_integration/prune.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/prune.rs
@@ -16,36 +16,18 @@ async fn prune_dirty_removes_dirty_runs_on_a_feature_branch() {
     workspace.seed_dirty_callgrind("2024-01-03", "f1", 200.0);
 
     // Before: the target-side dirty snapshot is part of the data set.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "runs"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 3, "{message}");
 
     // `prune --dirty` removes exactly the one dirty run.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["prune", "--dirty"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["dry_run"], false, "{message}");
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 
     // After: only the two clean runs remain; the dirty snapshot is gone.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "runs"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 2, "{message}");
     let commits = parsed["sets"][0]["commits"].as_array().unwrap();
@@ -67,13 +49,7 @@ async fn prune_dirty_removes_the_base_branch_tip_dirty_with_a_clean_tree() {
     workspace.seed_dirty_callgrind("2024-01-02", "c1", 200.0);
 
     // With a clean working tree, `list` excludes the base-tip dirty snapshot.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "runs"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -81,31 +57,16 @@ async fn prune_dirty_removes_the_base_branch_tip_dirty_with_a_clean_tree() {
     );
 
     // `prune --dirty` removes it anyway (with the base-branch guard confirmed).
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--prune-base", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--prune-base"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 
     // A second pass finds nothing left to remove.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
-            "prune",
-            "--dirty",
-            "--prune-base",
-            "--dry-run",
-            "--format",
-            "json",
-        ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--prune-base", "--dry-run"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 0,
@@ -125,25 +86,15 @@ async fn prune_dry_run_reports_without_deleting() {
     workspace.commit_dated("2024-01-02", "f1");
     workspace.seed_dirty_callgrind("2024-01-02", "f1", 200.0);
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--dry-run", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--dry-run"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["dry_run"], true, "{message}");
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 
     // The dry run deleted nothing: a real prune still removes the same run.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["prune", "--dirty"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["dry_run"], false, "{message}");
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
@@ -163,20 +114,9 @@ async fn prune_dirty_scopes_by_engine() {
     workspace.seed_dirty_criterion("2024-01-02", "f1", "m1", 20.0);
 
     // Prune only the callgrind set.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
-            "prune",
-            "--dirty",
-            "--engine",
-            "callgrind",
-            "--format",
-            "json",
-        ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--engine", "callgrind"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -186,8 +126,8 @@ async fn prune_dirty_scopes_by_engine() {
 
     // The criterion dirty snapshot survives: a criterion-scoped prune still finds it
     // once the windows triple and its non-host machine key are named explicitly.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
+    let message = workspace
+        .drive_json(&[
             "prune",
             "--dirty",
             "--engine",
@@ -197,14 +137,8 @@ async fn prune_dirty_scopes_by_engine() {
             "--machine-key",
             "m1",
             "--dry-run",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -228,20 +162,14 @@ async fn prune_dirty_scopes_by_target_triple_facet() {
     workspace.seed_dirty_criterion("2024-01-02", "f1", "m1", 20.0);
 
     // The Linux triple removes only the callgrind (linux) dirty run.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
+    let message = workspace
+        .drive_json(&[
             "prune",
             "--dirty",
             "--target-triple",
             "x86_64-unknown-linux-gnu",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
     assert_eq!(
@@ -252,8 +180,8 @@ async fn prune_dirty_scopes_by_target_triple_facet() {
 
     // The Windows (criterion) dirty run survives: a Windows-triple pass still finds
     // it once the machine facet is widened to its non-host machine key.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
+    let message = workspace
+        .drive_json(&[
             "prune",
             "--dirty",
             "--target-triple",
@@ -261,14 +189,8 @@ async fn prune_dirty_scopes_by_target_triple_facet() {
             "--machine-key",
             "m1",
             "--dry-run",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -306,8 +228,6 @@ async fn prune_dirty_removes_runs_across_multiple_discriminant_sets() {
             "all",
             "--machine-key",
             "all",
-            "--format",
-            "text",
         ])
         .await
         .unwrap()
@@ -320,8 +240,8 @@ async fn prune_dirty_removes_runs_across_multiple_discriminant_sets() {
     );
 
     // Both sets are now empty: a second pass finds nothing to remove.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
+    let message = workspace
+        .drive_json(&[
             "prune",
             "--dirty",
             "--target-triple",
@@ -329,14 +249,8 @@ async fn prune_dirty_removes_runs_across_multiple_discriminant_sets() {
             "--machine-key",
             "all",
             "--dry-run",
-            "--format",
-            "json",
         ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 0, "{message}");
 }
@@ -357,52 +271,25 @@ async fn prune_dirty_since_only_removes_runs_on_or_after_the_cutoff() {
     workspace.seed_dirty_callgrind("2024-01-05", "f2", 200.0);
 
     // Only the 2024-01-05 run is on or after the cutoff.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
-            "prune",
-            "--dirty",
-            "--since",
-            "2024-01-04",
-            "--format",
-            "json",
-        ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--since", "2024-01-04"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 
     // The on-or-after run is gone; the earlier run survives the cutoff.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
-            "prune",
-            "--dirty",
-            "--since",
-            "2024-01-04",
-            "--dry-run",
-            "--format",
-            "json",
-        ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--since", "2024-01-04", "--dry-run"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 0,
         "the late run was removed: {message}"
     );
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--dry-run", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--dry-run"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -425,31 +312,16 @@ async fn prune_dirty_until_only_removes_runs_on_or_before_the_cutoff() {
     workspace.seed_dirty_callgrind("2024-01-05", "f2", 200.0);
 
     // Only the 2024-01-02 run is on or before the cutoff.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&[
-            "prune",
-            "--dirty",
-            "--until",
-            "2024-01-03",
-            "--format",
-            "json",
-        ])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--until", "2024-01-03"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 
     // The later run survives the cutoff; only the on-or-before run was removed.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--dry-run", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--dry-run"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -473,24 +345,14 @@ async fn prune_all_removes_clean_and_dirty_for_a_commit() {
     let f1 = workspace.commit("f1");
 
     // Narrowed to f1, the `--all` scope removes its clean and dirty runs.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", &f1, "--all", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["prune", &f1, "--all"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 2, "clean + dirty f1: {message}");
 
     // Only the base-branch clean run remains.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--context", "feature", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["list", "runs", "--context", "feature"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 }
@@ -523,13 +385,9 @@ async fn prune_all_removes_only_the_feature_side() {
     workspace.commit_dated("2024-01-02", "f1");
     workspace.seed_callgrind("f1", 100.0);
 
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--all", "--context", "feature", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--all", "--context", "feature"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -537,13 +395,9 @@ async fn prune_all_removes_only_the_feature_side() {
     );
 
     // The base commit survives; only the base-branch baseline remains.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "runs", "--context", "feature", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["list", "runs", "--context", "feature"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -566,13 +420,7 @@ async fn prune_clean_scope_removes_clean_and_keeps_dirty() {
     let f1 = workspace.commit("f1");
 
     // `--clean` narrowed to f1 removes only its clean run.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", &f1, "--clean", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["prune", &f1, "--clean"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["totals"]["runs"], 1,
@@ -580,13 +428,9 @@ async fn prune_clean_scope_removes_clean_and_keeps_dirty() {
     );
 
     // The dirty f1 snapshot survives: a `--dirty` pass still finds it.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", "--dirty", "--dry-run", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", "--dirty", "--dry-run"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "dirty f1 survived: {message}");
 }
@@ -603,13 +447,7 @@ async fn prune_removes_a_blessing_with_its_clean_run() {
     workspace.drive(&["bless", "nm/nm::observe"]).await.unwrap();
 
     // The blessing is recorded at HEAD.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "blessings", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "blessings"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(
         parsed["blessings"].as_array().unwrap().len(),
@@ -619,25 +457,15 @@ async fn prune_removes_a_blessing_with_its_clean_run() {
 
     // Pruning HEAD's clean run also deletes the blessing that rode on it. The
     // checkout is the base branch tip, so the base-branch guard must be confirmed.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["prune", &head, "--all", "--prune-base", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace
+        .drive_json(&["prune", &head, "--all", "--prune-base"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "the clean HEAD run: {message}");
     assert_eq!(parsed["totals"]["blessings"], 1, "{message}");
 
     // The blessing is gone.
-    let RunOutcome::Completed { message } = workspace
-        .drive(&["list", "blessings", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected a completed outcome");
-    };
+    let message = workspace.drive_json(&["list", "blessings"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert!(
         parsed["blessings"].as_array().unwrap().is_empty(),

--- a/packages/cargo-bench-history/tests/cbh_integration/run.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/run.rs
@@ -475,13 +475,7 @@ async fn run_then_analyze_round_trips_a_sanitizing_project_id() {
     );
 
     // The reader must sanitize the same way; otherwise it lists an empty history.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["runs"], 1,
@@ -530,13 +524,9 @@ async fn run_then_analyze_preserves_unusual_identity_characters() {
 
     // The reader reconstructs the series, proving the unusual identity is a stable
     // series key end to end.
-    let RunOutcome::Analyzed { report, .. } = workspace
-        .drive(&["analyze", "--machine-key", "pool", "--format", "json"])
-        .await
-        .unwrap()
-    else {
-        panic!("expected an analyzed outcome");
-    };
+    let report = workspace
+        .drive_json(&["analyze", "--machine-key", "pool"])
+        .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["runs"], 1, "{report}");
     assert_eq!(parsed["series"], 1, "{report}");


### PR DESCRIPTION
Closes #285.

Replaces the single mutually-exclusive `--format text|json|markdown` flag on the `cargo-bench-history` reporting commands (`analyze`, `list`, `prune`) with composable per-format output toggles, all produced from one analysis pass.

## Behavior

- The text report goes to stdout by default; `--no-text` suppresses it.
- `--markdown <path>` writes the Markdown report to a file.
- `--json <path>` writes the JSON report to a file.
- The toggles compose, so `analyze --no-text --markdown report.md --json report.json` runs one analysis and emits both files with no stdout.
- Requesting no output at all (`--no-text` with neither file) is a clear up-front error.

`--format` is removed entirely — the approved breaking change the issue calls for. JSON and Markdown reports now go to files rather than stdout.

## Implementation

- New `output` module: `OutputSelection` validates the request before any storage/git work, and an injected `OutputWriter` IO-port mirrors the existing `ConfigWriter` used by `install`. The real `TokioOutputWriter` rebases relative paths against the workspace directory, creates parent directories, and truncate-overwrites; a `MemoryOutputWriter` fake keeps the orchestrators Miri-drivable under test.
- The three orchestrators (`analyze_with`/`list_with`/`prune_with`) thread the writer generic, render each requested format from one model, and return the stdout text (empty under `--no-text`). `RunOutcome::stdout_text()` returns `None` when suppressed, so `main` prints nothing rather than a blank line.
- The nightly `gh-analyze-bench-history` automation collapses from two analyze passes to one, and the `cargo-bench-history-stress` harness reads the JSON report back from a file.

## Tests

- Converted every integration test off `--format` via new `drive_json`/`drive_markdown` harness helpers; added single-pass dual-file, `--no-text` suppression, and text-coexists-with-file cases; replaced the obsolete unknown-format test with a "no output selected" validation test.
- New unit coverage for `OutputSelection::resolve` and `RunOutcome::stdout_text`.

## Validation

`just package="cargo-bench-history" validate-local` passes end to end (format-check, check, clippy, test, test-docs, docs, Miri with 635 tests, machete, default-features dev and release).
