### PR TITLE
Auto-close nightly bench-history failure alert on recovery

### DIFF
--- a/.github/bench-history-failure-issue.md
+++ b/.github/bench-history-failure-issue.md
@@ -8,5 +8,5 @@ benchmark history may be missing the latest `main` commit until this is fixed.
 
 Failed run: {{ env.RUN_URL }}
 
-This issue is updated, not duplicated, on each failing night, and can be closed
-once the workflow runs green again.
+This issue is updated, not duplicated, on each failing night, and is closed
+automatically once the workflow runs green again.

--- a/.github/bench-history-failure-issue.md
+++ b/.github/bench-history-failure-issue.md
@@ -1,5 +1,5 @@
 ---
-title: Nightly benchmark-history workflow failed
+title: "{{ env.FAILURE_ISSUE_TITLE }}"
 labels: bench-history, ci-failure
 ---
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -217,16 +217,20 @@ exists today; PR-time collection/validation may follow once this proves out.
   with `fetch-depth: 0` so the first-parent history resolves.
 - **`alert` job** (`needs: [collect, analyze]`, `if: failure()` + main-only) — opens a
   deduplicated `.github/bench-history-failure-issue.md` when any prior job fails, so a
-  broken nightly is noticed. Its companion `resolve` job closes that issue automatically
-  once the workflow is green again.
-- **`resolve` job** (`needs: [collect, analyze]`, `if: success()` + main-only) — mirror of
+  broken nightly is noticed. The issue title comes from the workflow-level
+  `FAILURE_ISSUE_TITLE` env constant (the template renders `{{ env.FAILURE_ISSUE_TITLE }}`),
+  which is also the title create-an-issue dedups on. Its companion `resolve` job closes that
+  issue automatically once the workflow is green again.
+- **`resolve` job** (`needs: [collect, analyze]`, closes on success + main-only) — mirror of
   `alert`: when collection and analysis both pass, it finds any still-open failure issue
-  (matched by the `ci-failure` label + the fixed title the `alert` template sets) and closes
-  it via the `gh` CLI with a comment linking the green run, so a fixed nightly does not leave
-  a stale alert open. A no-op on nights when no failure issue is open. `success()` (not
-  `always()`) ensures it never closes the alert when `collect` or `analyze` actually failed —
-  those cases fall to `alert` instead. The advisory regression issue (label `regression`) is
-  out of scope and stays manual.
+  (listed by the `ci-failure` label, then exact-matched against the shared
+  `FAILURE_ISSUE_TITLE` constant) and closes it via the `gh` CLI with a comment linking the
+  green run, so a fixed nightly does not leave a stale alert open. A no-op on nights when no
+  failure issue is open. Its gate is the explicit `needs.collect.result == 'success' &&
+  needs.analyze.result == 'success'` (rather than the bare `success()` function) so a future
+  unrelated job cannot affect the decision; when `collect` or `analyze` actually failed those
+  cases fall to `alert` instead. The advisory regression issue (label `regression`) is out of
+  scope and stays manual.
 
 ## Design Decisions
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -217,7 +217,16 @@ exists today; PR-time collection/validation may follow once this proves out.
   with `fetch-depth: 0` so the first-parent history resolves.
 - **`alert` job** (`needs: [collect, analyze]`, `if: failure()` + main-only) — opens a
   deduplicated `.github/bench-history-failure-issue.md` when any prior job fails, so a
-  broken nightly is noticed. Closed by hand once the workflow is green again.
+  broken nightly is noticed. Its companion `resolve` job closes that issue automatically
+  once the workflow is green again.
+- **`resolve` job** (`needs: [collect, analyze]`, `if: success()` + main-only) — mirror of
+  `alert`: when collection and analysis both pass, it finds any still-open failure issue
+  (matched by the `ci-failure` label + the fixed title the `alert` template sets) and closes
+  it via the `gh` CLI with a comment linking the green run, so a fixed nightly does not leave
+  a stale alert open. A no-op on nights when no failure issue is open. `success()` (not
+  `always()`) ensures it never closes the alert when `collect` or `analyze` actually failed —
+  those cases fall to `alert` instead. The advisory regression issue (label `regression`) is
+  out of scope and stays manual.
 
 ## Design Decisions
 

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -15,6 +15,15 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+# Title of the rolling failure-alert issue, defined once and shared by the two jobs that
+# reference it: the `alert` job stamps it as the issue title (via the
+# .github/bench-history-failure-issue.md front matter, which create-an-issue renders with
+# `{{ env.FAILURE_ISSUE_TITLE }}`), and the `resolve` job matches on it to close that issue.
+# create-an-issue dedups solely by exact title, so this string is the alert's identity; a
+# single definition keeps the open and close paths from drifting apart.
+env:
+  FAILURE_ISSUE_TITLE: Nightly benchmark-history workflow failed
+
 jobs:
   collect:
     # Skip everywhere the OIDC sign-in cannot work: forks (only this repository's
@@ -183,24 +192,31 @@ jobs:
   resolve:
     # Mirror of `alert`: when collection AND analysis are green again, auto-close the
     # rolling failure issue (if one is open) so a fixed nightly does not leave a stale
-    # alert rotting open. Gated on success() so it only runs when both prior jobs passed;
-    # if either failed, alert (failure()) handles it and this is skipped. Same main-only
-    # gate as the others. A no-op on nights when no failure issue is open.
+    # alert rotting open. Gated on both needs' results being 'success' (explicit rather
+    # than the implicit success() function, so a future unrelated job cannot affect this
+    # decision); if either failed, alert (failure()) handles it and this is skipped. Same
+    # main-only gate as the others. A no-op on nights when no failure issue is open.
     needs: [collect, analyze]
-    if: success() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    if: >-
+      needs.collect.result == 'success'
+      && needs.analyze.result == 'success'
+      && github.repository == 'folo-rs/folo'
+      && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # Least privilege: this job only talks to the issues API (no checkout, no contents).
     permissions:
-      contents: read
       issues: write
 
     steps:
-      # The alert job files exactly one rolling issue with this fixed title and the
+      # The alert job files exactly one rolling issue carrying $FAILURE_ISSUE_TITLE and the
       # ci-failure label; find any still-open instance and close it with an audit trail
       # linking the green run. Uses the preinstalled gh CLI (GH_REPO lets it run without a
-      # checkout). The label+title filter excludes the advisory `regression` issue, which
-      # carries the `regression` label and is closed by hand.
+      # checkout). Listing by `--label ci-failure` already excludes the advisory regression
+      # issue (label `regression`, closed by hand); the exact-title jq match (the search the
+      # alert path dedups on is substring/word-based) is a further guard. `--limit` defeats
+      # the 30-result default so a backlog of historical duplicates would all be closed.
       - name: Close failure issue if open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -212,8 +228,9 @@ jobs:
           numbers=$(gh issue list \
             --state open \
             --label ci-failure \
-            --search 'in:title "Nightly benchmark-history workflow failed"' \
-            --json number --jq '.[].number')
+            --limit 100 \
+            --json number,title \
+            | jq -r --arg title "$FAILURE_ISSUE_TITLE" '.[] | select(.title == $title) | .number')
           if [ -z "$numbers" ]; then
             echo "No open failure issue to close."
             exit 0

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -179,3 +179,48 @@ jobs:
           filename: .github/bench-history-failure-issue.md
           update_existing: true
           search_existing: open
+
+  resolve:
+    # Mirror of `alert`: when collection AND analysis are green again, auto-close the
+    # rolling failure issue (if one is open) so a fixed nightly does not leave a stale
+    # alert rotting open. Gated on success() so it only runs when both prior jobs passed;
+    # if either failed, alert (failure()) handles it and this is skipped. Same main-only
+    # gate as the others. A no-op on nights when no failure issue is open.
+    needs: [collect, analyze]
+    if: success() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      # The alert job files exactly one rolling issue with this fixed title and the
+      # ci-failure label; find any still-open instance and close it with an audit trail
+      # linking the green run. Uses the preinstalled gh CLI (GH_REPO lets it run without a
+      # checkout). The label+title filter excludes the advisory `regression` issue, which
+      # carries the `regression` label and is closed by hand.
+      - name: Close failure issue if open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          numbers=$(gh issue list \
+            --state open \
+            --label ci-failure \
+            --search 'in:title "Nightly benchmark-history workflow failed"' \
+            --json number --jq '.[].number')
+          if [ -z "$numbers" ]; then
+            echo "No open failure issue to close."
+            exit 0
+          fi
+          for n in $numbers; do
+            echo "Closing #$n"
+            gh issue close "$n" \
+              --reason completed \
+              --comment "✅ The nightly bench-history workflow is green again — auto-closing this alert. Successful run: $RUN_URL"
+          done


### PR DESCRIPTION
## Problem

The nightly `bench-history` workflow's `alert` job opens a single rolling issue when the collect/analyze pipeline fails, but nothing closed it once the workflow went green again. Fixed nightlies left a stale alert open (e.g. #286), which is untidy.

## Change

Add a `resolve` job that mirrors `alert` but is gated on `if: success()` over `[collect, analyze]` (same `repository == 'folo-rs/folo' && ref == refs/heads/main` gate). When both jobs pass, it finds any still-open `ci-failure` failure issue — matched by the `ci-failure` label plus the fixed title the `alert` template sets — and closes it via the preinstalled `gh` CLI with a comment linking the green run. It is a no-op on nights when no failure issue is open, and needs no checkout (`gh` uses `GH_TOKEN` + `GH_REPO`).

`success()` (not `always()`) ensures the alert is never closed when `collect` or `analyze` actually failed — those cases fall to `alert`. Because `success()` and `failure()` are mutually exclusive, `resolve` and `alert` can never both run in the same nightly.

## Scope notes

The advisory regression issue (label `regression`, different title) is intentionally out of scope and stays manual, since an open regression may be knowingly unfixed. The label+title filter cannot match it. Existing (already-open) alerts like #286 are not touched retroactively; they auto-close on the next green nightly.

## Also updated

- `.github/bench-history-failure-issue.md` — wording now states the issue is closed automatically on recovery.
- `.github/workflows/AGENTS.md` — documents the new `resolve` job.

## Validation

YAML parses; the `resolve` run-block passes `bash -n`.