### PR TITLE
Deduplicate x86_64 test execution and rename coverage job to test

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -26,15 +26,27 @@ Split from the monolithic `just validate-local` into individual jobs:
 - **Multi-platform jobs** (run on ubuntu-latest, macos-latest, windows-latest):
   - check-dev
   - clippy-dev
-  - test-more-x64
+  - **test-x64** — the x86_64 test pass (ubuntu-latest, macos-latest, windows-latest)
+    - Runs the full test suite (unit, integration and example tests) **with coverage
+      instrumentation**, plus the benchmark targets once (`test-benches`) to verify they
+      do not panic. Coverage is therefore a *side effect* of the regular test run, not a
+      separately re-executed pass — there is intentionally no standalone `coverage` job.
+    - Runs on the **nightly** toolchain because coverage needs `llvm-tools-preview`, which
+      `just install-tools` installs only for nightly. The **MSRV** test pass lives on
+      `test-arm`, and MSRV compilation of every target is covered by `check-dev`.
+    - Uploads both the coverage report (lcov) and the test results (junit) to Codecov.
+    - Paired with `test-arm`; both carry an explicit `-x64`/`-arm` suffix for symmetry.
   - test-docs
   - **docs** — Multi-platform because conditional compilation affects generated documentation
   - miri-x64
-  - **test-more-arm** — ARM64 coverage (ubuntu-24.04-arm, windows-11-arm)
+  - **test-arm** — the ARM64 test pass (ubuntu-24.04-arm, windows-11-arm)
     - Exercises ARM-specific code paths (anything gated behind
       `cfg(target_arch = "aarch64")` or similar) which x86_64 runners never compile
-      or execute. Platform-neutral code is already validated by the x86_64 matrix.
-    - Paired with `test-more-x64`; both carry an explicit `-x64`/`-arm` suffix for
+      or execute, and doubles as the **MSRV** test pass (`test-x64` runs on nightly so it
+      can collect coverage). Platform-neutral code is already validated by the x86_64 matrix.
+    - Collects no coverage: `llvm-tools-preview`-based instrumentation is gathered on
+      x86_64 only (the `test-x64` job).
+    - Paired with `test-x64`; both carry an explicit `-x64`/`-arm` suffix for
       symmetry. Other jobs that have no ARM counterpart remain unsuffixed.
   - **miri-arm** — ARM64 coverage for Miri (ubuntu-24.04-arm, windows-11-arm)
     - Miri is an interpreter with its own memory model and is architecture-agnostic
@@ -86,11 +98,11 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     fully covers it and Linux is the cheapest runner.
   - The Azure backend's network paths **self-skip** when
     no emulator is reachable, so the multi-platform test jobs
-    (`test-more`, `coverage`) stay green without one. They run for real only in
+    (`test-x64`, `test-arm`) stay green without one. They run for real only in
     this job: Azurite is provisioned on the runner host (via the `start-azurite`
     composite action) and `BENCH_HISTORY_REQUIRE_AZURITE=1` turns an unreachable
     emulator into a hard failure so it can never silently skip every test.
-  - The multi-platform `coverage` job runs without an emulator and therefore
+  - The multi-platform `test-x64` job runs without an emulator and therefore
     cannot cover `azure.rs`; this job uploads an `azure`-flagged lcov report that
     Codecov merges with it (a line covered in any upload counts as covered).
   - Linux-only because Azurite runs directly on the host: GitHub service
@@ -245,11 +257,11 @@ exists today; PR-time collection/validation may follow once this proves out.
      versions)
    - `miri-x64` and `miri-arm` depend on `check-dev` (Miri is much slower than `cargo check`;
      if the code does not even compile in dev mode, there is nothing for Miri to interpret)
-   - `miri-x64` also depends on `test-more-x64`, and `miri-arm` also depends on
-     `test-more-arm` (there is no point running the slow Miri interpreter unless the tests
+   - `miri-x64` also depends on `test-x64`, and `miri-arm` also depends on
+     `test-arm` (there is no point running the slow Miri interpreter unless the tests
      already pass in their base configuration)
-   - `mutants` depends on `test-more-x64` (mutation testing is meaningless if base tests fail)
-   - `careful` depends on `test-more-x64` (running the slow `cargo careful` test pass is
+   - `mutants` depends on `test-x64` (mutation testing is meaningless if base tests fail)
+   - `careful` depends on `test-x64` (running the slow `cargo careful` test pass is
      pointless unless the tests already pass in their base configuration)
    - `miri-harder-*` depend on both `miri-x64` and `miri-arm` (many-seeds runs are
      orders of magnitude slower than a single Miri pass)
@@ -259,7 +271,7 @@ exists today; PR-time collection/validation may follow once this proves out.
    - `docs` and `machete` remain multi-platform due to conditional compilation differences
    - `miri-harder-*` jobs are Windows-only due to high cost; sharded across parallel runners
    - Most checks run on the 3 x86_64 platforms (ubuntu, macos, windows)
-   - `test-more-arm` and `miri-arm` extend coverage to ARM64 (ubuntu-24.04-arm,
+   - `test-arm` and `miri-arm` extend coverage to ARM64 (ubuntu-24.04-arm,
      windows-11-arm) solely to exercise ARM-gated code paths
      (`cfg(target_arch = "aarch64")` and similar). Platform-neutral code is already
      covered by the x86_64 matrices — Miri in particular is an interpreter with its
@@ -289,10 +301,11 @@ exists today; PR-time collection/validation may follow once this proves out.
 The `setup-environment` action installs Valgrind on Linux runners and `gungraun-runner` (via
 `just install-tools`). Both are required for the Callgrind `*_cg` bench targets that
 live in `packages/*/benches/`. Even when those targets are not executed, `cargo test
---benches` (which `test-more` uses) invokes each bench binary's `main()` once, which forwards
+--benches` (which `test-x64` and `test-arm` use, via the `test-benches` and `test-more`
+recipes) invokes each bench binary's `main()` once, which forwards
 its args to `gungraun-runner`. Without `gungraun-runner` on `$PATH` the call fails with
-`Failed to run benchmarks: No such file or directory`, which breaks `test-more` and
-`coverage`. The Callgrind bench binaries are compiled to no-op stubs on Windows and macOS via
+`Failed to run benchmarks: No such file or directory`, which breaks `test-x64` and
+`test-arm`. The Callgrind bench binaries are compiled to no-op stubs on Windows and macOS via
 `#[cfg(not(target_os = "linux"))] fn main() {}`, so neither tool is required there.
 
 The `start-azurite` composite action (`.github/actions/start-azurite`) installs the Azurite

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -26,11 +26,14 @@ Split from the monolithic `just validate-local` into individual jobs:
 - **Multi-platform jobs** (run on ubuntu-latest, macos-latest, windows-latest):
   - check-dev
   - clippy-dev
-  - **test-x64** — the x86_64 test pass (ubuntu-latest, macos-latest, windows-latest)
+  - **test-x64** — the x86_64 test pass (ubuntu-latest, windows-latest)
     - Runs the full test suite (unit, integration and example tests) **with coverage
       instrumentation**, plus the benchmark targets once (`test-benches`) to verify they
       do not panic. Coverage is therefore a *side effect* of the regular test run, not a
       separately re-executed pass — there is intentionally no standalone `coverage` job.
+    - macOS is **not** in this matrix: GitHub's `macos-latest` runner is Apple Silicon
+      (arm64), so macOS is exercised by `test-arm`. Keeping this job x86_64-only keeps its
+      name accurate and stops the matrix drifting as the `-latest` labels change.
     - Runs on the **nightly** toolchain because coverage needs `llvm-tools-preview`, which
       `just install-tools` installs only for nightly. The **MSRV** test pass lives on
       `test-arm`, and MSRV compilation of every target is covered by `check-dev`.
@@ -39,11 +42,12 @@ Split from the monolithic `just validate-local` into individual jobs:
   - test-docs
   - **docs** — Multi-platform because conditional compilation affects generated documentation
   - miri-x64
-  - **test-arm** — the ARM64 test pass (ubuntu-24.04-arm, windows-11-arm)
+  - **test-arm** — the ARM64 test pass (ubuntu-24.04-arm, windows-11-arm, macos-latest)
     - Exercises ARM-specific code paths (anything gated behind
       `cfg(target_arch = "aarch64")` or similar) which x86_64 runners never compile
-      or execute, and doubles as the **MSRV** test pass (`test-x64` runs on nightly so it
-      can collect coverage). Platform-neutral code is already validated by the x86_64 matrix.
+      or execute. macOS lives here too because GitHub's `macos-latest` runner is Apple
+      Silicon (arm64). Doubles as the **MSRV** test pass (`test-x64` runs on nightly so it
+      can collect coverage). Platform-neutral code is also validated by the x86_64 matrix.
     - Collects no coverage: `llvm-tools-preview`-based instrumentation is gathered on
       x86_64 only (the `test-x64` job).
     - Paired with `test-x64`; both carry an explicit `-x64`/`-arm` suffix for
@@ -171,7 +175,7 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
 - **coverage-notify** — single-platform gate that releases Codecov's coverage
   notifications once every coverage upload for the commit has landed.
   - Coverage for one commit is uploaded by several jobs: one upload per platform from
-    the `coverage` matrix, plus a conditional `azure`-flagged upload from `test-azurite`
+    the `test-x64` matrix, plus a conditional `azure`-flagged upload from `test-azurite`
     when `cargo-bench-history` is affected. The per-commit upload count is therefore
     variable. (`test-azure` / `test-azure-gh` upload no coverage.)
   - By default Codecov re-posts its commit status / PR comment after every upload, so an
@@ -185,16 +189,16 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
     breaks. `codecov.yml` also disables `wait_for_ci` / `require_ci_to_pass` so the status
     posts as soon as coverage data is complete rather than waiting on unrelated slow jobs
     (`mutants`, etc.); those jobs gate merges through their own checks.
-  - `needs: [coverage, test-azurite]`; `if: !cancelled() && needs.coverage.result ==
+  - `needs: [test-x64, test-azurite]`; `if: !cancelled() && needs.test-x64.result ==
     'success' && (needs.test-azurite.result == 'success' || needs.test-azurite.result ==
     'skipped')`. The `!cancelled()` status function lets it run even when `test-azurite`
     is skipped (without it, the skipped dependency would skip this job too). It releases
-    notifications only when every expected upload landed: `coverage` succeeded, and
+    notifications only when every expected upload landed: `test-x64` succeeded, and
     `test-azurite` either succeeded (azure upload landed) or was skipped (cargo-bench-history
-    not affected, so no azure upload was expected). If `coverage` failed, or `test-azurite`
+    not affected, so no azure upload was expected). If `test-x64` failed, or `test-azurite`
     ran and failed, an expected upload is missing and the build is already red, so the gate
     does not release a status off an incomplete set. A `skip_all` run uploads no coverage at
-    all, so `coverage` is skipped and this job does not run.
+    all, so `test-x64` is skipped and this job does not run.
   - Runs for fork PRs too: the token is empty there and the action falls back to
     tokenless notification (public repository), so external-contributor PRs get the same
     gated, complete-data coverage status.
@@ -335,7 +339,7 @@ exists today; PR-time collection/validation may follow once this proves out.
    - `fail-fast: false` ensures all platform checks complete even if one fails
 
 6. **Codecov notification gating** — Coverage is uploaded by a variable number of jobs
-   per commit (the `coverage` platform matrix plus the conditional `test-azurite` azure
+   per commit (the `test-x64` platform matrix plus the conditional `test-azurite` azure
    upload). To stop Codecov posting a misleading status off a partial set of uploads,
    the repo-root `codecov.yml` enables `codecov.notify.manual_trigger` and the
    `coverage-notify` job releases notifications via the CLI `send-notifications` command

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -301,8 +301,8 @@ exists today; PR-time collection/validation may follow once this proves out.
 The `setup-environment` action installs Valgrind on Linux runners and `gungraun-runner` (via
 `just install-tools`). Both are required for the Callgrind `*_cg` bench targets that
 live in `packages/*/benches/`. Even when those targets are not executed, `cargo test
---benches` (which `test-x64` and `test-arm` use, via the `test-benches` and `test-more`
-recipes) invokes each bench binary's `main()` once, which forwards
+--benches` (which `test-x64` and `test-arm` use, via the `test-benches` recipe) invokes each
+bench binary's `main()` once, which forwards
 its args to `gungraun-runner`. Without `gungraun-runner` on `$PATH` the call fails with
 `Failed to run benchmarks: No such file or directory`, which breaks `test-x64` and
 `test-arm`. The Callgrind bench binaries are compiled to no-op stubs on Windows and macOS via

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -165,7 +165,17 @@ jobs:
       - name: Run clippy dev on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" clippy dev
 
-  test-more-x64:
+  # The x86_64 test pass. Runs the full test suite (unit, integration and example tests)
+  # with coverage instrumentation, so the coverage report is a side effect of the regular
+  # test run rather than a second, separately re-executed pass. Also runs the benchmark
+  # targets once to verify they do not panic. Uploads both the coverage report and the
+  # test results to Codecov.
+  #
+  # Coverage requires the nightly toolchain (llvm-tools-preview is installed only there via
+  # `just install-tools`), so this is the nightly test pass. The MSRV test pass runs on the
+  # ARM runners (`test-arm`), and MSRV compilation of every target is covered by `check-dev`.
+  # Paired with `test-arm`; both carry an explicit `-x64`/`-arm` suffix for symmetry.
+  test-x64:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
@@ -182,8 +192,17 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run test-more on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" test-more
+      - name: Run tests with coverage on ${{ matrix.platform }}
+        run: |
+          just package="${{ needs.delta.outputs.packages }}" coverage-measure
+          just coverage-report-ci
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -193,6 +212,9 @@ jobs:
           files: target/nextest/default/junit.xml
           flags: ${{ matrix.platform }}
           report_type: test_results
+
+      - name: Run benchmark targets on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" test-benches
 
   test-docs:
     needs: [delta]
@@ -238,7 +260,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" docs-default-features
 
   miri-x64:
-    needs: [delta, check-dev, test-more-x64]
+    needs: [delta, check-dev, test-x64]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -257,10 +279,12 @@ jobs:
       - name: Run miri on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" miri
 
-  # ARM64 coverage for test-more. Exercises ARM-specific code paths (anything gated
-  # behind cfg(target_arch = "aarch64") or similar) which x86_64 runners never compile
-  # or execute.
-  test-more-arm:
+  # The ARM64 test pass. Exercises ARM-specific code paths (anything gated behind
+  # cfg(target_arch = "aarch64") or similar) which x86_64 runners never compile or execute,
+  # and serves as the MSRV test pass (the x86_64 `test-x64` job runs on nightly so it can
+  # collect coverage). No coverage here: llvm-tools-preview-based instrumentation is gathered
+  # on x86_64 only. Paired with `test-x64`; both carry an explicit `-x64`/`-arm` suffix.
+  test-arm:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
@@ -293,7 +317,7 @@ jobs:
   # architecture-agnostic for platform-neutral code; we run it on ARM purely to exercise
   # cfg(target_arch = "aarch64") (and similar) code paths under Miri's UB detection.
   miri-arm:
-    needs: [delta, check-dev, test-more-arm]
+    needs: [delta, check-dev, test-arm]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -512,7 +536,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" check-frozen
 
   mutants:
-    needs: [delta, test-more-x64]
+    needs: [delta, test-x64]
     if: needs.delta.outputs.skip_all != 'true'
     timeout-minutes: 90
     strategy:
@@ -576,7 +600,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" hack
 
   careful:
-    needs: [delta, test-more-x64]
+    needs: [delta, test-x64]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -595,35 +619,6 @@ jobs:
       - name: Run careful on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" careful
 
-  coverage:
-    needs: [delta]
-    if: needs.delta.outputs.skip_all != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-
-      - name: Generate coverage on ${{ matrix.platform }}
-        run: |
-          just package="${{ needs.delta.outputs.packages }}" coverage-measure
-          just coverage-report-ci
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: true
-
   # Azure Blob storage backend tests against the Azurite emulator.
   #
   # The Azure backend's network paths self-skip when no
@@ -632,7 +627,7 @@ jobs:
   # and BENCH_HISTORY_REQUIRE_AZURITE turns an unreachable emulator into a hard
   # failure, so a misconfigured emulator can never silently degrade into skipping
   # every test. This job also collects coverage so the azure.rs network paths
-  # reach Codecov — the multi-platform `coverage` job runs without an emulator and
+  # reach Codecov — the multi-platform `test-x64` job runs without an emulator and
   # therefore cannot cover them; Codecov merges this azure-flagged upload with it.
   #
   # Runs on a single platform (Linux) by choice, not by limitation: the Azure Blob

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -301,8 +301,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run test-more on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" test-more
+      - name: Run tests on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" test
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -312,6 +312,9 @@ jobs:
           files: target/nextest/default/junit.xml
           flags: ${{ matrix.platform }}
           report_type: test_results
+
+      - name: Run benchmark targets on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" test-benches
 
   # ARM64 coverage for Miri. Miri is an interpreter with its own memory model and is
   # architecture-agnostic for platform-neutral code; we run it on ARM purely to exercise

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -165,11 +165,15 @@ jobs:
       - name: Run clippy dev on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" clippy dev
 
-  # The x86_64 test pass. Runs the full test suite (unit, integration and example tests)
-  # with coverage instrumentation, so the coverage report is a side effect of the regular
-  # test run rather than a second, separately re-executed pass. Also runs the benchmark
-  # targets once to verify they do not panic. Uploads both the coverage report and the
-  # test results to Codecov.
+  # The x86_64 test pass (ubuntu-latest and windows-latest — both x86_64). Runs the full
+  # test suite (unit, integration and example tests) with coverage instrumentation, so the
+  # coverage report is a side effect of the regular test run rather than a second,
+  # separately re-executed pass. Also runs the benchmark targets once to verify they do not
+  # panic. Uploads both the coverage report and the test results to Codecov.
+  #
+  # macOS is deliberately not here: GitHub's `macos-latest` runner is Apple Silicon (arm64),
+  # so macOS is exercised by the `test-arm` job instead. Keeping this job x86_64-only keeps
+  # its name accurate and stops the matrix drifting as the `-latest` labels change.
   #
   # Coverage requires the nightly toolchain (llvm-tools-preview is installed only there via
   # `just install-tools`), so this is the nightly test pass. The MSRV test pass runs on the
@@ -181,7 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -279,18 +283,20 @@ jobs:
       - name: Run miri on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" miri
 
-  # The ARM64 test pass. Exercises ARM-specific code paths (anything gated behind
-  # cfg(target_arch = "aarch64") or similar) which x86_64 runners never compile or execute,
-  # and serves as the MSRV test pass (the x86_64 `test-x64` job runs on nightly so it can
-  # collect coverage). No coverage here: llvm-tools-preview-based instrumentation is gathered
-  # on x86_64 only. Paired with `test-x64`; both carry an explicit `-x64`/`-arm` suffix.
+  # The ARM64 test pass (ubuntu-24.04-arm, windows-11-arm and macos-latest). Exercises
+  # ARM-specific code paths (anything gated behind cfg(target_arch = "aarch64") or similar)
+  # which x86_64 runners never compile or execute. macOS lives here too because GitHub's
+  # `macos-latest` runner is Apple Silicon (arm64). Also serves as the MSRV test pass (the
+  # x86_64 `test-x64` job runs on nightly so it can collect coverage). No coverage here:
+  # llvm-tools-preview-based instrumentation is gathered on x86_64 only. Paired with
+  # `test-x64`; both carry an explicit `-x64`/`-arm` suffix.
   test-arm:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-24.04-arm, windows-11-arm]
+        platform: [ubuntu-24.04-arm, windows-11-arm, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -834,7 +840,7 @@ jobs:
   # commit has landed.
   #
   # Coverage data arrives from several jobs: one upload per platform from the
-  # `coverage` matrix, plus a conditional `azure`-flagged upload from `test-azurite`
+  # `test-x64` matrix, plus a conditional `azure`-flagged upload from `test-azurite`
   # when cargo-bench-history is affected. The per-commit upload count is therefore
   # variable. codecov.yml sets `codecov.notify.manual_trigger: true`, so Codecov posts
   # NO coverage status or PR comment until this job runs the CLI `send-notifications`
@@ -843,26 +849,26 @@ jobs:
   # reporting a misleadingly low figure off a partial set (see codecov.yml for the
   # full rationale and why this is preferred over a hardcoded `after_n_builds`).
   #
-  # It depends on `coverage` and `test-azurite` (the only coverage producers;
+  # It depends on `test-x64` and `test-azurite` (the only coverage producers;
   # `test-azure` / `test-azure-gh` upload none). The `!cancelled()` status function lets
   # it run even when `test-azurite` is skipped — without a status function a skipped
   # dependency would skip this job too. It releases notifications only when every expected
-  # upload actually landed: `coverage` must have succeeded, and `test-azurite` must have
+  # upload actually landed: `test-x64` must have succeeded, and `test-azurite` must have
   # either succeeded (its azure upload landed) or been skipped (cargo-bench-history not
-  # affected, so no azure upload was expected). If `coverage` failed, or `test-azurite`
+  # affected, so no azure upload was expected). If `test-x64` failed, or `test-azurite`
   # ran and failed, an expected upload is missing and the build is already red — so we do
   # NOT release a status off an incomplete set, which would post the very "coverage
   # decreased" result this gate exists to prevent. A `skip_all` run uploads no coverage at
-  # all, so `coverage` is skipped and this job does not run.
+  # all, so `test-x64` is skipped and this job does not run.
   #
   # Like the upload jobs, this runs for fork PRs too: the token is empty there and the
   # action falls back to tokenless notification (this is a public repository), so
   # external-contributor PRs get the same gated, complete-data coverage status.
   coverage-notify:
-    needs: [coverage, test-azurite]
+    needs: [test-x64, test-azurite]
     if: >-
       !cancelled()
-      && needs.coverage.result == 'success'
+      && needs.test-x64.result == 'success'
       && (needs.test-azurite.result == 'success' || needs.test-azurite.result == 'skipped')
     runs-on: ubuntu-latest
 

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -11,14 +11,11 @@ coverage-measure:
     # This will run tests and generate test coverage data files, to be analyzed separately.
     #
     # We enumerate `--lib --bins --tests --examples` instead of using `--all-targets`
-    # because `--all-targets` would also pull in `--benches`. The Callgrind (`*_cg`)
-    # benches use Gungraun's `harness = false` main(), which is incompatible with nextest's
-    # per-test discover-then-dispatch model (its `--list` output is libtest "pretty" format,
-    # which nextest rejects). Upstream fix proposed in
-    # https://github.com/gungraun/gungraun/pull/644; until that lands (and possibly even
-    # after, for better isolation), excluding bench targets from `coverage-measure` is the
-    # simplest workaround. The `test-more` recipe runs the benches separately through
-    # `cargo test --benches` to verify they do not panic.
+    # because `--all-targets` would also pull in `--benches`. Bench targets are deliberately
+    # kept out of the coverage pass: they are slow and coverage of benchmark code is not
+    # meaningful. The benches are exercised separately (a "does it still build and run"
+    # smoke check) through the `test-benches` recipe, which runs them via `cargo test
+    # --benches`.
     cargo +{{ env_var('RUST_NIGHTLY') }} llvm-cov nextest {{ target_package }} --no-fail-fast --lib --bins --tests --examples --no-report --all-features --locked
 
 # This tool needs a different way to specify the package.

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -351,12 +351,9 @@ test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', ''):
 # consumed here; this is purely a "the benches still build and run" smoke check, separated
 # from "test" because benchmarks are quite slow.
 #
-# Benches go through `cargo test --benches` rather than nextest: nextest's per-test
-# discover-then-dispatch model is incompatible with the Callgrind (`*_cg`) benches, whose
-# `harness = false` main() spawns Valgrind for the entire suite in one shot. `cargo test
-# --benches` invokes each bench binary's main() once with `--test`, which Criterion treats
-# as "run each bench once" and Gungraun treats as its normal one-shot Valgrind run.
-# Upstream tracking: https://github.com/gungraun/gungraun/pull/644.
+# Benches go through `cargo test --benches` (not nextest): this invokes each bench binary's
+# main() once with `--test`, which Criterion treats as "run each bench once" and Gungraun
+# treats as its normal one-shot Valgrind run — exactly the smoke check we want here.
 [group('testing')]
 [script]
 test-benches FILTER="":

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -362,18 +362,6 @@ test-benches FILTER="":
 
     cargo +$env:RUST_MSRV test {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --benches
 
-# Runs regular tests as well as doing one iteration of benchmarks (the latter via the
-# `test-benches` recipe, run afterwards). We separate it from "test" because benchmarks are
-# quite slow, so we tend to only run them as part of a full validation pass. Tests go
-# through nextest (parallel execution, junit reporting, retries, etc.).
-[group('testing')]
-[script]
-test-more FILTER="": && (test-benches FILTER)
-    $ErrorActionPreference = "Stop"
-    $PSNativeCommandUseErrorActionPreference = $true
-
-    cargo +$env:RUST_MSRV nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --tests
-
 [group('testing')]
 [script]
 test-docs FILTER="":

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -347,18 +347,28 @@ test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', ''):
     Write-Host "Running real-Azure tests against account '$account' (Microsoft Entra ID; requires az login)."
     cargo +$env:RUST_MSRV nextest run -p cargo-bench-history real_azure --locked --no-fail-fast
 
-# Runs regular tests as well as doing one iteration of benchmarks.
-# We separate it from "test" because benchmarks are quite slow,
-# so we tend to only run them as part of a full validation pass.
+# Run the benchmark targets once to verify they do not panic. Their measurements are not
+# consumed here; this is purely a "the benches still build and run" smoke check, separated
+# from "test" because benchmarks are quite slow.
 #
-# Tests go through nextest (parallel execution, junit reporting, retries, etc.). Benches
-# go through `cargo test --benches` instead: nextest's per-test discover-then-dispatch
-# model is incompatible with the Callgrind (`*_cg`) benches, whose `harness =
-# false` main() spawns Valgrind for the entire suite in one shot. `cargo test --benches`
-# invokes each bench binary's main() once with `--test`, which Criterion treats as
-# "run each bench once" and Gungraun treats as its normal one-shot Valgrind run. We only
-# care that the benches do not panic; their measurements are not consumed here.
+# Benches go through `cargo test --benches` rather than nextest: nextest's per-test
+# discover-then-dispatch model is incompatible with the Callgrind (`*_cg`) benches, whose
+# `harness = false` main() spawns Valgrind for the entire suite in one shot. `cargo test
+# --benches` invokes each bench binary's main() once with `--test`, which Criterion treats
+# as "run each bench once" and Gungraun treats as its normal one-shot Valgrind run.
 # Upstream tracking: https://github.com/gungraun/gungraun/pull/644.
+[group('testing')]
+[script]
+test-benches FILTER="":
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    cargo +$env:RUST_MSRV test {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --benches
+
+# Runs regular tests as well as doing one iteration of benchmarks (the latter via
+# `test-benches`). We separate it from "test" because benchmarks are quite slow, so we tend
+# to only run them as part of a full validation pass. Tests go through nextest (parallel
+# execution, junit reporting, retries, etc.).
 [group('testing')]
 [script]
 test-more FILTER="":

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -365,18 +365,17 @@ test-benches FILTER="":
 
     cargo +$env:RUST_MSRV test {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --benches
 
-# Runs regular tests as well as doing one iteration of benchmarks (the latter via
-# `test-benches`). We separate it from "test" because benchmarks are quite slow, so we tend
-# to only run them as part of a full validation pass. Tests go through nextest (parallel
-# execution, junit reporting, retries, etc.).
+# Runs regular tests as well as doing one iteration of benchmarks (the latter via the
+# `test-benches` recipe, run afterwards). We separate it from "test" because benchmarks are
+# quite slow, so we tend to only run them as part of a full validation pass. Tests go
+# through nextest (parallel execution, junit reporting, retries, etc.).
 [group('testing')]
 [script]
-test-more FILTER="":
+test-more FILTER="": && (test-benches FILTER)
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
     cargo +$env:RUST_MSRV nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --tests
-    cargo +$env:RUST_MSRV test {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast --benches
 
 [group('testing')]
 [script]


### PR DESCRIPTION
## Problem

On x86_64 (ubuntu / macos / windows) the test suite was executed **twice** per platform:

- `test-more-x64` (MSRV): `nextest run --tests` + `cargo test --benches`
- `coverage` (nightly): `llvm-cov nextest --lib --bins --tests --examples` — a *superset* of the `--tests` part above, just with coverage instrumentation.

So every unit/integration test ran once for results and once for coverage. As you noted, gathering coverage is merely a side effect of running the tests, which also made the `coverage` job name misleading.

## Fix

Merge the two x86_64 jobs into a single `test-x64` job and rename the ARM counterpart for symmetry.

- **`coverage` → `test-x64`**: runs the full instrumented suite (the existing `coverage-measure` + `coverage-report-ci`), then runs the benchmark panic-check once. Uploads both the coverage report (lcov) and the test results (junit) to Codecov. It stays on the **nightly** toolchain because `llvm-tools-preview` is installed only for nightly (`just install-tools`), so coverage cannot move to MSRV without a larger toolchain change.
- **Removed `test-more-x64`**: its `--tests` run was the duplicate (already covered by the instrumented run); its `cargo test --benches` smoke-check is folded into `test-x64` via a new `test-benches` recipe.
- **`test-more-arm` → `test-arm`**: unchanged behaviour. It remains the **MSRV** test pass and the ARM-gated-code pass. No coverage here — instrumentation is x86_64-only, as before.
- Repointed dependents: `miri-x64`, `mutants`, `careful` → `test-x64`; `miri-arm` → `test-arm`.
- Updated the in-workflow comments and `.github/workflows/AGENTS.md` to match.

## Net effect on toolchain coverage

No platform runs the same tests twice, while both toolchains are still exercised:

- x86_64 unit / integration / example tests: **nightly** (`test-x64`, with coverage)
- x86_64 benchmark panic-check: **MSRV** (`test-x64` → `test-benches`)
- ARM tests + benchmark panic-check: **MSRV** (`test-arm`)
- MSRV compilation of every target: `check-dev`

## Verification

- Parsed `validation.yml` and confirmed every `needs:` resolves to a defined job (no dangling references to the old job names).
- `just --list` parses; the new `test-benches` recipe is registered.
- Ran `coverage-measure` locally and confirmed `llvm-cov nextest` still writes junit to `target/nextest/default/junit.xml`, so the test-results upload path is unchanged.
- Ran `test-benches` locally to confirm the recipe executes.
