### PR TITLE
Consolidate reporter enabled-guards behind a sealed note API

### DIFF
--- a/packages/cargo-bench-history-stress/src/lib.rs
+++ b/packages/cargo-bench-history-stress/src/lib.rs
@@ -114,10 +114,12 @@ async fn run_harness() -> Result<(), Error> {
     // combination rather than silently ignoring it.
     let cache = resolve_cache(&cli)?;
     if let Some(cache) = &cache {
-        logger.detail(&format!(
-            "measuring analyze against a read-through cache rooted at {}",
-            cache.display()
-        ));
+        logger.detail_with(|| {
+            format!(
+                "measuring analyze against a read-through cache rooted at {}",
+                cache.display()
+            )
+        });
     }
 
     // The git repository and the workspace (config + import marks) live in
@@ -288,10 +290,7 @@ async fn write_config(
     tokio::fs::write(&path, target.config_toml())
         .await
         .map_err(|error| fail(format!("failed to write {}: {error}", path.display())))?;
-    logger.detail(&format!(
-        "wrote analyze configuration to {}",
-        path.display()
-    ));
+    logger.detail_with(|| format!("wrote analyze configuration to {}", path.display()));
     Ok(())
 }
 

--- a/packages/cargo-bench-history-stress/src/logging.rs
+++ b/packages/cargo-bench-history-stress/src/logging.rs
@@ -5,9 +5,10 @@
 //!
 //! * [`Logger::step`] — always-on phase markers describing what the harness is
 //!   about to do.
-//! * [`Logger::detail`] — emitted only under `--verbose`. Each detail line is
-//!   *explanatory*: it states the inputs and the reasoning behind a decision so
-//!   the run can be reconstructed from the logs alone, never just the conclusion.
+//! * [`Logger::detail_with`] — emitted only under `--verbose`, formatted lazily.
+//!   Each detail line is *explanatory*: it states the inputs and the reasoning
+//!   behind a decision so the run can be reconstructed from the logs alone, never
+//!   just the conclusion.
 
 /// Operator-facing progress logger writing to stderr.
 #[derive(Clone, Copy, Debug)]
@@ -17,16 +18,17 @@ pub(crate) struct Logger {
 }
 
 impl Logger {
-    /// Creates a logger; `verbose` enables the explanatory [`detail`](Self::detail)
-    /// stream.
+    /// Creates a logger; `verbose` enables the explanatory
+    /// [`detail_with`](Self::detail_with) stream.
     pub(crate) fn new(verbose: bool) -> Self {
         Self { verbose }
     }
 
     /// Emits an always-on phase marker (`==> ...`) describing the next step.
     //
-    // Takes `self` for call-site symmetry with `detail` (both are `logger.x(..)`),
-    // even though a phase marker is unconditional and reads no state.
+    // Takes `self` for call-site symmetry with `detail_with` (both are
+    // `logger.x(..)`), even though a phase marker is unconditional and reads no
+    // state.
     #[expect(
         clippy::unused_self,
         reason = "kept an instance method so callers use one logger handle uniformly"
@@ -42,13 +44,16 @@ impl Logger {
         self.verbose
     }
 
-    /// Emits an explanatory detail line, only under `--verbose`.
+    /// Emits an explanatory detail line, only under `--verbose`, formatting it
+    /// lazily so a non-verbose run pays nothing.
     ///
     /// The message should state the inputs and reasoning behind a decision, not
-    /// merely announce its outcome.
-    pub(crate) fn detail(self, message: &str) {
+    /// merely announce its outcome. The `build` closure — typically an allocating
+    /// `format!` — runs only when `--verbose` is set, so an unconditional emit is
+    /// never reachable at a call site without its guard.
+    pub(crate) fn detail_with(self, build: impl FnOnce() -> String) {
         if self.verbose {
-            eprintln!("    {message}");
+            eprintln!("    {}", build());
         }
     }
 }

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -104,7 +104,7 @@ pub(crate) async fn measure(
 ) -> Result<MeasureResult, Error> {
     let options = build_options(workspace, repo, mode, storage, logger.verbose());
     logger.step(&format!("analyzing in {} mode", mode.keyword()));
-    logger.detail(&format!(
+    logger.detail_with(|| format!(
         "context={}, base={}, facets forced to all (seeded triples and the synthetic machine key \
          never match the host), repeats={repeat}",
         options.context.as_deref().unwrap_or(""),
@@ -150,16 +150,18 @@ pub(crate) async fn measure(
         let parsed: ReportCounts = serde_json::from_str(&report)
             .map_err(|error| fail(format!("failed to parse the analyze report: {error}")))?;
 
-        logger.detail(&format!(
-            "attempt {} took {:.3}s wall / {:.3}s CPU = {:.0}% of {cores} cores ({} objects, \
+        logger.detail_with(|| {
+            format!(
+                "attempt {} took {:.3}s wall / {:.3}s CPU = {:.0}% of {cores} cores ({} objects, \
              {} series)",
-            attempt.saturating_add(1),
-            elapsed.as_secs_f64(),
-            attempt_cpu.as_secs_f64(),
-            cpu_efficiency(attempt_cpu, elapsed, cores) * 100.0,
-            parsed.runs,
-            parsed.series,
-        ));
+                attempt.saturating_add(1),
+                elapsed.as_secs_f64(),
+                attempt_cpu.as_secs_f64(),
+                cpu_efficiency(attempt_cpu, elapsed, cores) * 100.0,
+                parsed.runs,
+                parsed.series,
+            )
+        });
         best = Some(keep_fastest(best, (elapsed, attempt_cpu)));
         counts = Some(parsed);
     }

--- a/packages/cargo-bench-history-stress/src/repo.rs
+++ b/packages/cargo-bench-history-stress/src/repo.rs
@@ -58,10 +58,11 @@ pub(crate) async fn build_repo(
         main_times.len(),
         feature_times.len()
     ));
-    logger.detail(
+    logger.detail_with(|| {
         "the whole history is one fast-import stream because analyze resolves topology from real \
-         git, so storage keys must be named by the SHAs git assigns",
-    );
+         git, so storage keys must be named by the SHAs git assigns"
+            .to_owned()
+    });
 
     run_git(dir, &["init", "-q", "-b", BRANCH_MAIN, "."]).await?;
 
@@ -73,14 +74,18 @@ pub(crate) async fn build_repo(
     // otherwise report as a tree full of deletions (a dirty tree). The marks file
     // lives outside the work tree so it never shows up as an untracked file.
     run_git(dir, &["reset", "--hard", BRANCH_MAIN]).await?;
-    logger.detail("reset the work tree to main so analyze sees a clean (non-dirty) checkout");
+    logger.detail_with(|| {
+        "reset the work tree to main so analyze sees a clean (non-dirty) checkout".to_owned()
+    });
 
     let marks = read_marks(marks_path).await?;
     let repo = resolve_commits(&marks, main_times, feature_times)?;
-    logger.detail(&format!(
-        "read back {} commit SHAs from the export-marks file",
-        repo.main.len().saturating_add(repo.feature.len())
-    ));
+    logger.detail_with(|| {
+        format!(
+            "read back {} commit SHAs from the export-marks file",
+            repo.main.len().saturating_add(repo.feature.len())
+        )
+    });
     Ok(repo)
 }
 

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -101,10 +101,11 @@ pub(crate) fn seed(
         tasks.len(),
         series
     ));
-    logger.detail(
+    logger.detail_with(|| {
         "each clean object holds every benchmark's primary metric at one commit; objects fan \
-         out across CPU cores because serialization, not I/O, dominates generation",
-    );
+         out across CPU cores because serialization, not I/O, dominates generation"
+            .to_owned()
+    });
 
     let bytes = write_tasks(root, scenario, sets, &tasks)?;
     let stats = SeedStats {
@@ -112,10 +113,12 @@ pub(crate) fn seed(
         bytes,
         series,
     };
-    logger.detail(&format!(
-        "wrote {} bytes across {} objects",
-        stats.bytes, stats.objects
-    ));
+    logger.detail_with(|| {
+        format!(
+            "wrote {} bytes across {} objects",
+            stats.bytes, stats.objects
+        )
+    });
     Ok(stats)
 }
 

--- a/packages/cargo-bench-history-stress/src/target.rs
+++ b/packages/cargo-bench-history-stress/src/target.rs
@@ -522,7 +522,7 @@ mod tests {
         let fake = Arc::new(FakeRunner::default());
         let target = fake_azure_target(&fake, PathBuf::from("staging"));
 
-        block_on(target.provision(Logger::new(false)))
+        block_on(target.provision(Logger::new(true)))
             .expect("provisioning succeeds with a passing runner");
 
         let calls = recorded(&fake);
@@ -531,6 +531,17 @@ mod tests {
         assert!(call.contains("storage container create"), "got: {call}");
         assert!(call.contains("--account-name acct"), "got: {call}");
         assert!(call.contains("--name cont"), "got: {call}");
+    }
+
+    #[test]
+    fn provision_reports_the_local_store_directory() {
+        // A local target provisions by only announcing where its store lives, with
+        // no external tool involved; a verbose run runs (and prints) that
+        // explanatory detail.
+        let target = local_target(PathBuf::from("store"));
+
+        block_on(target.provision(Logger::new(true)))
+            .expect("provisioning a local target is infallible");
     }
 
     #[test]
@@ -551,7 +562,7 @@ mod tests {
         let fake = Arc::new(FakeRunner::default());
         let target = fake_azure_target(&fake, PathBuf::from("staging"));
 
-        block_on(target.upload(Logger::new(false)))
+        block_on(target.upload(Logger::new(true)))
             .expect("uploading succeeds with a passing runner");
 
         let calls = recorded(&fake);

--- a/packages/cargo-bench-history-stress/src/target.rs
+++ b/packages/cargo-bench-history-stress/src/target.rs
@@ -184,17 +184,18 @@ impl StorageTarget {
     pub(crate) async fn provision(&self, logger: Logger) -> Result<(), Error> {
         match &self.kind {
             Kind::Local => {
-                logger.detail(&format!("local store directory is {}", self.root.display()));
+                logger.detail_with(|| format!("local store directory is {}", self.root.display()));
                 Ok(())
             }
             Kind::Azure { account, container } => {
                 logger.step(&format!(
                     "creating Azure blob container {container} in account {account}"
                 ));
-                logger.detail(
+                logger.detail_with(|| {
                     "a fresh container per run keeps stress data isolated and lets cleanup delete \
-                     the whole container in one call",
-                );
+                     the whole container in one call"
+                        .to_owned()
+                });
                 self.az(
                     &[
                         "storage",
@@ -227,10 +228,11 @@ impl StorageTarget {
         logger.step(&format!(
             "uploading the staged tree to container {container} with azcopy"
         ));
-        logger.detail(
+        logger.detail_with(|| {
             "azcopy authenticates as the current az login session (AZCOPY_AUTO_LOGIN_TYPE=AZCLI), \
-             so the same Entra identity is used locally and under workload-identity federation",
-        );
+             so the same Entra identity is used locally and under workload-identity federation"
+                .to_owned()
+        });
         let source = wildcard_source(&self.root);
         let destination = format!("https://{account}.blob.core.windows.net/{container}");
         self.run_tool(
@@ -318,7 +320,7 @@ impl StorageTarget {
         envs: &[(&str, &str)],
         logger: Logger,
     ) -> Result<(), Error> {
-        logger.detail(&format!("running {program} {}", args.join(" ")));
+        logger.detail_with(|| format!("running {program} {}", args.join(" ")));
         match &self.runner {
             Runner::Process => run_process(program, args, envs).await,
             #[cfg(test)]

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -107,9 +107,18 @@ the three).
 ## Verbose diagnostics (`report::Reporter`)
 
 `--verbose` is accepted by every command (`run`/`backfill`/`analyze`/`install`)
-and threads a `report::Reporter` through the relevant pipeline so an
-otherwise-silent outcome can be diagnosed. The trait has `enabled()` (gate
-expensive per-file note formatting) and `note(&str)`. Production uses
+and threads a `&dyn report::Reporter` through the relevant pipeline so an
+otherwise-silent outcome can be diagnosed. The whole point of the module's shape
+is that a note can never be emitted without its `--verbose` guard: the
+unconditional emit primitives live on a **sealed** `Sink` supertrait that cannot
+be named outside `report`, so the only note surface a caller sees is the guarded
+pair on `ReporterExt` — `note_with(|| format!(…))` for a single lazy line and
+`if_enabled(|notes| { notes.note(…); … })` for a block that emits several. A bare
+unconditional `note` is reachable *only* on the `Notes` handle passed to an
+`if_enabled` block, so call sites never call `enabled()` or `note()` directly and
+there is no `if reporter.enabled()` guard to forget. Stage timings are a separate
+channel (`ReporterExt::timing`), gated independently so the stress harness can ask
+for the per-stage breakdown without the per-object flood. Production uses
 `StderrReporter::new(verbose)`, which writes `[bench-history] …` lines to
 **standard error** only when verbose — never stdout, so machine-readable output
 stays clean. Tests use the `#[cfg(test)]` `RecordingReporter` (records notes in a
@@ -128,6 +137,7 @@ Verbose notes must be **explanatory, not conclusion-only** — see
 `docs/standalone-binaries.md`. State the inputs and the rule behind each decision
 (e.g. the mode note names whether the tip is its own merge-base and whether a dirty
 run is recorded) so the logic can be reconstructed from the log.
+
 
 `analyze` also renders a non-verbose diagnostic *hint* (carried on `ReportInput`/
 `JsonReport`, built by `empty_history_hint`) whenever facet-matching runs were

--- a/packages/cargo-bench-history/src/analyze/bless.rs
+++ b/packages/cargo-bench-history/src/analyze/bless.rs
@@ -51,10 +51,7 @@ pub(crate) async fn bless(
     let reporter = StderrReporter::new(options.verbose);
 
     let config_path = resolve_config_path(workspace_dir, options.config_path.as_deref());
-    reporter.note(&format!(
-        "loading configuration from {}",
-        config_path.display()
-    ));
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
     let config = load_config(&config_path, options.config_path.is_some()).await?;
 
     let project_id = resolve_project_id(&config, workspace_dir);
@@ -97,10 +94,7 @@ pub(crate) async fn unbless(
     let reporter = StderrReporter::new(options.verbose);
 
     let config_path = resolve_config_path(workspace_dir, options.config_path.as_deref());
-    reporter.note(&format!(
-        "loading configuration from {}",
-        config_path.display()
-    ));
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
     let config = load_config(&config_path, options.config_path.is_some()).await?;
 
     let project_id = resolve_project_id(&config, workspace_dir);

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -54,10 +54,7 @@ pub(crate) async fn execute(
     let reporter = StderrReporter::new(options.verbose);
 
     let config_path = resolve_config_path(workspace_dir, options.config_path.as_deref());
-    reporter.note(&format!(
-        "loading configuration from {}",
-        config_path.display()
-    ));
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
     let config = load_config(&config_path, options.config_path.is_some()).await?;
 
     let project_id = resolve_project_id(&config, workspace_dir);

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -73,10 +73,7 @@ pub(crate) async fn execute(
     let reporter = StderrReporter::with_timing(options.verbose, options.stage_timings_enabled());
 
     let config_path = resolve_config_path(workspace_dir, options.config_path.as_deref());
-    reporter.note(&format!(
-        "loading configuration from {}",
-        config_path.display()
-    ));
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
     let config = load_config(&config_path, options.config_path.is_some()).await?;
 
     let project_id = resolve_project_id(&config, workspace_dir);
@@ -602,19 +599,18 @@ async fn facet_filtered_candidates<S: Storage>(
     let project = sanitize_segment(project_id);
     let prefix = project_objects_prefix(project_id);
 
-    reporter.note(&format!(
-        "project id: {project_id} (storage segment: {project})"
-    ));
-    reporter.note(&format!("listing stored objects under prefix {prefix}"));
-    reporter.note_with(|| format!("facet filters: {}", describe_facets(facets)));
+    reporter.if_enabled(|notes| {
+        notes.note(&format!(
+            "project id: {project_id} (storage segment: {project})"
+        ));
+        notes.note(&format!("listing stored objects under prefix {prefix}"));
+        notes.note(&format!("facet filters: {}", describe_facets(facets)));
+    });
 
     let list_started = Instant::now();
     let keys = storage.list(&prefix).await.map_err(RunError::Storage)?;
     reporter.timing("storage.list(prefix) round-trip", list_started.elapsed());
-    reporter.note(&format!(
-        "storage returned {}",
-        count_noun(keys.len(), "object key")
-    ));
+    reporter.note_with(|| format!("storage returned {}", count_noun(keys.len(), "object key")));
 
     let mut candidates: Vec<(String, StorageKey)> = Vec::new();
     for key in keys {
@@ -639,10 +635,12 @@ async fn facet_filtered_candidates<S: Storage>(
         }
         candidates.push((key, parsed));
     }
-    reporter.note(&format!(
-        "{} match the facet filters",
-        count_noun(candidates.len(), "object")
-    ));
+    reporter.note_with(|| {
+        format!(
+            "{} match the facet filters",
+            count_noun(candidates.len(), "object")
+        )
+    });
     Ok(candidates)
 }
 
@@ -863,10 +861,12 @@ where
         .into_iter()
         .partition(|(_, parsed)| !parsed.is_bless());
     if !bless_candidates.is_empty() {
-        reporter.note(&format!(
-            "{} of those are blessing sidecars",
-            count_noun(bless_candidates.len(), "object")
-        ));
+        reporter.note_with(|| {
+            format!(
+                "{} of those are blessing sidecars",
+                count_noun(bless_candidates.len(), "object")
+            )
+        });
     }
 
     let topology_started = Instant::now();
@@ -914,17 +914,20 @@ where
 
     // The mode steers the analysis and the default `--since`. An explicit `--mode`
     // overrides the auto-detection.
-    let mode = match selection.mode_override {
-        Some(mode) => {
-            reporter.note(&format!(
-                "analysis mode: {} (set explicitly via --mode, overriding auto-detection)",
-                mode.as_str()
-            ));
-            mode
-        }
-        None => {
-            let mode = auto_mode(tip_is_merge_base, dirty_tip_run_present);
-            reporter.note(&format!(
+    let mode =
+        match selection.mode_override {
+            Some(mode) => {
+                reporter.note_with(|| {
+                    format!(
+                        "analysis mode: {} (set explicitly via --mode, overriding auto-detection)",
+                        mode.as_str()
+                    )
+                });
+                mode
+            }
+            None => {
+                let mode = auto_mode(tip_is_merge_base, dirty_tip_run_present);
+                reporter.note_with(|| format!(
                 "analysis mode: {} (auto-detected because the target tip {} its own merge-base \
                  with the base branch and {} recorded on top of it; the on-disk working-tree \
                  state is deliberately not consulted here)",
@@ -936,20 +939,24 @@ where
                     "no dirty run is"
                 },
             ));
-            mode
-        }
-    };
+                mode
+            }
+        };
     let since = resolve_since(selection.since, mode, now)?;
-    reporter.note(&format!(
-        "since cutoff: {} ({})",
-        since.map_or_else(|| "none".to_owned(), |since| since.to_string()),
-        since_cutoff_reason(selection.since.is_some(), mode)
-    ));
+    reporter.note_with(|| {
+        format!(
+            "since cutoff: {} ({})",
+            since.map_or_else(|| "none".to_owned(), |since| since.to_string()),
+            since_cutoff_reason(selection.since.is_some(), mode)
+        )
+    });
     let until = parse_until(selection.until)?;
-    reporter.note(&format!(
-        "until cutoff: {}",
-        until.map_or_else(|| "none".to_owned(), |until| until.to_string())
-    ));
+    reporter.note_with(|| {
+        format!(
+            "until cutoff: {}",
+            until.map_or_else(|| "none".to_owned(), |until| until.to_string())
+        )
+    });
 
     // Tally why candidates do not enter the analysis, so a `0 runs` outcome can
     // explain itself (via `--verbose` per object, and via a summary hint when
@@ -1091,12 +1098,14 @@ where
         "series build finalization (builder.finish: assemble + serial point sort)",
         finish_started.elapsed(),
     );
-    reporter.note(&format!(
-        "{} entered the analysis ({excluded_outside_history} outside history, \
+    reporter.note_with(|| {
+        format!(
+            "{} entered the analysis ({excluded_outside_history} outside history, \
          {excluded_dirty_base} dirty-on-base, {excluded_since} before --since, \
          {excluded_until} after --until)",
-        count_noun(run_index.total(), "object")
-    ));
+            count_noun(run_index.total(), "object")
+        )
+    });
 
     // Load the blessing sidecars on in-window commits into a per-set map. A
     // blessing on a commit outside the analyzed history (or that fails to parse) is
@@ -1365,15 +1374,17 @@ where
         None => None,
     };
 
-    reporter.note(&format!(
-        "target ref {target_ref} resolves to {target_sha}; {} on its first-parent line",
-        count_noun(commit_count, "commit")
-    ));
-    reporter.note(&format!(
-        "base ref resolves to {}; merge-base with target is {}",
-        base_sha.as_deref().unwrap_or("<none>"),
-        merge_base.as_deref().unwrap_or("<none>")
-    ));
+    reporter.if_enabled(|notes| {
+        notes.note(&format!(
+            "target ref {target_ref} resolves to {target_sha}; {} on its first-parent line",
+            count_noun(commit_count, "commit")
+        ));
+        notes.note(&format!(
+            "base ref resolves to {}; merge-base with target is {}",
+            base_sha.as_deref().unwrap_or("<none>"),
+            merge_base.as_deref().unwrap_or("<none>")
+        ));
+    });
 
     // The base-branch dirty-tip exception: `analyze`/`list` admit a base-side tip's
     // dirty runs only when the working tree is currently dirty (`--no-dirty` skips
@@ -1388,9 +1399,10 @@ where
                 git.is_dirty().await.map_err(RunError::Io)?
             };
             if working_tree_dirty {
-                reporter.note(
-                    "working tree is dirty: dirty snapshots on a base-side tip will be admitted",
-                );
+                reporter.note_with(|| {
+                    "working tree is dirty: dirty snapshots on a base-side tip will be admitted"
+                        .to_owned()
+                });
             }
             working_tree_dirty
         }

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -92,10 +92,7 @@ pub(crate) async fn execute(
     let reporter = StderrReporter::new(options.verbose);
 
     let config_path = resolve_config_path(workspace_dir, options.config_path.as_deref());
-    reporter.note(&format!(
-        "loading configuration from {}",
-        config_path.display()
-    ));
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
     let config = load_config(&config_path, options.config_path.is_some()).await?;
 
     let project_id = resolve_project_id(&config, workspace_dir);

--- a/packages/cargo-bench-history/src/bench_output.rs
+++ b/packages/cargo-bench-history/src/bench_output.rs
@@ -113,11 +113,13 @@ impl FsBenchOutputSource {
         let summary_name = OsStr::new(SUMMARY_FILE);
 
         let root = self.target_root.join(GUNGRAUN_DIR);
-        reporter.note(&format!(
-            "callgrind: scanning {} for {SUMMARY_FILE} files modified at or after {}",
-            root.display(),
-            format_mtime(threshold)
-        ));
+        reporter.note_with(|| {
+            format!(
+                "callgrind: scanning {} for {SUMMARY_FILE} files modified at or after {}",
+                root.display(),
+                format_mtime(threshold)
+            )
+        });
 
         let mut summaries = Vec::new();
         let mut stack = vec![root.clone()];
@@ -155,10 +157,12 @@ impl FsBenchOutputSource {
         }
 
         summaries.sort_by(|left, right| left.path.cmp(&right.path));
-        reporter.note(&format!(
-            "callgrind: harvested {}",
-            count_noun(summaries.len(), "fresh summary file")
-        ));
+        reporter.note_with(|| {
+            format!(
+                "callgrind: harvested {}",
+                count_noun(summaries.len(), "fresh summary file")
+            )
+        });
         Ok(summaries)
     }
 
@@ -180,7 +184,7 @@ impl FsBenchOutputSource {
         let new_dir_name = OsStr::new(CRITERION_NEW_DIR);
 
         let root = self.target_root.join(CRITERION_DIR);
-        reporter.note(&format!(
+        reporter.note_with(|| format!(
             "criterion: scanning {} for {CRITERION_NEW_DIR}/ cases with {CRITERION_ESTIMATES_FILE} \
              modified at or after {}",
             root.display(),
@@ -253,10 +257,12 @@ impl FsBenchOutputSource {
         }
 
         cases.sort_by(|left, right| left.dir.cmp(&right.dir));
-        reporter.note(&format!(
-            "criterion: harvested {}",
-            count_noun(cases.len(), "fresh case")
-        ));
+        reporter.note_with(|| {
+            format!(
+                "criterion: harvested {}",
+                count_noun(cases.len(), "fresh case")
+            )
+        });
         Ok(cases)
     }
 
@@ -277,11 +283,13 @@ impl FsBenchOutputSource {
         let json_extension = OsStr::new("json");
 
         let root = self.target_root.join(engine_dir);
-        reporter.note(&format!(
-            "{label}: scanning {} for *.json files modified at or after {}",
-            root.display(),
-            format_mtime(threshold)
-        ));
+        reporter.note_with(|| {
+            format!(
+                "{label}: scanning {} for *.json files modified at or after {}",
+                root.display(),
+                format_mtime(threshold)
+            )
+        });
 
         let mut files = Vec::new();
         let mut entries = match tokio::fs::read_dir(&root).await {
@@ -316,10 +324,12 @@ impl FsBenchOutputSource {
         }
 
         files.sort_by(|left, right| left.path.cmp(&right.path));
-        reporter.note(&format!(
-            "{label}: harvested {}",
-            count_noun(files.len(), "fresh operation file")
-        ));
+        reporter.note_with(|| {
+            format!(
+                "{label}: harvested {}",
+                count_noun(files.len(), "fresh operation file")
+            )
+        });
         Ok(files)
     }
 }
@@ -364,10 +374,12 @@ fn format_mtime(time: SystemTime) -> String {
 /// rare mid-scan race that is only noted in verbose mode.
 fn note_missing_dir(reporter: &dyn Reporter, engine: &str, dir: &Path, root: &Path) {
     if dir == root {
-        reporter.note(&format!(
-            "{engine}: directory {} does not exist; no output was produced here",
-            dir.display()
-        ));
+        reporter.note_with(|| {
+            format!(
+                "{engine}: directory {} does not exist; no output was produced here",
+                dir.display()
+            )
+        });
     } else {
         reporter.note_with(|| {
             format!(

--- a/packages/cargo-bench-history/src/commands/install.rs
+++ b/packages/cargo-bench-history/src/commands/install.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use crate::config::default_template;
 use crate::config_writer::{ConfigWriter, TokioConfigWriter};
-use crate::report::{Reporter, StderrReporter};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::wiring::resolve_config_path;
 use crate::{InstallOptions, RunError, RunOutcome};
 
@@ -34,15 +34,17 @@ async fn execute_install<W: ConfigWriter>(
 ) -> Result<RunOutcome, RunError> {
     let path = resolve_config_path(workspace_dir, options.config_path.as_deref());
 
-    reporter.note(&format!(
-        "writing a starter configuration to {} (only if absent)",
-        path.display()
-    ));
+    reporter.note_with(|| {
+        format!(
+            "writing a starter configuration to {} (only if absent)",
+            path.display()
+        )
+    });
     let written = writer.write_new(&path, default_template()).await?;
     if written {
-        reporter.note("configuration did not exist; wrote the starter template");
+        reporter.note_with(|| "configuration did not exist; wrote the starter template".to_owned());
     } else {
-        reporter.note("configuration already exists; left it unchanged");
+        reporter.note_with(|| "configuration already exists; left it unchanged".to_owned());
     }
 
     Ok(RunOutcome::Completed {

--- a/packages/cargo-bench-history/src/commands/run.rs
+++ b/packages/cargo-bench-history/src/commands/run.rs
@@ -96,43 +96,45 @@ pub(crate) async fn execute(
     let base = base.as_path();
 
     let config_path = resolve_config_path(base, options.config_path.as_deref());
-    reporter.note(&format!(
-        "loading configuration from {}",
-        config_path.display()
-    ));
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
     let config = load_config(&config_path, options.config_path.is_some()).await?;
 
     let project_id = resolve_project_id(&config, base);
-    reporter.note(&format!("project id: {project_id}"));
+    reporter.note_with(|| format!("project id: {project_id}"));
 
     // Under `--no-store` the run produces no stored objects, so storage selection
     // is skipped entirely: the command works with no `--local` and no configured
     // cloud backend, which would otherwise be an error.
     let storage = if let Some(backend) = storage_override {
-        reporter.note("storage backend: injected by test override");
+        reporter.note_with(|| "storage backend: injected by test override".to_owned());
         Some(backend)
     } else if options.no_store {
-        reporter.note(
+        reporter.note_with(|| {
             "not resolving a storage backend because --no-store was given; \
-             benchmarks will run but no results will be stored",
-        );
+             benchmarks will run but no results will be stored"
+                .to_owned()
+        });
         None
     } else {
         let local = resolve_local_path(options.local.as_ref(), storage_env().as_deref())?;
-        reporter.note(&format!(
-            "storage backend: {}",
-            describe_storage(options.local.as_ref(), local.as_deref(), &config)
-        ));
+        reporter.note_with(|| {
+            format!(
+                "storage backend: {}",
+                describe_storage(options.local.as_ref(), local.as_deref(), &config)
+            )
+        });
         Some(build_storage(local.as_deref(), &config, base, None)?)
     };
 
     let runner = TokioBenchRunner::in_dir(base);
     let probe = SystemProbe::in_dir(base);
     let target_root = target_root.unwrap_or_else(|| resolve_target_root_in(base));
-    reporter.note(&format!(
-        "cargo target directory (scanned for engine output): {}",
-        target_root.display()
-    ));
+    reporter.note_with(|| {
+        format!(
+            "cargo target directory (scanned for engine output): {}",
+            target_root.display()
+        )
+    });
     let output = FsBenchOutputSource::new(target_root.clone());
     let clock = Clock::new_tokio();
     let env = |name: &str| std::env::var(name).ok();
@@ -317,11 +319,13 @@ where
             code: status.code,
         });
     }
-    deps.reporter.note(&format!(
-        "benchmark command finished; harvesting output modified at or after {} \
+    deps.reporter.note_with(|| {
+        format!(
+            "benchmark command finished; harvesting output modified at or after {} \
          (older files are treated as stale leftovers)",
-        timestamp_from(run_start)
-    ));
+            timestamp_from(run_start)
+        )
+    });
 
     let rustc = deps.probe.toolchain().await?;
     let shared = SharedContext {
@@ -446,9 +450,9 @@ where
     // is no misconfiguration to report, since absence is the expected steady state
     // for an engine that does not apply here.
     if count == 0 {
-        deps.reporter.note(&format!(
-            "{engine}: no fresh benchmark cases harvested; nothing to store"
-        ));
+        deps.reporter.note_with(|| {
+            format!("{engine}: no fresh benchmark cases harvested; nothing to store")
+        });
         return Ok(EngineSummary {
             stored: false,
             count: 0,
@@ -457,10 +461,12 @@ where
     }
 
     if options.no_store {
-        deps.reporter.note(&format!(
-            "{engine}: harvested {}; not storing (--no-store)",
-            count_noun(count, "case")
-        ));
+        deps.reporter.note_with(|| {
+            format!(
+                "{engine}: harvested {}; not storing (--no-store)",
+                count_noun(count, "case")
+            )
+        });
         return Ok(EngineSummary {
             stored: false,
             count,
@@ -503,14 +509,16 @@ where
         key.clean_key(deps.project_id, commit)
     };
 
-    deps.reporter.note(&format!(
-        "{engine}: {} at commit {commit} ({}){} -> {object_key}",
-        count_noun(count, "case"),
-        if dirty { "dirty" } else { "clean" },
-        machine_key
-            .as_deref()
-            .map_or_else(String::new, |key| format!(", machine {key}")),
-    ));
+    deps.reporter.note_with(|| {
+        format!(
+            "{engine}: {} at commit {commit} ({}){} -> {object_key}",
+            count_noun(count, "case"),
+            if dirty { "dirty" } else { "clean" },
+            machine_key
+                .as_deref()
+                .map_or_else(String::new, |key| format!(", machine {key}")),
+        )
+    });
 
     // A freshly built run is composed of plain structs and finite counts, so
     // serialization cannot fail.
@@ -533,10 +541,12 @@ where
 
     match outcome {
         StoreOutcome::Skipped => {
-            deps.reporter.note(&format!(
-                "{engine}: {object_key} already exists; left unchanged (--skip-existing), \
+            deps.reporter.note_with(|| {
+                format!(
+                    "{engine}: {object_key} already exists; left unchanged (--skip-existing), \
                  so nothing was written and the cache-invalidation marker was not armed"
-            ));
+                )
+            });
             Ok(EngineSummary {
                 stored: false,
                 count,
@@ -547,7 +557,7 @@ where
         }
         StoreOutcome::Stored => {
             deps.reporter
-                .note(&format!("{engine}: stored {object_key}"));
+                .note_with(|| format!("{engine}: stored {object_key}"));
 
             // Replacing a clean run discards the data point its blessings accepted, so
             // any blessing sidecars on this commit no longer describe a stored level.
@@ -632,7 +642,7 @@ async fn invalidate_blessings<S: Storage>(
             .is_some_and(|name| name.starts_with("bless-"));
         if is_bless {
             storage.delete(&object_key).await?;
-            reporter.note(&format!("removed stale blessing {object_key}"));
+            reporter.note_with(|| format!("removed stale blessing {object_key}"));
         }
     }
     Ok(())

--- a/packages/cargo-bench-history/src/report.rs
+++ b/packages/cargo-bench-history/src/report.rs
@@ -7,37 +7,65 @@
 //! to standard output. The real adapter writes notes to standard error so they
 //! never contaminate machine-readable stdout; tests record them in memory.
 //!
-//! Stage timings are a *second*, independent channel ([`Reporter::timing`]): they
-//! report the wall-clock cost of each pipeline stage so a mystery slowdown can be
-//! localized. They are kept separate from per-object [`note`](Reporter::note)s
-//! precisely so a caller can ask for the coarse per-stage breakdown *without* the
-//! per-object flood — the stress harness, which analyzes tens of thousands of
-//! objects, would otherwise drown in (and be slowed by) one note per object.
+//! Stage timings are a *second*, independent channel ([`ReporterExt::timing`]):
+//! they report the wall-clock cost of each pipeline stage so a mystery slowdown
+//! can be localized. They are kept separate from per-object
+//! [`note`](Notes::note)s precisely so a caller can ask for the coarse per-stage
+//! breakdown *without* the per-object flood — the stress harness, which analyzes
+//! tens of thousands of objects, would otherwise drown in (and be slowed by) one
+//! note per object.
+//!
+//! The unconditional emit primitives live on a sealed [`Sink`] trait that cannot
+//! be named outside this module, so the only note-emitting surface a caller sees
+//! is the guarded [`note_with`](ReporterExt::note_with) /
+//! [`if_enabled`](ReporterExt::if_enabled) pair. An unconditional
+//! [`note`](Notes::note) is reachable *only* on the [`Notes`] handle passed to an
+//! `if_enabled` block, so a bare `note` can never escape its `--verbose` guard.
 
 use std::time::Duration;
 
-/// Receives human-facing diagnostic notes emitted while a command runs.
-pub(crate) trait Reporter {
-    /// Whether notes are consumed at all.
-    ///
-    /// Callers may use this to skip building an expensive note (for example, one
-    /// formatted per scanned file) when nothing would consume it.
-    fn enabled(&self) -> bool;
+mod sealed {
+    use std::time::Duration;
 
-    /// Records a single diagnostic note.
-    fn note(&self, message: &str);
-
-    /// Records the wall-clock duration of a named pipeline `stage`.
+    /// The unconditional emit primitives, sealed within [`report`](super) so no
+    /// caller can invoke them directly.
     ///
-    /// `stage` should name the stage *and* what it encompasses (so the breakdown
-    /// reconstructs where the time went), e.g. `"phase 2/3 fetch + parallel parse +
-    /// fold"`. This is a separate channel from [`note`](Reporter::note) so the
-    /// per-stage cost can be surfaced without the per-object note flood.
-    fn timing(&self, stage: &str, elapsed: Duration);
+    /// Every note or timing a command emits flows through the guarded helpers on
+    /// [`ReporterExt`](super::ReporterExt) — which are the only surface that can
+    /// reach these methods — so the `--verbose` guard is applied in exactly one
+    /// place and can never be bypassed or forgotten at a call site.
+    pub(in crate::report) trait Sink {
+        /// Whether notes are consumed at all, gating the guarded helpers.
+        fn enabled(&self) -> bool;
+
+        /// Records a single diagnostic note unconditionally.
+        fn emit_note(&self, message: &str);
+
+        /// Records the wall-clock duration of a named pipeline `stage`
+        /// unconditionally.
+        fn emit_timing(&self, stage: &str, elapsed: Duration);
+    }
 }
 
-/// Lazy-formatting helpers available on every [`Reporter`], including
-/// `&dyn Reporter`.
+use sealed::Sink;
+
+/// Receives human-facing diagnostic notes emitted while a command runs.
+///
+/// This is the threaded reporter type (`&dyn Reporter`). It deliberately exposes
+/// *no* unconditional emit method: callers reach the sink only through the
+/// guarded helpers on [`ReporterExt`], so a raw `note` can never be emitted
+/// without its `--verbose` guard. Any [`Sink`] is a `Reporter`.
+#[expect(
+    private_bounds,
+    reason = "Sink is sealed within this module on purpose so its unconditional \
+              emit primitives stay off the crate-facing reporter surface"
+)]
+pub(crate) trait Reporter: Sink {}
+
+impl<T: Sink + ?Sized> Reporter for T {}
+
+/// The guarded, crate-facing diagnostic API available on every [`Reporter`],
+/// including `&dyn Reporter`.
 ///
 /// These live on a separate trait rather than on [`Reporter`] itself so the base
 /// trait stays dyn-compatible: a method taking a generic closure cannot be
@@ -48,33 +76,64 @@ pub(crate) trait ReporterExt {
     /// consumed.
     ///
     /// The `build` closure — typically an allocating `format!` — is invoked only
-    /// when [`enabled`](Reporter::enabled) is true. On a hot path that emits one
-    /// note per scanned object this avoids building (and immediately discarding) a
-    /// string for every object when `--verbose` is off, without sprinkling an
+    /// when notes are enabled. On a hot path that emits one note per scanned
+    /// object this avoids building (and immediately discarding) a string for
+    /// every object when `--verbose` is off, without sprinkling an
     /// `if reporter.enabled()` guard around each call site.
     fn note_with(&self, build: impl FnOnce() -> String);
 
-    /// Runs `body` only when notes are consumed.
+    /// Runs `body` — handed a [`Notes`] emitter — only when notes are consumed.
     ///
     /// The counterpart to [`note_with`](Self::note_with) for a *block* that emits
     /// several notes (or computes intermediate values solely to note them): it
-    /// pays nothing when `--verbose` is off, behind a single
-    /// [`enabled`](Reporter::enabled) check rather than one per note. Keeping the
-    /// guard here — the one place it is tested — means call sites never repeat it.
-    fn if_enabled(&self, body: impl FnOnce());
+    /// pays nothing when `--verbose` is off, behind a single guard rather than
+    /// one per note. Because the unconditional [`note`](Notes::note) lives on the
+    /// [`Notes`] handle passed here — and nowhere else callers can reach — a bare
+    /// note is only ever emittable inside such a guarded block.
+    fn if_enabled(&self, body: impl FnOnce(Notes<'_, Self>));
+
+    /// Records the wall-clock duration of a named pipeline `stage`.
+    ///
+    /// `stage` should name the stage *and* what it encompasses (so the breakdown
+    /// reconstructs where the time went), e.g. `"phase 2/3 fetch + parallel parse +
+    /// fold"`. This is a separate channel from [`note`](Notes::note) so the
+    /// per-stage cost can be surfaced without the per-object note flood.
+    fn timing(&self, stage: &str, elapsed: Duration);
 }
 
 impl<R: Reporter + ?Sized> ReporterExt for R {
     fn note_with(&self, build: impl FnOnce() -> String) {
         if self.enabled() {
-            self.note(&build());
+            self.emit_note(&build());
         }
     }
 
-    fn if_enabled(&self, body: impl FnOnce()) {
+    fn if_enabled(&self, body: impl FnOnce(Notes<'_, Self>)) {
         if self.enabled() {
-            body();
+            body(Notes { reporter: self });
         }
+    }
+
+    fn timing(&self, stage: &str, elapsed: Duration) {
+        self.emit_timing(stage, elapsed);
+    }
+}
+
+/// The unconditional note emitter handed to an [`if_enabled`](ReporterExt::if_enabled)
+/// block.
+///
+/// A block already runs only when notes are enabled, so the notes it emits need
+/// no further guard — hence this is the one place an unconditional
+/// [`note`](Self::note) is exposed. It cannot be constructed elsewhere, so a bare
+/// note can never escape its `--verbose` guard.
+pub(crate) struct Notes<'a, R: ?Sized> {
+    reporter: &'a R,
+}
+
+impl<R: Reporter + ?Sized> Notes<'_, R> {
+    /// Records a single diagnostic note.
+    pub(crate) fn note(&self, message: &str) {
+        self.reporter.emit_note(message);
     }
 }
 
@@ -112,7 +171,7 @@ impl StderrReporter {
     }
 }
 
-impl Reporter for StderrReporter {
+impl Sink for StderrReporter {
     fn enabled(&self) -> bool {
         self.verbose
     }
@@ -123,7 +182,7 @@ impl Reporter for StderrReporter {
     /// so a mutation of its body cannot be caught by a test; the `verbose` flag it
     /// guards on is covered by `stderr_reporter_reports_enabled_state`.
     #[cfg_attr(test, mutants::skip)]
-    fn note(&self, message: &str) {
+    fn emit_note(&self, message: &str) {
         if self.verbose {
             eprintln!("[bench-history] {message}");
         }
@@ -132,10 +191,10 @@ impl Reporter for StderrReporter {
     /// Writes the stage timing to standard error when timing is enabled.
     ///
     /// A pure standard-error side effect, untestable for the same reason as
-    /// [`note`](Self::note); the `timing_enabled` flag it guards on is covered by
-    /// `stderr_reporter_reports_timing_state`.
+    /// [`emit_note`](Self::emit_note); the `timing_enabled` flag it guards on is
+    /// covered by `stderr_reporter_reports_timing_state`.
     #[cfg_attr(test, mutants::skip)]
-    fn timing(&self, stage: &str, elapsed: Duration) {
+    fn emit_timing(&self, stage: &str, elapsed: Duration) {
         if self.timing_enabled {
             eprintln!(
                 "[bench-history] timing: {stage} took {}",
@@ -166,10 +225,10 @@ mod test_support {
     use std::cell::RefCell;
     use std::time::Duration;
 
-    use super::Reporter;
+    use super::Sink;
 
-    /// A [`Reporter`] that records every note in memory so tests can assert on the
-    /// diagnostic trail.
+    /// A [`Reporter`](super::Reporter) that records every note in memory so tests
+    /// can assert on the diagnostic trail.
     #[derive(Debug, Default)]
     pub(crate) struct RecordingReporter {
         notes: RefCell<Vec<String>>,
@@ -201,16 +260,16 @@ mod test_support {
         }
     }
 
-    impl Reporter for RecordingReporter {
+    impl Sink for RecordingReporter {
         fn enabled(&self) -> bool {
             true
         }
 
-        fn note(&self, message: &str) {
+        fn emit_note(&self, message: &str) {
             self.notes.borrow_mut().push(message.to_owned());
         }
 
-        fn timing(&self, stage: &str, _elapsed: Duration) {
+        fn emit_timing(&self, stage: &str, _elapsed: Duration) {
             // Record only the stage label; the elapsed time is non-deterministic, so
             // tests assert that a stage *was* timed, not how long it took.
             self.timings.borrow_mut().push(stage.to_owned());
@@ -249,8 +308,8 @@ mod tests {
     #[test]
     fn recording_reporter_captures_timings_separately_from_notes() {
         let reporter = RecordingReporter::new();
-        reporter.note("a per-object note");
-        reporter.timing("select_dataset (full load)", Duration::from_millis(5));
+        reporter.emit_note("a per-object note");
+        reporter.emit_timing("select_dataset (full load)", Duration::from_millis(5));
 
         // Timings live in their own channel, so a per-object note assertion is not
         // disturbed by them and vice versa.
@@ -275,8 +334,8 @@ mod tests {
     fn recording_reporter_captures_notes() {
         let reporter = RecordingReporter::new();
         assert!(reporter.enabled());
-        reporter.note("scanning target/criterion");
-        reporter.note("excluding stale.json");
+        reporter.emit_note("scanning target/criterion");
+        reporter.emit_note("excluding stale.json");
 
         assert_eq!(
             reporter.notes(),
@@ -319,15 +378,16 @@ mod tests {
         // A disabled reporter must never run the block, so a multi-note diagnostic
         // section behind one guard costs nothing when `--verbose` is off.
         let ran = Cell::new(0_u32);
-        StderrReporter::new(false).if_enabled(|| ran.set(ran.get() + 1));
+        StderrReporter::new(false).if_enabled(|_notes| ran.set(ran.get() + 1));
         assert_eq!(ran.get(), 0);
 
-        // An enabled reporter runs the block, which can emit several notes.
+        // An enabled reporter runs the block, which emits several notes through the
+        // handle — the only place a bare `note` is reachable.
         let recording = RecordingReporter::new();
-        recording.if_enabled(|| {
+        recording.if_enabled(|notes| {
             ran.set(ran.get() + 1);
-            recording.note("first");
-            recording.note("second");
+            notes.note("first");
+            notes.note("second");
         });
         assert_eq!(ran.get(), 1);
         assert_eq!(

--- a/packages/cargo-bench-history/src/report.rs
+++ b/packages/cargo-bench-history/src/report.rs
@@ -89,8 +89,10 @@ pub(crate) trait ReporterExt {
     /// pays nothing when `--verbose` is off, behind a single guard rather than
     /// one per note. Because the unconditional [`note`](Notes::note) lives on the
     /// [`Notes`] handle passed here — and nowhere else callers can reach — a bare
-    /// note is only ever emittable inside such a guarded block.
-    fn if_enabled(&self, body: impl FnOnce(Notes<'_, Self>));
+    /// note is only ever emittable inside such a guarded block. The closure is
+    /// higher-ranked over the handle's lifetime (`for<'a>`), so the handle cannot
+    /// be moved into outer state and used after the guard completes.
+    fn if_enabled(&self, body: impl for<'a> FnOnce(Notes<'a, Self>));
 
     /// Records the wall-clock duration of a named pipeline `stage`.
     ///
@@ -108,7 +110,7 @@ impl<R: Reporter + ?Sized> ReporterExt for R {
         }
     }
 
-    fn if_enabled(&self, body: impl FnOnce(Notes<'_, Self>)) {
+    fn if_enabled(&self, body: impl for<'a> FnOnce(Notes<'a, Self>)) {
         if self.enabled() {
             body(Notes { reporter: self });
         }

--- a/packages/cargo-bench-history/src/storage/caching.rs
+++ b/packages/cargo-bench-history/src/storage/caching.rs
@@ -130,26 +130,26 @@ where
         };
 
         let reuse = recorded_epoch.as_deref() == Some(cloud_epoch.as_slice());
-        reporter.if_enabled(|| {
-            reporter.note(&format!(
+        reporter.if_enabled(|notes| {
+            notes.note(&format!(
                 "cache: cloud invalidation marker {marker_key} reads epoch {}",
                 String::from_utf8_lossy(&cloud_epoch)
             ));
             match &recorded_epoch {
-                Some(recorded) => reporter.note(&format!(
+                Some(recorded) => notes.note(&format!(
                     "cache: local mirror last synchronized at epoch {}",
                     String::from_utf8_lossy(recorded)
                 )),
-                None => reporter
+                None => notes
                     .note("cache: local mirror has no recorded epoch, so it is treated as cold"),
             }
             if reuse {
-                reporter.note(
+                notes.note(
                     "cache: epochs match, so the mirror is reused without re-downloading the \
                      history",
                 );
             } else {
-                reporter.note(
+                notes.note(
                     "cache: epochs differ, so this project's mirrored objects are wiped and the \
                      cloud epoch re-recorded before reloading",
                 );

--- a/packages/cargo-bench-history/src/storage/facade.rs
+++ b/packages/cargo-bench-history/src/storage/facade.rs
@@ -14,7 +14,7 @@ use azure_core::http::HttpClient;
 
 use crate::config::{CloudStorageConfig, Config};
 use crate::model::sanitize_segment;
-use crate::report::Reporter;
+use crate::report::{Reporter, ReporterExt};
 use crate::wiring::rebase;
 
 use super::azure::AzureBlobStorage;
@@ -283,7 +283,7 @@ pub(crate) fn resolve_storage(
 ) -> Result<StorageFacade, StorageError> {
     match storage_override {
         Some(backend) => {
-            reporter.note("storage backend: injected by test override");
+            reporter.note_with(|| "storage backend: injected by test override".to_owned());
             Ok(match cache {
                 Some(cache_dir) => {
                     // `cached_at` only fronts a plain `Azure` override with a mirror;
@@ -291,17 +291,19 @@ pub(crate) fn resolve_storage(
                     // which of the two actually happened rather than always claiming a
                     // wrap.
                     if matches!(backend, StorageFacade::Azure(_)) {
-                        reporter.note(
+                        reporter.note_with(|| {
                             "--cache is set: wrapping the injected Azure backend in a \
                              read-through cache mirror so the override honors --cache like \
-                             a configured backend does",
-                        );
+                             a configured backend does"
+                                .to_owned()
+                        });
                     } else {
-                        reporter.note(
+                        reporter.note_with(|| {
                             "--cache is set, but the injected backend is not a plain Azure \
                              backend, so it is used unchanged — a read-through cache only \
-                             fronts a cloud backend",
-                        );
+                             fronts a cloud backend"
+                                .to_owned()
+                        });
                     }
                     backend.cached_at(rebase(base, cache_dir.to_path_buf()))
                 }


### PR DESCRIPTION
Closes #296.

Redesigns cargo-bench-history's `Reporter` so the unconditional emit primitives (`emit_note`, `emit_timing`, `enabled`) live on a sealed `Sink` trait that cannot be named outside the `report` module. The threaded `&dyn Reporter` type now exposes only the guarded helpers on `ReporterExt`, so it is impossible to emit an unconditional note — or scatter `if reporter.enabled()` guards — at a call site. The `--verbose` guard is applied in exactly one place.

The crate-facing surface is now:

- `reporter.note_with(|| ...)` — a single, lazily-formatted note (the closure runs only when notes are consumed).
- `reporter.if_enabled(|notes| { notes.note(...); ... })` — a multi-note block behind one guard; a bare `notes.note(...)` is reachable *only* on the `Notes` handle passed to the block, so it can never escape its guard.
- `reporter.timing(stage, elapsed)` — the separate per-stage timing channel.

Every direct `reporter.note(...)` call site across the crate is converted to `note_with`/`if_enabled` accordingly.

The same idea is applied to cargo-bench-history-stress's `Logger`: the unconditional `detail(&str)` is replaced with a lazy `detail_with(|| String)` so its verbose guard likewise lives in one place, and all call sites are converted.

## Design notes

The sealed `Sink` is a supertrait of a marker `Reporter` trait (blanket-impl'd for every `Sink`), which keeps `&dyn Reporter` dyn-compatible while the generic-closure helpers live on the separate `ReporterExt` (also blanket-impl'd). `Notes<'a, R>` is generic over the reporter rather than holding a `&dyn Reporter`, because a `?Sized` blanket impl cannot coerce `&R` into `&dyn Reporter`.

## Validation

- `just package="cargo-bench-history cargo-bench-history-stress" validate-local` — green end-to-end (format-check, check, clippy, test, test-docs, docs, miri, machete, default-features-check for dev + release). 771 tests pass; 545 pass under Miri.
- Scoped local mutation testing over `report.rs` and `logging.rs`: 32 of 32 viable mutants caught (1 unviable, 0 missed). The guarded helpers (`note_with`, `if_enabled`, `timing`, `Notes::note`, `Sink::enabled`) and the stress `detail_with`/`verbose`/`step` are all covered.
