### PR TITLE
Release automation: print composed config and add verbose plan decision history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,8 @@ jobs:
         shell: pwsh
         # git_release_enable stays false in the committed release-plz.toml; this writes a
         # CI-only copy under RUNNER_TEMP (outside the working tree, so cargo publish sees a
-        # clean repo) with the flag enabled for exactly the derived binary crates.
+        # clean repo) with the flag enabled for exactly the derived binary crates. The
+        # composed file is printed to the step log so the effective config is inspectable.
         run: just gh-compose-release-config "$env:RUNNER_TEMP/release-plz.ci.toml"
 
       - name: Release to crates.io (Trusted Publishing) with retries
@@ -103,6 +104,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # The recipe defaults its Write-Verbose decision history ON in CI (the runner sets
+        # $env:CI), so the step log records how the missing-archive plan was derived per crate
+        # and target — not just the final count.
         run: just gh-plan-release-binaries
 
   build-binaries:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,8 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # The recipe defaults its Write-Verbose decision history ON in CI (the runner sets
-        # $env:CI), so the step log records how the missing-archive plan was derived per crate
-        # and target — not just the final count.
+        # The recipe always emits its Write-Verbose decision history, so the step log records how
+        # the missing-archive plan was derived per crate and target — not just the final count.
         run: just gh-plan-release-binaries
 
   build-binaries:

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -77,6 +77,12 @@ gh-compose-release-config output:
     New-ReleasePlzConfig -SourcePath 'release-plz.toml' -OutputPath '{{output}}' -CrateName $crates.Name
     Write-Verbose "Wrote CI release-plz config to {{output}}." -Verbose
 
+    # Print the composed config so the CI log records exactly what release-plz will run with
+    # (which crates got `git_release_enable = true`), without needing to unpack the runner temp.
+    Write-Host "----- Composed CI release-plz config ({{output}}) -----"
+    Get-Content -Path '{{output}}' -Raw | Write-Host
+    Write-Host "----- End composed CI release-plz config -----"
+
 # Publishes changed crates to crates.io via release-plz using the composed CI config, with
 # bounded retries (3 attempts, 15 minutes apart) to ride out crates.io rate limits and the
 # short-lived OIDC token. release-plz is idempotent — it re-checks the registry and skips
@@ -105,8 +111,15 @@ gh-plan-release-binaries:
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
 
+    # Get-MissingBinaryMatrix emits its decision history (per crate: expected tag, whether the
+    # release exists, and the per-target present/missing verdict) via Write-Verbose. Default it
+    # ON in CI ($env:CI is set by GitHub Actions) so the workflow log explains how the plan was
+    # derived, not just the final count; a local run stays quiet unless the caller passes -Verbose.
+    $verbose = @{ Verbose = [bool]$env:CI }
+
     $crates = @(Get-PublishableBinaryCrate)
-    $rows = if ($crates.Count -gt 0) { @(Get-MissingBinaryMatrix -Crate $crates) } else { @() }
+    Write-Verbose "Publishable binary crates: $($crates.Name -join ', ')" @verbose
+    $rows = if ($crates.Count -gt 0) { @(Get-MissingBinaryMatrix -Crate $crates @verbose) } else { @() }
 
     Write-Host "Missing (crate, target) archives: $($rows.Count)"
     Set-GitHubOutput -Name 'matrix' -Value (ConvertTo-MatrixJson -Row $rows)

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -112,15 +112,12 @@ gh-plan-release-binaries:
     Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
 
     # Get-MissingBinaryMatrix emits its decision history (per crate: expected tag, whether the
-    # release exists, and the per-target present/missing verdict) via Write-Verbose. Default it
-    # ON in CI so the workflow log explains how the plan was derived, not just the final count.
-    # GitHub Actions sets CI=true; the exact-string match avoids treating CI=false/0 (which some
-    # local shells export) as on. To enable it locally, run with $env:CI = 'true' set.
-    $verbose = @{ Verbose = ($env:CI -eq 'true') }
-
+    # release exists, and the per-target present/missing verdict) via Write-Verbose. This is an
+    # automation-only recipe, so always emit it: the reasoning is worth capturing in every run
+    # (CI log or a local diagnostic invocation), not just the final count.
     $crates = @(Get-PublishableBinaryCrate)
-    Write-Verbose "Publishable binary crates: $($crates.Name -join ', ')" @verbose
-    $rows = if ($crates.Count -gt 0) { @(Get-MissingBinaryMatrix -Crate $crates @verbose) } else { @() }
+    Write-Verbose "Publishable binary crates: $($crates.Name -join ', ')" -Verbose
+    $rows = if ($crates.Count -gt 0) { @(Get-MissingBinaryMatrix -Crate $crates -Verbose) } else { @() }
 
     Write-Host "Missing (crate, target) archives: $($rows.Count)"
     Set-GitHubOutput -Name 'matrix' -Value (ConvertTo-MatrixJson -Row $rows)

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -113,9 +113,10 @@ gh-plan-release-binaries:
 
     # Get-MissingBinaryMatrix emits its decision history (per crate: expected tag, whether the
     # release exists, and the per-target present/missing verdict) via Write-Verbose. Default it
-    # ON in CI ($env:CI is set by GitHub Actions) so the workflow log explains how the plan was
-    # derived, not just the final count; a local run stays quiet unless the caller passes -Verbose.
-    $verbose = @{ Verbose = [bool]$env:CI }
+    # ON in CI so the workflow log explains how the plan was derived, not just the final count.
+    # GitHub Actions sets CI=true; the exact-string match avoids treating CI=false/0 (which some
+    # local shells export) as on. To enable it locally, run with $env:CI = 'true' set.
+    $verbose = @{ Verbose = ($env:CI -eq 'true') }
 
     $crates = @(Get-PublishableBinaryCrate)
     Write-Verbose "Publishable binary crates: $($crates.Name -join ', ')" @verbose

--- a/scripts/release/ReleaseAutomation.Tests.ps1
+++ b/scripts/release/ReleaseAutomation.Tests.ps1
@@ -357,6 +357,48 @@ Describe 'Get-MissingBinaryMatrix (mocked gh release view)' {
         $rows = Get-MissingBinaryMatrix -Crate $crates -Target $script:TwoTargets
         $rows.Count | Should -Be 1
     }
+
+    Context 'verbose decision history (-Verbose)' {
+        BeforeAll {
+            function Get-VerboseMessage {
+                # Runs the reconciliation with -Verbose and returns just the verbose-stream
+                # messages (dropping the matrix rows the function also emits on the success stream).
+                param([object[]] $Crate)
+                Get-MissingBinaryMatrix -Crate $Crate -Target $script:TwoTargets -Verbose 4>&1 |
+                    Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } |
+                    ForEach-Object { $_.Message }
+            }
+        }
+
+        It 'is silent on the verbose stream without -Verbose' {
+            $crate = [pscustomobject]@{ Name = 'have-some'; Version = '2.0.0' }
+            $verbose = Get-MissingBinaryMatrix -Crate $crate -Target $script:TwoTargets 4>&1 |
+                Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+            $verbose | Should -BeNullOrEmpty
+        }
+
+        It 'logs the expected tag, the present verdict and the missing verdict for a partial release' {
+            $messages = Get-VerboseMessage -Crate ([pscustomobject]@{ Name = 'have-some'; Version = '2.0.0' })
+            ($messages -join "`n") | Should -Match "expected release tag 'have-some-v2.0.0'"
+            ($messages -join "`n") | Should -Match 'x86_64-unknown-linux-gnu.*already uploaded'
+            ($messages -join "`n") | Should -Match 'aarch64-apple-darwin.*missing.*macos-latest'
+        }
+
+        It 'explains why a crate with no release yet is skipped' {
+            $messages = Get-VerboseMessage -Crate ([pscustomobject]@{ Name = 'no-release'; Version = '3.0.0' })
+            ($messages -join "`n") | Should -Match "No GitHub release 'no-release-v3.0.0' found yet"
+        }
+
+        It 'reports the final missing-archive count' {
+            $messages = Get-VerboseMessage -Crate ([pscustomobject]@{ Name = 'empty-release'; Version = '4.0.0' })
+            ($messages -join "`n") | Should -Match 'Reconciliation complete: 2 missing \(crate, target\) archives'
+        }
+
+        It 'uses the singular noun for a single missing archive' {
+            $messages = Get-VerboseMessage -Crate ([pscustomobject]@{ Name = 'have-some'; Version = '2.0.0' })
+            ($messages -join "`n") | Should -Match 'Reconciliation complete: 1 missing \(crate, target\) archive queued to build\.'
+        }
+    }
 }
 
 Describe 'ConvertTo-MatrixJson' {

--- a/scripts/release/ReleaseAutomation.psm1
+++ b/scripts/release/ReleaseAutomation.psm1
@@ -175,15 +175,31 @@ function Get-MissingBinaryMatrix {
         [object[]] $Target = (Get-ReleaseTarget)
     )
 
+    # Verbose emits the full decision history — every crate, its expected tag, whether the
+    # release exists, and the per-target present/missing verdict — so a CI run's log explains
+    # exactly how the plan (and its emptiness or non-emptiness) was derived, not just the total.
+    Write-Verbose "Reconciling desired vs. uploaded binary archives. Crates: $($Crate.Name -join ', '). Target triples: $(($Target.Triple) -join ', ')."
+
     $rows = [System.Collections.Generic.List[object]]::new()
     foreach ($crate in $Crate) {
         $tag = "$($crate.Name)-v$($crate.Version)"
+        Write-Verbose "Crate '$($crate.Name)' v$($crate.Version): expected release tag '$tag'."
         $assets = Get-BinaryReleaseAsset -Tag $tag
-        if ($null -eq $assets) { continue }
+        if ($null -eq $assets) {
+            Write-Verbose "  No GitHub release '$tag' found yet; skipping this crate (nothing to reconcile until its release exists)."
+            continue
+        }
+
+        $uploaded = if ($assets.Count -gt 0) { $assets -join ', ' } else { '(none)' }
+        Write-Verbose "  Release '$tag' found; already-uploaded archives: $uploaded."
 
         foreach ($target in $Target) {
             $archive = "$($crate.Name)-v$($crate.Version)-$($target.Triple).zip"
-            if ($assets -contains $archive) { continue }
+            if ($assets -contains $archive) {
+                Write-Verbose "  Target $($target.Triple): '$archive' already uploaded — skipping."
+                continue
+            }
+            Write-Verbose "  Target $($target.Triple): '$archive' missing — queuing a build on runner '$($target.Os)'."
             $rows.Add([pscustomobject]@{
                     name    = $crate.Name
                     version = $crate.Version
@@ -193,6 +209,9 @@ function Get-MissingBinaryMatrix {
                 })
         }
     }
+
+    $noun = if ($rows.Count -eq 1) { 'archive' } else { 'archives' }
+    Write-Verbose "Reconciliation complete: $($rows.Count) missing (crate, target) $noun queued to build."
 
     , $rows.ToArray()
 }


### PR DESCRIPTION
## What

Two release-automation observability improvements so the `Release` workflow's decisions are auditable from the run log.

### 1. Print the composed CI release-plz config

`just gh-compose-release-config` writes the CI-only `release-plz.toml` (with `git_release_enable = true` injected for the derived binary crates) as before, and now also **prints the full composed file** to the step log between clear markers. This makes the effective config inspectable without unpacking `RUNNER_TEMP`.

### 2. Verbose decision history for `plan-binaries`

`Get-MissingBinaryMatrix` now emits a full `Write-Verbose` decision history:

- per crate: its expected release tag,
- whether the release exists yet (and *why* a crate is skipped),
- the already-uploaded archives,
- a per-target present/missing verdict with the runner it queues,
- and a final missing-archive count.

`just gh-plan-release-binaries` emits this **always** (it passes `-Verbose` unconditionally). These `gh-` recipes are automation-only, so the reasoning is worth capturing in every invocation — a CI run or a local diagnostic run — rather than only the final count. This matches the existing always-on `-Verbose` pattern in `gh-compose-release-config`.

## Why

Previously `plan-binaries` only showed the final line (e.g. `Missing (crate, target) archives: 0`), giving no insight into how it arrived there. Now the log explains the reasoning per crate and target.

## Testing

- Added 6 Pester tests covering the verbose stream (silent without `-Verbose`, tag / present / missing verdicts, skip explanation, singular/plural noun). All 68 script tests pass via `just test-scripts`.
- Smoke-tested both recipes locally.
- `just validate-workflows` passes.
