### PR TITLE
Rename "sha" to "commit ID" terminology (#313)

### DIFF
--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -49,7 +49,7 @@ format:
 
 [group('quality')]
 format-check:
-    cargo +{{ env_var('RUST_NIGHTLY') }} fmt --verbose --all --check
+    cargo +{{ env_var('RUST_NIGHTLY') }} fmt --verbose --all --check -- --config-path ./unstable-rustfmt.toml
     cargo sort --workspace --check
     cargo sort-derives --check
 

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -28,7 +28,6 @@
 //! This package is not meant for use in production, serving only as a development tool.
 //!
 //! # Features
-//!
 #![cfg_attr(
     feature = "panic_on_next_alloc",
     doc = "- `panic_on_next_alloc`: Enables the [`panic_on_next_alloc`] function for debugging"

--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -20,7 +20,7 @@ here, alongside the workspace-wide rules in `docs/` (especially
   [`RunPoints`](src/analyze/run_points.rs) projection — only the fields
   `SeriesBuilder::push` reads (per result, the id and the
   metric value/interval), dropping the run context and per-metric standard deviation —
-  and `push` consumes that projection rather than a full `Run`. The full commit SHA a
+  and `push` consumes that projection rather than a full `Run`. The full commit ID a
   point is labelled with comes from the storage key, not the run payload, so the
   projection carries no git fields. Keep that projection in
   lockstep with what the fold reads. **Note on memory:** folding in the worker did *not*

--- a/packages/cargo-bench-history-core/src/analyze/discriminant.rs
+++ b/packages/cargo-bench-history-core/src/analyze/discriminant.rs
@@ -107,7 +107,7 @@ pub struct StorageKey {
     pub project: String,
     /// The discriminant set the key belongs to.
     pub set: DiscriminantSet,
-    /// The commit directory segment (full SHA, or `unknown`).
+    /// The commit directory segment (full commit ID, or `unknown`).
     pub commit: String,
     /// The file segment (`clean.json`, `dirty-<unix>.json`, or `bless-<unix>.json`).
     pub file: String,

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -35,10 +35,8 @@ use anyspawn::Spawner;
 use serde::Serialize;
 
 use crate::analyze::parallel::{balanced_chunk_sizes, worker_count};
-use crate::analyze::stats;
-use crate::analyze::{Series, SeriesPoint};
-use crate::model::DiscriminantSet;
-use crate::model::{BenchmarkId, MetricKind};
+use crate::analyze::{Series, SeriesPoint, stats};
+use crate::model::{BenchmarkId, DiscriminantSet, MetricKind};
 
 /// Tunable parameters of the engine-aware analysis.
 #[derive(Clone, Copy, Debug)]
@@ -884,7 +882,7 @@ fn stamp_history(finding: &mut Finding, series: &Series) {
     }
 }
 
-/// Abbreviates a commit SHA for display (first 12 hex digits).
+/// Abbreviates a commit ID for display (first 12 hex digits).
 pub(crate) fn short_commit(commit: &str) -> String {
     commit.get(..12).unwrap_or(commit).to_owned()
 }
@@ -1226,17 +1224,14 @@ mod tests {
     )]
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
-    use jiff::Timestamp;
-
     use std::sync::Arc;
 
-    use crate::analyze::{Blessing, SeriesPoint};
-    use crate::model::DiscriminantSet;
-    use crate::model::MetricKind;
-
+    use jiff::Timestamp;
     use nonempty::nonempty;
 
     use super::*;
+    use crate::analyze::{Blessing, SeriesPoint};
+    use crate::model::{DiscriminantSet, MetricKind};
 
     /// Builds a deterministic (Callgrind) series carrying `values` in topological
     /// order, with no dispersion.

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -15,8 +15,7 @@ use serde::Serialize;
 
 use crate::analyze::findings::short_commit;
 use crate::analyze::{Direction, Finding, FindingMethod, SeriesValue};
-use crate::model::BenchmarkId;
-use crate::model::DiscriminantSet;
+use crate::model::{BenchmarkId, DiscriminantSet};
 
 /// Height, in rows, of a history-mode finding chart.
 const CHART_HEIGHT: u32 = 4;
@@ -204,7 +203,7 @@ struct JsonReport<'a> {
     /// The project the history belongs to.
     project: &'a str,
     /// The commit the analysis was run against (resolved `--context`, HEAD by
-    /// default): the full SHA, so a consumer can link the report to a commit.
+    /// default): the full commit ID, so a consumer can link the report to a commit.
     tip_commit: &'a str,
     /// Whether the working tree carried uncommitted changes when the analysis ran.
     tip_dirty: bool,
@@ -791,11 +790,10 @@ fn format_percent(relative_delta: f64) -> String {
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
-    use crate::model::MetricKind;
-
     use nonempty::nonempty;
 
     use super::*;
+    use crate::model::MetricKind;
 
     fn discriminant_set() -> DiscriminantSet {
         DiscriminantSet {

--- a/packages/cargo-bench-history-core/src/analyze/selection.rs
+++ b/packages/cargo-bench-history-core/src/analyze/selection.rs
@@ -11,7 +11,7 @@
 /// One commit selected for analysis, in oldest-first topological position.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SelectedCommit {
-    /// The commit SHA (the storage commit-directory segment).
+    /// The commit ID (the storage commit-directory segment).
     pub commit: String,
     /// Whether dirty snapshots on this commit are admitted (target-side, or the
     /// base-side tip under the dirty-working-tree exception).
@@ -70,7 +70,7 @@ pub fn select_commits(
 mod tests {
     use super::*;
 
-    fn shas(names: &[&str]) -> Vec<String> {
+    fn commit_ids(names: &[&str]) -> Vec<String> {
         names.iter().map(|name| (*name).to_owned()).collect()
     }
 
@@ -85,7 +85,7 @@ mod tests {
     fn official_view_admits_no_dirty_when_base_is_the_tip() {
         // Analyzing master with base==master: merge-base is the tip, so every
         // commit is base-side (clean only).
-        let ancestry = shas(&["c0", "c1", "c2", "c3"]);
+        let ancestry = commit_ids(&["c0", "c1", "c2", "c3"]);
         let selection = select_commits(&ancestry, Some("c3"), true, false);
         assert_eq!(
             admit(&selection),
@@ -102,7 +102,7 @@ mod tests {
     fn feature_view_admits_dirty_after_the_merge_base() {
         // feature ancestry [c0,c1,f1,f2] branched at c1: c0,c1 base-side; f1,f2
         // target-side (admit dirty).
-        let ancestry = shas(&["c0", "c1", "f1", "f2"]);
+        let ancestry = commit_ids(&["c0", "c1", "f1", "f2"]);
         let selection = select_commits(&ancestry, Some("c1"), true, false);
         assert_eq!(
             admit(&selection),
@@ -112,14 +112,14 @@ mod tests {
 
     #[test]
     fn no_dirty_suppresses_target_side_admission() {
-        let ancestry = shas(&["c0", "c1", "f1", "f2"]);
+        let ancestry = commit_ids(&["c0", "c1", "f1", "f2"]);
         let selection = select_commits(&ancestry, Some("c1"), false, false);
         assert!(selection.iter().all(|selected| !selected.admit_dirty));
     }
 
     #[test]
     fn absent_merge_base_treats_everything_as_target_side() {
-        let ancestry = shas(&["a0", "a1"]);
+        let ancestry = commit_ids(&["a0", "a1"]);
         let selection = select_commits(&ancestry, None, true, false);
         assert_eq!(admit(&selection), vec![("a0", true), ("a1", true)]);
     }
@@ -128,14 +128,14 @@ mod tests {
     fn merge_base_off_the_first_parent_chain_is_target_side() {
         // A merge-base that is not present in the ancestry list falls back to the
         // inclusive (target-side) treatment.
-        let ancestry = shas(&["c0", "c1", "c2"]);
+        let ancestry = commit_ids(&["c0", "c1", "c2"]);
         let selection = select_commits(&ancestry, Some("zz"), true, false);
         assert!(selection.iter().all(|selected| selected.admit_dirty));
     }
 
     #[test]
     fn ordering_is_preserved_oldest_first() {
-        let ancestry = shas(&["c0", "c1", "c2"]);
+        let ancestry = commit_ids(&["c0", "c1", "c2"]);
         let selection = select_commits(&ancestry, Some("c0"), true, false);
         let order: Vec<&str> = selection
             .iter()
@@ -149,7 +149,7 @@ mod tests {
         // Official view (everything base-side) but the working tree is dirty: only
         // the tip (c3) admits dirty runs, flagged as the base-branch exception;
         // earlier base-side commits stay clean-only.
-        let ancestry = shas(&["c0", "c1", "c2", "c3"]);
+        let ancestry = commit_ids(&["c0", "c1", "c2", "c3"]);
         let selection = select_commits(&ancestry, Some("c3"), true, true);
         assert_eq!(
             admit(&selection),
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn dirty_tip_exception_is_gated_by_allow_dirty() {
         // --no-dirty (allow_dirty == false) overrides the dirty-tree exception.
-        let ancestry = shas(&["c0", "c1", "c2", "c3"]);
+        let ancestry = commit_ids(&["c0", "c1", "c2", "c3"]);
         let selection = select_commits(&ancestry, Some("c3"), false, true);
         assert!(selection.iter().all(|selected| !selected.admit_dirty));
         assert!(
@@ -180,7 +180,7 @@ mod tests {
     fn dirty_tip_exception_does_not_flag_a_target_side_tip() {
         // On a feature view the tip is already target-side, so the exception adds
         // nothing and must not mark the tip as a base-branch exception.
-        let ancestry = shas(&["c0", "c1", "f1", "f2"]);
+        let ancestry = commit_ids(&["c0", "c1", "f1", "f2"]);
         let selection = select_commits(&ancestry, Some("c1"), true, true);
         assert!(
             selection

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -18,18 +18,17 @@ use std::collections::hash_map::Entry as MapEntry;
 use std::hash::BuildHasher;
 use std::sync::Arc;
 
-use foldhash::HashMap as FoldHashMap;
-use foldhash::HashMapExt;
 use foldhash::fast::RandomState;
+use foldhash::{HashMap as FoldHashMap, HashMapExt};
 use hashbrown::HashTable;
 use hashbrown::hash_table::Entry;
 use jiff::Timestamp;
 
 use crate::analyze::StorageKey;
 use crate::analyze::run_points::RunPoints;
-use crate::model::BlessingRecord;
-use crate::model::DiscriminantSet;
-use crate::model::{BenchmarkId, BenchmarkIdPrefix, MetricKind, Run};
+use crate::model::{
+    BenchmarkId, BenchmarkIdPrefix, BlessingRecord, DiscriminantSet, MetricKind, Run,
+};
 
 /// A single observation in a series.
 ///
@@ -50,7 +49,7 @@ pub struct SeriesPoint {
     /// standing in for the full storage key to keep the point small.
     pub object_ordinal: u32,
     /// Commit the run was measured against — the storage key's commit directory
-    /// segment (a full SHA, or `unknown`). Interned so all points on one commit
+    /// segment (a full commit ID, or `unknown`). Interned so all points on one commit
     /// share a single allocation.
     pub commit: Option<Arc<str>>,
     /// The measured value.
@@ -71,7 +70,7 @@ pub struct SeriesPoint {
 /// section of `DESIGN.md`.
 #[derive(Clone, Debug)]
 pub struct Blessing {
-    /// Full commit SHA the blessing was issued at (the report anchor).
+    /// Full commit ID the blessing was issued at (the report anchor).
     pub commit: String,
     /// Committer date of the blessed commit (resolved from git topology), for the
     /// report anchor. `None` when topology did not report a date for the commit.
@@ -289,7 +288,7 @@ impl SeriesBuilder {
     ///
     /// `topo_index` is the run commit's first-parent position, `object_ordinal` its
     /// rank in sorted storage-key order (the final point tie-break), and `commit`
-    /// the storage key's commit directory segment (a full SHA, or `unknown`); the
+    /// the storage key's commit directory segment (a full commit ID, or `unknown`); the
     /// caller supplies all three because they come from the storage key and git
     /// topology, not the run payload. `run` is the fold-relevant projection of the
     /// run (see [`RunPoints`]); only the matching metrics are retained — it can be
@@ -521,13 +520,13 @@ mod tests {
     )]
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
-    use crate::analyze::parse_key;
-    use crate::model::{BenchmarkResult, Metric};
-    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
-
     use nonempty::NonEmpty;
 
     use super::*;
+    use crate::analyze::parse_key;
+    use crate::model::{
+        BenchmarkResult, EnvironmentInfo, GitInfo, Metric, RunContext, ToolchainInfo,
+    };
 
     fn ts(seconds: i64) -> Timestamp {
         Timestamp::from_second(seconds).unwrap()

--- a/packages/cargo-bench-history-core/src/model/bless.rs
+++ b/packages/cargo-bench-history-core/src/model/bless.rs
@@ -20,7 +20,7 @@ use crate::model::{BenchmarkId, BenchmarkIdPrefix};
 ///
 /// Records which on-disk format a file was written with. Reads are not gated on
 /// it: version 2 dropped the redundant `commit_time` field (the blessed commit's
-/// date is resolved from git topology, keyed by the commit SHA), and older records
+/// date is resolved from git topology, keyed by the commit ID), and older records
 /// still deserialize because the removed field is simply ignored.
 pub const BLESS_SCHEMA_VERSION: u32 = 2;
 
@@ -29,7 +29,7 @@ pub const BLESS_SCHEMA_VERSION: u32 = 2;
 pub struct BlessingRecord {
     /// Schema version of this record (see [`BLESS_SCHEMA_VERSION`]).
     pub schema_version: u32,
-    /// Full commit SHA the blessing was issued at (the blessed data point). The
+    /// Full commit ID the blessing was issued at (the blessed data point). The
     /// commit's date, when a report needs it, is resolved from git topology.
     pub commit: String,
     /// Wall-clock time at which the blessing was issued (provenance).

--- a/packages/cargo-bench-history-core/src/model/context.rs
+++ b/packages/cargo-bench-history-core/src/model/context.rs
@@ -4,7 +4,7 @@
 //!
 //! A run is positioned on its series timeline purely by git topology — the
 //! first-parent index of its commit, resolved live during analysis from the
-//! stored commit SHA. The object records no commit timestamp of its own; the
+//! stored commit ID. The object records no commit timestamp of its own; the
 //! observation timestamp it does carry is provenance and is never used for
 //! ordering or windowing.
 
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// Metadata attached to every stored run.
 ///
-/// A run's timeline position comes from git topology (keyed by the commit SHA in
+/// A run's timeline position comes from git topology (keyed by the commit ID in
 /// [`git`](Self::git)), not from any stored timestamp. `observation` is provenance
 /// metadata and is never used for ordering or windowing.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/packages/cargo-bench-history-core/src/model/run.rs
+++ b/packages/cargo-bench-history-core/src/model/run.rs
@@ -9,9 +9,9 @@ use crate::model::{BenchmarkId, Metric, RunContext};
 ///
 /// Records which on-disk format a file was written with. Reads are not gated on
 /// it: version 2 dropped the redundant per-object `commit` timestamp (a run's
-/// timeline position is resolved from git topology, keyed by its commit SHA), and
+/// timeline position is resolved from git topology, keyed by its commit ID), and
 /// version 3 dropped the redundant `short_commit` (an abbreviation of the full
-/// commit SHA the analysis already has from the storage key). Older records still
+/// commit ID the analysis already has from the storage key). Older records still
 /// deserialize because the removed fields are simply ignored.
 pub const SCHEMA_VERSION: u32 = 3;
 

--- a/packages/cargo-bench-history-stress/src/repo.rs
+++ b/packages/cargo-bench-history-stress/src/repo.rs
@@ -2,7 +2,7 @@
 //!
 //! The whole history is created in one `git fast-import` stream: a `main` branch
 //! of dated first-parent commits plus a feature branch forked from `main`'s tip.
-//! `analyze` shells out to real `git` against this repository, so the commit SHAs
+//! `analyze` shells out to real `git` against this repository, so the commit IDs
 //! the seeded storage keys are named by must be the SHAs `git rev-list` reports —
 //! hence the import runs first and the SHAs are read back from the export-marks
 //! file before any storage object is written.
@@ -19,11 +19,11 @@ use crate::error::{Error, fail};
 use crate::logging::Logger;
 use crate::scenario::{BRANCH_FEATURE, BRANCH_MAIN};
 
-/// A single seeded commit: its SHA and the committer date it carries.
+/// A single seeded commit: its commit ID and the committer date it carries.
 #[derive(Clone, Debug)]
 pub(crate) struct Commit {
-    /// Full 40-character commit SHA, as `git rev-list` reports it.
-    pub(crate) sha: String,
+    /// Full 40-character commit ID, as `git rev-list` reports it.
+    pub(crate) commit_id: String,
     /// Committer date, mirrored into each run's context for `--since` windowing.
     pub(crate) time: Timestamp,
 }
@@ -82,7 +82,7 @@ pub(crate) async fn build_repo(
     let repo = resolve_commits(&marks, main_times, feature_times)?;
     logger.detail_with(|| {
         format!(
-            "read back {} commit SHAs from the export-marks file",
+            "read back {} commit IDs from the export-marks file",
             repo.main.len().saturating_add(repo.feature.len())
         )
     });
@@ -193,7 +193,7 @@ async fn import_stream(dir: &Path, marks_path: &Path, stream: &[u8]) -> Result<(
     Ok(())
 }
 
-/// Parses the export-marks file into a `mark -> SHA` map.
+/// Parses the export-marks file into a `mark -> commit ID` map.
 #[cfg_attr(coverage_nightly, coverage(off))]
 async fn read_marks(marks_path: &Path) -> Result<HashMap<usize, String>, Error> {
     let text = tokio::fs::read_to_string(marks_path)
@@ -201,19 +201,19 @@ async fn read_marks(marks_path: &Path) -> Result<HashMap<usize, String>, Error> 
         .map_err(|error| fail(format!("failed to read the fast-import marks: {error}")))?;
     let mut marks = HashMap::new();
     for line in text.lines() {
-        // Each line is ":<mark> <sha>".
-        let Some((mark, sha)) = line.split_once(' ') else {
+        // Each line is ":<mark> <commit_id>".
+        let Some((mark, commit_id)) = line.split_once(' ') else {
             continue;
         };
         let mark = mark.strip_prefix(':').unwrap_or(mark);
         if let Ok(mark) = mark.parse::<usize>() {
-            marks.insert(mark, sha.to_owned());
+            marks.insert(mark, commit_id.to_owned());
         }
     }
     Ok(marks)
 }
 
-/// Resolves the `mark -> SHA` map back into per-branch commit lists.
+/// Resolves the `mark -> commit ID` map back into per-branch commit lists.
 fn resolve_commits(
     marks: &HashMap<usize, String>,
     main_times: &[Timestamp],
@@ -221,16 +221,17 @@ fn resolve_commits(
 ) -> Result<SeededRepo, Error> {
     let main_count = main_times.len();
     let lookup = |mark: usize| -> Result<String, Error> {
-        marks
-            .get(&mark)
-            .cloned()
-            .ok_or_else(|| fail(format!("fast-import did not report a SHA for mark :{mark}")))
+        marks.get(&mark).cloned().ok_or_else(|| {
+            fail(format!(
+                "fast-import did not report a commit ID for mark :{mark}"
+            ))
+        })
     };
 
     let mut main = Vec::with_capacity(main_count);
     for (i, time) in main_times.iter().enumerate() {
         main.push(Commit {
-            sha: lookup(i.saturating_add(1))?,
+            commit_id: lookup(i.saturating_add(1))?,
             time: *time,
         });
     }
@@ -238,7 +239,7 @@ fn resolve_commits(
     let mut feature = Vec::with_capacity(feature_times.len());
     for (j, time) in feature_times.iter().enumerate() {
         feature.push(Commit {
-            sha: lookup(main_count.saturating_add(j).saturating_add(1))?,
+            commit_id: lookup(main_count.saturating_add(j).saturating_add(1))?,
             time: *time,
         });
     }

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -44,8 +44,8 @@ enum Task {
         set: usize,
         /// First-parent index of the commit on `main`.
         index: usize,
-        /// The commit SHA.
-        sha: String,
+        /// The commit ID.
+        commit_id: String,
         /// The committer date.
         time: Timestamp,
     },
@@ -53,8 +53,8 @@ enum Task {
     CleanFeature {
         /// Index into the discriminant-set matrix.
         set: usize,
-        /// The commit SHA.
-        sha: String,
+        /// The commit ID.
+        commit_id: String,
         /// The committer date.
         time: Timestamp,
     },
@@ -64,8 +64,8 @@ enum Task {
         set: usize,
         /// Which dirty snapshot this is (distinguishes the observation time).
         k: usize,
-        /// The feature-tip commit SHA the snapshot is based on.
-        sha: String,
+        /// The feature-tip commit ID the snapshot is based on.
+        commit_id: String,
         /// The feature-tip committer date.
         time: Timestamp,
         /// The snapshot's observation second (part of its key).
@@ -75,8 +75,8 @@ enum Task {
     Bless {
         /// Index into the discriminant-set matrix.
         set: usize,
-        /// The blessed commit SHA.
-        sha: String,
+        /// The blessed commit ID.
+        commit_id: String,
         /// The blessing's issued second (part of its key).
         issued: i64,
     },
@@ -136,14 +136,14 @@ fn plan_tasks(scenario: Scenario, sets: &[DiscriminantSet], repo: &SeededRepo) -
             tasks.push(Task::CleanMain {
                 set,
                 index,
-                sha: commit.sha.clone(),
+                commit_id: commit.commit_id.clone(),
                 time: commit.time,
             });
         }
         for commit in &repo.feature {
             tasks.push(Task::CleanFeature {
                 set,
-                sha: commit.sha.clone(),
+                commit_id: commit.commit_id.clone(),
                 time: commit.time,
             });
         }
@@ -153,7 +153,7 @@ fn plan_tasks(scenario: Scenario, sets: &[DiscriminantSet], repo: &SeededRepo) -
                 tasks.push(Task::Dirty {
                     set,
                     k,
-                    sha: tip.sha.clone(),
+                    commit_id: tip.commit_id.clone(),
                     time: tip.time,
                     observation,
                 });
@@ -164,7 +164,7 @@ fn plan_tasks(scenario: Scenario, sets: &[DiscriminantSet], repo: &SeededRepo) -
         {
             tasks.push(Task::Bless {
                 set,
-                sha: commit.sha.clone(),
+                commit_id: commit.commit_id.clone(),
                 issued: commit.time.as_second().saturating_add(60),
             });
         }
@@ -227,43 +227,61 @@ fn write_one(
         Task::CleanMain {
             set: s,
             index,
-            sha,
+            commit_id,
             time,
         } => {
-            let run = clean_run(scenario, set, *time, sha, BRANCH_MAIN, false, |b| {
+            let run = clean_run(scenario, set, *time, commit_id, BRANCH_MAIN, false, |b| {
                 scenario.main_clean_value(b, *s, *index, true)
             });
-            (set.clean_key(PROJECT, sha), run.to_json()?)
+            (set.clean_key(PROJECT, commit_id), run.to_json()?)
         }
-        Task::CleanFeature { set: s, sha, time } => {
-            let run = clean_run(scenario, set, *time, sha, BRANCH_FEATURE, false, |b| {
-                scenario.feature_clean_value(b, *s)
-            });
-            (set.clean_key(PROJECT, sha), run.to_json()?)
+        Task::CleanFeature {
+            set: s,
+            commit_id,
+            time,
+        } => {
+            let run = clean_run(
+                scenario,
+                set,
+                *time,
+                commit_id,
+                BRANCH_FEATURE,
+                false,
+                |b| scenario.feature_clean_value(b, *s),
+            );
+            (set.clean_key(PROJECT, commit_id), run.to_json()?)
         }
         Task::Dirty {
             set: s,
             k,
-            sha,
+            commit_id,
             time,
             observation,
         } => {
-            let run = clean_run(scenario, set, *time, sha, BRANCH_FEATURE, true, |b| {
+            let run = clean_run(scenario, set, *time, commit_id, BRANCH_FEATURE, true, |b| {
                 scenario.dirty_value(b, *s, *k)
             });
-            (set.dirty_key(PROJECT, sha, *observation), run.to_json()?)
+            (
+                set.dirty_key(PROJECT, commit_id, *observation),
+                run.to_json()?,
+            )
         }
-        Task::Bless { sha, issued, .. } => {
+        Task::Bless {
+            commit_id, issued, ..
+        } => {
             let prefix = BenchmarkIdPrefix::new(scenario::blessable_family_prefix())
                 .map_err(|error| fail(error.to_string()))?;
             let record = BlessingRecord::new(
-                sha.clone(),
+                commit_id.clone(),
                 Timestamp::from_second(*issued)
                     .map_err(|error| fail(format!("invalid blessing time: {error}")))?,
                 vec![prefix],
                 TOOL_VERSION.to_owned(),
             );
-            (set.bless_key(PROJECT, sha, *issued), record.to_json()?)
+            (
+                set.bless_key(PROJECT, commit_id, *issued),
+                record.to_json()?,
+            )
         }
     };
 
@@ -289,7 +307,7 @@ fn clean_run(
     scenario: Scenario,
     set: &DiscriminantSet,
     time: Timestamp,
-    sha: &str,
+    commit_id: &str,
     branch: &str,
     dirty: bool,
     value: impl Fn(usize) -> f64,
@@ -304,19 +322,19 @@ fn clean_run(
             )
         })
         .collect();
-    Run::new(run_context(set, time, sha, branch, dirty), results)
+    Run::new(run_context(set, time, commit_id, branch, dirty), results)
 }
 
 /// Builds the run context shared by every seeded run.
 fn run_context(
     set: &DiscriminantSet,
     time: Timestamp,
-    sha: &str,
+    commit_id: &str,
     branch: &str,
     dirty: bool,
 ) -> RunContext {
     let git = GitInfo {
-        commit: Some(sha.to_owned()),
+        commit: Some(commit_id.to_owned()),
         branch: Some(branch.to_owned()),
         dirty,
     };
@@ -366,7 +384,7 @@ mod tests {
         SeededRepo {
             main: (0..commits)
                 .map(|i| Commit {
-                    sha: format!("main{i:02}"),
+                    commit_id: format!("main{i:02}"),
                     time: ts(1_000_i64.saturating_add(i64_from(i))),
                 })
                 .collect(),
@@ -420,7 +438,7 @@ mod tests {
             set_index(&Task::CleanMain {
                 set: 7,
                 index: 0,
-                sha: "a".to_owned(),
+                commit_id: "a".to_owned(),
                 time: ts(1),
             }),
             7
@@ -428,7 +446,7 @@ mod tests {
         assert_eq!(
             set_index(&Task::CleanFeature {
                 set: 4,
-                sha: "b".to_owned(),
+                commit_id: "b".to_owned(),
                 time: ts(2),
             }),
             4
@@ -437,7 +455,7 @@ mod tests {
             set_index(&Task::Dirty {
                 set: 5,
                 k: 0,
-                sha: "c".to_owned(),
+                commit_id: "c".to_owned(),
                 time: ts(3),
                 observation: 10,
             }),
@@ -446,7 +464,7 @@ mod tests {
         assert_eq!(
             set_index(&Task::Bless {
                 set: 9,
-                sha: "d".to_owned(),
+                commit_id: "d".to_owned(),
                 issued: 11,
             }),
             9

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -27,7 +27,7 @@ against fakes under `block_on` (Miri-safe, no runtime). The ports:
   `put_overwrite`/`delete` are the escape hatches and arm the cache-invalidation marker.
 * `config_writer::ConfigWriter` — `install`'s config-file writer (`create_new`).
 * `git_history::GitHistory` — read-only commit topology (`resolve`, `default_branch`,
-  `merge_base`, `first_parent`, `committer_time`, `is_dirty`). `first_parent` pairs each SHA
+  `merge_base`, `first_parent`, `committer_time`, `is_dirty`). `first_parent` pairs each commit ID
   with its committer date and subject; `FakeGitHistory` models a canned graph.
 
 **When you add an IO edge, follow the same pattern.** Never call `SystemTime::now()` in

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -146,7 +146,7 @@ A clean run maps to the single deterministic key `…/<commit>/clean.json`, so c
 detection rides on the write-once storage contract: a second clean run of the same commit
 fails atomically with nothing written, with no separate exists-check round-trip. A dirty
 run is keyed by its observation second so successive snapshots coexist. Branch is not a
-path component — a commit SHA is globally unique, so the same commit on two branches is
+path component — a commit ID is globally unique, so the same commit on two branches is
 one point, and branch selection happens at query time. Each path segment is sanitized so a
 stray separator in a value cannot split the key into the wrong number of segments.
 

--- a/packages/cargo-bench-history/src/analyze/bless.rs
+++ b/packages/cargo-bench-history/src/analyze/bless.rs
@@ -22,6 +22,10 @@ use std::path::Path;
 use jiff::Timestamp;
 use tick::Clock;
 
+use super::{
+    AutoFacets, Selection, StorageKey, detect_auto_facets, facet_filtered_candidates,
+    resolve_base_ref, resolve_facets, resolve_now,
+};
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
 use crate::model::BlessingRecord;
@@ -32,12 +36,6 @@ use crate::wiring::{
     resolve_config_path, resolve_local_path, resolve_project_id, resolve_repo, storage_env,
 };
 use crate::{BlessOptions, RunError, RunOutcome, UnblessOptions, finish_with_flush};
-
-use super::StorageKey;
-use super::{
-    AutoFacets, Selection, detect_auto_facets, facet_filtered_candidates, resolve_base_ref,
-    resolve_facets, resolve_now,
-};
 
 /// The real `bless`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
@@ -163,7 +161,7 @@ where
 
     let context = options.context.as_deref().unwrap_or("HEAD");
     let head = resolve_commit(git, context).await?;
-    let short = short_sha(&head);
+    let short = short_commit_id(&head);
 
     // Blessing is base-branch-only: a feature-branch blessing would silently
     // vanish (or duplicate) once the branch is squash-merged, so it is refused
@@ -185,7 +183,7 @@ where
                 "the context commit {short} is not on the base branch {}; blessings are only \
                  allowed on the base branch, since a feature-branch blessing would not survive \
                  a squash merge",
-                short_sha(&base)
+                short_commit_id(&base)
             ),
         });
     }
@@ -269,7 +267,7 @@ where
 {
     let context = options.context.as_deref().unwrap_or("HEAD");
     let head = resolve_commit(git, context).await?;
-    let short = short_sha(&head);
+    let short = short_commit_id(&head);
 
     let selection = Selection::from_unbless(options);
     let facets = resolve_facets(&selection, Some(auto))?;
@@ -298,8 +296,8 @@ where
     Ok(RunOutcome::Completed { message })
 }
 
-/// Resolves a context ref (for example `HEAD` or a commit SHA) to a full commit
-/// SHA, mapping an unresolvable ref (not a repository, or an unknown ref) to a
+/// Resolves a context ref (for example `HEAD` or a commit ID) to a full commit
+/// commit ID, mapping an unresolvable ref (not a repository, or an unknown ref) to a
 /// clear blessing error.
 async fn resolve_commit<G: GitHistory>(git: &G, reference: &str) -> Result<String, RunError> {
     git.resolve(reference)
@@ -313,9 +311,9 @@ async fn resolve_commit<G: GitHistory>(git: &G, reference: &str) -> Result<Strin
         })
 }
 
-/// The first twelve characters of a SHA (all of it when shorter), for messages.
-fn short_sha(sha: &str) -> &str {
-    sha.get(..12).unwrap_or(sha)
+/// The first twelve characters of a commit ID (all of it when shorter), for messages.
+fn short_commit_id(commit_id: &str) -> &str {
+    commit_id.get(..12).unwrap_or(commit_id)
 }
 
 #[cfg(test)]
@@ -323,16 +321,16 @@ fn short_sha(sha: &str) -> &str {
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
     use futures::executor::block_on;
-
-    use crate::git_history::FakeGitHistory;
-    use crate::model::{BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, Metric, MetricKind, Run};
-    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
-    use crate::report::RecordingReporter;
-    use crate::storage::MemoryStorage;
-
     use nonempty::nonempty;
 
     use super::*;
+    use crate::git_history::FakeGitHistory;
+    use crate::model::{
+        BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, EnvironmentInfo, GitInfo, Metric,
+        MetricKind, Run, RunContext, ToolchainInfo,
+    };
+    use crate::report::RecordingReporter;
+    use crate::storage::MemoryStorage;
 
     fn config() -> Config {
         Config::default()
@@ -488,7 +486,7 @@ mod tests {
         assert!(matches!(error, RunError::Bless { .. }), "{error:?}");
         assert!(error.to_string().contains("base branch"), "{error}");
         // The message names both the current commit and the base ref via
-        // `short_sha`, so both must appear verbatim.
+        // `short_commit_id`, so both must appear verbatim.
         assert!(error.to_string().contains("f1"), "names HEAD: {error}");
         assert!(error.to_string().contains("c2"), "names base: {error}");
         assert!(stored_blessings(&storage).is_empty(), "nothing written");

--- a/packages/cargo-bench-history/src/analyze/examine.rs
+++ b/packages/cargo-bench-history/src/analyze/examine.rs
@@ -21,10 +21,19 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use anyspawn::Spawner;
+use jiff::Timestamp;
 use serde::Serialize;
+use tick::Clock;
 
+use super::{
+    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, detect_auto_facets,
+    dirty_base_exception_warning, empty_history_hint, format_value, resolve_now, select_dataset,
+};
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
+use crate::model::{BenchmarkIdPrefix, DiscriminantSet, MetricKind};
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, StorageFacade, resolve_storage};
 use crate::text::count_noun;
@@ -33,18 +42,6 @@ use crate::wiring::{
     resolve_repo, storage_env,
 };
 use crate::{ExamineOptions, RunError, RunOutcome};
-
-use anyspawn::Spawner;
-use jiff::Timestamp;
-use tick::Clock;
-
-use super::{
-    AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
-    format_value, resolve_now, select_dataset,
-};
-use super::{ReportFormat, Series, SeriesFilter};
-use crate::model::{BenchmarkIdPrefix, DiscriminantSet, MetricKind};
-use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 
 /// How many leading characters of a commit title the text and Markdown tables
 /// keep. The truncation is a readability convenience of those renderings; the JSON
@@ -218,7 +215,7 @@ fn parse_metric(name: &str) -> Result<MetricKind, RunError> {
 /// One recorded observation of the examined series.
 #[derive(Clone, Debug)]
 struct DataPoint {
-    /// The commit the run was measured against (full SHA, or a label in tests).
+    /// The commit the run was measured against (full commit ID, or a label in tests).
     commit: String,
     /// The short commit id shown in the text and Markdown tables.
     short_commit: String,
@@ -274,7 +271,7 @@ fn build_pivot(
                     let commit = point.commit.as_deref().unwrap_or("unknown");
                     let title = commit_subjects.get(commit).cloned().unwrap_or_default();
                     DataPoint {
-                        short_commit: short_sha(commit).to_owned(),
+                        short_commit: short_commit_id(commit).to_owned(),
                         commit: commit.to_owned(),
                         value: point.value,
                         dirty: point.dirty,
@@ -319,10 +316,10 @@ fn truncate_title(title: &str) -> String {
     title.chars().take(TITLE_LIMIT).collect()
 }
 
-/// The short commit id: the first 12 characters of the SHA (mirrors the
+/// The short commit id: the first 12 characters of the commit ID (mirrors the
 /// abbreviation `list`, `bless`, and `backfill` use).
-fn short_sha(sha: &str) -> &str {
-    sha.get(..12).unwrap_or(sha)
+fn short_commit_id(commit_id: &str) -> &str {
+    commit_id.get(..12).unwrap_or(commit_id)
 }
 
 /// Renders the pivot in the requested format, appending the diagnostic hint and
@@ -501,15 +498,16 @@ mod tests {
     use jiff::Timestamp;
     use nonempty::nonempty;
 
+    use super::*;
     use crate::config::Config;
     use crate::git_history::FakeGitHistory;
-    use crate::model::{BenchmarkId, BenchmarkResult, Metric, MetricKind, Run};
-    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
+    use crate::model::{
+        BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, MetricKind, Run,
+        RunContext, ToolchainInfo,
+    };
     use crate::output::MemoryOutputWriter;
     use crate::report::RecordingReporter;
     use crate::storage::{MemoryStorage, Storage};
-
-    use super::*;
 
     fn config() -> Config {
         Config::default()

--- a/packages/cargo-bench-history/src/analyze/list.rs
+++ b/packages/cargo-bench-history/src/analyze/list.rs
@@ -15,10 +15,20 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use anyspawn::Spawner;
+use jiff::Timestamp;
 use serde::Serialize;
+use tick::Clock;
 
+use super::{
+    AutoFacets, ReportFormat, RunIndex, Selection, Series, SeriesFilter, apply_blessings,
+    detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
+    facet_filtered_candidates, resolve_facets, resolve_now, select_dataset,
+};
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
+use crate::model::{BlessingRecord, DiscriminantSet};
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, StorageFacade, resolve_storage};
 use crate::text::count_noun;
@@ -27,19 +37,6 @@ use crate::wiring::{
     resolve_repo, storage_env,
 };
 use crate::{ListOptions, ListSubject, RunError, RunOutcome};
-
-use anyspawn::Spawner;
-use jiff::Timestamp;
-use tick::Clock;
-
-use super::{
-    AutoFacets, Selection, detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
-    facet_filtered_candidates, resolve_facets, resolve_now, select_dataset,
-};
-use super::{ReportFormat, RunIndex, Series, SeriesFilter, apply_blessings};
-use crate::model::BlessingRecord;
-use crate::model::DiscriminantSet;
-use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 
 /// The real `list`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
@@ -204,7 +201,7 @@ where
 /// One commit's contribution to a discriminant set, in first-parent order.
 #[derive(Clone, Debug)]
 struct CommitEntry {
-    /// The commit the runs were measured against (full SHA, or a label in tests).
+    /// The commit the runs were measured against (full commit ID, or a label in tests).
     commit: String,
     /// Stored runs on this commit in the set.
     runs: usize,
@@ -619,13 +616,13 @@ where
         entries.push(BlessingEntry {
             set: parsed.set,
             benchmark: None,
-            commit: short_sha(&record.commit).to_owned(),
+            commit: short_commit_id(&record.commit).to_owned(),
             commit_time: head_commit_time,
             issued_at: Some(record.issued_at),
             prefixes: record.prefixes.into_iter().map(String::from).collect(),
         });
     }
-    Ok((short_sha(&head).to_owned(), entries))
+    Ok((short_commit_id(&head).to_owned(), entries))
 }
 
 /// Collects the most recent blessing of every benchmark across the analysis window
@@ -672,7 +669,7 @@ where
         entries.push(BlessingEntry {
             set: one.set.clone(),
             benchmark: Some(benchmark),
-            commit: short_sha(&blessing.commit).to_owned(),
+            commit: short_commit_id(&blessing.commit).to_owned(),
             commit_time: blessing.commit_time,
             issued_at: None,
             prefixes: Vec::new(),
@@ -681,9 +678,9 @@ where
     Ok((String::new(), entries))
 }
 
-/// The first twelve characters of a SHA (all of it when shorter), for display.
-fn short_sha(sha: &str) -> &str {
-    sha.get(..12).unwrap_or(sha)
+/// The first twelve characters of a commit ID (all of it when shorter), for display.
+fn short_commit_id(commit_id: &str) -> &str {
+    commit_id.get(..12).unwrap_or(commit_id)
 }
 
 /// Renders a blessing listing in the requested format.
@@ -874,22 +871,22 @@ fn render_blessings_json(
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
-    use futures::executor::block_on;
-    use jiff::Timestamp;
-
-    use crate::config::Config;
-    use crate::git_history::FakeGitHistory;
-    use crate::model::{BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, Metric, MetricKind, Run};
-    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
-    use crate::report::RecordingReporter;
-    use crate::storage::{MemoryStorage, Storage};
-
-    use crate::output::MemoryOutputWriter;
     use std::path::PathBuf;
 
+    use futures::executor::block_on;
+    use jiff::Timestamp;
     use nonempty::nonempty;
 
     use super::*;
+    use crate::config::Config;
+    use crate::git_history::FakeGitHistory;
+    use crate::model::{
+        BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, EnvironmentInfo, GitInfo, Metric,
+        MetricKind, Run, RunContext, ToolchainInfo,
+    };
+    use crate::output::MemoryOutputWriter;
+    use crate::report::RecordingReporter;
+    use crate::storage::{MemoryStorage, Storage};
 
     fn config() -> Config {
         Config::default()

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -17,13 +17,6 @@ pub(crate) mod examine;
 pub(crate) mod list;
 pub(crate) mod prune;
 
-pub(crate) use cargo_bench_history_core::analyze::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DiscriminantSetQuery,
-    FacetFilter, ReportFormat, ReportInput, RunPoints, Series, SeriesBuilder, SeriesFilter,
-    SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes, find_changes_spawned,
-    format_value, parse_key, render, select_commits, worker_count,
-};
-
 use std::collections::{BTreeMap, HashMap};
 use std::io::IsTerminal;
 use std::path::Path;
@@ -31,6 +24,12 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyspawn::Spawner;
+pub(crate) use cargo_bench_history_core::analyze::{
+    AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DiscriminantSetQuery,
+    FacetFilter, ReportFormat, ReportInput, RunPoints, Series, SeriesBuilder, SeriesFilter,
+    SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes, find_changes_spawned,
+    format_value, parse_key, render, select_commits, worker_count,
+};
 use futures::{StreamExt as _, TryStreamExt as _};
 use jiff::civil::Date;
 use jiff::tz::TimeZone;
@@ -41,8 +40,9 @@ use tick::Clock;
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
 use crate::machine::resolve_machine_key;
-use crate::model::BlessingRecord;
-use crate::model::{BenchmarkIdPrefix, DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment};
+use crate::model::{
+    BenchmarkIdPrefix, BlessingRecord, DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment,
+};
 use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 use crate::probe::{EnvironmentProbe, SystemProbe};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
@@ -446,7 +446,7 @@ pub(crate) struct AutoFacets {
 /// summaries and the `list runs` breakdown need.
 #[derive(Clone, Debug)]
 pub(crate) struct CommitCounts {
-    /// The commit the runs were measured against (full SHA, or a label in tests).
+    /// The commit the runs were measured against (full commit ID, or a label in tests).
     pub(crate) commit: String,
     /// Clean (committed-tree) runs recorded on the commit.
     pub(crate) clean: usize,
@@ -551,7 +551,7 @@ impl RunIndex {
     /// admitted. The report header uses it to state the span of analyzed history.
     // The oldest/newest tie-break is unobservable, so its comparison mutants are
     // equivalent: a first-parent topological position denotes exactly one commit, so
-    // every set records the same SHA at a given position and `<` vs `<=` (or `>` vs
+    // every set records the same commit ID at a given position and `<` vs `<=` (or `>` vs
     // `>=`) only ever chooses between identical strings.
     #[cfg_attr(test, mutants::skip)]
     pub(crate) fn commit_span(&self) -> Option<(&str, &str)> {
@@ -602,7 +602,7 @@ struct SelectedDataSet {
     /// each data point with what its commit changed. A commit absent here has an
     /// empty subject; only `examine` reads this.
     commit_subjects: HashMap<String, String>,
-    /// The full SHA of the analyzed tip commit (the resolved `--context`/HEAD),
+    /// The full commit ID of the analyzed tip commit (the resolved `--context`/HEAD),
     /// carried into the report so it names the exact commit the findings describe.
     tip_commit: String,
     /// Whether the working tree carried uncommitted changes when the analysis ran;
@@ -1381,12 +1381,12 @@ enum DirtyTipPolicy {
 
 /// The git topology a selection resolves to: the target ref it was resolved
 /// against, the first-parent position of each selected commit, and the per-commit
-/// dirty-admission flags. All maps use owned commit SHAs so the borrowed
+/// dirty-admission flags. All maps use owned commit IDs so the borrowed
 /// `selected` set can drop before the caller's load loop.
 struct ResolvedHistory {
     /// The target ref the timeline was resolved against (for diagnostics).
     target_ref: String,
-    /// The full SHA the target ref resolved to — the analyzed tip commit, carried
+    /// The full commit ID the target ref resolved to — the analyzed tip commit, carried
     /// into the report so it names the exact commit the findings describe.
     tip_commit: String,
     /// Whether the working tree carried uncommitted changes when the topology was
@@ -1437,7 +1437,7 @@ where
     // history, not from stored timestamps. An unresolvable target ref means there
     // is no repository here (or the branch does not exist), which is an error.
     let target_ref = selection.context.unwrap_or("HEAD");
-    let Some(target_sha) = git.resolve(target_ref).await.map_err(RunError::Io)? else {
+    let Some(target_commit_id) = git.resolve(target_ref).await.map_err(RunError::Io)? else {
         return Err(RunError::Analyze {
             message: format!(
                 "this command requires a git repository: could not resolve {target_ref:?}. \
@@ -1446,31 +1446,34 @@ where
         });
     };
 
-    let base_sha = resolve_base_ref(git, config, selection.base).await?;
+    let base_commit_id = resolve_base_ref(git, config, selection.base).await?;
     let first_parent_started = Instant::now();
-    let first_parent = git.first_parent(&target_sha).await.map_err(RunError::Io)?;
+    let first_parent = git
+        .first_parent(&target_commit_id)
+        .await
+        .map_err(RunError::Io)?;
     reporter.timing(
         "git.first_parent ancestry walk (target's first-parent line)",
         first_parent_started.elapsed(),
     );
-    // Split the first-parent ancestry into the SHA timeline (for commit selection
-    // and the merge-base lookup) and a SHA -> committer-time map (for the window).
+    // Split the first-parent ancestry into the commit ID timeline (for commit selection
+    // and the merge-base lookup) and a commit ID -> committer-time map (for the window).
     let commit_count = first_parent.len();
     let mut ancestry: Vec<String> = Vec::with_capacity(commit_count);
     let mut commit_times: HashMap<String, Timestamp> = HashMap::new();
     let mut commit_subjects: HashMap<String, String> = HashMap::new();
     for commit in first_parent {
         if let Some(time) = commit.committer_time {
-            commit_times.insert(commit.sha.clone(), time);
+            commit_times.insert(commit.commit_id.clone(), time);
         }
         if !commit.subject.is_empty() {
-            commit_subjects.insert(commit.sha.clone(), commit.subject);
+            commit_subjects.insert(commit.commit_id.clone(), commit.subject);
         }
-        ancestry.push(commit.sha);
+        ancestry.push(commit.commit_id);
     }
-    let merge_base = match &base_sha {
+    let merge_base = match &base_commit_id {
         Some(base) => git
-            .merge_base(&target_sha, base)
+            .merge_base(&target_commit_id, base)
             .await
             .map_err(RunError::Io)?,
         None => None,
@@ -1478,12 +1481,12 @@ where
 
     reporter.if_enabled(|notes| {
         notes.note(&format!(
-            "target ref {target_ref} resolves to {target_sha}; {} on its first-parent line",
+            "target ref {target_ref} resolves to {target_commit_id}; {} on its first-parent line",
             count_noun(commit_count, "commit")
         ));
         notes.note(&format!(
             "base ref resolves to {}; merge-base with target is {}",
-            base_sha.as_deref().unwrap_or("<none>"),
+            base_commit_id.as_deref().unwrap_or("<none>"),
             merge_base.as_deref().unwrap_or("<none>")
         ));
     });
@@ -1539,11 +1542,13 @@ where
         .and_then(|base| order.get(base).copied());
     // The target's tip is its own merge-base (or no base is known) exactly when
     // this is an official base-branch view rather than a feature branch.
-    let tip_is_merge_base = merge_base.as_deref().is_none_or(|base| base == target_sha);
+    let tip_is_merge_base = merge_base
+        .as_deref()
+        .is_none_or(|base| base == target_commit_id);
 
     Ok(ResolvedHistory {
         target_ref: target_ref.to_owned(),
-        tip_commit: target_sha,
+        tip_commit: target_commit_id,
         tip_dirty: working_tree_dirty,
         order,
         commit_times,
@@ -1564,7 +1569,7 @@ fn dirty_base_exception_warning() -> String {
 }
 
 /// Resolves the base ref the target's history is split against, returning its
-/// commit SHA or `None` when no base can be determined.
+/// commit ID or `None` when no base can be determined.
 ///
 /// Precedence: an explicit `--base` (an error if it does not resolve), then the
 /// configured `project.default_branch`, then the repository's detected default
@@ -1597,7 +1602,7 @@ async fn resolve_base_ref<G: GitHistory>(
     Ok(None)
 }
 
-/// Resolves the *display name* of the base ref (without resolving it to a SHA),
+/// Resolves the *display name* of the base ref (without resolving it to a commit ID),
 /// for diagnostics such as the `prune --prune-base` guard.
 ///
 /// Mirrors [`resolve_base_ref`]'s precedence: an explicit `--base`, then the
@@ -1840,22 +1845,22 @@ fn instant_before(span: Span, flag: &str, now: Timestamp) -> Result<Timestamp, R
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
-    use futures::executor::block_on;
-    use jiff::Timestamp;
-
-    use crate::config::{Config, parse_config};
-    use crate::git_history::FakeGitHistory;
-    use crate::model::{BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, Metric, MetricKind};
-    use crate::model::{EnvironmentInfo, GitInfo, Run, RunContext, ToolchainInfo};
-    use crate::output::MemoryOutputWriter;
-    use crate::report::RecordingReporter;
-    use crate::storage::{MemoryStorage, Storage};
-
     use std::path::{Path, PathBuf};
 
+    use futures::executor::block_on;
+    use jiff::Timestamp;
     use nonempty::nonempty;
 
     use super::*;
+    use crate::config::{Config, parse_config};
+    use crate::git_history::FakeGitHistory;
+    use crate::model::{
+        BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, EnvironmentInfo, GitInfo, Metric,
+        MetricKind, Run, RunContext, ToolchainInfo,
+    };
+    use crate::output::MemoryOutputWriter;
+    use crate::report::RecordingReporter;
+    use crate::storage::{MemoryStorage, Storage};
 
     fn ts(seconds: i64) -> Timestamp {
         Timestamp::from_second(seconds).unwrap()

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -25,8 +25,15 @@ use jiff::Timestamp;
 use serde::Serialize;
 use tick::Clock;
 
+use super::{
+    AutoFacets, DirtyTipPolicy, ReportFormat, ResolvedHistory, Selection, WindowEdge,
+    detect_auto_facets, facet_filtered_candidates, parse_since, parse_until, resolve_base_name,
+    resolve_facets, resolve_history, resolve_now, window_excludes,
+};
 use crate::config::{Config, load_config};
 use crate::git_history::{GitHistory, SystemGitHistory};
+use crate::model::DiscriminantSet;
+use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, StorageFacade, resolve_storage};
 use crate::text::count_noun;
@@ -35,15 +42,6 @@ use crate::wiring::{
     resolve_repo, storage_env,
 };
 use crate::{PruneOptions, RunError, RunOutcome, finish_with_flush};
-
-use super::ReportFormat;
-use super::{
-    AutoFacets, DirtyTipPolicy, ResolvedHistory, Selection, WindowEdge, detect_auto_facets,
-    facet_filtered_candidates, parse_since, parse_until, resolve_base_name, resolve_facets,
-    resolve_history, resolve_now, window_excludes,
-};
-use crate::model::DiscriminantSet;
-use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
 
 /// Which objects a prune pass deletes.
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -388,7 +386,7 @@ fn commit_is_eligible(
 }
 
 /// Whether a commit matches the `<commit>` selection (case-insensitive prefix
-/// match, so a short SHA selects the full one). An empty selection matches every
+/// match, so a short commit ID selects the full one). An empty selection matches every
 /// commit.
 fn commit_matches(commit: &str, filters: &[String]) -> bool {
     if filters.is_empty() {
@@ -434,7 +432,7 @@ struct RemovalItem {
 /// One commit's objects to remove, in first-parent order.
 #[derive(Clone)]
 struct CommitRemoval {
-    /// The commit the runs were measured against (full SHA, or a label in tests).
+    /// The commit the runs were measured against (full commit ID, or a label in tests).
     commit: String,
     /// How many runs (clean or dirty) are removed on this commit.
     runs: usize,
@@ -697,22 +695,22 @@ fn render_plan_json(plan: &Plan, dry_run: bool) -> String {
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
-    use futures::executor::block_on;
-    use jiff::Timestamp;
-
-    use crate::config::Config;
-    use crate::git_history::FakeGitHistory;
-    use crate::model::{BenchmarkId, BenchmarkResult, Metric, MetricKind, Run};
-    use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo};
-    use crate::report::RecordingReporter;
-    use crate::storage::{MemoryStorage, Storage};
-
-    use crate::output::MemoryOutputWriter;
     use std::path::PathBuf;
 
+    use futures::executor::block_on;
+    use jiff::Timestamp;
     use nonempty::nonempty;
 
     use super::*;
+    use crate::config::Config;
+    use crate::git_history::FakeGitHistory;
+    use crate::model::{
+        BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, MetricKind, Run,
+        RunContext, ToolchainInfo,
+    };
+    use crate::output::MemoryOutputWriter;
+    use crate::report::RecordingReporter;
+    use crate::storage::{MemoryStorage, Storage};
 
     fn config() -> Config {
         Config::default()

--- a/packages/cargo-bench-history/src/bench/callgrind.rs
+++ b/packages/cargo-bench-history/src/bench/callgrind.rs
@@ -13,8 +13,9 @@ use std::fmt;
 use nonempty::NonEmpty;
 use serde::Deserialize;
 
-use crate::model::{BenchmarkId, BenchmarkResult, Metric, MetricKind};
-use crate::model::{L1_HITS_EVENT, LL_HITS_EVENT, RAM_HITS_EVENT};
+use crate::model::{
+    BenchmarkId, BenchmarkResult, L1_HITS_EVENT, LL_HITS_EVENT, Metric, MetricKind, RAM_HITS_EVENT,
+};
 
 /// The Gungraun summary schema version this parser understands.
 const SUPPORTED_VERSION: &str = "6";

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -659,7 +659,7 @@ impl ExamineCommand {
         .required(true)
 ))]
 struct PruneCommand {
-    /// Restrict removal to these commits (a full or short SHA, prefix-matched);
+    /// Restrict removal to these commits (a full or short commit ID, prefix-matched);
     /// repeatable (default: every one of the selected commits).
     #[arg(value_name = "COMMIT")]
     commit: Vec<String>,
@@ -760,12 +760,12 @@ impl PruneCommand {
 /// Replay `collect` across a range of historical commits.
 #[derive(Args, Debug)]
 struct BackfillCommand {
-    /// Oldest commit of the range to backfill, inclusive; a SHA, tag, or ref such
+    /// Oldest commit of the range to backfill, inclusive; a commit ID, tag, or ref such
     /// as `HEAD~20`.
     #[arg(value_name = "FROM")]
     from: String,
 
-    /// Newest commit of the range to backfill, inclusive; a SHA, tag, or ref such
+    /// Newest commit of the range to backfill, inclusive; a commit ID, tag, or ref such
     /// as `HEAD`. Must be reachable from `<FROM>` along first-parent history.
     #[arg(value_name = "TO")]
     to: String,

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -358,7 +358,7 @@ pub struct PruneOptions {
     /// Base ref the context branched off from; defaults to the detected (or
     /// configured) default branch.
     pub base: Option<String>,
-    /// Restrict removal to specific commits (case-insensitive SHA-prefix match);
+    /// Restrict removal to specific commits (case-insensitive commit-ID prefix match);
     /// repeatable. Empty means every one of the selected commits.
     pub commit: Vec<String>,
     /// Only prune commits made on or after this cutoff, if set.

--- a/packages/cargo-bench-history/src/commands/backfill.rs
+++ b/packages/cargo-bench-history/src/commands/backfill.rs
@@ -32,6 +32,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use tick::Clock;
 
+use super::collect::{CollectDeps, CollectSummary, default_bench_command, run_engines};
 use crate::bench_output::FsBenchOutputSource;
 use crate::config::load_config;
 use crate::git_history::{GitHistory, SystemGitHistory};
@@ -45,12 +46,10 @@ use crate::wiring::{
 };
 use crate::{BackfillOptions, CollectOptions, RunError, RunOutcome, finish_with_flush};
 
-use super::collect::{CollectDeps, CollectSummary, default_bench_command, run_engines};
-
 /// Read access to a repository's commit topology plus the worktree lifecycle a
 /// backfill needs to check out each commit in isolation.
 trait BackfillGit {
-    /// Resolves a ref (branch, tag, `HEAD`, or SHA) to its full commit SHA, or
+    /// Resolves a ref (branch, tag, `HEAD`, or commit ID) to its full commit ID, or
     /// `Ok(None)` when it does not resolve.
     fn resolve(&self, reference: &str) -> impl Future<Output = io::Result<Option<String>>>;
 
@@ -71,7 +70,7 @@ trait BackfillGit {
 
 /// Runs and stores the configured engines for one already-checked-out commit.
 trait CommitRunner {
-    /// The set of commits (by full SHA) that already have a stored clean result
+    /// The set of commits (by full commit ID) that already have a stored clean result
     /// anywhere under this project's partitions. A commit in this set has already
     /// been backfilled, so the default skip-existing mode skips it without
     /// benchmarking. Probed once per backfill.
@@ -216,7 +215,7 @@ async fn plan_commits<G: BackfillGit>(
     Ok(ancestry.split_off(start))
 }
 
-/// Resolves `reference` to a commit SHA, mapping an absent ref to a clear error.
+/// Resolves `reference` to a commit ID, mapping an absent ref to a clear error.
 async fn resolve_required<G: BackfillGit>(
     git: &G,
     reference: &str,
@@ -329,9 +328,9 @@ impl BackfillReport {
     }
 }
 
-/// Abbreviates a commit SHA for display, falling back to the full value.
-fn short(sha: &str) -> &str {
-    sha.get(..12).unwrap_or(sha)
+/// Abbreviates a commit ID for display, falling back to the full value.
+fn short(commit_id: &str) -> &str {
+    commit_id.get(..12).unwrap_or(commit_id)
 }
 
 /// A unique scratch path for the backfill worktree, under the system temp dir.
@@ -373,7 +372,7 @@ fn map_collect_result(result: Result<CollectSummary, RunError>) -> Result<Commit
     }
 }
 
-/// The commit (full SHA) recorded by a stored clean object, or `None` when the key
+/// The commit (full commit ID) recorded by a stored clean object, or `None` when the key
 /// is not a clean object.
 ///
 /// A clean key is `…/<commit>/clean.json`, so the commit is the path segment
@@ -422,9 +421,9 @@ impl BackfillGit for SystemBackfillGit {
 
     #[cfg_attr(test, mutants::skip)] // Delegates to the git-shelling history port; no pure logic to assert.
     async fn first_parent(&self, reference: &str) -> io::Result<Vec<String>> {
-        // Backfill needs only the commit shas, not their committer timestamps.
+        // Backfill needs only the commit IDs, not their committer timestamps.
         let commits = self.history.first_parent(reference).await?;
-        Ok(commits.into_iter().map(|commit| commit.sha).collect())
+        Ok(commits.into_iter().map(|commit| commit.commit_id).collect())
     }
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; environment IO with no pure logic to assert.
@@ -572,11 +571,10 @@ mod tests {
 
     use futures::executor::block_on;
 
+    use super::*;
     use crate::StorageError;
     use crate::git_history::FakeGitHistory;
     use crate::storage::MemoryStorage;
-
-    use super::*;
 
     /// A canned per-commit result the fake [`CommitRunner`] returns.
     #[derive(Clone)]
@@ -616,7 +614,7 @@ mod tests {
             let future = self.history.first_parent(reference);
             async move {
                 let commits = future.await?;
-                Ok(commits.into_iter().map(|commit| commit.sha).collect())
+                Ok(commits.into_iter().map(|commit| commit.commit_id).collect())
             }
         }
 

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -19,9 +19,10 @@ use crate::bench_output::{BenchOutputSource, FsBenchOutputSource, Harvest};
 use crate::config::{CloudStorageConfig, Config, load_config};
 use crate::host::RustcInfo;
 use crate::machine::{HardwareProfile, resolve_machine_key};
-use crate::model::{BenchmarkResult, Run};
-use crate::model::{DiscriminantSet, Engine};
-use crate::model::{EnvironmentInfo, GitInfo, RunContext, ToolchainInfo, detect_environment};
+use crate::model::{
+    BenchmarkResult, DiscriminantSet, Engine, EnvironmentInfo, GitInfo, Run, RunContext,
+    ToolchainInfo, detect_environment,
+};
 use crate::probe::{EnvironmentProbe, SystemProbe};
 use crate::process::{BenchRunner, TokioBenchRunner};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
@@ -498,7 +499,7 @@ where
         .is_hardware_dependent()
         .then(|| resolve_machine_key(options.machine_key.as_deref(), &shared.hardware));
     let key = DiscriminantSet::new(engine, target_triple, machine_key.as_deref());
-    // History is organized by commit, so the full commit SHA names the directory
+    // History is organized by commit, so the full commit ID names the directory
     // (`analyze` resolves which commits to read from git topology). A clean run is
     // keyed solely by its commit and so is deterministic; a dirty snapshot adds its
     // observation time so concurrent snapshots of the same commit coexist.
@@ -771,8 +772,7 @@ mod tests {
     use crate::bench_output::{Harvest, RawCriterionCase, RawOperationFile, RawSummary};
     use crate::config::parse_config;
     use crate::git::parse_git_info;
-    use crate::model::BenchmarkIdPrefix;
-    use crate::model::BlessingRecord;
+    use crate::model::{BenchmarkIdPrefix, BlessingRecord};
     use crate::process::EngineStatus;
     use crate::report::RecordingReporter;
     use crate::storage::MemoryStorage;

--- a/packages/cargo-bench-history/src/commands/install.rs
+++ b/packages/cargo-bench-history/src/commands/install.rs
@@ -77,11 +77,10 @@ mod tests {
 
     use futures::executor::block_on;
 
+    use super::*;
     use crate::config_writer::MemoryConfigWriter;
     use crate::report::RecordingReporter;
     use crate::wiring::default_config_path;
-
-    use super::*;
 
     /// Tests pass an empty base so `resolve_config_path` leaves the relative
     /// configuration key untouched, keeping the in-memory writer keys relative.

--- a/packages/cargo-bench-history/src/commands/mod.rs
+++ b/packages/cargo-bench-history/src/commands/mod.rs
@@ -5,11 +5,12 @@ mod backfill;
 mod collect;
 mod install;
 
+pub(crate) use backfill::execute as backfill;
+pub(crate) use collect::execute as collect;
+pub(crate) use install::execute as install;
+
 pub(crate) use crate::analyze::bless::{bless, unbless};
 pub(crate) use crate::analyze::examine::execute as examine;
 pub(crate) use crate::analyze::execute as analyze;
 pub(crate) use crate::analyze::list::execute as list;
 pub(crate) use crate::analyze::prune::execute as prune;
-pub(crate) use backfill::execute as backfill;
-pub(crate) use collect::execute as collect;
-pub(crate) use install::execute as install;

--- a/packages/cargo-bench-history/src/config.rs
+++ b/packages/cargo-bench-history/src/config.rs
@@ -2,9 +2,8 @@
 //! and where its benchmark history is stored.
 
 use std::error::Error;
-use std::fmt;
-use std::io;
 use std::path::{Path, PathBuf};
+use std::{fmt, io};
 
 use serde::Deserialize;
 

--- a/packages/cargo-bench-history/src/dispatch.rs
+++ b/packages/cargo-bench-history/src/dispatch.rs
@@ -5,9 +5,8 @@ use std::path::PathBuf;
 
 use tick::Clock;
 
-use crate::commands;
 use crate::storage::StorageOverride;
-use crate::{Command, RunError, RunOutcome};
+use crate::{Command, RunError, RunOutcome, commands};
 
 /// Test-only overrides for [`run_with_overrides`].
 ///

--- a/packages/cargo-bench-history/src/git_history.rs
+++ b/packages/cargo-bench-history/src/git_history.rs
@@ -31,8 +31,8 @@ use crate::process::capture;
 /// when `git` reported no subject; commands other than `examine` ignore it.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct FirstParentCommit {
-    /// The commit's full SHA.
-    pub(crate) sha: String,
+    /// The commit's full ID.
+    pub(crate) commit_id: String,
     /// The commit's committer timestamp (`git`'s `%cI`), or `None` when absent or
     /// unparseable.
     pub(crate) committer_time: Option<Timestamp>,
@@ -46,7 +46,7 @@ pub(crate) struct FirstParentCommit {
 /// absent value (`Ok(None)` / an empty list), reserving `Err` for an unexpected
 /// failure to invoke `git`.
 pub(crate) trait GitHistory {
-    /// Resolves a ref (branch, tag, `HEAD`, or SHA) to its full commit SHA.
+    /// Resolves a ref (branch, tag, `HEAD`, or commit ID) to its full commit ID.
     ///
     /// Returns `Ok(None)` when the ref does not resolve — an absent branch, or a
     /// path that is not a git repository at all (which is how `analyze` detects
@@ -126,7 +126,7 @@ impl SystemGitHistory {
 }
 
 impl GitHistory for SystemGitHistory {
-    #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `parse_sha`.
+    #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `parse_commit_id`.
     async fn resolve(&self, reference: &str) -> io::Result<Option<String>> {
         // `^{commit}` peels tags/refs to the commit they name; `--verify --quiet`
         // makes an unknown ref a clean non-zero exit rather than noisy output.
@@ -134,7 +134,7 @@ impl GitHistory for SystemGitHistory {
         let output = self
             .run(&["rev-parse", "--verify", "--quiet", &spec])
             .await?;
-        Ok(output.and_then(|stdout| parse_sha(&stdout)))
+        Ok(output.and_then(|stdout| parse_commit_id(&stdout)))
     }
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `branch_from_symbolic_ref`.
@@ -156,10 +156,10 @@ impl GitHistory for SystemGitHistory {
         Ok(None)
     }
 
-    #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `parse_sha`.
+    #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `parse_commit_id`.
     async fn merge_base(&self, a: &str, b: &str) -> io::Result<Option<String>> {
         let output = self.run(&["merge-base", a, b]).await?;
-        Ok(output.and_then(|stdout| parse_sha(&stdout)))
+        Ok(output.and_then(|stdout| parse_commit_id(&stdout)))
     }
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; parsing delegated to `parse_first_parent_log`.
@@ -209,9 +209,9 @@ fn porcelain_is_dirty(stdout: &str) -> bool {
     !stdout.trim().is_empty()
 }
 
-/// Extracts a single commit SHA from `git rev-parse` / `git merge-base` output:
+/// Extracts a single commit ID from `git rev-parse` / `git merge-base` output:
 /// the first non-empty trimmed line, or `None` when there is none.
-fn parse_sha(stdout: &str) -> Option<String> {
+fn parse_commit_id(stdout: &str) -> Option<String> {
     stdout
         .lines()
         .map(str::trim)
@@ -222,18 +222,18 @@ fn parse_sha(stdout: &str) -> Option<String> {
 /// Parses `git log --first-parent --reverse -z --format=%H%x00%cI%x00%s` output
 /// into [`FirstParentCommit`]s in stream order. `-z` NUL-terminates each commit's
 /// record and the three fields are NUL-delimited, so the stream is a flat run of
-/// `<sha>\0<committer-date>\0<subject>` triples with a trailing empty token from
+/// `<commit_id>\0<committer-date>\0<subject>` triples with a trailing empty token from
 /// the final terminator. A field carrying an unparseable date yields
 /// `committer_time: None` and an empty subject field yields an empty string. With
 /// `--reverse` the input is oldest-first.
 fn parse_first_parent_log(stdout: &str) -> Vec<FirstParentCommit> {
     let mut fields = stdout.split('\0');
     let mut commits = Vec::new();
-    while let Some(sha) = fields.next() {
-        let sha = sha.trim();
-        // A real commit's SHA is never empty; the only empty leading token is the
+    while let Some(commit_id) = fields.next() {
+        let commit_id = commit_id.trim();
+        // A real commit's ID is never empty; the only empty leading token is the
         // one following the final record's terminator, which ends the stream.
-        if sha.is_empty() {
+        if commit_id.is_empty() {
             break;
         }
         let committer_time = fields
@@ -241,7 +241,7 @@ fn parse_first_parent_log(stdout: &str) -> Vec<FirstParentCommit> {
             .and_then(|field| field.trim().parse::<Timestamp>().ok());
         let subject = fields.next().unwrap_or_default().to_owned();
         commits.push(FirstParentCommit {
-            sha: sha.to_owned(),
+            commit_id: commit_id.to_owned(),
             committer_time,
             subject,
         });
@@ -298,13 +298,13 @@ mod fake {
     /// topologies with the real-git integration tests, not this fake.
     #[derive(Clone, Debug, Default)]
     pub(crate) struct FakeGitHistory {
-        /// Ref name (branch/tag/`HEAD`) -> the commit SHA it points at.
+        /// Ref name (branch/tag/`HEAD`) -> the commit ID it points at.
         refs: HashMap<String, String>,
-        /// Commit SHA -> its first parent (`None` for a root commit).
+        /// Commit ID -> its first parent (`None` for a root commit).
         parents: HashMap<String, Option<String>>,
-        /// Commit SHA -> its committer timestamp, for commits seeded with one.
+        /// Commit ID -> its committer timestamp, for commits seeded with one.
         times: HashMap<String, Timestamp>,
-        /// Commit SHA -> its subject line, for commits seeded with one.
+        /// Commit ID -> its subject line, for commits seeded with one.
         subjects: HashMap<String, String>,
         /// The detected default branch, if the repository advertises one.
         default_branch: Option<String>,
@@ -325,44 +325,45 @@ mod fake {
             }
         }
 
-        /// Records a commit `sha` with the given first `parent` (`None` = root).
-        pub(crate) fn commit(&mut self, sha: &str, parent: Option<&str>) -> &mut Self {
+        /// Records a commit `commit_id` with the given first `parent` (`None` = root).
+        pub(crate) fn commit(&mut self, commit_id: &str, parent: Option<&str>) -> &mut Self {
             self.parents
-                .insert(sha.to_owned(), parent.map(ToOwned::to_owned));
+                .insert(commit_id.to_owned(), parent.map(ToOwned::to_owned));
             self
         }
 
-        /// Records a commit `sha` (first `parent`, `None` = root) carrying a
+        /// Records a commit `commit_id` (first `parent`, `None` = root) carrying a
         /// committer timestamp, so the topology window can be exercised.
         pub(crate) fn commit_at(
             &mut self,
-            sha: &str,
+            commit_id: &str,
             parent: Option<&str>,
             time: Timestamp,
         ) -> &mut Self {
-            self.commit(sha, parent);
-            self.times.insert(sha.to_owned(), time);
+            self.commit(commit_id, parent);
+            self.times.insert(commit_id.to_owned(), time);
             self
         }
 
         /// Records the subject line of a commit, so `examine`'s point labeling can
         /// be exercised. The commit itself must be recorded separately (via
         /// [`commit`](Self::commit) or [`commit_at`](Self::commit_at)).
-        pub(crate) fn subject(&mut self, sha: &str, subject: &str) -> &mut Self {
-            self.subjects.insert(sha.to_owned(), subject.to_owned());
+        pub(crate) fn subject(&mut self, commit_id: &str, subject: &str) -> &mut Self {
+            self.subjects
+                .insert(commit_id.to_owned(), subject.to_owned());
             self
         }
 
         /// Points a named ref at a commit.
-        pub(crate) fn branch(&mut self, name: &str, sha: &str) -> &mut Self {
-            self.refs.insert(name.to_owned(), sha.to_owned());
+        pub(crate) fn branch(&mut self, name: &str, commit_id: &str) -> &mut Self {
+            self.refs.insert(name.to_owned(), commit_id.to_owned());
             self
         }
 
-        /// Points `HEAD` at the commit a ref or SHA resolves to.
+        /// Points `HEAD` at the commit a ref or commit ID resolves to.
         pub(crate) fn head(&mut self, reference: &str) -> &mut Self {
-            let sha = self.resolve_sync(reference).unwrap();
-            self.refs.insert("HEAD".to_owned(), sha);
+            let commit_id = self.resolve_sync(reference).unwrap();
+            self.refs.insert("HEAD".to_owned(), commit_id);
             self
         }
 
@@ -378,10 +379,10 @@ mod fake {
             self
         }
 
-        /// Resolves a ref or raw SHA to a commit SHA, without async.
+        /// Resolves a ref or raw commit ID to a commit ID, without async.
         fn resolve_sync(&self, reference: &str) -> Option<String> {
-            if let Some(sha) = self.refs.get(reference) {
-                return Some(sha.clone());
+            if let Some(commit_id) = self.refs.get(reference) {
+                return Some(commit_id.clone());
             }
             if self.parents.contains_key(reference) {
                 return Some(reference.to_owned());
@@ -389,10 +390,10 @@ mod fake {
             None
         }
 
-        /// The first-parent chain of `sha`, newest commit first.
-        fn chain(&self, sha: &str) -> Vec<String> {
+        /// The first-parent chain of `commit_id`, newest commit first.
+        fn chain(&self, commit_id: &str) -> Vec<String> {
             let mut chain = Vec::new();
-            let mut current = Some(sha.to_owned());
+            let mut current = Some(commit_id.to_owned());
             while let Some(commit) = current {
                 let next = self.parents.get(&commit).cloned().flatten();
                 chain.push(commit);
@@ -434,17 +435,17 @@ mod fake {
             &self,
             reference: &str,
         ) -> impl Future<Output = io::Result<Vec<FirstParentCommit>>> {
-            let Some(sha) = self.resolve_sync(reference) else {
+            let Some(commit_id) = self.resolve_sync(reference) else {
                 return ready(Ok(Vec::new()));
             };
-            let mut chain = self.chain(&sha);
+            let mut chain = self.chain(&commit_id);
             chain.reverse(); // oldest-first, matching `git log --reverse`.
             let commits = chain
                 .into_iter()
-                .map(|sha| FirstParentCommit {
-                    committer_time: self.times.get(&sha).copied(),
-                    subject: self.subjects.get(&sha).cloned().unwrap_or_default(),
-                    sha,
+                .map(|commit_id| FirstParentCommit {
+                    committer_time: self.times.get(&commit_id).copied(),
+                    subject: self.subjects.get(&commit_id).cloned().unwrap_or_default(),
+                    commit_id,
                 })
                 .collect();
             ready(Ok(commits))
@@ -456,7 +457,7 @@ mod fake {
         ) -> impl Future<Output = io::Result<Option<Timestamp>>> {
             let time = self
                 .resolve_sync(reference)
-                .and_then(|sha| self.times.get(&sha).copied());
+                .and_then(|commit_id| self.times.get(&commit_id).copied());
             ready(Ok(time))
         }
 
@@ -474,18 +475,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_sha_takes_first_non_empty_line() {
+    fn parse_commit_id_takes_first_non_empty_line() {
         assert_eq!(
-            parse_sha("  \n abc123 \n def \n"),
+            parse_commit_id("  \n abc123 \n def \n"),
             Some("abc123".to_owned())
         );
-        assert_eq!(parse_sha("   \n  \n"), None);
-        assert_eq!(parse_sha(""), None);
+        assert_eq!(parse_commit_id("   \n  \n"), None);
+        assert_eq!(parse_commit_id(""), None);
     }
 
     #[test]
     fn parse_first_parent_log_keeps_order_times_subjects_and_drops_blanks() {
-        // `-z` NUL-terminates each `<sha>\0<date>\0<subject>` record, so the input
+        // `-z` NUL-terminates each `<commit_id>\0<date>\0<subject>` record, so the input
         // is a flat NUL-separated run of triples ending in a terminator.
         let parsed = parse_first_parent_log(
             "c0\x002024-01-01T00:00:00+00:00\x00First commit\x00c1\x002024-02-01T00:00:00+00:00\x00Fix the thing\x00c2\x002024-03-01T00:00:00+00:00\x00Subject with spaces  \x00",
@@ -494,17 +495,17 @@ mod tests {
             parsed,
             vec![
                 FirstParentCommit {
-                    sha: "c0".to_owned(),
+                    commit_id: "c0".to_owned(),
                     committer_time: Some("2024-01-01T00:00:00+00:00".parse().unwrap()),
                     subject: "First commit".to_owned(),
                 },
                 FirstParentCommit {
-                    sha: "c1".to_owned(),
+                    commit_id: "c1".to_owned(),
                     committer_time: Some("2024-02-01T00:00:00+00:00".parse().unwrap()),
                     subject: "Fix the thing".to_owned(),
                 },
                 FirstParentCommit {
-                    sha: "c2".to_owned(),
+                    commit_id: "c2".to_owned(),
                     committer_time: Some("2024-03-01T00:00:00+00:00".parse().unwrap()),
                     subject: "Subject with spaces  ".to_owned(),
                 },
@@ -518,12 +519,12 @@ mod tests {
             ),
             vec![
                 FirstParentCommit {
-                    sha: "c0".to_owned(),
+                    commit_id: "c0".to_owned(),
                     committer_time: Some("2024-01-01T00:00:00+00:00".parse().unwrap()),
                     subject: String::new(),
                 },
                 FirstParentCommit {
-                    sha: "c1".to_owned(),
+                    commit_id: "c1".to_owned(),
                     committer_time: None,
                     subject: "has subject".to_owned(),
                 },
@@ -541,7 +542,7 @@ mod tests {
         assert_eq!(
             parse_first_parent_log("c0\x002024-01-01T00:00:00+00:00\x00Weird\u{1f}subject\x00"),
             vec![FirstParentCommit {
-                sha: "c0".to_owned(),
+                commit_id: "c0".to_owned(),
                 committer_time: Some("2024-01-01T00:00:00+00:00".parse().unwrap()),
                 subject: "Weird\u{1f}subject".to_owned(),
             }]
@@ -604,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn fake_resolves_refs_and_raw_shas() {
+    fn fake_resolves_refs_and_raw_commit_ids() {
         let git = fixture();
         assert_eq!(
             block_on(git.resolve("master")).unwrap(),
@@ -641,15 +642,15 @@ mod tests {
     #[test]
     fn fake_first_parent_is_oldest_first() {
         let git = fixture();
-        let shas = |reference: &str| {
+        let commit_ids = |reference: &str| {
             block_on(git.first_parent(reference))
                 .unwrap()
                 .into_iter()
-                .map(|commit| commit.sha)
+                .map(|commit| commit.commit_id)
                 .collect::<Vec<_>>()
         };
-        assert_eq!(shas("master"), vec!["c0", "c1", "c2", "c3"]);
-        assert_eq!(shas("feature"), vec!["c0", "c1", "f1", "f2"]);
+        assert_eq!(commit_ids("master"), vec!["c0", "c1", "c2", "c3"]);
+        assert_eq!(commit_ids("feature"), vec!["c0", "c1", "f1", "f2"]);
         assert!(block_on(git.first_parent("absent")).unwrap().is_empty());
     }
 
@@ -669,18 +670,18 @@ mod tests {
             block_on(git.first_parent("master")).unwrap(),
             vec![
                 FirstParentCommit {
-                    sha: "c0".to_owned(),
+                    commit_id: "c0".to_owned(),
                     committer_time: Some(t0),
                     subject: "Initial commit".to_owned(),
                 },
                 FirstParentCommit {
-                    sha: "c1".to_owned(),
+                    commit_id: "c1".to_owned(),
                     committer_time: Some(t1),
                     subject: "Fix the thing".to_owned(),
                 },
                 FirstParentCommit {
                     // A commit seeded without a subject carries an empty one.
-                    sha: "c2".to_owned(),
+                    commit_id: "c2".to_owned(),
                     committer_time: None,
                     subject: String::new(),
                 },
@@ -698,7 +699,7 @@ mod tests {
             .commit("c2", Some("c1")) // Seeded without a time.
             .branch("master", "c1")
             .head("master");
-        // Resolves a ref to its commit's time, and a raw SHA likewise.
+        // Resolves a ref to its commit's time, and a raw commit ID likewise.
         assert_eq!(block_on(git.committer_time("HEAD")).unwrap(), Some(t1));
         assert_eq!(block_on(git.committer_time("c0")).unwrap(), Some(t0));
         // A commit without a recorded time, and an unresolved ref, are `None`.

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -304,7 +304,6 @@ mod text;
 mod wiring;
 
 pub(crate) use cargo_bench_history_core::model;
-
 pub use cli::{Cli, EarlyExit};
 pub use command::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,

--- a/packages/cargo-bench-history/src/outcome.rs
+++ b/packages/cargo-bench-history/src/outcome.rs
@@ -2,8 +2,7 @@
 //! successful [`run`](crate::run) returns and the [`RunError`] it fails with.
 
 use std::error::Error;
-use std::fmt;
-use std::io;
+use std::{fmt, io};
 
 use crate::{ConfigError, StorageError};
 /// The outcome of a successful [`run`](crate::run).

--- a/packages/cargo-bench-history/src/storage/azure.rs
+++ b/packages/cargo-bench-history/src/storage/azure.rs
@@ -13,10 +13,8 @@
 //! (ambient developer/CLI session, or self-minted GitHub OIDC in CI).
 
 use std::collections::HashMap;
-use std::env;
-use std::fmt;
-use std::io;
 use std::sync::Arc;
+use std::{env, fmt, io};
 
 use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
 use azure_core::error::ErrorKind;
@@ -665,10 +663,10 @@ fn config_error(message: impl Into<String>) -> StorageError {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use super::*;
-
     use azure_core::http::headers::Headers;
     use futures::executor::block_on;
+
+    use super::*;
 
     /// Builds an Azure HTTP-response error with the given status and storage
     /// error code, mirroring what the SDK surfaces for a failed request.

--- a/packages/cargo-bench-history/src/storage/facade.rs
+++ b/packages/cargo-bench-history/src/storage/facade.rs
@@ -12,15 +12,14 @@ use std::sync::Arc;
 use azure_core::credentials::TokenCredential;
 use azure_core::http::HttpClient;
 
-use crate::config::{CloudStorageConfig, Config};
-use crate::model::sanitize_segment;
-use crate::report::{Reporter, ReporterExt};
-use crate::wiring::rebase;
-
 use super::azure::AzureBlobStorage;
 use super::caching::CachingStorage;
 use super::local::LocalStorage;
 use super::{Storage, StorageError};
+use crate::config::{CloudStorageConfig, Config};
+use crate::model::sanitize_segment;
+use crate::report::{Reporter, ReporterExt};
+use crate::wiring::rebase;
 
 /// A [`Storage`] backend selected at configuration time.
 #[derive(Clone, Debug)]
@@ -356,10 +355,9 @@ pub fn azure_backend_from_parts(
 mod tests {
     use tempfile::tempdir;
 
+    use super::*;
     use crate::config::parse_config;
     use crate::report::RecordingReporter;
-
-    use super::*;
 
     fn config_with_storage(storage: &str) -> Config {
         parse_config(storage).unwrap()

--- a/packages/cargo-bench-history/src/storage/github_oidc.rs
+++ b/packages/cargo-bench-history/src/storage/github_oidc.rs
@@ -29,8 +29,7 @@ use std::sync::Arc;
 use azure_core::Error;
 use azure_core::credentials::TokenCredential;
 use azure_core::error::ErrorKind;
-use azure_core::http::headers;
-use azure_core::http::{ClientMethodOptions, HttpClient, Method, Request, Url};
+use azure_core::http::{ClientMethodOptions, HttpClient, Method, Request, Url, headers};
 use azure_identity::{ClientAssertion, ClientAssertionCredential};
 use serde::Deserialize;
 
@@ -201,13 +200,13 @@ impl ClientAssertion for GithubOidcAssertion {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use super::*;
-
     use std::sync::Mutex;
 
     use azure_core::http::headers::Headers;
     use azure_core::http::{AsyncRawResponse, StatusCode};
     use futures::executor::block_on;
+
+    use super::*;
 
     /// Records the request a [`StubHttpClient`] saw, so a test can assert on the URL
     /// and bearer header the assertion built.

--- a/packages/cargo-bench-history/src/storage/local.rs
+++ b/packages/cargo-bench-history/src/storage/local.rs
@@ -7,9 +7,8 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tokio::io::AsyncWriteExt;
-
 use cargo_bench_history_core::codec;
+use tokio::io::AsyncWriteExt;
 
 use super::{Storage, StorageError, is_plain_segment};
 

--- a/packages/cargo-bench-history/src/storage/mod.rs
+++ b/packages/cargo-bench-history/src/storage/mod.rs
@@ -7,17 +7,15 @@ mod facade;
 mod github_oidc;
 mod local;
 
-pub(crate) use facade::{StorageFacade, build_storage, resolve_storage};
-pub use facade::{StorageOverride, azure_backend_from_parts};
-
 use std::error::Error;
-use std::fmt;
 use std::future::Future;
-use std::io;
 use std::path::{Component, Path};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::{fmt, io};
 
 use cargo_bench_history_core::model::{OBJECTS_SEGMENT, STORAGE_VERSION, sanitize_segment};
+pub(crate) use facade::{StorageFacade, build_storage, resolve_storage};
+pub use facade::{StorageOverride, azure_backend_from_parts};
 
 /// An object store of immutable, key-addressed result sets.
 ///

--- a/packages/cargo-bench-history/src/wiring.rs
+++ b/packages/cargo-bench-history/src/wiring.rs
@@ -147,9 +147,8 @@ pub(crate) fn resolve_project_id(config: &Config, workspace_dir: &Path) -> Strin
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use crate::config::parse_config;
-
     use super::*;
+    use crate::config::parse_config;
 
     fn config_with(extra: &str) -> Config {
         let text = format!("[storage.azure]\naccount = \"a\"\ncontainer = \"c\"\n\n{extra}");

--- a/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
@@ -19,14 +19,15 @@ async fn backfill_stores_one_clean_object_per_commit_and_restores_checkout() {
     };
     assert!(message.contains("2 stored"), "{message}");
 
-    // One clean object per commit, keyed by that commit's full SHA. `backfill`
+    // One clean object per commit, keyed by that commit's full ID. `backfill`
     // auto-detects the target triple, so derive it from a stored object to keep
     // the key assertions correct on every platform CI runs on.
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 2, "{objects:?}");
     let triple = objects[0].1.context.toolchain.target_triple.clone();
-    for sha in [&c1, &c2] {
-        let expected = format!("v1/testproj/objects/callgrind/{triple}/synthetic/{sha}/clean.json");
+    for commit_id in [&c1, &c2] {
+        let expected =
+            format!("v1/testproj/objects/callgrind/{triple}/synthetic/{commit_id}/clean.json");
         assert!(
             objects.iter().any(|(key, _)| key == &expected),
             "missing {expected} in {objects:?}"
@@ -76,8 +77,9 @@ async fn backfill_spans_a_merge_commit_along_first_parent() {
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 3, "{objects:?}");
     let triple = objects[0].1.context.toolchain.target_triple.clone();
-    for sha in [&c1, &m, &c3] {
-        let expected = format!("v1/testproj/objects/callgrind/{triple}/synthetic/{sha}/clean.json");
+    for commit_id in [&c1, &m, &c3] {
+        let expected =
+            format!("v1/testproj/objects/callgrind/{triple}/synthetic/{commit_id}/clean.json");
         assert!(
             objects.iter().any(|(key, _)| key == &expected),
             "missing {expected} in {objects:?}"
@@ -85,10 +87,12 @@ async fn backfill_spans_a_merge_commit_along_first_parent() {
     }
     // The merged-in side-branch commits are off the first-parent line: nothing is
     // stored for them.
-    for sha in [&sf1, &sf2] {
+    for commit_id in [&sf1, &sf2] {
         assert!(
-            !objects.iter().any(|(key, _)| key.contains(sha.as_str())),
-            "side-branch commit {sha} must not be backfilled: {objects:?}"
+            !objects
+                .iter()
+                .any(|(key, _)| key.contains(commit_id.as_str())),
+            "side-branch commit {commit_id} must not be backfilled: {objects:?}"
         );
     }
 }

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -52,7 +52,7 @@ async fn examine_pivots_a_rising_history_into_points() {
         points.iter().all(|point| point["dirty"] == false),
         "every seeded run is clean: {message}"
     );
-    // Every point carries the full commit SHA it was measured against.
+    // Every point carries the full commit ID it was measured against.
     assert!(
         points
             .iter()
@@ -87,8 +87,8 @@ async fn examine_renders_a_text_pivot_with_titles() {
         message.contains("Data points for nm/nm::observe/pull metric instruction_count"),
         "{message}"
     );
-    // The short commit id abbreviates each SHA to twelve characters.
-    let head = workspace.head_sha();
+    // The short commit id abbreviates each commit ID to twelve characters.
+    let head = workspace.head_commit_id();
     let short_head: String = head.chars().take(12).collect();
     assert!(
         message.contains(&short_head),

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -162,7 +162,7 @@ const SECONDS_PER_DAY: i64 = 86_400;
 /// integration suite, and a seed-heavy history pays it once per commit. Streaming
 /// the commits into one `fast-import` collapses an N-commit history into a single
 /// spawn: each commit is one buffered write plus a `get-mark` round-trip that
-/// reports the new SHA, so [`Workspace::commit`] and friends stay synchronous and
+/// reports the new commit ID, so [`Workspace::commit`] and friends stay synchronous and
 /// their call sites read exactly as they would against real `git commit`.
 ///
 /// All commits the harness creates this way carry the base template's empty tree,
@@ -184,7 +184,7 @@ struct GitGraph {
     /// down by [`finalize`](Self::finalize) before any real `git` command.
     session: Option<Session>,
     /// The next `fast-import` mark, used transiently to read back each commit's
-    /// SHA via `get-mark`.
+    /// commit ID via `get-mark`.
     next_mark: u32,
     /// The committer second handed to the next undated commit (see
     /// [`UNDATED_EPOCH_SECONDS`]).
@@ -221,7 +221,7 @@ impl GitGraph {
     }
 
     /// Streams an empty commit dated `second` (raw committer seconds, UTC) with
-    /// message `message` onto the current branch, returning its full SHA.
+    /// message `message` onto the current branch, returning its full commit ID.
     fn commit(&mut self, message: &str, second: i64) -> String {
         let mark = self
             .next_mark
@@ -262,13 +262,13 @@ impl GitGraph {
 
         let mut line = String::new();
         session.stdout.read_line(&mut line).unwrap();
-        let sha = line.trim().to_owned();
+        let commit_id = line.trim().to_owned();
         assert_eq!(
-            sha.len(),
+            commit_id.len(),
             40,
-            "git fast-import get-mark returned `{sha}`, not a full SHA"
+            "git fast-import get-mark returned `{commit_id}`, not a full commit ID"
         );
-        sha
+        commit_id
     }
 
     /// Allocates the committer second for the next undated commit, advancing the
@@ -366,12 +366,12 @@ impl GitGraph {
 /// temp-dir cleanup happen outside it (required on Windows).
 pub(crate) struct Workspace {
     dir: tempfile::TempDir,
-    /// Maps a short commit label (for example `c1`) to the full SHA of the empty
+    /// Maps a short commit label (for example `c1`) to the full commit ID of the empty
     /// commit created for it, so seeded storage keys and the live git topology
     /// agree on the commit-directory segment. Interior mutability lets the
     /// `&self` commit helpers populate it lazily as a test builds its topology.
     commits: RefCell<HashMap<String, String>>,
-    /// Read-through cache of each commit SHA's git committer timestamp, used to
+    /// Read-through cache of each commit ID's git committer timestamp, used to
     /// stamp a clean seed's provenance observation from the commit it sits on.
     /// [`commit_dated`](Self::commit_dated) populates it at creation (the common
     /// case, so no extra `git` spawn); undated commits are read from git on first
@@ -582,31 +582,31 @@ impl Workspace {
         );
         // Guard against a malformed template (for example a loose ref the copy
         // dropped): resolving HEAD straight from the copied `.git` must yield a full
-        // SHA, so a broken copy fails loudly here instead of misbehaving in a later
+        // commit ID, so a broken copy fails loudly here instead of misbehaving in a later
         // command. The read is cheap and never spawns git for a healthy template.
         assert_eq!(
-            self.head_sha().len(),
+            self.head_commit_id().len(),
             40,
             "copied base template did not yield a resolvable HEAD"
         );
     }
 
-    /// Reads `HEAD`'s commit SHA straight from the `.git` directory, avoiding a
+    /// Reads `HEAD`'s commit ID straight from the `.git` directory, avoiding a
     /// `git rev-parse` subprocess (process startup dominates these tests on
     /// Windows). For the small, freshly-created repositories the harness builds the
     /// branch ref is always loose; a `git rev-parse` fallback covers the unexpected
     /// (packed refs, detached `HEAD`).
-    pub(crate) fn head_sha(&self) -> String {
+    pub(crate) fn head_commit_id(&self) -> String {
         self.flush_git();
         let git_dir = self.root().join(".git");
         if let Ok(head) = std::fs::read_to_string(git_dir.join("HEAD")) {
             let head = head.trim();
             if let Some(reference) = head.strip_prefix("ref: ") {
                 // `refs/heads/<branch>` uses `/`, which the Windows path APIs accept.
-                if let Ok(sha) = std::fs::read_to_string(git_dir.join(reference)) {
-                    let sha = sha.trim();
-                    if sha.len() == 40 {
-                        return sha.to_owned();
+                if let Ok(commit_id) = std::fs::read_to_string(git_dir.join(reference)) {
+                    let commit_id = commit_id.trim();
+                    if commit_id.len() == 40 {
+                        return commit_id.to_owned();
                     }
                 }
             } else if head.len() == 40 {
@@ -618,17 +618,17 @@ impl Workspace {
     }
 
     /// Lazily creates an empty commit labeled `label` on the current branch and
-    /// returns its full SHA, reusing the SHA if the label was already created.
+    /// returns its full commit ID, reusing the commit ID if the label was already created.
     ///
     /// Creation order is the first-parent topology order, so seeding in oldest-first
     /// order makes the storage keys line up with the live git history `analyze`
     /// reconstructs the series from.
     pub(crate) fn commit(&self, label: &str) -> String {
-        if let Some(sha) = self.commits.borrow().get(label) {
-            return sha.clone();
+        if let Some(commit_id) = self.commits.borrow().get(label) {
+            return commit_id.clone();
         }
         let second = self.graph.borrow_mut().next_undated_second();
-        let sha = self.graph.borrow_mut().commit(label, second);
+        let commit_id = self.graph.borrow_mut().commit(label, second);
         // Cache the committer time from the synthetic second we just stamped, so an
         // interleaved seed reading this commit's provenance never has to spawn git
         // (which would finalize the stream mid-history). Git stays the source of
@@ -636,43 +636,43 @@ impl Workspace {
         let observed = Timestamp::from_second(second).unwrap();
         self.committer_times
             .borrow_mut()
-            .insert(sha.clone(), observed);
+            .insert(commit_id.clone(), observed);
         self.commits
             .borrow_mut()
-            .insert(label.to_owned(), sha.clone());
-        sha
+            .insert(label.to_owned(), commit_id.clone());
+        commit_id
     }
 
     /// Lazily creates an empty commit labeled `label`, dated `date` (`YYYY-MM-DD`,
-    /// at UTC midnight), on the current branch and returns its full SHA, reusing the
-    /// SHA (without redating) if the label already exists.
+    /// at UTC midnight), on the current branch and returns its full commit ID, reusing the
+    /// commit ID (without redating) if the label already exists.
     ///
     /// Pinning the author and committer date lets the window tests exercise
     /// `--since`/`--until`: `analyze`/`list` read each commit's committer timestamp
     /// from git topology to decide the window before any object is fetched, so the
     /// date stamped here governs how a seeded object behaves under the window.
     pub(crate) fn commit_dated(&self, date: &str, label: &str) -> String {
-        if let Some(sha) = self.commits.borrow().get(label) {
-            return sha.clone();
+        if let Some(commit_id) = self.commits.borrow().get(label) {
+            return commit_id.clone();
         }
         let when = format!("{date}T00:00:00+00:00");
         let observed: Timestamp = when.parse().unwrap();
-        let sha = self.graph.borrow_mut().commit(label, observed.as_second());
+        let commit_id = self.graph.borrow_mut().commit(label, observed.as_second());
         self.committer_times
             .borrow_mut()
-            .insert(sha.clone(), observed);
+            .insert(commit_id.clone(), observed);
         self.commits
             .borrow_mut()
-            .insert(label.to_owned(), sha.clone());
-        sha
+            .insert(label.to_owned(), commit_id.clone());
+        commit_id
     }
 
-    /// Resolves a previously created commit `label` to its full SHA, panicking if
+    /// Resolves a previously created commit `label` to its full commit ID, panicking if
     /// the label was never created. Seeds attach objects to commits the test owns,
     /// so a missing label means the test forgot to create its topology first (via
     /// [`commit`](Self::commit), [`commit_dated`](Self::commit_dated), or
     /// [`merge`](Self::merge)).
-    fn sha(&self, label: &str) -> String {
+    fn commit_id(&self, label: &str) -> String {
         self.commits
             .borrow()
             .get(label)
@@ -685,20 +685,20 @@ impl Workspace {
             })
     }
 
-    /// Returns `sha`'s git committer timestamp, used to stamp a clean seed's
+    /// Returns `commit_id`'s git committer timestamp, used to stamp a clean seed's
     /// provenance observation from the commit it sits on. Dated commits are served
     /// from the cache populated at creation; any other commit is read from git once
     /// (`git show -s --format=%cI`) and cached. Git is the source of truth here.
-    fn committer_time(&self, sha: &str) -> Timestamp {
-        if let Some(observed) = self.committer_times.borrow().get(sha) {
+    fn committer_time(&self, commit_id: &str) -> Timestamp {
+        if let Some(observed) = self.committer_times.borrow().get(commit_id) {
             return *observed;
         }
-        let output = self.git(&["show", "-s", "--format=%cI", sha]);
+        let output = self.git(&["show", "-s", "--format=%cI", commit_id]);
         let text = String::from_utf8(output.stdout).unwrap();
         let observed: Timestamp = text.trim().parse().unwrap();
         self.committer_times
             .borrow_mut()
-            .insert(sha.to_owned(), observed);
+            .insert(commit_id.to_owned(), observed);
         observed
     }
     pub(crate) fn checkout_new_branch(&self, name: &str) {
@@ -714,7 +714,7 @@ impl Workspace {
 
     /// Merges `branch` into the current branch with an always-materialized merge
     /// commit (`--no-ff`), labels the resulting merge commit `label`, and returns
-    /// its full SHA. The merge commit has the current branch's tip as its first
+    /// its full commit ID. The merge commit has the current branch's tip as its first
     /// parent and `branch`'s tip as its second, so it sits on the current branch's
     /// first-parent line while the merged-in commits stay off it — the topology the
     /// git-aware `analyze`/`backfill` selection must respect.
@@ -730,18 +730,18 @@ impl Workspace {
             &["merge", "--no-ff", "--no-edit", "-m", label, branch],
             second,
         );
-        let sha = self.head();
+        let commit_id = self.head();
         self.committer_times
             .borrow_mut()
-            .insert(sha.clone(), Timestamp::from_second(second).unwrap());
+            .insert(commit_id.clone(), Timestamp::from_second(second).unwrap());
         self.commits
             .borrow_mut()
-            .insert(label.to_owned(), sha.clone());
-        sha
+            .insert(label.to_owned(), commit_id.clone());
+        commit_id
     }
 
     /// Commits a tracked file with `contents` at `relative` on the current branch
-    /// and returns the new commit's full SHA. Unlike [`commit`](Self::commit), the
+    /// and returns the new commit's full ID. Unlike [`commit`](Self::commit), the
     /// commit changes the tree, so the file appears in any worktree checked out to
     /// it — used to stand in for a "broken" commit the mock engine reacts to. It
     /// takes the next synthetic committer date, keeping the timeline monotonic and
@@ -751,29 +751,29 @@ impl Workspace {
         self.git(&["add", relative]);
         let second = self.graph.borrow_mut().next_undated_second();
         self.git_at(&["commit", "-m", message], second);
-        let sha = self.head();
+        let commit_id = self.head();
         self.committer_times
             .borrow_mut()
-            .insert(sha.clone(), Timestamp::from_second(second).unwrap());
-        sha
+            .insert(commit_id.clone(), Timestamp::from_second(second).unwrap());
+        commit_id
     }
 
     /// Removes a previously tracked file at `relative`, commits the removal on the
-    /// current branch, and returns the new commit's full SHA. As with
+    /// current branch, and returns the new commit's full ID. As with
     /// [`commit_with_file`](Self::commit_with_file), the removal commit takes the
     /// next synthetic committer date.
     pub(crate) fn commit_removing_file(&self, message: &str, relative: &str) -> String {
         self.git(&["rm", relative]);
         let second = self.graph.borrow_mut().next_undated_second();
         self.git_at(&["commit", "-m", message], second);
-        let sha = self.head();
+        let commit_id = self.head();
         self.committer_times
             .borrow_mut()
-            .insert(sha.clone(), Timestamp::from_second(second).unwrap());
-        sha
+            .insert(commit_id.clone(), Timestamp::from_second(second).unwrap());
+        commit_id
     }
 
-    /// The full SHA of the current `HEAD`.
+    /// The full commit ID of the current `HEAD`.
     pub(crate) fn head(&self) -> String {
         let output = self.git(&["rev-parse", "HEAD"]);
         String::from_utf8(output.stdout).unwrap().trim().to_owned()
@@ -947,10 +947,14 @@ impl Workspace {
     /// for the previously created commit `label`, so a single commit can host
     /// objects in several comparable sets (as parallel CI pools produce).
     pub(crate) fn seed_callgrind_in(&self, triple: &str, machine: &str, label: &str, value: f64) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
-        let key = format!("v1/testproj/objects/callgrind/{triple}/{machine}/{sha}/clean.json");
-        self.seed(&key, &ir_result_set(observed.as_second(), &sha, value));
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
+        let key =
+            format!("v1/testproj/objects/callgrind/{triple}/{machine}/{commit_id}/clean.json");
+        self.seed(
+            &key,
+            &ir_result_set(observed.as_second(), &commit_id, value),
+        );
     }
 
     /// Seeds one *dirty* (uncommitted-tree) Callgrind snapshot with an `Ir` value on
@@ -959,24 +963,30 @@ impl Workspace {
     /// midnight). A real dirty run executes after the commit it is based on, so the
     /// effective second is legitimately later than the commit's own date.
     pub(crate) fn seed_dirty_callgrind(&self, observed: &str, label: &str, value: f64) {
-        let sha = self.sha(label);
+        let commit_id = self.commit_id(label);
         let effective: Timestamp = format!("{observed}T00:00:00Z").parse().unwrap();
         let key = format!(
-            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{sha}/dirty-{}.json",
+            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit_id}/dirty-{}.json",
             effective.as_second()
         );
-        self.seed(&key, &ir_result_set(effective.as_second(), &sha, value));
+        self.seed(
+            &key,
+            &ir_result_set(effective.as_second(), &commit_id, value),
+        );
     }
 
     /// Seeds one Callgrind result set carrying `metrics` for benchmark
     /// `nm::observe/pull` on the previously created commit `label`.
     pub(crate) fn seed_metrics(&self, label: &str, metrics: Vec<Metric>) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
         let key = format!(
-            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{sha}/clean.json"
+            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit_id}/clean.json"
         );
-        self.seed(&key, &result_set_with(observed.as_second(), &sha, metrics));
+        self.seed(
+            &key,
+            &result_set_with(observed.as_second(), &commit_id, metrics),
+        );
     }
 
     /// Seeds a flat history followed by a clear, sustained upward step — a
@@ -1000,14 +1010,14 @@ impl Workspace {
     /// Seeds one Criterion `wall_time` result set on the previously created commit
     /// `label`, in the machine-key partition `machine`.
     pub(crate) fn seed_criterion(&self, label: &str, machine: &str, value: f64) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
         let key = format!(
-            "v1/testproj/objects/criterion/x86_64-pc-windows-msvc/{machine}/{sha}/clean.json"
+            "v1/testproj/objects/criterion/x86_64-pc-windows-msvc/{machine}/{commit_id}/clean.json"
         );
         self.seed(
             &key,
-            &criterion_result_set(observed.as_second(), &sha, value),
+            &criterion_result_set(observed.as_second(), &commit_id, value),
         );
     }
 
@@ -1022,15 +1032,15 @@ impl Workspace {
         machine: &str,
         value: f64,
     ) {
-        let sha = self.sha(label);
+        let commit_id = self.commit_id(label);
         let effective: Timestamp = format!("{observed}T00:00:00Z").parse().unwrap();
         let key = format!(
-            "v1/testproj/objects/criterion/x86_64-pc-windows-msvc/{machine}/{sha}/dirty-{}.json",
+            "v1/testproj/objects/criterion/x86_64-pc-windows-msvc/{machine}/{commit_id}/dirty-{}.json",
             effective.as_second()
         );
         self.seed(
             &key,
-            &criterion_result_set(effective.as_second(), &sha, value),
+            &criterion_result_set(effective.as_second(), &commit_id, value),
         );
     }
 
@@ -1060,14 +1070,14 @@ impl Workspace {
     /// `alpha::bench/wide` and `beta::bench/narrow`, each with an `Ir` metric at the
     /// given value, on the previously created commit `label`.
     pub(crate) fn seed_two_benchmarks(&self, label: &str, alpha: f64, beta: f64) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
         let key = format!(
-            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{sha}/clean.json"
+            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit_id}/clean.json"
         );
         self.seed(
             &key,
-            &two_benchmark_result_set(observed.as_second(), &sha, alpha, beta),
+            &two_benchmark_result_set(observed.as_second(), &commit_id, alpha, beta),
         );
     }
 
@@ -1076,14 +1086,14 @@ impl Workspace {
     /// allocations per iteration. Allocation counts are deterministic, so the
     /// partition is `synthetic` (no machine key).
     pub(crate) fn seed_alloc_tracker(&self, label: &str, operation: &str, bytes: f64, allocs: f64) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
         let key = format!(
-            "v1/testproj/objects/alloc_tracker/x86_64-unknown-linux-gnu/synthetic/{sha}/clean.json"
+            "v1/testproj/objects/alloc_tracker/x86_64-unknown-linux-gnu/synthetic/{commit_id}/clean.json"
         );
         self.seed(
             &key,
-            &alloc_result_set(observed.as_second(), &sha, operation, bytes, allocs),
+            &alloc_result_set(observed.as_second(), &commit_id, operation, bytes, allocs),
         );
     }
 
@@ -1098,14 +1108,14 @@ impl Workspace {
         operation: &str,
         nanos: f64,
     ) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
         let key = format!(
-            "v1/testproj/objects/all_the_time/x86_64-unknown-linux-gnu/{machine}/{sha}/clean.json"
+            "v1/testproj/objects/all_the_time/x86_64-unknown-linux-gnu/{machine}/{commit_id}/clean.json"
         );
         self.seed(
             &key,
-            &time_result_set(observed.as_second(), &sha, operation, nanos),
+            &time_result_set(observed.as_second(), &commit_id, operation, nanos),
         );
     }
 
@@ -1121,16 +1131,16 @@ impl Workspace {
         nanos: f64,
         half_width: f64,
     ) {
-        let sha = self.sha(label);
-        let observed = self.committer_time(&sha);
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
         let key = format!(
-            "v1/testproj/objects/all_the_time/x86_64-unknown-linux-gnu/{machine}/{sha}/clean.json"
+            "v1/testproj/objects/all_the_time/x86_64-unknown-linux-gnu/{machine}/{commit_id}/clean.json"
         );
         self.seed(
             &key,
             &time_result_set_with_dispersion(
                 observed.as_second(),
-                &sha,
+                &commit_id,
                 operation,
                 nanos,
                 half_width,

--- a/packages/cargo-bench-history/tests/cbh_integration/install.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/install.rs
@@ -1,5 +1,4 @@
-use crate::harness::serial;
-use crate::harness::*;
+use crate::harness::{serial, *};
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)] // Touches the real filesystem, which Miri cannot do.

--- a/packages/future_deque/src/future_deque.rs
+++ b/packages/future_deque/src/future_deque.rs
@@ -54,7 +54,6 @@ impl<T> FutureHandle<T> for BlindPooledMut<dyn ErasedFuture<T>> {
 /// popping for convenience. They return `Poll::Ready(Some(value))` when the respective
 /// end has a completed future, `Poll::Ready(None)` when the deque is empty, or
 /// `Poll::Pending` when the respective end is not yet ready.
-///
 #[cfg_attr(
     any(test, feature = "futures-stream"),
     doc = "With the `futures-stream` feature, `FutureDeque` also implements [`Stream`][futures_core::Stream], yielding completed results from the front."

--- a/packages/future_deque/src/local_future_deque.rs
+++ b/packages/future_deque/src/local_future_deque.rs
@@ -52,7 +52,6 @@ impl<T> FutureHandle<T> for LocalBlindPooledMut<dyn ErasedFuture<T>> {
 /// popping for convenience. They return `Poll::Ready(Some(value))` when the respective
 /// end has a completed future, `Poll::Ready(None)` when the deque is empty, or
 /// `Poll::Pending` when the respective end is not yet ready.
-///
 #[cfg_attr(
     any(test, feature = "futures-stream"),
     doc = "With the `futures-stream` feature, `LocalFutureDeque` also implements [`Stream`][futures_core::Stream], yielding completed results from the front."

--- a/packages/many_cpus/src/lib.rs
+++ b/packages/many_cpus/src/lib.rs
@@ -284,7 +284,6 @@
 //! To make your code testable with fake hardware, accept `SystemHardware` as a value (typically
 //! as a function parameter or struct field) instead of always calling `SystemHardware::current()`.
 //! This allows tests to substitute fake hardware while production code uses real hardware.
-//!
 #![cfg_attr(
     any(test, feature = "test-util"),
     doc = "See the [`fake`] module for detailed examples and API documentation."
@@ -336,10 +335,9 @@
     html_favicon_url = "https://raw.githubusercontent.com/folo-rs/folo/refs/heads/main/packages/many_cpus/icon.ico"
 )]
 
+#[cfg(any(test, feature = "test-util"))]
+pub use many_cpus_impl::fake;
 pub use many_cpus_impl::{
     EfficiencyClass, MemoryRegionId, Processor, ProcessorId, ProcessorSet, ProcessorSetBuilder,
     ResourceQuota, SystemHardware,
 };
-
-#[cfg(any(test, feature = "test-util"))]
-pub use many_cpus_impl::fake;

--- a/packages/par_bench/src/lib.rs
+++ b/packages/par_bench/src/lib.rs
@@ -124,7 +124,6 @@
 //! ```
 //!
 //! # Resource usage tracking
-//!
 #![cfg_attr(
     any(feature = "alloc_tracker", feature = "all_the_time"),
     doc = "When either the `alloc_tracker` or `all_the_time` features are enabled, the [`ResourceUsageExt`]"


### PR DESCRIPTION
Closes #313.

## Terminology: "commit ID", not "sha"

Commit identifiers are IDs, not "shas". This consistently renames internal identifiers and prose across `cargo-bench-history`, `cargo-bench-history-core`, and `cargo-bench-history-stress`:

- `FirstParentCommit.sha` / stress `Commit.sha` → `commit_id`
- `short_sha` → `short_commit_id`, `parse_sha` → `parse_commit_id`, `shas()` → `commit_ids()`, harness `sha()` and locals → `commit_id`
- All "commit SHA" / "full SHA" / "raw SHA" / "SHA-prefix" doc, DESIGN, and AGENTS prose → "commit ID"

Genuine algorithm references are intentionally kept: the `machine.rs` SHA-256 machine fingerprint (a real content hash), and git's SHA-1/SHA-256 hash-length note. The serialized model (`GitInfo.commit`), storage keys, and CLI already used "commit", so there are **no storage/format/schema changes**.

## Bundled fix: format-check enforced the wrong config

`just format` formats with `--config-path ./unstable-rustfmt.toml` (enabling `format_code_in_doc_comments`, `imports_granularity = "Module"`, `group_imports = "StdExternalCrate"`), but `just format-check` (what CI runs) did **not** pass that config — so those three rules were never gated, and the tree had drifted (29 files workspace-wide failed under the unstable rules).

This PR makes `format-check` use the same config and runs `just format` to bring the workspace into conformance. The extra reformatted files (`many_cpus`, `future_deque`, `par_bench`, `alloc_tracker`, and some untouched `cargo-bench-history` files) are pure formatting: import grouping/granularity and blank doc-line removal before `#[cfg_attr(…, doc=…)]`.

## Validation

`just package="cargo-bench-history cargo-bench-history-core cargo-bench-history-stress" validate-local` — all primary steps pass (format-check, check, clippy, test, test-docs, docs, docs-default-features, miri, machete, default-features, release check/clippy/build); plus a workspace-wide `cargo check --all-targets`. The final `mutants` step was skipped locally: a pure rename + formatting change has no mutation signal.
