### PR TITLE
Upgrade toolchain to 1.96.1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ links to the relevant code.
 workaround for `std::hint::cold_path()` being unavailable at the workspace MSRV.
 
 The intrinsic stabilized in Rust 1.95. The workspace toolchain
-(`rust-toolchain.toml`) is at 1.96, but the workspace MSRV is 1.93, so
+(`rust-toolchain.toml`) is at 1.96.1, but the workspace MSRV is 1.93, so
 `std::hint::cold_path()` cannot yet be used without raising `nm`'s MSRV.
 
 Once the workspace MSRV (or just `nm`'s package MSRV) is raised to 1.95 or

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96"
+channel = "1.96.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Bumps the pinned stable Rust toolchain from `1.96` to `1.96.1` to pick up upstream Cargo fixes.

The stable channel is pinned only in `rust-toolchain.toml`. `constants.env` (MSRV `1.93`, nightly) and CI (which reads the toolchain file via `dtolnay/rust-toolchain@stable`) need no changes. MSRV stays at `1.93` — this is only a toolchain patch bump.

Also updated the matching version reference in `TODO.md` for consistency.

Verified locally: `rustc 1.96.1 (31fca3adb)` / `cargo 1.96.1` resolves for the repo and `cargo check -p nm` builds cleanly.
