### PR TITLE
Add design-doc convention chapter and conform existing design docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,17 @@ rules.
 resolving a Clippy lint where multiple valid forms exist; naming a constant,
 builder method, or variable.
 
+### [docs/design.md](docs/design.md)
+
+Where design documentation lives (inline `//` comments, package-level
+`docs/design.md`, per-component files), what it should contain (high-level
+patterns, tenets, and relationships — *what* and *why*, never *how*), and what to
+keep out of it (implementation detail, listings/catalogues, changelogs, decision
+logs).
+
+**Open this when**: writing or maintaining design documentation, and keeping it up
+to date with every commit.
+
 ### [docs/file-organization.md](docs/file-organization.md)
 
 How files, modules, and visibility are structured: small files, flat public

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -132,19 +132,6 @@ pool_id: u64,
 Do not use section separator comments (e.g. `// --- Section ---` or `// ======= Title =======`)
 to create visual "chapters" in code. Code organization should be clear from naming and structure.
 
-## Design documentation
-
-Document design elements, key decisions and architectural choices in inline
-comments in the files to which they apply. Use regular `//` comments, not API
-documentation comments.
-
-Put package-level design documentation in `package-name/docs/design.md`. It is expected that
-all major refactoring or redesign works are accompanied by design documentation which is kept
-up to date when design changes are made.
-
-If a package has multiple significant sub-components, create and maintain design documents for
-each of them as `package-name/docs/component1.md` and similar, referenced from the `design.md`.
-
 ## Named constants
 
 Avoid magic values in the code and use named constants instead. It does not matter

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,31 @@
+# Design documentation
+
+How design intent is captured across the workspace: where it lives, what it should
+contain, and how to keep it current.
+
+## Where design documentation lives
+
+* Record design elements, key decisions, and architectural choices as inline `//`
+  comments (not `///` API-documentation comments) in the files to which they apply.
+* Give each package a package-level `package-name/docs/design.md`. All major
+  refactoring or redesign work must be accompanied by design documentation, kept up
+  to date as the design changes.
+* When a package has multiple significant sub-components, give each its own
+  `package-name/docs/componentN.md`, referenced from that package's `design.md`.
+
+## What a design document contains
+
+Keep it a design document, not an implementation record: describe patterns, tenets,
+and relationships — *what* exists and *why*, never *how* it is coded.
+
+* Stay high-level. Do not name private types, methods, fields, or flags, and do not
+  transcribe control flow, data structures, or wire-protocol mechanics. Illustrate
+  with examples rather than catalogues or listings of types and functions.
+* Spell out implementation detail only for a genuinely exceptional corner case that
+  cannot be understood otherwise. When in doubt, cut detail — the code and its tests
+  are the record of *how*.
+* Describe the desired end state as the final achieved state. Do not write
+  "in progress" language, changelogs, or historical notes. Open questions are fine.
+* Do not maintain a running or numbered decision log. Recording the alternatives
+  that were considered and why they were not chosen is fine when it explains the
+  design; a chronological ledger of changes is not.

--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -29,8 +29,8 @@ here, alongside the workspace-wide rules in `docs/` (especially
   ~5% above a buffered-parallel variant; it is kept for the ~10% wall-time and CPU win.
   The lean `RunPoints` element likewise trims peak only ~1%. The repeated benchmark ids
   and merge coexistence dominate peak, so the open memory levers are bounded
-  merge-as-complete waves and id interning, not a leaner element — see
-  `docs/DESIGN.md` decision 36.
+  merge-as-complete waves and id interning, not a leaner element — see the load
+  section of `docs/analyze.md`.
 * **Operate in place; avoid hidden allocations.** Prefer
   [`sort_unstable_by`](slice::sort_unstable_by) over `sort_by` for the statistics
   primitives: the stable sort allocates a scratch buffer of up to `len`

--- a/packages/cargo-bench-history-core/src/analyze/run_points.rs
+++ b/packages/cargo-bench-history-core/src/analyze/run_points.rs
@@ -15,8 +15,8 @@
 //! parts are never
 //! materialized. (The leaner element trims overall peak only marginally — peak is
 //! set by the per-worker builders coexisting during the merge — but the lighter
-//! parse is still worth keeping; see `cargo-bench-history`'s `docs/DESIGN.md`
-//! decision 36.)
+//! parse is still worth keeping; see the load section of `cargo-bench-history`'s
+//! `docs/analyze.md`.)
 
 use serde::Deserialize;
 use smallvec::SmallVec;

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -7,18 +7,12 @@ synchronous and pushes async only to the IO edges, each modelled as a small
 
 > **Design reference:** [`docs/DESIGN.md`](docs/DESIGN.md) is the canonical, **high-level**
 > design document — the data model, comparability/storage rules, command semantics,
-> analysis algorithms, the two-crate (shell + `cargo-bench-history-core`) architecture,
-> and the numbered decision log (§13). Keep it up to date whenever you change a design
+> analysis algorithms, and the two-crate (shell + `cargo-bench-history-core`) architecture.
+> Keep it up to date whenever you change a design
 > decision, the data model, the crate layout, the storage format, or a command's
-> behaviour, recording non-trivial design changes as a new or amended decision entry.
->
-> **Keep it a design document, not an implementation record.** Describe the patterns,
-> concepts, and relationships — *what* exists and *why* — never *how* it is coded. Do
-> not name private types, methods, fields, or flags, and do not transcribe control flow,
-> data structures, or wire-protocol mechanics. Spell out implementation detail only for
-> a genuinely exceptional corner case that cannot be understood otherwise. When in
-> doubt, cut detail: the code and its tests are the record of *how*; the design document
-> is the record of *what* and *why*.
+> behaviour. It follows the workspace design-documentation conventions in
+> [`../../docs/design.md`](../../docs/design.md) — describe patterns, concepts, and
+> relationships, *what* exists and *why*, never *how* it is coded.
 
 ## Ports and fakes
 
@@ -306,7 +300,8 @@ speedup, so the `cargo-bench-history` binary installs `mimalloc` as its
 `#[global_allocator]` (the stress harness does the same for representative numbers). The
 lean `RunPoints` projection only trims peak ~1%; the repeated benchmark ids and the merge
 coexistence dominate peak, so the open memory levers are bounded merge-as-complete waves
-and id interning — see `docs/DESIGN.md` decision 36.
+and id interning — see the "Architecture" section of `docs/DESIGN.md` and the load
+section of `docs/analyze.md`.
 
 `analyze` assembles a series by **resolving git topology at query time** rather
 than reading a flat storage prefix — the storage layout cannot pre-assemble a

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1,158 +1,49 @@
-# cargo-bench-history — Design & Implementation Plan
+# cargo-bench-history — Design
 
-Status: implemented. All of the numbered iterations are shipped — `collect`,
-`analyze` (engine-aware change-point + drift detection), `install`, the Azure Blob
-backend, the Criterion adapter, the commit-centric storage model, git-aware
-`analyze`, and `backfill`. The resolved design decisions are logged in
-[§13 Decisions & open items](#13-decisions--open-items); the iteration mapping is
-in [§12 Implementation plan](#12-implementation-plan).
+A Cargo subcommand that maintains a **long-lived history** of benchmark results and
+analyzes that history for trends that snapshot / "previous run" tools cannot see:
 
-## 1. Purpose
-
-A Cargo subcommand that maintains a **long-lived history** of benchmark results
-and analyzes that history for trends that are invisible to snapshot/“previous
-run” tools:
-
-* slow incremental drift (“scenario X got 30 % slower over 12 months, 1 % at a
-  time”);
-* step changes attributable to a specific commit, visible only in hindsight once
-  the noise averages out;
-* regressions distinguished from measurement jitter by engine-aware statistics
-  (a change-point or drift that clears the noise floor) rather than a single noisy
-  neighbour.
+* slow incremental drift (a scenario that got 30 % slower over a year, 1 % at a time);
+* step changes attributable to a specific commit, visible only in hindsight once the
+  noise averages out;
+* regressions distinguished from measurement jitter by engine-aware statistics rather
+  than a single noisy neighbour.
 
 It stores every result over time (local path or Azure blob), runs in multiple
-environments (dev PC, GitHub Actions, ADO), and partitions data only when the
-results are not otherwise comparable.
+environments (dev PC, GitHub Actions, ADO), and partitions data only where results are
+not otherwise comparable. Its commands are `collect`, `install`, `analyze`, `backfill`,
+`list`, `prune`, `bless`, and `unbless`.
 
-Commands: `collect`, `install`, `analyze`, `backfill`, `list`, `prune`, `bless`,
-`unbless`.
+## 1. Benchmark engines and what they emit
 
-## 2. How the benchmark systems work (and what they emit)
+Understanding the producers is mandatory: comparability and parsing both depend on it.
+Four engines are supported, and they split along two axes that drive the whole data
+model — **hardware-dependent vs. hardware-independent**, and **noisy vs. deterministic**.
 
-Understanding the producers is mandatory: comparability and parsing both depend
-on it. Scope is what this workspace uses — **Criterion** (wall-clock),
-**Callgrind via Gungraun** (simulated instruction counts), and the two
-workspace-local measurement crates **`alloc_tracker`** (heap allocations) and
-**`all_the_time`** (processor time).
+* **Criterion** — wall-clock time. Hardware-dependent and noisy. Each measured case
+  yields a stable identity (group / function / value) and a point estimate (the
+  regression-line slope when Criterion sampled linearly, else the mean) with a standard
+  deviation and bootstrap confidence interval. It records no timestamp, commit, machine,
+  or package, so the tool supplies all run context.
+* **Callgrind (via Gungraun)** — simulated instruction counts and cache/branch events.
+  Hardware-independent and deterministic (a CPU simulator), so any persistent change is
+  real signal. Its machine-readable summary is the one output that must be opted into
+  with an environment variable — the narrow "special need" that justifies `collect`
+  existing at all.
+* **`alloc_tracker`** — heap allocations (bytes and counts). Hardware-independent and
+  deterministic, with no dispersion (an allocation count is exact).
+* **`all_the_time`** — processor (CPU) time. Hardware-dependent and noisy, carrying a
+  bootstrap confidence interval like Criterion.
 
-### 2.1 Criterion (wall-clock, hardware-dependent)
+The two workspace-local crates (`alloc_tracker`, `all_the_time`) each auto-emit one flat
+JSON file per operation on drop, so they need no opt-in and the operation name alone
+identifies the series.
 
-`cargo bench` with Criterion 0.8.2 writes, per measured case, under
-`target/criterion/`:
+Despite differing in units, noise, and hardware-dependence, all four reduce to the same
+shape: *a stable benchmark identity → a set of named numeric metrics*. That shared shape
+is the foundation of the model.
 
-* `…/<group>/<function>/<value>/new/benchmark.json` →
-  `BenchmarkId { group_id, function_id?, value_str?, throughput? }` — the stable
-  identity of the case.
-* `…/new/estimates.json` → `Estimates { mean, median, median_abs_dev, slope?,
-  std_dev }`, each `Estimate { confidence_interval { confidence_level,
-  lower_bound, upper_bound }, point_estimate, standard_error }`. **Units are
-  nanoseconds per iteration.**
-* `…/new/sample.json` → `SavedSample { sampling_mode, iters[], times[] }` (raw).
-* `…/new/tukey.json` (outlier fences).
-
-Key facts:
-
-* Results are **hardware-dependent and noisy** → must be partitioned by machine
-  and compared with noise-aware statistics.
-* Criterion records **no timestamp, no commit, no machine info, and no package**.
-  Our tool supplies all run context, and the stored `BenchmarkId.package` is left
-  `None` (the workspace's crate-prefixed group ids keep series distinct; see §3).
-* The on-disk JSON is criterion-internal (not a stability-guaranteed API), but
-  has been stable for many releases. `cargo-criterion` (a separate tool) emits a
-  documented `--message-format json` stream; the workspace does not use it
-  today. The adapter parses the on-disk files in isolation behind
-  `bench/criterion.rs`, so a later swap to `cargo-criterion` would not touch the
-  rest of the tool.
-
-### 2.2 Callgrind via Gungraun (simulated, hardware-independent)
-
-Gungraun 0.19.0 runs each scenario once under Valgrind/Callgrind and can emit a
-**machine-readable summary** — this is the “special need” the `collect` command
-exists to satisfy:
-
-* `--save-summary[=json|pretty-json]` (env `GUNGRAUN_SAVE_SUMMARY`) writes
-  `summary.json` next to each scenario’s output under `target/gungraun/…`.
-* `--output-format=json` streams one `BenchmarkSummary` per scenario to stdout
-  (everything else goes to stderr; `… -- --output-format=json | jq -s`).
-* Schema is **versioned** (`BenchmarkSummary.version`, currently `"6"`).
-  `BenchmarkSummary { version, module_path ("file::group::bench"),
-  function_name, id?, kind, profiles, benchmark_file, package_dir, project_root }`.
-  `profiles[].data` carries the Callgrind metrics per `EventKind`: instructions
-  (`Ir`), L1/LL/RAM hits, estimated cycles, branches (`Bc/Bcm/Bi/Bim`).
-
-Key facts:
-
-* Results are **deterministic and hardware-independent** (a CPU simulator), so
-  they do **not** need a machine-key partition.
-* They **are** toolchain/libc/arch sensitive (absolute counts shift with rustc
-  inlining, glibc, target arch). So `target_triple` must still partition, and
-  rustc/libc versions are recorded as metadata so a bump shows up as a step in
-  the timeline rather than silently forking history.
-* The default `cargo bench` output is human-readable text only → we must opt in
-  to the JSON summary. Tiny but real: that is what `collect` does (sets the env var /
-  arg). We therefore **implement `collect`, but it stays thin.**
-
-### 2.3 `alloc_tracker` (heap allocations, hardware-independent)
-
-The workspace-local `alloc_tracker` crate measures how much a benchmark allocates.
-Its `Session` auto-emits, on drop, one flat JSON file per operation under
-`target/alloc_tracker/<operation>.json`:
-
-* `{ operation, total_iterations, total_bytes_allocated, total_allocations_count,
-  mean_bytes_per_iteration, mean_allocations_per_iteration }` (all `u64`).
-* The adapter (`bench/alloc_tracker.rs`) reads `operation` and the two `mean_*`
-  fields, mapping them to an `AllocatedBytes` (`allocated_bytes`) and an
-  `AllocationCount` (`allocations`) metric. The `total_*` fields are ignored — the
-  per-iteration means are comparable across runs with differing iteration counts.
-
-Key facts:
-
-* Allocation behaviour is a **deterministic property of the code**, independent of
-  the hardware → partitions under `synthetic`, never reads a machine key, and (like
-  Callgrind) trusts any sustained step below the noise floor a noisy engine demands.
-* The output carries no dispersion (no CI, no standard deviation): an allocation
-  count is exact.
-* Like Criterion, the on-disk files carry no package, so `BenchmarkId.package` is
-  `None` and the operation name alone identifies the series.
-
-### 2.4 `all_the_time` (processor time, hardware-dependent)
-
-The workspace-local `all_the_time` crate measures processor (CPU) time. Its
-`Session` auto-emits, on drop, one flat JSON file per operation under
-`target/all_the_time/<operation>.json`:
-
-* `{ operation, total_iterations, total_processor_time_nanos,
-  mean_processor_time_nanos, span_count, slope_processor_time_nanos,
-  std_dev_processor_time_nanos, interval_low_processor_time_nanos,
-  interval_high_processor_time_nanos, min_processor_time_nanos,
-  max_processor_time_nanos }`. The `total_*`/`mean_*` counts are `u64`; the
-  dispersion fields (slope, standard deviation, the bootstrap confidence
-  interval bounds, and min/max) are `f64`.
-* The adapter (`bench/all_the_time.rs`) reads `operation`, prefers the
-  through-origin `slope_processor_time_nanos` as the per-iteration point estimate
-  (falling back to `mean_processor_time_nanos`), and records the confidence
-  interval and standard deviation on the metric — mapping it to a single
-  `ProcessorTime` (`processor_time`, unit `ns`) metric.
-
-Key facts:
-
-* Processor time is **hardware-dependent and noisy** (like Criterion wall time) →
-  partitions by machine key and is analysed with the noise-aware statistics.
-* `all_the_time` reports a bootstrap confidence interval over its measured spans
-  (mirroring Criterion), so the noise detector applies the CI-non-overlap gate to
-  processor time the same way it does for wall time. Older output that records
-  only a mean (no interval) still parses, in which case the detector falls back to
-  the Mann-Kendall trend and the practical floor.
-* `BenchmarkId.package` is `None`; the operation name identifies the series.
-
-### 2.5 Consequence for the data model
-
-The systems differ in units, noise, and hardware-dependence. All, however,
-reduce to the same shape: *a stable benchmark identity → a set of named numeric
-metrics*. That shared shape is the foundation of the model in §3.
-
-## 3. Core concepts & data model
+## 2. Core concepts and data model
 
 ```mermaid
 flowchart LR
@@ -160,2142 +51,666 @@ flowchart LR
     C[Criterion files] --> A1[Criterion adapter]
     G[Gungraun summary.json] --> A2[Callgrind adapter]
   end
-  A1 --> RR[BenchmarkResult*]
+  A1 --> RR[BenchmarkResult]
   A2 --> RR
   CTX[RunContext: git + env + toolchain + machine] --> RS[Run]
   RR --> RS
-  RS -->|run stores| ST[(Storage: local / Azure)]
+  RS -->|collect stores| ST[(Storage: local / Azure)]
   ST -->|analyze| SE[Series engine] --> F[Findings report]
 ```
 
-* **BenchmarkId** — stable identity of a series, modeled as an ordered
-  `segments: NonEmpty<String>` (the type enforces the at-least-one-segment
-  invariant). The engine-specific adapter decides what the segments
-  are, so the general-purpose type carries no engine-specific assumptions about
-  which component is the "group" or "case". Callgrind composes `[package?,
-  module_path, function_name, value?]` (the workspace `package` — the Gungraun
-  `package_dir` basename — keeps equally named bench targets in different packages,
-  e.g. `foo/benches/a.rs` and `bar/benches/a.rs`, from colliding into one series).
-  Criterion composes `[group_id, function_id, value_str?]`; it carries no package
-  because `target/criterion/` is flat and package-agnostic, which is safe because
-  the workspace crate-prefixes its Criterion group ids (`<crate>_<group>`). The
-  workspace measurement crates (`alloc_tracker`, `all_the_time`) compose a single
-  `[operation]` segment. Empty/absent components are dropped. Reports render the
-  full `qualified()` form (segments joined by `/`). Renaming a benchmark starts a
-  new series (documented caveat; see §13).
-* **Metric** — `{ kind, value: f64 }` plus optional dispersion (`std_dev`,
-  `interval_low`, `interval_high`) where the engine reports it. `kind ∈ {WallTime,
-  ProcessorTime, InstructionCount, EstimatedCycles, L1CacheHits,
-  LastLevelCacheHits, RamHits, ConditionalBranches, ConditionalBranchMisses,
-  IndirectBranches, IndirectBranchMisses, AllocatedBytes, AllocationCount}`. There
-  is no separate `name` or `unit` field: each kind has exactly one unit, obtained
-  via `kind.as_unit()` (`ns` / `bytes` / `count`), and the kind *is* the display
-  name (`kind.as_str()`, a stable `snake_case` label). `value` is the point
-  estimate — for noisy engines this is the regression-line `slope` where available,
-  otherwise the `mean`. Noisy engines (Criterion, `all_the_time`) also carry the
-  confidence interval and std-dev so analysis can be noise-aware.
-* **BenchmarkResult** — one `BenchmarkId` + its metrics from a single run.
-* **Run timestamp** — every run carries a single **observation timestamp** (§6):
-  the wall clock when the benches ran and were stored. It is provenance only and
-  **never** orders anything. The series is ordered by git topology (§8.3); runs on
-  one commit sub-order clean-before-dirty, then by storage key. The benchmarked
-  commit's committer date — its position on the timeline and the basis for the
-  `--since`/`--until` window — is read from the git graph at analyze time (§8.3),
-  not copied onto the run. There is no "effective timestamp" concept and no
-  `--timestamp` override. The observation time lives directly on `RunContext`.
-* **RunContext** — metadata attached to every stored run (see §6).
-* **Run** — `{ schema_version, context, results: [BenchmarkResult] }`; the
-  unit of storage (one immutable file per run).
-* **DiscriminantSet** — the partition under which a series accumulates. Two
-  results are comparable iff their discriminant sets match (§4).
-* **MachineKey** — a stable hardware fingerprint for hardware-dependent systems
-  (§5).
+* **Benchmark identity** — the stable identity of a series, an ordered non-empty list of
+  string segments. Each engine adapter decides the segments, so the identity type carries
+  no engine-specific assumptions about which component is the "group" or the "case".
+  Callgrind includes the workspace package (so equally named bench targets in different
+  packages do not collide); Criterion and the two measurement crates carry no package —
+  Criterion is safe because the workspace crate-prefixes its group ids, and the
+  measurement crates identify a series by operation name. Reports render the full form
+  with segments joined by `/`. Renaming a benchmark starts a new series.
+* **Metric** — a kind plus a value, with optional dispersion (standard deviation and a
+  confidence interval) where the engine reports it. Each kind has exactly one unit and
+  its own display name, so there is no separate unit or name field. The value is the
+  point estimate; for noisy engines it is the regression slope where available, else the
+  mean.
+* **Run** — one immutable stored file: the run context plus the benchmark results
+  produced by one engine in one execution.
+* **Observation timestamp** — every run carries a single wall-clock timestamp: when the
+  benches ran and were stored. It is **provenance only** and never orders anything. It
+  names dirty snapshot files so concurrent snapshots of one commit coexist. The
+  benchmarked commit's position on the timeline — and the basis for the `--since` /
+  `--until` window — is its committer date, read from the git graph at analyze time and
+  never copied onto the run, so a rebase or amended date can never leave a stale
+  timestamp behind. There is deliberately no "effective timestamp" concept and no
+  timestamp override.
+* **Discriminant set** — the partition under which a series accumulates. Two results are
+  comparable exactly when their discriminant sets match.
+* **Machine key** — a stable hardware fingerprint used only by hardware-dependent
+  engines.
 
-## 4. Comparability & storage partitioning
+## 3. Comparability and storage partitioning
 
-The central insight: **partition only by what makes results fundamentally
-incomparable; record everything else as metadata so the analysis can see its
-effect over time.**
+The central tenet: **partition only by what makes results fundamentally incomparable;
+record everything else as metadata so the analysis can see its effect over time.**
 
-DiscriminantSet =
-`{ project, engine, target_triple, machine_key? }`
+A discriminant set is `{ project, engine, target_triple, machine_key? }`:
 
-* `project` — workspace identity (config `project.id`, default = repo/workspace
-  dir name).
-* `engine` — `criterion` | `callgrind` | `alloc_tracker` | `all_the_time`
-  (different units & semantics).
-* `target_triple` — `x86_64-unknown-linux-gnu` etc. Even hardware-independent
-  counts (Callgrind, `alloc_tracker`) are not comparable across architectures.
-* `machine_key` — **only for hardware-dependent engines** (Criterion,
-  `all_the_time`). Omitted (literal `synthetic`) for Callgrind and `alloc_tracker`.
+* `project` — workspace identity (configured, defaulting to the repository directory
+  name).
+* `engine` — different units and semantics never mix.
+* `target_triple` — even hardware-independent counts are not comparable across
+  architectures (`…-windows-msvc` and `…-windows-gnu` are genuinely different binaries).
+* `machine_key` — present only for hardware-dependent engines; a literal `synthetic`
+  placeholder for the deterministic ones.
 
-Deliberately **metadata, not partition** (so a change is *visible* as a timeline
-step, which is the whole point of the tool): rustc/cargo version, OS/libc,
-commit, branch, environment provider. **Decided:** toolchain is recorded as
-metadata and the timeline stays continuous; `analyze` annotates/segments by
-toolchain so a bump shows up as a step rather than forking history.
+Deliberately **metadata, not partition** — so a change shows up as a timeline step, which
+is the whole point of the tool — are the toolchain versions, OS/libc, commit, branch, and
+environment provider. A rustc bump therefore appears as a step in the series rather than
+silently forking history.
 
-### 4.1 Target triple & cross-OS (WSL) execution
+### 3.1 Target triple and cross-OS (WSL) execution
 
-`target_triple` describes **where the benchmark binary actually ran**, and is
-**always** the target triple of the host the tool runs on — there is no manual
-override and no per-engine special-casing. The tool and the benchmarks it launches
-always run in the same environment (you do not benchmark a system other than the
-one you run the tool on), so the host's triple is the execution triple. A benchmark
-run under WSL is a Linux benchmark: the tool process runs inside WSL, the measured
-binary is `x86_64-unknown-linux-gnu`, and the detected triple is the Linux one.
+`target_triple` describes **where the benchmark binary actually ran**, and is always the
+triple of the host the tool runs on. There is no override and no per-engine special case:
+the tool and the benches it launches always run in the same environment, so the host's
+triple is the execution triple. A run under WSL is a Linux benchmark — the tool process
+runs inside WSL, the measured binary is the Linux target, and the detected triple is the
+Linux one. The golden rule follows directly: run the tool in the same OS context as the
+benches (invoke the whole tool inside WSL, not from the Windows side), because
+auto-detection at the tool is the only thing keeping each platform's data in its own
+series.
 
-The triple is composed from `std::env::consts::ARCH` + `std::env::consts::OS` of
-the running tool. This holds uniformly for every engine — including Callgrind,
-which is not pinned to Linux in the data model: Callgrind benches simply compile to
-no-ops off Linux (so nothing is harvested there), and where they *do* run, the host
-is Linux and the triple is the Linux one anyway. There is no separate "host triple"
-metadata; only the single execution `target_triple` exists.
+### 3.2 On-disk / blob layout
 
-**Golden rule:** run `cargo bench-history` in the same OS context as the benches
-(e.g. invoke the whole tool inside WSL, not from the Windows side). Because the
-triple is auto-detected where the tool runs, this is the only thing that keeps
-each platform's data in its own series.
-
-### 4.2 On-disk / blob layout
-
-The layout is an immutable, append-only-by-new-file, **commit-centric** model
-(works identically on local FS and blob storage, no read-modify-write races in
-concurrent CI). The path is `<discriminant set>/<commit_sha>/<run file>`:
+The layout is immutable and append-only-by-new-file, and works identically on a local
+filesystem and a blob container (no read-modify-write races in concurrent CI). The key
+shape is:
 
 ```
-<root>/v1/<project>/objects/<engine>/<target_triple>/<machine_key|synthetic>/<commit_sha>/
-    clean.json                       # ≤1 per commit — the canonical point
-    dirty-<observation_unix>.json    # 0..N snapshots taken on top of this base commit
+<root>/v1/<project>/objects/<engine>/<target_triple>/<machine|synthetic>/<commit>/
+    clean.json                    # ≤1 per commit — the canonical point for a clean tree
+    dirty-<observation_unix>.json # 0..N snapshots taken on top of this base commit
 ```
 
-Data objects live under a per-project **`objects/`** subtree; project-level **metadata**
-— today only the cache-invalidation marker (§7.2), tomorrow perhaps an index — sits as a
-**sibling** of `objects/`. A data listing therefore enumerates `…/<project>/objects/`
-and can never accidentally pick up a metadata object, and metadata can be added beside
-the data without a layout migration.
-
-The segment **above** `<commit_sha>` is the **discriminant set** — the dimensions
-that make two runs comparable (§4.3). The commit is a directory; **clean vs dirty
-is filename semantics** within it. This layout is dictated by how `analyze` selects
-data (§8.3): storage is **not** a pre-assembled timeline. A series is **pieced
-together at query time** by resolving git history into an ordered set of commits and
-then reading each commit's directory — so the storage key is indexed by *commit*,
-and ordering comes from *git topology*, never from a timestamp baked into the key.
-
-**Logical point identity (collisions).** Because the commit is a path segment, a
-**clean** run is identified by `<discriminant set> + <commit>` and maps to the single
-deterministic key `…/<commit>/clean.json`. Collision detection rides on the
-**write-once** `put` contract: the store refuses to overwrite an existing object, so a
-second clean `collect`/`backfill` of the same commit fails atomically (non-zero exit,
-nothing written) with no separate exists-check round-trip or TOCTOU window;
-`--overwrite` switches to a replacing write (e.g. to clobber data from broken infra). A
-**dirty** run is keyed by its observation time,
-`…/<commit>/dirty-<observation_unix>.json`, so successive snapshots on the same base
-commit coexist (the observation time is wall-clock now, §6, spreading them in the
-order taken); a same-timestamp collision is treated like any other write-once
-conflict (refused unless `--overwrite`).
-
-Branch is **not** a path component: a commit SHA is globally unique, so the same
-commit on two branches is one point. Branch selection happens at query time via git
-topology (§8.3); branch is recorded only as run metadata (§6).
-
-Each path segment (`<project>`, `<target_triple>`, `<machine_key>`, `<commit_sha>`)
-is **sanitized** before the key is built: any character outside `[A-Za-z0-9._-]`
-becomes `_`, and an otherwise-empty or all-dots segment becomes `_`. This keeps a
-stray `/` (e.g. a `project.id` of `team/app`) from silently splitting the key into
-the wrong number of segments — which `analyze` would then drop as unattributable —
-by mangling the value rather than rejecting the run.
-
-**Why the run kind is filename semantics, not a path segment.** A tempting future `v2` would
-hoist the run *kind* into the key path (`…/runs-clean/<commit>.json`, `…/runs-dirty/…`,
-`…/blessings/…`) so a single-kind query could narrow its `list` to one prefix. The kind stays
-**filename semantics within the commit directory** instead, for two reasons. First, the cost
-that split would save is **already saved**: `analyze` excludes non-admitted dirty (and
-off-history, and out-of-window) candidates in a **key-only pass before any body is fetched**
-(§8.3), reading the kind straight from the filename — so a clean-only analysis never issues a
-round-trip for a dirty snapshot today, and a kind prefix would remove `get`s that are never
-made. Second, the commit-centric grouping **co-locates** a commit's `clean.json`, its
-`dirty-*` snapshots, and its blessing sidecars under one `<commit>/` directory, which is
-exactly what lets `prune` drop a commit's whole set and keeps a blessing **adjacent to the
-`clean.json` it baselines** (§8.6, §8.7); a kind-first layout would scatter those across three
-subtrees and complicate both joins. The one genuine upside — independent single-kind
-enumeration (`list blessings`) — is minor and, if ever needed, is cheaper to obtain by
-narrowing the existing `list` prefix by **discriminant** (which this layout already permits)
-than by a migration. Deferred as a `v2` option, not adopted (decision 42).
-
-### 4.3 Discriminant set & query facets
-
-The discriminant set `<project>/<engine>/<target_triple>/<machine_key|synthetic>`
-is the comparability boundary; a series is only ever built **within** one set. The
-**full target triple** is kept as one segment on purpose — `…-windows-msvc` and
-`…-windows-gnu` are genuinely different binaries and must not merge.
-
-Three facets select which sets a query — `analyze`, `list`, `prune`, and the
-blessing commands `bless` / `unbless` (which annotate *existing* stored sets) —
-operate on: `--engine`, `--target-triple`, and `--machine-key`. (Earlier drafts
-also exposed derived `--os` / `--architecture` facets; they were removed because
-duplicating the target-triple dimension confused users. Filter on the triple
-directly.)
-
-* `list discriminants` lists the distinct sets present (a cheap key `list` under
-  `v1/<project>/objects/`, parsed and de-duplicated; an index file can be added later if
-  a store grows large), with their parsed engine / target triple / machine key.
-* Each facet is **repeatable** and accepts the literal `all`:
-  * Omitting a facet **auto-detects the current machine**: `--target-triple`
-    defaults to the host triple and `--machine-key` to the host fingerprint, so a
-    bare `analyze` reports *this* machine's data. `--engine` has no machine-derived
-    value, so its auto-detected default is *all engines*. (Exception: the
-    `list discriminants` discovery catalog defaults to *every* stored partition, not
-    the current machine — see §8.5.)
-  * Repeating a facet unions its values (`--engine criterion --engine callgrind`).
-  * `all` (e.g. `--machine-key all`) removes the filter for that dimension —
-    the explicit way to widen past the current machine. It is rejected in
-    create mode (see below).
-* A facet that matches several sets (e.g. a Windows and a Linux runner pool)
-  yields **one report per set** — parallel data sets, analyzed individually.
-
-**Hardware-independent sets and the machine-key facet.** Callgrind and
-`alloc_tracker` partitions carry the literal `machine = synthetic` because their
-results do not depend on the machine. A `synthetic` set therefore **always passes**
-the `--machine-key` facet, regardless of its value: auto-detecting the host
-fingerprint still includes every synthetic set alongside this machine's
-hardware-dependent (`criterion`, `all_the_time`) sets, and excludes only *other*
-machines' hardware-dependent data.
-
-**Create vs. query.** `collect` and `backfill` *record new benchmark data* into exactly
-one machine's reality, so they auto-detect every facet and accept only
-`--machine-key` as an override (for a stable CI-pool key). They do **not** accept
-`--engine` selection (engines come from config / what ran), a `--target-triple`
-override (always auto-detected, §4.1), or the `all` keyword. Every other command —
-`analyze`, `list`, `prune`, `bless`, `unbless` — *queries existing stored data*
-(the blessing commands write a sidecar **onto** an existing `clean.json`, so they
-select among the sets already present at the commit), and uses the full query facet
-model above: repeatable, `all`-aware, auto-detecting the current machine when
-omitted.
-
-## 5. Machine key (hardware fingerprint)
-
-Goal: equal for pool-equivalent machines, different for genuinely different
-hardware. **Never** keyed on hostname/serial (cloud pool nodes differ in name
-but are equivalent).
-
-Factors (hashed): the `many_cpus` maximum processor count and maximum
-memory-region (NUMA node) count, plus a best-effort CPU brand string. These are
-the stable, pool-equivalent attributes available without elevated privileges
-across Windows/Linux/macOS; finer signals (RAM size, base frequency) were left
-out of v1 because they add platform-specific probing for little discriminating
-value in homogeneous CI pools. User override: `--machine-key` (CLI only — the
-config file is committed and would be wrong for some checkouts), which wins over
-the computed fingerprint.
-
-* Reuse **`many_cpus`** (already in-workspace) for the processor and
-  memory-region counts; a small per-platform `detect_cpu_brand` supplies the CPU
-  brand (Windows/Linux/macOS impls, best-effort — `None` when unavailable).
-* **Stability requirement (correctness):** the key is persisted and compared
-  across machines and tool versions, so it uses a **fixed** hash — SHA-256 of a
-  version-tagged canonical string (`mk1\nprocessors=…\nmemory_regions=…\n
-  cpu_brand=…`), truncated to the first 16 hex characters — **not**
-  `foldhash`/`DefaultHasher` (seeded / not stable). A golden unit test pins a
-  fixed profile to its hex digest so an accidental change to the canonical form
-  is caught.
-* Computed only for **hardware-dependent** systems (Criterion, `all_the_time`).
-  Callgrind and `alloc_tracker` partition under `synthetic` and never read the
-  machine key.
-
-## 6. Run context (environment detection)
-
-Captured once per stored run and attached to the `Run`:
-
-* **Observation timestamp** — wall clock when the benches ran and were stored,
-  read from an injected `tick::Clock` (§10) so tests drive it deterministically.
-  Provenance only; **never** used to order a series. It names the dirty filename
-  (`dirty-<observation_unix>`) so concurrent dirty snapshots of one commit coexist.
-  This is the only timestamp the run stores: the benchmarked commit's position on
-  the timeline is its committer date, read from the git graph at analyze time
-  (§8.3) and never copied onto the run, so a rebase or an amended date can never
-  leave a stale timestamp behind.
-* **Git:** commit SHA, branch, dirty flag (`git`).
-  Branch is metadata only — query-time topology, not this field, decides series
-  membership (§8.3). Parent lineage and committer date are **not** recorded:
-  `analyze` resolves topology *and* each commit's committer date from a live repo
-  (§8.3), so storage never needs to reconstruct the commit graph or carry a
-  per-object date.
-* **Environment (`EnvironmentInfo`):** provider + run id + PR number, detected
-  from env. "Environment" rather than "CI" because `Local` is a first-class
-  provider and the automated providers are not always doing continuous integration:
-  * GitHub Actions: `GITHUB_ACTIONS`, `GITHUB_SHA`, `GITHUB_REF_NAME`,
-    `GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`.
-  * ADO: `TF_BUILD`, `BUILD_SOURCEVERSION`, `BUILD_SOURCEBRANCH`,
-    `BUILD_BUILDID`, `SYSTEM_PULLREQUEST_PULLREQUESTID`.
-  * else `Local`.
-* **Toolchain (`ToolchainInfo`):** rustc + cargo version and the resolved
-  execution `target_triple` (§4.1). There is no separate host triple — the tool
-  always runs where it benchmarks.
-* **Provenance:** cargo-bench-history version + schema version + machine_key.
-
-`jiff` parses `--since`/`--until` and formats stored times as RFC 3339 (UTC). Git
-and env access go through a small PAL so the logic is unit-testable without a real
-repo or CI.
-
-## 7. Storage abstraction
-
-```rust
-trait Storage {
-    async fn put(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError>;
-    async fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<(), StorageError>;
-    async fn get(&self, key: &str) -> Result<Vec<u8>, StorageError>;
-    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError>;
-    async fn delete(&self, key: &str) -> Result<(), StorageError>;
-}
-```
-
-`put` is write-once (a re-`put` of an existing key is `StorageError::AlreadyExists`,
-the basis of `collect`'s clean-collision refusal — §8.1); `put_overwrite` replaces in
-place (the `--overwrite` escape hatch). `delete` removes one object and returns
-`StorageError::NotFound` when it is absent — used by `prune` (§8.6) to delete the
-selected runs.
-
-Storage I/O is **async** (§10): `LocalStorage` over `tokio::fs`, `AzureBlobStorage`
-over async HTTP. `async fn` in a trait is not `dyn`-compatible, so backend
-selection is a `StorageFacade` **enum** (`Local` | `Azure`) with static dispatch
-rather than a boxed-future trait object, and `collect`/`analyze` stay
-backend-agnostic by holding a `StorageFacade`.
-
-* **LocalStorage** (iteration 1): root selected at run time from `--local` (§7.1);
-  create dirs; write/read/walk via `tokio::fs` (iterative directory walk — no boxed
-  async recursion).
-* **AzureBlobStorage** (iteration 4): `azure_storage_blob` (+ `azure_identity`),
-  always compiled in — `cargo-bench-history` is a CLI tool installed without
-  feature flags, so a build-time gate would only ever hide a backend the user
-  explicitly configured. It compiles on Windows, Linux **and macOS**. Auth is
-  **Microsoft Entra ID (OAuth) only**, resolved once in `from_config`: the
-  secret-free production default (CI managed identity / workload-identity
-  federation, local `az login`, env service principals), always over an **HTTPS**
-  endpoint (Entra bearer tokens require TLS). The concrete credential is picked by
-  `entra_credential`: in a GitHub Actions job configured for federation it is a
-  `ClientAssertionCredential` whose assertion self-mints a fresh GitHub OIDC JWT on
-  demand (`storage::github_oidc`); otherwise it is `DeveloperToolsCredential`
-  (which discovers the local `az login` session). Either way it is wrapped in a
-  `CachingCredential` decorator that serializes token acquisition and caches the
-  token per scope, so `analyze`'s concurrent object-load burst shares one
-  acquisition instead of driving that many simultaneous token fetches — which on
-  Windows collide on the exclusive MSAL token-cache lockfile and fail the whole
-  read.
-
-  Legacy shared-key/self-signed-account-SAS (`account_key`) and verbatim-SAS
-  (`sas_token`) modes were removed (decision 43): a leftover key/token field is now
-  a loud config parse error. Tested in regular CI two ways (decision 17): the
-  `test-azurite` job against the **Azurite emulator** and the additive `test-azure`
-  job against a **real Storage account**, both over the **Entra ID** path (signed in
-  via GitHub OIDC, a fresh container per test deleted afterward). Azurite has no real
-  Entra, so it runs in `--oauth basic` mode over HTTPS (self-signed cert) and the
-  tests inject a locally-faked Entra token plus a cert-trusting transport through
-  `from_parts` / the `azure_backend_from_parts` command seam; real signature
-  validation stays proven by `test-azure`. Neither job is `#[ignore]`; the network
-  tests **self-skip** when their backend is not configured and are
-  `#[cfg_attr(miri, ignore)]` (the faked token reads the wall clock for its
-  `iat`/`nbf`/`exp` claims).
-* An in-memory `Storage` fake (in `#[cfg(test)]`) backs the Miri-safe
-  orchestration tests; it mirrors the same key/prefix semantics as `LocalStorage`.
-* **Connection reuse & on-the-wire compression.** Every per-object blob and
-  container client is built from one shared, pooled `reqwest` transport — an
-  `Arc<dyn HttpClient>` injected through the SDK's transport seam and held on
-  `AzureBlobStorage`, built once in `from_config` — so `analyze`'s
-  high-concurrency object-load burst keeps TCP+TLS connections alive across objects
-  instead of paying a fresh handshake per object (and stops exhausting ephemeral
-  ports at high fetch concurrency). Stored bodies are **gzip-compressed** by the
-  shared `cargo_bench_history_core::codec` both backends call: `put`/`get`
-  compress/decompress at the edge, Azure tags the blob `Content-Encoding: gzip` and
-  leaves SDK auto-decompression off (the storage layer already returns compressed
-  bytes, so turning it on would double-inflate), and a legacy plaintext object fails
-  loudly on `get` because the gzip magic never collides with JSON's first byte.
-
-The blob/key model (flat keys, list-by-prefix, immutable objects) is the lowest
-common denominator of a filesystem and a blob container, so both backends
-implement the same trait with no special-casing upstream.
-
-### 7.1 Selecting a backend
-
-A local-storage path is **machine-dependent**, so it is never carried in the
-shared, version-controlled config file. The configuration file holds only the
-**cloud** backend (an optional, externally-tagged `[storage.<kind>]` table —
-`[storage.azure]` today — of which **at most one** may be configured; two tables
-fail to deserialize). Local storage is chosen at the command line or environment.
-A leftover `[storage.local]` table from an earlier scheme is **rejected** at parse
-time (`unknown variant 'local', expected 'azure'`), nudging the user to remove it
-and select local storage via `--local`.
-
-Every storage-backed command (`collect`, `analyze`, `list`, `prune`, `backfill`,
-`bless`/`unbless`) takes a `--local` flag and resolves the backend in this
-precedence:
-
-1. **`--local=<path>`** → local filesystem storage at `<path>` (relative paths are
-   taken relative to the repository base, so they resolve the same regardless of
-   the process current directory).
-2. **bare `--local`** (no value) → local filesystem storage at the path in the
-   `CARGO_BENCH_HISTORY_STORAGE` environment variable; an unset or empty variable
-   is an error. (`--local` uses `require_equals`, so the value form is always
-   `--local=<path>` and the bare form never accidentally swallows a following
-   positional argument.)
-3. **no `--local`** → the single cloud backend configured in the file. `--local`
-   thus always **overrides** a configured cloud backend.
-4. **neither `--local` nor a configured cloud backend** → a storage configuration
-   error telling the user to pass `--local` or configure a cloud backend.
-
-`collect --no-store` is the one exception: it skips storage selection entirely (the
-benchmarks run but nothing is written), so it works with no `--local` and no
-configured backend. The path resolution is split for testability and Miri safety:
-a thin edge helper reads the environment variable, and a pure resolver maps the
-`--local` choice plus that value to an optional path, so the decision logic is
-unit-tested without touching the process environment. The chosen backend (and why
-— flag, environment, or cloud config) is reported on the `--verbose` trail.
-
-### 7.2 Read-through cache for the cloud backend (issue #262)
-
-> Status: **implemented.** Decision 41 logs the rationale and the alternatives weighed.
-
-`analyze`/`list`/`prune` load the whole in-selection history before reconstructing the
-series, and against the cloud backend that is one download per object. The CI
-`analyze` re-fetches everything even though almost all of it is identical to the previous
-run. An optional on-disk **read-through cache** removes that waste: each run pays
-the network cost only for objects it has never seen, and the cache survives between CI
-runs via the GitHub [`actions/cache`](https://github.com/actions/cache) action.
-
-**What is cached, and why it stays correct.** The cache mirrors fetched **object
-bodies**, keyed by storage key. It never caches the **listing**: discovering the
-current key set is one cheap round-trip whose whole purpose is to see what is new, so
-it always goes to the cloud and a freshly stored object is still found (its body simply
-misses the cache and falls through). Trusting a cached body forever is sound because
-the storage model is **immutable per key** — the write-once `put` refuses to change an
-existing key, so clean runs, dirty snapshots, and blessing sidecars never change once
-written. Only two operations break that immutability, and both are rare, deliberate
-administrative actions never reached on the CI collection hot path: a `delete` (used by
-`prune`/`unbless`, and by `--overwrite` dropping a stale blessing) and a `put_overwrite`
-(the explicit `--overwrite` escape hatch). A cache must be discarded whenever either
-happens; a brand-new key never invalidates anything, because it was never cached.
-
-**Per-project invalidation.** Invalidation is signalled by a small **marker object**
-stored per project, holding an opaque epoch token. It lives inside that project's own
-versioned partition as a **sibling of the project's object subtree**: data objects are
-grouped under a dedicated subtree, so a data listing never trips over the marker (or any
-future metadata such as an index), and a future storage-format version can redefine the
-cache contract in lockstep with the layout it caches. The mirror is a **faithful image of
-a single cloud backend** under identical keys. Its root is namespaced by that backend's
-identity (account, then container), so two different backends that share one `--cache`
-directory never serve each other's bodies; within one backend's mirror several projects'
-objects still coexist. The marker and the wipe are scoped to a **single project's objects**,
-so a mutation in one project only ever discards **that project's** mirrored objects — every
-other project's cached objects survive untouched. Before a load, the reader compares the
-project's cloud marker against the epoch its mirror last recorded **under that same marker
-key**; on a mismatch it wipes that project's mirrored objects and re-records the new epoch,
-then reloads. The wipe is deliberately coarse — drop all of that project's mirrored objects
-rather than reason about which objects a deletion touched — because mutations are rare, so
-"throw it away and re-download once" is simpler and obviously correct. Only whether the
-token *differs* matters, never its value or ordering, so clock skew between runners is
-harmless. The marker is maintained by the cloud backend itself, not by the cache, so
-**every** writer — including a developer's cache-less `prune` — invalidates *other*
-machines' caches: the local cache is a read-side optimization, the marker a cloud-side
-correctness contract, and the two are independent.
-
-**Collection must stay append-only.** The cache only survives a CI run if that
-run never mutates an existing object. The collection previously used `--overwrite`
-purely so a re-run on an unchanged commit was idempotent rather than a duplicate
-failure — but overwriting routes every write (even the first write of a new commit)
-through the mutating path and would invalidate the cache on every run. A
-`collect --skip-existing` mode fixes this: a write-once collision becomes a **soft skip**
-(the run still benchmarks every engine, so a broken benchmark is still caught, but
-writes nothing) instead of a failure. Collection switches to it, keeping the
-production write path **purely additive** so it never bumps the marker. This is also
-better history hygiene — a stored measurement becomes immutable, so a re-run can never
-silently rewrite past data — while still meeting the original "a re-run must not fail
-red" goal. Regenerating data after a harness change stays a deliberate, manual
-`--overwrite`, which legitimately invalidates caches.
-
-**CLI and CI.** A `--cache <dir>` flag (with a `CARGO_BENCH_HISTORY_CACHE` environment
-fallback, resolved like `--local`) on `analyze`/`list`/`prune` selects the cache
-directory. It applies only to the cloud backend, so it **conflicts with `--local`** —
-a local backend's reads are already on disk. `collect`/`backfill` take no `--cache` (they
-do not read the bulk history) but still maintain the marker through the backend
-automatically. In CI the `collect` step uses `--skip-existing`, and the
-`analyze` job restores and saves the cache directory through `actions/cache`. The one
-scaling limit is the repository's Actions-cache quota (a default 10 GiB, raisable with
-paid billing); beyond it the cache degrades to a partial restore — still correct, just
-less effective — at which point a server-side cache or a pruned look-back window would
-be the next step.
-
-## 8. Commands
-
-The commands (`collect`, `install`, `analyze`, `backfill`, `list`, `prune`, `bless`,
-`unbless`) follow the established pattern: `main.rs` strips the injected
-`bench-history` arg, **`clap`** parses (with subcommands), and dispatches to
-`lib::run`, which returns a typed `Outcome`/`Error`.
-
-**Argument groups.** Because the surface is wide, every option is filed under a
-named `clap` help heading so `--help` reads as a small set of labelled groups
-rather than one flat list:
-
-* **Environment and execution** — `--config`, `--repo`, `--verbose`, `--dry-run`
-  (on `prune`), and `--help`.
-* **Output** — `--no-text` / `--markdown <path>` / `--json <path>`, on the
-  reporting commands (text on stdout by default; the two file toggles add
-  Markdown / JSON files; all rendered from one analysis pass).
-* **Benchmark scope** — `--workspace`, `--package`/`-p`, `--exclude`, `--bench`,
-  on the executing commands.
-* **Feature selection** — `--features`, `--all-features`, `--no-default-features`,
-  on the executing commands; forwarded verbatim to `cargo bench`.
-* **Discriminant selection** — `--engine`, `--target-triple`, `--machine-key`
-  (§4.3): repeatable + `all` in query mode; only `--machine-key` in create mode.
-* **Commit selection** — `--base`, `--context` (the ref the command runs in
-  context of; defaults to `HEAD`), `--since`, `--until`. `--since` defaults to
-  six months back uniformly; `--until` has no upper bound by default. These filter
-  by each commit's committer date, not by when a run executed.
-* **Data filtering** — `--no-dirty`.
-* **Subjects** — bare positional words, never flags: `list <runs|discriminants|
-  blessings>`, `bless <prefix…>`, `prune <commit…>`, `backfill <from> <to>`.
-
-A bare `list` with no subject is an error that names the available subjects.
-
-### 8.1 `cargo bench-history collect`
-
-**Engines are detected from output, not configured.** `collect` invokes the
-workspace's benches once with `cargo bench` and harvests whichever engines
-produced output. There is no `[engines]` configuration: the tool enables the
-combined environment every supported engine needs and then inspects each output
-tree to see which engines actually ran. This works because all supported engines
-can be driven from a single `cargo bench` invocation, and off-Linux the
-Callgrind (`_cg`) benches compile to `#[cfg(target_os = "linux")]` no-ops, so they
-simply produce no output — no OS logic is needed in the tool.
-
-`collect`:
-
-1. **Injects the combined bench environment via environment variables** (not
-   appended args). Env is robust regardless of how the benches launch. Callgrind
-   needs `GUNGRAUN_SAVE_SUMMARY=pretty-json`; Criterion, `alloc_tracker` and
-   `all_the_time` need nothing (they auto-emit JSON on drop). The union of
-   every supported engine's env (`injected_bench_env`, iterating `Engine::ALL`)
-   is set unconditionally — an engine that did not run merely ignores its variable.
-   * **Target directory pinning:** the tool also injects `CARGO_TARGET_DIR` set
-     to the *absolute* target root it will harvest, so the benches' output always
-     lands where the harvest scans. An absolute root is essential because cargo
-     runs each benchmark binary with its working directory set to the owning
-     package's directory: a relative `target/` would be resolved there by an
-     engine such as Criterion (which honors `CARGO_TARGET_DIR` as a path),
-     scattering output under each package instead of the workspace root. Pinning
-     an absolute root also overrides an ambient `CARGO_TARGET_DIR` (such as the
-     one `cargo llvm-cov` sets) that would otherwise redirect output elsewhere.
-2. Records the **run-start time**, then runs `cargo bench` (with the scope flags
-   below). A non-zero exit aborts the run.
-3. **Harvests every supported engine's output location**
-   (`target/gungraun/**/summary.json` for Callgrind,
-   `target/criterion/**/new/estimates.json` for Criterion,
-   `target/alloc_tracker/*.json` and `target/all_the_time/*.json` for the two
-   workspace measurement crates), filtered to files with
-   `mtime ≥ run-start` so stale cases from earlier runs are not re-ingested. Each
-   tree is attributed to its engine; an engine whose tree produced no cases is
-   silently skipped.
-4. Builds a `Run` per engine (with the resolved RunContext) and **stores it
-   immediately** — `collect` always persists; there is no separate publish step
-   (`--no-store` produces results without writing, for dry runs). A **clean** point
-   writes the deterministic key `…/<commit>/clean.json`; an existing one is refused
-   by default (non-zero exit, via the write-once `put` contract, §4.2) unless
-   `--overwrite`, which makes re-runs idempotent and safe to repeat (or `--skip-existing`,
-   which treats the existing point as a success and writes nothing — the append-only mode the
-   CI `collect` uses, §7.2). A **dirty**
-   snapshot writes
-   `…/<commit>/dirty-<observation_unix>.json` and coexists with prior snapshots (only a
-   same-timestamp clash is a conflict). An engine that harvests **zero** cases stores
-   nothing (an empty set carries no comparable data and would only inflate `analyze`'s
-   run count); the summary reports the empty harvest, and other engines in the same
-   run are unaffected.
-
-To collect Callgrind data, run the tool on Linux (or in WSL), where Valgrind is
-available; on other hosts only Criterion is harvested. This is automatic — the
-Callgrind benches are absent from the build there, so the tool never attempts
-Valgrind off-Linux.
-
-**Scope & filtering.** Scope flags translate directly to `cargo bench` arguments:
-`--workspace` (the default) benches the whole workspace; `--package`/`-p NAME`
-(repeatable) restricts to specific packages (and omits `--workspace`);
-`--exclude NAME` (repeatable, conflicts with `--package`) drops packages from the
-whole-workspace run; `--bench
-NAME` (repeatable) restricts to named bench targets. Cargo feature selection is
-forwarded too: `--features <FEATURES>` (repeatable), `--all-features`, and
-`--no-default-features` become the matching `cargo bench` flags, so feature-gated
-benchmarks can be reached. Everything after a `--`
-separator is forwarded **verbatim** to `cargo bench` after the scope and feature
-flags.
-Because harvest is scoped by `mtime ≥ run-start`, whatever subset actually ran is
-exactly what gets ingested. Note that two non-overlapping partial runs at the same
-commit (different `--package`/`--bench` subsets) do **not** merge: each stores its
-own `clean.json` and the second collides with the first (§4.2) — gaps in coverage
-are expected to come from *different commits* covering different subsets, not from
-multiple partial runs at one commit. Other flags: `--machine-key <key>` (override
-the hardware fingerprint, §4.1), `--no-store`, `--overwrite` (replace an existing
-same-commit point instead of refusing, §4.2), `--skip-existing` (mutually exclusive
-with `--overwrite`: a same-commit point that already exists is a **soft skip** —
-success, nothing written — instead of the `RunError::Duplicate` failure of the
-default write-once mode; used by the CI `collect` recipe so collection stays
-append-only and never invalidates the read-through cache, see §7.2), `--verbose` (print a step-by-step
-diagnostic trail to stderr — the benchmark command and injected env, directories
-scanned, files included/skipped-as-stale, and each stored key — to diagnose a run
-that unexpectedly stored nothing). The benchmarked commit's position on the
-timeline is its committer date, read from git at analyze time (§6) — there is no
-`--timestamp` override. The target triple
-is always auto-detected (§4.1) — there is no `--target-triple` override. `--engine`
-is **not** a `collect` flag — it is an `analyze` facet over stored data (§8.3).
-
-### 8.2 `cargo bench-history install`
-Generate an example `.cargo/bench_history.toml` if absent; print its path and
-next steps. Never overwrite an existing file (report and exit success). Honors
-`--config <path>` to write somewhere other than the default location. Writing is
-abstracted behind a `ConfigWriter` port (`TokioConfigWriter` in production, an
-in-memory fake in tests) whose `write_new` creates parent directories and uses
-`create_new` so an existing file is reported, never clobbered. The generated
-template is **fully commented**: it documents the optional `[storage.azure]` cloud
-backend and notes that local storage is *not* configured in the file but selected
-at run time via `--local=<path>` or `CARGO_BENCH_HISTORY_STORAGE` (§7.1). Engines
-are detected from output, not configured (§8.1); the template carries no
-machine-key setting (the key is a run-time-only `--machine-key` flag, since a
-committed config would be wrong for some checkouts) and the next-steps hint points
-at `backfill` for seeding an existing repository's history.
-
-### 8.3 `cargo bench-history analyze`
-
-**Analyze pieces a series together at query time from git topology** — storage is
-indexed by commit (§4.2), not pre-ordered. `analyze` therefore **requires a
-resolvable git repository** (the current checkout by default, or `--repo <path>`);
-with no repo it errors out rather than guessing an order. (Analyzing a foreign
-project's stored data means checking out that project's repo and pointing `analyze`
-at it.)
-
-**Selecting the discriminant sets.** `list discriminants` prints the sets
-present (§4.3), unfiltered by default. When *analyzing*, `--engine`,
-`--target-triple`, `--machine-key` filter the sets — each repeatable, each accepting
-`all`, each defaulting to the current machine (engine to *all engines*) when omitted
-(§4.3); every matched set is analyzed independently and produces its own report (so a
-Windows and a Linux runner pool come out as two reports).
-
-**Selecting the commits (the query model).** Two refs frame the analysis:
-* `--context <ref>` — the **target** whose history is analyzed (default: current
-  `HEAD`). When it is not `HEAD`, the working-tree state is ignored.
-* `--base <ref>` — the **integration branch** (default: the detected default branch
-  — `origin/HEAD`, else `main`/`master`; `project.default_branch` config override).
-
-`analyze` resolves the **first-parent** ancestry of the target and splits it at the
-merge-base with the base:
-* commits **in the base ancestry** (≤ merge-base) contribute **clean points only**;
-* commits **unique to the target** (the private branch commits, > merge-base)
-  contribute **clean *and* dirty** points (`--no-dirty` drops the dirty ones).
-
-This single rule covers both use cases: an "official" view is just
-`--context <default>` (target == base ⇒ everything is base ⇒ clean-only); the
-"how does my feature fit in" view is the default (clean default-branch baseline,
-then the branch's own clean + dirty snapshots). Series are **ordered by git
-topology**; multiple runs on one commit sub-order clean-before-dirty, then by
-storage key (§8.3). Branch
-*metadata* on a run is never consulted — membership is purely topological, so a
-dirty snapshot taken on a shared base commit (scratch work before committing) is
-excluded from an official view until it is committed.
-
-**Dirty-working-tree exception on the base tip.** There is one carve-out to the
-clean-only base rule, for the common "first impressions" scenario where a user
-runs `analyze` while sitting on the base branch with uncommitted changes (e.g. an
-untracked `.cargo/bench_history.toml`, so every stored run landed as a
-`dirty-*.json` on the base tip). When the **working tree is currently dirty** (the
-`GitHistory::is_dirty` probe — `git status --porcelain` non-empty, untracked files
-included, matching how a run decides clean-vs-dirty) **and** the target **tip**
-commit is base-side, that tip's dirty snapshots are admitted (they are the user's
-in-flight work, not stale leftovers). The exception is limited to the tip — earlier
-base-side commits stay clean-only — and is gated by `allow_dirty`, so `--no-dirty`
-overrides it. Whenever such a run is actually included, the report ends with a
-**warning** that the data is ephemeral ("…included dirty runs … on top of the base
-branch … Switch to a new branch to persist benchmark history of your changes.").
-On a feature view the tip is already target-side, so the exception is a no-op there.
-
-For each selected commit `analyze` reads its directory (`clean.json` and, when
-admitted, `dirty-*.json`), builds per-`(BenchmarkId, metric)` series in topological
-order, runs the finding algorithms (§9), and prints a report.
-
-* `--since <when>` drops commits whose committer date predates the cutoff, and
-  `--until <when>` drops commits after an upper cutoff, so the run count and every
-  series share the window. Both accept an RFC 3339 timestamp
-  (`2024-01-01T00:00:00Z`), a bare `YYYY-MM-DD` date (UTC midnight), or a relative
-  duration such as `6 months` or `30 days ago` (resolved against the wall clock).
-  `--since` defaults to a **six-month** look-back uniformly across modes (so a
-  scheduled trend watch does not silently widen as history accumulates, and an
-  unbounded scan of ancient data is never the default); widen it with an explicit
-  older `--since`. `--until` has no upper bound by default.
-* `--mode auto|history|branch|tip` selects the analysis mode (§9.6); `auto` (the
-  default) infers it from git topology and the recorded data set (never the on-disk
-  working-tree state). `--include-improvements` opts a history-mode analysis into
-  reporting sustained improvements (suppressed by default).
-* `--include-inactive` opts a history-mode analysis into reporting **resolved**
-  changes — a spike that has since recovered to its prior level (§9.7). These are
-  suppressed by default (the current state already matches the baseline, so there is
-  nothing to act on) but are useful for auditing history that self-corrected. The
-  underlying points are always part of the data set and the chart regardless of this
-  flag; it only controls whether the recovered finding is surfaced.
-* `<prefix…>` positional subjects scope the analysis to benchmarks whose id starts
-  with any given prefix (e.g. `analyze my_pkg/`), matched the same way `bless` matches
-  (§8.7). Omitting them analyzes every benchmark. There is no `--metric` filter:
-  metrics are an internal detail users are not expected to know; scope by benchmark
-  prefix instead.
-* **Output toggles** select which renderings a single analysis pass emits. The
-  text report goes to **stdout by default**; `--no-text` suppresses it,
-  `--markdown <path>` also writes the Markdown report to a file, and `--json
-  <path>` also writes the JSON report. The toggles compose — one pass can emit
-  all three — and relative file paths resolve against the workspace directory.
-  Requesting no output at all (`--no-text` with neither file) is an error, since
-  the pass would produce nothing.
-* **Findings never affect the exit code.** The process exits non-zero only when the
-  analysis fails to *run* (no repo, storage error, …); a finding is advisory. The
-  machine-readable signal lives in the `json` report (§9.6): `mode`, the boolean
-  `notable` (any finding survived), each finding's `direction` and `flipped_at`, and
-  the full per-finding `series`. Downstream automation (a scheduled regression watch
-  posting to a chat, a PR comment bot) reads those rather than the exit status.
-* `--verbose` prints a per-object diagnostic trail to stderr (the listing prefix,
-  facet filters, resolved target/base/merge-base, and why each candidate is
-  included or excluded). When facet-matching runs were stored but none entered the
-  analysis (commonly because every run is a dirty snapshot on a base-side commit),
-  the report itself carries a *hint* explaining the empty result even without
-  `--verbose`, so a `0 runs` outcome is never mistaken for "no data". `--verbose`
-  is accepted by every command.
-
-### 8.4 `cargo bench-history backfill`
-
-Reconstructs history by checking out each commit in a range and running
-`cargo bench-history collect` for it. Bootstraps an existing repo's timeline and is
-also the convenient path for ad-hoc evaluation over a span of commits.
-
-```
-cargo bench-history backfill <from> <to> \
-    [--workspace] [--package NAME] [--exclude NAME] [--bench NAME] \
-    [--features FEATURES] [--all-features] [--no-default-features] \
-    [--overwrite] [--ignore-errors] [--verbose] [-- <passthrough>]
-```
-
-**Range & ancestry.** Commits are enumerated **oldest-first** along the
-**first-parent** mainline of the current branch — `git rev-list --reverse
---first-parent <from>^..<to>` — so the timeline follows the linear branch
-progression and does not fan out into commits merged in from side branches.
-The `<from>` and `<to>` subjects (bare positional commits) are both inclusive. Before doing anything the tool verifies both endpoints resolve and that `<from>`
-is a first-parent ancestor of `<to>`; the range is then derived purely from
-`<to>`'s first-parent history, so backfilling does **not** depend on the current
-checkout or branch (you can backfill any range whose endpoints form a first-parent
-line, regardless of where `HEAD` sits).
-
-**Per commit**, in order, the tool first consults storage to decide whether the
-commit needs benchmarking at all, then (if it does) checks out the commit, runs the
-benches with `cargo bench` exactly as §8.1 (no `--timestamp` override exists — each
-point's position on the timeline is its own committer date, read from git §8.3), harvests every engine that
-produced output, and stores the result. Backfilled runs are always on a **clean**
-tree, so each is keyed by commit (§4.2) and collision-checked:
-
-* By **default** the commits that already have a stored result are listed once up
-  front (a single `list` of the `v1/<project>/objects/` prefix); a commit already present
-  is **skipped before its benches run** (reported, not an error), so no benchmark
-  execution is wasted on commits already covered. This makes backfill **resumable**
-  and cheap to re-issue — an interrupted run simply continues where it stopped. The
-  check is per-commit, not per-engine: a commit with results for only some engines
-  is still skipped (use `--overwrite` to fill it).
-* `--overwrite` regenerates and replaces existing points across the range (for
-  re-running after a broken-infra batch produced bad data, or to re-benchmark every
-  commit after adding a new bench).
-
-**Failure handling.** A *bench/build* failure for a commit (non-zero engine exit,
-or a commit that does not build) **stops** backfill by default; `--ignore-errors`
-records it in a skip list and continues to the next commit, printing a summary at
-the end (done / skipped-empty / failed counts + the failed SHAs). *Infrastructure*
-failures (storage unreachable, git errors) always abort regardless of
-`--ignore-errors`, since continuing cannot produce correct data.
-
-**Working-tree safety.** Backfill operates inside a dedicated **git worktree** (`git
-worktree add`) under the system temp dir rather than mutating the primary checkout,
-which isolates it from the user's working directory, removes the HEAD save/restore
-hazard, and leaves the
-user exactly where they were even if the run is interrupted. The primary checkout's
-state is therefore irrelevant — a dirty working tree neither blocks backfill nor
-affects what is measured (each point benches a specific commit SHA, never the
-working-tree state). Between commits the
-worktree is reset clean (`git reset --hard` + `git clean -fd`, preserving the
-ignored `target/` for incremental-build speed — the §8.1 `mtime ≥ run-start`
-harvest already excludes stale artifacts). The benches that run are whatever exist
-in each checked-out commit; benches absent at an old commit simply harvest
-nothing.
-
-`--config`, `--workspace`/`--package`/`--exclude`/`--bench`,
-`--features`/`--all-features`/`--no-default-features`, `--target-triple`,
-`--machine-key` and `-- <passthrough>` behave as for `collect`. To collect Callgrind
-data, run backfill on Linux/WSL — the worktree path is reachable from WSL exactly
-like the primary checkout.
-
-### 8.5 `cargo bench-history list`
-
-`list` previews the exact data set an `analyze` pass would consume, without running
-the analysis — letting the user inspect and confirm the commit range and the
-discriminant sets before committing to an `analyze`.
-
-```
-cargo bench-history list <runs|discriminants|blessings> [--all] \
-    [--repo PATH] [--context REF] [--base REF] \
-    [--engine NAME …] [--target-triple TRIPLE …] [--machine-key KEY …] \
-    [--no-dirty] [--since DATE] [--until DATE] \
-    [--no-text] [--markdown PATH] [--json PATH] [--verbose] [--config PATH]
-```
-
-`list` requires a **subject** — `runs`, `discriminants`, or `blessings`; a bare
-`list` is an error that names the three. For `runs` and `blessings`, `list`
-**mirrors `analyze`'s data-set-selection parameters exactly**: every selection
-flag `analyze` accepts (`--repo`/`--context`/`--base`/`--engine`/
-`--target-triple`/`--machine-key`/`--no-dirty`/`--since`/`--until`)
-selects the same data set here, resolved through the same shared selection
-pipeline (§8.3). The two commands must stay in lockstep — a selection parameter
-added to one is added to the other. `list` omits only the analysis-only flags
-`--mode` / `--include-improvements` / `--include-inactive` (it never analyzes).
-
-`list runs` reports — per discriminant set — the run, series, and per-commit
-counts of the selected runs (each commit's clean/dirty split), ordered
-oldest-first by git topology, so the user sees precisely which runs would feed the
-analysis.
-
-`list blessings` switches to a blessing audit (§8.7): the sidecars at the current
-commit by default, or — with `--all` — the most recent blessing of every benchmark
-across the analysis window.
-
-`list discriminants` switches to a storage index: it lists the discriminant sets
-present under `v1/<project>/objects/` (engine / target triple / machine key) **without
-requiring a repository** (§4.3). This is where the storage-set listing lives,
-separate from the repository-driven data-set preview, so it ignores the timeline
-and data-filtering groups. Because it is a **discovery catalog**, it is the one
-query view that does *not* default omitted facets to the current machine — with no
-facets it lists every stored partition (so a user can find triples and machine keys
-they do not already know); a facet still narrows it. `--all` is meaningful only for
-`list blessings`; passing it to `runs` or `discriminants` is a clear error rather
-than a silently ignored flag.
-
-### 8.6 `cargo bench-history prune`
-
-`prune` **deletes a chosen portion of the stored data set** — for reclaiming
-storage, discarding a bad run, or dropping the ephemeral uncommitted-tree snapshots
-left behind by evaluation/experiment runs. It selects the data set with the **same
-selection pipeline as `analyze`/`list`** (so the three stay in lockstep) and then
-removes the selected objects rather than reporting on them.
-
-```
-cargo bench-history prune (--clean | --dirty | --all) [<commit> …] \
-    [--dry-run] [--prune-base] \
-    [--repo PATH] [--context REF] [--base REF] \
-    [--engine NAME …] [--target-triple TRIPLE …] [--machine-key KEY …] \
-    [--since DATE] [--until DATE] \
-    [--no-text] [--markdown PATH] [--json PATH] [--verbose] [--config PATH]
-```
-
-**Deletion scope is required.** The user must say which kinds of run to delete:
-`--clean` removes clean runs and the blessing sidecars riding on them; `--dirty`
-removes the dirty (uncommitted-tree) snapshots only — the "drop the ephemeral runs"
-case; `--all` removes both (the same as `--clean --dirty`). Exactly one of these is
-required — there is no default scope, so a bare `prune` is an error that names the
-three. This explicit choice is the only "what to delete" knob; there is no separate
-narrowing guard.
-
-**Commit range (Design B).** `prune` walks the selected commits from `--context`
-(default `HEAD`) back toward `--base` (default the project's default branch). It
-deletes only the commits **strictly after** the merge-base of context and base —
-i.e. the context branch's own commits — and **preserves** the shared base history.
-The whole base branch's data set is deleted only when `--context` resolves to the
-**same** commit as `--base` (pruning the base in its own context). The `<commit>`
-subjects (repeatable, case-insensitive SHA-prefix) further restrict deletion to
-specific commits within that range; `--since`/`--until` bound it by each commit's
-committer date inclusively.
-
-**Base-branch guard (`--prune-base`).** Because deleting the base branch's data set
-wipes the mainline history every feature analysis compares against, that case
-(context == base) is refused unless the user passes `--prune-base`. Without the
-flag, `prune` stops with a warning naming the base branch ("Warning: this will
-delete benchmark history of the `<name>` branch, which is the base branch. Confirm
-with --prune-base if this is correct."). The guard depends solely on whether the
-context resolves to the base commit — not on which `<commit>` subjects were given.
-
-**Selection.** `prune` reuses `analyze`'s data-set-selection parameters through the
-shared pipeline (so the commands stay in lockstep). The base-branch tip's dirty runs
-are admitted **unconditionally** (the `DirtyTipPolicy::Always` parameter to the
-shared `resolve_history` helper, versus `WhenWorkingTreeDirty` for `analyze`/`list`),
-so a `prune --dirty` reclaims base-branch snapshots regardless of the current tree
-state. `prune` is history-scoped (it does not take an analyze `--mode`).
-
-**Blessings follow their clean run.** A blessing sidecar is removed only when the
-clean run it annotates is itself removed in the same pass — it is never time-filtered
-directly. So `--dirty` never touches blessings, and `--clean`/`--all` remove a
-commit's blessings exactly when they remove that commit's `clean.json`.
-
-`--dry-run` previews the removal — building the identical plan but skipping the
-deletes. The JSON report carries `dry_run`, the per-commit run/blessing counts, and
-the deleted object keys for transparency; text/markdown report counts only. Deletion
-is per object via the `Storage::delete` trait method (§7).
-
-### 8.7 `cargo bench-history bless` / `unbless`
-
-A blessing manually **accepts an intentional performance change on the base branch**
-so history analysis stops re-flagging it. Sometimes a regression is a deliberate
-tradeoff (a feature is worth some instructions); without a way to record that
-decision, every subsequent `analyze` would keep reporting the same accepted step
-forever. Blessing **re-baselines** the series from the blessed commit forward (§9.7).
-
-```
-cargo bench-history bless (<prefix> [<prefix> …] | --all) \
-    [--context REF] [--base REF] \
-    [--engine NAME …] [--target-triple TRIPLE …] [--machine-key KEY …] \
-    [--verbose] [--config PATH]
-
-cargo bench-history unbless \
-    [--context REF] [--base REF] \
-    [--engine NAME …] [--target-triple TRIPLE …] [--machine-key KEY …] \
-    [--verbose] [--config PATH]
-```
-
-**Per-benchmark, prefix-matched.** `bless` takes one or more benchmark-id prefixes
-matched against the qualified identity (`<package>/<group>/<case>/<value>`), so
-`bless all_the_time/read_cell` accepts one benchmark and `bless overhead/groups_`
-accepts a family. Blessing is deliberately scoped: accepting the benchmark that
-caused trouble must not silently accept every other benchmark that may be trending
-badly unnoticed. At least one prefix is required **unless `--all` is given**, which
-blesses every benchmark recorded at the context commit (the deliberate "accept the
-whole commit" case); `--all` and explicit prefixes are mutually exclusive.
-
-**Bless any commit, not just HEAD.** Both `bless` and `unbless` operate on a
-`--context` ref (default `HEAD`), so a user can bless or unbless a commit other than
-the one currently checked out. `--base` is the ref the context commit must sit on
-(default the project's default branch).
-
-**Base-branch-only, existing data point — hard errors otherwise.** A
-blessing is recorded only when **(a)** the context commit is on the base branch
-(`merge_base(context, base) == context`) and **(b)** a `clean.json` already exists at
-the context commit in each selected set. There is **no `--force` escape hatch**: a
-feature-branch blessing would silently vanish or duplicate once the branch is
-squash-merged, and blessing a commit with no recorded data point is meaningless.
-Each of these is refused with a clear message. A **dirty working tree is allowed** —
-the blessing applies to the committed `clean.json` at the context commit, which local
-edits do not change — but it emits a `Warning: uncommitted changes present …` so an
-accidental edit is visible.
-
-**Storage: append-only sidecar.** `bless` writes a `BlessingRecord` sidecar
-`…/<commit>/bless-<issued_unix>.json` alongside the commit's `clean.json` in every
-facet-selected discriminant set that has a result at the context commit. The record
-carries the blessed commit, the issue time, the prefix filters, and the tool
-version; the blessed commit's committer time is read from git at analyze time, not
-stored on the sidecar. Sidecars are **immutable** (append-only), so narrowing a
-blessing means `unbless` then re-bless the subset to keep. Overwriting a commit's
-`clean.json` (a `collect --overwrite`) deletes its stale blessing sidecars, since the
-accepted data point is gone.
-
-`unbless` deletes every blessing recorded **at the context commit** in the selected
-sets; it does not touch blessings at other commits. Blessings issued at **later**
-commits remain in effect, so the timeline may still be blessed past the context
-commit — to fully un-bless a benchmark you must remove every blessing along its
-timeline.
-
-**`list blessings`** audits blessings (§8.5 extends `list`): with no extra flag it
-lists the sidecars at the current commit (what `unbless` would remove); with `--all`
-it rolls up the **most recent** blessing of every benchmark across the analysis
-window (the same data-set selection `analyze` uses), so a reviewer can see which
-benchmarks are currently re-baselined and since which commit.
-
-## 9. Analysis algorithms
-
-Series: per `(DiscriminantSet, BenchmarkId, metric)`, ordered by git first-parent
-topology (§8.3) with runs on one commit sub-ordered clean-before-dirty, then by
-storage key (§8.3). The
-goal is **high signal-to-noise**: report level shifts and trends that are real,
-and stay silent on measurement jitter. The design is *engine-aware* because the
-two engines have fundamentally different noise profiles, and a single detector
-cannot serve both well:
-
-- **Deterministic engines (Callgrind: instruction counts, estimated cycles, cache
-  events, branches; `alloc_tracker`: allocated bytes and allocation counts).**
-  Output is exact and reproducible; any persistent change is real signal. There is
-  no measurement noise to suppress, so significance testing is neither needed nor
-  appropriate (a perfect integer step over few points has a *high* nonparametric
-  p-value — see below).
-- **Noisy engines (Criterion: wall time; `all_the_time`: processor time).** Output
-  is a noisy estimate carrying a reported standard deviation and bootstrap
-  confidence interval. A change must clear both a statistical-significance bar *and*
-  a practical-magnitude bar, and the family of tests across all series is corrected
-  for multiple comparisons. When an engine reports no confidence interval (older
-  mean-only output), the CI-non-overlap gate is skipped and the significance
-  decision rests on the Mann-Whitney/Mann-Kendall tests alone.
-
-`MetricKind::WallTime` and `MetricKind::ProcessorTime` are the noisy kinds
-(`is_deterministic` returns `false` for them and `true` for every Callgrind and
-`alloc_tracker` kind). All non-deterministic-output kinds are lower-is-better; only
-the L1 cache-hit metric is higher-is-better (the LL/RAM tiers are miss-escalation
-costs).
-
-### 9.1 Findings
-
-Two finding *methods*, each emitted per series and ranked together by descending
-relative move:
-
-1. **Change-point (step) detection** — the primary finding. A single most-likely
-   level shift is located with the **Pettitt** nonparametric change-point test
-   (rank-based, distribution-free). The series splits into a *before* regime and
-   an *after* regime at the change index; the finding's `baseline` is the median
-   of *before*, `latest` is the median of *after*, and the change is attributed to
-   the commit at the start of the *after* regime — answering "what changed, and
-   after which commit", visible only in hindsight over noisy data. **Persistence**
-   is built in: both regimes must contain at least `min_regime` points (default
-   2), so a single-commit blip cannot trip it (the regime medians absorb it).
-2. **Monotonic drift** — a separate finding type for slow trends ("incrementally
-   slower over 12 months"). The **Mann–Kendall** trend test establishes that a
-   monotonic trend exists; the **Theil–Sen** robust slope estimates its
-   magnitude; `baseline`/`latest` are the fitted line's endpoints. When both a
-   change-point and a drift fire on one series, the **better-fitting model wins**:
-   the step model and the line model are each scored by their residual against the
-   series, and the drift is kept only when the line fits more tightly than the step
-   (otherwise the change-point is kept, ties favouring it). This routes sharp steps
-   to the change-point method and smooth ramps to drift, so the two methods never
-   double-report one event.
-
-### 9.2 Engine-aware gating
-
-- **Deterministic series.** A change-point is reported when both regimes reach
-  `min_regime` points and the regime medians differ at all (exact change → ~0
-  noise floor; even a one-instruction step is real). No
-  significance test and no FDR — they would wrongly drop genuine small exact
-  steps. Confidence is reported as `1.0`. Drift requires a significant
-  Mann–Kendall trend and clears the practical-magnitude floor.
-- **Noisy series.** The Pettitt test only *locates* the most likely split — its
-  analytic p-value `2·exp(−6K²/(n³+n²))` is too conservative on short series (an
-  obvious ten-point step scores ≈ 0.07), so it is **not** used as a significance
-  gate. A change-point is reported only when *all* of these hold: a **Mann–Whitney
-  U** test of *before* vs *after* has p < `change_alpha` (default 0.05; the regimes
-  are statistically distinguishable, not merely split); the regime **confidence
-  intervals do not overlap** (using the stored CI bounds, when present); and a
-  practical-magnitude floor `|relative delta| ≥ practical_relative` (default 0.03)
-  so a statistically-real-but-tiny 0.5 % wobble stays silent. Confidence is
-  `1 − p_MannWhitney`. Drift requires the Mann–Kendall significance, the same
-  magnitude floor, **and** that the endpoint movement exceeds the per-measurement
-  noise floor (twice the median CI half-width), so run-to-run jitter never reads as
-  a trend.
-
-### 9.3 Multiple-comparison discipline (FDR)
-
-A repository has many benchmarks × metrics; testing each at α = 0.05 would yield a
-flood of false positives. Every **noisy** candidate's p-value enters a single
-**Benjamini–Hochberg** procedure at false-discovery rate `fdr_q` (default 0.10);
-only BH-significant candidates survive. Deterministic candidates bypass BH (they
-carry no measurement-noise false-positive risk and their exact steps would
-otherwise be discarded by the procedure).
-
-### 9.4 Ranking, polarity, and CI gating
-
-Findings rank by descending `|relative delta|`, then by method, then a
-deterministic identity tie-break (set, benchmark, metric). There is no severity
-classification: a finding's magnitude is conveyed by its relative-change percent,
-and which findings warrant action is left to human (or agent) judgement rather
-than an automatic tier. Polarity is unchanged: every metric is lower-is-better
-except `CacheEvents` (cache *hits* — higher is better). Findings are advisory and
-never gate the exit code (§8.3, §9.6).
-
-### 9.5 Statistical primitives
-
-All math lives in a pure, deterministic, Miri-safe `analyze/stats.rs` (in the
-`cargo-bench-history-core` library — §10):
-`median`, `pettitt` (rank-based `U_t`, `K = max|U_t|`, `p ≈ 2·exp(−6K²/(n³+n²))`,
-used only to locate the split), `mann_whitney_u_pvalue` (tie- and
-continuity-corrected normal approximation), `mann_kendall` (`S`, tie-corrected
-`Var(S)`, `Z`), `theil_sen_line` (median of pairwise slopes plus a median
-intercept), `benjamini_hochberg` (keep-mask at rate `q`), and `normal_cdf`
-(Abramowitz–Stegun erf). Each is unit-tested with named, value-asserting cases on
-hand-computable inputs (no threshold-mutation guards), so the whole detector is
-verifiable without real-time delays per workspace conventions.
-
-### 9.6 Analysis modes
-
-The same stored history answers two very different questions, so `analyze` runs in
-one of three **modes**. `--mode auto` (the default) infers the mode from git
-topology; `--mode history|branch|tip` forces it.
-
-**Auto-detection.** The decision keys off the **recorded data set and git
-topology**, never the on-disk working-tree state. The mode is **history** iff the
-analyzed tip *is* the merge-base with the base (i.e. the base branch — `target ==
-base`, nothing private) **and** no dirty run is recorded on top of that tip, and
-**branch** otherwise: either there are commits past the merge-base (a real feature
-branch), or a dirty run is recorded on the base tip and admitted by the §8.3
-exception ("an unnamed feature branch"). Crucially, a dirty *working tree* alone
-does not force branch mode — a dirty checkout that has only ever stored clean runs
-carries no feature-branch data and stays history. `tip` is never auto-selected; it
-is an explicit fast guard. This matches the two real scenarios:
-
-* **Scheduled trend watch (history).** A scheduled job looks back over the base
-  branch's last months for regressions and slow trends, posting findings to an
-  alert channel. Long-range techniques make sense here because the series is long.
-* **Feature-branch evaluation (branch).** One-to-several runs sit on top of the base
-  and we ask "did this branch change things, for better or worse, *as it stands
-  now*", feeding the answer into a PR comment. Long-range trend analysis is
-  meaningless on one or two points; only the latest state matters.
-
-**Which techniques apply, and why:**
-
-| Technique | history | branch | tip | Rationale |
-|---|---|---|---|---|
-| Change-point (Pettitt + engine gating, §9.1–9.3) | ✅ | — | — | Locates *where* in a long base history a level shifted; needs many points on both sides. |
-| Monotonic drift (Mann–Kendall + Theil–Sen) | ✅ | — | — | Catches slow multi-month trends; meaningless on a handful of branch points. |
-| Benjamini–Hochberg FDR (§9.3) | ✅ | — | — | Controls false positives across the many series a long history produces. |
-| Latest-regime vs base (branch algorithm, below) | — | ✅ | — | Answers "did the branch's *current* state move vs the base", tolerating an early wobble. |
-| Tip-vs-recent guard (below) | — | — | ✅ | Cheap "did the last commit make things worse" check. |
-| Improvements reported | opt-in | ✅ | — | History: improvement over time is expected, so only regressions by default (`--include-improvements` opts in). Branch: both directions (you want to know either way). Tip: a guard, regressions only. |
-| Resolved (inactive) findings reported | opt-in | — | — | History: a self-corrected spike or blessed step is re-baselined away by default (§9.7); `--include-inactive` surfaces it. Branch/tip judge only the latest state, so every finding is active. |
-
-**Branch algorithm — latest state, not the journey.** A branch may improve and then
-regress; we report the *latest* regime so "it ended up worse" is never masked by an
-earlier gain. The series splits at the merge-base into a base side (clean points ≤
-merge-base) and a branch side (the branch's own commits). Within the branch side,
-**Pettitt locates the most recent regime boundary**: if a within-branch flip clears
-the practical floor, only the after-segment is compared against the base and the
-finding's `flipped_at` names the commit the latest regime began at (so a "got worse
-late in the branch" finding points at the offending commit); with too few points or
-no real flip, the whole branch side is compared. The base-vs-after comparison reuses
-the engine-aware gate (§9.2): a deterministic engine flags any non-zero regime move;
-a noisy engine still requires Mann–Whitney separation, CI non-overlap, and the
-practical floor.
-
-**Tip guard.** Tip mode compares only the *last* point against the recently
-established level (a bounded window of preceding points) using the same engine gate,
-and reports regressions only.
-
-**JSON signal (downstream contract).** Because findings never gate the exit code
-(§8.3), the `json` report is the machine-readable output. It carries exactly the data
-the text and Markdown reports show — no underlying per-commit series (a presentation
-concern the human reports draw a chart from, not data a consumer reconstructs) — at
-full `f64` precision:
-
-```json
-{
-  "project": "myproj",
-  "mode": "branch",          // resolved mode: history | branch | tip
-  "notable": true,           // did any finding survive? the headline signal
-  "runs": 7, "series": 3,
-  "regressions": 1, "improvements": 0,
-  "findings": [
-    {
-      "engine": "callgrind",
-      "target_triple": "x86_64-unknown-linux-gnu",
-      "machine_key": "synthetic",
-      "segments": ["mypkg", "module::path", "case"],
-      "kind": "instruction_count",
-      "method": "change_point", "direction": "regression",
-      "baseline": 100.0, "latest": 130.0,
-      "relative_delta": 0.30, "confidence": 1.0,
-      "commit": "deadbee",       // commit the change is attributed to, if known
-      "active": true,            // false for a resolved/blessed finding (§9.7)
-      "flipped_at": "a1b2c3d",   // branch: where the latest regime began;
-                                 // history+inactive: where the level recovered
-      "blessed_at": "9f8e7d6",   // history only: the blessing that re-baselined this series
-      "blessed_commit_time": "2024-03-01T00:00:00Z"
-    }
-  ],
-  "sets": [                  // per-discriminant-set breakdown: identity + tallies only
-    {
-      "engine": "callgrind",
-      "target_triple": "x86_64-unknown-linux-gnu",
-      "machine_key": "synthetic",
-      "runs": 7, "series": 3,
-      "regressions": 1, "improvements": 0
-    }
-  ]
-}
-```
-
-Each finding is self-describing: it inlines its discriminant set
-(`engine`/`target_triple`/`machine_key`) and benchmark `segments`, so the flat,
-globally-ranked `findings` list is the single source of truth — findings are never
-duplicated under `sets`. A consumer keys off `notable` (post or stay silent), reads
-each finding's `direction`/`relative_delta`/`flipped_at`/`active`, and tallies per
-partition from `sets`. `commit`, `flipped_at`, `blessed_at`, and
-`blessed_commit_time` are present only when known (§9.7). JSON values keep full `f64`
-precision; only the human-readable text and Markdown reports round to four
-significant figures.
-
-**Text report layout.** The text report renders one paragraph per finding: a bold,
-direction-colored headline leading with the relative-change percent and the
-benchmark identifier + metric, a dimmed detail line (`direction via method ·
-confidence · baseline → latest · @ commit`, plus `· flips at <commit>` in branch
-mode), and — in **history mode only** — a small colored line chart of the series
-over commits drawn with `rasciigraph` (regressions red, improvements green). Each set
-header is followed by a one-line tally (`runs: <n>  series: <n>  regressions: <n>
-improvements: <n>`). The chart is omitted for branch/tip mode. Color (ANSI styling and
-chart hue) is enabled only when stdout is a terminal and `NO_COLOR` is unset, so
-piped output and tests stay plain.
-
-**Markdown report layout.** The Markdown report carries the same data as the text
-report with Markdown formatting: a top-level metadata list, an `## Set …` heading per
-partition with its tally as a bullet list, and one block per finding — a bold
-percentage headline (`` **+30.00%** — `pkg/group/case` · kind ``), the same detail
-line, an optional blessing note, and — in history mode — the chart inside a fenced
-` ```text ` block (rendered without ANSI so it survives Markdown viewers).
-
-### 9.7 Re-baselining: blessings, resolved spikes, and active/inactive segments
-
-History mode draws a distinction between a change that is **still in effect** and one
-that has **already been addressed**, so a long base-branch history does not keep
-re-flagging events a reviewer has handled. Every history-mode finding therefore
-carries an `active` flag and an `active_from` index into its `series`.
-
-**Resolved spikes (self-corrected).** When a level rose and later returned to its
-prior baseline, the *current* state matches the baseline — there is nothing to act on.
-Such a finding is **inactive**: suppressed by default and surfaced only with
-`--include-inactive` (§8.3). Its `flipped_at` names the commit at which the level
-recovered (the detail line reads "recovers at <commit>" rather than "flips at"). The
-recovered points always remain in the data set and on the chart; the flag only
-governs whether the finding is reported. Detection runs after the active change-point
-/ drift detectors decline (a symmetric up-then-down pulse yields equal before/after
-regime medians, so the change-point detector is silent) and locates the sustained
-plateau between the rise and the recovery.
-
-**Blessings (manually accepted).** A blessing (§8.7) re-baselines a series from the
-blessed commit forward. `apply_blessings` picks, per series, the **latest** blessing
-whose prefix matches the benchmark, and sets `active_from` to the first point at or
-after that commit; the detectors then run on the **active segment only**, so the
-pre-blessing step is no longer re-flagged. Blessings are honoured **only in history
-mode** — branch and tip judge the latest state against the base, which is treated as
-fully blessed by construction, so they ignore blessings entirely. The pre-blessing
-points still feed the chart and any long-range technique that needs context outside
-the active window; they are *excluded from detection*, not discarded. A finding whose
-series was re-baselined records `blessed_at` (the blessing's abbreviated commit) and
-`blessed_commit_time` (the blessed commit's committer time, read from git) for
-provenance.
-
-Blessings load only for commits inside the analysis window (the same topological
-selection as the rest of `analyze`); a blessing on a commit outside the window is not
-consulted. Because blessing requires a clean run at the blessed commit (§8.7), the
-active segment always begins at a real recorded data point.
-
-**Active period in the chart.** The history-mode chart greys the pre-active prefix
-(the re-baselined-away or pre-recovery history) and draws the active window in the
-finding's direction colour, so the "live" period a finding is really about is visually
-separated from the inactive context that is kept only for continuity.
-
-## 10. Crate architecture
-
-The tool is **two crates**: the **shell** `packages/cargo-bench-history/` (the
-`clap`-derive binary + its library) and the **core** library
-`packages/cargo-bench-history-core/` it depends on. The split follows the
-workspace's impl-crate pattern — a private-use `-core` extraction treated as the
-impl crate (`docs/impl-crate-split.md`): all **pure, I/O-free** logic (the stored
-data model, comparability/partitioning, the analysis math + rendering, and the
-shared gzip codec) lives in core so it can be exercised by a fast, Miri-friendly,
-cheap-to-mutation-test in-process suite, while everything that touches the outside
-world (storage, git, process, filesystem, the CLI) stays in the shell. The data-flow
-and parallelism map across the two crates is [`docs/analyze.md`](analyze.md). The
-other workspace cargo tools (`cargo-detect-package`/`cargo-freeze-deps`) also use
-`clap`, though their CLIs are trivial enough to need no grouped argument headings.
-
-**`cargo-bench-history-core` (pure, no I/O).** Three flat namespaces, each
-re-exporting its submodule types so consumers write `core::model::Run` /
-`core::analyze::Finding` rather than reaching into private submodules:
-
-```
-src/
-  model/                  # the stored data model (serde)
-    benchmark_id.rs       # BenchmarkId (NonEmpty<String> segments) + BenchmarkIdPrefix
-    metric.rs             # Metric / MetricKind
-    run.rs                # Run / BenchmarkResult
-    context.rs            # RunContext (CI/git/toolchain + observation time)
-    comparability.rs      # DiscriminantSet + commit-centric partition path
-    bless.rs              # BlessingRecord data model
-    constants.rs mod.rs   # schema versions + flat re-exports
-  analyze/
-    discriminant.rs       # parse v1 keys; DiscriminantSet/DiscriminantSetQuery
-    selection.rs          # split the target ancestry at the merge-base
-    series.rs             # per-(BenchmarkId, metric) series in topology order
-    stats.rs              # pure statistical primitives (Pettitt, Mann-Kendall, ...)
-    findings.rs           # engine-aware detectors + Spawner-driven parallel pass (decision 33)
-    parallel.rs           # balanced chunk math for the per-series parallel pass
-    report.rs             # text|json|markdown multi-set renderer
-    mod.rs                # AnalysisContext/AnalysisMode/Finding + flat re-exports
-  codec.rs                # gzip byte format shared by storage + the stress harness
-  testing.rs              # `private-test-util` fixtures (feature-gated; test-only)
-```
-
-**`cargo-bench-history` (the shell: I/O, git, CLI, orchestration).**
-
-```
-src/
-  main.rs                 # #[tokio::main]; strip "bench-history" arg, parse, dispatch
-  lib.rs                  # module wiring + public re-exports (incl. core's model)
-  cli.rs                  # clap subcommands + grouped args
-  command.rs              # the parsed Command enum + per-subcommand option structs
-  outcome.rs              # RunOutcome / RunError
-  dispatch.rs             # route a parsed Command to its command handler
-  wiring.rs               # locate config + project id, build the StorageFacade
-  config.rs               # load + generate .cargo/bench_history.toml (toml)
-  config_writer.rs        # ConfigWriter port (tokio adapter + fake) for `install`
-  process.rs              # ProcessRunner port (async) + tokio adapter + fake
-  probe.rs                # environment probe port (git/rustc) + shell adapter + fake
-  git.rs                  # pure parse of git output -> GitInfo
-  git_history.rs          # read-only GitHistory port (rev-list/merge-base) + fake
-  host.rs                 # rustc -vV pure parse -> toolchain/host triple
-  machine.rs              # machine key (many_cpus + SHA-256 fingerprint)
-  report.rs               # Reporter port (--verbose stderr trail) + fake
-  text.rs                 # singular/plural rendering for user-facing counts
-  bench/
-    mod.rs                # combined engine env injection + per-engine harvest glob
-    callgrind.rs          # Gungraun summary v6 serde + mapping
-    criterion.rs          # Criterion estimates/benchmark JSON -> WallTime records
-    alloc_tracker.rs      # alloc_tracker JSON -> Allocation{Bytes,Count} records
-    all_the_time.rs       # all_the_time JSON -> ProcessorTime records
-  bench_output.rs         # BenchOutputSource port: harvest target/ -> fresh cases
-  storage/
-    mod.rs                # Storage trait (async) + in-memory fake
-    local.rs              # tokio::fs backend (gzip via core::codec)
-    facade.rs             # StorageFacade enum (Local | Azure), static dispatch + test-seam
-    azure.rs              # AzureBlobStorage (one shared pooled reqwest transport, §7)
-  analyze/
-    mod.rs                # query orchestration (concurrent load + Spawner injection)
-    list.rs               # `list runs|discriminants|blessings` data-set preview
-    prune.rs              # `prune` deletes selected runs (mirrors list selection)
-    bless.rs              # `bless`/`unbless` + `list blessings` audit
-  commands/
-    mod.rs run.rs install.rs backfill.rs   # analyze/list/prune/bless/unbless handlers live in analyze/
-```
-
-The fake benchmark engine the integration tests launch is **not** in this crate: it
-is the sibling `mock_bench_engine` package (`packages/mock_bench_engine/`), a
-`publish = false` crate so `cargo install cargo-bench-history` ships only the one
-real binary (decision 40).
-
-**Async ports & adapters (the testability boundary).** The app is **async by
-default on the Tokio runtime** (`main` = `#[tokio::main]`, lib entry
-`async fn run`). PURE logic stays SYNC — parse, map, comparability, series,
-findings, format — and is the Miri-safe bulk of the code and tests. Async is
-pushed only to the I/O edges, each a small trait ("port") with a real Tokio
-adapter plus an in-lib `#[cfg(test)]` in-memory fake:
-
-* `ProcessRunner` (async) — launch the benchmark command (`cargo bench`) with
-  injected env; return exit status. Real = `tokio::process::Command`; fake records
-  the invocation and can drop fixture `summary.json` files to simulate a bench run.
-* `EnvProbe` (async, `probe.rs`) — discover the run-time git facts
-  (commit/branch/dirty) and toolchain facts; the real adapter
-  shells `git` and `rustc` (PARSE pure in `git.rs`/`host.rs`), the fake returns
-  canned facts.
-* `GitHistory` (async, `git_history.rs`) — the read-only history query
-  `analyze`/`backfill` need: resolve a ref, detect the default branch, compute a
-  merge-base, walk first-parent ancestry. Real shells `git -C <repo>`; the fake
-  serves a canned commit graph.
-* `BenchOutputSource` (async, `bench_output.rs`) — harvest the fresh
-  `summary.json`/`estimates.json` an engine wrote this run. Real walks the target
-  tree with `tokio::fs`; the fake returns canned cases.
-* `ConfigWriter` (async, `config_writer.rs`) — `install`'s create-if-absent file
-  write. Real uses `tokio::fs` `create_new`; the fake records writes in memory.
-* `Reporter` (`report.rs`) — the `--verbose` diagnostic-note sink; real writes to
-  stderr, the fake records notes for assertions.
-* `Storage` (async) — `StorageFacade` enum (§7); in-memory fake for tests.
-* Env access is a plain `Fn(&str) -> Option<String>` (matches `detect_ci`).
-* The clock is the **`tick` crate**, not a custom port: `tick::Clock`
-  (`Clock::new_tokio()` in prod) is injected into orchestration; tests use
-  `tick::ClockControl` (its `test-util` feature) for deterministic simulated time.
-  `tick` is machine-centric (`SystemTime`); convert to `jiff::Timestamp` for
-  stored commit/observation times.
-
-Orchestration takes injected ports — `run_with(&ports, &clock, &opts)` — and the
-public async entry wires the real adapters. **Miri strategy:** pure logic runs
-under Miri directly; the in-memory async orchestration tests run WITHOUT a Tokio
-runtime (`futures::executor::block_on` + always-`Ready` fakes + `ClockControl`),
-so they stay Miri-safe. Tests that use a real Tokio runtime, real fs/process, or
-Azurite are `#[cfg_attr(miri, ignore)]`.
-
-Conventions to honour (from `docs/`): flat small files; mockable ports for
-process / fs / storage / git / env / hardware; `#[serial]` on any test touching
-the process CWD (see `cargo-detect-package/AGENTS.md`); no `parking_lot`; no
-real-time sleeps (inject `tick::Clock`); proptest with bounded cases + Miri-safe
-regression twins; zero warnings; alphabetical no-default-features deps.
-
-**Sibling stress crate.** `packages/cargo-bench-history-stress` is a separate,
-`publish = false` binary that drives the `analyze` scaling experiment (decision 32).
-It depends on this crate (`default-features = false`) and on
-`cargo-bench-history-core` for the model types it constructs. It owns no production
-logic: it replicates only the storage *write* layout to seed a giant synthetic
-dataset, then calls the public `run_with_overrides` to measure each mode. A
-full-scale run is on-demand only; the crate's own small tests run as a normal
-workspace member (and so are subject to mutation testing and coverage). See its
-`README.md`.
-
-## 11. Cross-platform notes
-
-* `analyze`, `install`, and the harvest/store half of `collect` are platform-neutral
-  (pure file/IO/compute) and first-class on **Windows, Linux and macOS**.
-* Only the *bench execution* inside `collect` is constrained: Callgrind needs
-  Linux/Valgrind, so its benches are `#[cfg(target_os = "linux")]` and simply
-  produce no output on Windows/macOS — to collect Callgrind data, run the tool on
-  Linux (or in WSL). Criterion runs natively on all three OSes.
-* Target-triple resolution is covered in §4.1; the golden rule is to run the tool
-  in the same OS as the benches.
-* Optionally add `just bench-history-*` recipes later; the tool is standalone.
-
-## 12. Implementation plan
-
-**All nine iterations below were delivered.** A later refinement (the three
-analysis modes — §9.6, decision 28) layered the history/branch/tip split and the
-advisory-findings contract on top of iteration 9. They are kept here in their
-original sequence as the historical roadmap and as a map from this design to the
-shipped code.
-
-Phase 0 (foundation, preceded the numbered iterations): crate skeleton +
-CLI subcommands + `config.rs` + `model.rs` (incl.
-the timestamps) + `Storage` trait + `comparability` (incl. target-triple
-resolution, §4.1) + `RunContext` (git/CI + commit/observation times). Small and
-high-leverage; the iterations built on it.
-
-The plan folds the original "upload" step into "collect" (collect always persists) and
-adds macOS; mapped to the original request's numbering:
-
-1. ✅ **`collect` for Callgrind, end-to-end with local storage** (your 1 + 2) — adapter
-   injects `GUNGRAUN_SAVE_SUMMARY`, invokes the benches, `mtime`-scoped
-   harvest of `summary.json`, builds the Run, and writes it via
-   `LocalStorage` to the partition. `collect` persists by itself; no separate
-   `upload`. (Confirms the “special need” is just the summary flag — kept.)
-2. ✅ **`analyze` (useful finding)** (your 3) — series engine + rolling-baseline
-   regression over local Callgrind history; text report (+ `--fail-on`).
-3. ✅ **`install`** (your 4) — generate `.cargo/bench_history.toml`, point the user
-   to it.
-4. ✅ **Azure blob** (your 5) — `AzureBlobStorage`, **Microsoft Entra ID (OAuth)
-   only**; `collect`/`analyze` become storage-agnostic; verify it builds and runs on
-   Windows, Linux and macOS.
-5. ✅ **Criterion** (your 6) — adapter parses `target/criterion/**/new/{benchmark,
-   estimates}.json` into `WallTime` records (slope estimate when present, else the
-   mean; std-dev + CI bounds recorded for noise-aware analysis), plus machine-key
-   computation + partition (Windows/Linux/macOS CPU-brand detection). The stored
-   `BenchmarkId.package` is `None` (Criterion files are package-agnostic; §3).
-   Noise-aware thresholds and change-point/drift findings are split into a
-   follow-up iteration.
-6. ✅ **Commit-centric storage model + `collect` idempotency** (§4.2, §4.3) — commit-centric layout
-   (`…/<commit>/{clean.json | dirty-<unix>.json}`), a `Storage`
-   `put_overwrite` write-replacing escape hatch, the clean write-once collision refusal
-   (surfaced as `RunError::Duplicate`) + `--overwrite`, and the dirty effective=now
-   keying. Re-targets `comparability` and `collect`'s store step; small, in-process, heavily
-   unit-tested before the git-heavy work builds on it.
-7. ✅ **Git-aware `analyze`** (§8.3, §4.3) — the query model: a read-only git-history
-   port (`rev-list --first-parent`, `merge-base`, default-branch detection) with a
-   real adapter + in-memory fake; require-a-repo (else error); target/base ref split
-   with clean-only base + clean/dirty private; topology ordering; `--context` /
-   `--base` / `--no-dirty`; discriminant facet selection (`--engine` /
-   `--target-triple` / `--machine-key`; the set index is listed via `list
-   discriminants`). Largest reshape of an
-   existing command; the series engine moves from timestamp order to topology order.
-8. ✅ **`backfill`** (§8.4) — range enumeration + ancestry validation, per-commit
-   checkout in a dedicated git worktree, clean-state guards, default skip-existing
-   (resumable; backfill treats the it.6 write-once collision as a skip rather than
-   an error), `--ignore-errors`, end-of-run summary.
-   Builds on the idempotency (it.6) and the git port (it.7).
-9. ✅ **Statistical findings** — engine-aware noise-resistant analysis (§9):
-   nonparametric change-point (Pettitt) with built-in persistence + Mann–Whitney
-   and CI-non-overlap gating for noisy engines; Mann–Kendall + Theil–Sen drift as
-   a separate finding type; Benjamini–Hochberg FDR across noisy candidates;
-   deterministic (Callgrind) series bypass significance/FDR so exact steps of any
-   size are reported. Layered on the Criterion dispersion fields recorded in
-   iteration 5.
-10. ✅ **`prune`** (§8.6) — delete a chosen portion of the stored data set with the
-    `analyze`/`list` selection pipeline. A **required** scope (`--clean`, `--dirty`,
-    or `--all`) says what to delete; Design B walks the selected commits from
-    `--context` back to the merge-base with `--base`, deleting only the context
-    branch's own commits and preserving the shared base history. Deleting the base
-    branch's own data set (context == base) requires the `--prune-base` guard.
-    `<commit>`/`--since`/`--until` further narrow the range, and `--dry-run` previews.
-    The earlier `clean` command (drop the ephemeral dirty runs) is folded in as
-    `prune --dirty`.
-
-**Deferred:**
-
-* **`alloc_tracker` / `all_the_time` JSON as additional Criterion-side outputs** —
-  these workspace tools already emit per-operation JSON into `target/<crate>/<op>.json`
-  (allocations, wall time) alongside the Criterion wall-clock measurements. A future
-  iteration can harvest those JSON files as **extra metrics on the same Criterion runs**
-  (recorded side by side with `WallTime`, e.g. allocation counts / bytes), so a single
-  `collect` captures wall time *and* allocation behaviour for a benchmark and `analyze`
-  can flag a regression in either. This is purely additive to the harvest + model
-  (more `Metric` kinds on the existing Criterion `BenchmarkResult`s); the partition,
-  series, and analysis machinery are unchanged.
-
-Each iteration ships with tests and docs and leaves the tool runnable.
-
-## 13. Decisions & open items
-
-1. **Design-doc home** — *Decided:* committed to
-   `packages/cargo-bench-history/docs/DESIGN.md`.
-2. **Scaffold now?** — *Deferred:* design decisions resolved first; creating the
-   Phase 0 crate skeleton is the next step when you’re ready.
-3. **Storage granularity** — *Decided:* immutable one-file-per-run.
-4. **Toolchain handling** — *Decided:* recorded as metadata; the timeline stays
-   continuous and `analyze` annotates/segments by toolchain (a bump appears as a
-   step, not a fork).
-5. **`analyze` v1 finding** — *Decided:* rolling-baseline regression first;
-   change-point and drift plug in afterward.
-6. **Azure auth** — *Decided:* **Microsoft Entra ID (OAuth) only** — the secret-free
-   production default; a self-minting GitHub OIDC `ClientAssertionCredential` in a
-   federated CI job, otherwise `DeveloperToolsCredential` (see decision 38), always
-   over an HTTPS endpoint. *(Superseded by decision 43: the earlier priority-ordered
-   self-signed account SAS (`account_key`, HMAC-signed) and verbatim `sas_token`
-   modes were removed.)*
-7. **Date/time dependency** — *Decided:* `jiff` for timestamps and `--since`
-   parsing.
-8. **`collect` invocation** — *Decided:* `collect`/`backfill` invoke the
-   workspace's benches once with `cargo bench` (no per-engine config); the tool
-   injects the union of every supported engine's environment (e.g.
-   `GUNGRAUN_SAVE_SUMMARY` for Callgrind) plus `CARGO_TARGET_DIR`, then harvests
-   each engine's output tree and keeps whichever engines produced cases. Harvest is
-   scoped to the current run by `mtime ≥ run-start`. Off-Linux the Callgrind benches
-   compile to no-ops, so only Criterion is harvested — no OS logic in the tool.
-   *(Superseded: the earlier per-engine `command`/`os`/`extra_args` config and
-   `WSLENV` bridging are gone — to collect Callgrind data, run the tool natively on
-   Linux/WSL.)*
-9. **Commit time vs observation time** — *Decided:* a run records a single
-   **observation timestamp** (wall clock when the run executed and was stored). The
-   benchmarked commit's position on the timeline is its **committer date**, read
-   from the git graph at analyze time (decision 24) and never copied onto the run,
-   so a rebase or amended date can never leave a stale per-object timestamp behind.
-   It is never overridable from the CLI. The committer date **does not order a
-   series** (git topology does — decision 24); it only drives the `--since`/`--until`
-   window. The observation timestamp is provenance only — it names the dirty file and
-   is never used to order anything. *(Superseded: earlier models recorded the
-   committer date on each run as a `commit`/`commit_time` field, and earlier still
-   three times — effective, execution, ingest — with a `--timestamp` override of the
-   effective time; the stored commit timestamp, the effective-time concept, and
-   `--timestamp` are all gone.)*
-10. **Filtering** — *Decided:* `collect`/`backfill` expose first-class scope
-    flags — `--workspace` (default), `--package`/`-p NAME`, `--exclude NAME`,
-    `--bench NAME` — plus cargo feature-selection flags (`--features`,
-    `--all-features`, `--no-default-features`) that
-    translate directly to `cargo bench` arguments; everything after `--` is
-    forwarded verbatim after them. The `mtime ≥ run-start` harvest captures exactly
-    what ran. `--engine` is not a `collect` flag — it is an `analyze` facet over stored
-    data (decision 22). *(Superseded: the earlier filter-agnostic passthrough-only
-    model with `--engine`-scoped engine selection.)*
-11. **Target triple & WSL** — *Decided:* the partition triple is where the bench
-    *ran*, and is always the host triple of the running tool (composed from
-    `std::env::consts::ARCH` + `OS`). There is no `collect` override and no per-engine
-    constraint: the tool always runs where it benchmarks, so the host triple *is*
-    the execution triple. Callgrind data is collected by running the tool natively
-    on Linux/WSL (its benches no-op off Linux), so there is no Windows-trigger/
-    Linux-exec boundary to reconcile and no separate "host triple" metadata. Golden
-    rule: run the tool in the same OS as the benches. *(Superseded: an earlier model
-    resolved `--target-triple` > a Callgrind OS=`linux` pin > host detection and
-    stored the tool's `host_triple` as metadata; `--target-triple` is now only an
-    `analyze` facet, decision 22.)*
-12. **macOS** — *Decided:* first-class for `install` / `analyze` / Criterion /
-    Azure and the harvest-store half of `collect`; only Callgrind execution is
-    unavailable (no Valgrind), and its benches simply produce no output there.
-13. **`collect` vs `upload`** — *Decided:* `collect` always persists (execute → harvest →
-    store). A standalone `upload` (re-harvest existing `target/` output without
-    re-running benches) was considered and **dropped** as irrelevant: for Callgrind it
-    cannot work without `collect`'s run-time env injection (no summary is written
-    otherwise), and for Criterion the need never materialized.
-14. **Async runtime** — *Decided:* async by default on Tokio (`#[tokio::main]`,
-    `async fn run`); I/O edges (process, fs, storage/HTTP) are async behind small
-    ports with real adapters + in-memory fakes, while pure logic stays sync and
-    Miri-safe (§10).
-15. **Clock** — *Decided:* the `tick` crate (already a workspace dep) supplies the
-    injected clock; `tick::ClockControl` drives deterministic simulated time in
-    tests. No hand-rolled clock port; convert its `SystemTime` to `jiff::Timestamp`.
-16. **WSL env propagation** — *Superseded:* the earlier `WSLENV` bridging
-    is removed. `collect`/`backfill` invoke `cargo bench` in-process, so to collect
-    Callgrind data you run the tool natively on Linux/WSL and no env var has to
-    cross a WSL boundary (decision 8).
-17. **Cloud-storage testing** — *Decided:* the Azure backend is exercised in regular
-    CI two complementary ways.
-
-    **Azurite emulator** (`test-azurite` job): the default, fork-safe path — not real
-    cloud, not `#[ignore]`; only `#[cfg_attr(miri, ignore)]` for the network edge. The
-    emulator runs directly on the runner host (started by the `start-azurite` composite
-    action) in a Linux-only, package-gated job rather than as a service container,
-    which cannot reliably bind Azurite to a reachable address. Since Entra is the only
-    auth mode and it requires TLS, Azurite runs in `--oauth basic` mode over HTTPS
-    (behind a throwaway self-signed cert) and the tests inject a locally-faked Entra
-    token plus a cert-trusting transport (decision 43). The network tests
-    **self-skip** when no emulator is reachable so the multi-platform test
-    jobs stay green; `BENCH_HISTORY_REQUIRE_AZURITE=1` (set only in `test-azurite`)
-    turns an unreachable emulator into a hard failure so it can never silently skip.
-    That job also collects coverage so the `azure.rs` network paths reach Codecov.
-
-    **Real Azure account** (`test-azure` job): an additive job that exercises **real
-    Microsoft Entra ID** signature validation that the emulator (which only fakes the
-    token) cannot — a real Storage account with shared-key access disabled, reached over
-    HTTPS. No Rust change is needed: `DeveloperToolsCredential` already chains to the
-    Azure CLI, so the same credential works locally (after `az login`) and in CI (after
-    `azure/login@v2` signs in via **GitHub OIDC workload identity federation**, no
-    stored secret). Each test (`*_in_real_azure`) creates a fresh blob container and
-    deletes it when it finishes, even on panic (`catch_unwind` + `resume_unwind`); a
-    final `if: always()` sweep (`cleanup-containers.ps1`) is a backstop for a container
-    a crashed run might leave. The tests **self-skip** unless `ENABLE_AZURE` is set —
-    an explicit opt-in (set by the `just test-azure` recipe the job invokes), so the
-    account name living in `constants.env` does not by itself make a plain test run
-    target the cloud; when set, a then-missing `BENCH_HISTORY_TEST_AZURE_ACCOUNT` is a hard
-    failure rather than a silent skip. The job is gated to same-repo runs (fork PRs
-    cannot mint an OIDC token for our tenant). Its Azure identifiers
-    (`BENCH_HISTORY_TEST_AZURE_ACCOUNT`, `AZURE_TEST_CLIENT_ID`, `AZURE_TENANT_ID`,
-    `AZURE_SUBSCRIPTION_ID`) are committed, non-secret, in the repository-root
-    `constants.env` (the same source `just test-azure` reads), so local and CI target
-    the same account; a `grep` step surfaces them into `$GITHUB_ENV` for the
-    `azure/login` inputs. Because that job exports the client id as
-    `AZURE_TEST_CLIENT_ID` (not `AZURE_CLIENT_ID`), it does **not** trip the
-    self-minting OIDC path (decision 38) and stays on `DeveloperToolsCredential` via
-    the `azure/login` CLI session — exactly what this job exists to exercise. It
-    collects no coverage — `test-azurite` already covers
-    `azure.rs`; its value is the real Entra + real Blob round-trip. The account,
-    identity and federated credentials are scripted/Bicep'd in
-    `infra/azure-bench-history-test/` (decision 31).
-
-    **Real Azure account via self-minting OIDC** (`test-azure-gh` job): a second
-    additive job, identical to `test-azure` except it also exports `AZURE_CLIENT_ID`
-    (= `AZURE_TEST_CLIENT_ID`). That single switch routes `from_config` through the
-    **self-minting `ClientAssertionCredential`** (decision 38) — the exact credential
-    the per-push prod collection depends on — so PR-time CI proves the real GitHub OIDC →
-    Entra → Blob round-trip works, instead of only discovering a regression after merge
-    on the next collection run. `permissions: id-token: write` provides the
-    `ACTIONS_ID_TOKEN_REQUEST_*` values the tool reads to mint assertions, and the test
-    identity's `pull_request` federated credential lets same-repo PR runs federate in.
-    `azure/login@v2` is retained **only** so the harness's `az`-based container cleanup
-    has a session; the code under test ignores that session once `AZURE_CLIENT_ID` is
-    set. Together the pair covers both branches of `entra_credential`: `test-azure` the
-    local-`az` `DeveloperToolsCredential` fallback, `test-azure-gh` the CI self-minting
-    path.
-
-18. **Integration testing** — *Decided:* integration tests invoke the **library
-    entry** (`Cli::from_args(argv).into_command()` → `run()`), matching the
-    workspace pattern (no `assert_cmd`); a table-driven CLI-flag matrix runs over
-    fixture "testdata projects" with prebuilt fake `target/` trees.
-19. **Criterion `BenchmarkId.package`** — *Decided:* stored as `None`. Criterion's
-    on-disk files carry no package and `target/criterion/` is a flat tree, so the
-    owning package is unrecoverable from a harvest. This is safe because the
-    workspace crate-prefixes its Criterion group ids (`<crate>_<group>`), keeping
-    equally named cases in different packages distinct (§2.1/§3). The Callgrind
-    adapter still records `package` from the Gungraun `package_dir` basename.
-20. **Machine-key factors** — *Decided:* SHA-256 (first 16 hex chars) over a
-    version-tagged canonical string of the `many_cpus` processor count,
-    memory-region count, and a best-effort CPU brand string; truncated for a
-    compact path segment, fixed (not seeded) for cross-machine stability, and
-    pinned by a golden test. Finer signals (RAM size, base frequency) were left
-    out of v1 for little gain in homogeneous CI pools; `--machine-key` / `machine.
-    key` override the fingerprint (§5). Computed only for Criterion.
-21. **Storage layout & point identity** — *Decided:* **commit-centric** layout
-    `v1/<project>/objects/<engine>/<triple>/<machine|synthetic>/<commit>/{clean.json |
-    dirty-<observation_unix>.json}` (§4.2), with data objects grouped under a per-project
-    `objects/` subtree so project metadata (the cache marker, a future index) lives as a
-    sibling and a data listing never trips over it. The commit is a path segment, so a clean
-    point has the single deterministic key `…/<commit>/clean.json` and collision
-    detection rides on the write-once `put` contract — refused (as
-    `RunError::Duplicate`) unless `--overwrite`. Dirty
-    snapshots are keyed by observation time (wall-clock now) and coexist; only
-    a same-timestamp clash is a conflict. Branch is **not** in the key (a SHA is
-    globally unique); it is metadata only, and series membership is decided by
-    query-time topology, not by it. The storage layout is versioned `v1` (its prefix).
-22. **Analyze query model** — *Decided:* `analyze` **requires a resolvable git repo**
-    (current checkout or `--repo`; errors out otherwise — no committer-date fallback,
-    no stored parent lineage). It resolves the **first-parent** ancestry of a target
-    ref (`--context`, default `HEAD`) and splits it at the merge-base with a base ref
-    (`--base`, default the detected default branch): base-ancestry commits contribute
-    **clean only**, target-unique commits contribute **clean + dirty** (`--no-dirty`
-    to drop dirty). Series are ordered by **git topology** (decision 24 supersedes the
-    old effective-time ordering); runs within one commit sub-order clean-before-dirty,
-    then by storage key.
-    Discriminant sets are selected via the repeatable facets `--engine` /
-    `--target-triple` / `--machine-key`, each accepting the widening keyword `all`
-    and auto-detecting the current machine when omitted (decision 29, §4.3); each
-    matched set produces its own report (§4.3, §8.3); the set index is listed via the
-    `list discriminants` subject. **Dirty-tree base-tip exception:** when the working
-    tree is currently dirty (`git status --porcelain` non-empty) and the target tip is
-    base-side, that tip's dirty snapshots are admitted (the "evaluating the tool" /
-    "accidentally on the base branch" case), limited to the tip and gated by
-    `allow_dirty` (`--no-dirty` overrides). Including such a run appends an
-    ephemeral-data **warning** to the report. Rationale: these are the user's
-    in-flight changes, so showing them (with a nudge to branch) beats a confusing
-    `0 runs`; persisting them is still refused so committed history stays clean.
-23. **`backfill`** — *Decided:* a dedicated command (not a `collect` flag) that replays
-    `collect` across an inclusive first-parent commit range oldest-first
-    (`<from>` … `<to>`). It requires both endpoints to resolve and `<from>` to be a
-    first-parent ancestor of `<to>`, then derives the range purely from `<to>`'s
-    first-parent history — it does **not** depend on the current checkout or branch,
-    so any range whose endpoints form a first-parent line can be backfilled. Each
-    commit is benchmarked exactly as `collect` (no `--timestamp` override; a commit's
-    position on the timeline is its own committer date, read from git) from inside a dedicated **git worktree** so
-    the user's checkout is never disturbed and an interruption leaves them in place.
-    Existing points are **skipped before they are re-benchmarked** by default (the
-    commits already stored are listed once up front, so backfill is resumable without
-    re-running their benches; the it.6 write-once collision remains a post-bench safety
-    net), `--overwrite` regenerates them; a build/bench failure stops by
-    default and `--ignore-errors` skips and continues with an end-of-run summary,
-    while infrastructure failures always abort. Benches are whatever each commit
-    contains, run with `cargo bench` exactly as `collect` (§8.4).
-24. **Series ordering** — *Decided:* **git topology** (first-parent order of the
-    resolved commit list), not a stored commit timestamp. This removes the
-    committer-date monotonicity hazard (rebases / amended dates no longer misorder)
-    and is the reason `analyze` needs a live repo (decision 22). Each commit's
-    committer date — read from that same git topology, not from any stored field —
-    drives only the `--since`/`--until` window; runs sharing one commit sub-order
-    clean-before-dirty, then by storage key.
-25. **No engine configuration** — *Decided:* there is no `[engines]` config.
-    `collect`/`backfill` run the workspace's benches once with `cargo bench`, inject the
-    combined environment every supported engine needs, and detect each engine from
-    the output tree it wrote (decision 8). Scope is expressed with first-class
-    `--workspace`/`--package`/`--exclude`/`--bench` flags plus cargo
-    feature-selection flags (`--features`/`--all-features`/`--no-default-features`)
-    (decision 10). This supersedes the
-    per-engine `command`/`os`/`extra_args` config, the `--engine`-on-`collect` selector,
-    and the `WSLENV` bridging. The bet is that a single `cargo bench` invocation with
-    the union of engine env vars yields correct output for every supported engine —
-    true for Criterion + Callgrind, where off-Linux the Callgrind benches are
-    compiled-out no-ops.
-26. **`list` / `prune` mirror `analyze`'s selection** — *Decided:* `list` (preview
-    the data set, no analysis — §8.5) and `prune` (delete a chosen portion of the
-    data set — §8.6) reuse `analyze`'s exact data-set-selection pipeline,
-    so a selection flag added to one is added to all three (lockstep). The
-    analysis-only `--mode` / `--include-improvements` are not part of the selection
-    lockstep (neither `list` nor `prune` analyzes); `prune` adds the deletion-shaping
-    `--dirty`/`--clean`/`--all`/`<commit>` subjects/`--until` flags. The one
-    intentional divergence is the base-branch tip's dirty exception (decision 22):
-    `analyze`/`list` admit it only when the working tree is currently dirty, but
-    `prune` admits it **unconditionally** (the shared `resolve_history` helper's
-    `DirtyTipPolicy` parameter), so `prune --dirty` can reclaim ephemeral
-    base-branch snapshots regardless of the current tree state. `prune` adds a
-    write-once-safe `Storage::delete` (§7) and a `--dry-run` preview. (Refined: an
-    earlier dedicated `clean` command — delete only the dirty runs — was folded into
-    `prune` as the `--dirty` scope; deleting clean history is guarded by a mandatory
-    narrowing requirement with an `--all` override.)
-27. **Engine-aware analysis** — *Decided:* the detector is split by engine noise
-     profile (§9). Deterministic Callgrind metrics use a Pettitt change-point with
-     only a persistence requirement (both regimes ≥ `min_regime`) and a nonzero
-     median difference — no significance test or FDR, because a perfect integer step
-     over few points has a *high* nonparametric p-value and exact steps of any size
-     are real signal. Noisy Criterion wall time uses Pettitt only to *locate* the
-     split (its analytic p-value is too conservative to gate) and requires a
-     significant Mann–Whitney rank test, confidence-interval non-overlap, and a
-     practical-magnitude floor, and every noisy candidate passes through a single
-     Benjamini–Hochberg FDR gate so a repository full of benchmarks does not flood
-     the report with false positives. Monotonic drift (Mann–Kendall significance +
-     Theil–Sen slope, kept over a change-point only when the line fits the series
-     more tightly than a step) is a second finding type for slow trends. This
-     replaces the single-latest-point rolling-baseline detector of iteration 2,
-     which over-reported on measurement jitter (decision 5 superseded).
-28. **Analysis modes & advisory findings** — *Decided:* `analyze` runs in one of
-     three modes (§9.6), auto-detected from topology (`--mode auto`) or forced
-     (`--mode history|branch|tip`). **history** (clean base checkout) applies the
-     long-range change-point + drift + FDR techniques, defaults `--since` to a
-     six-month look-back, and reports regressions only (improvement over time is
-     expected; `--include-improvements` opts in). **branch** (feature branch or a
-     dirty base checkout) judges the branch by its **latest regime** vs the base —
-     Pettitt finds the most recent within-branch flip, only the after-segment is
-     compared, and `flipped_at` names where it began — reporting both directions.
-     **tip** is an explicit fast guard comparing the last commit against the recent
-     level, regressions only. **Findings never affect the exit code** — they are
-     advisory, so a regression is never a build-failing gate (the old
-     `--fail-on-regression` flag is removed). Downstream automation reads the `json`
-     report's `mode` / `notable` / per-finding `direction` / `flipped_at` / `series`
-     instead. The two driving scenarios are a scheduled base-branch regression watch
-     (history) and a per-PR feature-branch evaluation (branch).
-29. **Blessings & re-baselining** — *Decided:* an intentional base-branch change can
-     be **blessed** (§8.7) so history analysis stops re-flagging it. A blessing is an
-     append-only sidecar (`…/<commit>/bless-<issued_unix>.json`) recorded per
-     benchmark via prefix filters (or `--all` to accept every benchmark at the
-     commit), base-branch-only with an existing
-     `clean.json` at the commit (else hard errors; no `--force`; a dirty working tree
-     is allowed but warns). Both `bless` and `unbless` operate on a `--context` ref
-     (default `HEAD`), so any base-branch commit can be (un)blessed, not just the
-     checked-out one. It
-     re-baselines the series from the blessed commit forward — the detectors run on
-     the active segment only, while pre-blessing points stay for charting/context
-     (§9.7). `unbless` deletes blessings at the context commit (later blessings stay
-     in effect); `collect --overwrite` drops a commit's stale sidecars; `list blessings`
-     (`--all` for the window roll-up) audits them. Blessings are honoured **only in
-     history mode** (branch/tip treat the base as fully blessed). Separately, history
-     mode marks a self-corrected spike as an **inactive** finding (`active=false`),
-     suppressed unless `--include-inactive`. The findings JSON gains `active` /
-     `active_from` / `blessed_at`.
-30. **CLI library & grouped arguments** — *Decided:* the CLI is built with `clap`
-     (derive), chosen over `argh` because `argh` cannot group flags under named
-     headings and the command surface is wide enough that an ungrouped flat help
-     list is hard to navigate. Flags are organised into functional groups via clap
-     `help_heading`s — **Environment and execution** (`--config`/`--repo`/`--verbose`/
-     `--dry-run`), **Output** (`--no-text`/`--markdown`/`--json`), **Benchmark scope** (`--workspace`/
-     `--package`/`--exclude`/`--bench`), **Feature selection** (`--features`/
-     `--all-features`/`--no-default-features`), **Discriminant selection**
-     (`--engine`/`--target-triple`/
-     `--machine-key`), **Commit selection** (`--context`/`--base`/`--since`/
-     `--until`), and **Data filtering** (`--no-dirty`) — shared across commands via
-     flattened arg structs so a given group looks identical everywhere it appears.
-     Consequent CLI-shape changes: the `--os`/`--architecture` facets are dropped
-     (operate on `--target-triple` directly — the triple fixes both, and the
-     duplication confused users); the discriminant facets become **repeatable** and
-     accept the widening keyword `all`, auto-detecting the current machine when
-     omitted (decision 29-bis / §4.3); create-mode commands (`collect`/`backfill`) no
-     longer accept a `--target-triple` override (always auto-detected, §4.1) and gain
-     `--repo`; `--branch` is renamed `--context` (it need not be a branch); `--until`
-     is added to `analyze`/`list` for timeline symmetry with `--since`; **subjects**
-     (commits for `prune`, prefixes for `bless`, and the `runs|discriminants|
-     blessings` selector for `list`) are bare positional words, not flags; and a bare
-     `list` is an error that names its three subjects. The other workspace cargo tools
-     (`cargo-detect-package`/`cargo-freeze-deps`) also use `clap` (issue #252), though
-     their flat CLIs need no grouped argument headings.
-31. **Real-Azure test infrastructure (Bicep + UAMI federation)** — *Decided:* the
-     Azure resources backing the `test-azure` job are fully scripted in
-     `infra/azure-bench-history-test/` so the account and identity can be torn down and
-     re-created with one command. `main.bicep` (resource-group scope) provisions an
-     **Entra-only** Storage account (`allowSharedKeyAccess: false`, HTTPS/TLS1.2,
-     container + blob soft-delete disabled so a deleted test container's name is
-     immediately reusable), a **user-assigned managed identity** with **GitHub OIDC
-     federated credentials** (subjects `repo:folo-rs/folo:ref:refs/heads/main` and
-     `repo:folo-rs/folo:pull_request`; the federation loop is `@batchSize(1)` because
-     Azure rejects concurrent writes to one identity's credentials), and two
-     `Storage Blob Data Contributor` role assignments — for the managed identity (CI)
-     and an optional local developer principal. That single data-plane role covers
-     container create + delete and blob read/write/delete, so production `collect`
-     (`ensure_container`) and the test cleanup both work without a control-plane role.
-     A UAMI is chosen over an App Registration because user-assigned identities and
-     their federated credentials are natively Bicep-able (no Graph extension) and
-     `azure/login@v2` accepts a UAMI `client-id` for OIDC sign-in. The Bicep outputs
-     map one-to-one to the Azure identifiers committed (non-secret) in the
-     repository-root `constants.env` (`BENCH_HISTORY_TEST_AZURE_ACCOUNT`/`AZURE_TEST_CLIENT_ID`/
-     `AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`), the single source both `just
-     test-azure` and the CI `test-azure` job read so local and CI target the same
-     account. `deploy.ps1`/`teardown.ps1`/`cleanup-containers.ps1` wrap deploy,
-     teardown and the leftover-container sweep.
-32. **`analyze` stress harness** — *Decided:* a separate, `publish = false` binary
-     crate (`packages/cargo-bench-history-stress`, run via `just bench-history-stress`
-     / `just bench-history-stress-azure`) fabricates a giant synthetic history (default 1000
-     benchmarks × 2000 `main` commits over ~12 months — roughly half storing a run,
-     the rest left as realistic gaps — across every supported engine crossed with the
-     platforms it runs on: `callgrind` on Linux only, plus `criterion`,
-     `alloc_tracker`, and `all_the_time` on all six `{windows, linux, macos} × {x64,
-     arm}` triples, for 20 discriminant sets; plus a short feature branch with dirty
-     snapshots and partial blessings), seeds it into a storage backend, and times each
-     `analyze` mode over it. A full-scale run is on-demand only — launched by hand, so
-     it never runs in `just test` or CI — because it takes minutes and writes several
-     GiB; the package's own small unit and integration tests do run as a normal
-     workspace member (and so are subject to mutation testing and coverage), exercising
-     the harness at tiny sizes. It supports both storage
-     backends so the same scaling question can be asked of local-filesystem and Azure
-     Blob storage; Azure upload goes through `azcopy` (installed by
-     `just install-tools`) for throughput, against a fresh auto-deleted
-     `bh-stress-<unix>` container under the same `az login` + `constants.env` account
-     contract as `test-azure`. *Rejected* the `private-test-util`/`_impl`-crate split
-     and a test-only feature on the shell crate (features may gate only user-visible
-     API surface on a published crate): the harness instead replicates only the
-     storage *write* layout (the same object keys the backends already use) and reads
-     the data back through the real public `run_with_overrides` entry point, so it
-     measures exactly the production path while touching zero production code. The
-     synthetic value model spans every engine: the injected timeline shapes are sized
-     relatively, so *deterministic* engines (`callgrind`, `alloc_tracker`) store exact
-     values (any step detected exactly) while *noisy* engines (`criterion`,
-     `all_the_time`) store the same shape plus a tight confidence band (well inside the
-     step magnitudes) so the noise-aware detection path is exercised too; per-benchmark
-     families and cross-cutting divisors make each mode report an explainable mix of
-     regressions/improvements rather than all-or-nothing; a fixed dataset anchor +
-     SplitMix64 generator make a given seed and sizing reproduce a byte-identical
-     dataset. *Finding (full-scale run, default sizes, ~20000 objects / ~5.7 GiB on
-     local FS):* `history` ~240 s, `tip` ~126 s, `branch` ~81 s. All three modes shared
-     a multi-second floor spent loading and deserializing the ~20000 stored objects one
-     at a time; `analyze`/`list` fetch and deserialize them with **bounded
-     concurrency** (`analyze/mod.rs`'s `load_objects_concurrently` drives the survivors
-     through `futures::stream::…buffer_unordered`, completing out of order then re-sorting
-     by storage key for deterministic diagnostics), so the per-mode load floor is roughly
-     its slowest fetch rather than the sum — critically so for Azure, where the serial
-     loads were serial network round-trips. *(The run load was later moved off this path to
-     a chunked parallel fetch+parse+fold — decision 36; `load_objects_concurrently` now
-     serves only the blessing-sidecar load.)* The `--since`/`--until` window is applied
-     earlier still: each commit's committer time rides along its SHA on the first-parent
-     topology, so out-of-window commits are dropped during selection and their objects are
-     never fetched at all (issue #265). The per-series detection that each mode runs
-     over the 20000 series — `history`'s change-point/drift tests are the expensive case;
-     `tip` and `branch` use cheaper per-series detectors — is now parallelized (decision 33).
-
-33. **Parallel per-series change-point detection** — *Decided:* every mode's per-series
-     detection is distributed across worker tasks through an injected `anyspawn::Spawner`.
-     `analyze::findings::find_changes_spawned` splits the series into contiguous chunks — one
-     per worker, where the worker count is the available CPU count
-     (`thread::available_parallelism`) capped at the number of series — dispatches each chunk
-     to a blocking task via `Spawner::spawn_blocking` running the pure per-series
-     `detect_one`, then concatenates the chunk results **in series order**. Order
-     preservation is load-bearing: the downstream false-discovery alignment pairs
-     `candidates` with `noisy_p` positionally and the final ranking is a deterministic total
-     order, so the output is byte-identical to a plain serial scan — only the wall time
-     changes (the win is concentrated in `history`, whose change-point/drift tests are the
-     most expensive per-series work; see decision 32's finding). A single available CPU
-     yields a single worker — one chunk, one task over every series — so the one-worker
-     case is just the degenerate partition rather than a separate serial branch. Production
-     injects a Tokio-backed spawner; tests and Miri inject a synchronous spawner that runs
-     each task inline (Miri reports one CPU by default, so it exercises that single-worker
-     path), keeping the core
-     analysis runtime-agnostic and free of a hard Tokio dependency. *Rejected* `rayon`'s
-     `par_iter` (the issue's original suggestion): its transitive `crossbeam-epoch` dependency
-     trips Miri's Stacked Borrows model (a known, benign issue), which would force an ugly
-     `#[cfg(miri)]` serial fallback; the injected spawner is Miri-clean with no conditional
-     compilation. Also *rejected* spawning short-lived `std::thread::scope` workers per call:
-     it litters the profiler with transient threads and ties the core to OS-thread spawning
-     instead of the host's existing runtime. The worker-count and chunking arithmetic never
-     changes the output, so `worker_count` carries `#[mutants::skip]` while the real detection
-     logic in `detect_one` stays under mutation testing. The serial `find_changes` survives
-     only as the test-only oracle that pins the chunked path to a non-chunked reference.
-34. **Storage selection: `--local` flag + cloud-only config** — *Decided:* a local
-     storage path is machine-dependent, so it is no longer carried in the shared,
-     version-controlled config file. The config file holds only an **optional**
-     cloud backend (`[storage.azure]` today; modelled as
-     `Option<CloudStorageConfig>`, an externally-tagged enum so serde enforces "at
-     most one" — two tables fail to parse), and every storage-backed command takes
-     a `--local` flag. Resolution precedence (§7.1): `--local=<path>` →
-     local at `<path>`; bare `--local` → local at `CARGO_BENCH_HISTORY_STORAGE`
-     (unset/empty is an error); otherwise the configured cloud backend; otherwise a
-     config error. `--local` overrides a configured cloud backend, and `run
-     --no-store` skips selection entirely so it works config-free. `--local` uses
-     `require_equals` so the bare (env) form cannot swallow a following positional.
-     The environment read is isolated at a thin edge helper feeding a pure resolver,
-     keeping the decision logic unit-testable and Miri-safe. *No backward
-     compatibility:* at this early stage a leftover `[storage.local]` table gets no
-     special handling. Because `storage` is a known field whose only variant is
-     `azure`, such a table is **rejected** at parse time (`unknown variant 'local',
-     expected 'azure'`) rather than silently ignored the way a wholly unknown
-     section is — a clear signal to remove it and pass `--local` instead.
-     `install`'s template documents the optional cloud block and the `--local` /
-     env mechanism for local storage.
-35. **Report formats mirror the text output** — *Decided:* the three report formats
-     carry the **same data**, differing only in presentation. The `text` format is the
-     canonical layout; `markdown` is that data with Markdown formatting (per-finding blocks,
-     not a table; charts as fenced ` ```text ` code blocks rendered without ANSI); and
-     `json` is the machine-readable form of the same fields. The JSON `findings` list is
-     flat and globally ranked, each finding self-describing (inlining its discriminant set
-     and benchmark `segments`), and the `sets` array carries only per-partition identity and
-     tallies (`runs`/`series`/`regressions`/`improvements`) — findings are never duplicated
-     under `sets`. JSON omits the per-commit `series` (a charting/presentation concern the
-     text and Markdown reports draw from internally, not data a consumer reconstructs) and
-     the redundant absolute `delta` (derivable from `baseline`/`latest`). The per-set tally
-     is surfaced in all three formats (a set-counts line in text, a bullet list in Markdown,
-     the `sets` objects in JSON). *(Superseded: the earlier JSON embedded each finding's full
-     per-commit series and serialized every finding twice — once at the top level and once
-     under its set — which on a large history inflated the document to hundreds of MiB; the
-     earlier Markdown rendered a wide findings table per set with no charts.)*
-36. **Parallel object load + fold-in-worker + scalable allocator** — *Decided:*
-     `select_dataset`'s survivor load is distributed across worker tasks the same way the
-     detection is (decision 33). `analyze::fold_runs_chunked` splits the storage-key-sorted
-     survivors into one balanced contiguous chunk per worker (`worker_count` from
-     `analyze::parallel` = `thread::available_parallelism` capped at the survivor count) and
-     dispatches each chunk to a task via the injected `Spawner::spawn`. Each task fetches +
-     gzip-inflates + JSON-parses its slice — one object at a time into the lean
-     `analyze::run_points::RunPoints` projection (only what the fold reads: per result, the
-     id and metric value/interval, not a full `Run`; the full commit SHA a point is labelled
-     with comes from the storage key, not the run payload) — and
-     **folds each parsed run into its own `SeriesBuilder` / `RunIndex`, dropping the run the
-     moment its compact points are extracted**, so no worker ever buffers its chunk's parsed
-     runs. The driver awaits the tasks **in spawn order** and merges their per-worker
-     builders (`SeriesBuilder::merge`), run tallies (`RunIndex::merge`) and admission lists
-     into one `WorkerFold`; a single `SeriesBuilder::finish` then sorts the combined series.
-     Ordinals are assigned before chunking and the final sort is global, so the merge is
-     associative and the output stays byte-identical to a deterministic single-threaded fold
-     in storage-key order. This supersedes the streaming `buffer_unordered` fold
-     (decision 32) for the run load. *Speed (measured):* the gzip-inflate + JSON parse **and**
-     the fold now both fan across cores — phase 2/3 went ~18.8 → ~4.0 s and overall `analyze`
-     ~40 → ~21 s on a 32-core box. *Allocator is load-bearing:* serde_json's many small
-     allocations contend on the system allocator's cross-thread lock (acute on the Windows
-     process heap), which made the naive parallel parse *slower* than serial (negative scaling
-     even 1→2 threads); the `cargo-bench-history` binary therefore installs `mimalloc` as its
-     `#[global_allocator]` (the stress harness mirrors it), without which this decision is a
-     regression. *Memory (measured, accepted — fold-in-worker did **not** lower peak):*
-     fold-in-worker was adopted specifically to claw back the peak that parallelizing cost,
-     by never buffering the parsed runs. It did not: against an intermediate buffered-parallel
-     variant (each chunk parsed to a `Vec<RunPoints>` then folded serially on the main
-     thread), back-to-back on the ~20000-object local-FS history, fold-in-worker measured
-     ~19.0 s / ~47% CPU at **~7210 MiB** peak versus buffered-parallel's ~21.1 s / ~40% at
-     **~6880 MiB** — i.e. ~10% *faster* with better core use but ~5% (~330 MiB) *more* peak.
-     The reason: at merge time every worker's finished builder is resident at once alongside
-     the growing combined builder (~2× the compact point output transiently), plus one
-     mimalloc arena per worker thread — which outweighs the single `RunPoints` buffer the
-     buffered variant carried. So the buffered runs were never the dominant peak term; the
-     lean `RunPoints` projection likewise trimmed peak only ~1% in isolation (the repeated
-     ~1000 benchmark ids re-materialized per object, and mimalloc's retention of freed pages,
-     dominate). Fold-in-worker is kept for the wall-time and CPU-efficiency win, accepting the
-     ~5% higher peak; the remaining structural memory levers (bounded merge-as-complete waves
-     so fewer partials coexist, and id interning/dedup) are deferred. *Caveat (Azure):* each
-     worker awaits its chunk's `Storage::get`s sequentially, so the run load's I/O concurrency
-     drops from the `LOAD_CONCURRENCY`-wide streaming pipeline to ≈ the worker count; the win
-     is on the CPU-bound parse, not remote I/O, and the low-volume blessing-sidecar load keeps
-     the `buffer_unordered` path.
-
-37. **Full commit SHA only — no recorded abbreviation** — *Decided:* a run records only the
-     full commit SHA (`GitInfo.commit`); the previously stored `GitInfo.short_commit` is
-     removed from the data model entirely (and its `git rev-parse --short HEAD` capture
-     dropped). The analysis already has the full SHA in hand for every object — it is the
-     storage-key commit directory segment (`{…}/{commit}/{file}`) that drives topology and
-     ordinals — so the run payload's abbreviation was redundant *and* carried a (small) 48-bit
-     collision risk the full SHA does not. `analyze::SeriesBuilder::push` now labels each
-     `SeriesPoint` from the storage key's full SHA rather than the payload, and `RunPoints`
-     drops its git projection (it carries only `results`). This is a `SCHEMA_VERSION` 2 → 3
-     bump on the same backward-compatible footing as the v2 commit-timestamp removal: reads
-     are not gated on it, so older objects still deserialize (the removed field is ignored).
-     *Display:* a point's commit is now shown as the full SHA. Abbreviating purely for display
-     (e.g. the blessing `blessed_at`, which still calls a `short_commit` render helper on the
-     full SHA) is a separate, deferred concern — display abbreviation is questionable but not a
-     priority, so it is left as-is for now.
-
-38. **Self-minting GitHub OIDC credential for long CI runs** — *Decided:* in a
-     GitHub Actions job configured for Azure federation, the Entra path resolves to a
-     `ClientAssertionCredential` whose assertion (`storage::github_oidc::GithubOidcAssertion`)
-     fetches a **fresh** GitHub OIDC JWT on demand — `GET`ting
-     `${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange` with the
-     `ACTIONS_ID_TOKEN_REQUEST_TOKEN` bearer — for each Entra token exchange. The
-     `entra_credential` helper activates it only when `credential_from` finds all of
-     `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, `AZURE_CLIENT_ID`
-     and `AZURE_TENANT_ID` non-empty; otherwise it falls back to
-     `DeveloperToolsCredential` (local `az login`; the `test-azure` job, which exports
-     `AZURE_TEST_CLIENT_ID` rather than `AZURE_CLIENT_ID`, decision 17). *Why:* a
-     federated `azure/login` session yields a ~1h access token but caches a single OIDC
-     assertion that lives only minutes; a multi-hour collection run outlives the access
-     token, and the first refresh re-submits the long-dead assertion, which Entra
-     rejects (`AADSTS700024`). `ClientAssertionCredential` has its own `TokenCache`, so
-     it calls the assertion only when its access token is stale (~hourly) — and the
-     job-lifetime request token always yields a still-valid assertion, so the run never
-     re-submits an expired one. This needs `permissions: { id-token: write }`, no
-     `azure/login` step, and no stored secret. `GithubOidcAssertion` reuses the
-     backend's shared `HttpClient` for the token `GET`, redacts the request token in
-     `Debug`, and maps its own failures (a malformed request URL, a non-success HTTP
-     status, malformed/empty JSON) to `ErrorKind::Credential`, while a transport error
-     from the `GET` itself propagates unchanged (it stays `ErrorKind::Io`). It is
-     unit-tested with a stub `HttpClient` (no network, Miri-safe) covering success,
-     HTTP-error status, malformed/empty JSON, transport-error passthrough, the
-     audience-append and bearer header, `Debug` redaction, the federation-variable
-     detection, and credential construction; `entra_credential_from` (the getter-seam
-     under `entra_credential`) is unit-tested for both the self-minting and fallback
-     branches.
-
-39. **Composable per-format output toggles (single pass)** — *Decided:* the reporting
-     commands (`analyze`/`list`/`prune`) replace the single mutually-exclusive
-     `--format text|json|markdown` selector with **composable output toggles** rendered
-     from **one** analysis pass: the text report goes to stdout by default, `--no-text`
-     suppresses it, `--markdown <path>` also writes the Markdown report to a file, and
-     `--json <path>` also writes the JSON report. One invocation can therefore emit every
-     format at once (the automation that wanted both a Markdown report *and* the JSON
-     `notable` flag previously paid for two full analysis passes; it now runs one). The
-     toggles share a flattened `Output` clap group so the three commands stay in selection
-     lockstep, and an `OutputSelection` validates the request up front — `--no-text` with
-     neither file selected is an error (`RunError::Analyze`, "no output selected"), caught
-     before any storage/git work. File writes go through an injected `OutputWriter` IO-port
-     (mirroring the `ConfigWriter` port used by `install`): the real `TokioOutputWriter`
-     rebases relative paths against the workspace directory, creates parent directories, and
-     truncate-overwrites; a `MemoryOutputWriter` fake keeps the orchestrators Miri-drivable
-     in unit tests. The `RunOutcome` text string is unchanged — it is the stdout text, empty
-     when `--no-text`, and `main.rs` skips printing an empty string. *(Breaking change:
-     `--format` is removed entirely; JSON and Markdown reports now go to files rather than
-     stdout. Decision 35 still holds — the three renderings carry the same data — but they
-     are now selected independently rather than one-at-a-time.)*
-
-40. **Mock benchmark engine is its own `publish = false` package** — *Decided:* the
-     fake engine the integration tests launch lives in a standalone `mock_bench_engine`
-     package (`packages/mock_bench_engine/`), not as a `[[bin]]` inside
-     `cargo-bench-history`. *Why:* an auto-discovered binary in the published crate is
-     installed onto every user's PATH by `cargo install cargo-bench-history` — pure
-     test scaffolding leaking into the shipped tool (issue #289). A separate
-     `publish = false` package keeps it structurally out of the published artifact and
-     off users' PATHs, with no feature-flag gymnastics. *Cost:* Cargo only sets
-     `CARGO_BIN_EXE_*` for binaries of the package **under test**, so the tests can no
-     longer reference the mock that way (and artifact dependencies, which would set the
-     var cross-package, are nightly-only). Instead `mock_bench_engine` is a **lib + bin**
-     crate: the binary (`src/main.rs`) is the mock, and the library (`src/lib.rs`)
-     exposes a `binary_path()` locator that `cargo-bench-history` consumes as a normal
-     path `dev-dependency`. The locator builds its own crate on demand
-     (`cargo build --manifest-path <own Cargo.toml> --locked
-     --message-format=json-render-diagnostics`) and reads the
-     executable path Cargo reports for the bin artifact — the lib artifact reports none,
-     so filtering on a present `executable` selects the bin — caching it per process in a
-     `LazyLock<String>`. *(Shared library, not `#[path]`: common test-support code lives
-     in a proper library crate, never an `#[path]`-included source file.)* Cargo owns
-     freshness, so a plain `cargo test` run needs no setup. nextest, however, runs one
-     process per test, so each would run its own on-demand `cargo build` — which costs
-     ~190 ms per process and, worse, races the other processes' concurrent builds over the
-     shared target tree (transient engine-spawn `NotFound` failures surfaced on macOS
-     coverage runs). So every `just` recipe that runs the suite under nextest (`test`,
-     `test-azurite`, `test-azure`, `test-more`, `coverage-measure`) — plus `careful` —
-     pre-builds the mock once (`_mock-engine-path`) and passes its path in
-     `MOCK_BENCH_ENGINE`; the resolver trusts that env var when it points at an existing
-     file (resolving it to an absolute path) and skips the per-process build (~8 s saved on
-     the suite). The two Gungraun fixtures the mock `include_str!`s
-     stay in `cargo-bench-history/tests/fixtures/` — they double as schema-drift canaries
-     for the parser tests — and are referenced cross-package by relative path rather than
-     duplicated.
-
-41. **Read-through cache for the cloud backend (issue #262)** — *Implemented (§7.2).*
-     The cloud-backed read commands (`analyze`/`list`/`prune`) gain an optional on-disk
-     **body cache** so a run pays the network cost only for objects it has never seen,
-     persisted between CI runs via `actions/cache`. Correctness rests on the model's
-     **per-key immutability**: a cached body is valid forever because write-once `put`
-     cannot change an existing key; only `delete` and `put_overwrite` — rare, deliberate
-     administrative ops (`prune`/`unbless`, the manual `--overwrite` escape hatch) —
-     break it, and the listing is never cached, so newly stored objects are always
-     discovered. Invalidation is a small **per-project marker** holding an opaque epoch
-     token, kept inside that project's own versioned partition — as a **sibling of the
-     project's `objects/` subtree** — so a data listing never trips over it and a future
-     storage-format version can redefine the cache contract in lockstep with the layout
-     it caches. The mirror faithfully images **one cloud backend** under identical keys —
-     its root namespaced by that backend's identity (account, then container) so two
-     backends sharing one `--cache` directory never serve each other's bodies, while a
-     single backend's mirror still holds several projects at once; when a project's token
-     changes the reader discards only **that project's mirrored objects** (coarse but
-     correct, since mutations are rare); the marker is maintained by the
-     cloud backend, so every writer invalidates other machines' caches even when it holds
-     no cache itself. *Key enabler the issue did not consider:* the CI `collect`
-     used `--overwrite` for same-commit idempotency, which would mutate objects and wipe
-     the cache on every run; a new **`collect --skip-existing`** mode keeps the production write
-     path append-only — and makes stored measurements immutable, which is better history
-     hygiene — so collection never invalidates the cache it feeds. CLI: a `--cache <dir>`
-     (+ `CARGO_BENCH_HISTORY_CACHE` env) on the three read commands, applicable only to
-     the cloud backend, so it **conflicts with `--local`**. CI: the `collect` recipe
-     switches to `--skip-existing`, and the `analyze` job restores/saves the cache via
-     `actions/cache`. *Rejected:* (a) caching the listing — would hide newly stored
-     objects; (b) keeping collection on `--overwrite` and detecting create-vs-replace at
-     the backend to spare the cache — works, but adds a round-trip per write and leaves
-     history mutable, which `--skip-existing` avoids outright; (c) building the cache into
-     the Azure backend to cache raw wire bytes — cheaper on a miss, but not testable with
-     in-memory fakes and couples concerns, whereas a storage decorator is fake-driven and
-     reactor-free.
-
-42. **Type-segmented (`v2`) blob layout — deferred, not adopted (§4.2)** — a forward-looking
-     idea to hoist the run *kind* into the key path
-     (`v2/<project>/…/runs-clean/<commit>.json`, `…/runs-dirty/…`, `…/blessings/…`) instead of
-     encoding it in the filename, so a single-kind query could narrow its `list` to one prefix.
-     *Rejected for now* on three grounds. **(a)** The query cost it targets is already avoided:
-     `analyze`'s key-only Phase 1 (§8.3 — the "Phase 1 — key-only filtering" pass in
-     `analyze/mod.rs`) drops non-admitted dirty / off-history / out-of-window candidates *before*
-     any body fetch, reading the kind from the filename, so a clean-only analysis issues no
-     dirty-body `get`s today — a kind prefix would remove round-trips that are never made.
-     **(b)** It would break the **co-location** of a commit's clean run, dirty snapshots, and
-     blessing sidecars under one `<commit>/` directory, which `prune` (whole-commit deletion,
-     §8.6) and `bless` (the sidecar lives beside the `clean.json` it baselines, §8.7) rely on;
-     a kind-first layout scatters them across three subtrees. **(c)** Only **one** of {kind,
-     discriminant} can occupy the high prefix, and the layout already puts discriminants high
-     (the more common facet filter) — yet the loader does not even exploit that for `list`
-     narrowing, evidence that listing cost is not a felt pain. The one genuine upside,
-     independent single-kind enumeration (`list blessings`), is minor and, if ever needed, is a
-     migration-free `list`-prefix narrowing away. **Orthogonal to the issue #262 cache
-     (decision 41)** — which keys off whatever the layout is and never caches `list` — and
-     explicitly **not** bundled with it.
-
-43. **Azure auth is Microsoft Entra ID (OAuth) only** — *Decided:* the two legacy auth
-     modes — self-signed shared-key account SAS (`account_key`) and verbatim SAS
-     (`sas_token`) — were removed; `AzureBlobStorage` authenticates exclusively via
-     Microsoft Entra ID, so `credential` is always present and the endpoint is always
-     HTTPS. *Why:* the real Storage account already disables shared-key access
-     (`allowSharedKeyAccess: false`, decision 17 infra), so `account_key` never worked
-     against real Azure — it was Azurite-only legacy — and `sas_token` was an unused
-     historical escape hatch. Collapsing to one mode deletes the `storage::sas` HMAC
-     signer, the `hmac` dependency, and the priority-resolution + conflict-check logic
-     in `from_config`. A leftover `account_key`/`sas_token` field is a **loud config
-     parse error** (via `#[serde(deny_unknown_fields)]` on the `[storage.azure]`
-     struct), the same clean-migration stance the crate takes for unknown
-     `[storage.local]` fields — no silent back-compat. *Cost:* Azurite has no real
-     Entra, so its CI/local tests run it in `--oauth basic` mode over HTTPS (behind a
-     throwaway self-signed cert; `start-azurite` and `just test-azurite` provision it)
-     and inject two things the production `from_config` never builds: a fake
-     `TokenCredential` returning a locally-crafted JWT whose structure and
-     `iss`/`aud`/`nbf`/`iat`/`exp` claims satisfy Azurite's signature-free structural
-     check, and an `HttpClient` (a `reqwest` client with `danger_accept_invalid_certs`
-     + `no_gzip`) that trusts the cert. `AzureBlobStorage::from_parts(...)` assembles a
-     backend from those parts: the unit round-trips call it directly, and the `cbh_azure`
-     end-to-end tests inject a fully-built backend through `Overrides::storage_override`
-     (the `#[doc(hidden)]` `azure_backend_from_parts` seam), so production carries no
-     fake-token backdoor. Real signature validation stays proven by the `test-azure` /
-     `test-azure-gh` jobs against the real Entra-only account.
+Data objects live under a per-project `objects/` subtree so project-level metadata (today
+the cache-invalidation marker; perhaps an index later) can sit as a **sibling** without a
+layout migration and a data listing can never pick it up.
+
+The segment above the commit is the discriminant set; the commit is a directory, and
+**clean vs. dirty is filename semantics** within it. This is dictated by how `analyze`
+selects data: storage is not a pre-assembled timeline but is pieced together at query time
+by resolving git history into an ordered set of commits and reading each commit's
+directory. So the key is indexed by commit and ordering comes from git topology, never
+from a timestamp baked into the key.
+
+A clean run maps to the single deterministic key `…/<commit>/clean.json`, so collision
+detection rides on the write-once storage contract: a second clean run of the same commit
+fails atomically with nothing written, with no separate exists-check round-trip. A dirty
+run is keyed by its observation second so successive snapshots coexist. Branch is not a
+path component — a commit SHA is globally unique, so the same commit on two branches is
+one point, and branch selection happens at query time. Each path segment is sanitized so a
+stray separator in a value cannot split the key into the wrong number of segments.
+
+*Considered and not adopted:* hoisting the run *kind* into the key path (separate
+`runs-clean` / `runs-dirty` / `blessings` prefixes) so a single-kind query could narrow to
+one prefix. It is rejected because the cost it targets is already avoided — `analyze`
+filters non-admitted candidates from the key alone before any body is fetched — and
+because the commit-centric grouping co-locates a commit's clean run, dirty snapshots, and
+blessing sidecars under one directory, which is exactly what lets `prune` drop a commit's
+whole set and keeps a blessing adjacent to the run it baselines.
+
+### 3.3 Discriminant sets and query facets
+
+A series is only ever built within one discriminant set. Three facets select which sets a
+query operates on: engine, target triple, and machine key. (Earlier drafts also exposed
+derived OS / architecture facets; they were removed because duplicating the target-triple
+dimension confused users — filter on the triple directly.)
+
+Each facet is repeatable, unions its values, and accepts the literal `all` to widen past a
+dimension. Omitting a facet **auto-detects the current machine**: the triple defaults to
+the host triple and the machine key to the host fingerprint, so a bare query reports *this*
+machine's data; engine has no machine-derived value, so it defaults to all engines. A
+`synthetic` set always passes the machine-key facet regardless of its value, so
+auto-detecting the host fingerprint still includes every hardware-independent set. A facet
+that matches several sets yields one report per set — parallel data sets analyzed
+individually.
+
+The commands divide into **create** and **query** roles. `collect` and `backfill` record
+new data into exactly one machine's reality, so they auto-detect every facet and accept
+only a machine-key override (for a stable CI-pool key); they reject engine or triple
+selection and the `all` keyword. Every other command queries existing data and uses the
+full repeatable, `all`-aware, auto-detecting facet model.
+
+## 4. Machine key
+
+The goal is a fingerprint equal for pool-equivalent machines and different for genuinely
+different hardware; it is **never** keyed on hostname or serial, since cloud pool nodes
+differ in name but are equivalent. It hashes the stable, pool-equivalent attributes
+available without elevated privileges across platforms — the processor and memory-region
+counts (from the in-workspace `many_cpus`) and a best-effort CPU brand string. Finer
+signals such as RAM size or base frequency were left out for little discriminating value
+in homogeneous CI pools.
+
+Because the key is persisted and compared across machines and tool versions, it uses a
+**fixed** hash (not a seeded/default hasher) over a version-tagged canonical string,
+truncated to a compact path segment, and a golden test pins a fixed profile to its digest
+so an accidental change to the canonical form is caught. A command-line override wins over
+the computed fingerprint (it is CLI-only — a committed config would carry a machine key
+wrong for some checkouts). The key is computed only for hardware-dependent engines.
+
+## 5. Run context
+
+Captured once per stored run: the observation timestamp (above); the git commit, branch,
+and dirty flag (branch is metadata only — query-time topology decides series membership,
+and parent lineage and committer date are resolved from a live repo at analyze time rather
+than stored); the environment provider, run id, and PR number detected from the
+environment (with `Local` a first-class provider alongside the automated ones); the rustc
+and cargo versions and the resolved execution triple; and provenance (tool version, schema
+version, machine key). Git and environment access go through a small abstraction so the
+logic is unit-testable without a real repo or CI.
+
+## 6. Storage
+
+Storage is modelled as a small async port with two backends. Its object model is the
+lowest common denominator of a filesystem and a blob container — flat keys, list-by-prefix,
+immutable objects — so both backends implement it with no special-casing upstream. Because
+async trait methods are not object-safe, backend selection is a static-dispatch enum rather
+than a boxed trait object, and the commands stay backend-agnostic by holding it.
+
+The defining tenet is **write-once immutability**: writing an existing key fails, which is
+the basis of the clean-collision refusal. A replacing write is a deliberate escape hatch
+(the `--overwrite` path). Delete removes one object and is used only by `prune` and
+`unbless`. Per-key immutability is what makes the read-through cache correct.
+
+Stored bodies are **gzip-compressed** at the port boundary by a shared codec both backends
+call, so every command hands and receives plain JSON and is unaffected. This is a breaking
+format with no migration: a legacy plaintext object fails loudly on read because the gzip
+magic never collides with JSON's first byte. The test fake stays plaintext (no test
+inspects raw bytes, and it keeps the Miri-driven suite fast).
+
+The two backends:
+
+* **Local filesystem** — root selected at run time (below), created on demand, walked
+  iteratively.
+* **Azure Blob** — always compiled in, because the tool is installed without feature
+  flags and a build-time gate would only hide a backend the user explicitly configured.
+  Authentication is **Microsoft Entra ID (OAuth) only**, resolved once and always over
+  HTTPS (bearer tokens require TLS); the legacy shared-key and verbatim-SAS modes were
+  removed, and a leftover key/token field is now a loud config parse error. In a GitHub
+  Actions job configured for federation the credential self-mints a fresh GitHub OIDC
+  token on demand for each Entra exchange; otherwise it discovers a local `az login`
+  session. Self-minting is load-bearing for multi-hour collection runs: a single federated
+  sign-in caches one OIDC assertion that expires within minutes, so a long run's first
+  token refresh would otherwise re-submit a dead assertion and be rejected. The chosen
+  credential is wrapped in a caching decorator that serializes token acquisition, so a
+  concurrent read burst shares one acquisition instead of racing the platform token-cache
+  lock. Every per-object blob client shares **one** pooled HTTP transport, so a
+  high-concurrency load keeps connections alive across objects instead of paying a fresh
+  handshake per object (and exhausting ephemeral ports); the transport keeps automatic
+  decompression off, since the storage layer inflates gzip itself.
+
+The Azure backend is exercised in CI two complementary ways: against the **Azurite
+emulator** (the default, fork-safe path — Azurite has no real Entra, so it runs in a
+signature-free OAuth mode over HTTPS behind a throwaway certificate, with a faked token and
+a cert-trusting transport injected through a test seam) and against a **real Storage
+account** (which proves real Entra signature validation the emulator cannot, using a fresh
+auto-deleted container per test). The network tests self-skip when their backend is not
+configured, so a normal run stays green without one.
+
+### 6.1 Selecting a backend
+
+A local-storage path is machine-dependent, so it is never carried in the shared,
+version-controlled config file. The config holds only an optional cloud backend (an
+externally-tagged table of which at most one may be configured); local storage is chosen
+at the command line or environment. A leftover local-storage table from an earlier scheme
+is rejected at parse time rather than silently ignored, nudging the user to remove it.
+
+Every storage-backed command takes a `--local` flag and resolves the backend in
+precedence: an explicit `--local=<path>`; a bare `--local` meaning "the path in the
+storage environment variable" (unset/empty is an error); otherwise the configured cloud
+backend; otherwise a configuration error. `--local` thus always overrides a configured
+cloud backend. `collect --no-store` is the one exception — it skips selection entirely.
+The environment read is isolated behind a thin edge feeding a pure resolver, so the
+decision logic is unit-testable without touching the process environment.
+
+### 6.2 Read-through cache for the cloud backend
+
+The read commands (`analyze` / `list` / `prune`) load the whole in-selection history before
+reconstructing a series, and against the cloud backend that is one download per object — so
+CI re-fetches everything even though almost all of it is identical to the previous run. An
+optional on-disk **read-through cache** removes that waste: each run pays the network cost
+only for objects it has never seen, and the cache survives between CI runs via the standard
+Actions cache.
+
+The cache mirrors fetched object **bodies**, keyed by storage key. It never caches the
+**listing**: discovering the current key set is one cheap round-trip whose whole purpose is
+to see what is new, so it always goes to the cloud and a freshly stored object is still
+found (its body simply misses and falls through). Trusting a cached body forever is sound
+because the model is **immutable per key**. Only delete and replacing-write break that, and
+both are rare, deliberate administrative actions off the collection hot path.
+
+Invalidation is a small **per-project marker** holding an opaque epoch token, kept as a
+sibling of that project's object subtree. Before a load, the reader compares the project's
+cloud marker against the epoch its mirror last recorded; on a mismatch it wipes **that
+project's** mirrored objects and re-records the epoch. The wipe is deliberately coarse
+(drop and re-download once) because mutations are rare, and only whether the token differs
+matters — never its value or ordering — so clock skew between runners is harmless. The
+marker is maintained by the cloud backend itself, so **every** writer, even a developer's
+cache-less `prune`, invalidates other machines' caches: the local cache is a read-side
+optimization, the marker a cloud-side correctness contract.
+
+A cache only survives a CI run if that run never mutates an existing object. Collection is
+therefore **append-only**: a same-commit re-run is a soft skip (the run still benchmarks
+every engine, so a broken benchmark is still caught, but writes nothing) rather than an
+overwrite. This keeps the production write path purely additive so it never bumps the
+marker, and it makes stored measurements immutable — better history hygiene. Regenerating
+data after a harness change stays a deliberate manual overwrite, which legitimately
+invalidates caches.
+
+A `--cache <dir>` flag (with an environment fallback) selects the directory on the read
+commands. It is meaningful only with the cloud backend, so it **conflicts with `--local`**.
+Its one scaling limit is the repository's Actions-cache quota; beyond it the cache degrades
+to a partial restore — still correct, just less effective.
+
+*Considered and not adopted:* caching the listing (would hide newly stored objects);
+keeping collection on overwrite and detecting create-vs-replace at the backend (adds a
+round-trip per write and leaves history mutable); building the cache into the Azure backend
+to cache raw wire bytes (cheaper on a miss but not testable with in-memory fakes and
+couples concerns — a storage decorator is fake-driven instead).
+
+## 7. Commands
+
+Every option is filed under a named help heading so `--help` reads as a small set of
+labelled groups rather than one flat list, and the groups are shared across commands so a
+given group looks identical everywhere it appears. The functional groups are environment
+and execution, output, benchmark scope, feature selection, discriminant selection, commit
+selection, and data filtering. Subjects are bare positional words, never flags: the
+`runs|discriminants|blessings` selector for `list`, prefixes for `bless`, commits for
+`prune`, and the range endpoints for `backfill`. A bare `list` with no subject is an error
+that names the three.
+
+### 7.1 `collect`
+
+`collect` invokes the workspace's benches once with `cargo bench` and harvests whichever
+engines produced output — there is no engine configuration. It enables the combined
+environment every supported engine needs (only Callgrind needs an opt-in variable; the
+others auto-emit) and then inspects each output tree to see which engines actually ran.
+Off-Linux the Callgrind benches compile to no-ops and simply produce nothing, so no OS
+logic is needed in the tool.
+
+The tool also pins an **absolute** target directory into the bench environment, because
+cargo runs each benchmark binary with its working directory set to the owning package, so a
+relative target path would be resolved there by an engine that honours it and scatter
+output away from the workspace-rooted harvest. Harvest is scoped to files modified at or
+after the run start, so stale cases from earlier runs are never re-ingested and whatever
+subset actually ran is exactly what is stored.
+
+`collect` always persists — there is no separate publish step (`--no-store` runs without
+writing, for dry runs). A clean point writes the deterministic clean key, refused by
+default if it exists (overwrite to replace, or skip-existing to treat it as a success and
+write nothing — the append-only mode CI uses). A dirty snapshot coexists with prior
+snapshots. An engine that harvests zero cases stores nothing, since an empty set carries no
+comparable data.
+
+Scope flags (`--workspace`, `--package`, `--exclude`, `--bench`) and cargo feature flags
+translate directly to `cargo bench` arguments, and everything after `--` is forwarded
+verbatim. Two non-overlapping partial runs at one commit do **not** merge — each would
+write the same clean key and the second collides — so coverage gaps are expected to come
+from *different commits* covering different subsets, not from multiple partial runs at one
+commit.
+
+### 7.2 `install`
+
+Generates a fully commented example config if absent and points the user at it, never
+clobbering an existing file. The template documents the optional cloud backend and notes
+that local storage is selected at run time (flag or environment), not configured in the
+committed file; it carries no engine or machine-key settings, and its next-steps hint
+points at `backfill` for seeding an existing repository's history. The file write goes
+through a port so the command is testable without touching the filesystem.
+
+### 7.3 `analyze`
+
+`analyze` **pieces a series together at query time from git topology**, so it requires a
+resolvable git repository (the current checkout by default, or an explicit path); with no
+repo it errors rather than guessing an order. Analyzing a foreign project's data means
+checking out that project's repo and pointing `analyze` at it.
+
+Two refs frame the analysis: a **target** (`--context`, default `HEAD`) whose history is
+analyzed, and a **base** (`--base`, default the detected default branch). `analyze`
+resolves the first-parent ancestry of the target and splits it at the merge-base with the
+base: commits in the base ancestry contribute **clean points only**, while commits unique
+to the target contribute **clean and dirty** points (a flag drops the dirty ones). This
+single rule covers both use cases — an official view is `--context <default>` (everything
+is base, so clean-only), and the "how does my feature fit in" view is the default (clean
+base baseline plus the branch's own clean and dirty snapshots). Membership is purely
+topological, so a dirty snapshot taken on a shared base commit is excluded from an official
+view until it is committed.
+
+There is one carve-out to the clean-only base rule, for the common "first impressions"
+case where a user runs `analyze` on the base branch with uncommitted changes (for instance
+an untracked config file, so every stored run landed as a dirty snapshot on the base tip).
+When the **working tree is currently dirty** and the target tip is base-side, that tip's
+dirty snapshots are admitted — they are the user's in-flight work, not stale leftovers —
+and the report ends with a warning that the data is ephemeral and suggests switching to a
+branch to persist history. The exception is limited to the tip and a flag overrides it.
+
+Series are ordered by git topology; runs on one commit sub-order clean-before-dirty, then
+by storage key. The `--since` / `--until` window drops whole runs by each commit's
+committer date (decided from topology before any out-of-window body is fetched); `--since`
+defaults to a six-month look-back uniformly, so a scheduled trend watch does not silently
+widen as history accumulates. Positional prefix subjects scope the analysis to benchmarks
+whose id starts with a prefix; there is no metric filter, since metrics are an internal
+detail users are not expected to know.
+
+Output toggles select which renderings one analysis pass emits — text to stdout by default,
+with file toggles that compose so a single pass can emit text, Markdown, and JSON at once;
+requesting no output at all is an error. **Findings never affect the exit code**: the
+process exits non-zero only when the analysis fails to *run*. A finding is advisory, and
+the machine-readable signal lives in the JSON report. Downstream automation (a scheduled
+regression watch, a PR comment bot) reads that rather than the exit status. When
+facet-matching runs were stored but none entered the analysis, the report carries a plain
+hint explaining the empty result even without verbose diagnostics, so a zero-run outcome is
+never mistaken for "no data".
+
+### 7.4 `backfill`
+
+`backfill` reconstructs history by checking out each commit in a range and running
+`collect` for it — bootstrapping an existing repository's timeline, and also the convenient
+path for ad-hoc evaluation over a span of commits. The range endpoints are inclusive
+positional subjects. Commits are enumerated oldest-first along the first-parent mainline;
+the tool first verifies both endpoints resolve and that the start is a first-parent
+ancestor of the end, then derives the range purely from the end's history — so backfilling
+does not depend on the current checkout or branch.
+
+All work happens inside a dedicated **git worktree** under the temp directory rather than
+in the primary checkout, so a dirty primary tree neither blocks backfill nor affects what
+is measured (each point benchmarks a specific commit, never the working tree), and an
+interruption leaves the user exactly where they were. Between commits the worktree is reset
+clean while preserving the ignored build directory for incremental speed. By default,
+commits that already have a stored result are listed once up front and **skipped before
+their benches run**, making backfill resumable and cheap to re-issue; overwrite regenerates
+them. A build or bench failure stops by default (or, with a flag, is recorded and skipped
+with an end-of-run summary), while infrastructure failures always abort since continuing
+cannot produce correct data.
+
+### 7.5 `list`
+
+`list` **previews the exact data set an `analyze` pass would consume**, without running the
+analysis, letting a user confirm the commit range and discriminant sets first. For the
+`runs` and `blessings` subjects it **mirrors `analyze`'s data-set-selection parameters
+exactly** through the same shared selection pipeline, and the two must stay in lockstep — a
+selection parameter added to one is added to the other. It omits only the analysis-only
+flags. `list runs` reports, per discriminant set, the run / series / per-commit counts of
+the selected runs (each commit's clean/dirty split), oldest-first by topology.
+
+`list discriminants` is a different view: a **discovery catalog** of the sets present in
+storage, which requires **no repository** and so ignores the timeline and data-filtering
+groups. Because it is a catalog, it is the one query view that does *not* default omitted
+facets to the current machine — with no facets it lists every stored partition, so a user
+can find triples and machine keys they do not already know. `list blessings` audits
+blessings (below).
+
+### 7.6 `prune`
+
+`prune` **deletes a chosen portion of the stored data set** — to reclaim storage, discard a
+bad run, or drop the ephemeral uncommitted-tree snapshots that evaluation runs leave
+behind. It reuses `analyze`'s selection pipeline (keeping the three commands in lockstep)
+and then removes the selected objects rather than reporting on them.
+
+A deletion **scope is required** — clean runs (and the blessings riding on them), dirty
+snapshots only, or both — so a bare `prune` is an error that names the three. Pruning never
+touches base-branch history: it walks the selected commits from the context back to the
+merge-base with the base and deletes only the context branch's own commits, preserving the
+shared base. Deleting the base branch's own data set (context resolves onto the base) wipes
+the mainline every feature analysis compares against, so it is refused unless a confirming
+flag is passed. The one intentional divergence from `analyze` / `list` is that the base
+tip's dirty snapshots are admitted **unconditionally**, so a dirty prune can reclaim
+ephemeral base-branch snapshots regardless of the current tree state. A blessing is removed
+only when the clean run it annotates is removed in the same pass, so blessings follow their
+clean run and are never time-filtered directly. A dry-run builds the identical plan but
+skips the deletes.
+
+### 7.7 `bless` / `unbless`
+
+A **blessing** manually accepts an intentional performance change on the base branch so
+history analysis stops re-flagging it: sometimes a regression is a deliberate tradeoff, and
+without a way to record that, every subsequent `analyze` would keep reporting the same
+accepted step forever. Blessing re-baselines the series from the blessed commit forward.
+
+`bless` takes one or more benchmark-id prefixes matched against the qualified identity, so
+it is deliberately per-benchmark — accepting the benchmark that caused trouble must not
+silently accept every other benchmark that may be trending badly unnoticed. An all-switch
+(mutually exclusive with prefixes) accepts every benchmark recorded at the commit. Both
+commands operate on a context ref (default `HEAD`), so any base-branch commit can be
+(un)blessed, not just the checked-out one. A blessing is recorded only when the context
+commit is **on the base branch** and a clean run already exists there; both are hard errors
+otherwise, with no force escape hatch, because a feature-branch blessing would vanish or
+duplicate once the branch is squash-merged and blessing a commit with no data point is
+meaningless. A dirty working tree is allowed (the blessing targets the committed run) but
+warns.
+
+A blessing is an **append-only sidecar** alongside the commit's clean run, so narrowing one
+means unbless-then-re-bless the subset to keep, and overwriting a commit's clean run drops
+its stale sidecars. `unbless` deletes only the blessings recorded at the context commit;
+blessings at later commits stay in effect, so the timeline may remain blessed past the
+unblessed commit. `list blessings` audits them — the sidecars at the current commit by
+default, or the most recent blessing of every benchmark across the analysis window.
+
+## 8. Analysis
+
+A series is built per `(discriminant set, benchmark identity, metric)`, ordered by git
+first-parent topology. The goal is **high signal-to-noise**: report level shifts and trends
+that are real and stay silent on measurement jitter. The design is *engine-aware* because
+the engines have fundamentally different noise profiles and a single detector cannot serve
+both well:
+
+* **Deterministic engines** (Callgrind, `alloc_tracker`) produce exact, reproducible
+  output, so any persistent change is real signal. Significance testing is neither needed
+  nor appropriate — a perfect integer step over few points has a *high* nonparametric
+  p-value.
+* **Noisy engines** (Criterion, `all_the_time`) produce noisy estimates carrying a
+  standard deviation and confidence interval. A change must clear both a
+  statistical-significance bar *and* a practical-magnitude bar, and the family of tests
+  across all series is corrected for multiple comparisons.
+
+Every metric is lower-is-better except cache *hits* (higher is better); the higher cache
+tiers are miss-escalation costs, so polarity keys off the metric, not just its category.
+
+### 8.1 Findings: change-points and drift
+
+Two finding *methods* are emitted per series and ranked together by descending relative
+move:
+
+1. **Change-point (step)** — the primary finding. A single most-likely level shift is
+   located with the **Pettitt** nonparametric change-point test, splitting the series into
+   a before regime and an after regime; the change is attributed to the commit at the start
+   of the after regime, answering "what changed, and after which commit". Persistence is
+   built in — both regimes must contain a minimum number of points — so a single-commit
+   blip cannot trip it.
+2. **Monotonic drift** — a separate finding type for slow trends. A **Mann–Kendall** trend
+   test establishes that a monotonic trend exists and a robust **Theil–Sen** slope
+   estimates its magnitude.
+
+When both fire on one series, the **better-fitting model wins**: the step and line models
+are each scored by their residual, so sharp steps route to the change-point method and
+smooth ramps to drift, and the two never double-report one event.
+
+### 8.2 Engine-aware gating
+
+For a **deterministic** series a change-point is reported once both regimes reach the
+persistence minimum and their medians differ at all — no significance test and no
+multiple-comparison filter, which would wrongly drop genuine small exact steps.
+
+For a **noisy** series the Pettitt test is used only to *locate* the split (its analytic
+p-value is too conservative on short series to serve as a gate). A change-point is reported
+only when all of these hold: a **Mann–Whitney** rank test finds the two regimes
+statistically distinguishable; the regime confidence intervals do not overlap (when
+present); and the move clears a practical-magnitude floor, so a statistically-real but tiny
+wobble stays silent. Drift additionally requires the endpoint movement to exceed a noise
+floor derived from the confidence-interval width, so run-to-run jitter never reads as a
+trend. When an engine reports no confidence interval (older mean-only output), the
+CI-non-overlap gate is skipped and the decision rests on the rank and trend tests alone.
+
+### 8.3 Multiple-comparison discipline
+
+A repository has many benchmarks × metrics; testing each independently would flood the
+report with false positives. Every **noisy** candidate's p-value enters a single
+**Benjamini–Hochberg** false-discovery-rate procedure, and only survivors are reported.
+Deterministic candidates bypass it — they carry no measurement-noise false-positive risk
+and their exact steps would otherwise be discarded.
+
+All of this math lives in a pure, deterministic, Miri-safe statistics module in the core
+crate, unit-tested with named, value-asserting cases on hand-computable inputs rather than
+threshold-mutation guards, so the whole detector is verifiable without real-time delays.
+
+### 8.4 Ranking and polarity
+
+Findings rank by descending relative delta, then by method, then a deterministic identity
+tie-break. There is **no severity classification** — a finding's magnitude is conveyed by
+its relative-change percent, and which findings warrant action is left to human or agent
+judgement rather than an automatic tier.
+
+### 8.5 Analysis modes
+
+The same stored history answers two very different questions, so `analyze` runs in one of
+three **modes**, auto-detected from git topology and the recorded data set (never the
+on-disk working-tree state), or forced explicitly.
+
+* **history** — the base-branch view: auto-selected when the analyzed tip *is* the
+  merge-base with the base and no dirty run is recorded on top of it. It applies the
+  long-range change-point, drift, and false-discovery techniques, and reports regressions
+  only by default (steady improvement on the base branch is expected; a flag opts into
+  improvements).
+* **branch** — auto-selected otherwise (commits past the merge-base, or a dirty run
+  admitted on the base tip by the exception above). It judges the branch by its **latest
+  regime** against the base — a branch may improve then regress, and we report where it
+  *ended up* rather than mask a late regression behind an early gain — reporting both
+  directions.
+* **tip** — never auto-selected; an explicit fast guard comparing only the last point
+  against a bounded window of recent points, regressions only.
+
+The two driving scenarios are a scheduled base-branch regression watch (history) and a
+per-PR feature-branch evaluation (branch). Long-range trend analysis is meaningless on one
+or two branch points, which is why the techniques differ by mode:
+
+| Technique | history | branch | tip |
+|---|---|---|---|
+| Change-point (Pettitt + engine gating) | ✅ | — | — |
+| Monotonic drift (Mann–Kendall + Theil–Sen) | ✅ | — | — |
+| Benjamini–Hochberg false-discovery filter | ✅ | — | — |
+| Latest-regime vs. base | — | ✅ | — |
+| Tip-vs-recent guard | — | — | ✅ |
+| Improvements reported | opt-in | ✅ | — |
+| Resolved (inactive) findings reported | opt-in | — | — |
+
+Modes apply to `analyze` only; `list` and `prune` reuse the same data-set *selection* but
+never analyze, so the mode and improvement/inactive flags are analyze-only and not part of
+the selection lockstep.
+
+### 8.6 Re-baselining: blessings and resolved spikes
+
+History mode distinguishes a change that is **still in effect** from one that has **already
+been addressed**, so a long history does not keep re-flagging events a reviewer has handled.
+Every history-mode finding therefore carries an active flag and an active-from boundary.
+
+* **Resolved spikes** — when a level rose and later returned to its prior baseline, the
+  current state matches the baseline and there is nothing to act on. Such a finding is
+  **inactive**: suppressed by default and surfaced only on request, with its recovery
+  commit named. The recovered points always remain in the data set and on the chart; the
+  flag only governs whether the finding is reported.
+* **Blessings** — a blessing (see `bless`) re-baselines a series from the blessed commit
+  forward: the detectors run on the **active segment only**, so the pre-blessing step is no
+  longer re-flagged, while the earlier points still feed the chart and any long-range
+  technique that needs context. Blessings are honoured **only in history mode** — branch and
+  tip judge the latest state against the base, which is treated as fully blessed by
+  construction. A re-baselined finding records the blessing's commit and time for
+  provenance.
+
+The history-mode chart greys the pre-active prefix and draws the active window in the
+finding's direction colour, so the live period a finding is about is visually separated
+from the inactive context kept only for continuity.
+
+### 8.7 Report formats
+
+The three report formats carry the **same data** and differ only in presentation; the text
+layout is canonical. Text goes to stdout as one paragraph per finding (a
+direction-coloured headline leading with the relative-change percent, a dimmed detail line,
+and — in history mode only — a small line chart of the series), with colour enabled only
+when stdout is a terminal and not disabled by environment. Markdown is that data with
+Markdown formatting (per-finding blocks, not a table; charts as fenced code blocks without
+ANSI). JSON is the machine-readable form: a flat, globally-ranked findings list where each
+finding is **self-describing** (it inlines its discriminant set and benchmark segments), so
+findings are never duplicated under the per-set breakdown, which carries only identity and
+tallies. JSON keeps full precision and omits the per-commit series (a charting concern the
+human reports draw from internally, not data a consumer reconstructs); the text and
+Markdown values round to four significant figures. A consumer keys off a top-level
+"notable" flag (post or stay silent) and reads each finding's direction, magnitude, and
+attribution.
+
+## 9. Architecture
+
+The tool is **two crates**: a **shell** (the CLI binary and its library) and a **core**
+library it depends on. The split follows the workspace's impl-crate pattern — a private-use
+core extraction treated as the impl crate. All **pure, I/O-free** logic — the stored data
+model, comparability and partitioning, the analysis math and rendering, and the shared
+compression codec — lives in core so it can be exercised by a fast, Miri-friendly,
+cheap-to-mutation-test in-process suite, while everything that touches the outside world —
+storage, git, process, filesystem, and the CLI — stays in the shell.
+
+**Async ports and adapters.** The app is async by default on the Tokio runtime, but pure
+logic stays synchronous — parse, map, comparability, series, findings, format — and is the
+Miri-safe bulk of the code and tests. Async is pushed only to the I/O edges, each a small
+port trait (`impl Future` return, no async-trait macro) with a real Tokio adapter and an
+in-`#[cfg(test)]` in-memory fake: the process runner, the environment and git-history
+probes, the benchmark-output harvester, the config writer for `install`, the verbose
+reporter, and storage. Time comes from an injected clock (the workspace `tick` crate), so
+tests drive it deterministically and orchestration never reads the wall clock directly.
+Orchestration takes the injected ports, and the public async entry wires the real adapters.
+
+**Miri strategy.** Pure logic runs under Miri directly, and the in-memory async
+orchestration tests run *without* a Tokio runtime (a synchronous block-on plus
+always-ready fakes plus a frozen clock), so they stay Miri-safe. Tests that use a real
+runtime, real filesystem or process, or the network emulator are Miri-ignored with a
+reason.
+
+**Compute parallelism.** `analyze`'s two expensive stages — loading and parsing the stored
+objects, and running per-series detection — both fan out across cores, routed through an
+**injected spawner** rather than ad-hoc threads so the work runs on the runtime's shared
+pool in production and inline under Miri, and stays legible in a profiler. The object load
+splits the storage-key-sorted survivors into one balanced chunk per worker; each worker
+fetches, inflates, parses, and **folds** its chunk into its own series builder, dropping
+each parsed run as it goes, and the driver merges the per-worker builders in a serial pass
+whose global sort makes the result byte-identical to a single-threaded fold. Objects are
+parsed into a lean projection carrying only the fields the fold reads (the commit a point
+is labelled with comes from the storage key, not the payload). The parallel parse is only a
+net win with a **scalable global allocator** — the JSON parser's many small allocations
+otherwise contend on the system allocator's cross-thread lock and erase the speedup — so
+the binary installs one. Folding in the worker parallelizes the fold for a wall-time and
+CPU win but does not lower peak memory (every worker's finished builder is briefly resident
+alongside the growing merged one), an accepted tradeoff; further memory reduction (bounded
+merge-as-complete waves and id interning) is deliberately left unexploited in favour of that
+win. The data-flow and parallelism
+map lives in [`analyze.md`](analyze.md).
+
+*Considered and not adopted for the fan-out:* a data-parallelism library whose transitive
+dependency trips Miri's aliasing model (forcing an ugly conditional-compilation serial
+fallback), and short-lived per-call worker threads (which litter the profiler and tie the
+core to OS-thread spawning instead of the host's runtime). The injected spawner is
+Miri-clean and runtime-agnostic with no conditional compilation.
+
+**Companion crates.** The fake benchmark engine the integration tests launch is a separate
+non-published package, kept structurally out of the shipped tool so installing
+`cargo-bench-history` only ever places the one real binary on a user's PATH. A separate
+non-published **stress harness** drives the `analyze` scaling experiment: it replicates only
+the storage *write* layout to seed a giant synthetic history, then reads it back through the
+real public entry point, so it measures the production path while touching zero production
+code (and needs no test-only feature on the shell crate).
+
+## 10. Cross-platform notes
+
+`analyze`, `install`, and the harvest-and-store half of `collect` are platform-neutral and
+first-class on Windows, Linux, and macOS. Only the *bench execution* inside `collect` is
+constrained: Callgrind needs Linux and Valgrind, so its benches compile out elsewhere and
+simply produce no output — to collect Callgrind data, run the tool on Linux or in WSL.
+Criterion and the two measurement crates run natively on all three. Target-triple
+resolution is auto-detected where the tool runs, so the golden rule is to run the tool in
+the same OS as the benches.

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -1,364 +1,193 @@
-# `analyze` data-flow & parallelism reference
+# `analyze` — data-flow and parallelism
 
-A mental model of the `analyze` pipeline: what loads where, in what order, what is
-computed/sorted, and exactly where concurrency vs. parallelism happens. This is the
-canonical reference for the load and detection path; keep it in sync with the logic
-(see `AGENTS.md`, the `analyze` section). For the *statistical* design (detectors,
-re-baselining semantics) see `DESIGN.md`; this document is about *flow and
-performance*.
+A component design of the `analyze` pipeline: what loads where, in what order, and
+exactly where I/O concurrency versus CPU parallelism happens. The statistical design
+(detectors, gating, re-baselining) lives in [`DESIGN.md`](DESIGN.md); this document is
+about **flow and performance**.
 
-Code lives in two crates, referenced by symbol + file:
+## Two kinds of "going wide"
 
-- **shell** `cargo-bench-history` — IO, git, storage, orchestration
-  (`src/analyze/mod.rs`, `src/storage/`).
-- **core** `cargo-bench-history-core` — pure compute leaves
-  (`src/analyze/{series,stats,findings,parallel,report}.rs`).
+The single most important distinction is between overlapping *waiting* and overlapping
+*work*:
 
----
+* **I/O concurrency** overlaps in-flight storage reads on one cooperative task. It hides
+  per-object latency but adds no compute throughput, and is used only for the low-volume
+  blessing-sidecar load.
+* **CPU parallelism** fans real work across cores. The two expensive stages — loading and
+  parsing the stored objects, and running per-series detection — each fan out this way.
 
-## 1. Two kinds of "going wide" (read this first)
+Both fan-out stages route through an **injected spawner** rather than ad-hoc threads, so
+the work runs on the runtime's shared blocking pool in production and inline on the calling
+thread under Miri and in-memory tests. That single seam is what lets the whole load run
+reactor-free and unchanged under Miri while still scaling on real hardware.
 
-The single most important distinction:
-
-| Mechanism | What it is | Where | Threads |
-|---|---|---|---|
-| **CPU parallelism (load)** | the storage-key-sorted survivors are split into one balanced contiguous chunk per worker; each chunk is fetched + decompressed + JSON-parsed **and folded** into that worker's own `SeriesBuilder` on a blocking task through an injected `anyspawn::Spawner` (`spawn`) | `fold_runs_chunked` in `select_dataset` | runtime worker threads, not freshly spawned per call |
-| **CPU parallelism (detect)** | one balanced contiguous chunk of series per worker is dispatched to a blocking task through the same `Spawner` (`spawn_blocking`); chunk math in `analyze::parallel` | `find_changes_spawned` (the detection step) | runtime worker threads |
-| **I/O concurrency** | `buffer_unordered(LOAD_CONCURRENCY)` multiplexes in-flight `Storage::get` futures on **one** `!Send` task | the blessing-sidecar load (`load_objects_concurrently`) | cooperative on a single task — **not** OS-thread parallelism |
-
-"Folding across cores" and "detecting across cores" are the two stages that fan compute
-out across cores, and both do so through a `Spawner` so the work runs on the runtime's
-shared blocking pool (production) — or inline on the calling thread (tests/Miri) — rather
-than on anonymous per-call OS threads. The low-volume blessing-sidecar load still uses
-the older single-task `buffer_unordered` I/O concurrency. Production runs all of this
-under `#[tokio::main]`; tests drive `select_dataset` through the
-`synchronous_spawner` and `futures::executor::block_on`, so the load stays reactor-free
-and runs unchanged under Miri.
-
----
-
-## 2. Top-level flow (one `analyze` invocation)
+## Top-level flow
 
 ```mermaid
 flowchart TD
-  EXEC["analyze::execute()"] --> AW["analyze_with()"]
-  AW --> SD["select_dataset()"]
-  SD --> DS[("SelectedDataSet:\nseries + run_index + blessings")]
-  DS --> AB["apply_blessings()\n(history mode re-baseline)"]
-  AB --> FC["find_changes_spawned()"]
+  EXEC["analyze"] --> SD["select data set (the load)"]
+  SD --> DS[("series + run tallies + blessings")]
+  DS --> AB["apply blessings (history re-baseline)"]
+  AB --> FC["detect changes (per series)"]
   FC --> SUM["per-set summaries"]
-  SUM --> RENDER["render()"]
-  RENDER --> OUT["RunOutcome::Analyzed\nreport + regressions"]
+  SUM --> RENDER["render reports"]
 ```
 
-The cost is overwhelmingly in **`select_dataset`** (the load) and secondarily in
-**`find_changes_spawned`** (the detect). Everything else is bookkeeping.
+The cost is overwhelmingly in the **load** and secondarily in the **detect**; everything
+else is bookkeeping. Each analysis mode (`history`, `branch`, `tip`) is a separate
+invocation with its own load — there is no dataset cache across modes — and the mode is
+auto-detected once per run from git topology.
 
-Each analysis **mode** (`history`, `branch`, `tip`) is a *separate* `analyze`
-invocation with its *own* `select_dataset` load — there is no shared dataset cache
-across modes. The mode is auto-detected once per run from git topology
-(`auto_mode`), unless `--mode` overrides it.
-
----
-
-## 3. `select_dataset` — the load (where the wall-clock goes)
+## The load
 
 ```mermaid
 flowchart TD
-  subgraph P1["Phase 1 — key-only filtering (NO payload fetched)"]
-    L["storage.list(prefix)\n1 round-trip, returns all keys"] --> KF["parse_key + facet match"]
+  subgraph P1["Phase 1 — key-only filtering (no payload fetched)"]
+    L["list keys (one round-trip)"] --> KF["parse key + facet match"]
     KF --> WF["history / dirty / since-until filters\n(commit time + topology)"]
-    WF --> TF["to_fetch: Vec<(key, StorageKey)>"]
-    TF --> SK["sort by storage key\n→ each object's rank = object_ordinal"]
+    WF --> SK["sort survivors by storage key\n→ assign each a global ordinal"]
   end
-  SK --> LOAD
+  SK --> P23
   subgraph P23["Phase 2/3 — chunked parallel fetch+parse+fold, then merge"]
-    LOAD["fold_runs_chunked: split survivors into\none balanced contiguous chunk per worker"] -->|"spawn(chunk) ★ BLOCKING TASKS ★"| WORK["each worker: for key in chunk →\nStorage::get → gzip inflate → JSON → RunPoints\n→ push into its OWN SeriesBuilder, drop RunPoints"]
-    WORK -->|"await in spawn order"| MERGE["merge per-worker SeriesBuilders\n+ RunIndexes into one"]
+    LOAD["split survivors into one balanced chunk per worker"]
+    LOAD -->|spawn| WORK["each worker: fetch → inflate → parse →\nfold into own builder"]
+    WORK -->|await in spawn order| MERGE["merge per-worker builders + tallies"]
   end
-  MERGE --> FIN["SeriesBuilder.finish()"]
+  MERGE --> FIN["finalize series"]
 ```
 
-Key properties:
+Design properties that make this both fast and deterministic:
 
-- **Phase 1 never fetches a payload.** History-membership, base-side dirty admission
-  and the `--since`/`--until` window are all decided from the *key* and git topology
-  (`window_excludes`), so an excluded object costs zero round-trips.
-- **Ordinals are assigned up front** by sorting `to_fetch` by key. Each survivor's rank
-  in that order is its `object_ordinal`, captured before chunking so the result is
-  independent of which worker finishes first. `object_ordinal` is the final point
-  tie-break and stands in for the full storage key to keep points small.
-- **The parse and the fold both run across cores; a serial merge follows.**
-  `fold_runs_chunked` splits the key-sorted survivors into one balanced contiguous chunk
-  per worker (sizes differ by at most one) and spawns one blocking task per chunk; each
-  task fetches, inflates, and JSON-parses each object into a lean `RunPoints` (the
-  projection below) and **folds it straight into that worker's own `SeriesBuilder` /
-  `RunIndex`, dropping the `RunPoints` immediately** — so a worker never buffers its
-  chunk's parsed runs. The driver awaits the tasks **in spawn order** and merges their
-  builders (`SeriesBuilder::merge`), run tallies (`RunIndex::merge`) and admission lists
-  into one. Because ordinals are global and the final `finish()` sort is global, the
-  merge is associative and the result is byte-identical to a single-threaded fold in
-  storage-key order. Both the parse and the fold — the local-backend load's dominant
-  costs — now scale with cores; only the merge and the final sort stay serial.
-- **The parsed element is lean (`RunPoints`).** Each object is parsed into `RunPoints`
-  (`analyze::run_points`), which carries only what `SeriesBuilder::push` reads from the
-  run payload — per result, the benchmark id and each metric's
-  `kind`/`value`/`interval_low`/`interval_high` — and `push` consumes that projection
-  rather than a full `Run` (the commit a point is labelled with comes from the storage
-  key, not the payload, so `RunPoints` holds no git fields). Serde ignores the rest of the
-  run JSON, so the discarded run context (environment, toolchain, timestamps) and
+* **Phase 1 never fetches a payload.** History membership, base-side dirty admission, and
+  the `--since`/`--until` window are all decided from the *key* and git topology, so an
+  excluded object costs zero round-trips.
+* **Ordering is fixed before parallelism.** Survivors are sorted by storage key and each is
+  assigned a global ordinal *before* chunking, so the result never depends on which worker
+  finishes first. That ordinal is also each point's final tie-break, standing in for the
+  full key to keep points small.
+* **Parse and fold both run across cores; only the merge is serial.** The key-sorted
+  survivors split into one balanced contiguous chunk per worker (sizes differing by at most
+  one, so a slice just above the worker count still uses every worker). Each worker fetches,
+  inflates, JSON-parses, and folds each object straight into its own series builder,
+  dropping the parsed run immediately so no chunk's parsed runs are ever buffered. The
+  driver then merges the per-worker builders in a serial pass. Because ordinals are global
+  and the finalizing sort is global, the merge is associative and the result is
+  byte-identical to a single-threaded fold in storage-key order.
+* **The parsed element is lean.** Each object is parsed into a projection carrying only the
+  fields the fold reads — per result the benchmark identity and each metric's kind, value,
+  and confidence interval. The commit a point is labelled with comes from the storage key,
+  not the payload, so the discarded run context (environment, toolchain, timestamps) and
   per-metric standard deviation are never materialized.
-- **Memory: fold-in-worker did not lower peak (the accepted tradeoff).** Folding in the
-  worker means no chunk's parsed runs are ever buffered — yet this is *not* a memory win.
-  At merge time every worker's finished `SeriesBuilder` is resident at once alongside the
-  growing combined builder (~2× the compact point output transiently), plus one mimalloc
-  arena per worker thread. Measured back-to-back on the ~20000-object local-FS history,
-  fold-in-worker ran ~19.0 s / ~47% CPU at **~7210 MiB** peak versus an intermediate
-  buffered-parallel variant (parse a chunk to `Vec<RunPoints>`, fold serially on the main
-  thread) at ~21.1 s / ~40% / **~6880 MiB** — i.e. ~10% faster with better core use but
-  ~5% (~330 MiB) *more* peak. So the buffered runs were never the dominant peak term, and
-  the lean `RunPoints` projection trims peak only ~1% in isolation (the repeated ~1000
-  benchmark ids re-materialized per object, plus mimalloc's page retention, dominate).
-  Fold-in-worker is kept for the wall-time and CPU win; the remaining memory levers
-  (bounded merge-as-complete waves, id interning) are deferred — see `DESIGN.md`
-  decision 36.
-- **The parallel parse needs a scalable allocator.** serde_json makes many small
-  allocations; on the system allocator their cross-thread contention (acute on the
-  Windows process heap) serializes the worker threads and erases the parallel win — the
-  naive change measured *slower* than serial. The `cargo-bench-history` binary therefore
-  installs `mimalloc` as its `#[global_allocator]` (so does the stress harness, for
-  representative numbers); with it the parse scales cleanly across cores.
 
-### `SeriesBuilder::push` — what the fold does (`analyze::series`)
+A large history materializes tens of millions of series points, so the fold keeps them
+compact and interns each commit into one shared reference across all its points, cloning a
+benchmark identity only on a true first-seen miss rather than per point. The worker count
+derives from the host's available parallelism, capped at the survivor count so a small data
+set never spawns idle workers.
 
-Per parsed `RunPoints`: intern the commit from the storage key (not the
-run payload) into an `Arc<str>` shared by every point
-on that commit (`intern`); resolve the benchmark id's bucket in a `HashTable` with a
-single `entry` probe — hashing `BenchmarkId` with the builder's one fixed hasher
-instance and **cloning the id only on a true cache miss** (one id-clone per distinct
-series, never per point); push a compact `SeriesPoint` (`topo_index`, `dirty`,
-`object_ordinal: u32`, `commit: Arc<str>`, `value`, `interval_low/high`) into the
-`(set, id, kind)` group. A large history materialises tens of millions of these,
-hence the compactness and interning.
+**Memory is the accepted tradeoff, not a win.** Folding in the worker parallelizes the fold
+for a wall-time and CPU gain but does not lower peak memory: at merge time every worker's
+finished builder is briefly resident alongside the growing merged one, plus one allocator
+arena per worker thread. Further memory reduction is possible — bounded merge-as-complete
+waves and identity interning across workers — but is deliberately left unexploited in
+favour of the wall-time and CPU win.
 
-### Tuning constants (`analyze::mod`)
+**The parallel parse needs a scalable global allocator.** The JSON parser makes many small
+allocations; on the system allocator their cross-thread contention (acute on the Windows
+process heap) serializes the workers and erases the parallel win — the naive parallel parse
+measures *slower* than serial. The binary therefore installs a scalable allocator
+(`mimalloc`) so per-thread heaps remove the contention; the stress harness installs the same
+one for representative numbers. This dependency is load-bearing: do not remove the allocator
+without re-measuring the parallel load.
 
-- **Load worker count** (`worker_count`, from `analyze::parallel`) — how many blocking
-  tasks the run load fans across: `thread::available_parallelism()`, capped at the
-  survivor count so a small data set does not spawn idle workers. This bounds both the
-  parallel parse+fold width and (on the run-load path) the number of concurrent in-flight
-  `Storage::get`s, since each worker awaits its chunk's gets sequentially.
-- `LOAD_CONCURRENCY` — how many `Storage::get` round-trips the **blessing-sidecar** load
-  overlaps on its single `buffer_unordered` task. Hides per-object latency (critical on
-  the remote backend); set near the knee where in-flight fetches saturate the network
-  path, past which extra concurrency only subdivides the fixed path bandwidth and
-  lengthens each request without lifting throughput.
-
----
-
-## 4. `SeriesBuilder::finish()` + `find_changes_spawned()` — build & detect
+## Build and detect
 
 ```mermaid
 flowchart TD
-  FIN["finish()"] --> FLAT["flatten nested maps → Vec<Series>"]
-  FLAT --> SS["sort series by (set,id,kind)\n— SERIAL —"]
-  SS --> PPS["sort each series' points by topology\n— SERIAL —"]
-  PPS --> SERIES[("Vec<Series> → Arc<[Series]>")]
-  SERIES --> DALL["detect_all_spawned: one chunk per worker\n→ spawn_blocking(detect_one)\n★ SPAWNED BLOCKING TASKS ★"]
-  DALL --> CANDS["Vec<Candidate>"]
-  CANDS --> BH["benjamini_hochberg FDR filter\n— SERIAL —"]
-  BH --> MAT["materialise surviving findings'\nchart points"]
-  MAT --> SF["sort findings by |Δ|, method, identity\n— SERIAL —"]
-  SF --> FINDINGS[("Vec<Finding>")]
+  FIN["finalize"] --> FLAT["flatten to a series list"]
+  FLAT --> SS["sort series, then sort each series' points by topology\n— serial —"]
+  SS --> DALL["detect: one chunk of series per worker\n(spawned)"]
+  DALL --> CANDS["candidate findings"]
+  CANDS --> BH["false-discovery filter — serial —"]
+  BH --> MAT["materialize surviving findings' chart points"]
+  MAT --> SF["sort findings by magnitude, method, identity — serial —"]
+  SF --> FINDINGS[("findings")]
 ```
 
-### Inside one `detect_one` (`analyze::findings`) — per series, runs on a worker
+Detection has no cross-series state, so the series split into one balanced chunk per worker
+— the same split-once, spawn, await-and-recombine pattern as the load — and the output is
+identical to a sequential pass. A single available CPU (as Miri reports) yields a single
+worker over the whole input. Per series the mode selects the detector: history runs both a
+change-point and a drift detector and keeps the better fit (plus an optional recovered-spike
+pass); branch compares the branch tip's level against its base; tip guards only the newest
+point.
 
-The detection step has no cross-series state, so the series are split into one
-balanced contiguous chunk per worker and each chunk is detected on its own blocking
-task; the chunks recombine in series order, so the output is identical to a sequential
-pass. The mode selects the detector:
+The statistical kernels are chosen to keep the tens-of-millions-of-points path affordable —
+an in-place unstable sort for the median (no scratch buffer, and ties are bit-identical so
+reordering cannot change the result), pre-sized buffers for the pairwise Theil–Sen slope,
+and a single sort for the false-discovery filter across all noisy candidates.
 
-- **History** (long-range trend): project point values once, then run a
-  **change-point** detector *and* a **drift** detector and keep the better fit
-  (`arbitrate`); optionally a recovered-spike pass when inactive findings are
-  requested.
-- **Branch**: compare the branch tip's level against its base across the merge-base.
-- **Tip**: guard only the newest point.
+## The full parallelism / serial map
 
-These detectors call the **stats kernels**, per series:
+| Stage | Concurrency type | Unit of work |
+|---|---|---|
+| List keys | single async request | the whole prefix |
+| Phase-1 filtering | serial | per candidate key |
+| **Fetch + parse + fold (runs)** | **CPU-parallel (spawned)** | one chunk of survivors per worker |
+| Merge per-worker builders | serial | per worker partial |
+| Series sort + point sort | serial | the series list / per series |
+| **Detect** | **CPU-parallel (spawned)** | one chunk of series per worker |
+| Blessing-sidecar fetch | I/O-concurrent (one task) | per object, bounded in flight |
+| False-discovery filter + finding sort + render | serial | the candidate / finding list |
 
-| Kernel | File | Cost | Allocation |
-|---|---|---|---|
-| `median_in_place` | `analyze::stats` | `sort_unstable_by(f64::total_cmp)` then midpoint | **none** — sorts the caller's slice in place, no scratch buffer |
-| `theil_sen_line` | `analyze::stats` | `O(n²)` pairwise slopes, two `median_in_place`s | sizes its slope/intercept buffers once up front (`pair_count`) |
-| `benjamini_hochberg` | `analyze::stats` | one `sort_unstable_by` over the p-values | once, across all noisy candidates |
+## Where the bottlenecks live
 
-`median_in_place` is genuinely in-place: the unstable sort orders without the scratch
-buffer a stable sort would allocate, and ties under `total_cmp` are bit-identical so
-reordering them cannot change the median.
+* **Local-filesystem backend** — the load is **parse-bound**, and both parse and fold fan
+  across cores, so the ceiling is the slowest chunk's parse+fold plus the serial merge
+  throughput. Levers: a cheaper fold, a leaner parsed shape, and fewer/larger objects. This
+  parallel parse only pays off with the scalable allocator above.
+* **Azure backend** — **network-bound**. The run load drives at most one in-flight read per
+  worker (each worker awaits its chunk's reads sequentially), which is well below the
+  blessing-sidecar load's wider pipeline — so the win from the parallel design is on the
+  CPU-bound parse+fold, not on remote I/O. With the shared connection pool (below) the
+  per-object handshake is amortised across a keep-alive pool, leaving path bandwidth and,
+  for small objects, a per-request round-trip rate as the two ceilings; fewer, larger blobs
+  help more than more concurrency.
 
----
+## Azure connection reuse
 
-## 5. The full parallelism / serial map
-
-| Stage | Concurrency type | Unit of work | Fork/join criterion |
-|---|---|---|---|
-| `storage.list` | single async request | the whole prefix | — |
-| Phase-1 filtering | serial | per candidate key | — |
-| **fetch + parse + fold (runs)** | **CPU-parallel (spawned blocking tasks)** | one chunk of survivors per worker | `fold_runs_chunked`: split once, each worker folds its own builder, await + merge in spawn order |
-| merge (`SeriesBuilder::merge`) | **serial** | per worker partial | runs after the parallel load completes |
-| series sort | serial | the `Vec<Series>` | — |
-| point sort | serial | per series | — |
-| **detect** | **CPU-parallel (spawned blocking tasks)** | one chunk of series per worker | split once over all series, await + concat |
-| blessing-sidecar fetch | **I/O-concurrent (one task)** | per object, bounded in flight | `buffer_unordered(LOAD_CONCURRENCY)` |
-| BH filter + finding sort + render | serial | the candidate/finding list | — |
-
-Both `fold_runs_chunked` and `find_changes_spawned` split their input into **exactly one
-balanced chunk per worker** (sizes differ by at most one, so a slice just above the worker
-count still uses every worker rather than collapsing to fewer chunks), dispatch each chunk
-to a blocking task through the injected `Spawner`, then await them in spawn order —
-`fold_runs_chunked` merges the per-worker partials, `find_changes_spawned` concatenates the
-per-worker results — for output identical to a sequential pass. A single available CPU
-(Miri reports one) yields a single worker: one chunk, one task over the whole input.
-
----
-
-## 6. Where the bottlenecks live (to steer optimization)
-
-- **Local-filesystem backend:** the load is **parse-bound**, and both the parse and the
-  fold now fan across cores. `fold_runs_chunked` spreads the gzip-inflate + JSON-parse +
-  fold over one blocking task per CPU, so the ceiling is the slowest chunk's parse+fold
-  plus the serial merge throughput. Levers: cheaper `push`, parse into a leaner shape
-  (`RunPoints` already drops the run context and per-metric std-dev — less to
-  allocate/parse), fewer/larger objects. Note folding inside the workers did **not** lower
-  peak memory (every worker's partial builder coexists with the merged builder during the
-  merge — see §3 and `DESIGN.md` decision 36); the open memory levers are bounded
-  merge-as-complete waves and id interning, not a leaner buffered element. This parallel
-  parse only pays off with a scalable global allocator (see the mimalloc note below).
-- **Azure backend:** network-bound, and the run load now drives **at most one in-flight
-  `Storage::get` per worker** (≈ CPU count), because each worker awaits its chunk's gets
-  sequentially. That is well below the `LOAD_CONCURRENCY`-wide pipeline the streaming load
-  used, so on a latency-bound remote path the run load can be *less* I/O-concurrent than
-  before; the win from this change is on the CPU-bound parse+fold, not on remote I/O. With
-  the shared connection pool (§7) the per-object TCP+TLS handshake is amortised across a
-  keep-alive pool, leaving two ceilings: the path bandwidth and — for small objects — a
-  per-request round-trip rate. Fewer-larger blobs (and fewer bytes) help more than more
-  concurrency. (The blessing-sidecar load keeps the `LOAD_CONCURRENCY`-wide path.)
-- **The global allocator is load-bearing for the parallel parse.** serde_json's many
-  small allocations contend on the system allocator's cross-thread lock; on the Windows
-  process heap that contention made the naive parallel parse *slower* than serial
-  (negative scaling even 1→2 threads). The binary installs `mimalloc` as its
-  `#[global_allocator]` so the per-thread heaps eliminate the contention and the parse
-  scales. Do not remove it without re-measuring the parallel load.
-- **Data-structure hot spots:** `SeriesPoint` compactness, `Arc<str>` commit interning
-  and single-probe `HashTable` id lookups (clone-on-miss) keep the
-  tens-of-millions-of-points fold affordable. Preserve these; do not regress them.
-
----
-
-## 7. Azure connection reuse
-
-The Azure backend (`storage::azure::AzureBlobStorage`) needs a separate per-object
-`BlobClient` (and a `BlobContainerClient` for `list`) to address each blob, but they
-all share **one** pooled HTTP client so every `get`/`put`/`delete`/`list` reuses a
-single `reqwest` connection pool.
-
-The reuse matters because `reqwest` pools connections *inside each `Client`*. If each
-per-object client built its own transport — which is what `BlobClient::new(url,
-credential, None)` does (`None` options → `Transport::default()` →
-`new_http_client(None)` → a brand-new `reqwest::Client`) — every object would pay a
-fresh TCP+TLS handshake with **no HTTP keep-alive reuse**. Raising fetch concurrency
-would not help (each object still pays full connection setup) and at high concurrency
-would exhaust ephemeral ports.
+`reqwest` pools connections *inside each client*, but the SDK builds a fresh transport for
+every per-object blob client by default — so naively addressing each blob would pay a fresh
+TCP+TLS handshake with no keep-alive reuse, and raising fetch concurrency would only exhaust
+ephemeral ports without helping.
 
 ```mermaid
 flowchart LR
-  subgraph NOW["Client per object — no reuse"]
-    direction TB
-    A1["get A"] --> AC1["BlobClient::new(None)"] --> AR1["new reqwest::Client\n(own pool)"] --> AH1["TCP+TLS handshake"] --> AZ[("Azure")]
-    B1["get B"] --> BC1["BlobClient::new(None)"] --> BR1["new reqwest::Client\n(own pool)"] --> BH1["TCP+TLS handshake"] --> AZ
+  subgraph BAD["Client per object — no reuse"]
+    A1["get A"] --> AR1["own pool → handshake"] --> AZ[("Azure")]
+    B1["get B"] --> BR1["own pool → handshake"] --> AZ
   end
-  subgraph FIX["Shared pooled client — keep-alive"]
-    direction TB
-    A2["get A"] --> SP["shared Arc<dyn HttpClient>\n(one pooled reqwest::Client)"]
+  subgraph GOOD["Shared pooled client — keep-alive"]
+    A2["get A"] --> SP["one shared pooled client"]
     B2["get B"] --> SP
     SP --> KH["reused keep-alive connection"] --> AZ2[("Azure")]
   end
 ```
 
-**How it is wired:** `AzureBlobStorage::from_config` builds **one** pooled HTTP client
-(stored as the `http_client: Arc<dyn HttpClient>` field) and `shared_client_options()`
-injects it into every per-object client through the transport seam, so all operations
-share a single connection pool. The relevant symbols are re-exported from
-`azure_core::http` (`new_http_client`, `HttpClientOptions`, `Transport`, `HttpClient`,
-`ClientOptions`):
+The backend therefore builds **one** pooled HTTP client and injects it into every
+per-object client through the transport seam, so all operations share a single connection
+pool. Automatic decompression stays **off** on that transport: the storage layer stores gzip
+and inflates it itself, so letting the transport auto-inflate would double-inflate the
+bytes. This is validated end-to-end against both the Azurite emulator and a real Storage
+account.
 
-```rust
-// built once in from_config:
-let http_client = new_http_client(Some(HttpClientOptions {
-    // The storage layer stores gzip and inflates it itself in `get`, so the
-    // transport must hand back raw compressed bytes. This mirrors the SDK's own
-    // per-client default; turning auto-decompression on would double-inflate.
-    automatic_decompression: false,
-}));
+## Localizing a slowdown with `--verbose`
 
-// per client (via shared_client_options):
-let options = BlobClientOptions {
-    client_options: ClientOptions {
-        transport: Some(Transport::new(Arc::clone(&self.http_client))),
-        ..Default::default()
-    },
-    ..Default::default()
-};
-BlobClient::new(url, self.credential.clone(), Some(options))
-```
-
-`automatic_decompression` must stay **off**: the SDK's own per-client transport sets it
-to `false` and the storage layer inflates gzip manually in `get` (`codec::decompress`).
-A shared client built with `new_http_client(None)` would default it to `true`, so
-`reqwest` would auto-inflate and the manual `codec::decompress` would then double-inflate
-the bytes.
-
-This shared pool gives keep-alive connection reuse (far fewer handshakes, lower
-per-object latency, no port exhaustion) and lets fetch concurrency actually pay off on
-the remote backend. Validated by the Azurite round-trip tests (`storage::azure`) and the
-real-Azure end-to-end tests (`cbh_azure::*_in_real_azure`).
-
----
-
-## 8. Localizing a slowdown with `--verbose` stage timings
-
-`analyze --verbose` emits a per-stage wall-clock breakdown to standard error, on a
-channel separate from the per-object notes, so a mystery slowdown can be pinned to a
-specific stage of the diagrams above without reading the code. Each line reads
-`[bench-history] timing: <stage> took <elapsed>`. The stages mirror this document:
-
-| Stage label (substring)        | Diagram location                                  |
-|--------------------------------|---------------------------------------------------|
-| `select_dataset (full load …)` | §2 `select_dataset` — the whole load              |
-| `candidate listing + facet …`  | §3 Phase 1 listing + facet filter                 |
-| `storage.list(prefix) …`       | §3 the single `storage.list` round-trip alone     |
-| `git topology resolution`      | §2/§3 `resolve_history` (commit order + times)    |
-| `git.first_parent ancestry …`  | §3 the first-parent ancestry walk alone (scales with history) |
-| `phase 1 — key-only …`         | §3 Phase 1 filtering loop (no fetches)            |
-| `phase 2/3 — chunked parallel fetch …` | §3 Phase 2/3 chunked parallel fetch + parse + per-worker fold, then merge |
-| `series build finalization`    | §4 `SeriesBuilder::finish()` (+ serial point sort) |
-| `blessing sidecar load`        | §3 history-mode blessing fetch (history only)     |
-| `re-baseline blessed series`   | §2 `apply_blessings`                              |
-| `change detection (find_changes …)` | §4 `find_changes_spawned` (per-series detect + FDR) |
-| `report render`                | §2 `render`                                       |
-
-The timing channel is *deliberately independent* of the per-object note stream. The
-notes emit one line per stored object; at stress scale (tens of thousands of objects)
-that flood would both bury the timings and distort the very wall clock being measured.
-So a programmatic caller can request timings alone: `AnalyzeOptions.timing` turns on the
-stage breakdown without the notes (the `--verbose` CLI flag turns on both). The stress
-harness (`cargo-bench-history-stress --verbose`) uses exactly this to surface the load
-breakdown while keeping its own measurement clean.
-
-Implementation: `report::Reporter::timing(stage, elapsed)` is the sink;
-`StderrReporter::with_timing(verbose, timing)` controls the two streams independently;
-the stage boundaries are timed with `Instant` in `analyze_with` and `select_dataset`.
-Keep the labels above in sync with the diagrams when stage boundaries move.
-
+`analyze --verbose` emits a per-stage wall-clock breakdown to standard error on a channel
+**deliberately independent** of the per-object note stream, so a mystery slowdown can be
+pinned to a specific stage of the diagrams above without reading the code. The independence
+matters at stress scale: the per-object notes emit one line per stored object, and tens of
+thousands of them would both bury the timings and distort the very wall clock being
+measured. A programmatic caller can therefore request the stage timings alone, without the
+note flood — which is exactly how the stress harness surfaces the load breakdown while
+keeping its own measurement clean.

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -741,7 +741,8 @@ struct WorkerFold {
 /// ~5% above the buffered-parallel variant; the win it buys is the ~10% faster wall
 /// time and better core use from moving the fold off the main thread. The decompress +
 /// JSON parse — the CPU-dominated cost — is spread across the runtime's worker threads.
-/// See `docs/DESIGN.md` decision 36.
+/// See the "Architecture" section of `docs/DESIGN.md` and the load section of
+/// `docs/analyze.md`.
 async fn fold_runs_chunked<S>(
     storage: &S,
     spawner: &Spawner,


### PR DESCRIPTION
## What

Consolidate the repo's design-documentation guidelines into a single
repo-scoped chapter, then bring the existing design docs into conformance
with it.

## New convention chapter

- **`docs/design.md`** (new): the canonical guidance for design docs — where
  they live (inline `//` comments; `package/docs/design.md` + per-component
  `componentN.md`), the high-level *patterns/tenets/relationships, what & why
  not how* rule, no listings/catalogues of types/functions, desired-end-state
  phrasing, and **no numbered/running decision log** (recording rejected
  alternatives inline is still fine).
- Wired into the root **`AGENTS.md`** table of contents.
- Removed the duplicated "Design documentation" section from
  **`docs/code-style.md`**.
- Deduped the **`packages/cargo-bench-history/AGENTS.md`** design-reference
  block to point at `docs/design.md` and drop the decision-log mandate.

## Conformed design docs

- **`packages/cargo-bench-history/docs/DESIGN.md`** (2301 → 715 lines): dropped
  the implementation plan and the 43-item numbered decision log; removed
  code-block catalogues, exhaustive field/type listings, and
  issue/iteration/decision cross-refs; kept the high-level design (tenets,
  relationships, the data-flow diagram, the analysis-modes table) and folded a
  few rejected alternatives inline as allowed `Considered and not adopted`
  notes.
- **`packages/cargo-bench-history/docs/analyze.md`** (364 → 188 lines): removed
  the decision-log references, the embedded Rust code block, specific benchmark
  measurement figures, and private-symbol/control-flow transcription;
  deduplicated the repeated fold/allocator narrative; kept the Mermaid flow
  diagrams and the concurrency-vs-parallelism pattern.

## Reference fixes

Repointed the five external references to the removed decision log (in both
packages' `AGENTS.md`, `cargo-bench-history-core/src/analyze/run_points.rs`,
and `cargo-bench-history/src/analyze/mod.rs`) at the relevant `DESIGN.md`
"Architecture" and `analyze.md` load sections. The Rust changes are
comment-only.

## Notes

Docs-only plus comment-only changes. All edited docs verified ≤100 columns; no
`decision N` / `§12` / `§13` / changelog / "in progress" language remains.
