### PR TITLE
Gate Codecov coverage status until all uploads land

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -156,6 +156,32 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     coverage. Together the two jobs cover both credential branches: `test-azure` the
     local-`az` fallback, `test-azure-gh` the CI self-minting path.
 
+- **coverage-notify** — single-platform gate that releases Codecov's coverage
+  notifications once every coverage upload for the commit has landed.
+  - Coverage for one commit is uploaded by several jobs: one upload per platform from
+    the `coverage` matrix, plus a conditional `azure`-flagged upload from `test-azurite`
+    when `cargo-bench-history` is affected. The per-commit upload count is therefore
+    variable. (`test-azure` / `test-azure-gh` upload no coverage.)
+  - By default Codecov re-posts its commit status / PR comment after every upload, so an
+    early upload makes it report a misleadingly low "coverage decreased" figure just
+    because the remaining uploads have not arrived yet. The repo-root `codecov.yml` sets
+    `codecov.notify.manual_trigger: true`, which holds ALL coverage notifications until
+    the CLI `send-notifications` command runs; this job (`codecov/codecov-action@v7` with
+    `run_command: send-notifications`) issues it once, so the status is computed from the
+    complete set of uploads. `manual_trigger` is preferred over `after_n_builds` because
+    the latter would need a hardcoded count that the conditional `test-azurite` upload
+    breaks. `codecov.yml` also disables `wait_for_ci` / `require_ci_to_pass` so the status
+    posts as soon as coverage data is complete rather than waiting on unrelated slow jobs
+    (`mutants`, etc.); those jobs gate merges through their own checks.
+  - `needs: [coverage, test-azurite]`; `if: !cancelled() && needs.coverage.result ==
+    'success'`. The `!cancelled()` status function lets it run even when `test-azurite`
+    is skipped (without it, the skipped dependency would skip this job too). It triggers
+    only when the `coverage` matrix succeeded: if coverage failed the build is already
+    red with missing uploads, and a `skip_all` run uploads no coverage at all.
+  - Runs for fork PRs too: the token is empty there and the action falls back to
+    tokenless notification (public repository), so external-contributor PRs get the same
+    gated, complete-data coverage status.
+
 ### cache-warmup.yml
 
 A scheduled workflow that keeps GitHub Actions caches warm. GitHub evicts caches after
@@ -277,6 +303,14 @@ exists today; PR-time collection/validation may follow once this proves out.
      subtly depend on image-specific dylibs and system tools, even when the
      lockfile and rust toolchain are identical)
    - `fail-fast: false` ensures all platform checks complete even if one fails
+
+6. **Codecov notification gating** — Coverage is uploaded by a variable number of jobs
+   per commit (the `coverage` platform matrix plus the conditional `test-azurite` azure
+   upload). To stop Codecov posting a misleading status off a partial set of uploads,
+   the repo-root `codecov.yml` enables `codecov.notify.manual_trigger` and the
+   `coverage-notify` job releases notifications via the CLI `send-notifications` command
+   only once all coverage-producing jobs have finished. See the `coverage-notify` job
+   description above for details.
 
 ## Maintenance Notes
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -174,10 +174,15 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     posts as soon as coverage data is complete rather than waiting on unrelated slow jobs
     (`mutants`, etc.); those jobs gate merges through their own checks.
   - `needs: [coverage, test-azurite]`; `if: !cancelled() && needs.coverage.result ==
-    'success'`. The `!cancelled()` status function lets it run even when `test-azurite`
-    is skipped (without it, the skipped dependency would skip this job too). It triggers
-    only when the `coverage` matrix succeeded: if coverage failed the build is already
-    red with missing uploads, and a `skip_all` run uploads no coverage at all.
+    'success' && (needs.test-azurite.result == 'success' || needs.test-azurite.result ==
+    'skipped')`. The `!cancelled()` status function lets it run even when `test-azurite`
+    is skipped (without it, the skipped dependency would skip this job too). It releases
+    notifications only when every expected upload landed: `coverage` succeeded, and
+    `test-azurite` either succeeded (azure upload landed) or was skipped (cargo-bench-history
+    not affected, so no azure upload was expected). If `coverage` failed, or `test-azurite`
+    ran and failed, an expected upload is missing and the build is already red, so the gate
+    does not release a status off an incomplete set. A `skip_all` run uploads no coverage at
+    all, so `coverage` is skipped and this job does not run.
   - Runs for fork PRs too: the token is empty there and the action falls back to
     tokenless notification (public repository), so external-contributor PRs get the same
     gated, complete-data coverage status.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -831,3 +831,43 @@ jobs:
         # deleting the sibling job's still-in-use (freshly written) containers; a genuine
         # leak is older than the cutoff and gets swept here or on a later run.
         run: ./infra/azure-bench-history-test/cleanup-containers.ps1 -MinAgeMinutes 180
+
+  # Releases Codecov's coverage notifications once every coverage upload for this
+  # commit has landed.
+  #
+  # Coverage data arrives from several jobs: one upload per platform from the
+  # `coverage` matrix, plus a conditional `azure`-flagged upload from `test-azurite`
+  # when cargo-bench-history is affected. The per-commit upload count is therefore
+  # variable. codecov.yml sets `codecov.notify.manual_trigger: true`, so Codecov posts
+  # NO coverage status or PR comment until this job runs the CLI `send-notifications`
+  # command — which it does only after every coverage-producing job has finished. That
+  # way Codecov computes the status from the complete set of uploads instead of
+  # reporting a misleadingly low figure off a partial set (see codecov.yml for the
+  # full rationale and why this is preferred over a hardcoded `after_n_builds`).
+  #
+  # It depends on `coverage` and `test-azurite` (the only coverage producers;
+  # `test-azure` / `test-azure-gh` upload none). `!cancelled()` lets it run even when
+  # `test-azurite` is skipped (cargo-bench-history not affected) — without a status
+  # function the skipped dependency would skip this job too. It triggers only when the
+  # `coverage` matrix succeeded: if coverage itself failed the build is already red and
+  # some platform uploads are missing, so there is nothing complete to notify about
+  # (and when the whole run is skipped via `skip_all`, no coverage was uploaded at all).
+  #
+  # Like the upload jobs, this runs for fork PRs too: the token is empty there and the
+  # action falls back to tokenless notification (this is a public repository), so
+  # external-contributor PRs get the same gated, complete-data coverage status.
+  coverage-notify:
+    needs: [coverage, test-azurite]
+    if: ${{ !cancelled() && needs.coverage.result == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Release Codecov coverage notifications
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: send-notifications
+          fail_ci_if_error: true

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -846,19 +846,26 @@ jobs:
   # full rationale and why this is preferred over a hardcoded `after_n_builds`).
   #
   # It depends on `coverage` and `test-azurite` (the only coverage producers;
-  # `test-azure` / `test-azure-gh` upload none). `!cancelled()` lets it run even when
-  # `test-azurite` is skipped (cargo-bench-history not affected) — without a status
-  # function the skipped dependency would skip this job too. It triggers only when the
-  # `coverage` matrix succeeded: if coverage itself failed the build is already red and
-  # some platform uploads are missing, so there is nothing complete to notify about
-  # (and when the whole run is skipped via `skip_all`, no coverage was uploaded at all).
+  # `test-azure` / `test-azure-gh` upload none). The `!cancelled()` status function lets
+  # it run even when `test-azurite` is skipped — without a status function a skipped
+  # dependency would skip this job too. It releases notifications only when every expected
+  # upload actually landed: `coverage` must have succeeded, and `test-azurite` must have
+  # either succeeded (its azure upload landed) or been skipped (cargo-bench-history not
+  # affected, so no azure upload was expected). If `coverage` failed, or `test-azurite`
+  # ran and failed, an expected upload is missing and the build is already red — so we do
+  # NOT release a status off an incomplete set, which would post the very "coverage
+  # decreased" result this gate exists to prevent. A `skip_all` run uploads no coverage at
+  # all, so `coverage` is skipped and this job does not run.
   #
   # Like the upload jobs, this runs for fork PRs too: the token is empty there and the
   # action falls back to tokenless notification (this is a public repository), so
   # external-contributor PRs get the same gated, complete-data coverage status.
   coverage-notify:
     needs: [coverage, test-azurite]
-    if: ${{ !cancelled() && needs.coverage.result == 'success' }}
+    if: >-
+      !cancelled()
+      && needs.coverage.result == 'success'
+      && (needs.test-azurite.result == 'success' || needs.test-azurite.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Codecov configuration.
+#
+# Coverage data for a single commit is produced by several jobs in
+# .github/workflows/validation.yml, each uploading its own report:
+#   * `coverage`     — one upload per platform (the platform matrix).
+#   * `test-azurite` — one extra `azure`-flagged upload, but ONLY when the
+#                      cargo-bench-history package is affected by the change.
+# The number of coverage uploads per commit therefore varies (one per platform,
+# plus the conditional azure upload). The `test-azure` / `test-azure-gh` jobs
+# upload no coverage, so they do not factor in here.
+#
+# By default Codecov re-computes and re-posts its commit status / PR comment after
+# every upload it receives. With several uploads trickling in, an early upload
+# gives Codecov an incomplete view and it posts a misleading "coverage decreased"
+# status simply because the remaining uploads have not arrived yet.
+#
+# `manual_trigger` is Codecov's documented mechanism for pipelines that upload a
+# variable number of reports per commit: Codecov sends NO coverage status or PR
+# comment until it is explicitly told the pipeline is done, via the CLI
+# `send-notifications` command. The `coverage-notify` job in validation.yml issues
+# that command once, after every coverage-producing job has finished, so the status
+# is computed from the complete set of uploads. Because the count is variable, this
+# is preferable to `after_n_builds`, which would need a hardcoded upload count that
+# the conditional `test-azurite` upload would break.
+#
+# `wait_for_ci` / `require_ci_to_pass` are disabled so that the coverage status is
+# posted as soon as `send-notifications` fires (i.e. once coverage data is complete)
+# instead of additionally waiting on unrelated slow jobs such as `mutants`. Coverage
+# is an independent signal; the other jobs gate merges through their own checks.
+codecov:
+  require_ci_to_pass: false
+  notify:
+    manual_trigger: true
+    wait_for_ci: false


### PR DESCRIPTION
## Problem

Codecov re-computes and re-posts its coverage status / PR comment after **every** upload it receives. Coverage for a single commit is produced by several jobs in `validation.yml`, so an early upload gives Codecov an incomplete view and it posts a misleading "coverage decreased" status simply because the remaining uploads have not arrived yet.

The number of coverage uploads per commit is **variable**, which rules out a hardcoded `after_n_builds`:

- `coverage` — one `lcov.info` upload per platform (always runs).
- `test-azurite` — one extra `azure`-flagged upload, but **only** when `cargo-bench-history` is affected.
- `test-azure` / `test-azure-gh` — the same-repo-gated "real Azure" jobs collect **no coverage**, so the trusted-vs-untrusted distinction does not change the coverage set.

## Approach

Use Codecov's documented mechanism for pipelines that upload a variable number of reports per commit: `codecov.notify.manual_trigger`. Codecov holds all coverage notifications until an explicit end-of-pipeline signal, and a new gate job issues that signal once every coverage-producing job has finished — so the status is computed from the complete set of uploads, whatever subset actually ran.

## Changes

- **`codecov.yml`** (new, repo root) — enables `codecov.notify.manual_trigger`, plus `wait_for_ci: false` / `require_ci_to_pass: false` so the status posts as soon as coverage data is complete rather than waiting on unrelated slow jobs (`mutants`, etc.). Validated against `https://codecov.io/validate`.
- **`coverage-notify`** job in `validation.yml` — `needs: [coverage, test-azurite]`, `if: !cancelled() && needs.coverage.result == 'success'`, runs `codecov/codecov-action@v7` with `run_command: send-notifications`. Linted clean with `actionlint`.
- **`.github/workflows/AGENTS.md`** — documents the new job and adds a design-decision note, per the workflow folder's update rule.

## Scenario coverage

- **Trusted same-repo PR / main-branch push** — gate waits for `coverage` + `test-azurite`, triggers once; status reflects all uploads.
- **`cargo-bench-history` not affected** — `test-azurite` is skipped; `!cancelled()` lets the gate still fire after the platform matrix.
- **External-contributor (fork) PR** — `coverage` + `test-azurite` still upload (tokenless on a public repo); `send-notifications` uses the same tokenless path. The real-Azure jobs skip, but they carry no coverage anyway.
- **Doc-only / `skip_all`** — coverage is skipped, the gate is skipped, no notification fires (unchanged from before).
- **Coverage job fails** — the gate skips: the build is already red and uploads are incomplete, so there is nothing complete to notify about.

The variability is handled by explicitly signaling completion after the jobs run, rather than computing how many uploads to expect.
