### PR TITLE
Tidy cargo-bench-history report layout

### DIFF
--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -170,6 +170,14 @@ impl AnalysisContext {
             AnalysisMode::Tip => direction == Direction::Regression,
         }
     }
+
+    /// Whether this analysis reports improvements at all. `false` for the
+    /// regressions-only cases (history mode's default drift watch, and tip mode),
+    /// where an always-zero improvement tally is noise the report omits.
+    #[must_use]
+    pub fn reports_improvements(&self) -> bool {
+        self.keeps(Direction::Improvement)
+    }
 }
 
 /// Which detector produced a finding.
@@ -867,7 +875,7 @@ fn stamp_history(finding: &mut Finding, series: &Series) {
 }
 
 /// Abbreviates a commit SHA for display (first 12 hex digits).
-fn short_commit(commit: &str) -> String {
+pub(crate) fn short_commit(commit: &str) -> String {
     commit.get(..12).unwrap_or(commit).to_owned()
 }
 

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -13,6 +13,7 @@ use colored::{Color, Colorize};
 use rasciigraph::{Config, plot_colored, plot_many_colored};
 use serde::Serialize;
 
+use crate::analyze::findings::short_commit;
 use crate::analyze::{Direction, Finding, FindingMethod, SeriesValue};
 use crate::model::BenchmarkId;
 use crate::model::DiscriminantSet;
@@ -71,8 +72,18 @@ pub struct ReportInput<'a> {
     pub notable: bool,
     /// Total stored runs loaded across every set.
     pub runs: usize,
-    /// Total distinct series compared across every set.
+    /// Total distinct series compared across every set. Carried for the JSON report;
+    /// the text and Markdown reports omit it as an uninformative tally.
     pub series: usize,
+    /// The oldest and newest analyzed commit (full SHAs, first-parent order), so the
+    /// header can state the span of history the analysis covered. `None` when no run
+    /// entered the analysis.
+    pub commit_span: Option<(&'a str, &'a str)>,
+    /// Whether this analysis reports improvements. When `false` (history mode's
+    /// default regressions-only watch, and tip mode) the text and Markdown reports
+    /// omit the improvement tally, which would always be zero. The JSON report always
+    /// carries it.
+    pub report_improvements: bool,
     /// Every set's findings, globally ranked most-notable first.
     pub findings: &'a [Finding],
     /// The per-set breakdown, one entry per set that contributed data.
@@ -289,14 +300,21 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
     let _color = ColorOverride::force(color);
 
     let regressions = count_top(input.findings, Direction::Regression);
-    let improvements = count_top(input.findings, Direction::Improvement);
+
+    let mut header = vec![
+        format!("runs: {}", runs_with_span(input.runs, input.commit_span)),
+        format!("regressions: {regressions}"),
+    ];
+    if input.report_improvements {
+        header.push(format!(
+            "improvements: {}",
+            count_top(input.findings, Direction::Improvement)
+        ));
+    }
 
     let mut lines = vec![
         format!("Analyzed project {} ({} mode)", input.project, input.mode),
-        format!(
-            "  runs: {}  series: {}  regressions: {regressions}  improvements: {improvements}",
-            input.runs, input.series
-        ),
+        format!("  {}", header.join("  ")),
     ];
 
     if input.findings.is_empty() {
@@ -317,8 +335,8 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
             continue;
         }
         lines.push(String::new());
-        lines.push(format!("Set {}", set_label(summary.set)));
-        lines.push(set_counts_line(summary));
+        lines.push(set_label(summary.set));
+        lines.push(set_counts_line(summary, input.report_improvements));
         for finding in &summary.findings {
             push_finding_block(&mut lines, finding, chart_enabled);
         }
@@ -365,15 +383,37 @@ fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled:
 }
 
 /// The per-set summary line — the cheap tally the JSON `sets` block carries, shown
-/// under each set header so the text and Markdown reports surface it too.
-fn set_counts_line(summary: &SetSummary<'_>) -> String {
-    format!(
-        "  runs: {}  series: {}  regressions: {}  improvements: {}",
-        summary.runs,
-        summary.series,
-        count_direction(&summary.findings, Direction::Regression),
-        count_direction(&summary.findings, Direction::Improvement),
-    )
+/// under each set header so the text and Markdown reports surface it too. The
+/// improvement tally is omitted when the analysis does not report improvements.
+fn set_counts_line(summary: &SetSummary<'_>, report_improvements: bool) -> String {
+    let mut fields = vec![
+        format!("runs: {}", summary.runs),
+        format!(
+            "regressions: {}",
+            count_direction(&summary.findings, Direction::Regression)
+        ),
+    ];
+    if report_improvements {
+        fields.push(format!(
+            "improvements: {}",
+            count_direction(&summary.findings, Direction::Improvement)
+        ));
+    }
+    format!("  {}", fields.join("  "))
+}
+
+/// Formats the run tally with the analyzed commit span appended, so the report
+/// header states both how many runs entered the analysis and the stretch of history
+/// they cover. A single analyzed commit collapses the range to that one commit; with
+/// no runs the count stands alone.
+fn runs_with_span(runs: usize, span: Option<(&str, &str)>) -> String {
+    match span {
+        Some((first, last)) if first == last => format!("{runs} ({})", short_commit(first)),
+        Some((first, last)) => {
+            format!("{runs} ({} → {})", short_commit(first), short_commit(last))
+        }
+        None => runs.to_string(),
+    }
 }
 
 /// The plain-text detail body shared by the text and Markdown reports: the
@@ -496,17 +536,23 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
     let _color = ColorOverride::force(false);
 
     let regressions = count_top(input.findings, Direction::Regression);
-    let improvements = count_top(input.findings, Direction::Improvement);
 
     let mut lines = vec![
         format!("# Benchmark history analysis: {}", input.project),
         String::new(),
         format!("- Mode: {}", input.mode),
-        format!("- Runs analyzed: {}", input.runs),
-        format!("- Series compared: {}", input.series),
+        format!(
+            "- Runs analyzed: {}",
+            runs_with_span(input.runs, input.commit_span)
+        ),
         format!("- Regressions: {regressions}"),
-        format!("- Improvements: {improvements}"),
     ];
+    if input.report_improvements {
+        lines.push(format!(
+            "- Improvements: {}",
+            count_top(input.findings, Direction::Improvement)
+        ));
+    }
 
     if input.findings.is_empty() {
         lines.push(String::new());
@@ -527,18 +573,19 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
             continue;
         }
         lines.push(String::new());
-        lines.push(format!("## Set {}", set_label(summary.set)));
+        lines.push(format!("## {}", set_label(summary.set)));
         lines.push(String::new());
         lines.push(format!("- Runs: {}", summary.runs));
-        lines.push(format!("- Series: {}", summary.series));
         lines.push(format!(
             "- Regressions: {}",
             count_direction(&summary.findings, Direction::Regression)
         ));
-        lines.push(format!(
-            "- Improvements: {}",
-            count_direction(&summary.findings, Direction::Improvement)
-        ));
+        if input.report_improvements {
+            lines.push(format!(
+                "- Improvements: {}",
+                count_direction(&summary.findings, Direction::Improvement)
+            ));
+        }
         for finding in &summary.findings {
             push_finding_markdown(&mut lines, finding, chart_enabled);
         }
@@ -560,7 +607,7 @@ fn push_finding_markdown(lines: &mut Vec<String>, finding: &Finding, chart_enabl
         " _(recovered)_".to_owned()
     };
     lines.push(format!(
-        "**{}** — `{}` · {}{status}",
+        "**{}** — `{}` · `{}`{status}",
         format_percent(finding.relative_delta),
         describe_id(&finding.id),
         finding.kind.as_str(),
@@ -772,6 +819,8 @@ mod tests {
             notable: !findings.is_empty(),
             runs: findings.len().saturating_add(3),
             series: findings.len().max(1),
+            commit_span: None,
+            report_improvements: true,
             findings,
             sets: summaries,
             hint: None,
@@ -799,6 +848,8 @@ mod tests {
             notable: false,
             runs: 3,
             series: 1,
+            commit_span: None,
+            report_improvements: false,
             findings: &[],
             sets: &[],
             hint: None,
@@ -818,6 +869,8 @@ mod tests {
             notable: false,
             runs: 0,
             series: 0,
+            commit_span: None,
+            report_improvements: false,
             findings: &[],
             sets: &[],
             hint: Some("Found 2 stored runs ... dirty snapshots"),
@@ -836,7 +889,10 @@ mod tests {
         let input = single_set_input("folo", &set, &findings, &mut summaries);
         let report = render(&input, ReportFormat::Text, false);
         assert!(report.contains("regressions: 1"), "{report}");
-        assert!(report.contains("Set callgrind/"), "{report}");
+        assert!(
+            report.contains("callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            "the set heading drops the redundant `Set ` prefix: {report}"
+        );
         // The percentage leads the finding paragraph; severity is gone.
         assert!(report.contains("+30.00%"), "{report}");
         assert!(!report.contains("[major]"), "{report}");
@@ -869,6 +925,8 @@ mod tests {
             notable: true,
             runs: 99,
             series: 88,
+            commit_span: None,
+            report_improvements: true,
             findings: &findings,
             sets: &summaries,
             hint: None,
@@ -876,11 +934,12 @@ mod tests {
         };
         let report = render(&input, ReportFormat::Text, false);
         // The per-set counts line carries the set's own tallies, distinct from the
-        // top-level totals (`runs: 99  series: 88`).
+        // top-level totals (`runs: 99`). The series count is no longer surfaced.
         assert!(
-            report.contains("  runs: 7  series: 5  regressions: 1  improvements: 0"),
+            report.contains("  runs: 7  regressions: 1  improvements: 0"),
             "{report}"
         );
+        assert!(!report.contains("series:"), "{report}");
     }
 
     #[test]
@@ -982,15 +1041,15 @@ mod tests {
             "{report}"
         );
         assert!(
-            report.contains("## Set callgrind/x86_64-unknown-linux-gnu/synthetic"),
-            "{report}"
+            report.contains("## callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            "the set heading drops the redundant `Set ` prefix: {report}"
         );
         // The per-set tally mirrors the JSON metadata and the text header.
         assert!(report.contains("- Regressions: 1"), "{report}");
         // Findings render as bold-headline blocks, not a table.
         assert!(!report.contains("| Change | Direction |"), "{report}");
         assert!(
-            report.contains("**+30.00%** — `nm/nm::observe/pull` · instruction_count"),
+            report.contains("**+30.00%** — `nm/nm::observe/pull` · `instruction_count`"),
             "{report}"
         );
         // An active finding carries no recovered suffix.
@@ -1014,7 +1073,7 @@ mod tests {
         // The headline suffix flags a recovered finding; the shared detail line names
         // the recovery commit.
         assert!(
-            report.contains("· instruction_count _(recovered)_"),
+            report.contains("· `instruction_count` _(recovered)_"),
             "{report}"
         );
         assert!(report.contains("recovers at c4"), "{report}");
@@ -1058,6 +1117,8 @@ mod tests {
             notable: false,
             runs: 0,
             series: 0,
+            commit_span: None,
+            report_improvements: false,
             findings: &[],
             sets: &[],
             hint: Some("Found 2 stored runs ... commit your working tree"),
@@ -1076,6 +1137,8 @@ mod tests {
             notable: false,
             runs: 0,
             series: 0,
+            commit_span: None,
+            report_improvements: false,
             findings: &[],
             sets: &[],
             hint: Some("dirty snapshots on base-branch commits"),
@@ -1119,6 +1182,8 @@ mod tests {
             notable: false,
             runs: 1,
             series: 1,
+            commit_span: None,
+            report_improvements: false,
             findings: &[],
             sets: &[],
             hint: None,
@@ -1140,6 +1205,8 @@ mod tests {
             notable: false,
             runs: 0,
             series: 0,
+            commit_span: None,
+            report_improvements: false,
             findings: &[],
             sets: &[],
             hint: None,
@@ -1419,6 +1486,8 @@ mod tests {
             notable: true,
             runs: 10,
             series: 2,
+            commit_span: None,
+            report_improvements: false,
             findings: &findings,
             sets: &summaries,
             hint: None,
@@ -1458,6 +1527,8 @@ mod tests {
             notable: true,
             runs: 10,
             series: 2,
+            commit_span: None,
+            report_improvements: false,
             findings: &findings,
             sets: &summaries,
             hint: None,
@@ -1470,5 +1541,111 @@ mod tests {
             !report.contains("aarch64-apple-darwin"),
             "the empty set is skipped: {report}"
         );
+    }
+
+    #[test]
+    fn header_shows_the_analyzed_commit_span() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let mut input = single_set_input("folo", &set, &findings, &mut summaries);
+        input.runs = 12;
+        input.commit_span = Some(("a1b2c3d4e5f60000", "f6e5d4c3b2a10000"));
+
+        // Both ends abbreviate to 12 hex digits, joined by an arrow, so the reader can
+        // see the stretch of history the analysis covered.
+        let text = render(&input, ReportFormat::Text, false);
+        assert!(
+            text.contains("runs: 12 (a1b2c3d4e5f6 → f6e5d4c3b2a1)"),
+            "{text}"
+        );
+        let markdown = render(&input, ReportFormat::Markdown, false);
+        assert!(
+            markdown.contains("- Runs analyzed: 12 (a1b2c3d4e5f6 → f6e5d4c3b2a1)"),
+            "{markdown}"
+        );
+    }
+
+    #[test]
+    fn header_collapses_a_single_commit_span() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let mut input = single_set_input("folo", &set, &findings, &mut summaries);
+        input.runs = 1;
+        input.commit_span = Some(("abcdef0123456789", "abcdef0123456789"));
+
+        // One analyzed commit reads as a single anchor, not `x → x`.
+        let text = render(&input, ReportFormat::Text, false);
+        assert!(text.contains("runs: 1 (abcdef012345)"), "{text}");
+    }
+
+    #[test]
+    fn improvement_tally_is_omitted_when_improvements_are_not_reported() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let mut input = single_set_input("folo", &set, &findings, &mut summaries);
+        input.report_improvements = false;
+
+        // Neither the top-level header nor the per-set breakdown counts improvements
+        // when the analysis reports none (an always-zero tally).
+        let text = render(&input, ReportFormat::Text, false);
+        assert!(text.contains("regressions: 1"), "{text}");
+        assert!(!text.contains("improvements:"), "{text}");
+
+        let markdown = render(&input, ReportFormat::Markdown, false);
+        assert!(markdown.contains("- Regressions: 1"), "{markdown}");
+        assert!(!markdown.contains("- Improvements:"), "{markdown}");
+    }
+
+    #[test]
+    fn improvement_tally_is_shown_when_improvements_are_reported() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let mut input = single_set_input("folo", &set, &findings, &mut summaries);
+        input.report_improvements = true;
+
+        let text = render(&input, ReportFormat::Text, false);
+        assert!(text.contains("improvements: 0"), "{text}");
+        let markdown = render(&input, ReportFormat::Markdown, false);
+        assert!(markdown.contains("- Improvements: 0"), "{markdown}");
+    }
+
+    #[test]
+    fn series_tally_is_omitted_from_text_and_markdown_but_kept_in_json() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let input = single_set_input("folo", &set, &findings, &mut summaries);
+
+        let text = render(&input, ReportFormat::Text, false);
+        assert!(!text.contains("series:"), "{text}");
+        let markdown = render(&input, ReportFormat::Markdown, false);
+        assert!(!markdown.contains("- Series"), "{markdown}");
+
+        // JSON keeps the series count for machine consumers (e.g. the stress harness).
+        let json = render(&input, ReportFormat::Json, false);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["series"].is_number(), "{json}");
+        assert!(parsed["sets"][0]["series"].is_number(), "{json}");
+    }
+
+    #[test]
+    fn markdown_wraps_the_metric_name_in_inline_code() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let input = single_set_input("folo", &set, &findings, &mut summaries);
+
+        // The metric name is a keyword-like identifier, so Markdown renders it as inline
+        // code (backticks) rather than bare prose. The text report carries no such markup.
+        let markdown = render(&input, ReportFormat::Markdown, false);
+        assert!(markdown.contains("· `instruction_count`"), "{markdown}");
+
+        let text = render(&input, ReportFormat::Text, false);
+        assert!(text.contains("· instruction_count"), "{text}");
+        assert!(!text.contains("`instruction_count`"), "{text}");
     }
 }

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -267,6 +267,8 @@ where
         notable,
         runs: dataset.run_index.total(),
         series: series.len(),
+        commit_span: dataset.run_index.commit_span(),
+        report_improvements: context.reports_improvements(),
         findings: &findings,
         sets: &summaries,
         hint: hint.as_deref(),
@@ -507,6 +509,26 @@ impl RunIndex {
         &self,
     ) -> impl Iterator<Item = (&DiscriminantSet, &BTreeMap<usize, CommitCounts>)> {
         self.sets.iter()
+    }
+
+    /// The oldest and newest commit that contributed a run, by first-parent
+    /// topological position, as `(first, last)` full SHAs. `None` when no run was
+    /// admitted. The report header uses it to state the span of analyzed history.
+    pub(crate) fn commit_span(&self) -> Option<(&str, &str)> {
+        let mut first: Option<(usize, &str)> = None;
+        let mut last: Option<(usize, &str)> = None;
+        for by_commit in self.sets.values() {
+            for (&topo_index, counts) in by_commit {
+                let commit = counts.commit.as_str();
+                if first.is_none_or(|(index, _)| topo_index < index) {
+                    first = Some((topo_index, commit));
+                }
+                if last.is_none_or(|(index, _)| topo_index > index) {
+                    last = Some((topo_index, commit));
+                }
+            }
+        }
+        Some((first?.1, last?.1))
     }
 }
 
@@ -3529,6 +3551,54 @@ mod tests {
                 .collect::<Vec<_>>()
         };
         assert_eq!(summarize(&first), summarize(&reference));
+    }
+
+    #[test]
+    fn commit_span_spans_the_oldest_and_newest_analyzed_commit() {
+        let set = DiscriminantSet {
+            engine: "criterion".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        };
+        let other_set = DiscriminantSet {
+            engine: "callgrind".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        };
+
+        let mut index = RunIndex::new();
+        assert_eq!(index.commit_span(), None, "an empty index spans nothing");
+
+        // Record out of topological order and across two sets: the span must key off
+        // the first-parent position, not the insertion order, and must consider every
+        // set so the header covers the whole analyzed history.
+        index.record(&set, 2, "c2", false);
+        index.record(&set, 0, "c0", false);
+        index.record(&other_set, 1, "c1", false);
+
+        assert_eq!(
+            index.commit_span(),
+            Some(("c0", "c2")),
+            "the span runs from the lowest to the highest topological position"
+        );
+    }
+
+    #[test]
+    fn commit_span_collapses_to_a_single_commit() {
+        let set = DiscriminantSet {
+            engine: "criterion".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        };
+        let mut index = RunIndex::new();
+        index.record(&set, 0, "solo", false);
+        index.record(&set, 0, "solo", true);
+
+        assert_eq!(
+            index.commit_span(),
+            Some(("solo", "solo")),
+            "a single analyzed commit is both ends of the span"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Tidies the `cargo-bench-history` analyze **report layout** (text + Markdown),
leaving the JSON report unchanged since it is a machine contract the stress
harness consumes.

## Changes

- **Drop the redundant `Set` prefix** from discriminant-set headings: text
  `Set callgrind/…` → `callgrind/…`; Markdown `## Set …` → `## …`.
- **Omit the improvements tally when improvements are not reported** (history
  mode's default regressions-only watch, and tip mode). Gated on
  `AnalysisContext::reports_improvements()`, so branch mode and
  `--include-improvements` still show it. Applies to both the header and each
  per-set line.
- **Add the analyzed commit span to the header**: "Runs analyzed" now reads
  e.g. `12 (a1b2c3d4e5f6 → f6e5d4c3b2a1)`, collapsing to a single anchor when
  only one commit was analyzed. Sourced from a new `RunIndex::commit_span()`.
- **Remove the "series compared" tally** from the text and Markdown reports
  (kept in JSON).
- **Escape the metric name as inline code in Markdown**: the keyword-like
  metric identifier is now rendered in backticks, e.g.
  ``**+30.00%** — `nm/nm::observe/pull` · `instruction_count` ``.

## Why JSON is untouched

`cargo-bench-history-stress` deserializes the `runs`/`series`/`regressions`/
`improvements` fields from the analyze `--json` output, so those fields stay
stable. The tidy-up is scoped to the human-facing layout.

## Validation

- `cargo-bench-history-core` report tests (incl. 6 new) and
  `cargo-bench-history` analyze tests (incl. 2 new `commit_span` tests) pass.
- Full test suites for both packages pass; `cargo clippy --all-targets` is clean.
