### PR TITLE
Run bench-history per-push instead of nightly

### DIFF
--- a/.github/bench-history-failure-issue.md
+++ b/.github/bench-history-failure-issue.md
@@ -3,10 +3,10 @@ title: "{{ env.FAILURE_ISSUE_TITLE }}"
 labels: bench-history, ci-failure
 ---
 
-The nightly **bench-history** workflow failed (collection or analysis). The
-benchmark history may be missing the latest `main` commit until this is fixed.
+The **bench-history** workflow failed (collection or analysis). The
+benchmark history may be missing the pushed `main` commit until this is fixed.
 
 Failed run: {{ env.RUN_URL }}
 
-This issue is updated, not duplicated, on each failing night, and is closed
+This issue is updated, not duplicated, on each failing run, and is closed
 automatically once the workflow runs green again.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -151,12 +151,12 @@ Split from the monolithic `just validate-extra-local` into individual jobs, all 
 
 - **test-azure-gh** — single-platform (Linux) by choice, package-gated to `cargo-bench-history`
   - Variant of `test-azure` that exercises cargo-bench-history's **self-minting GitHub
-    OIDC credential** — the credential the nightly prod collection (`bench-history.yml`)
+    OIDC credential** — the credential the per-push prod collection (`bench-history.yml`)
     depends on — against the real test account. The `storage/github_oidc.rs` unit tests
     stub the HTTP exchange and `test-azure` takes the local-`az`
     `DeveloperToolsCredential` fallback, so without this job nothing proves the
     self-minting path actually round-trips real GitHub OIDC → Entra → Blob until the
-    post-merge nightly run.
+    post-merge collection run.
   - **Only difference from `test-azure`**: an extra step exports `AZURE_CLIENT_ID`
     (= `AZURE_TEST_CLIENT_ID`). Setting `AZURE_CLIENT_ID` is the switch that makes
     `from_config` build a `ClientAssertionCredential` (which GETs a fresh OIDC JWT,
@@ -216,27 +216,29 @@ for manual cache warming after toolchain updates.
 
 ### bench-history.yml
 
-A scheduled workflow that collects the workspace's benchmark results into the
-long-lived Azure history store every night, building the performance history that
-`cargo-bench-history analyze` reads to detect regressions. Only nightly collection
-exists today; PR-time collection/validation may follow once this proves out.
+A push-triggered workflow that collects the workspace's benchmark results into the
+long-lived Azure history store on every push to `main`, building the performance history
+that `cargo-bench-history analyze` reads to detect regressions. It runs per-push rather
+than on a nightly schedule: a nightly run re-benchmarks an unchanged tip for no gain and
+misses intermediate same-day commits, whereas per-push collects exactly one data point per
+commit. The accepted trade-off is more runner time on busy days.
 
 - **Multi-platform matrix** (ubuntu-latest, windows-latest, ubuntu-24.04-arm,
   windows-11-arm) with `fail-fast: false`: each OS/architecture is a distinct
   measurement target, and a failure on one platform must not abandon the others'
-  history for that night. macOS is omitted — there is no macOS-hosted history store
+  history for that commit. macOS is omitted — there is no macOS-hosted history store
   consumer yet; add it to the matrix if/when macOS performance tracking is wanted.
 - **Whole workspace except the `benchmarks` package**, via the
   `just gh-collect-bench-history` recipe (`cargo-bench-history run --workspace --exclude
   benchmarks --skip-existing`). The `benchmarks` package holds slow, special-purpose
   benchmarks that are not part of the tracked history. `--skip-existing` makes a re-run on
-  an unchanged `main` commit a no-op append (each already-stored object is skipped, not
-  overwritten) rather than failing as a duplicate — and, crucially, never bumps the
-  cache-invalidation marker the `analyze` job's read-through cache depends on, so an
-  append-only night never wipes that cache.
+  an already-collected `main` commit a no-op append (each already-stored object is skipped,
+  not overwritten) rather than failing as a duplicate — and, crucially, never bumps the
+  cache-invalidation marker the `analyze` job's read-through cache depends on, so a
+  re-triggered append-only run never wipes that cache.
 - **Uses a dedicated prod managed identity** (`id-folo-bench-history-prod`, provisioned
   by `infra/azure-bench-history-prod/` alongside the account), not the test identity: a
-  scheduled run on `main` produces the OIDC subject
+  push (or gated dispatch) on `main` produces the OIDC subject
   `repo:folo-rs/folo:ref:refs/heads/main`, which matches that identity's `main`-branch
   federated credential. The prod stack is self-contained so the data store never depends
   on test infrastructure. So this workflow needs only `permissions: { id-token: write,
@@ -249,15 +251,23 @@ exists today; PR-time collection/validation may follow once this proves out.
   target. The prod account is baked into the committed `.cargo/bench_history.toml` (where
   cargo-bench-history config belongs), so no account name is surfaced into `$GITHUB_ENV`;
   only the `azure/login` inputs need the grep step.
-- **Same-repo gate** (`if: github.repository == 'folo-rs/folo'`): scheduled workflows
-  also trigger on forks that enable Actions, but only this repository's identity can
-  federate into Azure, so the job skips everywhere else.
+- **Same-repo + main-only gate** (`if: github.repository == 'folo-rs/folo' && github.ref ==
+  'refs/heads/main'`): only this repository's identity can federate into Azure, and the
+  federated credential is scoped to `refs/heads/main`, so a fork or a `workflow_dispatch`
+  from a feature branch skips cleanly instead of failing at OIDC exchange.
 - **Auto-detected machine key**: the wall-clock engines partition by the runner's
   auto-detected machine fingerprint (no override) — the `target-triple` already separates
   OS/arch, and an explicit key would risk merging dissimilar hosts under one partition.
-- `timeout-minutes: 360`; schedule offset to 03:00 UTC so it does not contend with the
-  00:00 `cache-warmup` cron (and runs against an already-warm Rust cache). Like
-  `cache-warmup`, it is schedule-triggered and so carries no `concurrency` cancel key.
+- `timeout-minutes: 360` (a generous ceiling that only bounds a genuinely stuck run, since
+  the matrix runs in parallel). Unlike `cache-warmup`, this workflow IS commit-driven, so it
+  carries a `concurrency` block — but keyed on the commit **SHA**
+  (`${{ github.workflow }}-${{ github.sha }}`), NOT the ref. Distinct commits must collect
+  in parallel: each is its own history data point, and the ref-keyed cancel-in-progress used
+  by `validation.yml` would cancel an in-flight commit's benchmarks whenever a newer commit
+  landed, dropping that commit's data and defeating the per-commit goal. With a SHA key,
+  `cancel-in-progress: true` only dedups a redundant re-trigger of the SAME commit (a re-run
+  or a dispatch on an already-pushed commit), which `--skip-existing` would make a no-op
+  append anyway.
 - **`analyze` job** (`needs: collect`, `if: always()` + same main-only gate) — after
   collection it runs `just gh-analyze-bench-history` (`analyze --engine all --target-triple
   all --machine-key all` across every platform's history) which writes a Markdown report
@@ -267,18 +277,18 @@ exists today; PR-time collection/validation may follow once this proves out.
   the tool always exits 0; the issue is advisory. Needs `issues: write`. It checks out
   with `fetch-depth: 0` so the first-parent history resolves. An `actions/cache` step
   ("Restore benchmark-history read-through cache") persists the recipe's `--cache`
-  directory (`bench-history-cache/`, the read-through mirror) between nights so the bulk
+  directory (`bench-history-cache/`, the read-through mirror) between runs so the bulk
   history is downloaded at most once rather than in full every run. The cache key is unique
   per run (`bench-history-cache-<run_id>`; entries are immutable per key) with
   `restore-keys: bench-history-cache-`, so each run restores the most recent prior mirror,
-  the analyze step tops it up with the night's new objects, and the run saves a fresh entry
+  the analyze step tops it up with this run's new objects, and the run saves a fresh entry
   on success. The step's `path:` must stay in lockstep with the directory the recipe passes
   to `--cache`. Correctness does not depend on the cache being fresh: the cloud history is
   append-only (collect uses `--skip-existing`), and a deliberate `--overwrite`/`prune`
   bumps a cloud-side marker that wipes the mirror on the next read.
 - **`alert` job** (`needs: [collect, analyze]`, `if: failure()` + main-only) — opens a
   deduplicated `.github/bench-history-failure-issue.md` when any prior job fails, so a
-  broken nightly is noticed. The issue title comes from the workflow-level
+  broken run is noticed. The issue title comes from the workflow-level
   `FAILURE_ISSUE_TITLE` env constant (the template renders `{{ env.FAILURE_ISSUE_TITLE }}`),
   which is also the title create-an-issue dedups on. Its companion `resolve` job closes that
   issue automatically once the workflow is green again.
@@ -286,7 +296,7 @@ exists today; PR-time collection/validation may follow once this proves out.
   `alert`: when collection and analysis both pass, it finds any still-open failure issue
   (listed by the `ci-failure` label, then exact-matched against the shared
   `FAILURE_ISSUE_TITLE` constant) and closes it via the `gh` CLI with a comment linking the
-  green run, so a fixed nightly does not leave a stale alert open. A no-op on nights when no
+  green run, so a fixed run does not leave a stale alert open. A no-op on runs when no
   failure issue is open. Its gate is the explicit `needs.collect.result == 'success' &&
   needs.analyze.result == 'success'` (rather than the bare `success()` function) so a future
   unrelated job cannot affect the decision; when `collect` or `analyze` actually failed those
@@ -299,8 +309,11 @@ exists today; PR-time collection/validation may follow once this proves out.
    key with `group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}` and
    `cancel-in-progress: true`. This automatically cancels in-progress runs when new commits
    are pushed to the same PR branch or to main, avoiding wasted runner time on outdated code.
-   The `cache-warmup` and `bench-history` workflows are excluded because they are
-   schedule-triggered and not commit-driven.
+   The `cache-warmup` workflow is excluded because it is schedule-triggered and not
+   commit-driven. `bench-history` is commit-driven (push to main) and so DOES carry a
+   `concurrency` block, but keyed on the commit **SHA** rather than the ref: it collects one
+   history data point per commit, so cancelling an in-flight commit to favour a newer one
+   would drop measurements. See its section above for the full rationale.
 
 2. **Parallelization over sequential execution** — Individual jobs provide:
    - Faster CI feedback (first failure visible immediately)

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -1,19 +1,29 @@
 name: Benchmark history
 
-# Nightly collection of the workspace's benchmark results into the long-lived Azure
+# Per-commit collection of the workspace's benchmark results into the long-lived Azure
 # history store (account folohistory, baked into .cargo/bench_history.toml; see also
-# infra/azure-bench-history-prod/). Each run benchmarks the whole workspace EXCEPT the
-# slow, special-purpose `benchmarks` package, on every supported OS/architecture, and
-# appends the results keyed by the current `main` commit. Over time this builds the
-# performance history that `cargo-bench-history analyze` reads to spot regressions.
+# infra/azure-bench-history-prod/). Each push to `main` benchmarks the whole workspace
+# EXCEPT the slow, special-purpose `benchmarks` package, on every supported OS/architecture,
+# and appends the results keyed by the pushed commit. Over time this builds the performance
+# history that `cargo-bench-history analyze` reads to spot regressions.
 #
-# Only nightly for now. PR-time collection/validation may follow once this proves out.
+# Runs per-push rather than on a nightly schedule: a nightly run re-benchmarks an unchanged
+# tip for no gain and misses intermediate same-day commits, whereas per-push collects one
+# data point per commit. The trade-off is more runner time on busy days.
 on:
-  schedule:
-    # 03:00 UTC, offset from the 00:00 cache-warmup cron so the two do not contend for
-    # the runner pool (and so this runs against an already-warm Rust cache).
-    - cron: '0 3 * * *'
+  push:
+    branches: [main]
   workflow_dispatch:
+
+# Group by the commit SHA, not the ref. Distinct commits must collect in parallel — each is
+# its own history data point, and cancelling one to favour a newer commit would drop that
+# commit's measurements, defeating the per-commit goal (so the usual ref-keyed
+# cancel-in-progress from validation.yml would be wrong here). cancel-in-progress therefore
+# only dedups a redundant re-trigger of the SAME commit (a re-run, or a workflow_dispatch on
+# an already-pushed commit), which `--skip-existing` would make a no-op append anyway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
 
 # Title of the rolling failure-alert issue, defined once and shared by the two jobs that
 # reference it: the `alert` job stamps it as the issue title (via the
@@ -22,7 +32,7 @@ on:
 # create-an-issue dedups solely by exact title, so this string is the alert's identity; a
 # single definition keeps the open and close paths from drifting apart.
 env:
-  FAILURE_ISSUE_TITLE: Nightly benchmark-history workflow failed
+  FAILURE_ISSUE_TITLE: Benchmark-history workflow failed
 
 jobs:
   collect:
@@ -34,8 +44,8 @@ jobs:
     if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
 
     strategy:
-      # One platform's benchmarks failing must not abandon the others' history for the
-      # night; each platform stores into its own partition independently.
+      # One platform's benchmarks failing must not abandon the others' history for this
+      # commit; each platform stores into its own partition independently.
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
@@ -90,7 +100,7 @@ jobs:
   analyze:
     # Survey the freshly-updated history for regressions and post a rolling issue when
     # any finding survives. Runs after every platform finishes (even partially:
-    # fail-fast is off) so the night's analysis reflects whatever did land, and only on
+    # fail-fast is off) so this commit's analysis reflects whatever did land, and only on
     # main (where OIDC sign-in works), matching collect's gate.
     needs: collect
     if: always() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
@@ -131,10 +141,10 @@ jobs:
           } >> "$GITHUB_ENV"
 
       # Persist the read-through cache (cargo-bench-history's --cache directory) across
-      # nightly runs so the bulk history is downloaded at most once instead of in full
-      # every night. The key is unique per run (cache entries are immutable per key), and
+      # runs so the bulk history is downloaded at most once instead of in full every
+      # run. The key is unique per run (cache entries are immutable per key), and
       # restore-keys falls back to the most recent prior `bench-history-cache-` entry, so
-      # each run restores the latest mirror, the analyze step tops it up with the night's
+      # each run restores the latest mirror, the analyze step tops it up with this run's
       # new objects, and this run saves a fresh entry on success. The path MUST match the
       # `--cache` directory the `gh-analyze-bench-history` recipe passes (relative to the
       # repo root). The cloud history is append-only (collect uses --skip-existing), so a
@@ -160,17 +170,16 @@ jobs:
 
       # JasonEtco/create-an-issue derives the issue title/labels from the file's YAML
       # front matter; the report the tool renders has none, so prepend a fixed header.
-      # The fixed title is also the dedup key that turns nightly findings into one
-      # rolling issue.
+      # The fixed title is also the dedup key that turns findings into one rolling issue.
       - name: Compose regression issue
         if: steps.notable.outputs.value == 'true'
         shell: bash
         run: |
-          { printf -- '---\ntitle: Benchmark regressions detected (nightly)\nlabels: bench-history, regression\n---\n\n'; cat bench-history-report.md; } > bench-history-issue.md
+          { printf -- '---\ntitle: Benchmark regressions detected\nlabels: bench-history, regression\n---\n\n'; cat bench-history-report.md; } > bench-history-issue.md
 
-      # One rolling issue, updated rather than duplicated each night (the fixed title is
+      # One rolling issue, updated rather than duplicated each run (the fixed title is
       # the dedup key), so a regression that persists does not spam new issues. Opened
-      # only when findings exist; nights with none touch nothing.
+      # only when findings exist; runs with none touch nothing.
       - name: File rolling regression issue
         if: steps.notable.outputs.value == 'true'
         uses: JasonEtco/create-an-issue@v2
@@ -183,7 +192,7 @@ jobs:
 
   alert:
     # Open a deduplicated issue whenever collection or analysis fails, so a broken
-    # nightly is noticed instead of silently rotting. Same main-only gate as the others.
+    # run is noticed instead of silently rotting. Same main-only gate as the others.
     needs: [collect, analyze]
     if: failure() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -209,11 +218,11 @@ jobs:
 
   resolve:
     # Mirror of `alert`: when collection AND analysis are green again, auto-close the
-    # rolling failure issue (if one is open) so a fixed nightly does not leave a stale
+    # rolling failure issue (if one is open) so a fixed run does not leave a stale
     # alert rotting open. Gated on both needs' results being 'success' (explicit rather
     # than the implicit success() function, so a future unrelated job cannot affect this
     # decision); if either failed, alert (failure()) handles it and this is skipped. Same
-    # main-only gate as the others. A no-op on nights when no failure issue is open.
+    # main-only gate as the others. A no-op on runs when no failure issue is open.
     needs: [collect, analyze]
     if: >-
       needs.collect.result == 'success'
@@ -257,5 +266,5 @@ jobs:
             echo "Closing #$n"
             gh issue close "$n" \
               --reason completed \
-              --comment "✅ The nightly bench-history workflow is green again — auto-closing this alert. Successful run: $RUN_URL"
+              --comment "✅ The bench-history workflow is green again — auto-closing this alert. Successful run: $RUN_URL"
           done

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -766,11 +766,11 @@ jobs:
         run: ./infra/azure-bench-history-test/cleanup-containers.ps1 -MinAgeMinutes 180
 
   # Variant of test-azure that exercises cargo-bench-history's SELF-MINTING GitHub
-  # OIDC credential — the exact credential the nightly prod collection (bench-history.yml)
+  # OIDC credential — the exact credential the prod collection (bench-history.yml)
   # depends on — against the real test account. The unit tests in storage/github_oidc.rs
   # stub the HTTP exchange, and test-azure above takes the local-az DeveloperToolsCredential
   # fallback, so without this job nothing would prove the self-minting path actually
-  # round-trips real GitHub OIDC -> Entra -> Blob until the post-merge nightly run.
+  # round-trips real GitHub OIDC -> Entra -> Blob until the post-merge collection run.
   #
   # The only difference from test-azure is exporting AZURE_CLIENT_ID: setting it is the
   # switch that makes from_config build a ClientAssertionCredential (which mints a fresh

--- a/infra/azure-bench-history-prod/README.md
+++ b/infra/azure-bench-history-prod/README.md
@@ -1,4 +1,4 @@
-# Azure infrastructure for the nightly benchmark-history data store
+# Azure infrastructure for the benchmark-history data store
 
 This directory provisions the Azure storage account that holds the **real,
 long-lived benchmark history** collected by the `bench-history` GitHub workflow
@@ -17,11 +17,11 @@ the environment can be deleted and re-created with one command.
   disabled** (Entra ID only, so there is no account key to leak). Container and blob
   soft-delete are disabled, matching the test account.
 - A **dedicated user-assigned managed identity** (`id-folo-bench-history-prod`) with a
-  **GitHub OIDC federated credential** for `main`. The nightly workflow federates into
+  **GitHub OIDC federated credential** for `main`. The bench-history workflow federates into
   it with no stored secret: `cargo-bench-history` mints a fresh GitHub OIDC token on
   demand and exchanges it with Entra for each access token (so a multi-hour run stays
   authenticated). Only `main` is trusted — there is no pull-request credential —
-  because collection only ever runs on `main` (schedule + gated dispatch).
+  because collection only ever runs on `main` (push + gated dispatch).
 - **`Storage Blob Data Contributor`** role assignments on the account for that managed
   identity and (optionally) a local developer principal. That single role covers
   container create/delete and blob read/write/delete via the data plane, which is all
@@ -83,7 +83,7 @@ This benches every workspace package except `benchmarks` (the slow, special-purp
 one) and stores into the account from `.cargo/bench_history.toml`. It requires your
 user to hold the `Storage Blob Data Contributor` role on the account (deploy with
 `-LocalPrincipalId` as above). For a throwaway run that never touches Azure, add
-`--local <path>`. The nightly automation uses the dedicated `just gh-collect-bench-history`
+`--local <path>`. The CI automation uses the dedicated `just gh-collect-bench-history`
 recipe instead.
 
 ## Tear down / re-create
@@ -94,5 +94,5 @@ recipe instead.
 ```
 
 Tearing down permanently deletes the collected history. It is reconstructible with
-`cargo bench-history backfill` over past commits, but the nightly job otherwise only
+`cargo bench-history backfill` over past commits, but the collection job otherwise only
 repopulates history going forward.

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -10,9 +10,9 @@
 # machine partition for noisy wall-clock engines is auto-detected; deterministic engines
 # (Callgrind, allocation/time counters) are hardware-independent. `--skip-existing` makes a
 # re-run on an unchanged commit a no-op append (each already-stored object is skipped, not
-# overwritten), so the nightly never bumps the cache-invalidation marker the `analyze` job's
-# read-through cache depends on — a re-run of the same commit is not "better" data, so there
-# is nothing to replace.
+# overwritten), so a re-triggered run of an already-collected commit never bumps the
+# cache-invalidation marker the `analyze` job's read-through cache depends on — a re-run of
+# the same commit is not "better" data, so there is nothing to replace.
 [group('automation')]
 gh-collect-bench-history:
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- run --workspace --exclude benchmarks --skip-existing --verbose
@@ -27,9 +27,9 @@ gh-collect-bench-history:
 #
 # `--cache` mirrors fetched cloud objects under `bench-history-cache/` (relative to the
 # repo root, the working directory here) so the bulk history is downloaded at most once
-# across nights instead of in full every run. The bench-history.yml `analyze` job persists
+# across runs instead of in full every run. The bench-history.yml `analyze` job persists
 # that directory between runs via `actions/cache`; its `path:` MUST match the directory
-# named here. The cloud history is append-only (the nightly collection uses
+# named here. The cloud history is append-only (collection uses
 # `--skip-existing`), so the cache only ever tops up — a stale mirror is wiped via the
 # cloud-side marker only after a deliberate `--overwrite`/`prune`.
 [group('automation')]
@@ -43,7 +43,7 @@ gh-analyze-bench-history:
     $notablePath = Join-Path (Get-Location) "bench-history-notable.txt"
     $common = @('--engine', 'all', '--target-triple', 'all', '--machine-key', 'all')
 
-    Write-Verbose "Analyzing benchmark history in a single pass; writing Markdown to $reportPath and JSON to $jsonPath, mirroring fetched cloud objects under bench-history-cache/ so the history is downloaded at most once across nights." -Verbose
+    Write-Verbose "Analyzing benchmark history in a single pass; writing Markdown to $reportPath and JSON to $jsonPath, mirroring fetched cloud objects under bench-history-cache/ so the history is downloaded at most once across runs." -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --cache=bench-history-cache --no-text --markdown $reportPath --json $jsonPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -189,7 +189,7 @@ several projects' objects at once, so invalidation is **per project**: a cloud-s
 arm and a per-command flush bumps; `synchronize_cache` (before a load) wipes that
 project's stale mirrored objects (`storage::project_objects_prefix`, `v1/<project>/objects/`),
 and `report_cache_tally` notes hits/misses after. Append-only
-`put` never arms it, so the nightly `run --skip-existing` collection never wipes the
+`put` never arms it, so the CI `run --skip-existing` collection never wipes the
 cache it feeds.
 
 **Testing note:** the `cbh_integration` harness (`Workspace`) auto-injects
@@ -214,7 +214,7 @@ test process's.
   `AlreadyExists` collision into a soft skip (`StoreOutcome::Skipped`): the run still
   benchmarks every engine — so a broken benchmark is still caught — but writes
   nothing and does not arm the cache-invalidation marker. This is the append-only
-  mode the nightly collection uses (see [storage selection](#storage-selection-local--cloud-config)).
+  mode the CI collection uses (see [storage selection](#storage-selection-local--cloud-config)).
 * `dirty_key(commit, observation_unix)` → `…/<commit>/dirty-<observation_unix>.json`
   — a snapshot of an uncommitted tree, distinguished by its observation second so
   multiple dirty snapshots on one base commit coexist; only a same-second clash is

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -352,7 +352,7 @@ directly.)
   * `all` (e.g. `--machine-key all`) removes the filter for that dimension —
     the explicit way to widen past the current machine. It is rejected in
     create mode (see below).
-* A facet that matches several sets (e.g. a Windows and a Linux nightly pool)
+* A facet that matches several sets (e.g. a Windows and a Linux runner pool)
   yields **one report per set** — parallel data sets, analyzed individually.
 
 **Hardware-independent sets and the machine-key facet.** Callgrind and
@@ -556,9 +556,9 @@ unit-tested without touching the process environment. The chosen backend (and wh
 > Status: **implemented.** Decision 41 logs the rationale and the alternatives weighed.
 
 `analyze`/`list`/`prune` load the whole in-selection history before reconstructing the
-series, and against the cloud backend that is one download per object. The nightly
-`analyze` re-fetches everything even though almost all of it is identical to the night
-before. An optional on-disk **read-through cache** removes that waste: each run pays
+series, and against the cloud backend that is one download per object. The CI
+`analyze` re-fetches everything even though almost all of it is identical to the previous
+run. An optional on-disk **read-through cache** removes that waste: each run pays
 the network cost only for objects it has never seen, and the cache survives between CI
 runs via the GitHub [`actions/cache`](https://github.com/actions/cache) action.
 
@@ -570,7 +570,7 @@ misses the cache and falls through). Trusting a cached body forever is sound bec
 the storage model is **immutable per key** — the write-once `put` refuses to change an
 existing key, so clean runs, dirty snapshots, and blessing sidecars never change once
 written. Only two operations break that immutability, and both are rare, deliberate
-administrative actions never reached on the nightly hot path: a `delete` (used by
+administrative actions never reached on the CI collection hot path: a `delete` (used by
 `prune`/`unbless`, and by `--overwrite` dropping a stale blessing) and a `put_overwrite`
 (the explicit `--overwrite` escape hatch). A cache must be discarded whenever either
 happens; a brand-new key never invalidates anything, because it was never cached.
@@ -598,14 +598,14 @@ harmless. The marker is maintained by the cloud backend itself, not by the cache
 machines' caches: the local cache is a read-side optimization, the marker a cloud-side
 correctness contract, and the two are independent.
 
-**The nightly must stay append-only.** The cache only survives a nightly run if that
+**Collection must stay append-only.** The cache only survives a CI run if that
 run never mutates an existing object. The collection previously used `--overwrite`
 purely so a re-run on an unchanged commit was idempotent rather than a duplicate
 failure — but overwriting routes every write (even the first write of a new commit)
-through the mutating path and would invalidate the cache every night. A
+through the mutating path and would invalidate the cache on every run. A
 `run --skip-existing` mode fixes this: a write-once collision becomes a **soft skip**
 (the run still benchmarks every engine, so a broken benchmark is still caught, but
-writes nothing) instead of a failure. The nightly switches to it, keeping the
+writes nothing) instead of a failure. Collection switches to it, keeping the
 production write path **purely additive** so it never bumps the marker. This is also
 better history hygiene — a stored measurement becomes immutable, so a re-run can never
 silently rewrite past data — while still meeting the original "a re-run must not fail
@@ -617,7 +617,7 @@ fallback, resolved like `--local`) on `analyze`/`list`/`prune` selects the cache
 directory. It applies only to the cloud backend, so it **conflicts with `--local`** —
 a local backend's reads are already on disk. `run`/`backfill` take no `--cache` (they
 do not read the bulk history) but still maintain the marker through the backend
-automatically. In CI the nightly `collect` switches to `--skip-existing`, and the
+automatically. In CI the `collect` step uses `--skip-existing`, and the
 `analyze` job restores and saves the cache directory through `actions/cache`. The one
 scaling limit is the repository's Actions-cache quota (a default 10 GiB, raisable with
 paid billing); beyond it the cache degrades to a partial restore — still correct, just
@@ -701,7 +701,7 @@ simply produce no output — no OS logic is needed in the tool.
    by default (non-zero exit, via the write-once `put` contract, §4.2) unless
    `--overwrite`, which makes re-runs idempotent and safe to repeat (or `--skip-existing`,
    which treats the existing point as a success and writes nothing — the append-only mode the
-   nightly `collect` uses, §7.2). A **dirty**
+   CI `collect` uses, §7.2). A **dirty**
    snapshot writes
    `…/<commit>/dirty-<observation_unix>.json` and coexists with prior snapshots (only a
    same-timestamp clash is a conflict). An engine that harvests **zero** cases stores
@@ -735,7 +735,7 @@ the hardware fingerprint, §4.1), `--no-store`, `--overwrite` (replace an existi
 same-commit point instead of refusing, §4.2), `--skip-existing` (mutually exclusive
 with `--overwrite`: a same-commit point that already exists is a **soft skip** —
 success, nothing written — instead of the `RunError::Duplicate` failure of the
-default write-once mode; used by the nightly `collect` recipe so collection stays
+default write-once mode; used by the CI `collect` recipe so collection stays
 append-only and never invalidates the read-through cache, see §7.2), `--verbose` (print a step-by-step
 diagnostic trail to stderr — the benchmark command and injected env, directories
 scanned, files included/skipped-as-stale, and each stored key — to diagnose a run
@@ -774,7 +774,7 @@ present (§4.3), unfiltered by default. When *analyzing*, `--engine`,
 `--target-triple`, `--machine-key` filter the sets — each repeatable, each accepting
 `all`, each defaulting to the current machine (engine to *all engines*) when omitted
 (§4.3); every matched set is analyzed independently and produces its own report (so a
-Windows and a Linux nightly pool come out as two reports).
+Windows and a Linux runner pool come out as two reports).
 
 **Selecting the commits (the query model).** Two refs frame the analysis:
 * `--context <ref>` — the **target** whose history is analyzed (default: current
@@ -1227,7 +1227,7 @@ does not force branch mode — a dirty checkout that has only ever stored clean 
 carries no feature-branch data and stays history. `tip` is never auto-selected; it
 is an explicit fast guard. This matches the two real scenarios:
 
-* **Scheduled trend watch (history).** A nightly/weekly job looks back over the base
+* **Scheduled trend watch (history).** A scheduled job looks back over the base
   branch's last months for regressions and slow trends, posting findings to an
   alert channel. Long-range techniques make sense here because the series is long.
 * **Feature-branch evaluation (branch).** One-to-several runs sit on top of the base
@@ -1749,9 +1749,9 @@ Each iteration ships with tests and docs and leaves the tool runnable.
     additive job, identical to `test-azure` except it also exports `AZURE_CLIENT_ID`
     (= `AZURE_TEST_CLIENT_ID`). That single switch routes `from_config` through the
     **self-minting `ClientAssertionCredential`** (decision 38) — the exact credential
-    the nightly prod collection depends on — so PR-time CI proves the real GitHub OIDC →
+    the per-push prod collection depends on — so PR-time CI proves the real GitHub OIDC →
     Entra → Blob round-trip works, instead of only discovering a regression after merge
-    on the next nightly run. `permissions: id-token: write` provides the
+    on the next collection run. `permissions: id-token: write` provides the
     `ACTIONS_ID_TOKEN_REQUEST_*` values the tool reads to mint assertions, and the test
     identity's `pull_request` federated credential lets same-repo PR runs federate in.
     `azure/login@v2` is retained **only** so the harness's `az`-based container cleanup
@@ -2237,16 +2237,16 @@ Each iteration ships with tests and docs and leaves the tool runnable.
      changes the reader discards only **that project's mirrored objects** (coarse but
      correct, since mutations are rare); the marker is maintained by the
      cloud backend, so every writer invalidates other machines' caches even when it holds
-     no cache itself. *Key enabler the issue did not consider:* the nightly `collect`
+     no cache itself. *Key enabler the issue did not consider:* the CI `collect`
      used `--overwrite` for same-commit idempotency, which would mutate objects and wipe
-     the cache nightly; a new **`run --skip-existing`** mode keeps the production write
+     the cache on every run; a new **`run --skip-existing`** mode keeps the production write
      path append-only — and makes stored measurements immutable, which is better history
-     hygiene — so the nightly never invalidates the cache it feeds. CLI: a `--cache <dir>`
+     hygiene — so collection never invalidates the cache it feeds. CLI: a `--cache <dir>`
      (+ `CARGO_BENCH_HISTORY_CACHE` env) on the three read commands, applicable only to
      the cloud backend, so it **conflicts with `--local`**. CI: the `collect` recipe
      switches to `--skip-existing`, and the `analyze` job restores/saves the cache via
      `actions/cache`. *Rejected:* (a) caching the listing — would hide newly stored
-     objects; (b) keeping the nightly on `--overwrite` and detecting create-vs-replace at
+     objects; (b) keeping collection on `--overwrite` and detecting create-vs-replace at
      the backend to spare the cache — works, but adds a round-trip per write and leaves
      history mutable, which `--skip-existing` avoids outright; (c) building the cache into
      the Azure backend to cache raw wire bytes — cheaper on a miss, but not testable with

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -363,7 +363,7 @@ struct RunCommand {
 
     /// Treat an already-stored result for this run as a success that writes
     /// nothing, instead of refusing it as a duplicate. Mutually exclusive with
-    /// `--overwrite`; the append-only mode the nightly collection uses.
+    /// `--overwrite`; the append-only mode the CI collection uses.
     #[arg(long, help_heading = HEADING_ENV, conflicts_with = "overwrite")]
     skip_existing: bool,
 

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -101,7 +101,7 @@ pub struct RunOptions {
     pub overwrite: bool,
     /// Treat an already-stored result for this run's identity as a success that
     /// writes nothing, instead of refusing the run as a duplicate. Mutually
-    /// exclusive with `overwrite`; the append-only mode the nightly `collect`
+    /// exclusive with `overwrite`; the append-only mode the CI `collect`
     /// recipe uses so collection never overwrites (and so never invalidates the
     /// cloud read-through cache).
     pub skip_existing: bool,

--- a/packages/cargo-bench-history/src/commands/run.rs
+++ b/packages/cargo-bench-history/src/commands/run.rs
@@ -585,7 +585,7 @@ enum StoreOutcome {
 /// the collision surfaces as [`RunError::Duplicate`] so the caller can refuse it.
 /// `--overwrite` replaces any existing object in place instead; `--skip-existing`
 /// instead treats the existing object as a success that writes nothing — the
-/// append-only mode the nightly collection uses so it never overwrites an object
+/// append-only mode the CI collection uses so it never overwrites an object
 /// (and so never invalidates the cloud read-through cache).
 async fn store_result<S: Storage>(
     storage: &S,

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -243,7 +243,7 @@
 //!    managed identity below.
 //! 3. **For CI, authenticate with GitHub OIDC workload identity federation** instead
 //!    of a stored secret: create a user-assigned managed identity, add a federated
-//!    credential whose subject matches the workflow's OIDC token (for a scheduled run
+//!    credential whose subject matches the workflow's OIDC token (for a run
 //!    on the default branch that is `repo:<owner>/<repo>:ref:refs/heads/main`) and
 //!    whose audience is `api://AzureADTokenExchange`, then grant it the role from
 //!    step 2. Run the tool from a job that has `permissions: { id-token: write }`,
@@ -262,7 +262,7 @@
 //! <https://github.com/folo-rs/folo/tree/main/infra/azure-bench-history-prod> and a
 //! separate test account/identity at
 //! <https://github.com/folo-rs/folo/tree/main/infra/azure-bench-history-test>, with the
-//! account name baked into the committed `.cargo/bench_history.toml` and the nightly
+//! account name baked into the committed `.cargo/bench_history.toml` and the per-push
 //! consumer at <https://github.com/folo-rs/folo/blob/main/.github/workflows/bench-history.yml>.
 
 mod analyze;

--- a/packages/cargo-bench-history/src/storage/caching.rs
+++ b/packages/cargo-bench-history/src/storage/caching.rs
@@ -305,7 +305,7 @@ mod tests {
         block_on(storage.get("v1/p/objects/criterion/a.json")).unwrap();
 
         // A key added to the cloud after the mirror was populated must still be
-        // listed, so the load discovers the night's new objects.
+        // listed, so the load discovers the run's new objects.
         block_on(storage.inner().put("v1/p/objects/criterion/b.json", b"b")).unwrap();
         let keys = block_on(storage.list("v1/p/objects/criterion/")).unwrap();
         assert_eq!(

--- a/packages/cargo-bench-history/src/storage/mod.rs
+++ b/packages/cargo-bench-history/src/storage/mod.rs
@@ -220,9 +220,9 @@ pub(crate) fn project_objects_prefix(project: &str) -> String {
 /// [`take`](Self::take)s it and, when set, writes one fresh [`cache_epoch_key`]
 /// marker. Coalescing every mutation in a command into a single marker write keeps
 /// the bump to one round-trip. Creating a new key never arms it — whether through
-/// write-once `put` (the additive path the nightly collection uses) or a
+/// write-once `put` (the additive path the CI collection uses) or a
 /// `put_overwrite` that turns out to add rather than replace — so an append-only
-/// night never invalidates the cache, and a read-through mirror still discovers the
+/// run never invalidates the cache, and a read-through mirror still discovers the
 /// new key through its always-fresh listing.
 #[derive(Debug, Default)]
 pub(crate) struct PendingInvalidation {


### PR DESCRIPTION
## What

Converts the `bench-history` GitHub workflow from a nightly cron schedule to a per-push-to-`main` run, and sweeps the now-inaccurate "nightly" terminology through the surrounding docs and comments.

## Why

Nightly collection is wasteful and lossy: if `main` does not change from one night to the next it re-benchmarks an identical tip for no gain, and it silently misses intermediate commits that land on the same day. Per-push collection stores exactly one data point per commit, which is what the history is for. The accepted trade-off is more runner time on busy days.

## How

- **Trigger**: `schedule: cron '0 3 * * *'` → `push: branches: [main]` (kept `workflow_dispatch`).
- **Concurrency**: added a block keyed on the commit **SHA** (`${{ github.workflow }}-${{ github.sha }}`) with `cancel-in-progress: true`. This is a deliberate deviation from the repo's usual ref-keyed cancel-in-progress (correct for `validation.yml`, wrong here): distinct commits must collect in parallel because each is its own history data point, and cancelling an in-flight commit to favour a newer one would drop that commit's measurements. SHA-keying only dedups a redundant re-trigger of the same commit, which `--skip-existing` already makes a no-op append.
- **Terminology**: renamed the failure-alert issue title and the regression-issue title, and replaced every "nightly"/"night" cadence reference in the workflow, its `AGENTS.md` section and its concurrency-control design note, the `validation.yml` cross-reference, the failure-issue template, the `gh-collect`/`gh-analyze` automation recipes, the prod infra README, and the `cargo-bench-history` package docs/comments (`DESIGN.md`, package `AGENTS.md`, and source rustdoc in `cli.rs`/`command.rs`/`commands/run.rs`/`lib.rs`/`storage/mod.rs`/`storage/caching.rs`).

## Not changed (on purpose)

`coverage_nightly` cfg attributes, the Rust artifact-dependencies "nightly-only" note in `DESIGN.md`, and generic "scheduled trend watch" language describing an abstract `analyze` consumer scenario are all left as-is — they are not about this workflow's cadence.

## Validation

Workflow YAML and the justfile both parse. Changes are comments/docs/YAML/markdown only — zero code-token changes, so no build behaviour is affected.

## Note

The failure-alert issue title changes (`Nightly benchmark-history workflow failed` → `Benchmark-history workflow failed`), so any currently-open failure issue would be orphaned once (create-an-issue dedups by exact title). Harmless, but worth knowing.
