### PR TITLE
Suppress analyze findings below a 1% basic noise floor

### DIFF
--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -1,15 +1,16 @@
 //! The finding algorithms: locate *sustained* level shifts and slow drifts in
 //! each series and flag only those that survive engine-aware significance,
-//! practical-magnitude, and false-discovery gates.
+//! practical-magnitude, and false-discovery gates, then a basic noise filter that
+//! drops any move below a minimum relative magnitude regardless of engine.
 //!
 //! The design deliberately distinguishes the two engine families this tool
 //! records:
 //!
 //! * **Deterministic** engines (Callgrind: instruction counts, estimated cycles,
 //!   cache hits, branch counts; `alloc_tracker`: allocations) produce noise-free
-//!   numbers. A real step is real no matter how small, so a deterministic change
-//!   is flagged on persistence alone — no significance test, no false-discovery
-//!   correction.
+//!   numbers. A real step is flagged on persistence alone — no significance test, no
+//!   false-discovery correction — provided it clears the basic noise floor: a sub-1%
+//!   move is meaningless even when exact, so it is still suppressed.
 //! * **Noisy** engines (Criterion wall time, `all_the_time` processor time) jitter
 //!   from run to run. A move is flagged only when a Pettitt change-point locates a
 //!   split that a Mann–Whitney rank test then confirms, the confidence intervals of
@@ -70,6 +71,14 @@ pub struct AnalysisConfig {
     /// Multiple of the per-measurement noise floor a noisy branch/tip move with too
     /// few points to rank-test must exceed before it is trusted.
     pub branch_noise_multiple: f64,
+    /// Minimum relative magnitude (1%) any finding must reach to be reported, applied
+    /// as a final basic noise filter across every detector and engine. Even at full
+    /// statistical confidence a sub-1% move is treated as measurement noise: it is too
+    /// small to be worth a human's attention, so it is suppressed regardless of
+    /// direction. This floor sits below the per-engine practical-magnitude floors
+    /// (`practical_relative`, `branch_practical_relative`), which already exceed it for
+    /// noisy engines; it is what gates the otherwise-unbounded deterministic engines.
+    pub noise_floor: f64,
 }
 
 impl Default for AnalysisConfig {
@@ -84,6 +93,7 @@ impl Default for AnalysisConfig {
             compare_window: 8,
             branch_practical_relative: 0.05,
             branch_noise_multiple: 2.0,
+            noise_floor: 0.01,
         }
     }
 }
@@ -1068,6 +1078,14 @@ fn finalize_findings(
                 source_index,
                 ..
             } = candidate;
+            // Basic noise filter: a sub-`noise_floor` move is measurement noise even at
+            // full confidence, so it is suppressed regardless of direction or engine.
+            // This gates the otherwise-unbounded deterministic engines and backstops the
+            // per-engine practical-magnitude floors. Applied before charting points are
+            // materialised so a dropped finding never pays for them.
+            if finding.relative_delta.abs() < config.noise_floor {
+                return None;
+            }
             if !context.keeps(finding.direction) {
                 return None;
             }
@@ -1602,14 +1620,34 @@ mod tests {
     }
 
     #[test]
-    fn deterministic_tiny_exact_step_is_still_flagged() {
-        // A one-instruction step is real on a deterministic engine, so it flags
-        // despite being far below any practical-magnitude floor.
+    fn deterministic_step_below_the_noise_floor_is_suppressed() {
+        // A one-instruction step is real on a deterministic engine, but a sub-1% move
+        // is meaningless even at full confidence, so the basic noise filter suppresses
+        // it: 1000 -> 1001 is a 0.1% move.
         let series = series_of(&[1000.0, 1000.0, 1000.0, 1001.0, 1001.0, 1001.0]);
+        assert!(changes(&[series]).is_empty());
+    }
+
+    #[test]
+    fn deterministic_step_at_the_noise_floor_is_flagged() {
+        // The noise floor is a strict `<` rejection, so a deterministic step whose
+        // relative move EQUALS the 1% floor is still reported: 1000 -> 1010 is exactly
+        // a 1% move.
+        let series = series_of(&[1000.0, 1000.0, 1000.0, 1010.0, 1010.0, 1010.0]);
         let finding = only(changes(&[series]));
         assert_eq!(finding.method, FindingMethod::ChangePoint);
-        assert_eq!(finding.delta, 1.0);
+        assert_eq!(finding.delta, 10.0);
+        assert!((finding.relative_delta - 0.01).abs() <= 1e-9);
         assert_eq!(finding.confidence, 1.0);
+    }
+
+    #[test]
+    fn sub_noise_floor_improvement_is_also_suppressed() {
+        // The noise filter applies in any direction: a sub-1% improvement on a
+        // deterministic engine is just as meaningless as a sub-1% regression, so
+        // 1000 -> 999 (a 0.1% drop) raises nothing.
+        let series = series_of(&[1000.0, 1000.0, 1000.0, 999.0, 999.0, 999.0]);
+        assert!(changes(&[series]).is_empty());
     }
 
     #[test]

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -359,13 +359,18 @@ being analyzed:
   the **Mann–Kendall** / **Theil–Sen** pair. When both fire, the better-fitting model
   wins (step vs line residual). Both regimes of a change-point need `min_regime`
   points (persistence — a single blip never flags). A deterministic step flags on
-  persistence alone (any non-zero step is real). A noisy change additionally requires
+  persistence alone (any real step counts), subject only to the basic noise floor below.
+  A noisy change additionally requires
   a significant **Mann–Whitney** rank test, non-overlapping regime CIs (when present —
   both Criterion and `all_the_time` report a bootstrap CI, so the gate applies to
   both; only older mean-only output skips it),
   and a practical-magnitude floor; a noisy drift also clears a noise floor of twice
   the median CI half-width. Noisy candidates pass a **Benjamini–Hochberg** FDR filter;
-  deterministic ones bypass it. **Pettitt only locates the split — its analytic
+  deterministic ones bypass it. Underneath every engine's gates, a single **basic noise
+  floor** (`AnalysisConfig::noise_floor`, 1%) drops any finding whose `|relative_delta|`
+  is below it, regardless of direction, engine, or confidence — a sub-percent move is
+  meaningless even when exact, and this is what bounds the deterministic path.
+  **Pettitt only locates the split — its analytic
   p-value is too conservative on short series, so it is never used as a significance
   gate.** All math lives in pure, Miri-safe `analyze::stats`; keep it deterministic
   and cover boundaries with named value-asserting tests, not threshold guards. When

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -537,7 +537,7 @@ smooth ramps to drift, and the two never double-report one event.
 ### 8.2 Engine-aware gating
 
 For a **deterministic** series a change-point is reported once both regimes reach the
-persistence minimum and their medians differ at all — no significance test and no
+persistence minimum and their medians differ — no significance test and no
 multiple-comparison filter, which would wrongly drop genuine small exact steps.
 
 For a **noisy** series the Pettitt test is used only to *locate* the split (its analytic
@@ -549,6 +549,13 @@ wobble stays silent. Drift additionally requires the endpoint movement to exceed
 floor derived from the confidence-interval width, so run-to-run jitter never reads as a
 trend. When an engine reports no confidence interval (older mean-only output), the
 CI-non-overlap gate is skipped and the decision rests on the rank and trend tests alone.
+
+Underneath every engine's gates sits one **basic noise floor**: any finding whose relative
+move is below a minimum magnitude is dropped regardless of direction, engine, or
+confidence. A sub-percent change is not worth a human's attention even when a deterministic
+engine reports it with certainty, so this floor is what keeps the otherwise-unbounded
+deterministic path from surfacing trivia; it sits below the noisy engines' higher
+practical-magnitude floors, which already subsume it.
 
 ### 8.3 Multiple-comparison discipline
 

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -583,6 +583,12 @@ async fn analyze_callgrind_step_below_the_noise_floor_is_suppressed() {
         parsed["regressions"], 0,
         "a 0.1% deterministic step is below the 1% noise floor and must not flag: {report}"
     );
+    let findings = parsed["findings"].as_array().expect("findings is an array");
+    assert!(
+        findings.is_empty(),
+        "the sub-floor move is fully suppressed, so no finding of any direction reaches \
+         the report: {report}"
+    );
 }
 
 /// A Callgrind series that steps up by 2% - above the 1% basic noise filter yet

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -556,14 +556,13 @@ async fn analyze_criterion_slow_drift_is_flagged_as_drift() {
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
 }
 
-/// A Callgrind series whose instruction count steps up by a single count - far
-/// below the 3% practical floor a noisy engine demands - is still flagged, because
-/// deterministic engines carry no measurement noise and trust any sustained step.
-/// This proves the engine-aware split: the same tiny move would be discarded as
-/// noise on a Criterion series but is a real change on a deterministic one.
+/// A Callgrind series whose instruction count steps up by a single count - a 0.1%
+/// move - is suppressed by the basic 1% noise filter even though the engine is
+/// deterministic and reports the step with certainty. A sub-percent change is
+/// meaningless regardless of confidence, so it never reaches the report.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_callgrind_tiny_deterministic_step_is_flagged() {
+async fn analyze_callgrind_step_below_the_noise_floor_is_suppressed() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
     workspace.seed_callgrind("c1", 1000.0);
@@ -581,8 +580,38 @@ async fn analyze_callgrind_tiny_deterministic_step_is_flagged() {
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
+        parsed["regressions"], 0,
+        "a 0.1% deterministic step is below the 1% noise floor and must not flag: {report}"
+    );
+}
+
+/// A Callgrind series that steps up by 2% - above the 1% basic noise filter yet
+/// still below the 3% practical-magnitude floor a *noisy* engine would demand - is
+/// flagged, because deterministic engines carry no measurement noise and trust any
+/// sustained step that clears the basic floor. This proves the engine-aware split:
+/// the same 2% move would be discarded as noise on a Criterion series.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_callgrind_deterministic_step_above_the_noise_floor_is_flagged() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 1000.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.seed_callgrind("c2", 1000.0);
+    workspace.commit_dated("2024-01-03", "c3");
+    workspace.seed_callgrind("c3", 1000.0);
+    workspace.commit_dated("2024-01-04", "c4");
+    workspace.seed_callgrind("c4", 1020.0);
+    workspace.commit_dated("2024-01-05", "c5");
+    workspace.seed_callgrind("c5", 1020.0);
+    workspace.commit_dated("2024-01-06", "c6");
+    workspace.seed_callgrind("c6", 1020.0);
+
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
         parsed["regressions"], 1,
-        "a one-count deterministic step is real and must flag below the noise floor: {report}"
+        "a 2% deterministic step clears the 1% noise floor and must flag: {report}"
     );
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
@@ -590,14 +619,15 @@ async fn analyze_callgrind_tiny_deterministic_step_is_flagged() {
 
 /// An `alloc_tracker` series whose allocated-bytes count steps up is flagged as a
 /// `change_point`: allocation statistics are a deterministic property of the code,
-/// so - like Callgrind instruction counts - any sustained step is a real change,
-/// trusted below the noise floor a noisy engine would demand.
+/// so - like Callgrind instruction counts - a sustained step that clears the basic
+/// noise floor is a real change, even when it stays below the practical-magnitude
+/// floor a noisy engine would demand.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_alloc_tracker_step_is_flagged_as_change_point() {
     let workspace = Workspace::repo(&storage_only_config());
-    // A flat allocated-bytes baseline that steps up by one byte at the fourth
-    // commit; the allocation count stays constant throughout.
+    // A flat allocated-bytes baseline that steps up by 2% at the fourth commit; the
+    // allocation count stays constant throughout.
     workspace.commit_dated("2024-03-01", "a1");
     workspace.seed_alloc_tracker("a1", "allocate_vec", 200.0, 2.0);
     workspace.commit_dated("2024-03-02", "a2");
@@ -605,17 +635,17 @@ async fn analyze_alloc_tracker_step_is_flagged_as_change_point() {
     workspace.commit_dated("2024-03-03", "a3");
     workspace.seed_alloc_tracker("a3", "allocate_vec", 200.0, 2.0);
     workspace.commit_dated("2024-03-04", "a4");
-    workspace.seed_alloc_tracker("a4", "allocate_vec", 201.0, 2.0);
+    workspace.seed_alloc_tracker("a4", "allocate_vec", 204.0, 2.0);
     workspace.commit_dated("2024-03-05", "a5");
-    workspace.seed_alloc_tracker("a5", "allocate_vec", 201.0, 2.0);
+    workspace.seed_alloc_tracker("a5", "allocate_vec", 204.0, 2.0);
     workspace.commit_dated("2024-03-06", "a6");
-    workspace.seed_alloc_tracker("a6", "allocate_vec", 201.0, 2.0);
+    workspace.seed_alloc_tracker("a6", "allocate_vec", 204.0, 2.0);
 
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["regressions"], 1,
-        "a one-byte deterministic step is real and must flag: {report}"
+        "a 2% deterministic step clears the noise floor and must flag: {report}"
     );
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");


### PR DESCRIPTION
## What

Adds a global **1% basic noise floor** to `cargo-bench-history analyze`. Even at 100% confidence, a change of less than 1% is meaningless, so any finding whose relative magnitude is below 1% in either direction is now suppressed.

## Why

Deterministic engines (Callgrind, `alloc_tracker`) previously flagged *any* sustained non-zero step, no matter how small — a one-instruction or one-byte move would surface as a finding. That is noise, not signal.

## How

- New `AnalysisConfig::noise_floor` field (default `0.01`).
- Applied once in `finalize_findings` — the shared tail of both the serial and spawner-distributed detection passes — so it covers **every** detector (change-point, drift, spike, branch, tip) and **both** engine families. The check runs before charting points are materialized, so a dropped finding pays no extra cost.
- It sits *below* the existing per-engine practical-magnitude floors (`practical_relative` 3%, `branch_practical_relative` 5%), which already exceed it for noisy engines; its job is to bound the otherwise-unbounded deterministic path.

## Tests

- Unit: rewrote the old "tiny deterministic step still flags" test into a suppression test, plus a boundary test (exactly 1% still flags — strict `<`) and an improvement-direction suppression test.
- Integration: updated `analyze_callgrind_*` / `analyze_alloc_tracker_*` — a sub-1% deterministic step is now suppressed; added a positive test that a 2%-but-below-3% deterministic step still flags (preserving the engine-aware split).

## Validation

`just package="cargo-bench-history-core cargo-bench-history" validate-local` passes (format-check, check, clippy, test, test-docs, docs, miri, machete, default-features dev+release).
