### PR TITLE
Extract cargo-bench-history mock engine into its own package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "jiff",
  "many_cpus",
  "mimalloc",
+ "mock_bench_engine",
  "mutants",
  "nonempty",
  "serde",
@@ -1969,6 +1970,13 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mock_bench_engine"
+version = "0.0.0"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -3,10 +3,21 @@ clippy PROFILE='dev':
     cargo clippy {{ target_package }} --profile {{ PROFILE }} --all-targets --all-features --locked -- -D warnings
 
 [group('quality')]
+[script]
 coverage-measure:
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
     # Before running the tests, we need to clear old test coverage data because the coverage report
     # simply sums up all the data in the target folder, even if it is from old builds.
     cargo +{{ env_var('RUST_NIGHTLY') }} llvm-cov clean --workspace
+
+    # Pre-build the mock benchmark engine once and hand each per-test process its path via
+    # MOCK_BENCH_ENGINE. nextest runs every test in its own process, so without this each
+    # cargo-bench-history integration test would build the engine on demand and those
+    # concurrent `cargo build` invocations would race over the shared coverage target tree
+    # (observed as transient "No such file or directory" engine-spawn failures on macOS).
+    $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
 
     # This will run tests and generate test coverage data files, to be analyzed separately.
     #
@@ -60,8 +71,17 @@ default-features-check:
     cargo ensure-no-default-features
 
 [group('quality')]
+[script]
 careful FILTER="":
-    cargo +{{ env_var('RUST_NIGHTLY') }} careful test {{ target_package }} --no-fail-fast --all-features {{ FILTER }} --locked
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    # Pre-build the mock benchmark engine once and pass its path via MOCK_BENCH_ENGINE, so the
+    # cargo-bench-history integration tests skip the per-process on-demand engine build (the
+    # same pattern the `test` and `coverage-measure` recipes use).
+    $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
+
+    cargo +$env:RUST_NIGHTLY careful test {{ target_package }} --no-fail-fast --all-features {{ FILTER }} --locked
 
 # Separate file because it is a giant script.
 import 'just_quality_mutants.just'

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -74,12 +74,13 @@ mutants SHARD="" CAREFUL='false':
         "-e"
         (Escape-Wildcards "packages/benchmarks/**")
 
-        # The mock benchmark engine is a test-support binary (a `[[bin]]` so the
-        # integration tests can spawn it). It is scaffolding, not shipped code, so mutating it
-        # yields no production coverage signal - it only spawns extra subprocess-heavy test runs
-        # that time out on slower runners. Its own behavior is covered by the integration tests.
+        # The mock benchmark engine is a test-support binary (its own never-published
+        # `mock_bench_engine` package, which the integration tests spawn). It is scaffolding,
+        # not shipped code, so mutating it yields no production coverage signal - it only spawns
+        # extra subprocess-heavy test runs that time out on slower runners. Its own behavior is
+        # covered by the integration tests.
         "-e"
-        (Escape-Wildcards "packages/cargo-bench-history/src/bin/**")
+        (Escape-Wildcards "packages/mock_bench_engine/**")
 
         # `testing.rs` is an in-workspace test utility (gated behind the `private-test-util`
         # feature, consumed only by the shell crate's tests). It is scaffolding with no public

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -162,7 +162,12 @@ _mock-engine-path:
 
     $messages = cargo +$env:RUST_MSRV build -p mock_bench_engine --message-format=json-render-diagnostics --locked
     $exe = $messages |
-        ForEach-Object { $_ | ConvertFrom-Json } |
+        ForEach-Object {
+            # Tolerate non-JSON lines (e.g. rendered diagnostics or blank lines), just
+            # as the Rust-side resolver does; only parsed objects flow downstream.
+            if ([string]::IsNullOrWhiteSpace($_)) { return }
+            try { $_ | ConvertFrom-Json -ErrorAction Stop } catch { return }
+        } |
         Where-Object { $_.reason -eq "compiler-artifact" -and $_.target.name -eq "mock_bench_engine" -and $_.executable } |
         Select-Object -Last 1 -ExpandProperty executable
     if (-not $exe) { throw "could not resolve the mock_bench_engine executable from cargo output" }

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -140,8 +140,33 @@ miri-example EXAMPLE:
     }
 
 [group('testing')]
+[script]
 test FILTER="":
-    cargo +{{ env_var('RUST_MSRV') }} nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
+    cargo +$env:RUST_MSRV nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast
+
+# Build the test-support `mock_bench_engine` binary and print its path. The mock is a
+# fake benchmark engine the cargo-bench-history integration tests drive; it lives in
+# its own never-published package (see packages/mock_bench_engine and issue #289), so
+# Cargo does not expose it via CARGO_BIN_EXE_* to the tests. The tests build and locate
+# it on demand, but a test runner can call this once up front and pass the path via
+# MOCK_BENCH_ENGINE so each per-test process skips a redundant Cargo freshness check.
+[group('testing')]
+[script]
+_mock-engine-path:
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $messages = cargo +$env:RUST_MSRV build -p mock_bench_engine --message-format=json-render-diagnostics --locked
+    $exe = $messages |
+        ForEach-Object { $_ | ConvertFrom-Json } |
+        Where-Object { $_.reason -eq "compiler-artifact" -and $_.target.name -eq "mock_bench_engine" -and $_.executable } |
+        Select-Object -Last 1 -ExpandProperty executable
+    if (-not $exe) { throw "could not resolve the mock_bench_engine executable from cargo output" }
+    Write-Output $exe
 
 # Run the cargo-bench-history "stress analyze" harness against LOCAL filesystem
 # storage: it seeds a giant synthetic benchmark history (default 1000 benchmarks ×
@@ -302,6 +327,7 @@ test-azurite:
         # AZURITE_BLOB_ENDPOINT cannot redirect the tests to a different target (the recipe
         # would then start/reuse one emulator while the tests hit another — non-hermetic).
         $env:AZURITE_BLOB_ENDPOINT = "http://${blobHost}:${blobPort}/devstoreaccount1"
+        $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
         Write-Host "Running Azurite-backed tests against ${blobHost}:${blobPort}."
         cargo +$env:RUST_MSRV nextest run -p cargo-bench-history --locked --no-fail-fast azure azurite
     } finally {
@@ -343,6 +369,7 @@ test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', ''):
 
     $env:BENCH_HISTORY_TEST_AZURE_ACCOUNT = $account
     $env:ENABLE_AZURE = "1"
+    $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
 
     Write-Host "Running real-Azure tests against account '$account' (Microsoft Entra ID; requires az login)."
     cargo +$env:RUST_MSRV nextest run -p cargo-bench-history real_azure --locked --no-fail-fast
@@ -365,6 +392,7 @@ test-more FILTER="":
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
+    $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
     cargo +$env:RUST_MSRV nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --tests
     cargo +$env:RUST_MSRV test {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --benches
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -727,7 +727,7 @@ way. The `mock_bench_engine` crate therefore ships **both** a binary (`src/main.
 the mock itself) and a library (`src/lib.rs`, a locator helper); `cargo-bench-history`
 takes a normal `dev-dependency` on it (`mock_bench_engine = { path = "..." }`) and the
 tests call `mock_bench_engine::binary_path()`. That helper builds its own crate on
-demand (`cargo build --manifest-path <own Cargo.toml>
+demand (`cargo build --manifest-path <own Cargo.toml> --locked
 --message-format=json-render-diagnostics`, cwd-independent), reads the `executable`
 path Cargo reports for the bin artifact (the lib artifact reports none, so filtering
 on a present `executable` selects the bin), and caches it in a `LazyLock<String>`.

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -733,10 +733,15 @@ path Cargo reports for the bin artifact (the lib artifact reports none, so filte
 on a present `executable` selects the bin), and caches it in a `LazyLock<String>`.
 Cargo handles freshness, so the path is always present and up to date after edits, and
 plain `cargo test`/`cargo nextest` work with no extra setup. A no-op build still costs
-~190 ms, and nextest runs one process per test, so the `just` test recipes pre-build
-the mock once via the `_mock-engine-path` recipe and pass its path in the
-`MOCK_BENCH_ENGINE` env var; when that points at an existing file the resolver trusts
-it and skips the per-process build. The two fixtures the mock `include_str!`s stay in
+~190 ms, and nextest runs one process per test, so every `just` recipe that runs the
+suite under nextest (`test`, `test-azurite`, `test-azure`, `test-more`,
+`coverage-measure`) — plus `careful`, which runs it under libtest — pre-builds the mock
+once via the `_mock-engine-path` recipe and passes its path in the `MOCK_BENCH_ENGINE`
+env var; when that points at an existing file the resolver trusts it and skips the
+per-process build. Under nextest this is also a correctness matter, not just a speed one:
+the per-test processes would otherwise each run `cargo build` concurrently against the
+shared target tree, and those builds race (transient "No such file or directory"
+engine-spawn failures were observed on macOS coverage runs). The two fixtures the mock `include_str!`s stay in
 `packages/cargo-bench-history/tests/fixtures/callgrind/` (they double as schema-drift
 canaries for the parser tests) and are referenced cross-package by relative path.
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -711,22 +711,43 @@ never insert real-time delays in tests.
 
 The integration tests drive `run` against the **real** process/filesystem/storage
 adapters, so they need a real program to launch as the "engine". That program is
-`src/bin/cargo-bench-history-mock-engine.rs`, an auto-discovered binary target
-(`cargo-bench-history-mock-engine`); tests reference it via
-`env!("CARGO_BIN_EXE_cargo-bench-history-mock-engine")`. It writes the committed
-Gungraun summary fixtures into `<target-root>/gungraun/GROUP/summary.json` (so the
-harvester finds fresh output) and exits with a chosen code — never use a shell
-builtin like `exit 7`, because the runner no longer goes through a shell. Resolve
-`<target-root>` the same way the harvester does (`CARGO_TARGET_DIR` or `target`),
-so the mock writes where the harvester reads. The integration harness injects the
-mock as the benchmark command via the `run_with_overrides` `bench_command`
-override (`[MOCK_ENGINE] + self.bench`, set with `Workspace::with_bench`), so the
-program path and each fixture-describing argument are passed verbatim as distinct
-argv entries — no shell, no quoting, no config `command`. After the mock's own
-contiguous arguments, `run` appends the cargo scope flags (`--workspace`,
-`--exclude NAME`, `--package NAME`, `--bench NAME`), the feature-selection flags
-(`--features`, `--all-features`, `--no-default-features`), and any `--`
-passthrough, which the mock ignores
+the **`mock_bench_engine` package** (`packages/mock_bench_engine/src/main.rs`), a
+standalone `publish = false` crate kept deliberately out of the published
+`cargo-bench-history` crate so `cargo install cargo-bench-history` only ever places
+the one real binary on a user's PATH (issue #289). It writes the committed Gungraun
+summary fixtures into `<target-root>/gungraun/GROUP/summary.json` (so the harvester
+finds fresh output) and exits with a chosen code — never use a shell builtin like
+`exit 7`, because the runner no longer goes through a shell. Resolve `<target-root>`
+the same way the harvester does (`CARGO_TARGET_DIR` or `target`), so the mock writes
+where the harvester reads.
+
+Cargo only exposes `CARGO_BIN_EXE_*` for binaries of the package **under test**, so
+moving the mock to its own package means the tests can no longer reference it that
+way. The `mock_bench_engine` crate therefore ships **both** a binary (`src/main.rs`,
+the mock itself) and a library (`src/lib.rs`, a locator helper); `cargo-bench-history`
+takes a normal `dev-dependency` on it (`mock_bench_engine = { path = "..." }`) and the
+tests call `mock_bench_engine::binary_path()`. That helper builds its own crate on
+demand (`cargo build --manifest-path <own Cargo.toml>
+--message-format=json-render-diagnostics`, cwd-independent), reads the `executable`
+path Cargo reports for the bin artifact (the lib artifact reports none, so filtering
+on a present `executable` selects the bin), and caches it in a `LazyLock<String>`.
+Cargo handles freshness, so the path is always present and up to date after edits, and
+plain `cargo test`/`cargo nextest` work with no extra setup. A no-op build still costs
+~190 ms, and nextest runs one process per test, so the `just` test recipes pre-build
+the mock once via the `_mock-engine-path` recipe and pass its path in the
+`MOCK_BENCH_ENGINE` env var; when that points at an existing file the resolver trusts
+it and skips the per-process build. The two fixtures the mock `include_str!`s stay in
+`packages/cargo-bench-history/tests/fixtures/callgrind/` (they double as schema-drift
+canaries for the parser tests) and are referenced cross-package by relative path.
+
+The integration harness injects the mock as the benchmark command via the
+`run_with_overrides` `bench_command` override (`[binary_path()] + self.bench`, set with
+`Workspace::with_bench`), so the program path and each fixture-describing argument are
+passed verbatim as distinct argv entries — no shell, no quoting, no config `command`.
+After the mock's own contiguous arguments, `run` appends the cargo scope flags
+(`--workspace`, `--exclude NAME`, `--package NAME`, `--bench NAME`), the
+feature-selection flags (`--features`, `--all-features`, `--no-default-features`), and
+any `--` passthrough, which the mock ignores
 (it stops at the first argument it does not recognize). Like every other crate
 root that uses `#[cfg_attr(coverage_nightly, coverage(off))]`, the mock engine
 must declare `#![cfg_attr(coverage_nightly, feature(coverage_attribute))]` at its

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -731,17 +731,17 @@ demand (`cargo build --manifest-path <own Cargo.toml> --locked
 --message-format=json-render-diagnostics`, cwd-independent), reads the `executable`
 path Cargo reports for the bin artifact (the lib artifact reports none, so filtering
 on a present `executable` selects the bin), and caches it in a `LazyLock<String>`.
-Cargo handles freshness, so the path is always present and up to date after edits, and
-plain `cargo test`/`cargo nextest` work with no extra setup. A no-op build still costs
-~190 ms, and nextest runs one process per test, so every `just` recipe that runs the
-suite under nextest (`test`, `test-azurite`, `test-azure`, `test-more`,
-`coverage-measure`) — plus `careful`, which runs it under libtest — pre-builds the mock
-once via the `_mock-engine-path` recipe and passes its path in the `MOCK_BENCH_ENGINE`
-env var; when that points at an existing file the resolver trusts it and skips the
-per-process build. Under nextest this is also a correctness matter, not just a speed one:
-the per-test processes would otherwise each run `cargo build` concurrently against the
-shared target tree, and those builds race (transient "No such file or directory"
-engine-spawn failures were observed on macOS coverage runs). The two fixtures the mock `include_str!`s stay in
+Cargo handles freshness, so the path is always present and up to date after edits, and a
+plain `cargo test` run needs no extra setup. nextest, however, runs one process per test,
+so each would run its own on-demand `cargo build` — which both costs ~190 ms per process
+and, worse, races the other processes' concurrent builds over the shared target tree
+(transient "No such file or directory" engine-spawn failures were observed on macOS
+coverage runs). So every `just` recipe that runs the suite under nextest (`test`,
+`test-azurite`, `test-azure`, `test-more`, `coverage-measure`) — plus `careful`, which
+runs it under libtest — pre-builds the mock once via the `_mock-engine-path` recipe and
+passes its path in the `MOCK_BENCH_ENGINE` env var; when that points at an existing file
+the resolver trusts it (resolving it to an absolute path) and skips the per-process build.
+The two fixtures the mock `include_str!`s stay in
 `packages/cargo-bench-history/tests/fixtures/callgrind/` (they double as schema-drift
 canaries for the parser tests) and are referenced cross-package by relative path.
 

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -44,6 +44,7 @@ toml = { workspace = true, features = ["parse", "serde"] }
 [dev-dependencies]
 cargo-bench-history-core = { path = "../cargo-bench-history-core", features = ["private-test-util"] }
 futures = { workspace = true, features = ["executor"] }
+mock_bench_engine = { path = "../mock_bench_engine" }
 mutants = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -2099,7 +2099,8 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      crate: the binary (`src/main.rs`) is the mock, and the library (`src/lib.rs`)
      exposes a `binary_path()` locator that `cargo-bench-history` consumes as a normal
      path `dev-dependency`. The locator builds its own crate on demand
-     (`cargo build --manifest-path <own Cargo.toml> --message-format=json`) and reads the
+     (`cargo build --manifest-path <own Cargo.toml> --locked
+     --message-format=json-render-diagnostics`) and reads the
      executable path Cargo reports for the bin artifact — the lib artifact reports none,
      so filtering on a present `executable` selects the bin — caching it per process in a
      `LazyLock<String>`. *(Shared library, not `#[path]`: common test-support code lives

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -2105,15 +2105,16 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      so filtering on a present `executable` selects the bin — caching it per process in a
      `LazyLock<String>`. *(Shared library, not `#[path]`: common test-support code lives
      in a proper library crate, never an `#[path]`-included source file.)* Cargo owns
-     freshness, so plain `cargo test`/`cargo nextest` need no setup. Because nextest runs
-     one process per test and each no-op build costs ~190 ms, every `just` recipe that runs
-     the suite under nextest (`test`, `test-azurite`, `test-azure`, `test-more`,
-     `coverage-measure`) — plus `careful` — pre-builds the mock once (`_mock-engine-path`)
-     and passes its path in `MOCK_BENCH_ENGINE`; the resolver trusts that env var when it
-     points at an existing file and skips the per-process build (~8 s saved on the suite).
-     Under nextest this also avoids the per-test processes racing concurrent `cargo build`
-     invocations over the shared target tree (transient engine-spawn `NotFound` failures
-     surfaced on macOS coverage runs). The two Gungraun fixtures the mock `include_str!`s
+     freshness, so a plain `cargo test` run needs no setup. nextest, however, runs one
+     process per test, so each would run its own on-demand `cargo build` — which costs
+     ~190 ms per process and, worse, races the other processes' concurrent builds over the
+     shared target tree (transient engine-spawn `NotFound` failures surfaced on macOS
+     coverage runs). So every `just` recipe that runs the suite under nextest (`test`,
+     `test-azurite`, `test-azure`, `test-more`, `coverage-measure`) — plus `careful` —
+     pre-builds the mock once (`_mock-engine-path`) and passes its path in
+     `MOCK_BENCH_ENGINE`; the resolver trusts that env var when it points at an existing
+     file (resolving it to an absolute path) and skips the per-process build (~8 s saved on
+     the suite). The two Gungraun fixtures the mock `include_str!`s
      stay in `cargo-bench-history/tests/fixtures/` — they double as schema-drift canaries
      for the parser tests — and are referenced cross-package by relative path rather than
      duplicated.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -2106,11 +2106,14 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      `LazyLock<String>`. *(Shared library, not `#[path]`: common test-support code lives
      in a proper library crate, never an `#[path]`-included source file.)* Cargo owns
      freshness, so plain `cargo test`/`cargo nextest` need no setup. Because nextest runs
-     one process per test and each no-op build costs ~190 ms, the `just` test recipes
-     pre-build the mock once (`_mock-engine-path`) and pass its path in
-     `MOCK_BENCH_ENGINE`; the resolver trusts that env var when it
-     points at an existing file and skips the per-process build (~8 s saved on the
-     suite). The two Gungraun fixtures the mock `include_str!`s stay in
-     `cargo-bench-history/tests/fixtures/` — they double as schema-drift canaries for the
-     parser tests — and are referenced cross-package by relative path rather than
+     one process per test and each no-op build costs ~190 ms, every `just` recipe that runs
+     the suite under nextest (`test`, `test-azurite`, `test-azure`, `test-more`,
+     `coverage-measure`) — plus `careful` — pre-builds the mock once (`_mock-engine-path`)
+     and passes its path in `MOCK_BENCH_ENGINE`; the resolver trusts that env var when it
+     points at an existing file and skips the per-process build (~8 s saved on the suite).
+     Under nextest this also avoids the per-test processes racing concurrent `cargo build`
+     invocations over the shared target tree (transient engine-spawn `NotFound` failures
+     surfaced on macOS coverage runs). The two Gungraun fixtures the mock `include_str!`s
+     stay in `cargo-bench-history/tests/fixtures/` — they double as schema-drift canaries
+     for the parser tests — and are referenced cross-package by relative path rather than
      duplicated.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1362,9 +1362,12 @@ src/
     bless.rs              # `bless`/`unbless` + `list blessings` audit
   commands/
     mod.rs run.rs install.rs backfill.rs   # analyze/list/prune/bless/unbless handlers live in analyze/
-  bin/
-    cargo-bench-history-mock-engine.rs     # test-support fake bench engine
 ```
+
+The fake benchmark engine the integration tests launch is **not** in this crate: it
+is the sibling `mock_bench_engine` package (`packages/mock_bench_engine/`), a
+`publish = false` crate so `cargo install cargo-bench-history` ships only the one
+real binary (decision 40).
 
 **Async ports & adapters (the testability boundary).** The app is **async by
 default on the Tokio runtime** (`main` = `#[tokio::main]`, lib entry
@@ -2081,3 +2084,32 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      `--format` is removed entirely; JSON and Markdown reports now go to files rather than
      stdout. Decision 35 still holds — the three renderings carry the same data — but they
      are now selected independently rather than one-at-a-time.)*
+
+40. **Mock benchmark engine is its own `publish = false` package** — *Decided:* the
+     fake engine the integration tests launch lives in a standalone `mock_bench_engine`
+     package (`packages/mock_bench_engine/`), not as a `[[bin]]` inside
+     `cargo-bench-history`. *Why:* an auto-discovered binary in the published crate is
+     installed onto every user's PATH by `cargo install cargo-bench-history` — pure
+     test scaffolding leaking into the shipped tool (issue #289). A separate
+     `publish = false` package keeps it structurally out of the published artifact and
+     off users' PATHs, with no feature-flag gymnastics. *Cost:* Cargo only sets
+     `CARGO_BIN_EXE_*` for binaries of the package **under test**, so the tests can no
+     longer reference the mock that way (and artifact dependencies, which would set the
+     var cross-package, are nightly-only). Instead `mock_bench_engine` is a **lib + bin**
+     crate: the binary (`src/main.rs`) is the mock, and the library (`src/lib.rs`)
+     exposes a `binary_path()` locator that `cargo-bench-history` consumes as a normal
+     path `dev-dependency`. The locator builds its own crate on demand
+     (`cargo build --manifest-path <own Cargo.toml> --message-format=json`) and reads the
+     executable path Cargo reports for the bin artifact — the lib artifact reports none,
+     so filtering on a present `executable` selects the bin — caching it per process in a
+     `LazyLock<String>`. *(Shared library, not `#[path]`: common test-support code lives
+     in a proper library crate, never an `#[path]`-included source file.)* Cargo owns
+     freshness, so plain `cargo test`/`cargo nextest` need no setup. Because nextest runs
+     one process per test and each no-op build costs ~190 ms, the `just` test recipes
+     pre-build the mock once (`_mock-engine-path`) and pass its path in
+     `MOCK_BENCH_ENGINE`; the resolver trusts that env var when it
+     points at an existing file and skips the per-process build (~8 s saved on the
+     suite). The two Gungraun fixtures the mock `include_str!`s stay in
+     `cargo-bench-history/tests/fixtures/` — they double as schema-drift canaries for the
+     parser tests — and are referenced cross-package by relative path rather than
+     duplicated.

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -38,9 +38,6 @@ use cargo_bench_history::{Cli, Command, Overrides, RunError, RunOutcome, run_wit
 use futures::FutureExt as _;
 use serial_test::serial;
 
-/// The mock engine binary path, provided by Cargo for the auto-discovered binary target.
-const MOCK_ENGINE: &str = env!("CARGO_BIN_EXE_cargo-bench-history-mock-engine");
-
 /// The well-known Azurite development account key (public, fixed, not secret).
 const AZURITE_KEY: &str =
     "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
@@ -428,7 +425,7 @@ impl AzureWorkspace {
         // Drive `run`/`backfill` against the mock engine instead of `cargo bench`:
         // the program plus its fixture-describing arguments form the benchmark
         // command, which the single bench invocation runs to produce engine output.
-        let mut bench_command = vec![MOCK_ENGINE.to_owned()];
+        let mut bench_command = vec![mock_bench_engine::binary_path().to_owned()];
         bench_command.extend(self.bench.iter().cloned());
         run_with_overrides(
             &command_from(args),

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -17,11 +17,6 @@ use nonempty::nonempty;
 pub(crate) use serial_test::serial;
 pub(crate) use testing::CwdGuard;
 
-/// The mock engine binary path, provided by Cargo for the auto-discovered binary
-/// target. It writes Gungraun summary fixtures into the target tree and exits with
-/// a chosen code, standing in for a real benchmark engine.
-pub(crate) const MOCK_ENGINE: &str = env!("CARGO_BIN_EXE_cargo-bench-history-mock-engine");
-
 /// The tool version recorded with each run. The integration test compiles within
 /// the package, so its `CARGO_PKG_VERSION` matches the version `run` records.
 pub(crate) const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -798,7 +793,7 @@ impl Workspace {
         // Drive `run`/`backfill` against the mock engine instead of `cargo bench`:
         // the program plus its fixture-describing arguments form the benchmark
         // command, which the single bench invocation runs to produce engine output.
-        let mut bench_command = vec![MOCK_ENGINE.to_owned()];
+        let mut bench_command = vec![mock_bench_engine::binary_path().to_owned()];
         bench_command.extend(self.bench.iter().cloned());
 
         let effective = self.effective_args(args);
@@ -824,7 +819,7 @@ impl Workspace {
         args: &[&str],
     ) -> Result<RunOutcome, RunError> {
         self.flush_git();
-        let mut bench_command = vec![MOCK_ENGINE.to_owned()];
+        let mut bench_command = vec![mock_bench_engine::binary_path().to_owned()];
         bench_command.extend(self.bench.iter().cloned());
 
         let effective = self.effective_args(args);

--- a/packages/mock_bench_engine/Cargo.toml
+++ b/packages/mock_bench_engine/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mock_bench_engine"
+description = "Test-support stand-in benchmark engine for the cargo-bench-history integration tests; never published"
+publish = false
+version = "0.0.0"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -64,7 +64,18 @@ fn resolve(env_override: Option<OsString>, build: impl FnOnce() -> BuildOutput) 
     if let Some(path) = env_override {
         let path = PathBuf::from(path);
         if path.is_file() {
-            return path.to_string_lossy().into_owned();
+            // `binary_path` promises an absolute path, but the override may be relative.
+            // Resolve it to absolute now — while the working directory is still the one
+            // the override was written against — so the cached value keeps naming the
+            // same file after a later directory change (the mock honors `--chdir` and the
+            // integration harness drives commands from various directories). The build
+            // path Cargo reports is already absolute, so this keeps both resolution paths
+            // consistent. `std::path::absolute` is preferred over `canonicalize` to avoid
+            // the Windows `\\?\` verbatim prefix, which need not appear in spawn argv or logs.
+            return std::path::absolute(&path)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .into_owned();
         }
     }
 
@@ -262,13 +273,41 @@ mod tests {
 
     #[cfg(not(miri))]
     #[test]
-    fn env_override_naming_an_existing_file_is_used_verbatim() {
-        // This crate's own manifest is a file that is guaranteed to exist.
+    fn env_override_naming_an_existing_absolute_file_is_returned_unchanged() {
+        // This crate's own manifest is an absolute path that is guaranteed to exist;
+        // making an already-absolute path absolute leaves it unchanged, so the override
+        // passes through without a build.
         let existing = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
         let resolved = resolve(Some(existing.clone().into_os_string()), || {
             panic!("must not build when the env override names an existing file")
         });
         assert_eq!(resolved, existing.to_string_lossy());
+    }
+
+    #[cfg(not(miri))]
+    #[test]
+    fn env_override_with_a_relative_path_is_resolved_to_absolute() {
+        // A bare manifest name resolves against the test's working directory (the package
+        // root cargo sets). `binary_path` promises an absolute path, so a relative override
+        // must be made absolute now — otherwise the cached value would break once a later
+        // `--chdir` moves the working directory.
+        let relative = PathBuf::from("Cargo.toml");
+        assert!(
+            relative.is_file(),
+            "expected the package manifest relative to the test working directory"
+        );
+        let resolved = resolve(Some(relative.into_os_string()), || {
+            panic!("must not build when the env override names an existing file")
+        });
+        let resolved = Path::new(&resolved);
+        assert!(
+            resolved.is_absolute(),
+            "a relative override should resolve to an absolute path, got {resolved:?}"
+        );
+        assert!(
+            resolved.ends_with("Cargo.toml"),
+            "the resolved path should still name the manifest, got {resolved:?}"
+        );
     }
 
     #[cfg(not(miri))]

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -31,13 +31,17 @@ use std::sync::LazyLock;
 /// build — the value is trusted only when it names an existing file.
 #[must_use]
 pub fn binary_path() -> &'static str {
-    static PATH: LazyLock<String> = LazyLock::new(|| {
-        let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
-        resolve(std::env::var_os("MOCK_BENCH_ENGINE"), || {
-            run_cargo_build(&manifest_path)
-        })
-    });
+    static PATH: LazyLock<String> = LazyLock::new(locate_or_build);
     PATH.as_str()
+}
+
+/// Resolves the path [`binary_path`] caches: trust `MOCK_BENCH_ENGINE` when it names an
+/// existing file, otherwise build this crate and read the path Cargo reports. Split out
+/// from the `LazyLock` initializer so it can be exercised directly, and passing
+/// [`run_cargo_build`] by name (rather than wrapping it in a closure) keeps the build seam
+/// a single named function the tests can call on its own.
+fn locate_or_build() -> String {
+    resolve(std::env::var_os("MOCK_BENCH_ENGINE"), run_cargo_build)
 }
 
 /// The outcome of spawning `cargo build`, reduced to the fields the resolver inspects.
@@ -83,11 +87,12 @@ fn resolve(env_override: Option<OsString>, build: impl FnOnce() -> BuildOutput) 
 }
 
 /// Spawns `cargo build` for this crate and captures its outcome.
-fn run_cargo_build(manifest_path: &Path) -> BuildOutput {
+fn run_cargo_build() -> BuildOutput {
     // `--manifest-path` (absolute, derived from this crate's own manifest directory)
     // makes the build independent of the current working directory, which some tests
     // change before first touching the engine. `--locked` matches the
     // `just _mock-engine-path` recipe and refuses to silently rewrite the lockfile.
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
     let output = std::process::Command::new(env!("CARGO"))
         .args([
             "build",
@@ -95,7 +100,7 @@ fn run_cargo_build(manifest_path: &Path) -> BuildOutput {
             "--message-format=json-render-diagnostics",
             "--manifest-path",
         ])
-        .arg(manifest_path)
+        .arg(&manifest_path)
         .output()
         .expect("spawning `cargo build` for mock_bench_engine should succeed");
     BuildOutput {
@@ -318,5 +323,50 @@ mod tests {
             ok_build(artifact_line("mock_bench_engine", "/tmp/mock_bench_engine"))
         });
         assert_eq!(resolved, "/tmp/mock_bench_engine");
+    }
+
+    // The two cases below drive the real build seam (not the injected fakes): they spawn
+    // `cargo build` and read the filesystem, so they are native-only. Cargo's freshness
+    // check makes the build a fast no-op once the crate is already compiled.
+
+    #[cfg(not(miri))]
+    #[test]
+    fn run_cargo_build_reports_an_existing_executable() {
+        // Exercises the real spawn-and-capture path and feeds its output through the real
+        // `interpret_build`, proving the resolver actually builds and locates this crate's
+        // own binary end to end.
+        let output = run_cargo_build();
+        assert!(
+            output.success,
+            "building mock_bench_engine should succeed; stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let resolved = interpret_build(&output);
+        let resolved = Path::new(&resolved);
+        assert!(
+            resolved.is_file(),
+            "the reported executable should exist: {resolved:?}"
+        );
+        assert!(
+            resolved.to_string_lossy().contains("mock_bench_engine"),
+            "the reported executable should be the mock engine: {resolved:?}"
+        );
+    }
+
+    #[cfg(not(miri))]
+    #[test]
+    fn binary_path_returns_an_existing_absolute_file() {
+        // Drives `binary_path` (and thus `locate_or_build`) through whichever branch the
+        // ambient environment selects — `MOCK_BENCH_ENGINE` when a test runner pre-built
+        // the engine, an on-demand build otherwise — and confirms the contract either way.
+        let resolved = Path::new(binary_path());
+        assert!(
+            resolved.is_absolute(),
+            "binary_path should be absolute: {resolved:?}"
+        );
+        assert!(
+            resolved.is_file(),
+            "binary_path should name an existing file: {resolved:?}"
+        );
     }
 }

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -13,6 +13,10 @@
 //! The whole crate is `publish = false`, so neither the binary nor this locator ever
 //! ships, and `cargo install cargo-bench-history` places only the real tool on a
 //! user's PATH (issue #289).
+// The `coverage(off)` opt-out below lives only on the test module, so the feature is
+// gated to test builds; declaring it unconditionally would be unused (and warn) when
+// the library is compiled as a non-test dependency under coverage instrumentation.
+#![cfg_attr(all(test, coverage_nightly), feature(coverage_attribute))]
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -131,6 +135,7 @@ fn interpret_build(output: &BuildOutput) -> String {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -14,7 +14,8 @@
 //! ships, and `cargo install cargo-bench-history` places only the real tool on a
 //! user's PATH (issue #289).
 
-use std::path::Path;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 /// Returns the absolute path to the freshly built `mock_bench_engine` binary.
@@ -26,41 +27,86 @@ use std::sync::LazyLock;
 /// build — the value is trusted only when it names an existing file.
 #[must_use]
 pub fn binary_path() -> &'static str {
-    static PATH: LazyLock<String> = LazyLock::new(resolve);
+    static PATH: LazyLock<String> = LazyLock::new(|| {
+        let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        resolve(std::env::var_os("MOCK_BENCH_ENGINE"), || {
+            run_cargo_build(&manifest_path)
+        })
+    });
     PATH.as_str()
 }
 
-/// Builds this crate's binary and returns the absolute path to it, as reported by
-/// Cargo's JSON build messages.
-fn resolve() -> String {
-    if let Some(path) = std::env::var_os("MOCK_BENCH_ENGINE") {
-        let path = std::path::PathBuf::from(path);
+/// The outcome of spawning `cargo build`, reduced to the fields the resolver inspects.
+///
+/// Modeling it as a plain struct rather than [`std::process::Output`] keeps
+/// [`interpret_build`] unit-testable: an `ExitStatus` cannot be constructed portably,
+/// but these fields can be filled in directly to exercise every branch without
+/// spawning a real process.
+struct BuildOutput {
+    /// Whether the build process exited successfully.
+    success: bool,
+    /// The process exit code, if it terminated normally with one.
+    code: Option<i32>,
+    /// The captured standard output (Cargo's JSON build messages).
+    stdout: Vec<u8>,
+    /// The captured standard error (Cargo's rendered diagnostics).
+    stderr: Vec<u8>,
+}
+
+/// Resolves the mock-engine binary path: trust an existing file named by
+/// `env_override`, otherwise build the crate via `build` and read the path Cargo
+/// reports for the binary artifact.
+fn resolve(env_override: Option<OsString>, build: impl FnOnce() -> BuildOutput) -> String {
+    if let Some(path) = env_override {
+        let path = PathBuf::from(path);
         if path.is_file() {
             return path.to_string_lossy().into_owned();
         }
     }
 
+    interpret_build(&build())
+}
+
+/// Spawns `cargo build` for this crate and captures its outcome.
+fn run_cargo_build(manifest_path: &Path) -> BuildOutput {
     // `--manifest-path` (absolute, derived from this crate's own manifest directory)
     // makes the build independent of the current working directory, which some tests
-    // change before first touching the engine.
-    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    // change before first touching the engine. `--locked` matches the
+    // `just _mock-engine-path` recipe and refuses to silently rewrite the lockfile.
     let output = std::process::Command::new(env!("CARGO"))
         .args([
             "build",
+            "--locked",
             "--message-format=json-render-diagnostics",
             "--manifest-path",
         ])
-        .arg(&manifest_path)
+        .arg(manifest_path)
         .output()
         .expect("spawning `cargo build` for mock_bench_engine should succeed");
+    BuildOutput {
+        success: output.status.success(),
+        code: output.status.code(),
+        stdout: output.stdout,
+        stderr: output.stderr,
+    }
+}
+
+/// Reads the built binary's path from Cargo's JSON build output, panicking with the
+/// captured diagnostics (exit code, stdout, and stderr) when the build failed or
+/// reported no executable.
+fn interpret_build(output: &BuildOutput) -> String {
     assert!(
-        output.status.success(),
-        "building mock_bench_engine failed:\n{}",
+        output.success,
+        "building mock_bench_engine failed (exit code: {}):\nstdout:\n{}\nstderr:\n{}",
+        output
+            .code
+            .map_or_else(|| "unknown".to_owned(), |code| code.to_string()),
+        String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
 
     let stdout =
-        String::from_utf8(output.stdout).expect("cargo build JSON output should be valid UTF-8");
+        std::str::from_utf8(&output.stdout).expect("cargo build JSON output should be valid UTF-8");
     for line in stdout.lines() {
         let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
@@ -82,4 +128,151 @@ fn resolve() -> String {
         }
     }
     panic!("cargo build did not report an executable path for mock_bench_engine");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A single `compiler-artifact` JSON line for the named target with the given
+    /// executable path, matching the shape Cargo emits.
+    fn artifact_line(target_name: &str, executable: &str) -> String {
+        serde_json::json!({
+            "reason": "compiler-artifact",
+            "target": { "name": target_name },
+            "executable": executable,
+        })
+        .to_string()
+    }
+
+    /// A successful build whose stdout is `stdout`.
+    fn ok_build(stdout: String) -> BuildOutput {
+        BuildOutput {
+            success: true,
+            code: Some(0),
+            stdout: stdout.into_bytes(),
+            stderr: Vec::new(),
+        }
+    }
+
+    /// A failed build carrying a known exit code and stderr, for the failure-path
+    /// assertions.
+    fn failed_build() -> BuildOutput {
+        BuildOutput {
+            success: false,
+            code: Some(101),
+            stdout: b"some compiler chatter".to_vec(),
+            stderr: b"error: linker exploded".to_vec(),
+        }
+    }
+
+    #[test]
+    fn picks_the_executable_of_the_bin_artifact() {
+        let resolved = interpret_build(&ok_build(artifact_line(
+            "mock_bench_engine",
+            "/tmp/mock_bench_engine",
+        )));
+        assert_eq!(resolved, "/tmp/mock_bench_engine");
+    }
+
+    #[test]
+    fn ignores_non_json_lines_other_packages_and_the_lib_artifact() {
+        // The lib artifact has no executable; an unrelated package and a stray
+        // non-JSON line must both be skipped before the mock bin is found.
+        let lib_artifact = serde_json::json!({
+            "reason": "compiler-artifact",
+            "target": { "name": "mock_bench_engine" },
+            "executable": serde_json::Value::Null,
+        })
+        .to_string();
+        let stdout = format!(
+            "{}\n{lib_artifact}\nthis is not json\n{}\n",
+            artifact_line("serde_json", "/tmp/serde_json"),
+            artifact_line("mock_bench_engine", "/tmp/mock_bench_engine"),
+        );
+
+        assert_eq!(interpret_build(&ok_build(stdout)), "/tmp/mock_bench_engine");
+    }
+
+    #[test]
+    #[should_panic(expected = "did not report an executable path")]
+    fn panics_when_no_executable_is_reported() {
+        let lib_only = serde_json::json!({
+            "reason": "compiler-artifact",
+            "target": { "name": "mock_bench_engine" },
+            "executable": serde_json::Value::Null,
+        })
+        .to_string();
+        drop(interpret_build(&ok_build(lib_only)));
+    }
+
+    #[test]
+    #[should_panic(expected = "exit code: 101")]
+    fn build_failure_reports_the_exit_code() {
+        drop(interpret_build(&failed_build()));
+    }
+
+    #[test]
+    #[should_panic(expected = "error: linker exploded")]
+    fn build_failure_reports_stderr() {
+        drop(interpret_build(&failed_build()));
+    }
+
+    #[test]
+    #[should_panic(expected = "exit code: unknown")]
+    fn build_failure_without_an_exit_code_reports_unknown() {
+        let signalled = BuildOutput {
+            success: false,
+            code: None,
+            stdout: Vec::new(),
+            stderr: b"killed by signal".to_vec(),
+        };
+        drop(interpret_build(&signalled));
+    }
+
+    #[test]
+    #[should_panic(expected = "valid UTF-8")]
+    fn panics_on_non_utf8_output() {
+        let garbled = BuildOutput {
+            success: true,
+            code: Some(0),
+            stdout: vec![0xff, 0xfe, 0xfd],
+            stderr: Vec::new(),
+        };
+        drop(interpret_build(&garbled));
+    }
+
+    #[test]
+    fn no_env_override_falls_through_to_building() {
+        // `None` skips the file check entirely, so this exercises `resolve`'s build
+        // path without touching the filesystem (and stays Miri-safe).
+        let resolved = resolve(None, || {
+            ok_build(artifact_line("mock_bench_engine", "/tmp/mock_bench_engine"))
+        });
+        assert_eq!(resolved, "/tmp/mock_bench_engine");
+    }
+
+    // The remaining cases consult the filesystem (`Path::is_file`), which Miri's
+    // isolation does not support, so they are native-only.
+
+    #[cfg(not(miri))]
+    #[test]
+    fn env_override_naming_an_existing_file_is_used_verbatim() {
+        // This crate's own manifest is a file that is guaranteed to exist.
+        let existing = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let resolved = resolve(Some(existing.clone().into_os_string()), || {
+            panic!("must not build when the env override names an existing file")
+        });
+        assert_eq!(resolved, existing.to_string_lossy());
+    }
+
+    #[cfg(not(miri))]
+    #[test]
+    fn env_override_naming_a_missing_file_falls_through_to_building() {
+        let missing = Path::new(env!("CARGO_MANIFEST_DIR")).join("does-not-exist.invalid");
+        let resolved = resolve(Some(missing.into_os_string()), || {
+            ok_build(artifact_line("mock_bench_engine", "/tmp/mock_bench_engine"))
+        });
+        assert_eq!(resolved, "/tmp/mock_bench_engine");
+    }
 }

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -1,0 +1,85 @@
+//! Test-support crate providing a fake benchmark engine for the `cargo-bench-history`
+//! integration tests.
+//!
+//! The fake engine itself is this crate's **binary** (`src/main.rs`); it writes
+//! benchmark-engine output files into the target tree and exits with a caller-chosen
+//! code, standing in for a real engine. This **library** exists only to let the
+//! consuming tests locate that binary: Cargo exposes `CARGO_BIN_EXE_*` only to the
+//! integration tests of the package that owns the binary, so `cargo-bench-history`'s
+//! tests cannot reference it that way. Instead they take a normal `dev-dependency` on
+//! this crate and call [`binary_path`], which builds the binary on demand and reports
+//! its path.
+//!
+//! The whole crate is `publish = false`, so neither the binary nor this locator ever
+//! ships, and `cargo install cargo-bench-history` places only the real tool on a
+//! user's PATH (issue #289).
+
+use std::path::Path;
+use std::sync::LazyLock;
+
+/// Returns the absolute path to the freshly built `mock_bench_engine` binary.
+///
+/// The binary is built on demand (a fast no-op once it is up to date) and rebuilt
+/// automatically after edits, so the path is always present and current; it is
+/// resolved once per process. A test runner that has already built the binary may
+/// point the `MOCK_BENCH_ENGINE` environment variable at it to skip the per-process
+/// build — the value is trusted only when it names an existing file.
+#[must_use]
+pub fn binary_path() -> &'static str {
+    static PATH: LazyLock<String> = LazyLock::new(resolve);
+    PATH.as_str()
+}
+
+/// Builds this crate's binary and returns the absolute path to it, as reported by
+/// Cargo's JSON build messages.
+fn resolve() -> String {
+    if let Some(path) = std::env::var_os("MOCK_BENCH_ENGINE") {
+        let path = std::path::PathBuf::from(path);
+        if path.is_file() {
+            return path.to_string_lossy().into_owned();
+        }
+    }
+
+    // `--manifest-path` (absolute, derived from this crate's own manifest directory)
+    // makes the build independent of the current working directory, which some tests
+    // change before first touching the engine.
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let output = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "--message-format=json-render-diagnostics",
+            "--manifest-path",
+        ])
+        .arg(&manifest_path)
+        .output()
+        .expect("spawning `cargo build` for mock_bench_engine should succeed");
+    assert!(
+        output.status.success(),
+        "building mock_bench_engine failed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("cargo build JSON output should be valid UTF-8");
+    for line in stdout.lines() {
+        let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let is_artifact =
+            message.get("reason").and_then(serde_json::Value::as_str) == Some("compiler-artifact");
+        let is_mock = message
+            .get("target")
+            .and_then(|target| target.get("name"))
+            .and_then(serde_json::Value::as_str)
+            == Some("mock_bench_engine");
+        if is_artifact
+            && is_mock
+            && let Some(executable) = message
+                .get("executable")
+                .and_then(serde_json::Value::as_str)
+        {
+            return executable.to_owned();
+        }
+    }
+    panic!("cargo build did not report an executable path for mock_bench_engine");
+}

--- a/packages/mock_bench_engine/src/main.rs
+++ b/packages/mock_bench_engine/src/main.rs
@@ -8,11 +8,11 @@
 //! Usage:
 //!
 //! ```text
-//! cargo-bench-history-mock-engine [--exit-code N] [--summary GROUP=KIND]...
-//!                                 [--criterion GROUP|FUNCTION|VALUE=NANOS]...
-//!                                 [--alloc-tracker OPERATION=BYTES/COUNT]...
-//!                                 [--all-the-time OPERATION=NANOS[@LOW:HIGH]]...
-//!                                 [--fail-if-exists PATH]
+//! mock_bench_engine [--exit-code N] [--summary GROUP=KIND]...
+//!                   [--criterion GROUP|FUNCTION|VALUE=NANOS]...
+//!                   [--alloc-tracker OPERATION=BYTES/COUNT]...
+//!                   [--all-the-time OPERATION=NANOS[@LOW:HIGH]]...
+//!                   [--fail-if-exists PATH]
 //! ```
 //!
 //! `--summary GROUP=KIND` writes a Gungraun (Callgrind) `summary.json`, where
@@ -66,12 +66,17 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+// These fixtures live in the sibling `cargo-bench-history` package's test tree
+// because they double as schema-drift canaries for that package's parser tests.
+// They are intentionally shared (not duplicated) so the mock and the parser can
+// never disagree about the on-disk summary shape.
 /// A committed Gungraun summary with no `id` (unparametrized), `Ir` = 36.
-const SINGLE_SUMMARY: &str =
-    include_str!("../../tests/fixtures/callgrind/single_unparametrized.summary.json");
+const SINGLE_SUMMARY: &str = include_str!(
+    "../../cargo-bench-history/tests/fixtures/callgrind/single_unparametrized.summary.json"
+);
 /// A committed Gungraun summary with `id` = `two_instants`, `Ir` = 87.
 const PARAMETRIZED_SUMMARY: &str =
-    include_str!("../../tests/fixtures/callgrind/parametrized.summary.json");
+    include_str!("../../cargo-bench-history/tests/fixtures/callgrind/parametrized.summary.json");
 
 /// The `package_dir` value of the committed single summary.
 const SINGLE_PACKAGE_DIR: &str = "\"/mnt/c/Source/folo/packages/fast_time\"";


### PR DESCRIPTION
Closes #289.

## Problem

The mock benchmark engine lived as an auto-discovered binary (`src/bin/cargo-bench-history-mock-engine.rs`) inside the published `cargo-bench-history` crate. That meant `cargo install cargo-bench-history` placed the test-only mock on the user's PATH alongside the real tool — test scaffolding leaking into the shipped artifact.

## Approach

Move the mock into its own standalone `mock_bench_engine` package (`packages/mock_bench_engine/`) with `publish = false`, so it is structurally excluded from the published crate and from `cargo install`. `cargo-bench-history` now has exactly one binary target (the real tool). This avoids feature-flag gymnastics — a separate package is the natural home for a test-support binary.

Cargo only exposes `CARGO_BIN_EXE_*` for binaries of the package under test, so the integration tests can no longer reference the mock that way (and artifact dependencies, which would set the var cross-package, are nightly-only). Instead `mock_bench_engine` is a **lib + bin** crate: the binary (`src/main.rs`) is the mock, and the library (`src/lib.rs`) exposes a `binary_path()` locator. `cargo-bench-history` takes a normal path `dev-dependency` on it and the tests call `mock_bench_engine::binary_path()`, which builds its own crate on demand (`cargo build --manifest-path <own Cargo.toml> --message-format=json-render-diagnostics`) and reads the `executable` path Cargo reports for the bin artifact, caching it per process in a `LazyLock<String>`. Common test-support code lives in a proper library crate rather than an `#[path]`-included source file. Cargo owns freshness, so plain `cargo test` / `cargo nextest` need no extra setup.

Because nextest runs one process per test and each no-op build costs ~190 ms, the `just` test recipes (`test`, `test-more`, `test-azurite`, `test-azure`) pre-build the mock once via a new `_mock-engine-path` recipe and pass its path in the `MOCK_BENCH_ENGINE` env var; the resolver trusts that env var when it points at an existing file and skips the per-process build. This keeps the suite at ~28s (vs ~37s without the fast-path, vs ~24s before).

The two Gungraun fixtures the mock `include_str!`s stay in `packages/cargo-bench-history/tests/fixtures/callgrind/` — they double as schema-drift canaries for the parser tests — and are referenced cross-package by relative path rather than duplicated.

## Validation

`just package="cargo-bench-history mock_bench_engine" validate-local` passes end to end: format-check, clippy, MSRV check, machete, default-features-check, docs, test-docs, full test suite, and miri. The locator has unit tests covering the `MOCK_BENCH_ENGINE` fast-path (existing and missing file), build failure (the panic reports the exit code and stderr), a missing executable, non-UTF-8 output, and selecting the bin artifact among the lib artifact, other packages, and non-JSON lines (filesystem cases are `#[cfg(not(miri))]`; the rest run under Miri too). Confirmed via `cargo metadata` that `cargo-bench-history` now exposes only the `cargo-bench-history` binary and `mock_bench_engine` is `publish = false`.
