### PR TITLE
Use mimalloc as the global allocator in all binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ name = "cargo-detect-package"
 version = "1.0.22"
 dependencies = [
  "clap",
+ "mimalloc",
  "mockall",
  "mutants",
  "serial_test",
@@ -507,6 +508,7 @@ name = "cargo-freeze-deps"
 version = "0.1.2"
 dependencies = [
  "clap",
+ "mimalloc",
  "mutants",
  "semver",
  "serial_test",
@@ -1951,6 +1953,7 @@ dependencies = [
 name = "mock_bench_engine"
 version = "0.0.0"
 dependencies = [
+ "mimalloc",
  "serde_json",
 ]
 

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
+mimalloc = { workspace = true }
 toml = { workspace = true, features = ["parse", "serde"] }
 
 [dev-dependencies]

--- a/packages/cargo-detect-package/src/main.rs
+++ b/packages/cargo-detect-package/src/main.rs
@@ -12,10 +12,11 @@ use std::process::ExitCode;
 
 use cargo_detect_package::{Cli, RunOutcome, run};
 
-// mimalloc is a scalable general-purpose allocator: faster small allocations and
-// no cross-thread allocator-lock contention (acute on the Windows process heap),
-// a broad low-risk win applied uniformly across the workspace's binaries. Miri
-// cannot call mimalloc's FFI, so under Miri the default allocator stands in.
+// Install mimalloc as a scalable, general-purpose allocator process-wide: faster
+// small allocations and no cross-thread allocator-lock contention (acute on the
+// Windows process heap), a broad low-risk win applied uniformly across the
+// workspace's binaries. Miri cannot call mimalloc's FFI, so under Miri the
+// default allocator stands in.
 #[cfg(not(miri))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/packages/cargo-detect-package/src/main.rs
+++ b/packages/cargo-detect-package/src/main.rs
@@ -12,6 +12,14 @@ use std::process::ExitCode;
 
 use cargo_detect_package::{Cli, RunOutcome, run};
 
+// mimalloc is a scalable general-purpose allocator: faster small allocations and
+// no cross-thread allocator-lock contention (acute on the Windows process heap),
+// a broad low-risk win applied uniformly across the workspace's binaries. Miri
+// cannot call mimalloc's FFI, so under Miri the default allocator stands in.
+#[cfg(not(miri))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // Binary entry point - mutations would require subprocess testing which is impractical.
 #[cfg_attr(test, mutants::skip)]
 fn main() -> ExitCode {

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
+mimalloc = { workspace = true }
 semver = { workspace = true }
 toml_edit = { workspace = true, features = ["parse", "display"] }
 

--- a/packages/cargo-freeze-deps/src/main.rs
+++ b/packages/cargo-freeze-deps/src/main.rs
@@ -12,10 +12,11 @@ use std::process::ExitCode;
 
 use cargo_freeze_deps::{Cli, run};
 
-// mimalloc is a scalable general-purpose allocator: faster small allocations and
-// no cross-thread allocator-lock contention (acute on the Windows process heap),
-// a broad low-risk win applied uniformly across the workspace's binaries. Miri
-// cannot call mimalloc's FFI, so under Miri the default allocator stands in.
+// Install mimalloc as a scalable, general-purpose allocator process-wide: faster
+// small allocations and no cross-thread allocator-lock contention (acute on the
+// Windows process heap), a broad low-risk win applied uniformly across the
+// workspace's binaries. Miri cannot call mimalloc's FFI, so under Miri the
+// default allocator stands in.
 #[cfg(not(miri))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/packages/cargo-freeze-deps/src/main.rs
+++ b/packages/cargo-freeze-deps/src/main.rs
@@ -12,6 +12,14 @@ use std::process::ExitCode;
 
 use cargo_freeze_deps::{Cli, run};
 
+// mimalloc is a scalable general-purpose allocator: faster small allocations and
+// no cross-thread allocator-lock contention (acute on the Windows process heap),
+// a broad low-risk win applied uniformly across the workspace's binaries. Miri
+// cannot call mimalloc's FFI, so under Miri the default allocator stands in.
+#[cfg(not(miri))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // Binary entry point — mutations would require subprocess testing which is impractical.
 #[cfg_attr(test, mutants::skip)]
 fn main() -> ExitCode {

--- a/packages/mock_bench_engine/Cargo.toml
+++ b/packages/mock_bench_engine/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+mimalloc = { workspace = true }
 serde_json = { workspace = true }
 
 [lints]

--- a/packages/mock_bench_engine/src/main.rs
+++ b/packages/mock_bench_engine/src/main.rs
@@ -66,10 +66,11 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-// mimalloc is a scalable general-purpose allocator: faster small allocations and
-// no cross-thread allocator-lock contention (acute on the Windows process heap),
-// a broad low-risk win applied uniformly across the workspace's binaries. Miri
-// cannot call mimalloc's FFI, so under Miri the default allocator stands in.
+// Install mimalloc as a scalable, general-purpose allocator process-wide: faster
+// small allocations and no cross-thread allocator-lock contention (acute on the
+// Windows process heap), a broad low-risk win applied uniformly across the
+// workspace's binaries. Miri cannot call mimalloc's FFI, so under Miri the
+// default allocator stands in.
 #[cfg(not(miri))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/packages/mock_bench_engine/src/main.rs
+++ b/packages/mock_bench_engine/src/main.rs
@@ -66,6 +66,14 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+// mimalloc is a scalable general-purpose allocator: faster small allocations and
+// no cross-thread allocator-lock contention (acute on the Windows process heap),
+// a broad low-risk win applied uniformly across the workspace's binaries. Miri
+// cannot call mimalloc's FFI, so under Miri the default allocator stands in.
+#[cfg(not(miri))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // These fixtures live in the sibling `cargo-bench-history` package's test tree
 // because they double as schema-drift canaries for that package's parser tests.
 // They are intentionally shared (not duplicated) so the mock and the parser can


### PR DESCRIPTION
Installs `mimalloc` as the `#[global_allocator]` in **every** remaining workspace
binary, so a scalable, general-purpose allocator now benefits all of the tools
uniformly (fewer cross-thread allocator-lock stalls, faster small allocations —
acute on the Windows process heap).

Previously only the `cargo-bench-history` family set it; this extends the same
pattern to the rest.

## Changes

For each of `cargo-detect-package`, `cargo-freeze-deps`, and `mock_bench_engine`:

* Added the `mimalloc` dependency (already a workspace dependency) to `Cargo.toml`.
* Installed the `mimalloc::MiMalloc` `#[global_allocator]` in `main.rs`, mirroring
  `cargo-bench-history/src/main.rs` — including the Miri carve-out
  (`#[cfg(not(miri))]`), since `mimalloc`'s FFI cannot run under Miri, so the
  default allocator stands in there.
* Kept a terse "why" comment at each site.

## Validation

* `cargo check` / `cargo clippy --all-targets` — clean.
* `cargo +nightly fmt --all --check` — clean.
* `cargo machete` — `mimalloc` correctly detected as used (referenced via the
  `#[global_allocator]` static).

Closes #304
