### PR TITLE
Add the `examine` command to cargo-bench-history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,15 @@ directly:
 * **Check for a package-local `AGENTS.md`** before doing nontrivial work in a
   specific crate (e.g. `packages/events_once/AGENTS.md`). Package-local
   guidance refines and sometimes overrides the workspace-wide rules.
+* **`AGENTS.md` files are agent instructions, not design docs.** A package-local
+  `AGENTS.md` holds only actionable guidance for working in that package —
+  conventions to follow, gotchas, invariants to preserve, how to run and test.
+  It must **not** duplicate design documentation (that lives in the
+  `docs/design.md`-style files), restate implementation detail, or keep a
+  decision/change history. If a fact explains *what* the code is or *why* it is
+  shaped that way, it belongs in a design doc; if it is trivia that does not
+  change how an agent works, leave it out. Point at the design doc instead of
+  repeating it.
 
 ## Chapters
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tick",
  "tokio",
 ]
 

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -2426,6 +2426,24 @@ mod tests {
     }
 
     #[test]
+    fn reports_improvements_reflects_the_mode() {
+        let context = |mode, include_improvements| AnalysisContext {
+            mode,
+            config: AnalysisConfig::default(),
+            merge_base_index: None,
+            include_improvements,
+            include_inactive: false,
+        };
+        // History reports improvements only when opted in; branch always compares
+        // both directions; tip (regressions-only) never reports them. Pinning both a
+        // true and a false case keeps the flag from collapsing to a constant.
+        assert!(!context(AnalysisMode::History, false).reports_improvements());
+        assert!(context(AnalysisMode::History, true).reports_improvements());
+        assert!(context(AnalysisMode::Branch, false).reports_improvements());
+        assert!(!context(AnalysisMode::Tip, false).reports_improvements());
+    }
+
+    #[test]
     fn resolved_spike_at_the_minimum_length_reports_the_deviation() {
         // Exactly min_regime * 3 (6) points is the shortest detectable spike; the
         // `n < min * 3` gate must be a strict `<`. The plateau (20) deviates from the

--- a/packages/cargo-bench-history-core/src/analyze/mod.rs
+++ b/packages/cargo-bench-history-core/src/analyze/mod.rs
@@ -23,7 +23,7 @@ pub use findings::{
     find_changes_spawned,
 };
 pub use parallel::{balanced_chunk_sizes, worker_count};
-pub use report::{ReportFormat, ReportInput, SetSummary, render};
+pub use report::{ReportFormat, ReportInput, SetSummary, format_value, render};
 pub use run_points::{MetricPoint, ResultPoints, RunPoints};
 pub use selection::{SelectedCommit, select_commits};
 pub use series::{

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -662,7 +662,8 @@ fn describe_id(id: &BenchmarkId) -> String {
 /// `96.7664` becomes `96.77`, `0.000001234` keeps all four (`0.000001234`), and a
 /// large `1234567.89` drops its fraction entirely (`1234568`). Trailing zeros are
 /// trimmed. The machine-readable JSON keeps full precision.
-fn format_value(value: f64) -> String {
+#[must_use]
+pub fn format_value(value: f64) -> String {
     if value.fract().abs() <= f64::EPSILON {
         return format!("{value:.0}");
     }

--- a/packages/cargo-bench-history-core/src/model/metric.rs
+++ b/packages/cargo-bench-history-core/src/model/metric.rs
@@ -103,6 +103,27 @@ pub enum MetricKind {
 }
 
 impl MetricKind {
+    /// Every metric kind, in declaration order.
+    ///
+    /// The single source of truth for enumerating the kinds — used to list the
+    /// valid names when a name lookup fails (see [`from_name`](Self::from_name))
+    /// and to exercise every kind in tests.
+    pub const ALL: [Self; 13] = [
+        Self::WallTime,
+        Self::ProcessorTime,
+        Self::InstructionCount,
+        Self::EstimatedCycles,
+        Self::L1CacheHits,
+        Self::LastLevelCacheHits,
+        Self::RamHits,
+        Self::ConditionalBranches,
+        Self::ConditionalBranchMisses,
+        Self::IndirectBranches,
+        Self::IndirectBranchMisses,
+        Self::AllocatedBytes,
+        Self::AllocationCount,
+    ];
+
     /// The stable `snake_case` label for this kind, matching its serialized wire
     /// name. Used as the metric's display name in reports.
     #[must_use]
@@ -122,6 +143,14 @@ impl MetricKind {
             Self::AllocatedBytes => "allocated_bytes",
             Self::AllocationCount => "allocation_count",
         }
+    }
+
+    /// Parses a stable `snake_case` metric name (as produced by
+    /// [`as_str`](Self::as_str)) back into its kind, or `None` when the name is
+    /// not one of the known metrics.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|kind| kind.as_str() == name)
     }
 
     /// The unit this kind is always measured in, for display.
@@ -180,26 +209,24 @@ mod tests {
     fn metric_kind_wire_name_matches_as_str() {
         // The kinds round-trip through stored JSON, so the serialized wire name
         // and the display label must stay in lockstep.
-        for kind in [
-            MetricKind::WallTime,
-            MetricKind::ProcessorTime,
-            MetricKind::InstructionCount,
-            MetricKind::EstimatedCycles,
-            MetricKind::L1CacheHits,
-            MetricKind::LastLevelCacheHits,
-            MetricKind::RamHits,
-            MetricKind::ConditionalBranches,
-            MetricKind::ConditionalBranchMisses,
-            MetricKind::IndirectBranches,
-            MetricKind::IndirectBranchMisses,
-            MetricKind::AllocatedBytes,
-            MetricKind::AllocationCount,
-        ] {
+        for kind in MetricKind::ALL {
             let json = serde_json::to_string(&kind).unwrap();
             assert_eq!(json, format!("\"{}\"", kind.as_str()));
             let parsed: MetricKind = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed, kind);
         }
+    }
+
+    #[test]
+    fn from_name_round_trips_every_kind_and_rejects_unknown() {
+        for kind in MetricKind::ALL {
+            assert_eq!(MetricKind::from_name(kind.as_str()), Some(kind));
+        }
+        assert_eq!(MetricKind::from_name("not_a_metric"), None);
+        assert_eq!(MetricKind::from_name(""), None);
+        // The match is exact, not a prefix or case-insensitive one.
+        assert_eq!(MetricKind::from_name("Instruction_Count"), None);
+        assert_eq!(MetricKind::from_name("instruction"), None);
     }
 
     #[test]
@@ -214,20 +241,10 @@ mod tests {
     #[test]
     fn only_l1_cache_hits_is_higher_is_better() {
         assert!(MetricKind::L1CacheHits.higher_is_better());
-        for kind in [
-            MetricKind::WallTime,
-            MetricKind::ProcessorTime,
-            MetricKind::InstructionCount,
-            MetricKind::EstimatedCycles,
-            MetricKind::LastLevelCacheHits,
-            MetricKind::RamHits,
-            MetricKind::ConditionalBranches,
-            MetricKind::ConditionalBranchMisses,
-            MetricKind::IndirectBranches,
-            MetricKind::IndirectBranchMisses,
-            MetricKind::AllocatedBytes,
-            MetricKind::AllocationCount,
-        ] {
+        for kind in MetricKind::ALL
+            .into_iter()
+            .filter(|kind| *kind != MetricKind::L1CacheHits)
+        {
             assert!(!kind.higher_is_better(), "{kind:?}");
         }
     }

--- a/packages/cargo-bench-history-stress/Cargo.toml
+++ b/packages/cargo-bench-history-stress/Cargo.toml
@@ -22,6 +22,7 @@ nonempty = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+tick = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "rt-multi-thread"] }
 
 [dev-dependencies]

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -18,6 +18,7 @@ use cargo_bench_history::{
 };
 use jiff::Timestamp;
 use serde::Deserialize;
+use tick::Clock;
 
 use crate::cli::ModeArg;
 use crate::error::{Error, fail};
@@ -284,7 +285,7 @@ fn overrides(workspace: &Path, anchor: Timestamp) -> Overrides {
         workspace_dir: Some(workspace.to_path_buf()),
         target_root: None,
         bench_command: None,
-        now: Some(anchor),
+        clock: Some(Clock::new_frozen_at(anchor)),
         storage_override: None,
     }
 }
@@ -309,7 +310,10 @@ mod tests {
         // measurement read synthetic data at a reproducible "now"; the other
         // overrides stay unset so production defaults apply.
         assert_eq!(overrides.workspace_dir.as_deref(), Some(workspace));
-        assert_eq!(overrides.now, Some(anchor));
+        assert_eq!(
+            overrides.clock.map(|c| c.system_time_as::<Timestamp>()),
+            Some(anchor)
+        );
         assert!(overrides.target_root.is_none());
         assert!(overrides.bench_command.is_none());
     }

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -1,1133 +1,143 @@
 # Agent notes for cargo-bench-history
 
-This is an async-by-default Tokio application. The architecture keeps all pure
-logic (parsing, mapping, comparability, key derivation, message formatting)
-synchronous and pushes async only to the IO edges, each modelled as a small
-"port" trait with a real Tokio adapter and an in-`#[cfg(test)]` in-memory fake.
+An async-by-default Tokio application. **All pure logic** (parsing, mapping, comparability,
+key derivation, analysis, message formatting) stays **synchronous**; async is pushed only to
+the IO edges. The code is **two crates**: this shell (CLI + IO adapters) and the pure,
+I/O-free `cargo-bench-history-core` (data model, analysis, codec), which also acts as the
+impl crate for in-workspace tests/benches.
 
-> **Design reference:** [`docs/DESIGN.md`](docs/DESIGN.md) is the canonical, **high-level**
-> design document — the data model, comparability/storage rules, command semantics,
-> analysis algorithms, and the two-crate (shell + `cargo-bench-history-core`) architecture.
-> Keep it up to date whenever you change a design
-> decision, the data model, the crate layout, the storage format, or a command's
-> behaviour. It follows the workspace design-documentation conventions in
-> [`../../docs/design.md`](../../docs/design.md) — describe patterns, concepts, and
-> relationships, *what* exists and *why*, never *how* it is coded.
+> **This file is agent instructions, not a design doc.** The *what* and *why* — data model,
+> storage/comparability rules, command semantics, analysis algorithms, architecture — live in
+> [`docs/DESIGN.md`](docs/DESIGN.md), and the `analyze` load/detect flow in
+> [`docs/analyze.md`](docs/analyze.md). **Keep both in sync** when you change a design
+> decision, the data model, the crate layout, the storage format, a command's behaviour, or
+> the analyze pipeline. Do not restate their content here — point at them.
 
 ## Ports and fakes
 
-The orchestrator (`commands::collect::execute_collect`) is generic over its ports and is
-driven in tests by fakes, never by real IO:
+Every IO edge is a small **port trait** (RPITIT — `impl Future` return, no `async_trait`)
+with a real Tokio adapter and an in-`#[cfg(test)]` in-memory fake, so orchestration runs
+against fakes under `block_on` (Miri-safe, no runtime). The ports:
 
-* `process::BenchRunner` — real `TokioBenchRunner` runs the benchmark command's
-  argv directly (no shell — `argv[0]` is the program and the rest are passed
-  verbatim, so forwarded arguments survive spaces and quotes intact); fake
-  `FakeRunner` records the argv and reports a canned exit status.
-* `probe::EnvironmentProbe` — real `SystemProbe` (shells `git`/`rustc`, and
-  reads the local hardware profile via `machine::system_profile`); fake
-  `FakeProbe` returns canned `GitInfo`/`RustcInfo`/`HardwareProfile`.
-* `bench_output::BenchOutputSource` — real `FsBenchOutputSource` walks the
-  engine's output tree and returns a `Harvest` enum: `Harvest::Callgrind` from
-  `target/gungraun/**/summary.json`, `Harvest::Criterion` from
-  `target/criterion/**/new/{benchmark,estimates}.json` (only `new/` dirs holding
-  both files), `Harvest::AllocTracker` from `target/alloc_tracker/*.json` and
-  `Harvest::AllTheTime` from `target/all_the_time/*.json` (the two flat
-  one-file-per-operation trees, scanned by `collect_flat`) — all `mtime`-scoped to
-  the run. Fake `FakeOutput` is engine-aware and returns in-memory `RawSummary`,
-  `RawCriterionCase` or `RawOperationFile` values.
-* `storage::Storage` — real `LocalStorage` and `AzureBlobStorage`, selected at
-  runtime by the `StorageFacade` enum that
-  `build_storage(local, config, base, cache)` returns (the optional `cache`
-  directory wraps an `Azure` backend in the read-through `CachingStorage` decorator —
-  the `CachedAzure` variant — whose mirror is rooted under `<cache>` at a per-backend
-  subpath (`<cache>/<account>/<container>`, so distinct backends never share one image)
-  and faithfully images the cloud namespace under identical keys); fake `MemoryStorage`.
-  `put` is **write-once** (an
-  existing key yields `StorageError::AlreadyExists`); `put_overwrite` is the
-  replacing escape hatch used only by `collect --overwrite` (and, later, `backfill
-  --overwrite`). A `put_overwrite`/`delete` also arms the backend's
-  cache-invalidation marker, flushed once per command. See [Storage
-  selection](#storage-selection-local--cloud-config) for how a command picks a backend.
-* `config_writer::ConfigWriter` — real `TokioConfigWriter` (creates parent dirs,
-  `create_new` so an existing file is never clobbered); fake `MemoryConfigWriter`.
-  Used by `commands::install::execute_install`. Its real adapter's IO error paths
-  are covered by `#[cfg_attr(miri, ignore)]` real-filesystem tests in
-  `config_writer::real_writer_tests` (blocked parent, interior-NUL open error).
+* `process::BenchRunner` — runs the bench argv directly (no shell).
+* `probe::EnvironmentProbe` — shells `git`/`rustc`, reads the hardware profile.
+* `bench_output::BenchOutputSource` — harvests each engine's output tree, `mtime`-scoped.
+* `storage::Storage` — `LocalStorage`/`AzureBlobStorage`, selected by `build_storage` into a
+  `StorageFacade`; `MemoryStorage` fake. `put` is **write-once** (`AlreadyExists`);
+  `put_overwrite`/`delete` are the escape hatches and arm the cache-invalidation marker.
+* `config_writer::ConfigWriter` — `install`'s config-file writer (`create_new`).
+* `git_history::GitHistory` — read-only commit topology (`resolve`, `default_branch`,
+  `merge_base`, `first_parent`, `committer_time`, `is_dirty`). `first_parent` pairs each SHA
+  with its committer date and subject; `FakeGitHistory` models a canned graph.
 
-When you add a new IO edge, follow the same pattern: a port trait with an
-`impl Future` return (RPITIT, no `async_trait`), a real adapter, and a fake.
+**When you add an IO edge, follow the same pattern.** Never call `SystemTime::now()` in
+orchestration — time comes from the injected `tick::Clock` (`new_tokio` in production,
+`new_frozen_at` in tests). Never insert real-time delays in tests.
 
-## CLI structure (clap derive + argument groups)
+## Compute fan-out
 
-The CLI is built with **clap** (derive API). It was chosen over `argh` because the
-command surface is wide and `argh` cannot group flags under named headings; clap's
-`help_heading` lets each command's `--help` present functionally grouped sections.
-The other workspace cargo tools (`cargo-detect-package`/`cargo-freeze-deps`) also use
-clap, but their CLIs are trivial — do **not** assume they share this crate's grouped
-argument conventions.
+Do **not** spawn ad-hoc threads (`std::thread::scope`, `map_parallel`-style helpers) for
+compute. Route every parallel pass through the injected `anyspawn::Spawner` that
+`analyze_with` threads through: production injects the Tokio blocking pool, tests inject
+`cargo_bench_history_core::testing::synchronous_spawner` (reached via core's
+`private-test-util` dev-dependency feature), so the work stays runtime-agnostic and Miri-safe.
+New per-series logic must be side-effect-free. Flow and rationale: [`docs/analyze.md`](docs/analyze.md).
 
-Flags are organised into functional groups, applied via `#[command(flatten)]` shared
-arg structs so a group looks identical everywhere it appears (and so analyze/list/
-prune stay in selection lockstep automatically — see those sections):
+## Selection lockstep (analyze / list / prune / examine)
 
-* **Environment & execution** — `--config`, `--repo`, `--verbose`.
-* **Output** (reporting commands) — `--no-text` / `--markdown <path>` /
-  `--json <path>`. Text on stdout by default; the file toggles compose and one
-  analysis pass renders every requested format. See `src/output.rs`.
-* **Benchmark scope** (`collect`/`backfill`) — `--workspace`, `--package`/`-p`,
-  `--exclude` (drops packages from a whole-workspace run; conflicts with
-  `--package`), `--bench`.
-* **Feature selection** (`collect`/`backfill`) — `--features`, `--all-features`,
-  `--no-default-features`, all forwarded verbatim to `cargo bench`.
-* **Discriminant selection** — `--engine`, `--target-triple`, `--machine-key`. On
-  query commands each is **repeatable** (a `Vec`), accepts the widening keyword
-  `all`, and auto-detects the current machine when omitted (§4.3). On create commands
-  (`collect`/`backfill`) only `--machine-key` is accepted (single override); there is no
-  `--engine`/`--target-triple` and no `all`.
-* **Commit selection** — `--context` (the target ref, formerly `--branch`),
-  `--base`, `--since`, `--until`. `--since`/`--until` filter by **commit** timestamp.
-* **Data filtering** — `--no-dirty`.
+`analyze`, `list`, `prune`, and `examine` share one **data-set-selection pipeline** in
+`analyze/mod.rs` (`Selection` + `parsed_facets` + `facet_filtered_candidates` +
+`resolve_history`/`select_dataset`), and all four live inside the `analyze` module tree
+(`list.rs`, `prune.rs`, `examine.rs`, each `pub(crate) mod`; `bless`/`unbless` in `bless.rs`
+reuse the same facet selection). **A selection parameter added to one must be added to all
+four** unless genuinely inapplicable. The analysis-only flags (`--mode`,
+`--include-improvements`, `--include-inactive`) are **not** part of the lockstep — only
+`analyze` detects; `list`/`prune`/`examine` reuse the selection but never analyze. Each is
+generic over the `GitHistory` + `Storage` ports so tests drive it with fakes + `block_on`.
+Semantics and per-command behaviour: DESIGN §7–§8.
 
-`--dry-run` (a `prune` execution flag) lives in the **environment & execution**
-group, not data filtering.
+`analyze` needs a resolvable repository (topology at query time); `list discriminants` is the
+one query view that does **not** (a pure index over storage keys). `examine` is the one
+command that names a `--metric` (its input is an `analyze` finding, which prints the metric).
 
-There are **no `--os`/`--architecture` facets** (operate on `--target-triple`
-directly). **Subjects** are bare positional words, not flags: `prune` takes
-`<commit>…`, `bless` and `analyze` take `<prefix>…` (benchmark-id prefixes, used
-respectively to choose what to accept and to scope the analysis), and `list` takes
-a required `runs|discriminants|blessings` selector (a bare `list` errors and names
-the three).
+## CLI (clap derive)
+
+The CLI uses **clap** derive (chosen over `argh` for `help_heading` grouping — the surface is
+wide). Flags live in shared `#[command(flatten)]` arg-group structs so a group looks identical
+everywhere and the selection lockstep holds automatically. Do not assume the other workspace
+cargo tools share these grouped conventions. Full group/flag map: DESIGN §7.
 
 ## Verbose diagnostics (`report::Reporter`)
 
-`--verbose` is accepted by every command (`collect`/`backfill`/`analyze`/`install`)
-and threads a `&dyn report::Reporter` through the relevant pipeline so an
-otherwise-silent outcome can be diagnosed. The whole point of the module's shape
-is that a note can never be emitted without its `--verbose` guard: the
-unconditional emit primitives live on a **sealed** `Sink` supertrait that cannot
-be named outside `report`, so the only note surface a caller sees is the guarded
-pair on `ReporterExt` — `note_with(|| format!(…))` for a single lazy line and
-`if_enabled(|notes| { notes.note(…); … })` for a block that emits several. A bare
-unconditional `note` is reachable *only* on the `Notes` handle passed to an
-`if_enabled` block, so call sites never call `enabled()` or `note()` directly and
-there is no `if reporter.enabled()` guard to forget. Stage timings are a separate
-channel (`ReporterExt::timing`), gated independently so the stress harness can ask
-for the per-stage breakdown without the per-object flood. Production uses
-`StderrReporter::new(verbose)`, which writes `[bench-history] …` lines to
-**standard error** only when verbose — never stdout, so machine-readable output
-stays clean. Tests use the `#[cfg(test)]` `RecordingReporter` (records notes in a
-`RefCell`, exposing `notes()`/`contains()`).
-`bench_output::collect` takes `&dyn Reporter` and notes each directory scanned and
-every file included/excluded/stale; `collect` notes the argv, injected env, harvest
-boundary, and each stored key. `analyze_with` notes the listing prefix, facet
-filters, the resolved target/base/merge-base, the **auto-detected mode and the
-reason for it** (which topology/data inputs it considered and that the on-disk
-working tree is deliberately ignored), the resolved `--since` cutoff and where it
-came from, and why each candidate object is included or excluded; `install` notes
-whether it wrote or left the config. The reporter is `&dyn Reporter` (not `+ Sync`),
-so the run futures stay `!Send` and Miri-driven via `block_on`.
-
-Verbose notes must be **explanatory, not conclusion-only** — see
-`docs/standalone-binaries.md`. State the inputs and the rule behind each decision
-(e.g. the mode note names whether the tip is its own merge-base and whether a dirty
-run is recorded) so the logic can be reconstructed from the log.
-
-
-`analyze` also renders a non-verbose diagnostic *hint* (carried on `ReportInput`/
-`JsonReport`, built by `empty_history_hint`) whenever facet-matching runs were
-stored but none entered the analysis — most commonly when every run is a dirty
-snapshot on a base-side commit (the "config file never committed" trap). The hint
-makes a `0 runs` result self-explanatory without needing `--verbose`.
-
-## Storage selection (`--local` + cloud config)
-
-Where a command reads and writes results is resolved at run time, **not** from the
-shared config file (a local path is machine-dependent and the file is
-version-controlled). The config file carries only an **optional** cloud backend:
-`config.storage` is `Option<CloudStorageConfig>`, an externally-tagged enum
-(`[storage.azure]` today) so serde enforces "at most one" cloud backend. There is
-no local variant in the config: because `storage` is a known field whose only
-variant is `azure`, a leftover `[storage.local]` table is **rejected** at parse
-time (`unknown variant 'local', expected 'azure'`) rather than silently ignored
-the way a wholly unknown section is. There is no backward-compat handling — remove
-`[storage.local]` and select local storage via `--local` instead.
-
-Every storage-backed command (`collect`, `analyze`, `list`, `prune`, `backfill`,
-`bless`/`unbless`) carries a `--local` flag (on the shared `EnvArgs` group) and
-resolves the backend with this precedence:
-
-1. `--local=<path>` → `LocalStorage` at `<path>` (relative paths rebased against
-   the repo base via `wiring::rebase`).
-2. bare `--local` (no value) → `LocalStorage` at `CARGO_BENCH_HISTORY_STORAGE`;
-   unset/empty is a `StorageError::Config`.
-3. no `--local` → the configured cloud backend; none configured is a
-   `StorageError::Config`.
-
-`--local` uses `require_equals` (`Option<Option<PathBuf>>`: `Some(Some(p))`→Path,
-`Some(None)`→FromEnv, `None`→unset), mapped to `LocalStorageSelection` by the free
-`cli::local_selection`. The environment read is isolated: `wiring::storage_env()`
-is the only edge that reads `CARGO_BENCH_HISTORY_STORAGE`, and the pure
-`wiring::resolve_local_path(selection, env)` turns the selection + injected value
-into an `Option<PathBuf>` (Miri-safe, unit-tested without touching the process
-env). `build_storage` then maps that optional path (override) or the config's
-cloud backend into a `StorageFacade`. `collect --no-store` is the exception: it skips
-selection entirely, so it runs with no `--local` and no configured backend.
-
-**Read-through cache (`--cache`).** The read commands `analyze`/`list`/`prune`
-additionally carry a `--cache` flag (its own `CacheArg`, same **Environment and
-execution** help group, three-state `require_equals` like `--local`:
-`Some(Some(p))`→Path, `Some(None)`→`CARGO_BENCH_HISTORY_CACHE`, `None`→unset). The
-env edge is `wiring::cache_env()` and the pure resolver `wiring::resolve_cache_path`
-(mirroring the `--local` split). It is meaningful **only with the cloud backend**:
-`build_storage` wraps an `Azure` backend in `storage::caching::CachingStorage`
-(`StorageFacade::CachedAzure`) whose mirror is rooted under `<cache>` at a per-backend
-subpath (`<cache>/<account>/<container>`, so reusing one `--cache` dir across distinct
-Azure backends can't serve one backend's image for another) and **faithfully images
-the cloud namespace** under identical keys, mirroring every fetched object so the bulk
-history downloads at most once across runs. A cache is pointless
-with a `--local` backend (reads are already local), so the two **conflict**: the CLI
-rejects `--cache` together with `--local` (clap `conflicts_with`). The mirror may hold
-several projects' objects at once, so invalidation is **per project**: a cloud-side marker
-(`storage::cache_epoch_key`, `v1/<project>/_cache-epoch` — a sibling of that project's
-`objects/` subtree) that `put_overwrite`/`delete`
-arm and a per-command flush bumps; `synchronize_cache` (before a load) wipes that
-project's stale mirrored objects (`storage::project_objects_prefix`, `v1/<project>/objects/`),
-and `report_cache_tally` notes hits/misses after. Append-only
-`put` never arms it, so the CI `collect --skip-existing` collection never wipes the
-cache it feeds.
-
-**Testing note:** the `cbh_integration` harness (`Workspace`) auto-injects
-`--local=<root>/store` for storage-backed commands so each test writes to its own
-store; `Workspace::without_local_storage()` disables that to exercise the
-no-storage-configured error path. The bare-`--local`-from-environment and
-missing-environment paths are exercised against the real binary in `cbh_integration`
-(`cli.rs`), each child process getting its own environment rather than mutating the
-test process's.
-
-## Storage model (commit-centric)
-
-`comparability::DiscriminantSet` builds object keys under the partition prefix
-`v1/<project>/objects/<engine>/<triple>/<machine|synthetic>` and then keys each point by
-**commit**:
-
-* `clean_key(commit)` → `…/<commit>/clean.json` — the one canonical point for a
-  clean working tree at that commit. It is deterministic, so a re-run of the same
-  commit maps to the same key; the write-once `put` turns that into a
-  `RunError::Duplicate` (refused) unless `--overwrite` switches to `put_overwrite`,
-  or `--skip-existing` (mutually exclusive with `--overwrite`) turns the
-  `AlreadyExists` collision into a soft skip (`StoreOutcome::Skipped`): the run still
-  benchmarks every engine — so a broken benchmark is still caught — but writes
-  nothing and does not arm the cache-invalidation marker. This is the append-only
-  mode the CI collection uses (see [storage selection](#storage-selection-local--cloud-config)).
-* `dirty_key(commit, observation_unix)` → `…/<commit>/dirty-<observation_unix>.json`
-  — a snapshot of an uncommitted tree, distinguished by its observation second so
-  multiple dirty snapshots on one base commit coexist; only a same-second clash is
-  a conflict.
-
-The commit segment is the **full** SHA (`git.commit`, `unknown` when there is
-no repo), because the git-aware `analyze` reads `v1/.../<full_sha>/` directories
-resolved from `git rev-list`. The `collect` store step picks clean vs dirty from
-`git.dirty`. A run stores only an **observation** timestamp (wall-clock now,
-provenance only); the commit's position on the timeline is its committer date,
-read from git topology at analyze time, not stored on the object. There is no
-"effective timestamp" concept and no `--timestamp` override. A dirty key uses the
-observation second so concurrent snapshots coexist. There is no run-id in the key.
-
-### Object byte format (gzip)
-
-Object **keys/filenames are unchanged** (still `…/clean.json` etc.), but the
-**body bytes are gzip**, not plaintext JSON. The storage layer compresses
-transparently at the `Storage` trait boundary: `put`/`put_overwrite` compress the
-caller's plaintext JSON and `get` inflates back to plaintext, so every caller
-(`collect`, `backfill`, `analyze`, `prune`, `bless`) keeps handing and receiving plain
-JSON and is unaffected. The single source of the encoding is
-`cargo_bench_history_core::codec` (`compress`/`decompress`, gzip level 6, pure-Rust
-`miniz_oxide`, deterministic, Miri-clean); both the storage backends and the stress
-harness call it, so they cannot drift apart. `AzureBlobStorage` additionally sets
-`Content-Encoding: gzip` on upload so a non-SDK reader can inflate the blob, though
-the backend still inflates on `get` itself rather than relying on the service.
-`MemoryStorage` (the test fake) deliberately stays **plaintext** — its contract is
-the key/value model, no test inspects raw stored bytes, and keeping it uncompressed
-keeps the Miri-driven `analyze` suite fast. This is a breaking storage-format change
-(there is no migration): `get` on a legacy plaintext object errors loudly because
-the gzip magic never collides with JSON's first byte.
-
-## The `analyze` command
-
-> **Data-flow & parallelism reference:** [`docs/analyze.md`](docs/analyze.md) is the
-> canonical map of the `analyze` load and detection path — what loads where, in what
-> order, what is computed/sorted, and exactly where I/O concurrency vs. CPU
-> parallelism happens (with Mermaid diagrams). Keep it in sync whenever you change the
-> chunked parallel fetch+parse+fold (`fold_runs_chunked`), the per-worker builder merge,
-> the detection distribution (`find_changes_spawned` + the `analyze::parallel` chunk
-> math), or the Azure transport.
-
-`analyze::execute` builds the real `SystemGitHistory` (rooted at `--repo` or the
-current directory) and the storage from `build_storage`, then delegates to
-`analyze::analyze_with`, which is generic over both the `GitHistory` and `Storage`
-ports so tests drive it with `FakeGitHistory` + `MemoryStorage` +
-`futures::executor::block_on` (Miri-safe, no Tokio). Everything below the IO ports
-is pure and synchronous.
-
-Two compute passes fan out across cores. The object load (`fold_runs_chunked`) splits
-the storage-key-sorted survivors into balanced contiguous chunks; each spawned task
-fetches, decompresses, JSON-parses **and folds** its chunk into its *own* `SeriesBuilder`
-/ `RunIndex`, dropping each parsed run as it goes, and the driver awaits the tasks in
-spawn order and merges the per-worker builders (`SeriesBuilder::merge`). Each object is
-parsed into the lean `cargo_bench_history_core::analyze::RunPoints` projection — only the
-fields the fold reads (per result, the id and the metric
-value/interval) — not a full `Run`; the full commit SHA a point is labelled with comes
-from the storage key, not the run payload. Detection (`find_changes_spawned`) then dispatches
-per-series detection chunks to blocking tasks the same way. Both take the
-`&anyspawn::Spawner` `analyze_with` threads through; `execute` injects
-`Spawner::new_tokio()` (the runtime's blocking pool), while tests inject
-`cargo_bench_history_core::testing::synchronous_spawner()` (the shell takes core as a
-dev-dependency with its `private-test-util` feature) so `block_on`/Miri runs need no
-Tokio runtime. The per-worker builder merge and point sort stay serial (the merge is
-associative and `finish` sorts globally, so output equals a single-threaded fold). Do
-**not** spawn ad-hoc threads (`std::thread::scope`, `map_parallel`-style helpers) for
-compute — route fan-out through the injected `Spawner` so it shares the runtime's threads
-and stays legible in a profiler.
-
-Folding in the worker (instead of buffering each chunk's parsed runs and folding serially)
-parallelizes the fold for a ~10% wall-time and CPU win, but it did **not** lower peak
-memory: at merge time every worker's finished builder is resident alongside the growing
-combined builder (~2× the compact point output transiently), which measured ~5% above a
-buffered-parallel variant. The parallel parse is only a net win with a scalable global
-allocator: serde_json's many small allocations contend on the system allocator's
-cross-thread lock (acute on the Windows process heap) and otherwise erase the parallel
-speedup, so the `cargo-bench-history` binary installs `mimalloc` as its
-`#[global_allocator]` (the stress harness does the same for representative numbers). The
-lean `RunPoints` projection only trims peak ~1%; the repeated benchmark ids and the merge
-coexistence dominate peak, so the open memory levers are bounded merge-as-complete waves
-and id interning — see the "Architecture" section of `docs/DESIGN.md` and the load
-section of `docs/analyze.md`.
-
-`analyze` assembles a series by **resolving git topology at query time** rather
-than reading a flat storage prefix — the storage layout cannot pre-assemble a
-timeline because which commits belong to a line of history depends on the branch
-being analyzed:
-
-* **Discriminant facets first.** `analyze::discriminant::parse_key` turns each
-  `v1/<project>/objects/<engine>/<triple>/<machine|synthetic>/<commit>/<file>` key into a
-  `DiscriminantSet` (engine, triple, machine). `--engine`/`--target-triple`/
-  `--machine-key` select sets — each facet is **repeatable**, accepts the widening
-  keyword `all`, and auto-detects the current machine when omitted (`--target-triple`
-  → host triple, `--machine-key` → host fingerprint, `--engine` → all engines since
-  it has no machine-derived value). A `synthetic` set (Callgrind / `alloc_tracker`)
-  **always passes** the `--machine-key` facet regardless of its value, so the
-  current-machine default still includes every hardware-independent set. Each
-  surviving set becomes its own sub-report. (There are no `--os`/`--architecture`
-  facets — operate on the triple directly.) The `list discriminants` subject (not
-  `analyze`) prints the present sets and returns **without requiring a repository**
-  (it is a pure index over storage keys).
-* **Repository required for analysis.** Resolving a timeline needs git, so when not
-  just listing discriminants `analyze` errors if no repository resolves. The target
-  ref is `--context` (default `HEAD`); the base ref is `--base` >
-  `config.project.default_branch` > detected default branch (`origin/HEAD` → `main`
-  → `master`). `analyze::selection::select_commits` walks the target's
-  first-parent ancestry and splits it at the merge-base with the base: commits on
-  the base side admit **clean runs only**; commits unique to the target side also
-  admit **dirty** snapshots (so the official line stays clean while a feature branch
-  can carry work-in-progress points). `--no-dirty` drops dirty everywhere. **One
-  exception:** when the working tree is currently dirty (`GitHistory::is_dirty`) and
-  the target **tip** is base-side, that tip's dirty snapshots are admitted and the
-  report ends with an ephemeral-data warning — the "evaluating the tool" /
-  "accidentally on the base branch" case. It is tip-only and `--no-dirty` overrides
-  it. `select_commits`'s fourth parameter (`dirty_tip_exception`) carries this, and
-  `SelectedCommit::dirty_base_exception` flags the tip so `analyze` knows to warn.
-* `analyze::series` reconstructs one series per `(location, benchmark, metric)`
-  ordered by **git topology** (first-parent index of the commit), then within a
-  commit by `(dirty, object key)` so a clean point precedes same-commit
-  dirty snapshots deterministically. Topology — not any timestamp — is primary, so
-  back-dated backfill runs still sort by where their commit sits in history.
-  `--since`/`--until` drop whole runs outside the window by each commit's **committer
-  date**. `analyze`/`list` decide this from git topology — each commit's committer
-  time is carried alongside its SHA on the `first_parent` ancestry
-  (`FirstParentCommit`), so the window is applied in `select_dataset`'s key-only
-  phase, *before* any out-of-window object is fetched (the `window_excludes` helper;
-  a commit with an unknown time is kept). `prune` decides the same window from the
-  same git-topology `commit -> committer_time` map (no per-object fetch). Bare
-  `<prefix>` positionals scope the analysis to
-  benchmarks whose qualified id starts with one of the prefixes (`series::prefixes_accept`).
-* `analyze::findings` is the **engine-aware, noise-resistant** detector. It splits
-  metrics into *deterministic* (every Callgrind kind plus the `alloc_tracker`
-  allocation kinds — exact, no noise) and *noisy* (`WallTime` and `ProcessorTime`;
-  `is_deterministic` decides). It emits at most
-  one finding per series, of one of two methods: a **change-point** (sustained level
-  shift) located by the **Pettitt** test, or a **drift** (slow monotonic trend) from
-  the **Mann–Kendall** / **Theil–Sen** pair. When both fire, the better-fitting model
-  wins (step vs line residual). Both regimes of a change-point need `min_regime`
-  points (persistence — a single blip never flags). A deterministic step flags on
-  persistence alone (any non-zero step is real). A noisy change additionally requires
-  a significant **Mann–Whitney** rank test, non-overlapping regime CIs (when present —
-  both Criterion and `all_the_time` report a bootstrap CI, so the gate applies to
-  both; only older mean-only output skips it),
-  and a practical-magnitude floor; a noisy drift also clears a noise floor of twice
-  the median CI half-width. Noisy candidates pass a **Benjamini–Hochberg** FDR filter;
-  deterministic ones bypass it. **Pettitt only locates the split — its analytic
-  p-value is too conservative on short series, so it is never used as a significance
-  gate.** All math lives in pure, Miri-safe `analyze::stats`; keep it deterministic
-  and cover boundaries with named value-asserting tests, not threshold guards. When
-  seeding test histories, a noisy (Criterion / `all_the_time`) step needs **≥ 4
-  points on each side** for the rank test to have power, while a deterministic
-  (Callgrind / `alloc_tracker`) step needs only
-  `min_regime` (2) — and a single elevated last point can no longer flag either.
-* `analyze::report` renders text/json/markdown. The top-level aggregate carries a
-  `sets` array (one entry per discriminant set). Rendering is infallible: the
-  report is plain structs of finite numbers, so the JSON path uses `.expect`
-  rather than threading a serialization error nobody can trigger. Findings carry no
-  severity tier — they rank by descending `|relative_delta|`. The `text` report is
-  one paragraph per finding (headline leads with the relative-change percent; dimmed
-  detail line; in **history mode only** a colored `rasciigraph` line chart of the
-  series). `analyze_with` receives an explicit `color: bool` (production computes
-  `stdout().is_terminal() && NO_COLOR unset`; tests pass `false`) and `render_text`
-  installs a scoped `colored` override (a `ColorOverride` RAII guard) so both
-  `colored` styling and the chart honor it deterministically (and stay Miri-safe — no
-  isatty syscall); the guard restores ambient auto-detection when rendering returns.
-  Text and Markdown values are rounded to four significant figures via `format_value`
-  (the integer part is never truncated); the JSON keeps full `f64` precision.
-
-The read-only `git_history::GitHistory` port (`resolve`, `default_branch`,
-`merge_base`, `first_parent`) has a `SystemGitHistory` adapter that shells
-`git -C <repo>` and a `#[cfg(test)]` `FakeGitHistory` over a canned commit graph.
-`first_parent` returns `FirstParentCommit { sha, committer_time }` per commit
-(`git log --first-parent --reverse --format=%H %cI`), pairing each SHA with its
-committer date so the `--since`/`--until` window is decidable from topology alone.
-Integration tests build a **real** git repo in a tempdir (`Workspace::repo` /
-`Workspace::clean_repo`) and seed storage keys under the commits' real SHAs so the
-live topology and the stored keys agree; `Workspace::commit_dated` pins each seed
-commit's committer date so the git-topology `--since`/`--until` window matches.
-
-### Analysis modes (`analyze` only)
-
-`analyze` runs in one of three modes, resolved in `analyze/mod.rs` (`auto_mode`,
-`parse_mode`, `resolve_since`) and dispatched per series in `analyze::findings`
-(`detect_one`, reached through `find_changes_spawned`) on `AnalysisMode`:
-
-* **history** — auto-selected when the analyzed tip *is* the merge-base with the
-  base **and** no dirty run is recorded on top of that tip (the official base-branch
-  view: `auto_mode(tip_is_merge_base=true, dirty_tip_run_present=false)`). Applies
-  the long-range change-point + drift + FDR techniques above. `resolve_since` gives
-  it a **default six-month look-back** when `--since` is omitted
-  (`default_history_since`, calendar-correct months via jiff); branch/tip have no
-  default. `AnalysisContext::keeps` reports **regressions only** unless
-  `--include-improvements` (steady improvement on the base branch is expected).
-* **branch** — auto-selected otherwise: there are commits past the merge-base (a
-  feature branch), or a dirty run is recorded on the base tip and admitted by the
-  dirty-tree exception. `evaluate_branch` splits the series at the merge-base
-  (`split_at_merge_base`), then `latest_regime` uses Pettitt to find the most recent
-  within-branch flip and compares **only the after-segment** against the base,
-  setting `Finding::flipped_at` to the commit the latest regime began at — so "got
-  better then worse" reports worse and points at the flip. Reports **both**
-  directions.
-* **tip** — never auto-selected; forced with `--mode tip`. `evaluate_tip` compares
-  the last point against a bounded window of recent preceding points. Reports
-  **regressions only**.
-
-Auto-detection is **data-driven, not working-tree-driven.** `dirty_tip_run_present`
-(the second `auto_mode` arg) is computed in `select_dataset` from the recorded
-candidates (a dirty run exists on a commit whose `dirty_base_exception` is set) —
-**not** from `git.is_dirty()`. So a dirty working tree that has only ever stored
-clean runs stays **history** mode; only an actually-recorded dirty run on the base
-tip (or commits past the merge-base) flips it to branch. The on-disk tree state is
-deliberately never consulted for mode selection (it still gates *admission* of
-dirty runs in the §dirty-tree exception, a separate concern).
-
-`--mode auto|history|branch|tip` overrides detection (`parse_mode`; `auto`/absent →
-`None` → auto-detect; unknown → `RunError::Analyze`). **Findings never affect the
-exit code** — `RunOutcome::Analyzed` is always a success; the machine-readable
-signal is the `json` report's `mode` / `notable` (any finding survived) /
-per-finding `direction` / `flipped_at` / `series`. There is **no**
-`--fail-on-regression` flag: findings are advisory, never a build gate.
-The two driving scenarios are a scheduled base-branch regression watch (history) and
-a per-PR feature-branch evaluation (branch). Modes apply to `analyze` only; `list`
-and `prune` reuse the same data-set *selection* but never analyze, so `--mode` /
-`--include-improvements` / `--include-inactive` are analyze-only and **not** part of
-the selection lockstep.
-
-### Blessings and re-baselining (`analyze` history mode only)
-
-A **blessing** manually accepts an intentional performance change on the base branch
-so history analysis re-baselines past it and stops re-flagging it. Blessings matter
-**only in history mode** — branch/tip modes treat the base as fully blessed already
-(they compare against the base, not within it), so they ignore blessings entirely.
-
-* **Data model — append-only sidecars.** A blessing is a
-  `…/<machine|synthetic>/<commit>/bless-<issued_unix>.json` object alongside the
-  commit's `clean.json`. It records the blessed benchmark-id prefixes and the
-  issuing commit (there is **no** `reason` field — it was removed to keep the model
-  small). Sidecars are append-only and never mutate a `clean.json`; `unbless`
-  deletes the sidecar(s) at the context commit, and `collect --overwrite` drops a
-  commit's stale sidecars when it rewrites that commit.
-* **`bless` rules (hard errors, no `--force`).** `analyze::bless::bless_with`
-  requires: the context commit (HEAD by default, or `--context <ref>`) is on the
-  base branch (`merge_base(context, base) == context`) and a `clean.json` already
-  exists at that commit. The on-base check fires **first**. Neither state would
-  survive a history analysis, so a feature-branch / data-less blessing is rejected
-  rather than silently ignored. A **dirty working tree is allowed** (the blessing
-  targets the committed `clean.json`) but emits a `Warning: uncommitted changes
-  present …`. `bless <prefix> [<prefix> …]` matches each prefix against the qualified
-  `<package>/<group>/<case>/<value>` identity via `starts_with` (per-benchmark, not
-  all-or-nothing); `--all` (mutually exclusive with `<prefix>`) accepts **every**
-  benchmark recorded at the context commit. It accepts the same discriminant facets
-  as `analyze`.
-* **Effect on analysis — active/inactive segments.** In history mode
-  `select_dataset` loads `dataset.blessings` (only for in-window base commits). A
-  blessed benchmark's *active window* starts at `max(last_blessed_commit,
-  first_active_segment_commit)`; the change-point/drift detectors only consider the
-  active segment, so a step that predates the blessing is no longer reported. Earlier
-  (inactive) points stay in the series for charting (greyed) and for any long-range
-  technique that needs more data. A `Finding` carries `active`, `blessed_at`, and
-  `blessed_commit_time` so a consumer can see what re-baselined it.
-* **Resolved spikes.** Independently of blessings, a spike that has since recovered
-  to its prior level is **inactive by default** — its current state already matches
-  the baseline, so re-flagging it is noise. `--include-inactive` surfaces such
-  findings (`active: false`, `flipped_at` = the recovery commit) for auditing. The
-  JSON `regressions` count and `notable` flag include any inactive finding that is
-  present, but inactive findings are absent by default.
-* **`unbless`** (`unbless_with`) deletes the blessings recorded **at the context
-  commit** (HEAD by default, or `--context <ref>`) only — it never touches blessings
-  defined at later commits, so the timeline can remain blessed past the unblessed
-  commit. It reports `"Removed <count> blessing[s] at commit <short>."` (via
-  `count_noun`, which computes the singular/plural) or `"No blessings recorded …"`.
-* **`list blessings [--all]`** audits blessings without analyzing: the default
-  (`scope: "head"`) lists blessings recorded at HEAD; `--all` (`scope: "window"`)
-  lists the most recent blessing of every benchmark across the analysis window. See
-  `analyze::list::blessings_at_head` / `blessings_across_window`.
-
-## The `list` command
-
-**`list` mirrors `analyze`'s data-set-selection parameters exactly** (a hard
-requirement — keep them in lockstep). It takes a required **subject** — `runs`,
-`discriminants`, or `blessings` — and a bare `list` is an error that names the
-three. `list runs` and `list blessings` accept the same selection flags
-(`--repo`/`--context`/`--base`/`--engine`/`--target-triple`/`--machine-key`/
-`--no-dirty`/`--since`/`--until`/`--no-text`/`--markdown`/`--json`/`--config`) but, instead of
-analyzing, only *preview* which data set an `analyze` pass would consume: `list
-runs` reports, per discriminant set, the run, series, and per-commit counts of the
-selected runs (each commit's clean/dirty split), ordered oldest-first by git
-topology. Whenever you add or change a selection parameter on `analyze`, add the
-same parameter to **both** `list` and `prune` (see below) unless it is genuinely
-inapplicable. The analysis-only flags `--mode` / `--include-improvements` /
-`--include-inactive` are not part of the selection lockstep (they govern analysis,
-which `list` never does).
-
-`list discriminants` lists the discriminant sets present in storage **without
-requiring a repository** (it ignores the timeline / data-filtering groups). It is a
-**discovery catalog**, so — unlike every other query command — it does **not**
-default omitted facets to the current machine; with no facets it lists *every*
-stored partition (`resolve_facets(&selection, None)`), and a facet narrows it.
-`list blessings [--all]` audits blessings instead of previewing the data set (it
-requires a repository) — see the Blessings subsection above. `--all` is a
-`blessings`-only switch: `list_with` errors (`RunError::Analyze`) if it is passed
-with `runs` or `discriminants` rather than silently ignoring it.
-
-`list` lives **inside** the analyze module tree as `src/analyze/list.rs`
-(`pub(crate) mod list;`), reusing the selection pipeline that was extracted from
-`analyze_with` into `analyze/mod.rs`: `Selection` (a borrow of the selection
-fields, built via `from_analyze`/`from_list`), `parsed_facets`,
-`facet_filtered_candidates` (shared by both the discriminants index and the
-topology query), `select_dataset` (git topology + commit selection + object load),
-and `dirty_base_exception_warning`. `list_with` resolves the output selection and subject, builds a
-`Selection`, then either renders the discriminants index (no repo) or runs
-`select_dataset` → `build_listing` → `render_listing`, returning a
-`RunOutcome::Completed { message }`. `count_noun` (text.rs) appends `s` when the
-count ≠ 1, so list.rs uses a local `series_noun` to avoid "seriess".
-
-## The `prune` command
-
-**`prune` mirrors `analyze`'s/`list`'s data-set-selection parameters** (the same
-hard lockstep requirement) — it accepts `--repo`/`--context`/`--base`/`--engine`/
-`--target-triple`/`--machine-key`/`--since`/`--until`/`--no-text`/`--markdown`/`--json`/
-`--config`/`--verbose`, plus its own deletion-shaping flags: `--dirty`/`--clean`/
-`--all` (scope, **required** — exactly one kind of run must be named), `--prune-base`
-(base-branch confirmation), `--dry-run`, and `<commit>` subjects (repeatable bare
-positional words, case-insensitive SHA-prefix). Instead of analyzing, it **deletes**
-the selected objects.
-
-**Deletion scopes** (`Scope::from_options`, fed from the clap `PruneCommitArgs`):
-`--dirty` → dirty snapshots only; `--clean` → clean runs and their blessings only;
-`--all` → both. A scope is **required** — the clap `ArgGroup("prune-kind")` is
-`required(true)`, so a bare `prune` is rejected at parse time. `--all` expands in
-`into_options` (`clean = self.clean || self.all`, `dirty = self.dirty || self.all`);
-`Scope::from_options` maps `(clean, dirty)` → `All`/`Clean`/`Dirty` and errors on
-`(false, false)` (defence in depth behind the clap group).
-
-**Base-branch preservation (Design B) + the `--prune-base` guard.** Pruning never
-touches base-branch history: `commit_is_eligible(index, merge_base_index,
-tip_is_merge_base)` removes only commits **strictly after** the merge-base with
-`--base` (the context branch's own commits); base-side commits are skipped with a
-note. When the context resolves onto the base branch itself (`context == base`, i.e.
-`tip_is_merge_base`), the whole selection *is* base-branch history, so `prune_with`
-refuses with a `RunError::Analyze` naming the base branch unless `--prune-base`
-confirms it (`resolve_base_name` resolves the branch name for the message, mirroring
-`resolve_base_ref` precedence). There is **no** narrowing guard and no `--all`
-override of one — the base-branch guard is the only protection against a large
-accidental delete.
-
-The one **intentional divergence** from `analyze`/`list`: the base-branch tip's
-dirty runs are admitted **unconditionally** (`DirtyTipPolicy::Always`), whereas
-`analyze`/`list` only admit them when the working tree is currently dirty
-(`DirtyTipPolicy::WhenWorkingTreeDirty`). This is what lets `prune --dirty` reclaim
-ephemeral base-branch snapshots regardless of the current tree state. The policy is
-the parameter to the shared `resolve_history` helper in `analyze/mod.rs` (extracted
-from `select_dataset`); `select_dataset` passes `WhenWorkingTreeDirty`, `prune`
-passes `Always`.
-
-`prune` lives **inside** the analyze module tree as `src/analyze/prune.rs`
-(`pub(crate) mod prune;`), reusing the same `Selection` (built via `from_prune`,
-which hardwires `no_dirty: false`), `parsed_facets`, `facet_filtered_candidates`,
-and `resolve_history` pipeline. `prune_with` resolves the history, applies the
-`--prune-base` guard, partitions the candidate objects into runs (clean/dirty, via
-`RunKind`) and blessings, applies the eligibility / scope / `<commit>` /
-`--since`/`--until` filters, then deletes in **two passes**: pass 1 removes the
-selected runs (recording which clean `(set, commit)` pairs were removed); pass 2 —
-only when the scope touches clean runs — removes a blessing sidecar iff its
-`(set, commit)` had its clean run removed (so blessings follow their clean run and
-are never time-filtered directly). `--since`/`--until` decide the window from the
-git-topology `commit -> committer_time` map (`window_excludes`), keyed by each
-candidate's commit SHA — no per-object body fetch. The deletions are grouped
-into a `Plan` (by discriminant set, commits oldest-first by topology) and — unless
-`--dry-run` — each key is removed via `Storage::delete`. The JSON report carries
-`dry_run`, the per-commit run/blessing counts, and the deleted `keys` per commit;
-text/markdown report counts only (the `verb` helper switches "Would remove" ↔
-"Removed").
-
-`Storage::delete(&self, key)` is on the `Storage` trait and all four impls
-(Memory, Local, Azure, Facade); it returns `StorageError::NotFound`
-when the object is absent (the local/memory impls validate the key first; Azure maps
-a 404 / missing-container fault to `NotFound`).
-
-## The `backfill` command
-
-`commands::backfill` replays `collect` across an inclusive commit range, bootstrapping
-history for commits that predate the tool. The range endpoints are **positional
-subjects** — `backfill <from> <to>` (oldest-first inclusive), not `--from`/`--to`
-flags. It is generic over two ports so the
-loop logic runs against Miri-safe fakes:
-
-* `BackfillGit` — `resolve`/`first_parent` (topology, delegating to an embedded
-  `SystemGitHistory`) plus the worktree lifecycle
-  (`add_worktree`/`reset_to`/`remove_worktree`). The real `SystemBackfillGit`
-  shells `git worktree add --detach --force`, `checkout --detach --force` +
-  `reset --hard` + `clean -fd` (ignored build artifacts survive for incremental
-  speed), and `worktree remove --force`. The fake `FakeBackfillGit` wraps
-  `FakeGitHistory` and records `added`/`resets`/`removed` via `RefCell`.
-* `CommitRunner` — `recorded_commits` (the set of commits already stored, probed
-  once) plus `run` (runs and stores one already-checked-out commit). The real
-  `SystemCommitRunner` reuses the `collect` pipeline (`collect::run_engines`) against a
-  worktree-rooted `SystemProbe::in_dir` / `TokioBenchRunner::in_dir` /
-  `FsBenchOutputSource` (`target_root = worktree/target`); the fake returns canned
-  per-commit outcomes and a canned recorded set.
-
-Key invariants:
-
-* **The primary checkout is never mutated.** All work happens in a worktree under
-  the system temp dir; config/project-id/storage are loaded once from the invoking
-  checkout, never from the worktree. A dirty primary working tree is therefore
-  fine — there is no clean-tree guard.
-* **Validation precedes any worktree work** (`plan_commits`):
-  require both endpoints to resolve and require the `<from>` subject to be a
-  first-parent ancestor of the `<to>` subject. The range does **not** have to lie on
-  `HEAD`'s history — any first-parent chain from `<from>` to `<to>` is backfillable.
-  The range is enumerated oldest-first and inclusive via
-  `first_parent(to).split_off(position(from))` (avoid `vec[a..]` — clippy
-  `indexing_slicing`).
-* **Pre-run existence check** (`run_commits`): in the default skip-existing mode,
-  `recorded_commits` lists the project objects prefix (`v1/{project}/objects/`) once and
-  `commit_of_clean_key` extracts each clean object's commit segment; a commit in
-  that set is reported `SkippedExisting` and its benchmark execution is skipped
-  outright (no `reset_to`, no `run`). This makes backfill resumable without paying
-  for already-benchmarked commits. The check is intentionally per-commit, not
-  per-engine: a commit with a clean result for only some engines is still skipped —
-  `--overwrite` clears the set so every commit is re-benchmarked and replaced.
-* **Failure model** (`map_collect_result`, a pure classifier): a stored set →
-  `Stored{cases}`; an empty harvest → `SkippedEmpty`; `RunError::Duplicate` →
-  `SkippedExisting` (a post-bench safety net for a commit not caught by the
-  pre-check); `Engine`/`Command`/`Parse` → `BenchFailed` (a recoverable, per-commit
-  failure that stops the loop unless `--ignore-errors`); every other `RunError`
-  (storage, config, I/O) is **infrastructure** and aborts regardless of
-  `--ignore-errors`. A stop surfaces as `RunError::Backfill` (a non-zero exit)
-  carrying the partial summary.
-* **Teardown always runs.** `execute_backfill` computes the `remove_worktree`
-  result before propagating any per-commit error, so the worktree is removed on
-  both the success and the error path.
-
-Integration tests (`backfill_*`) drive the real adapters against a `clean_repo`
-git tempdir: the mock engine's `--fail-if-exists PATH` flag exits non-zero when a
-marker file is present in the checked-out worktree, so a commit that tracks the
-marker stands in for one that fails to build. Helpers `commit_with_file` /
-`commit_removing_file` / `make_dirty` build the needed histories.
-
-These integration tests are deliberately kept to a small real-adapter smoke
-subset (a clean-object success across a range, a merge-spanning range, and a
-stop-on-failure drive) using **minimal commit ranges**. The planning, skip,
-overwrite, error-handling, and reporting logic is exhaustively covered by the
-fake-driven unit tests in `commands/backfill.rs` (over `FakeBackfillGit` /
-`FakeCommitRunner` / `MemoryStorage`), so do not re-prove that logic with extra
-real-git drives — each one spawns many git subprocesses and is the dominant cost
-under mutation testing. Add coverage at the fake level instead.
-
-## Engine adapters (Callgrind, Criterion, `alloc_tracker`, `all_the_time`)
-
-Four benchmark engines are supported, each behind a pure parser in `bench/`:
-
-* `bench::callgrind` parses a Gungraun v6 `summary.json` into a `BenchmarkResult`
-  (instruction count, cache hits, estimated cycles, branches). `package` comes
-  from the `package_dir` basename. Hardware-independent → stored under the
-  `synthetic` partition segment, no machine key.
-* `bench::criterion` parses a `new/benchmark.json` + `new/estimates.json` pair
-  into a `WallTime` `BenchmarkResult`. The metric value is the `slope` point
-  estimate when present (linear `b.iter` sampling) else the `mean`; the std-dev
-  and the chosen estimate's CI bounds are recorded on the `Metric` (dispersion
-  fields) so later analysis can be noise-aware. The identity is
-  `group_id`/`function_id`/`value_str`, and **`package` is `None`** — Criterion
-  files carry no package and `target/criterion/` is flat, so it is unrecoverable;
-  the workspace's crate-prefixed group ids keep series distinct anyway. Criterion
-  is hardware-dependent → partitioned by the host triple and a machine key.
-* `bench::alloc_tracker` parses a flat `target/alloc_tracker/<operation>.json`
-  file (one per operation, auto-emitted on `Session` drop) into a `BenchmarkResult`
-  with an `AllocatedBytes` (`allocated_bytes`) and an `AllocationCount`
-  (`allocations`) metric, both from the `mean_*_per_iteration` fields. `package`
-  is `None`; the operation name is the identity. Allocation behaviour is a
-  deterministic property of the code → `synthetic` partition, no machine key, no
-  dispersion (treated like Callgrind for change-point detection).
-* `bench::all_the_time` parses a flat `target/all_the_time/<operation>.json` file
-  into a `BenchmarkResult` with a single `ProcessorTime` (`processor_time`, unit
-  `ns`) metric. It prefers the through-origin `slope_processor_time_nanos` as the
-  point estimate (falling back to `mean_processor_time_nanos`) and records the
-  bootstrap confidence interval and standard deviation on the metric, mirroring
-  the Criterion adapter. `package` is `None`. Processor time is hardware-dependent
-  and noisy → partitioned by the host triple and a machine key; because it now
-  carries a CI, the noise detector applies the CI-non-overlap gate to it (older
-  mean-only output without an interval falls back to the
-  Mann-Whitney/Mann-Kendall tests).
-
-There is no engine configuration. `collect` and `backfill` invoke `cargo bench` once
-with the combined environment every supported engine needs
-(`injected_bench_env`, today `GUNGRAUN_SAVE_SUMMARY=pretty-json`; the other three
-engines auto-emit JSON on drop and need no env), then harvest every output tree
-(`target/criterion/**`, `target/gungraun/**`, `target/alloc_tracker/*.json`,
-`target/all_the_time/*.json`); an engine that produced no cases (for example
-Callgrind off Linux, where the `_cg` benches are `#[cfg(target_os = "linux")]`
-no-ops) is silently skipped. Scope a run with `--workspace` (the default),
-`--package`/`-p NAME` (repeatable), `--exclude NAME` (repeatable, drops packages
-from the whole-workspace run; conflicts with `--package`), or `--bench NAME`
-(repeatable), and select cargo features with `--features` (repeatable),
-`--all-features`, or `--no-default-features` — these
-translate to the matching `cargo bench` arguments. `--engine` is **not** a
-`collect`/`backfill` flag; it is an `analyze` facet over already-stored data.
-`Engine::ALL` enumerates the engines harvested per run.
-
-## Machine key
-
-`machine::system_profile` reads the `many_cpus` processor and memory-region
-counts plus a best-effort, per-platform `detect_cpu_brand`. `machine::fingerprint`
-hashes a version-tagged canonical string (`mk1\nprocessors=…\nmemory_regions=…\n
-cpu_brand=…`) with SHA-256 and truncates to the first 16 hex chars — a **fixed**
-(not seeded) hash so the key is stable across machines and tool versions; a golden
-test pins a fixed profile to its digest. `resolve_machine_key` prefers an explicit
-`--machine-key` override (a CLI-only flag — the config file is committed, so it must
-not carry a machine key that would be wrong for some checkouts) over the
-fingerprint. The key is
-computed only when `engine.is_hardware_dependent()` (Criterion, `all_the_time`);
-Callgrind and `alloc_tracker` never read it.
-
-All time comes from an injected `tick::Clock`. Production uses
-`Clock::new_tokio()`; tests use `Clock::new_frozen_at(...)` for deterministic
-keys and timestamps. Do not call `SystemTime::now()` in orchestration code and
-never insert real-time delays in tests.
-
-## Miri strategy
-
-* Pure logic and fake-driven orchestration tests are plain `#[test]` using
-  `futures::executor::block_on` plus a frozen clock — no Tokio runtime, no IO —
-  so they run under Miri.
-* Any test that touches the real filesystem, spawns a process, starts a Tokio
-  runtime, or reads the wall clock must be `#[tokio::test]` (or `#[test]` for
-  `std::fs`) **and** `#[cfg_attr(miri, ignore = "…")]` with a reason. This covers
-  the real-IO end-to-end tests and the Azurite network tests (the fake Entra token
-  they inject reads the clock for its `iat`/`nbf`/`exp` claims).
-
-## Mock engine for end-to-end tests
-
-The integration tests drive `collect` against the **real** process/filesystem/storage
-adapters, so they need a real program to launch as the "engine". That program is
-the **`mock_bench_engine` package** (`packages/mock_bench_engine/src/main.rs`), a
-standalone `publish = false` crate kept deliberately out of the published
-`cargo-bench-history` crate so `cargo install cargo-bench-history` only ever places
-the one real binary on a user's PATH (issue #289). It writes the committed Gungraun
-summary fixtures into `<target-root>/gungraun/GROUP/summary.json` (so the harvester
-finds fresh output) and exits with a chosen code — never use a shell builtin like
-`exit 7`, because the runner no longer goes through a shell. Resolve `<target-root>`
-the same way the harvester does (`CARGO_TARGET_DIR` or `target`), so the mock writes
-where the harvester reads.
-
-Cargo only exposes `CARGO_BIN_EXE_*` for binaries of the package **under test**, so
-moving the mock to its own package means the tests can no longer reference it that
-way. The `mock_bench_engine` crate therefore ships **both** a binary (`src/main.rs`,
-the mock itself) and a library (`src/lib.rs`, a locator helper); `cargo-bench-history`
-takes a normal `dev-dependency` on it (`mock_bench_engine = { path = "..." }`) and the
-tests call `mock_bench_engine::binary_path()`. That helper builds its own crate on
-demand (`cargo build --manifest-path <own Cargo.toml> --locked
---message-format=json-render-diagnostics`, cwd-independent), reads the `executable`
-path Cargo reports for the bin artifact (the lib artifact reports none, so filtering
-on a present `executable` selects the bin), and caches it in a `LazyLock<String>`.
-Cargo handles freshness, so the path is always present and up to date after edits, and a
-plain `cargo test` run needs no extra setup. nextest, however, runs one process per test,
-so each would run its own on-demand `cargo build` — which both costs ~190 ms per process
-and, worse, races the other processes' concurrent builds over the shared target tree
-(transient "No such file or directory" engine-spawn failures were observed on macOS
-coverage runs). So every `just` recipe that runs the suite under nextest (`test`,
-`test-azurite`, `test-azure`, `test-more`, `coverage-measure`) — plus `careful`, which
-runs it under libtest — pre-builds the mock once via the `_mock-engine-path` recipe and
-passes its path in the `MOCK_BENCH_ENGINE` env var; when that points at an existing file
-the resolver trusts it (resolving it to an absolute path) and skips the per-process build.
-The two fixtures the mock `include_str!`s stay in
-`packages/cargo-bench-history/tests/fixtures/callgrind/` (they double as schema-drift
-canaries for the parser tests) and are referenced cross-package by relative path.
-
-The integration harness injects the mock as the benchmark command via the
-`run_with_overrides` `bench_command` override (`[binary_path()] + self.bench`, set with
-`Workspace::with_bench`), so the program path and each fixture-describing argument are
-passed verbatim as distinct argv entries — no shell, no quoting, no config `command`.
-After the mock's own contiguous arguments, `collect` appends the cargo scope flags
-(`--workspace`, `--exclude NAME`, `--package NAME`, `--bench NAME`), the
-feature-selection flags (`--features`, `--all-features`, `--no-default-features`), and
-any `--` passthrough, which the mock ignores
-(it stops at the first argument it does not recognize). Like every other crate
-root that uses `#[cfg_attr(coverage_nightly, coverage(off))]`, the mock engine
-must declare `#![cfg_attr(coverage_nightly, feature(coverage_attribute))]` at its
-top, or the coverage job fails to compile it (E0658).
-
-The mock engine accepts `--summary GROUP=KIND` (repeatable). `KIND` is `single`
-(unparametrized, `Ir` = 36, package `fast_time`), `parametrized` (id
-`two_instants`, `Ir` = 87), or `single-alt-pkg` — the `single` fixture with its
-`package_dir` swapped for a different package while the `module_path`/
-`function_name` stay identical. `single-alt-pkg` exists to simulate two equally
-named bench targets in different packages: their `BenchmarkId`s differ only in
-`package`, so they must stay distinct series rather than silently merge. If the
-parser ever stops folding `package_dir` into the identity, the
-`run_distinguishes_same_module_path_across_packages` test fails. `GROUP` may
-contain `/`, which splits into nested directories under `gungraun/` so a test can
-reproduce a real engine's per-binary nesting (and the on-disk collision of two
-same-named bench binaries in different packages, exercised by
-`run_harvests_colliding_bench_binary_names_in_distinct_packages`).
-
-It also accepts `--criterion GROUP|FUNCTION|VALUE=NANOS` (repeatable), which
-writes a Criterion `new/benchmark.json` + `new/estimates.json` pair under
-`<target-root>/criterion/<group>/<function>[/<value>]/new/` whose `slope` point
-estimate is `NANOS` nanoseconds (an empty `VALUE` omits the parameter component).
-Distinct identities never share a directory, so one run can emit several Criterion
-cases that harvest into one result set as separate records.
-
-It accepts `--alloc-tracker OPERATION=BYTES/COUNT` (repeatable), which writes a
-flat `<target-root>/alloc_tracker/<OPERATION>.json` reporting `BYTES` mean bytes
-and `COUNT` mean allocations per iteration, and
-`--all-the-time OPERATION=NANOS[@LOW:HIGH]` (repeatable), which writes a flat
-`<target-root>/all_the_time/<OPERATION>.json` reporting `NANOS` mean (and slope)
-processor-time nanoseconds per iteration. An optional `@LOW:HIGH` suffix also
-records a bootstrap confidence interval (plus a matching standard deviation, span
-count and min/max), exercising the adapter's dispersion path and the noise
-detector's CI-non-overlap gate on processor time. Both mirror the real crates'
-one-file-per-operation auto-emitted output.
-
-Finally, `--fail-if-exists PATH` exits with code 1 and writes no output when
-`PATH` (relative to the working directory) exists. Backfill runs each engine in a
-checked-out worktree, so a commit that tracks the named marker file stands in for
-a commit that fails to build or benchmark; the `backfill_*` integration tests use
-this to exercise the stop-on-failure and `--ignore-errors` paths.
-
-## End-to-end tests and the current directory
-
-The real-adapter end-to-end test changes the process current directory into a
-tempdir, so it must be `#[serial]` (from `serial_test`). On Windows a `TempDir`
-cannot be dropped while it is the current directory, so restore the original CWD
-**before** running assertions and before the tempdir is dropped. Prefer setting
-`[project] id` in the test config rather than relying on the CWD basename.
-
-Each test also points the harvest at its own tempdir `target/` for the duration
-of `collect`, and drives `collect`/`backfill` against the mock benchmark program instead
-of `cargo bench`, by passing both an explicit target root and the benchmark
-command through the `run_with_overrides` entry. `collect` injects that resolved root
-into the benchmark environment as `CARGO_TARGET_DIR`, so the engine writes exactly
-where the harvest scans. This matters under the coverage job, which runs `cargo
-llvm-cov nextest` and redirects every build and bin into one shared
-`target/llvm-cov-target`: that ambient `CARGO_TARGET_DIR` would otherwise make the
-mock engine (which honors it) write its summaries into the shared directory while
-the overridden harvester looked in the tempdir, harvesting nothing. Pinning both
-ends to the same root keeps each test hermetic **without mutating the process
-environment** — do not reintroduce a `set_var("CARGO_TARGET_DIR", …)` guard. The
-production `run` entry passes `None` for both, resolves the root from the
-environment as usual, runs `cargo bench`, and injects that same value so the real
-engine and harvest never diverge either.
-
-Because that override pins an absolute root and runs the mock from the workspace
-root, it cannot catch a bug in `resolve_target_root` itself. The resolved root
-must be **absolute**: cargo runs each `--package`-scoped benchmark binary with its
-working directory set to the owning package's directory, so a relative
-`CARGO_TARGET_DIR` would be resolved there by an engine that honors it (Criterion),
-scattering output away from the workspace-rooted harvest — the "Stored 0 result
-sets" symptom. `run_harvests_output_when_the_engine_runs_in_a_package_directory`
-guards this by driving through `drive_resolving_target_root` (no override, so the
-real `resolve_target_root` runs) with the mock's `--chdir` flag standing in for
-that per-package cwd. Keep both: a regression in `resolve_target_root` would slip
-past every override-driven test.
-
-`tests/cbh_real_engine.rs` is the one true end-to-end test: it
-writes a tiny standalone crate with a single real Criterion benchmark into a
-tempdir and drives the production `run` (no overrides) against an actual `cargo
-bench`, asserting the genuine wall-time output is harvested and stored. It is the
-only test that exercises `resolve_target_root`, real cargo argument passing, and
-Criterion's real on-disk layout together, so it would have caught the relative
-`CARGO_TARGET_DIR` bug on its own. It is deliberately heavyweight (it compiles
-Criterion and runs a benchmark process), so it is gated off under Miri and under
-coverage (`#[cfg_attr(coverage_nightly, ignore)]`); the benchmark is shrunk to
-Criterion's smallest run (10 samples, sub-second warm-up/measurement) and
-Criterion is taken with `default-features = false` to keep the build quick. When
-touching the run/harvest pipeline, do not let this test's gating tempt you to skip
-it locally — run it with plain `cargo test`/`nextest` (it is not Miri- or
-coverage-gated there). It is additionally `#[cfg_attr(mutants, ignore)]`: the
-mock-engine integration tests and the `resolve_target_root` unit test cover the same
-pipeline under mutation, so this heavyweight build (it recompiles Criterion on every
-mutant) carries no unique mutation signal — see the Mutation testing section.
-
-## Fixture-golden canaries
-
-`tests/fixtures/callgrind/*.summary.json` are **real** Gungraun output,
-`tests/fixtures/criterion/*/{benchmark,estimates}.json` are **real** Criterion
-output, and `tests/fixtures/alloc_tracker/*.json` + `tests/fixtures/all_the_time/
-*.json` are **real** `alloc_tracker` / `all_the_time` output, all committed
-verbatim. They are schema-drift canaries used by the parser
-tests, the orchestration tests, and the integration test. Do not hand-edit them to
-make a test pass — regenerate the Callgrind fixtures from `just bench-cg` (and the
-Criterion / `alloc_tracker` / `all_the_time` fixtures from a `cargo bench` run) if
-the upstream schema genuinely changes, and update the parser/tests to match.
-
-## Azure Blob storage
-
-`AzureBlobStorage` is a `Storage` backed by an Azure Blob container. It is
-**always compiled in** — `cargo-bench-history` is a CLI tool that users install
-without choosing feature flags, so gating the backend behind a build feature
-would only ever hide a backend the user explicitly configured. It pulls in the
-Azure SDK. Object keys map 1:1 to `/`-separated blob names, so the key model is
-identical to `LocalStorage` (write-once, list-by-prefix).
-
-Authentication is **Microsoft Entra ID (OAuth) only**, resolved once in
-`AzureBlobStorage::from_config`: a token credential is attached to every request
-and the endpoint is always HTTPS (Entra bearer tokens require TLS). The Entra
-credential is chosen by the `entra_credential` helper: in a GitHub Actions job
-configured for Azure federation (detected by `github_oidc::credential_from` finding
-`AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and the `ACTIONS_ID_TOKEN_REQUEST_*` pair) it
-builds a `ClientAssertionCredential` whose assertion
-(`storage::github_oidc::GithubOidcAssertion`) mints a **fresh** GitHub OIDC JWT on
-demand for each Entra token exchange; everywhere else (local `az login`, the
-`test-azure` CI job) it falls back to `DeveloperToolsCredential`. Self-minting is
-what keeps a multi-hour collection run authenticated: a single `azure/login` session
-caches one OIDC assertion that expires within minutes, so the first access-token
-refresh after it lapses re-submits a dead assertion and Entra rejects it
-(`AADSTS700024`).
-The chosen Entra credential is then wrapped in a `CachingCredential` decorator that
-holds a cache lock across the inner acquisition, so a concurrent read burst collapses
-to one token acquisition rather than racing the Windows MSAL token-cache lockfile
-(which fails the read with a permission error).
-`CachingCredential` and `GithubOidcAssertion` implement the azure SDK's
-`#[async_trait]` `TokenCredential`/`ClientAssertion` traits, so they are where the
-crate pulls in `async_trait` — the crate's own IO ports still use RPITIT
-(`impl Future`), as the external traits leave no choice.
-
-Legacy shared-key/account-SAS and verbatim-SAS auth modes have been removed; a
-leftover `account_key` or `sas_token` in a `[storage.azure]` block is now a loud
-configuration parse error (`#[serde(deny_unknown_fields)]`), the same clean-migration
-stance the crate takes for unknown `[storage.local]` fields.
-
-### The Azurite / test seam
-
-Azurite has no real Entra, so the network tests run it in `--oauth basic` mode over
-HTTPS behind a throwaway self-signed certificate. Two things are injected to make
-that work, neither of which `from_config` produces:
-
-* a **fake `TokenCredential`** returning a locally-crafted JWT whose structure and
-  `iss`/`aud`/`nbf`/`iat`/`exp` claims satisfy Azurite's `--oauth basic` check (it
-  never verifies the signature); and
-* an **`HttpClient`** that trusts the emulator's cert (a `reqwest` client with
-  `danger_accept_invalid_certs(true)` and `no_gzip()` to match production's
-  no-auto-decompression transport).
-
-`AzureBlobStorage::from_parts(account, container, endpoint, credential, http_client)`
-assembles a backend from those parts. The `storage::azure` unit round-trips call it
-directly; the `cbh_azure` end-to-end tests inject a fully-built backend through
-`Overrides::storage_override` (built via the `#[doc(hidden)]`
-`azure_backend_from_parts` seam), so production carries no "fake token" backdoor.
-Real signature validation stays proven by the `test-azure` / `test-azure-gh` jobs
-against a real Entra-only account.
-
-### Running the Azurite tests locally
-
-The network tests (`storage::azure::tests` and the `cbh_azure`
-integration file) talk to a live [Azurite](https://github.com/Azure/Azurite)
-blob emulator. They **self-skip** when no emulator is reachable, so a normal test
-run stays green without one; they run for real once Azurite is up.
-
-The `just test-azurite` recipe wraps the whole flow. Install the emulator once with
-`just install-tools` (or manually with `npm install -g azurite`), then:
-
-```powershell
-just test-azurite
-```
-
-It generates a throwaway self-signed certificate, starts an in-memory Azurite on
-`127.0.0.1:10000` in `--oauth basic` mode over HTTPS (reusing one already running),
-runs the Azure-backend tests with `BENCH_HISTORY_REQUIRE_AZURITE=1` so an
-unreachable emulator is a hard error rather than a silent skip, and stops the
-emulator it started afterward — even on failure (it never stops one it did not
-start). It is the local counterpart of `just test-azure`. To run the tests by hand
-instead, start the emulator with a cert and OAuth, then point `cargo` at it:
-
-```powershell
-# Generate a self-signed cert (PFX) that Azurite serves over HTTPS:
-$pfx = "$env:TEMP\azurite.pfx"
-$cert = New-SelfSignedCertificate -DnsName "127.0.0.1" -CertStoreLocation Cert:\CurrentUser\My
-Export-PfxCertificate -Cert $cert -FilePath $pfx -Password (ConvertTo-SecureString "azurite" -AsPlainText -Force)
-# On Windows azurite-blob is a .cmd, so launch it through cmd:
-cmd /c azurite-blob --blobHost 127.0.0.1 --blobPort 10000 --cert $pfx --pwd azurite --oauth basic --inMemoryPersistence --skipApiVersionCheck --silent --loose
-# then, in another shell:
-cargo test -p cargo-bench-history
-```
-
-* `AZURITE_BLOB_ENDPOINT` overrides the default
-  `https://127.0.0.1:10000/devstoreaccount1` endpoint.
-* `BENCH_HISTORY_REQUIRE_AZURITE=1` turns an unreachable emulator into a hard
-  failure instead of a skip. `just test-azurite` sets it for you; CI also sets it
-  in the dedicated `test-azurite` job so a misconfigured emulator can never
-  silently degrade into skipping every test.
-
-In CI these tests run only in the Linux-only `test-azurite` job (see
-`.github/workflows/validation.yml`), which starts Azurite on the runner host via
-the `start-azurite` composite action and also collects coverage so the
-`azure.rs` network paths reach Codecov (the multi-platform `coverage` job runs
-without an emulator and so cannot cover them).
-
-### Running the real-Azure tests locally
-
-The `*_in_real_azure` tests in `cbh_azure` exercise the **Microsoft Entra ID**
-path against a real Storage account, driven from configuration (no injected
-backend), which is what proves the real credential and real signature validation
-that Azurite's faked-token path cannot. They **self-skip** unless `ENABLE_AZURE` is
-set — an explicit opt-in, so the account name living in `constants.env` does not by
-itself make a plain test run target the cloud. Each test uses a fresh container that
-is deleted when it finishes, even on panic.
-
-One-time: deploy the account, managed identity and federated credentials with the
-Bicep + scripts in [`infra/azure-bench-history-test/`](../../infra/azure-bench-history-test/)
-(see its README) and record the identifiers in the repository-root `constants.env`.
-Then, signing in as your own Entra user, the `just test-azure` recipe wraps the run
-(it sets `ENABLE_AZURE` and reads the account from `constants.env` for you):
-
-```powershell
-az login
-just test-azure
-# tidy up any container a crashed run left behind:
-./infra/azure-bench-history-test/cleanup-containers.ps1
-```
-
-`just test-azure` reads the account from `BENCH_HISTORY_TEST_AZURE_ACCOUNT` (committed in
-`constants.env`); pass a name to target a different account
-(`just test-azure <storage-account-name>`). The equivalent raw command is
-`cargo test -p cargo-bench-history real_azure` with `ENABLE_AZURE`
-and `BENCH_HISTORY_TEST_AZURE_ACCOUNT` set.
-
-* `BENCH_HISTORY_AZURE_ENDPOINT` overrides the default
-  `https://<account>.blob.core.windows.net` endpoint.
-* `ENABLE_AZURE` is the gate: when set, the real-Azure tests run, and a then-missing
-  `BENCH_HISTORY_TEST_AZURE_ACCOUNT` is a hard failure instead of a skip. `just test-azure`
-  sets it locally; CI sets it (via that recipe) in the dedicated `test-azure` job,
-  which signs in via GitHub OIDC workload identity federation, so it can never
-  silently skip. It is deliberately NOT in `constants.env`, so a plain `just test`
-  leaves the real-Azure tests skipped.
-
-In CI these tests run only in the Linux-only, same-repo-only `test-azure` job (see
-`.github/workflows/validation.yml` and `.github/workflows/AGENTS.md`). It collects
-no coverage — `test-azurite` already covers `azure.rs`; its value is proving the
-real Entra + real Blob endpoint round-trip.
-
-### Mutation testing
-
-The `mutants` CI jobs run without Azurite, so the SDK-delegating IO methods
-(`put`/`put_overwrite`/`get`/`list`/`delete`/`ensure_container` plus the
-`upload_with_retry` and `upload` helpers) — whose only coverage is the Azurite
-round-trip tests — carry `#[cfg_attr(test, mutants::skip)]`, the same pattern
-`probe.rs` uses for its `git`/`rustc` shell-outs. The pure logic those methods
-lean on (`classify`, `map_error`, and the endpoint/URL construction) has dedicated
-unit tests and stays under mutation testing, so the error-mapping behavior is still
-mutation-covered.
-
-**Skipping non-discriminating tests under mutation.** The `just mutants` recipe builds
-with `--cfg mutants` set (it ensures `RUSTFLAGS` contains `--cfg mutants`, preserving any
-flags you already set; cargo-mutants itself defines no such cfg), so a test that carries
-no mutation signal here can opt out at
-the test site with `#[cfg_attr(mutants, ignore = "<why>")]`. Unlike `mutants::skip`
-on production code, this is self-documenting where the test is defined and leaves
-normal `cargo test`, coverage, and the `test-azurite`/`test-azure` jobs untouched —
-the test still compiles and runs everywhere except under mutation. The Azurite and
-real-Azure network tests (`storage::azure::tests` round-trips and the whole
-`cbh_azure` suite) use this: without an emulator they only self-skip — slowly,
-through a TCP connect timeout — while the IO they would cover is already
-`mutants::skip`. `tests/cbh_real_engine.rs` uses it too: its run/harvest pipeline is
-also driven by the mock-engine integration tests and the `resolve_target_root` unit
-test, so it adds no unique mutation signal yet would recompile Criterion on every
-mutant. The `cfg(mutants)` name is registered in the workspace `unexpected_cfgs`
-`check-cfg` list so the zero-warnings policy still holds.
-
-## Stress harness (`cargo-bench-history-stress`)
-
-The sibling `cargo-bench-history-stress` package (under `packages/`) is an
-**on-demand** binary that fabricates a giant synthetic benchmark history, seeds it
-into a storage backend, and times each `analyze` mode (`history`, `branch`, `tip`)
-over it. Its purpose is to observe how `analyze` scales; a full-scale run is on-demand
-only and never runs automatically in `just test` or CI. The package's own small unit
-and integration tests do run as a normal workspace member (and are subject to mutation
-testing and coverage). See that package's `README.md` for the dataset shape and flags.
-
-Key facts when touching it:
-
-* **Zero production-code coupling.** The harness only *writes* objects in the same
-  key layout the storage backends use (`v1/{project}/objects/{engine}/{triple}/
-  {machine}/{commit}/{file}`) and in the same **gzip body encoding** — it calls
-  `cargo_bench_history_core::codec::compress` (the exact function the backends use)
-  rather than reimplementing it, and `seed.rs` reports the *compressed* byte length
-  so the total-bytes figure reflects real on-disk/wire volume. It then reads the
-  objects back through the real public `cargo_bench_history::run_with_overrides`
-  entry point, which inflates them transparently. It deliberately does **not**
-  reach into private storage internals, so it needs no `_impl`-crate split and no
-  test-only feature on the shell crate. If a refactor changes the on-disk key layout
-  or the JSON report's top-level fields, the harness's `seed.rs` / `report.rs` must
-  be updated in lockstep.
-* **Storage selection** mirrors the tests: local filesystem by default, Azure Blob
-  under `--storage azure` (the Azure backend is always compiled in). Local mode
-  passes the store path to `analyze` as `--local=<abs path>`
-  (`StorageTarget::local_path`) rather than configuring it in the seeded file; the
-  seeded config carries only `[project]` for local and `[storage.azure]` for Azure.
-  Azure upload uses `azcopy` (installed by `just install-tools`)
-  for throughput, authenticating as the Entra user via the Azure CLI — same
-  `az login` + `BENCH_HISTORY_TEST_AZURE_ACCOUNT` contract as `test-azure`. Each run uses
-  a fresh `bh-stress-<unix>` container, deleted on exit unless `--keep`.
-* **Run it** with `just bench-history-stress` (local) or `just bench-history-stress-azure`
-  (real Azure); both pass extra flags through to the binary, e.g.
-  `just bench-history-stress --commits 100`.
-* **Determinism.** A given `--seed` and sizing reproduce a byte-identical dataset
-  (fixed dataset anchor + SplitMix64 value generator), so timings are comparable
-  across runs. The synthetic value model is shaped so each mode reports a sensible,
-  explainable mix of regressions/improvements rather than all-or-nothing (see the
-  family/divisor comments in `scenario.rs`).
-* **Dataset shape.** The default fabricates 1000 benchmarks × 2000 `main` commits
-  (only ~half store a run — the rest are gaps that exercise the "commit with no run"
-  path) across **all** engines crossed with the platforms they run on (`callgrind`
-  Linux-only; `criterion`/`alloc_tracker`/`all_the_time` on all six triples), for 20
-  discriminant sets. Deterministic engines (`callgrind`, `alloc_tracker`) store exact
-  values with no dispersion; noisy engines (`criterion`, `all_the_time`) store the
-  same shape plus a tight confidence band — kept well below the injected step
-  magnitudes — so both the exact and the noise-aware detection paths are exercised.
-  `scenario::metric_for` picks the metric kind and band per engine.
-
+`--verbose` threads a `&dyn report::Reporter` through each pipeline. Emit notes **only**
+through the guarded `ReporterExt` surface — `note_with(|| format!(…))` for one lazy line,
+`if_enabled(|notes| …)` for a block; the unconditional `Sink` is sealed, so there is no
+`enabled()`/`note()` guard to forget. Stage timings are a separate channel
+(`ReporterExt::timing`). Production `StderrReporter` writes `[bench-history] …` to **stderr
+only when verbose** (never stdout, so machine-readable output stays clean). The reporter is
+`&dyn` (not `+ Sync`) so run futures stay `!Send` / Miri-driven. Notes must be **explanatory,
+not conclusion-only** (see `docs/standalone-binaries.md`). Tests use the `#[cfg(test)]`
+`RecordingReporter`.
+
+## Storage & engines (essentials)
+
+* Object bodies are **gzip** at the `Storage` boundary via `cargo_bench_history_core::codec`;
+  callers hand/receive plain JSON. `MemoryStorage` deliberately stays **plaintext** (keeps the
+  Miri `analyze` suite fast) — do not compress it.
+* The backend is chosen at run time by `--local` / configured cloud (never a local path in the
+  committed config); read commands add a `--cache` read-through mirror. `--machine-key` is
+  CLI-only for the same reason (the config is committed). Details: DESIGN §4, §6.
+* Four engines are parsed in `bench/` — deterministic (`callgrind`, `alloc_tracker`) vs noisy
+  (`criterion`, `all_the_time`). `collect`/`backfill` invoke `cargo bench` once and harvest
+  whatever ran; `--engine` is an `analyze` facet, not a collect flag. Details: DESIGN §1.
+
+## Testing
+
+**Miri.** Pure logic and fake-driven orchestration tests are plain `#[test]` +
+`futures::executor::block_on` + a frozen clock (no runtime, no IO) so they run under Miri. Any
+test touching the real filesystem/process/runtime/wall-clock or the network emulator must be
+`#[tokio::test]` (or `#[test]`) **and** `#[cfg_attr(miri, ignore = "…")]` with a reason.
+
+**Mock engine.** End-to-end tests launch the standalone `publish = false` **`mock_bench_engine`
+package** (kept out of the shipped crate so `cargo install` places only the one real binary).
+Tests resolve it via `mock_bench_engine::binary_path()`; every `just` recipe that runs the
+suite under nextest pre-builds it once and passes `MOCK_BENCH_ENGINE` (avoids per-process
+`cargo build` races). Its crate root needs
+`#![cfg_attr(coverage_nightly, feature(coverage_attribute))]`. It writes per-engine fixture
+output on demand via repeatable flags (`--summary`/`--criterion`/`--alloc-tracker`/
+`--all-the-time`) and `--fail-if-exists` to simulate a failing commit.
+
+**CWD & target root.** The real-adapter e2e test changes CWD, so it is `#[serial]`; on Windows
+restore the original CWD **before** the `TempDir` drops. Each test pins its own tempdir target
+root through the `run_with_overrides` entry (injected as `CARGO_TARGET_DIR` for the engine) —
+**do not** reintroduce a `set_var("CARGO_TARGET_DIR", …)` guard. `tests/cbh_real_engine.rs` is
+the one true e2e (real `cargo bench` + Criterion) and the only exercise of
+`resolve_target_root`; keep it and its `resolve_target_root` guard test.
+
+**Fixtures.** `tests/fixtures/**` are **real** committed engine output doubling as schema-drift
+canaries — do not hand-edit to make a test pass; regenerate from a real run.
+
+**Backfill coverage.** Planning/skip/overwrite/error logic is exhaustively covered by
+fake-driven unit tests in `commands/backfill.rs`; keep the real-git integration drives a small
+smoke subset (each spawns many git subprocesses and dominates mutation cost) — add new
+coverage at the fake level.
+
+**Mutation.** SDK-delegating Azure IO methods carry `#[cfg_attr(test, mutants::skip)]` (only
+Azurite covers them); their pure logic stays under mutation. A test with no mutation signal
+opts out with `#[cfg_attr(mutants, ignore = "<why>")]` — `just mutants` sets `--cfg mutants`
+(registered in `unexpected_cfgs`).
+
+**Azure.** The Azure backend is always compiled in (Entra-OAuth only). Network tests
+**self-skip** when no emulator/account is reachable. Run them with `just test-azurite` (local
+Azurite; sets `BENCH_HISTORY_REQUIRE_AZURITE=1`) or `just test-azure` (real account; sets
+`ENABLE_AZURE`, reads the account from `constants.env`, needs `az login`). Auth/seam design:
+DESIGN + `storage/azure.rs`.
+
+## Stress harness
+
+`cargo-bench-history-stress` (sibling package) is an on-demand scaling experiment for
+`analyze` with **zero production-code coupling**: it writes objects in the exact storage key
+layout + gzip body (via `core::codec`) and reads them back through the public
+`run_with_overrides` entry — so if you change the on-disk key layout or the JSON report's
+top-level fields, update its `seed.rs`/`report.rs` in lockstep. Run via
+`just bench-history-stress[-azure]`; dataset shape is in its `README.md`.

--- a/packages/cargo-bench-history/README.md
+++ b/packages/cargo-bench-history/README.md
@@ -32,6 +32,11 @@ cargo bench-history backfill --local=./bench-history <from-commit> <to-commit>
 
 # Analyze the recorded history for regressions and drift.
 cargo bench-history analyze --local=./bench-history
+
+# Inspect the raw per-commit data points behind a finding, to correlate a change
+# with the commit that caused it (both --benchmark and --metric are required).
+cargo bench-history examine --local=./bench-history \
+    --benchmark my_pkg/my_group/my_case --metric instruction_count
 ```
 
 ## See also

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -11,8 +11,8 @@ analyzes that history for trends that snapshot / "previous run" tools cannot see
 
 It stores every result over time (local path or Azure blob), runs in multiple
 environments (dev PC, GitHub Actions, ADO), and partitions data only where results are
-not otherwise comparable. Its commands are `collect`, `install`, `analyze`, `backfill`,
-`list`, `prune`, `bless`, and `unbless`.
+not otherwise comparable. Its commands are `collect`, `install`, `analyze`, `examine`,
+`backfill`, `list`, `prune`, `bless`, and `unbless`.
 
 ## 1. Benchmark engines and what they emit
 
@@ -495,6 +495,45 @@ blessings at later commits stay in effect, so the timeline may remain blessed pa
 unblessed commit. `list blessings` audits them — the sidecars at the current commit by
 default, or the most recent blessing of every benchmark across the analysis window.
 
+### 7.8 `examine`
+
+`examine` answers the question a finding raises: *which commits actually moved this
+number?* Where `analyze` reports that a benchmark's metric shifted and draws a small chart,
+`examine` **pivots that chart into its data points** — one row per recorded observation of a
+single `(benchmark, metric)` series, in git first-parent order, each row pairing the value
+with the short commit id and the start of the commit's title. A maintainer reads the values
+down the column, spots where one jumps, and reads across to the title to correlate the move
+with what that commit changed.
+
+It is a **drill-down sibling of `list runs`**: both are read-only previews over `analyze`'s
+exact data-set selection that never analyze, so `examine` reuses that selection pipeline
+unchanged and stays in the same lockstep — a selection parameter added to `analyze` is added
+to `list`, `prune`, and `examine` alike. Like `analyze` it requires a resolvable repository
+(it needs first-parent topology to order the points and each commit's title to label them)
+and repeats the pivot once **per matching discriminant set**, since the same series can exist
+under several triples or machine keys.
+
+Two required options name the series, and they are the one place a command names a
+**metric**: `--benchmark <qualified-id>` selects exactly one benchmark identity and
+`--metric <name>` one metric by its stable name. `analyze` deliberately exposes no metric
+filter because a user is not expected to know the internal metric names — but `examine`'s
+input is an `analyze` *finding*, which already prints both the benchmark identity and the
+metric, so pasting them back in is natural rather than guesswork. An unknown metric name is
+rejected up front against the known set; an unknown or unmatched benchmark id is not an error
+but yields an empty pivot with the same "matched no runs" hint `analyze` gives, since whether
+an id exists is data-dependent.
+
+`examine` runs **no detection and no re-baselining** — it has no findings, modes, or
+blessings. It shows every selected point exactly as the chart would plot it (a commit
+carrying both a clean run and dirty snapshots contributes a row each, ordered
+clean-before-dirty and flagged, so a value's provenance is unambiguous), which is why the
+analysis-only flags (mode, improvements, inactive findings) are not part of its surface. The
+three output renderings compose from one pass as everywhere else: the per-commit table on
+stdout by default, the same table in Markdown, and a machine-readable JSON form that carries,
+per discriminant set, the ordered points with full-precision values and each commit's full
+title — the 50-character title truncation is a readability convenience of the text and
+Markdown tables, not of the data.
+
 ## 8. Analysis
 
 A series is built per `(discriminant set, benchmark identity, metric)`, ordered by git
@@ -602,9 +641,9 @@ or two branch points, which is why the techniques differ by mode:
 | Improvements reported | opt-in | ✅ | — |
 | Resolved (inactive) findings reported | opt-in | — | — |
 
-Modes apply to `analyze` only; `list` and `prune` reuse the same data-set *selection* but
-never analyze, so the mode and improvement/inactive flags are analyze-only and not part of
-the selection lockstep.
+Modes apply to `analyze` only; `list`, `prune`, and `examine` reuse the same data-set
+*selection* but never analyze, so the mode and improvement/inactive flags are analyze-only
+and not part of the selection lockstep.
 
 ### 8.6 Re-baselining: blessings and resolved spikes
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -519,9 +519,11 @@ Two required options name the series, and they are the one place a command names
 filter because a user is not expected to know the internal metric names — but `examine`'s
 input is an `analyze` *finding*, which already prints both the benchmark identity and the
 metric, so pasting them back in is natural rather than guesswork. An unknown metric name is
-rejected up front against the known set; an unknown or unmatched benchmark id is not an error
-but yields an empty pivot with the same "matched no runs" hint `analyze` gives, since whether
-an id exists is data-dependent.
+rejected up front against the known set. An unknown or unmatched benchmark id is not an error
+— whether an id exists is data-dependent — but yields an empty pivot explained by one of two
+hints: when no run enters the selection at all, the same "matched no runs" hint `analyze`
+gives; when runs enter but none carry the named `(benchmark, metric)` pair, a distinct hint
+pointing at the unmatched benchmark id or metric name.
 
 `examine` runs **no detection and no re-baselining** — it has no findings, modes, or
 blessings. It shows every selected point exactly as the chart would plot it (a commit

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -38,6 +38,12 @@ else is bookkeeping. Each analysis mode (`history`, `branch`, `tip`) is a separa
 invocation with its own load — there is no dataset cache across modes — and the mode is
 auto-detected once per run from git topology.
 
+The read-only `examine` command is a **lighter consumer of the same load**: it runs Phase 1
+and Phase 2/3 through the identical `select_dataset` pipeline, then narrows to a single
+`(benchmark, metric)` series and prints its points instead of running the detect stage — the
+tabular pivot of a finding's chart, with no per-series statistics. See the `examine` command
+in [`DESIGN.md`](DESIGN.md).
+
 ## The load
 
 ```mermaid

--- a/packages/cargo-bench-history/src/analyze/bless.rs
+++ b/packages/cargo-bench-history/src/analyze/bless.rs
@@ -20,6 +20,7 @@
 use std::path::Path;
 
 use jiff::Timestamp;
+use tick::Clock;
 
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
@@ -35,18 +36,20 @@ use crate::{BlessOptions, RunError, RunOutcome, UnblessOptions, finish_with_flus
 use super::StorageKey;
 use super::{
     AutoFacets, Selection, detect_auto_facets, facet_filtered_candidates, resolve_base_ref,
-    resolve_facets,
+    resolve_facets, resolve_now,
 };
 
 /// The real `bless`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
 ///
-/// `now_override` pins the issue time so end-to-end tests are deterministic;
-/// production passes `None` and uses the wall clock.
+/// `clock_override` injects the [`tick::Clock`] that stamps each blessing's issue
+/// time: `None` reads the runtime wall clock (`Clock::new_tokio`) in production,
+/// while tests inject a frozen clock (`Clock::new_frozen_at`) so the recorded time
+/// is deterministic.
 pub(crate) async fn bless(
     options: &BlessOptions,
     workspace_dir: &Path,
-    now_override: Option<Timestamp>,
+    clock_override: Option<Clock>,
 ) -> Result<RunOutcome, RunError> {
     let reporter = StderrReporter::new(options.verbose);
 
@@ -61,7 +64,7 @@ pub(crate) async fn bless(
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
     let auto = detect_auto_facets().await?;
 
-    let now = now_override.unwrap_or_else(Timestamp::now);
+    let now = resolve_now(clock_override);
     let result = bless_with(
         &git,
         &storage,

--- a/packages/cargo-bench-history/src/analyze/examine.rs
+++ b/packages/cargo-bench-history/src/analyze/examine.rs
@@ -36,10 +36,11 @@ use crate::{ExamineOptions, RunError, RunOutcome};
 
 use anyspawn::Spawner;
 use jiff::Timestamp;
+use tick::Clock;
 
 use super::{
     AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
-    format_value, select_dataset,
+    format_value, resolve_now, select_dataset,
 };
 use super::{ReportFormat, Series, SeriesFilter};
 use crate::model::{BenchmarkIdPrefix, DiscriminantSet, MetricKind};
@@ -53,12 +54,13 @@ const TITLE_LIMIT: usize = 50;
 /// The real `examine`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
 ///
-/// `now_override` anchors the history-mode default `--since` lookback to a fixed
-/// instant (see [`execute`](super::execute)); production passes `None`.
+/// `clock_override` injects the [`tick::Clock`] the shared selection anchors its
+/// "now" to (see [`execute`](super::execute)); production passes `None` for the
+/// runtime wall clock.
 pub(crate) async fn execute(
     options: &ExamineOptions,
     workspace_dir: &Path,
-    now_override: Option<Timestamp>,
+    clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
 ) -> Result<RunOutcome, RunError> {
     let reporter = StderrReporter::new(options.verbose);
@@ -83,7 +85,7 @@ pub(crate) async fn execute(
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
     let auto = detect_auto_facets().await?;
 
-    let now = now_override.unwrap_or_else(Timestamp::now);
+    let now = resolve_now(clock_override);
     // The object-load work shares the ambient Tokio worker threads (mirrors
     // `analyze::execute`).
     let spawner = Spawner::new_tokio();

--- a/packages/cargo-bench-history/src/analyze/examine.rs
+++ b/packages/cargo-bench-history/src/analyze/examine.rs
@@ -1,0 +1,1017 @@
+//! The `examine` command: pivot one `(benchmark, metric)` series into its raw
+//! per-commit data points.
+//!
+//! `examine` is a drill-down sibling of `list runs`: both are read-only previews
+//! over `analyze`'s exact data-set selection (see
+//! [`AnalyzeOptions`](crate::AnalyzeOptions) and [`ExamineOptions`]) resolved via
+//! the shared [`select_dataset`](super::select_dataset) path, so a selection
+//! parameter added to `analyze` applies here unchanged. Where `list` counts the
+//! selected runs, `examine` names one `(benchmark, metric)` series and prints its
+//! points — one row per recorded observation, in git first-parent order, pairing
+//! the value with the short commit id and the start of the commit's title so a
+//! maintainer can correlate a value's move with the commit that caused it.
+//!
+//! It runs no detection, re-baselining, or blessing: it shows every selected point
+//! exactly as the chart would plot it (a commit's clean run and its dirty snapshots
+//! each contribute a flagged row, clean before dirty). Like `analyze` it needs a
+//! resolvable repository — first-parent topology to order the points and each
+//! commit's title to label them — and repeats the pivot once per matching
+//! discriminant set.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::config::{Config, load_config};
+use crate::git_history::{GitHistory, SystemGitHistory};
+use crate::report::{Reporter, ReporterExt, StderrReporter};
+use crate::storage::{Storage, StorageFacade, resolve_storage};
+use crate::text::count_noun;
+use crate::wiring::{
+    cache_env, resolve_cache_path, resolve_config_path, resolve_local_path, resolve_project_id,
+    resolve_repo, storage_env,
+};
+use crate::{ExamineOptions, RunError, RunOutcome};
+
+use anyspawn::Spawner;
+use jiff::Timestamp;
+
+use super::{
+    AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
+    format_value, select_dataset,
+};
+use super::{ReportFormat, Series, SeriesFilter};
+use crate::model::{BenchmarkIdPrefix, DiscriminantSet, MetricKind};
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
+
+/// How many leading characters of a commit title the text and Markdown tables
+/// keep. The truncation is a readability convenience of those renderings; the JSON
+/// form carries the full title.
+const TITLE_LIMIT: usize = 50;
+
+/// The real `examine`: load configuration, wire the configured storage and git
+/// history, and orchestrate.
+///
+/// `now_override` anchors the history-mode default `--since` lookback to a fixed
+/// instant (see [`execute`](super::execute)); production passes `None`.
+pub(crate) async fn execute(
+    options: &ExamineOptions,
+    workspace_dir: &Path,
+    now_override: Option<Timestamp>,
+    storage_override: Option<StorageFacade>,
+) -> Result<RunOutcome, RunError> {
+    let reporter = StderrReporter::new(options.verbose);
+
+    let config_path = resolve_config_path(workspace_dir, options.config_path.as_deref());
+    reporter.note_with(|| format!("loading configuration from {}", config_path.display()));
+    let config = load_config(&config_path, options.config_path.is_some()).await?;
+
+    let project_id = resolve_project_id(&config, workspace_dir);
+    let local = resolve_local_path(options.local.as_ref(), storage_env().as_deref())?;
+    let cache = resolve_cache_path(options.cache.as_ref(), cache_env().as_deref())?;
+    let storage = resolve_storage(
+        storage_override,
+        local.as_deref(),
+        &config,
+        workspace_dir,
+        cache.as_deref(),
+        &reporter,
+    )?;
+    storage.synchronize_cache(&project_id, &reporter).await?;
+
+    let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
+    let auto = detect_auto_facets().await?;
+
+    let now = now_override.unwrap_or_else(Timestamp::now);
+    // The object-load work shares the ambient Tokio worker threads (mirrors
+    // `analyze::execute`).
+    let spawner = Spawner::new_tokio();
+    let writer = TokioOutputWriter::new(workspace_dir.to_path_buf());
+    let outcome = examine_with(
+        &git,
+        &storage,
+        &project_id,
+        &config,
+        options,
+        &auto,
+        now,
+        &reporter,
+        &writer,
+        &spawner,
+    )
+    .await;
+    storage.report_cache_tally(&reporter);
+    outcome
+}
+
+/// Storage- and git-generic `examine`: resolve the same data set `analyze` would,
+/// narrow it to one `(benchmark, metric)` series per discriminant set, and render
+/// the ordered data points.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors the analyze selection pipeline, which threads the same injected ports"
+)]
+pub(crate) async fn examine_with<G, S, W>(
+    git: &G,
+    storage: &S,
+    project_id: &str,
+    config: &Config,
+    options: &ExamineOptions,
+    auto: &AutoFacets,
+    now: Timestamp,
+    reporter: &dyn Reporter,
+    writer: &W,
+    spawner: &Spawner,
+) -> Result<RunOutcome, RunError>
+where
+    G: GitHistory,
+    S: Storage + Clone + 'static,
+    W: OutputWriter,
+{
+    let output = OutputSelection::resolve(
+        options.no_text,
+        options.markdown.as_deref(),
+        options.json.as_deref(),
+    )?;
+
+    // Reject an unknown metric name up front, before any load — the one command
+    // that names a metric validates it against the known set.
+    let metric_kind = parse_metric(&options.metric)?;
+
+    // The benchmark identity scopes the series load coarsely (a prefix of the
+    // qualified id); the exact `id == benchmark` narrowing happens after series
+    // reconstruction. An unmatched id is not an error — it yields an empty pivot.
+    let prefix =
+        BenchmarkIdPrefix::new(options.benchmark.clone()).map_err(|_empty| RunError::Analyze {
+            message: "--benchmark must not be empty".to_owned(),
+        })?;
+    let prefixes = [prefix];
+    let filter = SeriesFilter {
+        prefixes: &prefixes,
+    };
+
+    let selection = Selection::from_examine(options);
+    let dataset = select_dataset(
+        git, storage, project_id, config, &selection, filter, auto, now, reporter, spawner,
+    )
+    .await?;
+
+    let pivot = build_pivot(
+        project_id,
+        &options.benchmark,
+        metric_kind,
+        &dataset.series,
+        &dataset.commit_subjects,
+    );
+
+    // When the pivot is empty, explain why: either no run entered the selection at
+    // all (the same self-explaining hint `analyze` gives), or runs entered but none
+    // carried this `(benchmark, metric)` pair (a data-dependent id/name mismatch).
+    let hint = if !pivot.sets.is_empty() {
+        None
+    } else if dataset.run_index.is_empty() {
+        empty_history_hint(
+            true,
+            dataset.candidate_count,
+            &dataset.target_ref,
+            dataset.tally,
+        )
+    } else {
+        Some(unmatched_series_hint(
+            &options.benchmark,
+            metric_kind,
+            dataset.run_index.total(),
+        ))
+    };
+
+    // The same ephemeral-data warning `analyze`/`list` show when a dirty
+    // base-branch-tip run was admitted because the working tree is dirty.
+    let warning = dataset
+        .included_dirty_base_exception
+        .then(dirty_base_exception_warning);
+
+    let message = emit(&output, writer, reporter, |format| {
+        render_pivot(&pivot, format, hint.as_deref(), warning.as_deref())
+    })
+    .await?;
+    Ok(RunOutcome::Completed { message })
+}
+
+/// Parses the `--metric` value into a [`MetricKind`], rejecting an unknown name
+/// with the list of valid names.
+fn parse_metric(name: &str) -> Result<MetricKind, RunError> {
+    MetricKind::from_name(name).ok_or_else(|| {
+        let valid = MetricKind::ALL
+            .iter()
+            .map(|kind| kind.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        RunError::Analyze {
+            message: format!("unknown metric {name:?}; expected one of: {valid}"),
+        }
+    })
+}
+
+/// One recorded observation of the examined series.
+#[derive(Clone, Debug)]
+struct DataPoint {
+    /// The commit the run was measured against (full SHA, or a label in tests).
+    commit: String,
+    /// The short commit id shown in the text and Markdown tables.
+    short_commit: String,
+    /// The measured value.
+    value: f64,
+    /// Whether the observation came from a dirty (uncommitted-tree) snapshot.
+    dirty: bool,
+    /// The commit's full title (subject), empty when topology reported none.
+    title: String,
+}
+
+/// One discriminant set's slice of the pivot.
+#[derive(Clone, Debug)]
+struct SetPivot {
+    /// The comparable partition these points share.
+    set: DiscriminantSet,
+    /// The observations, oldest first by git topology (clean before dirty).
+    points: Vec<DataPoint>,
+}
+
+/// The fully resolved pivot of one `(benchmark, metric)` series, ready to render.
+#[derive(Clone, Debug)]
+struct Pivot {
+    /// The project the data belongs to.
+    project: String,
+    /// The qualified benchmark identity that was examined.
+    benchmark: String,
+    /// The metric's stable name.
+    metric: &'static str,
+    /// The metric's unit, for display.
+    unit: &'static str,
+    /// The per-set slices, one entry per discriminant set carrying the series.
+    sets: Vec<SetPivot>,
+}
+
+/// Narrows the reconstructed series to the one `(benchmark, metric)` pair, once per
+/// discriminant set, and turns each into its ordered data points.
+fn build_pivot(
+    project_id: &str,
+    benchmark: &str,
+    metric_kind: MetricKind,
+    series: &[Series],
+    commit_subjects: &HashMap<String, String>,
+) -> Pivot {
+    let mut sets: Vec<SetPivot> = series
+        .iter()
+        .filter(|one| one.kind == metric_kind && one.id.qualified() == benchmark)
+        .map(|one| {
+            let points = one
+                .points
+                .iter()
+                .map(|point| {
+                    let commit = point.commit.as_deref().unwrap_or("unknown");
+                    let title = commit_subjects.get(commit).cloned().unwrap_or_default();
+                    DataPoint {
+                        short_commit: short_sha(commit).to_owned(),
+                        commit: commit.to_owned(),
+                        value: point.value,
+                        dirty: point.dirty,
+                        title,
+                    }
+                })
+                .collect();
+            SetPivot {
+                set: one.set.clone(),
+                points,
+            }
+        })
+        .collect();
+    // Sort the sets deterministically so the same data set always renders in the
+    // same order regardless of series-build order.
+    sets.sort_by(|left, right| left.set.cmp(&right.set));
+
+    Pivot {
+        project: project_id.to_owned(),
+        benchmark: benchmark.to_owned(),
+        metric: metric_kind.as_str(),
+        unit: metric_kind.as_unit(),
+        sets,
+    }
+}
+
+/// The hint shown when runs entered the selection but none carried the examined
+/// `(benchmark, metric)` pair — a data-dependent id or name mismatch.
+fn unmatched_series_hint(benchmark: &str, metric: MetricKind, entered: usize) -> String {
+    format!(
+        "{} entered the analysis, but none recorded benchmark {benchmark:?} with metric {:?}. \
+         Check the benchmark id and metric name — copy them verbatim from an `analyze` finding \
+         (`list runs` shows the benchmark ids present in the data set).",
+        count_noun(entered, "run"),
+        metric.as_str(),
+    )
+}
+
+/// The first [`TITLE_LIMIT`] characters of a commit title, for the text and
+/// Markdown tables.
+fn truncate_title(title: &str) -> String {
+    title.chars().take(TITLE_LIMIT).collect()
+}
+
+/// The short commit id: the first 12 characters of the SHA (mirrors the
+/// abbreviation `list`, `bless`, and `backfill` use).
+fn short_sha(sha: &str) -> &str {
+    sha.get(..12).unwrap_or(sha)
+}
+
+/// Renders the pivot in the requested format, appending the diagnostic hint and
+/// ephemeral-data warning (if any).
+fn render_pivot(
+    pivot: &Pivot,
+    format: ReportFormat,
+    hint: Option<&str>,
+    warning: Option<&str>,
+) -> String {
+    match format {
+        ReportFormat::Text => render_pivot_text(pivot, hint, warning),
+        ReportFormat::Markdown => render_pivot_markdown(pivot, hint, warning),
+        ReportFormat::Json => render_pivot_json(pivot, hint, warning),
+    }
+}
+
+fn render_pivot_text(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -> String {
+    let mut lines = vec![format!(
+        "Data points for {} metric {} ({}) in project {}",
+        pivot.benchmark, pivot.metric, pivot.unit, pivot.project
+    )];
+    if pivot.sets.is_empty() {
+        lines.push(String::new());
+        lines.push("No data point matches the selection.".to_owned());
+    } else {
+        for set in &pivot.sets {
+            lines.push(String::new());
+            lines.push(set.set.to_string());
+            // Align the commit and value columns so a maintainer can read the values
+            // straight down and spot where one jumps.
+            let commit_width = set
+                .points
+                .iter()
+                .map(|point| point.short_commit.len())
+                .max()
+                .unwrap_or(0);
+            let values: Vec<String> = set
+                .points
+                .iter()
+                .map(|point| format_value(point.value))
+                .collect();
+            let value_width = values.iter().map(String::len).max().unwrap_or(0);
+            for (point, value) in set.points.iter().zip(&values) {
+                let title = truncate_title(&point.title);
+                let marker = if point.dirty { "  (dirty)" } else { "" };
+                lines.push(format!(
+                    "  {commit:<commit_width$}  {value:>value_width$}  {title}{marker}",
+                    commit = point.short_commit,
+                ));
+            }
+        }
+    }
+    append_hint_and_warning(&mut lines, hint, warning);
+    format!("{}\n", lines.join("\n"))
+}
+
+fn render_pivot_markdown(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -> String {
+    let mut lines = vec![
+        format!("# Data points for {} in {}", pivot.benchmark, pivot.project),
+        String::new(),
+        format!("**Metric:** {} ({})", pivot.metric, pivot.unit),
+    ];
+    if pivot.sets.is_empty() {
+        lines.push(String::new());
+        lines.push("No data point matches the selection.".to_owned());
+    } else {
+        for set in &pivot.sets {
+            lines.push(String::new());
+            lines.push(format!("## {}", set.set));
+            lines.push(String::new());
+            lines.push("| Commit | Value | Kind | Title |".to_owned());
+            lines.push("| --- | --- | --- | --- |".to_owned());
+            for point in &set.points {
+                let kind = if point.dirty { "dirty" } else { "clean" };
+                lines.push(format!(
+                    "| {} | {} | {} | {} |",
+                    point.short_commit,
+                    format_value(point.value),
+                    kind,
+                    escape_cell(&truncate_title(&point.title)),
+                ));
+            }
+        }
+    }
+    append_hint_and_warning(&mut lines, hint, warning);
+    format!("{}\n", lines.join("\n"))
+}
+
+fn render_pivot_json(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -> String {
+    #[derive(Serialize)]
+    struct JsonPoint<'a> {
+        commit: &'a str,
+        value: f64,
+        dirty: bool,
+        title: &'a str,
+    }
+    #[derive(Serialize)]
+    struct JsonSet<'a> {
+        engine: &'a str,
+        target_triple: &'a str,
+        machine_key: &'a str,
+        points: Vec<JsonPoint<'a>>,
+    }
+    #[derive(Serialize)]
+    struct JsonPivot<'a> {
+        project: &'a str,
+        benchmark: &'a str,
+        metric: &'a str,
+        unit: &'a str,
+        sets: Vec<JsonSet<'a>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hint: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        warning: Option<&'a str>,
+    }
+
+    let sets: Vec<JsonSet<'_>> = pivot
+        .sets
+        .iter()
+        .map(|set| JsonSet {
+            engine: &set.set.engine,
+            target_triple: &set.set.target_triple,
+            machine_key: &set.set.machine_key,
+            points: set
+                .points
+                .iter()
+                .map(|point| JsonPoint {
+                    commit: &point.commit,
+                    value: point.value,
+                    dirty: point.dirty,
+                    title: &point.title,
+                })
+                .collect(),
+        })
+        .collect();
+
+    let document = JsonPivot {
+        project: &pivot.project,
+        benchmark: &pivot.benchmark,
+        metric: pivot.metric,
+        unit: pivot.unit,
+        sets,
+        hint,
+        warning,
+    };
+    serde_json::to_string_pretty(&document).expect("pivot structures always serialize to JSON")
+}
+
+/// Escapes a Markdown table cell so a commit title's pipe characters do not break
+/// the table's column layout.
+fn escape_cell(value: &str) -> String {
+    value.replace('|', "\\|")
+}
+
+/// Appends the hint and warning (if any) as trailing, blank-line-separated blocks
+/// so they read at the very end of a text or Markdown pivot.
+fn append_hint_and_warning(lines: &mut Vec<String>, hint: Option<&str>, warning: Option<&str>) {
+    if let Some(hint) = hint {
+        lines.push(String::new());
+        lines.push(hint.to_owned());
+    }
+    if let Some(warning) = warning {
+        lines.push(String::new());
+        lines.push(warning.to_owned());
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
+    use std::path::{Path, PathBuf};
+
+    use futures::executor::block_on;
+    use jiff::Timestamp;
+    use nonempty::nonempty;
+
+    use crate::config::Config;
+    use crate::git_history::FakeGitHistory;
+    use crate::model::{BenchmarkId, BenchmarkResult, Metric, MetricKind, Run};
+    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
+    use crate::output::MemoryOutputWriter;
+    use crate::report::RecordingReporter;
+    use crate::storage::{MemoryStorage, Storage};
+
+    use super::*;
+
+    fn config() -> Config {
+        Config::default()
+    }
+
+    /// The auto-detected facets for the default synthetic partition the tests seed.
+    fn auto() -> AutoFacets {
+        AutoFacets {
+            triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        }
+    }
+
+    fn options() -> ExamineOptions {
+        ExamineOptions {
+            benchmark: "nm/nm::observe/pull".to_owned(),
+            metric: "instruction_count".to_owned(),
+            ..ExamineOptions::default()
+        }
+    }
+
+    /// An inline spawner that runs the load tasks on the calling thread, so the
+    /// tests need no Tokio runtime under `block_on` or Miri.
+    fn spawner() -> Spawner {
+        cargo_bench_history_core::testing::synchronous_spawner()
+    }
+
+    /// A run with one benchmark carrying a single instruction-count metric of the
+    /// given value on the given commit.
+    fn single_metric_run(effective: i64, commit: &str, value: f64) -> Run {
+        let time = Timestamp::from_second(effective).unwrap();
+        let context = RunContext::new(
+            time,
+            GitInfo {
+                commit: Some(commit.to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let record = BenchmarkResult::new(
+            BenchmarkId::new(nonempty![
+                "nm".to_owned(),
+                "nm::observe".to_owned(),
+                "pull".to_owned(),
+            ]),
+            vec![Metric::new(MetricKind::InstructionCount, value)],
+        );
+        Run::new(context, vec![record])
+    }
+
+    /// A run whose one benchmark carries two metrics, so the partition reconstructs
+    /// two distinct series (only one of which any single `--metric` selects).
+    fn two_metric_run(effective: i64, commit: &str, ir: f64, cycles: f64) -> Run {
+        let time = Timestamp::from_second(effective).unwrap();
+        let context = RunContext::new(
+            time,
+            GitInfo {
+                commit: Some(commit.to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let record = BenchmarkResult::new(
+            BenchmarkId::new(nonempty![
+                "nm".to_owned(),
+                "nm::observe".to_owned(),
+                "pull".to_owned(),
+            ]),
+            vec![
+                Metric::new(MetricKind::InstructionCount, ir),
+                Metric::new(MetricKind::EstimatedCycles, cycles),
+            ],
+        );
+        Run::new(context, vec![record])
+    }
+
+    fn clean_key(commit: &str) -> String {
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json")
+    }
+
+    fn dirty_key(commit: &str, unix: i64) -> String {
+        format!(
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/dirty-{unix}.json"
+        )
+    }
+
+    fn store(storage: &MemoryStorage, key: &str, run: &Run) {
+        let json = run.to_json().unwrap();
+        block_on(storage.put(key, json.as_bytes())).unwrap();
+    }
+
+    /// A linear history `c0 <- c1 <- c2 <- c3` with commit titles, on the default
+    /// branch `master`.
+    fn linear_git() -> FakeGitHistory {
+        let mut git = FakeGitHistory::new();
+        git.commit("c0", None)
+            .commit("c1", Some("c0"))
+            .commit("c2", Some("c1"))
+            .commit("c3", Some("c2"))
+            .subject("c0", "Add the pull benchmark")
+            .subject("c1", "Optimize the hot loop")
+            .subject(
+                "c2",
+                "Refactor the observer to shave allocations off the record path",
+            )
+            .branch("master", "c3")
+            .head("master")
+            .mark_default("master");
+        git
+    }
+
+    /// A throwaway in-memory output writer for tests that assert on the returned
+    /// text message rather than on written files.
+    fn writer() -> MemoryOutputWriter {
+        MemoryOutputWriter::new()
+    }
+
+    /// Drives `examine_with` and unwraps the rendered text message.
+    fn examine(storage: &MemoryStorage, git: &FakeGitHistory, options: &ExamineOptions) -> String {
+        let outcome = block_on(examine_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            options,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap();
+        match outcome {
+            RunOutcome::Completed { message } => message,
+            RunOutcome::Analyzed { .. } => panic!("examine returns a Completed outcome"),
+        }
+    }
+
+    /// Drives `examine_with` requesting the JSON report into an in-memory writer and
+    /// returns the JSON text (the text report is suppressed).
+    fn examine_json(
+        storage: &MemoryStorage,
+        git: &FakeGitHistory,
+        options: &ExamineOptions,
+    ) -> String {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.markdown = None;
+        options.json = Some(PathBuf::from("report.json"));
+        let writer = MemoryOutputWriter::new();
+        block_on(examine_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer,
+            &spawner(),
+        ))
+        .unwrap();
+        writer
+            .written(Path::new("report.json"))
+            .expect("the JSON report was written to the requested path")
+    }
+
+    /// Drives `examine_with` requesting the Markdown report into an in-memory writer
+    /// and returns the Markdown text.
+    fn examine_markdown(
+        storage: &MemoryStorage,
+        git: &FakeGitHistory,
+        options: &ExamineOptions,
+    ) -> String {
+        let mut options = options.clone();
+        options.no_text = true;
+        options.json = None;
+        options.markdown = Some(PathBuf::from("report.md"));
+        let writer = MemoryOutputWriter::new();
+        block_on(examine_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer,
+            &spawner(),
+        ))
+        .unwrap();
+        writer
+            .written(Path::new("report.md"))
+            .expect("the Markdown report was written to the requested path")
+    }
+
+    #[test]
+    fn pivots_one_series_into_ordered_points() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        store(
+            &storage,
+            &clean_key("c2"),
+            &single_metric_run(2, "c2", 128.0),
+        );
+        let git = linear_git();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+
+        assert_eq!(parsed["benchmark"], "nm/nm::observe/pull");
+        assert_eq!(parsed["metric"], "instruction_count");
+        assert_eq!(parsed["unit"], "count");
+        let sets = parsed["sets"].as_array().unwrap();
+        assert_eq!(sets.len(), 1);
+        let points = sets[0]["points"].as_array().unwrap();
+        assert_eq!(points.len(), 3);
+        // Oldest first by topology.
+        assert_eq!(points[0]["commit"], "c0");
+        assert_eq!(points[0]["value"], 100.0);
+        assert_eq!(points[0]["dirty"], false);
+        assert_eq!(points[0]["title"], "Add the pull benchmark");
+        assert_eq!(points[2]["commit"], "c2");
+        assert_eq!(points[2]["value"], 128.0);
+    }
+
+    #[test]
+    fn json_keeps_full_precision_and_full_title() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c2"),
+            &single_metric_run(2, "c2", 128.499_999),
+        );
+        let git = linear_git();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let point = &parsed["sets"][0]["points"][0];
+        assert_eq!(point["value"], 128.499_999);
+        // The full, untruncated title (54 chars) survives in JSON.
+        assert_eq!(
+            point["title"],
+            "Refactor the observer to shave allocations off the record path"
+        );
+    }
+
+    #[test]
+    fn text_truncates_the_title_to_fifty_characters() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c2"),
+            &single_metric_run(2, "c2", 128.0),
+        );
+        let git = linear_git();
+
+        let report = examine(&storage, &git, &options());
+        assert!(
+            report.contains("Data points for nm/nm::observe/pull"),
+            "{report}"
+        );
+        // The 62-char subject is cut to its first 50 characters ("...off the"),
+        // dropping the trailing " record path".
+        assert!(
+            report.contains("Refactor the observer to shave allocations off the"),
+            "{report}"
+        );
+        assert!(
+            !report.contains("record path"),
+            "the title is truncated to 50 characters: {report}"
+        );
+    }
+
+    #[test]
+    fn flags_dirty_snapshots_after_the_clean_run() {
+        // On the base branch (linear history, tip == merge-base) with a dirty
+        // working tree, the tip's clean run and its dirty snapshot both show — the
+        // dirty snapshot admitted via the base-tip dirty exception, ordered after
+        // the clean run and flagged.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c3"),
+            &single_metric_run(3, "c3", 100.0),
+        );
+        store(
+            &storage,
+            &dirty_key("c3", 400),
+            &single_metric_run(4, "c3", 118.0),
+        );
+        let mut git = linear_git();
+        git.mark_dirty();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(points.len(), 2, "clean and dirty both shown: {report}");
+        assert_eq!(points[0]["dirty"], false, "clean first");
+        assert_eq!(points[0]["value"], 100.0);
+        assert_eq!(points[1]["dirty"], true, "dirty second");
+        assert_eq!(points[1]["value"], 118.0);
+        // The dirty tip snapshot is ephemeral, so the pivot carries the warning.
+        assert!(
+            parsed["warning"].as_str().is_some(),
+            "ephemeral-data warning present: {report}"
+        );
+
+        let text = examine(&storage, &git, &options());
+        assert!(text.contains("(dirty)"), "the dirty row is flagged: {text}");
+    }
+
+    #[test]
+    fn selects_only_the_named_metric_of_a_multi_metric_benchmark() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &two_metric_run(0, "c0", 100.0, 250.0),
+        );
+        let git = linear_git();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(points.len(), 1);
+        // The instruction-count value, not the estimated-cycles one.
+        assert_eq!(points[0]["value"], 100.0);
+
+        let cycles = ExamineOptions {
+            metric: "estimated_cycles".to_owned(),
+            ..options()
+        };
+        let report = examine_json(&storage, &git, &cycles);
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["sets"][0]["points"][0]["value"], 250.0);
+    }
+
+    #[test]
+    fn markdown_renders_a_per_set_table() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = linear_git();
+
+        let report = examine_markdown(&storage, &git, &options());
+        assert!(
+            report.contains("# Data points for nm/nm::observe/pull in folo"),
+            "{report}"
+        );
+        assert!(
+            report.contains("**Metric:** instruction_count (count)"),
+            "{report}"
+        );
+        assert!(
+            report.contains("| Commit | Value | Kind | Title |"),
+            "{report}"
+        );
+        assert!(report.contains("| c0 | 100 | clean |"), "{report}");
+    }
+
+    #[test]
+    fn unknown_metric_is_rejected_up_front() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = linear_git();
+
+        let opts = ExamineOptions {
+            metric: "not_a_metric".to_owned(),
+            ..options()
+        };
+        let error = block_on(examine_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &opts,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap_err();
+        match error {
+            RunError::Analyze { message } => {
+                assert!(message.contains("unknown metric"), "{message}");
+                assert!(message.contains("instruction_count"), "{message}");
+            }
+            other => panic!("expected an Analyze error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unmatched_benchmark_yields_empty_pivot_with_hint() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = linear_git();
+
+        let opts = ExamineOptions {
+            benchmark: "nm/nm::observe/nonexistent".to_owned(),
+            ..options()
+        };
+        let report = examine(&storage, &git, &opts);
+        assert!(
+            report.contains("No data point matches the selection."),
+            "{report}"
+        );
+        // Runs entered, but none carried the pair: the id/name-mismatch hint.
+        assert!(report.contains("entered the analysis"), "{report}");
+        assert!(report.contains("nonexistent"), "{report}");
+    }
+
+    #[test]
+    fn requires_a_repository() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = FakeGitHistory::new(); // No commits: HEAD does not resolve.
+        let error = block_on(examine_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &options(),
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &RecordingReporter::new(),
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap_err();
+        assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
+    }
+
+    #[test]
+    fn pivots_each_matching_discriminant_set() {
+        // The same benchmark and metric recorded under two engines.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/synthetic/c0/clean.json",
+            &single_metric_run(0, "c0", 200.0),
+        );
+        let git = linear_git();
+
+        let opts = ExamineOptions {
+            engine: vec!["all".to_owned()],
+            ..options()
+        };
+        let report = examine_json(&storage, &git, &opts);
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let sets = parsed["sets"].as_array().unwrap();
+        assert_eq!(sets.len(), 2, "one pivot per discriminant set: {report}");
+    }
+
+    #[test]
+    fn parse_metric_lists_every_valid_name_on_error() {
+        let error = parse_metric("bogus").unwrap_err();
+        let RunError::Analyze { message } = error else {
+            panic!("expected an Analyze error");
+        };
+        for kind in MetricKind::ALL {
+            assert!(
+                message.contains(kind.as_str()),
+                "the error should list {}: {message}",
+                kind.as_str()
+            );
+        }
+    }
+}

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -30,10 +30,11 @@ use crate::{ListOptions, ListSubject, RunError, RunOutcome};
 
 use anyspawn::Spawner;
 use jiff::Timestamp;
+use tick::Clock;
 
 use super::{
     AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
-    facet_filtered_candidates, resolve_facets, select_dataset,
+    facet_filtered_candidates, resolve_facets, resolve_now, select_dataset,
 };
 use super::{ReportFormat, RunIndex, Series, SeriesFilter, apply_blessings};
 use crate::model::BlessingRecord;
@@ -43,12 +44,13 @@ use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 /// The real `list`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
 ///
-/// `now_override` anchors the history-mode default `--since` lookback to a fixed
-/// instant (see [`execute`](super::execute)); production passes `None`.
+/// `clock_override` injects the [`tick::Clock`] the shared selection anchors its
+/// "now" to (see [`execute`](super::execute)); production passes `None` for the
+/// runtime wall clock.
 pub(crate) async fn execute(
     options: &ListOptions,
     workspace_dir: &Path,
-    now_override: Option<Timestamp>,
+    clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
 ) -> Result<RunOutcome, RunError> {
     let reporter = StderrReporter::new(options.verbose);
@@ -73,7 +75,7 @@ pub(crate) async fn execute(
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
     let auto = detect_auto_facets().await?;
 
-    let now = now_override.unwrap_or_else(Timestamp::now);
+    let now = resolve_now(clock_override);
     // The object-load and detection work shares the ambient Tokio worker threads
     // (mirrors `analyze::execute`).
     let spawner = Spawner::new_tokio();

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -550,20 +550,27 @@ impl RunIndex {
     /// topological position, as `(first, last)` full SHAs. `None` when no run was
     /// admitted. The report header uses it to state the span of analyzed history.
     pub(crate) fn commit_span(&self) -> Option<(&str, &str)> {
-        let mut first: Option<(usize, &str)> = None;
-        let mut last: Option<(usize, &str)> = None;
-        for by_commit in self.sets.values() {
-            for (&topo_index, counts) in by_commit {
-                let commit = counts.commit.as_str();
-                if first.is_none_or(|(index, _)| topo_index < index) {
-                    first = Some((topo_index, commit));
-                }
-                if last.is_none_or(|(index, _)| topo_index > index) {
-                    last = Some((topo_index, commit));
-                }
-            }
-        }
-        Some((first?.1, last?.1))
+        // A given first-parent position maps to exactly one commit, so every set records
+        // the same commit under it: the span is simply the commit at the lowest position
+        // and the one at the highest. Reading those extremes with `min_by_key`/`max_by_key`
+        // keeps the ordering in the standard library rather than a hand-rolled comparison.
+        let first = self
+            .sets
+            .values()
+            .flat_map(|by_commit| by_commit.iter())
+            .min_by_key(|entry| *entry.0)?
+            .1
+            .commit
+            .as_str();
+        let last = self
+            .sets
+            .values()
+            .flat_map(|by_commit| by_commit.iter())
+            .max_by_key(|entry| *entry.0)?
+            .1
+            .commit
+            .as_str();
+        Some((first, last))
     }
 }
 
@@ -2987,10 +2994,15 @@ mod tests {
             no_dirty: true,
             ..options()
         };
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
+        let (report, _, reporter) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 3, "--no-dirty drops the dirty tip snapshot");
         assert!(parsed["warning"].is_null(), "no warning under --no-dirty");
+        assert!(
+            !reporter.contains("dirty snapshots on a base-side tip will be admitted"),
+            "--no-dirty skips the dirtiness probe, so the dirty-tree exception never fires: {:?}",
+            reporter.notes()
+        );
     }
 
     #[test]
@@ -3693,6 +3705,15 @@ mod tests {
             Some(("solo", "solo")),
             "a single analyzed commit is both ends of the span"
         );
+    }
+
+    #[test]
+    fn resolve_now_reads_the_injected_clock() {
+        // The analyze family sources its wall-clock anchor through an injectable
+        // `tick::Clock`; a frozen clock must surface its own instant verbatim rather than
+        // any default minted independently of the clock.
+        let anchor = ts(1_700_000_000);
+        assert_eq!(resolve_now(Some(Clock::new_frozen_at(anchor))), anchor);
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -36,6 +36,7 @@ use jiff::civil::Date;
 use jiff::tz::TimeZone;
 use jiff::{Span, Timestamp};
 use nonempty::NonEmpty;
+use tick::Clock;
 
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
@@ -59,14 +60,16 @@ use crate::{
 /// The real `analyze`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
 ///
-/// `now_override` anchors the history-mode default `--since` lookback to a fixed
-/// instant; production passes `None` so the anchor is the wall clock, while tests
-/// pass a deterministic instant (the relative-`--since` parsing keeps using the
-/// real clock regardless — only the *default* lookback uses this anchor).
+/// `clock_override` injects the [`tick::Clock`] the analysis anchors its "now" to:
+/// `None` reads the runtime wall clock (`Clock::new_tokio`), while tests pass a
+/// frozen clock (`Clock::new_frozen_at`) so the anchor is deterministic. That
+/// single anchor drives both the history-mode default `--since` look-back and the
+/// resolution of any relative `--since`/`--until` duration, so the whole window is
+/// deterministic under a frozen clock.
 pub(crate) async fn execute(
     options: &AnalyzeOptions,
     workspace_dir: &Path,
-    now_override: Option<Timestamp>,
+    clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
 ) -> Result<RunOutcome, RunError> {
     // Per-object notes follow `--verbose`; stage timings are emitted under either
@@ -96,7 +99,7 @@ pub(crate) async fn execute(
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
     let auto = detect_auto_facets().await?;
 
-    let now = now_override.unwrap_or_else(Timestamp::now);
+    let now = resolve_now(clock_override);
     let color = should_colorize(
         std::io::stdout().is_terminal(),
         std::env::var_os("NO_COLOR").is_some(),
@@ -126,6 +129,20 @@ pub(crate) async fn execute(
     // diagnosed as a cold or invalidated mirror regardless of the load's outcome.
     storage.report_cache_tally(&reporter);
     outcome
+}
+
+/// Reads the analysis anchor instant from a [`tick::Clock`], the single source of
+/// wall-clock time for the whole analyze family (`analyze`/`list`/`examine`/`prune`/
+/// `bless`).
+///
+/// Production passes `clock_override: None` and reads the runtime clock
+/// (`Clock::new_tokio`); tests inject a frozen clock (`Clock::new_frozen_at`) so the
+/// resolved window is deterministic. Sourcing the instant through the clock keeps
+/// time injectable rather than minting it from a bare `Timestamp::now()`.
+pub(super) fn resolve_now(clock_override: Option<Clock>) -> Timestamp {
+    clock_override
+        .unwrap_or_else(Clock::new_tokio)
+        .system_time_as::<Timestamp>()
 }
 
 /// Whether colored output should be emitted: only to an interactive terminal with
@@ -1004,7 +1021,7 @@ where
             since_cutoff_reason(selection.since.is_some(), mode)
         )
     });
-    let until = parse_until(selection.until)?;
+    let until = parse_until(selection.until, now)?;
     reporter.note_with(|| {
         format!(
             "until cutoff: {}",
@@ -1296,7 +1313,7 @@ fn resolve_since(
     now: Timestamp,
 ) -> Result<Option<Timestamp>, RunError> {
     if value.is_some() {
-        return parse_since(value);
+        return parse_since(value, now);
     }
     if mode == AnalysisMode::History {
         return default_history_since(now).map(Some);
@@ -1696,16 +1713,18 @@ fn parse_engine(name: Option<&str>) -> Result<Option<Engine>, RunError> {
 
 /// Parses the `--since` option into an absolute lower-bound instant, if set.
 ///
-/// See [`parse_instant`] for the accepted input forms.
-fn parse_since(value: Option<&str>) -> Result<Option<Timestamp>, RunError> {
-    parse_instant(value, "--since")
+/// See [`parse_instant`] for the accepted input forms. `now` anchors a relative
+/// duration.
+fn parse_since(value: Option<&str>, now: Timestamp) -> Result<Option<Timestamp>, RunError> {
+    parse_instant(value, "--since", now)
 }
 
 /// Parses the `--until` option into an absolute upper-bound instant, if set.
 ///
-/// See [`parse_instant`] for the accepted input forms.
-fn parse_until(value: Option<&str>) -> Result<Option<Timestamp>, RunError> {
-    parse_instant(value, "--until")
+/// See [`parse_instant`] for the accepted input forms. `now` anchors a relative
+/// duration.
+fn parse_until(value: Option<&str>, now: Timestamp) -> Result<Option<Timestamp>, RunError> {
+    parse_instant(value, "--until", now)
 }
 
 /// Which edge of the `--since`/`--until` window a commit falls outside of.
@@ -1749,14 +1768,22 @@ fn window_excludes(
 /// * a bare `YYYY-MM-DD` date, interpreted at UTC midnight, and
 /// * a relative duration in jiff's friendly or ISO 8601 form (`5 months`,
 ///   `5 months ago`, `P6M`, `2w`), interpreted as *that far in the past* —
-///   resolved against the current instant via calendar-correct zoned arithmetic.
+///   resolved against `now` via calendar-correct zoned arithmetic.
+///
+/// `now` is the analysis anchor sourced from the injected clock (see
+/// [`resolve_now`]), so the relative form is deterministic under a frozen clock
+/// rather than reading the wall clock afresh.
 ///
 /// The relative form is normalized through [`Span::abs`] before subtracting, so a
 /// duration written with the friendly `ago` suffix (which jiff parses as a
 /// *negative* span) still means "this far back" rather than flipping into the
 /// future. A cutoff in the future is never a sensible bound, so both `5 months`
 /// and `5 months ago` resolve to the same past instant.
-fn parse_instant(value: Option<&str>, flag: &str) -> Result<Option<Timestamp>, RunError> {
+fn parse_instant(
+    value: Option<&str>,
+    flag: &str,
+    now: Timestamp,
+) -> Result<Option<Timestamp>, RunError> {
     let Some(value) = value else {
         return Ok(None);
     };
@@ -1772,7 +1799,7 @@ fn parse_instant(value: Option<&str>, flag: &str) -> Result<Option<Timestamp>, R
         return Ok(Some(zoned.timestamp()));
     }
     if let Ok(span) = value.parse::<Span>() {
-        return Ok(Some(instant_before_now(span, flag)?));
+        return Ok(Some(instant_before(span, flag, now)?));
     }
     Err(RunError::Analyze {
         message: format!(
@@ -1782,14 +1809,14 @@ fn parse_instant(value: Option<&str>, flag: &str) -> Result<Option<Timestamp>, R
     })
 }
 
-/// Resolves a relative [`Span`] to the instant that far before now, treating the
+/// Resolves a relative [`Span`] to the instant that far before `now`, treating the
 /// span's magnitude as a look-back regardless of its sign (see [`parse_instant`]).
 ///
 /// Calendar units (months, years) have no fixed length, so the subtraction is
-/// anchored to the current UTC zoned datetime rather than to a bare duration.
-fn instant_before_now(span: Span, flag: &str) -> Result<Timestamp, RunError> {
-    let now = Timestamp::now().to_zoned(TimeZone::UTC);
-    now.checked_sub(span.abs())
+/// anchored to `now`'s UTC zoned datetime rather than to a bare duration.
+fn instant_before(span: Span, flag: &str, now: Timestamp) -> Result<Timestamp, RunError> {
+    now.to_zoned(TimeZone::UTC)
+        .checked_sub(span.abs())
         .map(|zoned| zoned.timestamp())
         .map_err(|error| RunError::Analyze {
             message: format!("{flag} duration is out of the representable range: {error}"),
@@ -3487,54 +3514,50 @@ mod tests {
 
     #[test]
     fn since_accepts_timestamp_and_date() {
+        let now: Timestamp = "2024-06-01T00:00:00Z".parse().unwrap();
         assert_eq!(
-            parse_since(Some("2024-01-01T00:00:00Z")).unwrap(),
+            parse_since(Some("2024-01-01T00:00:00Z"), now).unwrap(),
             Some("2024-01-01T00:00:00Z".parse().unwrap())
         );
         assert_eq!(
-            parse_since(Some("2024-01-01")).unwrap(),
+            parse_since(Some("2024-01-01"), now).unwrap(),
             Some("2024-01-01T00:00:00Z".parse().unwrap())
         );
-        assert_eq!(parse_since(None).unwrap(), None);
+        assert_eq!(parse_since(None, now).unwrap(), None);
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "relative `--since` parsing reads the wall clock")]
     fn since_accepts_relative_durations_as_look_back() {
         // A friendly duration resolves to an instant in the past, and the `ago`
         // suffix (which jiff parses as a negative span) means the same look-back
-        // rather than flipping into the future.
-        let now = Timestamp::now();
-        let plain = parse_since(Some("5 months")).unwrap().unwrap();
-        let with_ago = parse_since(Some("5 months ago")).unwrap().unwrap();
-        assert!(plain < now, "a look-back must be in the past");
-        assert!(with_ago < now, "the `ago` suffix must still look back");
-        // The cutoff is `now - 5 months`, NOT the 1970 epoch: a constant default
-        // would also satisfy `< now`, so bound it from below at roughly a year back.
-        let one_year_back = now.as_second() - 400 * 24 * 60 * 60;
-        assert!(
-            plain.as_second() > one_year_back,
-            "a 5-month look-back must land near now, not the epoch"
+        // rather than flipping into the future. Anchored to a fixed `now`, both
+        // spellings land on exactly the same instant — five calendar months
+        // before 2024-06-01 is 2024-01-01.
+        let now: Timestamp = "2024-06-01T00:00:00Z".parse().unwrap();
+        let expected: Timestamp = "2024-01-01T00:00:00Z".parse().unwrap();
+        let plain = parse_since(Some("5 months"), now).unwrap().unwrap();
+        let with_ago = parse_since(Some("5 months ago"), now).unwrap().unwrap();
+        assert_eq!(plain, expected, "5 months before 2024-06-01 is 2024-01-01");
+        assert_eq!(
+            with_ago, expected,
+            "the `ago` suffix looks back the same amount"
         );
-        // Both spellings denote the same magnitude, so they land within a tiny
-        // wall-clock window of each other (the two `now` reads differ by µs).
-        let gap = (plain.as_second() - with_ago.as_second()).abs();
-        assert!(gap <= 1, "`5 months` and `5 months ago` agree (gap {gap}s)");
+        assert!(plain < now, "a look-back must be in the past");
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "relative `--since` parsing reads the wall clock")]
     fn since_accepts_iso_and_week_durations() {
-        let now = Timestamp::now();
+        let now: Timestamp = "2024-06-01T00:00:00Z".parse().unwrap();
         for input in ["P6M", "2w", "30 days", "-P1Y"] {
-            let cutoff = parse_since(Some(input)).unwrap().unwrap();
+            let cutoff = parse_since(Some(input), now).unwrap().unwrap();
             assert!(cutoff < now, "{input:?} must resolve to the past");
         }
     }
 
     #[test]
     fn since_rejects_garbage() {
-        let error = parse_since(Some("not-a-date")).unwrap_err();
+        let now: Timestamp = "2024-06-01T00:00:00Z".parse().unwrap();
+        let error = parse_since(Some("not-a-date"), now).unwrap_err();
         assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
     }
 

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -13,14 +13,15 @@
 //! storage- and git-generic orchestrator the in-memory tests drive.
 
 pub(crate) mod bless;
+pub(crate) mod examine;
 pub(crate) mod list;
 pub(crate) mod prune;
 
 pub(crate) use cargo_bench_history_core::analyze::{
     AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DiscriminantSetQuery,
     FacetFilter, ReportFormat, ReportInput, RunPoints, Series, SeriesBuilder, SeriesFilter,
-    SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes, find_changes_spawned, parse_key,
-    render, select_commits, worker_count,
+    SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes, find_changes_spawned,
+    format_value, parse_key, render, select_commits, worker_count,
 };
 
 use std::collections::{BTreeMap, HashMap};
@@ -51,7 +52,8 @@ use crate::wiring::{
     resolve_repo, storage_env,
 };
 use crate::{
-    AnalyzeOptions, BlessOptions, ListOptions, PruneOptions, RunError, RunOutcome, UnblessOptions,
+    AnalyzeOptions, BlessOptions, ExamineOptions, ListOptions, PruneOptions, RunError, RunOutcome,
+    UnblessOptions,
 };
 
 /// The real `analyze`: load configuration, wire the configured storage and git
@@ -338,6 +340,20 @@ impl<'a> Selection<'a> {
         }
     }
 
+    fn from_examine(options: &'a ExamineOptions) -> Self {
+        Self {
+            context: options.context.as_deref(),
+            base: options.base.as_deref(),
+            no_dirty: options.no_dirty,
+            since: options.since.as_deref(),
+            until: options.until.as_deref(),
+            engine: &options.engine,
+            target_triple: &options.target_triple,
+            machine_key: &options.machine_key,
+            mode_override: None,
+        }
+    }
+
     fn from_prune(options: &'a PruneOptions) -> Self {
         Self {
             context: options.context.as_deref(),
@@ -529,6 +545,10 @@ struct SelectedDataSet {
     included_dirty_base_exception: bool,
     /// The target ref the timeline was resolved against (for diagnostics).
     target_ref: String,
+    /// Subject line of each in-history commit that has one, so `examine` can label
+    /// each data point with what its commit changed. A commit absent here has an
+    /// empty subject; only `examine` reads this.
+    commit_subjects: HashMap<String, String>,
     /// The resolved analysis mode (auto-detected from topology, or overridden).
     mode: AnalysisMode,
     /// First-parent topological index of the merge-base, used by branch mode to
@@ -875,6 +895,7 @@ where
         target_ref,
         order,
         commit_times,
+        commit_subjects,
         admit_dirty,
         dirty_base_exception,
         merge_base_index,
@@ -1182,6 +1203,7 @@ where
         },
         included_dirty_base_exception,
         target_ref,
+        commit_subjects,
         mode,
         merge_base_index,
         blessings,
@@ -1308,6 +1330,10 @@ struct ResolvedHistory {
     /// `--since`/`--until` window from topology before any object is fetched. A
     /// commit absent here has an unknown time and is treated as in-window.
     commit_times: HashMap<String, Timestamp>,
+    /// Subject line of each first-parent commit that has one, for labeling
+    /// `examine`'s per-commit data points. A commit absent here has an empty
+    /// subject; only `examine` reads this.
+    commit_subjects: HashMap<String, String>,
     /// Whether each selected commit admits dirty (uncommitted-tree) snapshots.
     admit_dirty: HashMap<String, bool>,
     /// Whether a commit's dirty runs are admitted *only* by the base-branch
@@ -1361,9 +1387,13 @@ where
     let commit_count = first_parent.len();
     let mut ancestry: Vec<String> = Vec::with_capacity(commit_count);
     let mut commit_times: HashMap<String, Timestamp> = HashMap::new();
+    let mut commit_subjects: HashMap<String, String> = HashMap::new();
     for commit in first_parent {
         if let Some(time) = commit.committer_time {
             commit_times.insert(commit.sha.clone(), time);
+        }
+        if !commit.subject.is_empty() {
+            commit_subjects.insert(commit.sha.clone(), commit.subject);
         }
         ancestry.push(commit.sha);
     }
@@ -1442,6 +1472,7 @@ where
         target_ref: target_ref.to_owned(),
         order,
         commit_times,
+        commit_subjects,
         admit_dirty,
         dirty_base_exception,
         merge_base_index,

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -21,7 +21,9 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
+use jiff::Timestamp;
 use serde::Serialize;
+use tick::Clock;
 
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
@@ -38,7 +40,7 @@ use super::ReportFormat;
 use super::{
     AutoFacets, DirtyTipPolicy, ResolvedHistory, Selection, WindowEdge, detect_auto_facets,
     facet_filtered_candidates, parse_since, parse_until, resolve_base_name, resolve_facets,
-    resolve_history, window_excludes,
+    resolve_history, resolve_now, window_excludes,
 };
 use crate::model::DiscriminantSet;
 use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
@@ -84,9 +86,14 @@ impl Scope {
 
 /// The real `prune`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
+///
+/// `clock_override` injects the [`tick::Clock`] that anchors a relative
+/// `--since`/`--until` bound (see [`resolve_now`](super::resolve_now)); production
+/// passes `None` for the runtime wall clock.
 pub(crate) async fn execute(
     options: &PruneOptions,
     workspace_dir: &Path,
+    clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
 ) -> Result<RunOutcome, RunError> {
     let reporter = StderrReporter::new(options.verbose);
@@ -112,6 +119,7 @@ pub(crate) async fn execute(
     let auto = detect_auto_facets().await?;
 
     let writer = TokioOutputWriter::new(workspace_dir.to_path_buf());
+    let now = resolve_now(clock_override);
     let result = prune_with(
         &git,
         &storage,
@@ -119,6 +127,7 @@ pub(crate) async fn execute(
         &config,
         options,
         &auto,
+        now,
         &reporter,
         &writer,
     )
@@ -147,6 +156,7 @@ pub(crate) async fn prune_with<G, S, W>(
     config: &Config,
     options: &PruneOptions,
     auto: &AutoFacets,
+    now: Timestamp,
     reporter: &dyn Reporter,
     writer: &W,
 ) -> Result<RunOutcome, RunError>
@@ -160,8 +170,8 @@ where
         options.markdown.as_deref(),
         options.json.as_deref(),
     )?;
-    let since = parse_since(options.since.as_deref())?;
-    let until = parse_until(options.until.as_deref())?;
+    let since = parse_since(options.since.as_deref(), now)?;
+    let until = parse_until(options.until.as_deref(), now)?;
     let scope = Scope::from_options(options)?;
     let selection = Selection::from_prune(options);
 
@@ -852,6 +862,15 @@ mod tests {
         MemoryOutputWriter::new()
     }
 
+    /// A fixed analysis anchor for prune tests. These exercise absolute or
+    /// unset `--since`/`--until` windows, so the exact instant is immaterial; it
+    /// only stands in for the clock reading `prune::execute` supplies in production.
+    fn now() -> Timestamp {
+        "2024-06-01T00:00:00Z"
+            .parse()
+            .expect("valid RFC 3339 instant")
+    }
+
     /// Drives `prune_with` and unwraps the rendered message.
     fn prune(storage: &MemoryStorage, git: &FakeGitHistory, options: &PruneOptions) -> String {
         let outcome = block_on(prune_with(
@@ -861,6 +880,7 @@ mod tests {
             &config(),
             options,
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer(),
         ))
@@ -887,6 +907,7 @@ mod tests {
             &config(),
             &options,
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer,
         ))
@@ -915,6 +936,7 @@ mod tests {
             &config(),
             &options,
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer,
         ))
@@ -937,6 +959,7 @@ mod tests {
             &config(),
             &dirty_options(),
             &auto(),
+            now(),
             &reporter,
             &writer(),
         ))
@@ -1116,6 +1139,7 @@ mod tests {
             &config(),
             &PruneOptions::default(),
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer(),
         ))
@@ -1153,6 +1177,7 @@ mod tests {
             &config(),
             &opts,
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer(),
         ))
@@ -1214,6 +1239,7 @@ mod tests {
             &config(),
             &opts,
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer(),
         ))
@@ -1317,6 +1343,7 @@ mod tests {
             &config(),
             &dirty_options(),
             &auto(),
+            now(),
             &RecordingReporter::new(),
             &writer(),
         ))

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -14,7 +14,8 @@ use clap::{ArgGroup, Args, Parser, Subcommand as ClapSubcommand, ValueEnum};
 use crate::model::BenchmarkIdPrefix;
 use crate::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,
-    InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions, UnblessOptions,
+    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions,
+    UnblessOptions,
 };
 
 const HEADING_ENV: &str = "Environment and execution";
@@ -91,6 +92,7 @@ impl Cli {
             Subcommand::Backfill(command) => Command::Backfill(command.into_options()),
             Subcommand::Bless(command) => Command::Bless(command.into_options()),
             Subcommand::Collect(command) => Command::Collect(command.into_options()),
+            Subcommand::Examine(command) => Command::Examine(command.into_options()),
             Subcommand::Install(command) => Command::Install(command.into_options()),
             Subcommand::List(command) => Command::List(command.into_options()),
             Subcommand::Prune(command) => Command::Prune(command.into_options()),
@@ -127,6 +129,8 @@ enum Subcommand {
     Install(InstallCommand),
     /// List the data set a matching `analyze` would include, without analyzing it.
     List(ListCommand),
+    /// Show the raw per-commit data points of one `(benchmark, metric)` series.
+    Examine(ExamineCommand),
     /// Delete stored runs (and their blessing sidecars) from the resolved data set.
     Prune(PruneCommand),
     /// Remove blessings recorded at the current commit.
@@ -578,6 +582,70 @@ impl ListCommand {
     }
 }
 
+/// Show the raw per-commit data points of one `(benchmark, metric)` series.
+///
+/// A drill-down sibling of `list runs`: it resolves exactly the data set a matching
+/// `analyze`/`list` would, then pivots one named series into its data points — one
+/// row per recorded observation, in git first-parent order, pairing the value with
+/// the short commit id and the start of the commit's title. Both `--benchmark` and
+/// `--metric` are required.
+#[derive(Args, Debug)]
+struct ExamineCommand {
+    #[command(flatten)]
+    env: EnvArgs,
+
+    #[command(flatten)]
+    cache: CacheArg,
+
+    #[command(flatten)]
+    output: OutputArgs,
+
+    #[command(flatten)]
+    facets: QueryFacetArgs,
+
+    #[command(flatten)]
+    timeline: TimelineArgs,
+
+    /// The exact qualified benchmark id to examine, e.g.
+    /// `nm/nm::observe/pull` (required). Copy it from an `analyze` finding.
+    #[arg(long, value_name = "ID", help_heading = HEADING_SCOPE)]
+    benchmark: String,
+
+    /// The metric to examine by its stable name, e.g. `instruction_count` or
+    /// `wall_time` (required). Copy it from an `analyze` finding.
+    #[arg(long, value_name = "NAME", help_heading = HEADING_SCOPE)]
+    metric: String,
+
+    /// Exclude dirty (uncommitted-tree) snapshots from the pivot.
+    #[arg(long, help_heading = HEADING_FILTER)]
+    no_dirty: bool,
+}
+
+impl ExamineCommand {
+    fn into_options(self) -> ExamineOptions {
+        ExamineOptions {
+            config_path: self.env.config,
+            repo: self.env.repo,
+            local: local_selection(self.env.local),
+            cache: cache_selection(self.cache.cache),
+            context: self.timeline.context,
+            base: self.timeline.base,
+            no_dirty: self.no_dirty,
+            since: self.timeline.since,
+            until: self.timeline.until,
+            engine: self.facets.engine,
+            target_triple: self.facets.target_triple,
+            machine_key: self.facets.machine_key,
+            benchmark: self.benchmark,
+            metric: self.metric,
+            no_text: self.output.no_text,
+            markdown: self.output.markdown,
+            json: self.output.json,
+            verbose: self.env.verbose,
+        }
+    }
+}
+
 /// Delete stored runs (and their blessing sidecars) from the data set a matching
 /// `analyze`/`list` would resolve.
 ///
@@ -895,7 +963,8 @@ mod tests {
         let help = Cli::help("cargo-bench-history");
         assert!(!help.is_empty(), "help text is non-empty");
         for command in [
-            "analyze", "backfill", "bless", "collect", "install", "list", "prune", "unbless",
+            "analyze", "backfill", "bless", "collect", "examine", "install", "list", "prune",
+            "unbless",
         ] {
             assert!(help.contains(command), "help lists {command}: {help}");
         }
@@ -1485,6 +1554,86 @@ mod tests {
             panic!("expected list command");
         };
         assert!(!options.all);
+    }
+
+    #[test]
+    fn examine_collects_selection_scope_and_output() {
+        let command = parse(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+            "--repo",
+            "/work/folo",
+            "--context",
+            "feature",
+            "--base",
+            "master",
+            "--no-dirty",
+            "--engine",
+            "callgrind",
+            "--target-triple",
+            "x86_64-unknown-linux-gnu",
+            "--machine-key",
+            "ci-pool",
+            "--since",
+            "2024-01-01",
+            "--until",
+            "2024-02-01",
+            "--no-text",
+            "--markdown",
+            "examine.md",
+            "--json",
+            "examine.json",
+            "--verbose",
+        ]);
+        let Command::Examine(options) = command else {
+            panic!("expected examine command");
+        };
+        assert_eq!(options.benchmark, "nm/nm::observe/pull");
+        assert_eq!(options.metric, "instruction_count");
+        assert_eq!(options.repo, Some(PathBuf::from("/work/folo")));
+        assert_eq!(options.context.as_deref(), Some("feature"));
+        assert_eq!(options.base.as_deref(), Some("master"));
+        assert!(options.no_dirty);
+        assert_eq!(options.engine, vec!["callgrind".to_owned()]);
+        assert_eq!(
+            options.target_triple,
+            vec!["x86_64-unknown-linux-gnu".to_owned()]
+        );
+        assert_eq!(options.machine_key, vec!["ci-pool".to_owned()]);
+        assert_eq!(options.since.as_deref(), Some("2024-01-01"));
+        assert_eq!(options.until.as_deref(), Some("2024-02-01"));
+        assert!(options.no_text);
+        assert_eq!(options.markdown, Some(PathBuf::from("examine.md")));
+        assert_eq!(options.json, Some(PathBuf::from("examine.json")));
+        assert!(options.verbose);
+    }
+
+    #[test]
+    fn examine_requires_benchmark_and_metric() {
+        // With neither required scope flag, clap reports both as missing.
+        let early = Cli::from_args(&["cargo-bench-history"], &["examine"]).unwrap_err();
+        assert!(
+            early.status.is_err(),
+            "missing required flags are a parse error"
+        );
+        assert!(early.output.contains("--benchmark"), "{}", early.output);
+        assert!(early.output.contains("--metric"), "{}", early.output);
+
+        // Supplying only one still fails, naming the other.
+        let missing_metric = Cli::from_args(
+            &["cargo-bench-history"],
+            &["examine", "--benchmark", "nm/nm::observe/pull"],
+        )
+        .unwrap_err();
+        assert!(missing_metric.status.is_err());
+        assert!(
+            missing_metric.output.contains("--metric"),
+            "{}",
+            missing_metric.output
+        );
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -57,6 +57,9 @@ pub enum Command {
     /// Delete stored runs (and their blessing sidecars) from the data set a
     /// matching `analyze`/`list` pass resolves.
     Prune(PruneOptions),
+    /// Show the raw per-commit data points of one `(benchmark, metric)` series
+    /// from the data set a matching `analyze`/`list` pass resolves.
+    Examine(ExamineOptions),
     /// Replay `collect` across a range of historical commits.
     Backfill(BackfillOptions),
     /// Accept a benchmark's current level on the base branch as intentional.
@@ -269,10 +272,66 @@ pub struct ListOptions {
     pub verbose: bool,
 }
 
+/// Options for the `examine` command.
+///
+/// The data-set-selection options mirror [`AnalyzeOptions`]/[`ListOptions`] so an
+/// `examine` invocation drills into exactly the data set the same `analyze`/`list`
+/// invocation would resolve. Unlike them, it names a single `(benchmark, metric)`
+/// series to pivot into raw per-commit data points.
+#[doc(hidden)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ExamineOptions {
+    /// Path to the configuration file, if overridden.
+    pub config_path: Option<PathBuf>,
+    /// Repository to resolve git topology from; defaults to the working directory.
+    pub repo: Option<PathBuf>,
+    /// Local-storage selection from `--local`; overrides the configured cloud
+    /// backend. `None` means `--local` was not given (use the configured backend).
+    pub local: Option<LocalStorageSelection>,
+    /// Read-through cache selection from `--cache`; mirrors fetched cloud objects
+    /// under a local directory so repeated reads avoid re-downloading the history.
+    /// `None` means `--cache` was not given. Ignored with a `--local` backend.
+    pub cache: Option<CacheSelection>,
+    /// Target ref whose history is examined; defaults to `HEAD`.
+    pub context: Option<String>,
+    /// Base ref the target's history is split at; defaults to the detected (or
+    /// configured) default branch.
+    pub base: Option<String>,
+    /// Exclude dirty (uncommitted-tree) snapshots from the target side.
+    pub no_dirty: bool,
+    /// Only consider commits made on or after this cutoff, if set.
+    pub since: Option<String>,
+    /// Only consider commits made on or before this cutoff, if set.
+    pub until: Option<String>,
+    /// Restrict the examination to these engines (repeatable). Empty auto-detects
+    /// every engine; the `all` keyword is an explicit synonym for no filter.
+    pub engine: Vec<String>,
+    /// Restrict the examination to these full target triples (repeatable). Empty
+    /// auto-detects the current machine's triple; `all` matches every triple.
+    pub target_triple: Vec<String>,
+    /// Restrict the examination to these machine keys (repeatable). Empty
+    /// auto-detects the current machine's fingerprint; `all` matches every machine.
+    pub machine_key: Vec<String>,
+    /// The exact qualified benchmark id whose series is examined (required).
+    pub benchmark: String,
+    /// The metric name (a [`MetricKind`](crate::model::MetricKind) `as_str` value)
+    /// whose series is examined (required).
+    pub metric: String,
+    /// Suppress the default text report on standard output (`--no-text`).
+    pub no_text: bool,
+    /// Write the Markdown report to this path, if set (`--markdown <path>`). A
+    /// relative path resolves against the working directory.
+    pub markdown: Option<PathBuf>,
+    /// Write the JSON report to this path, if set (`--json <path>`). A relative
+    /// path resolves against the working directory.
+    pub json: Option<PathBuf>,
+    /// Emit detailed diagnostic notes to standard error describing each step.
+    pub verbose: bool,
+}
+
 /// Options for the `prune` command.
 ///
 /// The data-set-selection options mirror [`AnalyzeOptions`]/[`ListOptions`] so a
-/// `prune` invocation deletes runs from exactly the data set the same
 /// `analyze`/`list` invocation would resolve. The caller must say which kinds of
 /// run to delete: `clean` removes clean runs (plus the blessing sidecars on every
 /// commit whose clean run is removed), `dirty` removes dirty (uncommitted-tree)

--- a/packages/cargo-bench-history/src/commands/mod.rs
+++ b/packages/cargo-bench-history/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod collect;
 mod install;
 
 pub(crate) use crate::analyze::bless::{bless, unbless};
+pub(crate) use crate::analyze::examine::execute as examine;
 pub(crate) use crate::analyze::execute as analyze;
 pub(crate) use crate::analyze::list::execute as list;
 pub(crate) use crate::analyze::prune::execute as prune;

--- a/packages/cargo-bench-history/src/dispatch.rs
+++ b/packages/cargo-bench-history/src/dispatch.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use jiff::Timestamp;
+use tick::Clock;
 
 use crate::commands;
 use crate::storage::StorageOverride;
@@ -30,8 +30,10 @@ pub struct Overrides {
     pub target_root: Option<PathBuf>,
     /// The benchmark command `collect`/`backfill` invoke instead of `cargo bench`.
     pub bench_command: Option<Vec<String>>,
-    /// The clock anchor for the analysis default `--since` lookback window.
-    pub now: Option<Timestamp>,
+    /// The clock the analysis family reads "now" from — the default `--since`
+    /// lookback anchor and each blessing's issue time. `None` uses the runtime
+    /// wall clock; tests inject a frozen `Clock` for deterministic windows.
+    pub clock: Option<Clock>,
     /// A pre-built storage backend for `collect`/`analyze` to use instead of the one
     /// resolved from configuration. End-to-end tests use this to drive commands
     /// against an Azurite backend behind a locally-faked Entra token and a
@@ -58,8 +60,9 @@ pub async fn run(command: &Command) -> Result<RunOutcome, RunError> {
 /// This exists so end-to-end tests can drive the full `collect`/`backfill` flow
 /// against a mock benchmark program instead of `cargo bench`, operate on a
 /// temporary workspace without mutating the process environment or current
-/// directory, and pin a deterministic `now` for the analysis default `--since`
-/// window. Production code calls [`run`], which passes [`Overrides::default`].
+/// directory, and inject a deterministic [`tick::Clock`] for the analysis default
+/// `--since` window. Production code calls [`run`], which passes
+/// [`Overrides::default`].
 ///
 /// # Errors
 ///
@@ -74,7 +77,7 @@ pub async fn run_with_overrides(
         workspace_dir,
         target_root,
         bench_command,
-        now,
+        clock,
         storage_override,
     } = overrides;
     let workspace_dir = match workspace_dir {
@@ -96,19 +99,21 @@ pub async fn run_with_overrides(
         }
         Command::Install(options) => commands::install(options, workspace_dir).await,
         Command::Analyze(options) => {
-            commands::analyze(options, workspace_dir, now, storage_override).await
+            commands::analyze(options, workspace_dir, clock, storage_override).await
         }
         Command::List(options) => {
-            commands::list(options, workspace_dir, now, storage_override).await
+            commands::list(options, workspace_dir, clock, storage_override).await
         }
         Command::Examine(options) => {
-            commands::examine(options, workspace_dir, now, storage_override).await
+            commands::examine(options, workspace_dir, clock, storage_override).await
         }
-        Command::Prune(options) => commands::prune(options, workspace_dir, storage_override).await,
+        Command::Prune(options) => {
+            commands::prune(options, workspace_dir, clock, storage_override).await
+        }
         Command::Backfill(options) => {
             commands::backfill(options, workspace_dir, bench_command).await
         }
-        Command::Bless(options) => commands::bless(options, workspace_dir, now).await,
+        Command::Bless(options) => commands::bless(options, workspace_dir, clock).await,
         Command::Unbless(options) => commands::unbless(options, workspace_dir).await,
     }
 }

--- a/packages/cargo-bench-history/src/dispatch.rs
+++ b/packages/cargo-bench-history/src/dispatch.rs
@@ -101,6 +101,9 @@ pub async fn run_with_overrides(
         Command::List(options) => {
             commands::list(options, workspace_dir, now, storage_override).await
         }
+        Command::Examine(options) => {
+            commands::examine(options, workspace_dir, now, storage_override).await
+        }
         Command::Prune(options) => commands::prune(options, workspace_dir, storage_override).await,
         Command::Backfill(options) => {
             commands::backfill(options, workspace_dir, bench_command).await

--- a/packages/cargo-bench-history/src/git_history.rs
+++ b/packages/cargo-bench-history/src/git_history.rs
@@ -16,7 +16,8 @@ use jiff::Timestamp;
 
 use crate::process::capture;
 
-/// A commit on a first-parent ancestry, paired with its committer timestamp.
+/// A commit on a first-parent ancestry, paired with its committer timestamp and
+/// its subject line.
 ///
 /// `analyze` orders a series by first-parent topology and filters it by the
 /// `--since`/`--until` window. The window is a per-commit property — a commit's
@@ -24,6 +25,10 @@ use crate::process::capture;
 /// skipped before any stored object is fetched. `committer_time` is `None` only
 /// when `git` emitted an unparseable date, which a real commit never does; such a
 /// commit is treated as in-window (never excluded by the window).
+///
+/// `subject` is the commit's title (`git`'s `%s`), harvested on the same walk so
+/// `examine` can label each data point with what its commit changed. It is empty
+/// when `git` reported no subject; commands other than `examine` ignore it.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct FirstParentCommit {
     /// The commit's full SHA.
@@ -31,6 +36,8 @@ pub(crate) struct FirstParentCommit {
     /// The commit's committer timestamp (`git`'s `%cI`), or `None` when absent or
     /// unparseable.
     pub(crate) committer_time: Option<Timestamp>,
+    /// The commit's subject line (`git`'s `%s`), or empty when absent.
+    pub(crate) subject: String,
 }
 
 /// Read-only access to a repository's commit topology.
@@ -60,7 +67,8 @@ pub(crate) trait GitHistory {
     ///
     /// This is the linear mainline of the ref — the timeline `analyze` orders a
     /// series by. Each commit carries its committer timestamp, which `analyze`
-    /// uses to apply the `--since`/`--until` window before fetching any object.
+    /// uses to apply the `--since`/`--until` window before fetching any object,
+    /// and its subject line, which `examine` uses to label each data point.
     /// An unresolvable ref yields an empty list.
     fn first_parent(
         &self,
@@ -156,14 +164,18 @@ impl GitHistory for SystemGitHistory {
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `parse_first_parent_log`.
     async fn first_parent(&self, reference: &str) -> io::Result<Vec<FirstParentCommit>> {
-        // `%H %cI` pairs each first-parent commit with its committer date (strict
-        // ISO 8601), so the window can be decided from topology before any fetch.
+        // `%H`, `%cI`, `%s` pair each first-parent commit with its committer date
+        // (strict ISO 8601) and subject, so the window can be decided from
+        // topology before any fetch and `examine` can label each point. The fields
+        // are joined by a unit separator (`%x1f`) rather than a space, because the
+        // subject contains spaces and would otherwise be indistinguishable from the
+        // preceding fields.
         let output = self
             .run(&[
                 "log",
                 "--first-parent",
                 "--reverse",
-                "--format=%H %cI",
+                "--format=%H%x1f%cI%x1f%s",
                 reference,
             ])
             .await?;
@@ -205,20 +217,28 @@ fn parse_sha(stdout: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-/// Parses `git log --first-parent --reverse --format=%H %cI` output into
+/// Parses `git log --first-parent --reverse --format=%H%x1f%cI%x1f%s` output into
 /// [`FirstParentCommit`]s in line order, dropping blank lines. Each line is
-/// `<sha> <committer-date>`; a line missing the date — or carrying an unparseable
-/// one — yields `committer_time: None`. With `--reverse` the input is oldest-first.
+/// `<sha>\x1f<committer-date>\x1f<subject>`; a line missing the date — or carrying
+/// an unparseable one — yields `committer_time: None`, and a missing subject
+/// yields an empty string. With `--reverse` the input is oldest-first.
 fn parse_first_parent_log(stdout: &str) -> Vec<FirstParentCommit> {
     stdout
         .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
+        .filter(|line| !line.trim().is_empty())
         .map(|line| {
-            let (sha, rest) = line.split_once(' ').unwrap_or((line, ""));
+            let mut fields = line.split('\u{1f}');
+            // The first field is always the SHA; the record separator keeps the
+            // subject (which may contain spaces) cleanly distinct from it.
+            let sha = fields.next().unwrap_or_default().trim().to_owned();
+            let committer_time = fields
+                .next()
+                .and_then(|field| field.trim().parse::<Timestamp>().ok());
+            let subject = fields.next().unwrap_or_default().to_owned();
             FirstParentCommit {
-                sha: sha.to_owned(),
-                committer_time: rest.trim().parse::<Timestamp>().ok(),
+                sha,
+                committer_time,
+                subject,
             }
         })
         .collect()
@@ -279,6 +299,8 @@ mod fake {
         parents: HashMap<String, Option<String>>,
         /// Commit SHA -> its committer timestamp, for commits seeded with one.
         times: HashMap<String, Timestamp>,
+        /// Commit SHA -> its subject line, for commits seeded with one.
+        subjects: HashMap<String, String>,
         /// The detected default branch, if the repository advertises one.
         default_branch: Option<String>,
         /// Whether the working tree has uncommitted changes.
@@ -292,6 +314,7 @@ mod fake {
                 refs: HashMap::new(),
                 parents: HashMap::new(),
                 times: HashMap::new(),
+                subjects: HashMap::new(),
                 default_branch: None,
                 dirty: false,
             }
@@ -314,6 +337,14 @@ mod fake {
         ) -> &mut Self {
             self.commit(sha, parent);
             self.times.insert(sha.to_owned(), time);
+            self
+        }
+
+        /// Records the subject line of a commit, so `examine`'s point labeling can
+        /// be exercised. The commit itself must be recorded separately (via
+        /// [`commit`](Self::commit) or [`commit_at`](Self::commit_at)).
+        pub(crate) fn subject(&mut self, sha: &str, subject: &str) -> &mut Self {
+            self.subjects.insert(sha.to_owned(), subject.to_owned());
             self
         }
 
@@ -407,6 +438,7 @@ mod fake {
                 .into_iter()
                 .map(|sha| FirstParentCommit {
                     committer_time: self.times.get(&sha).copied(),
+                    subject: self.subjects.get(&sha).cloned().unwrap_or_default(),
                     sha,
                 })
                 .collect();
@@ -447,9 +479,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_first_parent_log_keeps_order_times_and_drops_blanks() {
+    fn parse_first_parent_log_keeps_order_times_subjects_and_drops_blanks() {
         let parsed = parse_first_parent_log(
-            "c0 2024-01-01T00:00:00+00:00\nc1 2024-02-01T00:00:00+00:00\n\n  c2 2024-03-01T00:00:00+00:00  \n",
+            "c0\u{1f}2024-01-01T00:00:00+00:00\u{1f}First commit\nc1\u{1f}2024-02-01T00:00:00+00:00\u{1f}Fix the thing\n\n  c2\u{1f}2024-03-01T00:00:00+00:00\u{1f}Subject with spaces  \n",
         );
         assert_eq!(
             parsed,
@@ -457,28 +489,34 @@ mod tests {
                 FirstParentCommit {
                     sha: "c0".to_owned(),
                     committer_time: Some("2024-01-01T00:00:00+00:00".parse().unwrap()),
+                    subject: "First commit".to_owned(),
                 },
                 FirstParentCommit {
                     sha: "c1".to_owned(),
                     committer_time: Some("2024-02-01T00:00:00+00:00".parse().unwrap()),
+                    subject: "Fix the thing".to_owned(),
                 },
                 FirstParentCommit {
                     sha: "c2".to_owned(),
                     committer_time: Some("2024-03-01T00:00:00+00:00".parse().unwrap()),
+                    subject: "Subject with spaces  ".to_owned(),
                 },
             ]
         );
-        // A line missing the date, or carrying an unparseable one, is timeless.
+        // A line missing the date, or carrying an unparseable one, is timeless; a
+        // missing subject field yields an empty subject.
         assert_eq!(
-            parse_first_parent_log("c0\nc1 not-a-date\n"),
+            parse_first_parent_log("c0\nc1\u{1f}not-a-date\u{1f}has subject\n"),
             vec![
                 FirstParentCommit {
                     sha: "c0".to_owned(),
                     committer_time: None,
+                    subject: String::new(),
                 },
                 FirstParentCommit {
                     sha: "c1".to_owned(),
                     committer_time: None,
+                    subject: "has subject".to_owned(),
                 },
             ]
         );
@@ -591,13 +629,15 @@ mod tests {
     }
 
     #[test]
-    fn fake_first_parent_carries_committer_times() {
+    fn fake_first_parent_carries_committer_times_and_subjects() {
         let mut git = FakeGitHistory::new();
         let t0: Timestamp = "2024-01-01T00:00:00+00:00".parse().unwrap();
         let t1: Timestamp = "2024-02-01T00:00:00+00:00".parse().unwrap();
         git.commit_at("c0", None, t0)
             .commit_at("c1", Some("c0"), t1)
             .commit("c2", Some("c1")) // A commit seeded without a time stays None.
+            .subject("c0", "Initial commit")
+            .subject("c1", "Fix the thing")
             .branch("master", "c2")
             .head("master");
         assert_eq!(
@@ -606,14 +646,18 @@ mod tests {
                 FirstParentCommit {
                     sha: "c0".to_owned(),
                     committer_time: Some(t0),
+                    subject: "Initial commit".to_owned(),
                 },
                 FirstParentCommit {
                     sha: "c1".to_owned(),
                     committer_time: Some(t1),
+                    subject: "Fix the thing".to_owned(),
                 },
                 FirstParentCommit {
+                    // A commit seeded without a subject carries an empty one.
                     sha: "c2".to_owned(),
                     committer_time: None,
+                    subject: String::new(),
                 },
             ]
         );

--- a/packages/cargo-bench-history/src/git_history.rs
+++ b/packages/cargo-bench-history/src/git_history.rs
@@ -166,16 +166,18 @@ impl GitHistory for SystemGitHistory {
     async fn first_parent(&self, reference: &str) -> io::Result<Vec<FirstParentCommit>> {
         // `%H`, `%cI`, `%s` pair each first-parent commit with its committer date
         // (strict ISO 8601) and subject, so the window can be decided from
-        // topology before any fetch and `examine` can label each point. The fields
-        // are joined by a unit separator (`%x1f`) rather than a space, because the
-        // subject contains spaces and would otherwise be indistinguishable from the
-        // preceding fields.
+        // topology before any fetch and `examine` can label each point. `-z`
+        // NUL-terminates each commit's record and the fields are NUL-delimited
+        // (`%x00`): NUL cannot occur in git object content, so no field — the
+        // subject, which may contain any printable character, included — can be
+        // confused with a delimiter.
         let output = self
             .run(&[
                 "log",
                 "--first-parent",
                 "--reverse",
-                "--format=%H%x1f%cI%x1f%s",
+                "-z",
+                "--format=%H%x00%cI%x00%s",
                 reference,
             ])
             .await?;
@@ -217,31 +219,34 @@ fn parse_sha(stdout: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-/// Parses `git log --first-parent --reverse --format=%H%x1f%cI%x1f%s` output into
-/// [`FirstParentCommit`]s in line order, dropping blank lines. Each line is
-/// `<sha>\x1f<committer-date>\x1f<subject>`; a line missing the date — or carrying
-/// an unparseable one — yields `committer_time: None`, and a missing subject
-/// yields an empty string. With `--reverse` the input is oldest-first.
+/// Parses `git log --first-parent --reverse -z --format=%H%x00%cI%x00%s` output
+/// into [`FirstParentCommit`]s in stream order. `-z` NUL-terminates each commit's
+/// record and the three fields are NUL-delimited, so the stream is a flat run of
+/// `<sha>\0<committer-date>\0<subject>` triples with a trailing empty token from
+/// the final terminator. A field carrying an unparseable date yields
+/// `committer_time: None` and an empty subject field yields an empty string. With
+/// `--reverse` the input is oldest-first.
 fn parse_first_parent_log(stdout: &str) -> Vec<FirstParentCommit> {
-    stdout
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| {
-            let mut fields = line.split('\u{1f}');
-            // The first field is always the SHA; the record separator keeps the
-            // subject (which may contain spaces) cleanly distinct from it.
-            let sha = fields.next().unwrap_or_default().trim().to_owned();
-            let committer_time = fields
-                .next()
-                .and_then(|field| field.trim().parse::<Timestamp>().ok());
-            let subject = fields.next().unwrap_or_default().to_owned();
-            FirstParentCommit {
-                sha,
-                committer_time,
-                subject,
-            }
-        })
-        .collect()
+    let mut fields = stdout.split('\0');
+    let mut commits = Vec::new();
+    while let Some(sha) = fields.next() {
+        let sha = sha.trim();
+        // A real commit's SHA is never empty; the only empty leading token is the
+        // one following the final record's terminator, which ends the stream.
+        if sha.is_empty() {
+            break;
+        }
+        let committer_time = fields
+            .next()
+            .and_then(|field| field.trim().parse::<Timestamp>().ok());
+        let subject = fields.next().unwrap_or_default().to_owned();
+        commits.push(FirstParentCommit {
+            sha: sha.to_owned(),
+            committer_time,
+            subject,
+        });
+    }
+    commits
 }
 
 /// Parses `git log -1 --format=%cI` output into a single committer [`Timestamp`]:
@@ -480,8 +485,10 @@ mod tests {
 
     #[test]
     fn parse_first_parent_log_keeps_order_times_subjects_and_drops_blanks() {
+        // `-z` NUL-terminates each `<sha>\0<date>\0<subject>` record, so the input
+        // is a flat NUL-separated run of triples ending in a terminator.
         let parsed = parse_first_parent_log(
-            "c0\u{1f}2024-01-01T00:00:00+00:00\u{1f}First commit\nc1\u{1f}2024-02-01T00:00:00+00:00\u{1f}Fix the thing\n\n  c2\u{1f}2024-03-01T00:00:00+00:00\u{1f}Subject with spaces  \n",
+            "c0\x002024-01-01T00:00:00+00:00\x00First commit\x00c1\x002024-02-01T00:00:00+00:00\x00Fix the thing\x00c2\x002024-03-01T00:00:00+00:00\x00Subject with spaces  \x00",
         );
         assert_eq!(
             parsed,
@@ -503,14 +510,16 @@ mod tests {
                 },
             ]
         );
-        // A line missing the date, or carrying an unparseable one, is timeless; a
-        // missing subject field yields an empty subject.
+        // An unparseable date is timeless; an empty subject field yields an empty
+        // subject.
         assert_eq!(
-            parse_first_parent_log("c0\nc1\u{1f}not-a-date\u{1f}has subject\n"),
+            parse_first_parent_log(
+                "c0\x002024-01-01T00:00:00+00:00\x00\x00c1\x00not-a-date\x00has subject\x00"
+            ),
             vec![
                 FirstParentCommit {
                     sha: "c0".to_owned(),
-                    committer_time: None,
+                    committer_time: Some("2024-01-01T00:00:00+00:00".parse().unwrap()),
                     subject: String::new(),
                 },
                 FirstParentCommit {
@@ -520,7 +529,23 @@ mod tests {
                 },
             ]
         );
-        assert!(parse_first_parent_log("\n   \n").is_empty());
+        assert!(parse_first_parent_log("").is_empty());
+        assert!(parse_first_parent_log("\x00").is_empty());
+    }
+
+    #[test]
+    fn parse_first_parent_log_preserves_delimiter_like_bytes_in_subjects() {
+        // NUL-delimiting (rather than the unit separator `\x1f`) keeps a subject
+        // that happens to contain the old delimiter intact: only NUL, which git
+        // object content can never hold, separates fields.
+        assert_eq!(
+            parse_first_parent_log("c0\x002024-01-01T00:00:00+00:00\x00Weird\u{1f}subject\x00"),
+            vec![FirstParentCommit {
+                sha: "c0".to_owned(),
+                committer_time: Some("2024-01-01T00:00:00+00:00".parse().unwrap()),
+                subject: "Weird\u{1f}subject".to_owned(),
+            }]
+        );
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -141,6 +141,20 @@
 //! `--prune-base` confirms it. Narrow the selection with a facet, a `<commit>`
 //! argument, `--since`, or `--until`. `--dry-run` previews without deleting.
 //!
+//! ## `examine`
+//!
+//! A drill-down sibling of `list runs` over the same `analyze`/`list` selection: it
+//! pivots the small chart `analyze` draws into its raw data points. Given the two
+//! required options `--benchmark <qualified-id>` and `--metric <name>` — the one
+//! command that names a metric, meant to be pasted from an `analyze` finding — it
+//! prints one row per recorded observation of that series, in git first-parent
+//! order and once per matching discriminant set, pairing the value with the short
+//! commit id and the first 50 characters of the commit's title (JSON keeps the full
+//! title and full-precision value). It requires a repository, runs no detection or
+//! re-baselining, and shows every selected point (clean before dirty, each flagged).
+//! An unknown metric name is rejected; an unmatched benchmark yields an empty pivot
+//! with the same "matched no runs" hint `analyze` gives.
+//!
 //! ## `bless` / `unbless`
 //!
 //! `bless` accepts an intentional performance change on the base branch so history
@@ -158,8 +172,8 @@
 //!
 //! # Selecting data: options shared by the query commands
 //!
-//! `analyze`, `list`, and `prune` share one selection model, organized in `--help`
-//! into named groups:
+//! `analyze`, `list`, `prune`, and `examine` share one selection model, organized
+//! in `--help` into named groups:
 //!
 //! * **Discriminant selection** (`--engine`, `--target-triple`, `--machine-key`) —
 //!   chooses which discriminant sets to operate on. Each facet is repeatable
@@ -292,7 +306,8 @@ pub(crate) use cargo_bench_history_core::model;
 pub use cli::{Cli, EarlyExit};
 pub use command::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,
-    InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions, UnblessOptions,
+    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions,
+    UnblessOptions,
 };
 pub use config::{ConfigError, default_template};
 pub use dispatch::{Overrides, run, run_with_overrides};

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -152,8 +152,10 @@
 //! commit id and the first 50 characters of the commit's title (JSON keeps the full
 //! title and full-precision value). It requires a repository, runs no detection or
 //! re-baselining, and shows every selected point (clean before dirty, each flagged).
-//! An unknown metric name is rejected; an unmatched benchmark yields an empty pivot
-//! with the same "matched no runs" hint `analyze` gives.
+//! An unknown metric name is rejected. An empty pivot is explained by one of two
+//! hints: when no run enters the selection at all, the same "matched no runs" hint
+//! `analyze` gives; when runs enter but none carry the named `(benchmark, metric)`
+//! pair, a distinct hint pointing at the unmatched benchmark id or metric name.
 //!
 //! ## `bless` / `unbless`
 //!

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -533,7 +533,7 @@ impl AzureWorkspace {
                 workspace_dir: Some(self.dir.path().to_path_buf()),
                 target_root: Some(target_root),
                 bench_command: Some(bench_command),
-                now: None,
+                clock: None,
                 storage_override,
             },
         )

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -1,0 +1,463 @@
+use crate::harness::*;
+
+/// `examine` pivots one `(benchmark, metric)` series into its raw per-commit data
+/// points: one JSON row per recorded observation, oldest first by git topology,
+/// pairing each value with the commit it was measured against and that commit's
+/// title.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_pivots_a_rising_history_into_points() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(parsed["benchmark"], "nm/nm::observe/pull", "{message}");
+    assert_eq!(parsed["metric"], "instruction_count", "{message}");
+
+    let sets = parsed["sets"].as_array().unwrap();
+    assert_eq!(sets.len(), 1, "one comparable set: {message}");
+    let points = sets[0]["points"].as_array().unwrap();
+    assert_eq!(points.len(), 6, "one point per commit: {message}");
+
+    // The values follow the seeded rising history in topology order, each paired
+    // with its commit's title (the commit message the harness stamps).
+    let values: Vec<f64> = points
+        .iter()
+        .map(|point| point["value"].as_f64().unwrap())
+        .collect();
+    assert_eq!(
+        values,
+        vec![100.0, 100.0, 100.0, 130.0, 130.0, 130.0],
+        "{message}"
+    );
+    let titles: Vec<&str> = points
+        .iter()
+        .map(|point| point["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["c1", "c2", "c3", "c4", "c5", "c6"],
+        "{message}"
+    );
+    assert!(
+        points.iter().all(|point| point["dirty"] == false),
+        "every seeded run is clean: {message}"
+    );
+    // Every point carries the full commit SHA it was measured against.
+    assert!(
+        points
+            .iter()
+            .all(|point| point["commit"].as_str().unwrap().len() == 40),
+        "full commit ids: {message}"
+    );
+}
+
+/// The default text pivot pairs each value with the short commit id and the start
+/// of the commit's title, so a maintainer reading `examine` can correlate a value
+/// change with the commit that caused it.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_renders_a_text_pivot_with_titles() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let RunOutcome::Completed { message } = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await
+        .unwrap()
+    else {
+        panic!("expected a completed outcome");
+    };
+    assert!(
+        message.contains("Data points for nm/nm::observe/pull metric instruction_count"),
+        "{message}"
+    );
+    // The short commit id abbreviates each SHA to twelve characters.
+    let head = workspace.head_sha();
+    let short_head: String = head.chars().take(12).collect();
+    assert!(
+        message.contains(&short_head),
+        "short head id present: {message}"
+    );
+    // Values and their titles both appear.
+    assert!(message.contains("100"), "{message}");
+    assert!(message.contains("130"), "{message}");
+    assert!(
+        message.contains("c6"),
+        "the tip's title is shown: {message}"
+    );
+}
+
+/// `examine` renders a per-set Markdown table with a row per observation.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_renders_a_markdown_table() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.seed_callgrind("c2", 130.0);
+
+    let markdown = workspace
+        .drive_markdown(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    assert!(
+        markdown.contains("# Data points for nm/nm::observe/pull"),
+        "{markdown}"
+    );
+    assert!(
+        markdown.contains("| Commit | Value | Kind | Title |"),
+        "the table header is present: {markdown}"
+    );
+    assert!(markdown.contains("| clean | c1 |"), "{markdown}");
+    assert!(markdown.contains("130"), "{markdown}");
+}
+
+/// `examine` names one metric, isolating it from the other metrics recorded on the
+/// same benchmark: only the requested metric's values appear.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_selects_only_the_named_metric() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    // One benchmark carrying two metrics on the same run.
+    workspace.seed_metrics(
+        "c1",
+        vec![
+            Metric::new(MetricKind::InstructionCount, 100.0),
+            Metric::new(MetricKind::L1CacheHits, 42.0),
+        ],
+    );
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "l1_cache_hits",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(parsed["metric"], "l1_cache_hits", "{message}");
+    let points = parsed["sets"][0]["points"].as_array().unwrap();
+    assert_eq!(points.len(), 1, "{message}");
+    assert_eq!(
+        points[0]["value"].as_f64().unwrap(),
+        42.0,
+        "the l1_cache_hits value, not the instruction count: {message}"
+    );
+}
+
+/// Like `analyze`, `examine` repeats per matching discriminant set and honors the
+/// facet filters: with two comparable pools present, a `--target-triple` scopes the
+/// pivot to just the matching set.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_facet_selection_mirrors_analyze() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
+    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 50.0);
+
+    // Unfiltered, both comparable sets pivot.
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(parsed["sets"].as_array().unwrap().len(), 2, "{message}");
+
+    // `--target-triple` narrows to the Linux pool only.
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+            "--target-triple",
+            "x86_64-unknown-linux-gnu",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let sets = parsed["sets"].as_array().unwrap();
+    assert_eq!(sets.len(), 1, "{message}");
+    assert_eq!(
+        sets[0]["target_triple"], "x86_64-unknown-linux-gnu",
+        "{message}"
+    );
+    assert_eq!(
+        sets[0]["points"][0]["value"].as_f64().unwrap(),
+        100.0,
+        "{message}"
+    );
+}
+
+/// `examine` pivots a Criterion `wall_time` series just as it does a Callgrind one,
+/// proving it reads any engine's reconstructed series and any metric name.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_pivots_a_criterion_wall_time_series() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-02-01", "d1");
+    workspace.seed_criterion("d1", "mk-fixed", 20.0);
+    workspace.commit_dated("2024-02-02", "d2");
+    workspace.seed_criterion("d2", "mk-fixed", 30.0);
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "time/capture/std_instant",
+            "--metric",
+            "wall_time",
+            "--target-triple",
+            "x86_64-pc-windows-msvc",
+            "--machine-key",
+            "mk-fixed",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(parsed["metric"], "wall_time", "{message}");
+    let sets = parsed["sets"].as_array().unwrap();
+    assert_eq!(sets.len(), 1, "{message}");
+    assert_eq!(sets[0]["engine"], "criterion", "{message}");
+    let values: Vec<f64> = sets[0]["points"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|point| point["value"].as_f64().unwrap())
+        .collect();
+    assert_eq!(values, vec![20.0, 30.0], "{message}");
+}
+
+/// On a feature branch a dirty snapshot on the target tip pivots by default,
+/// ordered after the commit's clean run and flagged; `--no-dirty` drops it — the
+/// same admission `analyze`/`list` apply.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_admits_and_flags_dirty_on_a_feature_branch() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.checkout_new_branch("feature");
+    workspace.commit_dated("2024-01-02", "f1");
+    workspace.seed_callgrind("f1", 100.0);
+    workspace.seed_dirty_callgrind("2024-01-03", "f1", 200.0);
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let points = parsed["sets"][0]["points"].as_array().unwrap();
+    // c1 clean, then f1's clean run before its dirty snapshot.
+    assert_eq!(points.len(), 3, "{message}");
+    assert_eq!(
+        points[1]["dirty"], false,
+        "clean before dirty on f1: {message}"
+    );
+    assert_eq!(points[2]["dirty"], true, "{message}");
+    assert_eq!(points[2]["value"].as_f64().unwrap(), 200.0, "{message}");
+
+    // The text pivot flags the dirty row.
+    let RunOutcome::Completed { message } = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await
+        .unwrap()
+    else {
+        panic!("expected a completed outcome");
+    };
+    assert!(message.contains("(dirty)"), "{message}");
+
+    // `--no-dirty` drops the dirty snapshot, leaving only the two clean runs.
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+            "--no-dirty",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let points = parsed["sets"][0]["points"].as_array().unwrap();
+    assert_eq!(points.len(), 2, "{message}");
+    assert!(
+        points.iter().all(|point| point["dirty"] == false),
+        "{message}"
+    );
+}
+
+/// A genuinely dirty working tree on the base branch admits the tip's dirty
+/// snapshot via the base exception, and the pivot carries the ephemeral-data
+/// warning — matching `analyze`'s behavior.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_dirty_tree_on_the_base_warns() {
+    let workspace = Workspace::clean_repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.seed_callgrind("c2", 100.0);
+    workspace.seed_dirty_callgrind("2024-01-03", "c2", 130.0);
+    workspace.make_dirty("uncommitted.txt");
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let points = parsed["sets"][0]["points"].as_array().unwrap();
+    assert_eq!(
+        points.len(),
+        3,
+        "the dirty tip snapshot is admitted: {message}"
+    );
+    assert!(
+        parsed["warning"].as_str().is_some(),
+        "the ephemeral-data warning is present: {message}"
+    );
+
+    // `--no-dirty` skips the exception, dropping the dirty tip and its warning.
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+            "--no-dirty",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(
+        parsed["sets"][0]["points"].as_array().unwrap().len(),
+        2,
+        "{message}"
+    );
+    assert!(parsed["warning"].is_null(), "{message}");
+}
+
+/// An unknown `--metric` is rejected up front, before any load, listing the valid
+/// names so the maintainer can correct the typo.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_rejects_an_unknown_metric() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+
+    let error = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "cycles_per_second",
+        ])
+        .await
+        .unwrap_err();
+    let RunError::Analyze { message } = error else {
+        panic!("expected an analyze error, got {error:?}");
+    };
+    assert!(message.contains("unknown metric"), "{message}");
+    assert!(
+        message.contains("instruction_count"),
+        "the error lists valid names: {message}"
+    );
+}
+
+/// An unmatched benchmark id is not an error: runs enter the analysis but none
+/// carry the pair, so the pivot is empty and a hint explains why.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_unmatched_benchmark_reports_a_hint() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/does-not-exist",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert!(
+        parsed["sets"].as_array().unwrap().is_empty(),
+        "no set matches the id: {message}"
+    );
+    let hint = parsed["hint"].as_str().unwrap();
+    assert!(hint.contains("entered the analysis"), "{hint}");
+    assert!(hint.contains("does-not-exist"), "{hint}");
+}
+
+/// Like `analyze`/`list`, `examine` needs a repository to order the points by
+/// topology and to label them with commit titles; without one it errors.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_without_a_repository_errors() {
+    let workspace = Workspace::new(&storage_only_config());
+
+    let error = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await
+        .unwrap_err();
+    let RunError::Analyze { message } = error else {
+        panic!("expected an analyze error, got {error:?}");
+    };
+    assert!(message.contains("requires a git repository"), "{message}");
+}

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -461,3 +461,112 @@ async fn examine_without_a_repository_errors() {
     };
     assert!(message.contains("requires a git repository"), "{message}");
 }
+
+/// The benchmark id names the series to pivot, so it must be present: an empty
+/// `--benchmark` is rejected up front, before any load.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_rejects_an_empty_benchmark() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+
+    let error = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "",
+            "--metric",
+            "instruction_count",
+        ])
+        .await
+        .unwrap_err();
+    let RunError::Analyze { message } = error else {
+        panic!("expected an analyze error, got {error:?}");
+    };
+    assert!(
+        message.contains("--benchmark must not be empty"),
+        "{message}"
+    );
+}
+
+/// `--no-text` suppresses the text report, so with no file output requested there
+/// is nothing left to emit — an error rather than a silent no-op.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_requires_an_output() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+
+    let error = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+            "--no-text",
+        ])
+        .await
+        .unwrap_err();
+    let RunError::Analyze { message } = error else {
+        panic!("expected an analyze error, got {error:?}");
+    };
+    assert!(message.contains("no output selected"), "{message}");
+}
+
+/// When runs exist but the selection window excludes them all, `examine` gives the
+/// same self-explaining empty-history hint `analyze` does (distinct from the
+/// unmatched-series hint): the pivot is empty because no run entered the analysis,
+/// not because the pair was unmatched.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_empty_after_since_reports_the_analyze_hint() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    // Every seeded run lands in January 2024; a March cutoff excludes them all.
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+            "--since",
+            "2024-03-01",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert!(
+        parsed["sets"].as_array().unwrap().is_empty(),
+        "the --since cutoff excludes every run: {message}"
+    );
+    let hint = parsed["hint"].as_str().unwrap();
+    assert!(hint.contains("entered the analysis"), "{hint}");
+    assert!(hint.contains("--since cutoff"), "{hint}");
+}
+
+/// The Markdown report of an empty pivot states plainly that nothing matched
+/// rather than emitting a headerless, rowless table.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_markdown_renders_an_empty_pivot() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let markdown = workspace
+        .drive_markdown(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/does-not-exist",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    assert!(
+        markdown.contains("No data point matches the selection."),
+        "{markdown}"
+    );
+}

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -16,6 +16,7 @@ pub(crate) use jiff::Timestamp;
 use nonempty::nonempty;
 pub(crate) use serial_test::serial;
 pub(crate) use testing::CwdGuard;
+use tick::Clock;
 
 /// The tool version recorded with each run. The integration test compiles within
 /// the package, so its `CARGO_PKG_VERSION` matches the version `collect` records.
@@ -819,7 +820,7 @@ impl Workspace {
                 workspace_dir: Some(self.root().to_path_buf()),
                 target_root: Some(target_root),
                 bench_command: Some(bench_command),
-                now: Some(analysis_now()),
+                clock: Some(Clock::new_frozen_at(analysis_now())),
                 storage_override: None,
             },
         )
@@ -846,7 +847,7 @@ impl Workspace {
                 workspace_dir: Some(self.root().to_path_buf()),
                 target_root: None,
                 bench_command: Some(bench_command),
-                now: Some(analysis_now()),
+                clock: Some(Clock::new_frozen_at(analysis_now())),
                 storage_override: None,
             },
         )

--- a/packages/cargo-bench-history/tests/cbh_integration/main.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/main.rs
@@ -16,6 +16,7 @@ mod backfill;
 mod bless;
 mod cli;
 mod collect;
+mod examine;
 mod harness;
 mod install;
 mod list;


### PR DESCRIPTION
## Summary

Adds the `examine` command to `cargo-bench-history` (resolves #310).

`examine --benchmark <id> --metric <name>` pivots one `(benchmark, metric)` series into its raw per-commit data points — one row per recorded observation, in git first-parent order, pairing each value with the short commit id and the start of the commit's title. It lets a maintainer drill into an `analyze` finding and correlate a value's move with the commit that caused it.

It joins the read-only selection-lockstep family (**analyze / list / prune / examine**), reusing `analyze`'s exact data-set-selection pipeline, so a selection parameter added to one applies here unchanged. It repeats the pivot once per matching discriminant set, runs no detection/re-baselining/blessing, and — like `analyze` — needs a resolvable repository (first-parent topology to order points, commit titles to label them).

## Details

- **Output**: shared composable per-format toggles — text on stdout by default, `--markdown <path>`, `--json <path>`, `--no-text`. Text/Markdown truncate the title to 50 characters; JSON keeps the full title and full-precision value.
- **Dirty snapshots**: a commit's clean run and its dirty snapshots each contribute a flagged row (clean before dirty), matching `analyze`/`list` admission; `--no-dirty` drops them. A dirty working tree on the base tip surfaces the same ephemeral-data warning.
- **Core**: `MetricKind::ALL` + `from_name` validate `--metric` up front (listing valid names on error); `format_value` is now public so examine values match analyze charts.
- **Git port**: the first-parent walk now also carries each commit's subject (no extra round-trips), threaded through the resolved history into the selected data set as commit titles.
- **Docs**: incorporates the design into `DESIGN.md` §7.8, `README.md`, and `docs/analyze.md`; condenses the package `AGENTS.md` to instructions-only (no design duplication), with a matching meta-principle in the root `AGENTS.md`.

## Testing

- 11 `examine` unit tests (Miri-safe; fakes + `block_on`).
- 11 `examine` integration tests: rising history, text/Markdown rendering, metric isolation, facet selection, a Criterion `wall_time` series, feature-branch dirty admission + `--no-dirty`, base-tree-dirty warning, unknown-metric rejection, unmatched-benchmark hint, and the no-repository error.
- CLI parse tests + `MetricKind::from_name` round-trip tests.
- `just package="cargo-bench-history cargo-bench-history-core" validate-local` passes clean (format-check, clippy `-D warnings`, test, test-docs, docs, Miri, machete, default-features-check dev+release).
