### PR TITLE
Treat all benchmark metrics as non-deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,6 @@ dependencies = [
  "criterion",
  "folo_utils",
  "mutants",
- "rand 0.10.1",
  "serde",
  "serde_json",
  "static_assertions",
@@ -1084,6 +1083,7 @@ name = "folo_utils"
 version = "0.1.9"
 dependencies = [
  "mutants",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 [dependencies]
 cpu-time = { workspace = true }
 folo_utils = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -27,10 +27,11 @@
 //! iterations-weighted, through-origin fit of each span's total time against its
 //! iteration count, which recovers the marginal per-iteration cost even when the
 //! blend of warm-up and steady-state spans shifts. Each figure is paired with a
-//! bootstrap 95% confidence interval so its run-to-run uncertainty is shown
-//! rather than implied. The stdout summary and the JSON output both lead with the
-//! slope and interval; the pooled mean stays available through
-//! [`ReportOperation::mean`] for callers that still want it.
+//! bootstrap 95% confidence interval so its run-to-run uncertainty can be
+//! inspected. The stdout summary leads with the slope alone for readability; the
+//! JSON output records the slope together with that confidence interval, and the
+//! pooled mean stays available through [`ReportOperation::mean`] for callers that
+//! still want it.
 //!
 //! # Example
 //!
@@ -68,7 +69,8 @@
 //! bootstrap confidence interval, and the observed minimum and maximum. The
 //! bootstrap uses a fixed seed, so the confidence interval is reproducible across
 //! runs of identical measurements. The stdout summary leads with the same
-//! warmup-robust slope and its confidence interval (see "Primary metric").
+//! warmup-robust slope (see "Primary metric"), without the interval, for
+//! readability.
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
 //! to create a session and record work.

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -150,5 +150,6 @@ pub(crate) use operation_metrics::*;
 pub use process_span::*;
 pub use report::*;
 pub use session::*;
-pub(crate) use statistics::*;
+pub use statistics::OperationStatistics;
+pub(crate) use statistics::{SpanRecord, compute_statistics};
 pub use thread_span::*;

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -171,5 +171,5 @@ pub use process_span::*;
 pub use report::*;
 pub use session::*;
 pub use statistics::OperationStatistics;
-pub(crate) use statistics::{SpanRecord, compute_statistics};
+pub(crate) use statistics::{SpanRecord, compute_slope_nanos, compute_statistics};
 pub use thread_span::*;

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -11,9 +11,26 @@
 //! - [`Report`] - Thread-safe processor time statistics that can be merged and processed independently
 //! - [`ThreadSpan`] - Tracks thread processor time over a time period
 //! - [`ProcessSpan`] - Tracks process processor time over a time period
-//! - [`Operation`] - Calculates mean processor time per operation
+//! - [`Operation`] - Measures per-iteration processor time for a repeated operation
 //!
 //! This package is not meant for use in production, serving only as a development tool.
+//!
+//! # Primary metric
+//!
+//! Processor time is not deterministic: it jitters run to run with system load
+//! and scheduling. On top of that, Criterion chooses how many iterations to time
+//! and how many to discard as warm-up, so a raw pooled **mean** silently folds
+//! warm-up and one-off costs into the per-iteration figure and drifts as that
+//! sample mix changes between runs.
+//!
+//! The headline metric is therefore the **warmup-robust slope**: an
+//! iterations-weighted, through-origin fit of each span's total time against its
+//! iteration count, which recovers the marginal per-iteration cost even when the
+//! blend of warm-up and steady-state spans shifts. Each figure is paired with a
+//! bootstrap 95% confidence interval so its run-to-run uncertainty is shown
+//! rather than implied. The stdout summary and the JSON output both lead with the
+//! slope and interval; the pooled mean stays available through
+//! [`ReportOperation::mean`] for callers that still want it.
 //!
 //! # Example
 //!
@@ -50,7 +67,8 @@
 //! spans: a through-origin slope point estimate, the standard deviation, a 95%
 //! bootstrap confidence interval, and the observed minimum and maximum. The
 //! bootstrap uses a fixed seed, so the confidence interval is reproducible across
-//! runs of identical measurements. The stdout summary remains mean-only.
+//! runs of identical measurements. The stdout summary leads with the same
+//! warmup-robust slope and its confidence interval (see "Primary metric").
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
 //! to create a session and record work.

--- a/packages/all_the_time/src/operation.rs
+++ b/packages/all_the_time/src/operation.rs
@@ -353,4 +353,13 @@ mod tests {
             "Display should show the 100ms per-iteration slope: got {display}"
         );
     }
+
+    #[test]
+    fn display_reports_no_measurements_when_empty() {
+        // An operation with no recorded spans has no statistics, so its Display takes
+        // the `None` leg.
+        let session = create_test_session();
+        let operation = session.operation("test");
+        assert_eq!(operation.to_string(), "no measurements");
+    }
 }

--- a/packages/all_the_time/src/operation.rs
+++ b/packages/all_the_time/src/operation.rs
@@ -1,16 +1,20 @@
-//! Mean processor time tracking.
+//! Per-iteration processor time tracking.
 
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::pal::PlatformFacade;
+use crate::statistics::nanos_to_duration;
 use crate::{ERR_POISONED_LOCK, OperationMetrics, ProcessSpan, ThreadSpan};
 
-/// Calculates mean processor time per operation across multiple iterations.
+/// Measures per-iteration processor time for a repeated operation.
 ///
 /// This utility is particularly useful for benchmarking scenarios where you want
-/// to understand the mean processor time footprint of repeated operations.
+/// to understand the processor time footprint of repeated operations. The
+/// headline figure is the warmup-robust per-iteration slope (see the crate-level
+/// "Primary metric" documentation), with the pooled [`mean`](Self::mean) still
+/// available.
 ///
 /// Operations share data directly with the session - data is merged when spans are dropped.
 ///
@@ -192,7 +196,16 @@ impl Operation {
 
 impl fmt::Display for Operation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} (mean)", self.mean())
+        match self.metrics.lock().expect(ERR_POISONED_LOCK).statistics() {
+            Some(stats) => write!(
+                f,
+                "{:?} per iteration [{:?}, {:?}]",
+                nanos_to_duration(stats.slope_nanos),
+                nanos_to_duration(stats.interval_low_nanos),
+                nanos_to_duration(stats.interval_high_nanos),
+            ),
+            None => write!(f, "no measurements"),
+        }
     }
 }
 
@@ -317,22 +330,27 @@ mod tests {
     );
 
     #[test]
-    fn display_shows_mean() {
+    fn display_shows_robust_per_iteration_estimate() {
         let session = create_test_session();
         let operation = session.operation("test");
 
-        // Add some data: 100ms per iteration * 2 iterations = 200ms total, mean = 100ms
+        // One span of 100ms per iteration across 2 iterations: the through-origin
+        // slope recovers 100ms, and with a single span the interval collapses onto
+        // it.
         {
             let mut metrics = operation.metrics.lock().expect(ERR_POISONED_LOCK);
             metrics.add_iterations(Duration::from_millis(100), 2);
         }
 
         let display = operation.to_string();
-        assert!(display.contains("mean"), "Display should mention 'mean'");
-        // Duration debug format varies, but should contain '100' for 100ms mean
+        assert!(
+            display.contains("per iteration"),
+            "Display should report the per-iteration estimate: got {display}"
+        );
+        // Duration debug format varies, but should contain '100' for the 100ms slope.
         assert!(
             display.contains("100"),
-            "Display should show the mean duration containing '100' (for 100ms): got {display}"
+            "Display should show the 100ms per-iteration slope: got {display}"
         );
     }
 }

--- a/packages/all_the_time/src/operation.rs
+++ b/packages/all_the_time/src/operation.rs
@@ -197,13 +197,13 @@ impl Operation {
 impl fmt::Display for Operation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.metrics.lock().expect(ERR_POISONED_LOCK).statistics() {
-            Some(stats) => write!(
-                f,
-                "{:?} per iteration [{:?}, {:?}]",
-                nanos_to_duration(stats.slope_nanos),
-                nanos_to_duration(stats.interval_low_nanos),
-                nanos_to_duration(stats.interval_high_nanos),
-            ),
+            Some(stats) => {
+                write!(
+                    f,
+                    "{:?} per iteration",
+                    nanos_to_duration(stats.slope_nanos)
+                )
+            }
             None => write!(f, "no measurements"),
         }
     }

--- a/packages/all_the_time/src/operation.rs
+++ b/packages/all_the_time/src/operation.rs
@@ -196,13 +196,11 @@ impl Operation {
 
 impl fmt::Display for Operation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.metrics.lock().expect(ERR_POISONED_LOCK).statistics() {
-            Some(stats) => {
-                write!(
-                    f,
-                    "{:?} per iteration",
-                    nanos_to_duration(stats.slope_nanos)
-                )
+        // The summary shows only the slope, so take the cheap slope-only path and
+        // skip the bootstrap confidence interval the full statistics would resample.
+        match self.metrics.lock().expect(ERR_POISONED_LOCK).slope_nanos() {
+            Some(slope_nanos) => {
+                write!(f, "{:?} per iteration", nanos_to_duration(slope_nanos))
             }
             None => write!(f, "no measurements"),
         }

--- a/packages/all_the_time/src/operation_metrics.rs
+++ b/packages/all_the_time/src/operation_metrics.rs
@@ -6,8 +6,11 @@ use crate::{OperationStatistics, SpanRecord, compute_statistics};
 ///
 /// Sized to cover Criterion's default sample count (100) plus its warm-up calls
 /// with headroom, so that recording a span is an allocation-free push in the
-/// common case. The buffer is allocated once, when the operation is created,
-/// keeping the measured region free of allocations.
+/// common case. A benchmark configured with a larger `sample_size` eventually
+/// exceeds this and the next push grows the buffer. That growth is harmless to
+/// the measurement: a span records itself from `Drop`, after it has already
+/// captured its elapsed delta and before the next span starts, so the
+/// reallocation falls between measured spans and never lands inside one.
 const DEFAULT_SPAN_CAPACITY: usize = 256;
 
 /// Metrics tracked for each operation in the session.

--- a/packages/all_the_time/src/operation_metrics.rs
+++ b/packages/all_the_time/src/operation_metrics.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::{OperationStatistics, SpanRecord, compute_statistics};
+use crate::{OperationStatistics, SpanRecord, compute_slope_nanos, compute_statistics};
 
 /// Initial capacity reserved for an operation's span buffer.
 ///
@@ -100,6 +100,16 @@ impl OperationMetrics {
     /// spans were recorded.
     pub(crate) fn statistics(&self) -> Option<OperationStatistics> {
         compute_statistics(&self.spans)
+    }
+
+    /// The warmup-robust per-iteration slope in nanoseconds, or `None` when no
+    /// spans were recorded.
+    ///
+    /// The cheap path for the console summary: it computes only the headline
+    /// slope, skipping the bootstrap confidence interval that
+    /// [`statistics`](Self::statistics) resamples.
+    pub(crate) fn slope_nanos(&self) -> Option<f64> {
+        compute_slope_nanos(&self.spans)
     }
 
     /// Appends another operation's spans onto this one.

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -247,9 +247,39 @@ impl ReportOperation {
 
     /// Computes dispersion statistics over the recorded spans.
     ///
-    /// Returns `None` when no spans were recorded.
+    /// Returns `None` when no spans were recorded. The returned
+    /// [`OperationStatistics`] carries the same warmup-robust slope, bootstrap
+    /// confidence interval, standard deviation and extremes that are written to
+    /// the machine-readable JSON output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use all_the_time::Session;
+    ///
+    /// # fn main() {
+    /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
+    /// let operation = session.operation("work");
+    /// let _span = operation.measure_thread().iterations(100);
+    /// for _ in 0..100 {
+    ///     std::hint::black_box(42 * 2);
+    /// }
+    /// drop(_span);
+    ///
+    /// let report = session.to_report();
+    /// for (_name, op) in report.operations() {
+    ///     if let Some(stats) = op.statistics() {
+    ///         println!(
+    ///             "slope: {} ns/iter over {} spans",
+    ///             stats.slope_nanos, stats.span_count
+    ///         );
+    ///     }
+    /// }
+    /// # }
+    /// ```
     #[must_use]
-    pub(crate) fn statistics(&self) -> Option<OperationStatistics> {
+    pub fn statistics(&self) -> Option<OperationStatistics> {
         self.metrics.statistics()
     }
 }

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -287,13 +287,11 @@ impl ReportOperation {
 
 impl fmt::Display for ReportOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.statistics() {
-            Some(stats) => {
-                write!(
-                    f,
-                    "{:?} per iteration",
-                    nanos_to_duration(stats.slope_nanos)
-                )
+        // The summary shows only the slope, so take the cheap slope-only path and
+        // skip the bootstrap confidence interval the full statistics would resample.
+        match self.metrics.slope_nanos() {
+            Some(slope_nanos) => {
+                write!(f, "{:?} per iteration", nanos_to_duration(slope_nanos))
             }
             None => write!(f, "no measurements"),
         }
@@ -318,12 +316,13 @@ impl fmt::Display for Report {
         // folds warmup and one-off costs into the figure, while the slope recovers
         // the marginal per-iteration cost. The bootstrap confidence interval is
         // kept out of this summary for readability; it is preserved in the JSON
-        // output and the `statistics()` API.
+        // output and the `statistics()` API. Rendering the slope alone also lets the
+        // table skip the bootstrap resampling the full statistics would perform.
         let cells: Vec<(&str, String)> = sorted_ops
             .iter()
             .map(|(name, operation)| {
-                let value = match operation.statistics() {
-                    Some(stats) => format!("{:?}", nanos_to_duration(stats.slope_nanos)),
+                let value = match operation.metrics.slope_nanos() {
+                    Some(slope_nanos) => format!("{:?}", nanos_to_duration(slope_nanos)),
                     None => "n/a".to_owned(),
                 };
                 (name.as_str(), value)

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
 
+use crate::statistics::nanos_to_duration;
 use crate::{OperationMetrics, OperationStatistics};
 
 /// Thread-safe processor time tracking report.
@@ -286,7 +287,16 @@ impl ReportOperation {
 
 impl fmt::Display for ReportOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} (mean)", self.mean())
+        match self.statistics() {
+            Some(stats) => write!(
+                f,
+                "{:?} per iteration [{:?}, {:?}]",
+                nanos_to_duration(stats.slope_nanos),
+                nanos_to_duration(stats.interval_low_nanos),
+                nanos_to_duration(stats.interval_high_nanos),
+            ),
+            None => write!(f, "no measurements"),
+        }
     }
 }
 
@@ -295,65 +305,75 @@ impl fmt::Display for Report {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.operations.values().all(|op| op.metrics.is_empty()) {
             writeln!(f, "No processor time statistics captured.")?;
-        } else {
-            writeln!(f, "Processor time statistics:")?;
-            writeln!(f)?;
+            return Ok(());
+        }
+        writeln!(f, "Processor time statistics:")?;
+        writeln!(f)?;
 
-            // Sort operations by name for consistent output
-            let mut sorted_ops: Vec<_> = self.operations.iter().collect();
-            sorted_ops.sort_by_key(|(name, _)| *name);
+        // Sort operations by name for consistent output.
+        let mut sorted_ops: Vec<_> = self.operations.iter().collect();
+        sorted_ops.sort_by_key(|(name, _)| *name);
 
-            // Calculate the maximum width needed for the operation name column
-            let max_name_width = sorted_ops
-                .iter()
-                .map(|(name, _)| name.len())
-                .max()
-                .unwrap_or(0)
-                .max("Operation".len());
+        // Render the warmup-robust per-iteration slope and its bootstrap
+        // confidence interval, not the raw mean: the mean folds warmup and
+        // one-off costs into the figure, while the slope recovers the marginal
+        // per-iteration cost and the interval shows its run-to-run uncertainty.
+        let cells: Vec<(&str, String)> = sorted_ops
+            .iter()
+            .map(|(name, operation)| {
+                let value = match operation.statistics() {
+                    Some(stats) => format!(
+                        "{:?} [{:?}, {:?}]",
+                        nanos_to_duration(stats.slope_nanos),
+                        nanos_to_duration(stats.interval_low_nanos),
+                        nanos_to_duration(stats.interval_high_nanos),
+                    ),
+                    None => "n/a".to_owned(),
+                };
+                (name.as_str(), value)
+            })
+            .collect();
 
-            // Calculate the maximum width needed for the mean column
-            let max_mean_width = sorted_ops
-                .iter()
-                .map(|(_, operation)| format!("{:?}", operation.mean()).len())
-                .max()
-                .unwrap_or(0)
-                .max("Mean".len());
+        let max_name_width = cells
+            .iter()
+            .map(|(name, _)| name.len())
+            .max()
+            .unwrap_or(0)
+            .max("Operation".len());
+        let max_value_width = cells
+            .iter()
+            .map(|(_, value)| value.len())
+            .max()
+            .unwrap_or(0)
+            .max("Per iteration".len());
 
-            // Print table header
-            writeln!(
-                f,
-                "| {:<name_width$} | {:>mean_width$} |",
-                "Operation",
-                "Mean",
-                name_width = max_name_width,
-                mean_width = max_mean_width
-            )?;
-            let separator_name_width = max_name_width
-                .checked_add(2)
-                .expect("operation name width fits in memory, adding 2 cannot overflow");
-            let separator_mean_width = max_mean_width
-                .checked_add(2)
-                .expect("mean width fits in memory, adding 2 cannot overflow");
-            writeln!(
-                f,
-                "|{:-<name_width$}|{:-<mean_width$}|",
-                "",
-                "",
-                name_width = separator_name_width,
-                mean_width = separator_mean_width
-            )?;
+        // Print table header.
+        writeln!(
+            f,
+            "| {:<name_width$} | {:>value_width$} |",
+            "Operation",
+            "Per iteration",
+            name_width = max_name_width,
+            value_width = max_value_width
+        )?;
+        let separator_name_width = max_name_width
+            .checked_add(2)
+            .expect("operation name width fits in memory, adding 2 cannot overflow");
+        let separator_value_width = max_value_width
+            .checked_add(2)
+            .expect("value width fits in memory, adding 2 cannot overflow");
+        writeln!(
+            f,
+            "|{:-<name_width$}|{:-<value_width$}|",
+            "",
+            "",
+            name_width = separator_name_width,
+            value_width = separator_value_width
+        )?;
 
-            // Print table rows
-            for (name, operation) in sorted_ops {
-                writeln!(
-                    f,
-                    "| {:<name_width$} | {:>mean_width$} |",
-                    name,
-                    format!("{:?}", operation.mean()),
-                    name_width = max_name_width,
-                    mean_width = max_mean_width
-                )?;
-            }
+        // Print table rows.
+        for (name, value) in cells {
+            writeln!(f, "| {name:<max_name_width$} | {value:>max_value_width$} |",)?;
         }
         Ok(())
     }
@@ -543,14 +563,14 @@ mod tests {
     );
 
     #[test]
-    fn report_operation_display_shows_mean() {
+    fn report_operation_display_shows_robust_per_iteration_estimate() {
         use crate::pal::{FakePlatform, PlatformFacade};
 
         let fake_platform = FakePlatform::new();
         let platform_facade = PlatformFacade::fake(fake_platform.clone());
         let session = Session::with_platform(platform_facade);
 
-        // Set up timing: 100ms total for 2 iterations = 50ms mean
+        // 100ms total for 2 iterations: the through-origin slope recovers 50ms.
         fake_platform.set_thread_time(Duration::from_millis(0));
         {
             let operation = session.operation("test_op");
@@ -562,11 +582,14 @@ mod tests {
         let (_name, op) = report.operations().next().unwrap();
 
         let display = op.to_string();
-        assert!(display.contains("mean"), "Display should mention 'mean'");
-        // Duration debug format varies, but should contain '50' for 50ms
+        assert!(
+            display.contains("per iteration"),
+            "Display should report the per-iteration estimate: got {display}"
+        );
+        // Duration debug format varies, but should contain '50' for the 50ms slope.
         assert!(
             display.contains("50"),
-            "Display should show the mean duration containing '50' (for 50ms): got {display}"
+            "Display should show the 50ms per-iteration slope: got {display}"
         );
     }
 }

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -288,13 +288,13 @@ impl ReportOperation {
 impl fmt::Display for ReportOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.statistics() {
-            Some(stats) => write!(
-                f,
-                "{:?} per iteration [{:?}, {:?}]",
-                nanos_to_duration(stats.slope_nanos),
-                nanos_to_duration(stats.interval_low_nanos),
-                nanos_to_duration(stats.interval_high_nanos),
-            ),
+            Some(stats) => {
+                write!(
+                    f,
+                    "{:?} per iteration",
+                    nanos_to_duration(stats.slope_nanos)
+                )
+            }
             None => write!(f, "no measurements"),
         }
     }
@@ -314,20 +314,16 @@ impl fmt::Display for Report {
         let mut sorted_ops: Vec<_> = self.operations.iter().collect();
         sorted_ops.sort_by_key(|(name, _)| *name);
 
-        // Render the warmup-robust per-iteration slope and its bootstrap
-        // confidence interval, not the raw mean: the mean folds warmup and
-        // one-off costs into the figure, while the slope recovers the marginal
-        // per-iteration cost and the interval shows its run-to-run uncertainty.
+        // Render the warmup-robust per-iteration slope, not the raw mean: the mean
+        // folds warmup and one-off costs into the figure, while the slope recovers
+        // the marginal per-iteration cost. The bootstrap confidence interval is
+        // kept out of this summary for readability; it is preserved in the JSON
+        // output and the `statistics()` API.
         let cells: Vec<(&str, String)> = sorted_ops
             .iter()
             .map(|(name, operation)| {
                 let value = match operation.statistics() {
-                    Some(stats) => format!(
-                        "{:?} [{:?}, {:?}]",
-                        nanos_to_duration(stats.slope_nanos),
-                        nanos_to_duration(stats.interval_low_nanos),
-                        nanos_to_duration(stats.interval_high_nanos),
-                    ),
+                    Some(stats) => format!("{:?}", nanos_to_duration(stats.slope_nanos)),
                     None => "n/a".to_owned(),
                 };
                 (name.as_str(), value)
@@ -373,7 +369,7 @@ impl fmt::Display for Report {
 
         // Print table rows.
         for (name, value) in cells {
-            writeln!(f, "| {name:<max_name_width$} | {value:>max_value_width$} |",)?;
+            writeln!(f, "| {name:<max_name_width$} | {value:>max_value_width$} |")?;
         }
         Ok(())
     }

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -588,4 +588,14 @@ mod tests {
             "Display should show the 50ms per-iteration slope: got {display}"
         );
     }
+
+    #[test]
+    fn report_operation_display_reports_no_measurements_when_empty() {
+        // A report operation whose metrics recorded no spans has no statistics, so
+        // its Display takes the `None` leg.
+        let op = ReportOperation {
+            metrics: OperationMetrics::default(),
+        };
+        assert_eq!(op.to_string(), "no measurements");
+    }
 }

--- a/packages/all_the_time/src/statistics.rs
+++ b/packages/all_the_time/src/statistics.rs
@@ -160,4 +160,13 @@ mod tests {
         assert_eq!(stats.interval_low_nanos, 20.0);
         assert_eq!(stats.interval_high_nanos, 20.0);
     }
+
+    #[test]
+    fn nanos_to_duration_clamps_negatives_to_zero() {
+        // A tiny negative fit (possible from the bootstrap on near-zero data) is
+        // clamped so the formatter never panics, while a positive figure converts
+        // faithfully.
+        assert_eq!(nanos_to_duration(-5.0), Duration::ZERO);
+        assert_eq!(nanos_to_duration(1_000_000_000.0), Duration::from_secs(1));
+    }
 }

--- a/packages/all_the_time/src/statistics.rs
+++ b/packages/all_the_time/src/statistics.rs
@@ -3,44 +3,16 @@
 //! Each measured span contributes one `(iterations, total_nanos)` observation.
 //! Because a span corresponds to one Criterion sample (one `iter_custom`
 //! closure call), the spans of an operation form the same per-sample population
-//! Criterion analyzes for its own wall-clock estimates. This module reproduces
-//! the parts of that analysis that the history tool consumes:
-//!
-//! * a through-origin OLS **slope** as the per-iteration point estimate
-//!   (`slope = Σ(nᵢ·tᵢ) / Σ(nᵢ²)`), robust to fixed per-call overhead and, as a
-//!   side effect, to low-iteration warm-up spans, and
-//! * a **bootstrap** confidence interval of that slope (resample the spans with
-//!   replacement, recompute the slope, take percentiles), matching Criterion's
-//!   confidence-interval method.
+//! Criterion analyzes for its own wall-clock estimates. The warmup-robust
+//! estimator itself — an iterations²-weighted through-origin OLS slope and a
+//! bootstrap confidence interval of that slope — lives in
+//! [`folo_utils::SpanStats`], shared with the other tracker crates. This module
+//! only maps this crate's nanosecond-typed [`SpanRecord`] onto that estimator.
 //!
 //! All work here runs once, when a [`Report`](crate::Report) is materialized for
 //! output — never inside a measured span.
 
-#![expect(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    reason = "iteration and nanosecond counts stay well below 2^53, and bootstrap \
-              percentile indices are clamped into range before the cast"
-)]
-
-use rand::rngs::SmallRng;
-use rand::{RngExt, SeedableRng};
-
-/// Number of bootstrap resamples drawn when estimating the confidence interval.
-///
-/// Matches Criterion's default so the two engines' intervals are produced by the
-/// same method at the same resolution.
-const BOOTSTRAP_RESAMPLES: usize = 100_000;
-
-/// Confidence level of the reported interval (95%, matching Criterion's default).
-const CONFIDENCE_LEVEL: f64 = 0.95;
-
-/// Fixed seed for the bootstrap RNG.
-///
-/// A fixed seed makes the interval a deterministic function of the recorded
-/// spans, so re-running an analysis over unchanged data yields identical bounds.
-const BOOTSTRAP_SEED: u64 = 0x5A11_0C8E_BEE5_F00D;
+use folo_utils::{Span, SpanStats};
 
 /// One recorded span: the processor time a single measured span consumed and the
 /// number of iterations it covered.
@@ -57,184 +29,57 @@ pub(crate) struct SpanRecord {
 }
 
 /// Dispersion statistics for one operation, derived from its spans.
+///
+/// A nanosecond-typed view of [`folo_utils::SpanStats`]: every value is a
+/// per-iteration processor time in nanoseconds. Exposed publicly through
+/// [`ReportOperation::statistics`](crate::ReportOperation::statistics) so callers
+/// can consume the same dispersion the JSON output records.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct OperationStatistics {
+#[non_exhaustive]
+pub struct OperationStatistics {
     /// Number of spans recorded (distinct from the total iteration count).
-    pub(crate) span_count: u64,
+    pub span_count: u64,
 
     /// Through-origin OLS slope: the per-iteration processor time point estimate.
-    pub(crate) slope_nanos: f64,
+    pub slope_nanos: f64,
 
     /// Sample standard deviation of the per-iteration values across spans.
-    pub(crate) std_dev_nanos: f64,
+    pub std_dev_nanos: f64,
 
     /// Lower bound of the slope's bootstrap confidence interval.
-    pub(crate) interval_low_nanos: f64,
+    pub interval_low_nanos: f64,
 
     /// Upper bound of the slope's bootstrap confidence interval.
-    pub(crate) interval_high_nanos: f64,
+    pub interval_high_nanos: f64,
 
     /// Smallest per-iteration value observed across spans.
-    pub(crate) min_nanos: f64,
+    pub min_nanos: f64,
 
     /// Largest per-iteration value observed across spans.
-    pub(crate) max_nanos: f64,
+    pub max_nanos: f64,
 }
 
 /// Computes the dispersion statistics for a non-empty set of spans.
 ///
 /// Returns `None` when `spans` is empty, since an operation with no measured
-/// work has no statistics to report.
+/// work has no statistics to report. Delegates the estimation to the shared
+/// [`folo_utils::SpanStats`], then re-labels the unit-agnostic figures as
+/// nanoseconds.
 pub(crate) fn compute_statistics(spans: &[SpanRecord]) -> Option<OperationStatistics> {
-    if spans.is_empty() {
-        return None;
-    }
-
-    let slope_nanos = slope_nanos(spans);
-    let (interval_low_nanos, interval_high_nanos) = bootstrap_interval(spans);
-    let (min_nanos, max_nanos) = min_max(spans);
-
+    let owned: Vec<Span> = spans
+        .iter()
+        .map(|span| Span::new(span.iterations, span.total_nanos))
+        .collect();
+    let stats = SpanStats::from_spans(&owned)?;
     Some(OperationStatistics {
-        span_count: spans.len() as u64,
-        slope_nanos,
-        std_dev_nanos: std_dev_nanos(spans),
-        interval_low_nanos,
-        interval_high_nanos,
-        min_nanos,
-        max_nanos,
+        span_count: stats.span_count,
+        slope_nanos: stats.slope,
+        std_dev_nanos: stats.std_dev,
+        interval_low_nanos: stats.interval_low,
+        interval_high_nanos: stats.interval_high,
+        min_nanos: stats.min,
+        max_nanos: stats.max,
     })
-}
-
-/// Per-iteration value of a span: its total processor time divided by iterations.
-fn per_iteration_nanos(span: SpanRecord) -> f64 {
-    let iterations = span.iterations as f64;
-    if iterations == 0.0 {
-        0.0
-    } else {
-        span.total_nanos as f64 / iterations
-    }
-}
-
-/// Through-origin OLS slope `Σ(nᵢ·tᵢ) / Σ(nᵢ²)` over the spans.
-fn slope_nanos(spans: &[SpanRecord]) -> f64 {
-    let mut numerator = 0.0_f64;
-    let mut denominator = 0.0_f64;
-    for span in spans {
-        let iterations = span.iterations as f64;
-        let total = span.total_nanos as f64;
-        numerator += iterations * total;
-        denominator += iterations * iterations;
-    }
-
-    if denominator == 0.0 {
-        0.0
-    } else {
-        numerator / denominator
-    }
-}
-
-/// Sample standard deviation (Bessel-corrected) of the per-iteration values.
-///
-/// Returns zero for fewer than two spans, where dispersion is undefined.
-fn std_dev_nanos(spans: &[SpanRecord]) -> f64 {
-    let count = spans.len() as f64;
-    if count < 2.0 {
-        return 0.0;
-    }
-
-    let mut sum = 0.0_f64;
-    for span in spans {
-        sum += per_iteration_nanos(*span);
-    }
-    let mean = sum / count;
-
-    let mut sum_squared_deviation = 0.0_f64;
-    for span in spans {
-        let deviation = per_iteration_nanos(*span) - mean;
-        sum_squared_deviation += deviation * deviation;
-    }
-
-    (sum_squared_deviation / (count - 1.0)).sqrt()
-}
-
-/// Smallest and largest per-iteration values across the spans.
-fn min_max(spans: &[SpanRecord]) -> (f64, f64) {
-    let mut min = f64::INFINITY;
-    let mut max = f64::NEG_INFINITY;
-    for span in spans {
-        let value = per_iteration_nanos(*span);
-        min = min.min(value);
-        max = max.max(value);
-    }
-    (min, max)
-}
-
-/// Bootstrap percentile confidence interval of the slope.
-///
-/// Resamples the spans with replacement [`BOOTSTRAP_RESAMPLES`] times, recomputes
-/// the slope of each resample, and returns the lower and upper percentiles for
-/// [`CONFIDENCE_LEVEL`]. With a single span the interval collapses to the point
-/// estimate.
-fn bootstrap_interval(spans: &[SpanRecord]) -> (f64, f64) {
-    if spans.len() < 2 {
-        let slope = slope_nanos(spans);
-        return (slope, slope);
-    }
-
-    let count = spans.len();
-    let mut rng = SmallRng::seed_from_u64(BOOTSTRAP_SEED);
-    let mut slopes = Vec::with_capacity(BOOTSTRAP_RESAMPLES);
-
-    for _ in 0..BOOTSTRAP_RESAMPLES {
-        let mut numerator = 0.0_f64;
-        let mut denominator = 0.0_f64;
-        for _ in 0..count {
-            let index = rng.random_range(0..count);
-            let span = *spans
-                .get(index)
-                .expect("random_range yields an in-bounds index");
-            let iterations = span.iterations as f64;
-            let total = span.total_nanos as f64;
-            numerator += iterations * total;
-            denominator += iterations * iterations;
-        }
-        slopes.push(if denominator == 0.0 {
-            0.0
-        } else {
-            numerator / denominator
-        });
-    }
-
-    slopes.sort_unstable_by(f64::total_cmp);
-
-    let lower_fraction = (1.0 - CONFIDENCE_LEVEL) / 2.0;
-    let upper_fraction = 1.0 - lower_fraction;
-    (
-        percentile(&slopes, lower_fraction),
-        percentile(&slopes, upper_fraction),
-    )
-}
-
-/// Linearly interpolated percentile of a sorted slice (type-7 quantile).
-fn percentile(sorted: &[f64], fraction: f64) -> f64 {
-    match sorted {
-        [] => 0.0,
-        _ => {
-            let max_index = sorted.len().saturating_sub(1);
-            let rank = fraction * max_index as f64;
-            let lower_index = rank.floor() as usize;
-            let upper_index = lower_index.saturating_add(1).min(max_index);
-            let interpolation = rank - rank.floor();
-
-            let lower = *sorted
-                .get(lower_index)
-                .expect("lower index is clamped within bounds");
-            let upper = *sorted
-                .get(upper_index)
-                .expect("upper index is clamped within bounds");
-            lower + interpolation * (upper - lower)
-        }
-    }
 }
 
 #[cfg(test)]
@@ -260,87 +105,18 @@ mod tests {
     }
 
     #[test]
-    fn constant_iterations_make_slope_equal_the_mean() {
-        // Every span runs the same iteration count, so the slope degenerates to
-        // the plain per-iteration mean: (10 + 20 + 30) / 3 = 20.
+    fn maps_every_field_from_the_shared_estimator() {
+        // Per-iteration values 10, 20, 30 (constant single iterations): the slope
+        // degenerates to their mean 20, the standard deviation to 10, and the
+        // extremes to 10 and 30. This confirms the nanosecond re-labelling wires
+        // each shared field to the matching output.
         let spans = [span(1, 10), span(1, 20), span(1, 30)];
         let stats = compute_statistics(&spans).unwrap();
+        assert_eq!(stats.span_count, 3);
         assert_eq!(stats.slope_nanos, 20.0);
-    }
-
-    #[test]
-    fn slope_weights_spans_by_iteration_count() {
-        // Two spans on a perfectly linear series (5 ns/iter): the slope recovers
-        // exactly 5 regardless of the differing iteration counts.
-        let spans = [span(2, 10), span(8, 40)];
-        let stats = compute_statistics(&spans).unwrap();
-        assert_eq!(stats.slope_nanos, 5.0);
-    }
-
-    #[test]
-    fn low_iteration_outlier_barely_moves_the_slope() {
-        // A noisy single-iteration warm-up span (1000 ns) alongside many
-        // high-iteration spans at 5 ns/iter is down-weighted by iters², so the
-        // slope stays close to 5 rather than being dragged toward 1000.
-        let spans = [span(1, 1000), span(1000, 5000), span(1000, 5000)];
-        let stats = compute_statistics(&spans).unwrap();
-        assert!(
-            stats.slope_nanos < 6.0,
-            "slope should resist the warm-up outlier: {}",
-            stats.slope_nanos
-        );
-    }
-
-    #[test]
-    fn span_count_is_the_number_of_spans() {
-        let spans = [span(1, 10), span(1, 20), span(1, 30), span(1, 40)];
-        let stats = compute_statistics(&spans).unwrap();
-        assert_eq!(stats.span_count, 4);
-    }
-
-    #[test]
-    fn standard_deviation_of_a_single_span_is_zero() {
-        let stats = compute_statistics(&[span(1, 42)]).unwrap();
-        assert_eq!(stats.std_dev_nanos, 0.0);
-    }
-
-    #[test]
-    fn standard_deviation_matches_a_hand_computed_value() {
-        // Per-iteration values 10, 20, 30: mean 20, variance (100+0+100)/2 = 100,
-        // standard deviation 10.
-        let spans = [span(1, 10), span(1, 20), span(1, 30)];
-        let stats = compute_statistics(&spans).unwrap();
         assert_eq!(stats.std_dev_nanos, 10.0);
-    }
-
-    #[test]
-    fn min_and_max_track_the_per_iteration_extremes() {
-        let spans = [span(2, 20), span(1, 5), span(4, 200)];
-        // Per-iteration values: 10, 5, 50.
-        let stats = compute_statistics(&spans).unwrap();
-        assert_eq!(stats.min_nanos, 5.0);
-        assert_eq!(stats.max_nanos, 50.0);
-    }
-
-    #[test]
-    fn single_span_interval_collapses_to_the_point_estimate() {
-        let stats = compute_statistics(&[span(4, 80)]).unwrap();
-        assert_eq!(stats.slope_nanos, 20.0);
-        assert_eq!(stats.interval_low_nanos, 20.0);
-        assert_eq!(stats.interval_high_nanos, 20.0);
-    }
-
-    #[test]
-    fn interval_brackets_the_point_estimate() {
-        let spans = [
-            span(1, 18),
-            span(1, 20),
-            span(1, 22),
-            span(1, 19),
-            span(1, 21),
-            span(1, 20),
-        ];
-        let stats = compute_statistics(&spans).unwrap();
+        assert_eq!(stats.min_nanos, 10.0);
+        assert_eq!(stats.max_nanos, 30.0);
         assert!(
             stats.interval_low_nanos <= stats.slope_nanos
                 && stats.slope_nanos <= stats.interval_high_nanos,
@@ -352,138 +128,20 @@ mod tests {
     }
 
     #[test]
-    fn wider_spread_yields_a_wider_interval() {
-        let tight = [
-            span(1, 19),
-            span(1, 20),
-            span(1, 21),
-            span(1, 20),
-            span(1, 19),
-            span(1, 21),
-        ];
-        let wide = [
-            span(1, 5),
-            span(1, 20),
-            span(1, 35),
-            span(1, 8),
-            span(1, 32),
-            span(1, 20),
-        ];
-
-        let tight_stats = compute_statistics(&tight).unwrap();
-        let wide_stats = compute_statistics(&wide).unwrap();
-
-        let tight_width = tight_stats.interval_high_nanos - tight_stats.interval_low_nanos;
-        let wide_width = wide_stats.interval_high_nanos - wide_stats.interval_low_nanos;
-        assert!(
-            wide_width > tight_width,
-            "wide interval ({wide_width}) should exceed tight interval ({tight_width})"
-        );
-    }
-
-    #[test]
-    fn bootstrap_is_deterministic_across_runs() {
-        let spans = [
-            span(1, 18),
-            span(1, 20),
-            span(1, 22),
-            span(1, 19),
-            span(1, 21),
-        ];
-        let first = compute_statistics(&spans).unwrap();
-        let second = compute_statistics(&spans).unwrap();
-        assert_eq!(first.interval_low_nanos, second.interval_low_nanos);
-        assert_eq!(first.interval_high_nanos, second.interval_high_nanos);
-    }
-
-    #[test]
-    fn two_spans_have_a_bessel_corrected_standard_deviation() {
-        // Two spans is the smallest sample with defined dispersion: per-iteration
-        // values 10 and 30, mean 20, sum of squared deviations 200, divided by the
-        // Bessel-corrected (n - 1 = 1) denominator, square-rooted.
-        let stats = compute_statistics(&[span(1, 10), span(1, 30)]).unwrap();
-        assert_eq!(stats.std_dev_nanos, 200.0_f64.sqrt());
-    }
-
-    #[test]
-    fn two_distinct_spans_widen_the_interval_beyond_the_point() {
-        // With two differing spans the bootstrap resamples take three values
-        // (both-low, mixed, both-high), so the interval spans a real range rather
-        // than collapsing to the point estimate.
-        let stats = compute_statistics(&[span(1, 10), span(1, 30)]).unwrap();
-        assert!(
-            stats.interval_low_nanos < stats.interval_high_nanos,
-            "interval [{}, {}] should be non-degenerate",
-            stats.interval_low_nanos,
-            stats.interval_high_nanos
-        );
-    }
-
-    #[test]
-    fn identical_multi_iteration_spans_collapse_to_the_true_slope() {
-        // Two identical spans (2 iterations, 80 ns total → 40 ns/iter) enter the
-        // bootstrap loop, but every resample is identical, so the interval
-        // collapses onto the true slope. The differing-from-one iteration count
-        // makes the resampled slope sensitive to the weighting arithmetic.
-        let stats = compute_statistics(&[span(2, 80), span(2, 80)]).unwrap();
-        assert_eq!(stats.slope_nanos, 40.0);
-        assert_eq!(stats.interval_low_nanos, 40.0);
-        assert_eq!(stats.interval_high_nanos, 40.0);
-    }
-
-    #[test]
-    fn bootstrap_interval_uses_the_two_and_a_half_percent_tails() {
-        // A deterministic six-span fixture pins the exact 2.5%/97.5% bootstrap
-        // bounds. Shifting the tail fractions (e.g. to 5%/95%) would land the
-        // percentiles on different resampled slopes, changing these values.
-        let spans = [
-            span(1, 10),
-            span(1, 14),
-            span(1, 18),
-            span(1, 22),
-            span(1, 26),
-            span(1, 30),
-        ];
+    fn slope_weights_spans_by_iteration_count() {
+        // Two spans on a perfectly linear series (5 ns/iter): the slope recovers
+        // exactly 5 regardless of the differing iteration counts, so the
+        // weighting survives the mapping.
+        let spans = [span(2, 10), span(8, 40)];
         let stats = compute_statistics(&spans).unwrap();
-        assert_eq!(stats.interval_low_nanos, 14.666_666_666_666_666);
-        assert_eq!(stats.interval_high_nanos, 25.333_333_333_333_332);
+        assert_eq!(stats.slope_nanos, 5.0);
     }
 
     #[test]
-    fn percentile_of_an_empty_slice_is_zero() {
-        assert_eq!(percentile(&[], 0.5), 0.0);
-    }
-
-    #[test]
-    fn percentile_interpolates_between_neighbors() {
-        // fraction 0.625 over five points (max index 4) gives rank 2.5: halfway
-        // between sorted[2] = 30 and sorted[3] = 40, i.e. 35.
-        let sorted = [10.0, 20.0, 30.0, 40.0, 50.0];
-        assert_eq!(percentile(&sorted, 0.625), 35.0);
-    }
-
-    #[test]
-    fn per_iteration_value_of_a_zero_iteration_span_is_zero() {
-        // A span recording zero iterations cannot be divided by its count, so its
-        // per-iteration value degrades to zero rather than producing NaN.
-        assert_eq!(per_iteration_nanos(span(0, 1000)), 0.0);
-    }
-
-    #[test]
-    fn slope_of_zero_iteration_spans_is_zero() {
-        // With every span at zero iterations the weighted denominator Σ(nᵢ²) is
-        // zero, so the slope collapses to zero instead of dividing by zero.
-        assert_eq!(slope_nanos(&[span(0, 1000), span(0, 2000)]), 0.0);
-    }
-
-    #[test]
-    fn bootstrap_interval_of_zero_iteration_spans_is_zero() {
-        // Two zero-iteration spans clear the `< 2` early return and enter the
-        // resample loop, where every resample's denominator Σ(nᵢ²) is zero, so each
-        // resampled slope — and thus both interval bounds — is zero.
-        assert_eq!(
-            bootstrap_interval(&[span(0, 100), span(0, 200)]),
-            (0.0, 0.0)
-        );
+    fn single_span_interval_collapses_to_the_point_estimate() {
+        let stats = compute_statistics(&[span(4, 80)]).unwrap();
+        assert_eq!(stats.slope_nanos, 20.0);
+        assert_eq!(stats.interval_low_nanos, 20.0);
+        assert_eq!(stats.interval_high_nanos, 20.0);
     }
 }

--- a/packages/all_the_time/src/statistics.rs
+++ b/packages/all_the_time/src/statistics.rs
@@ -12,6 +12,8 @@
 //! All work here runs once, when a [`Report`](crate::Report) is materialized for
 //! output — never inside a measured span.
 
+use std::time::Duration;
+
 use folo_utils::{Span, SpanStats};
 
 /// One recorded span: the processor time a single measured span consumed and the
@@ -30,8 +32,13 @@ pub(crate) struct SpanRecord {
 
 /// Dispersion statistics for one operation, derived from its spans.
 ///
-/// A nanosecond-typed view of [`folo_utils::SpanStats`]: every value is a
-/// per-iteration processor time in nanoseconds. Exposed publicly through
+/// Every value is a per-iteration processor time in nanoseconds. Processor time
+/// is not deterministic — it jitters run to run with system load and scheduling,
+/// and the raw pooled mean silently folds warmup and one-off costs into the
+/// per-iteration figure — so the point estimate is a warmup-robust through-origin
+/// slope and the interval is a bootstrap confidence interval of that slope. When
+/// every span recorded the same per-iteration value the interval collapses onto
+/// the point estimate. Exposed through
 /// [`ReportOperation::statistics`](crate::ReportOperation::statistics) so callers
 /// can consume the same dispersion the JSON output records.
 #[derive(Clone, Copy, Debug)]
@@ -80,6 +87,15 @@ pub(crate) fn compute_statistics(spans: &[SpanRecord]) -> Option<OperationStatis
         min_nanos: stats.min,
         max_nanos: stats.max,
     })
+}
+
+/// Converts a per-iteration processor-time figure in nanoseconds to a `Duration`
+/// for human-readable rendering.
+///
+/// Tiny negative fits — possible from the bootstrap on near-zero data — are
+/// clamped to zero so the formatter never panics on a negative input.
+pub(crate) fn nanos_to_duration(nanos: f64) -> Duration {
+    Duration::from_secs_f64(nanos.max(0.0) / 1_000_000_000.0)
 }
 
 #[cfg(test)]

--- a/packages/all_the_time/src/statistics.rs
+++ b/packages/all_the_time/src/statistics.rs
@@ -89,6 +89,20 @@ pub(crate) fn compute_statistics(spans: &[SpanRecord]) -> Option<OperationStatis
     })
 }
 
+/// Computes just the warmup-robust per-iteration slope in nanoseconds, or `None`
+/// when `spans` is empty.
+///
+/// The cheap counterpart to [`compute_statistics`] for the console summary, which
+/// shows only the slope: it skips the bootstrap confidence-interval resampling
+/// that dominates the full computation.
+pub(crate) fn compute_slope_nanos(spans: &[SpanRecord]) -> Option<f64> {
+    let owned: Vec<Span> = spans
+        .iter()
+        .map(|span| Span::new(span.iterations, span.total_nanos))
+        .collect();
+    folo_utils::slope_of(&owned)
+}
+
 /// Converts a per-iteration processor-time figure in nanoseconds to a `Duration`
 /// for human-readable rendering.
 ///

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -42,11 +42,11 @@
 //! span's total against its iteration count, which recovers the marginal
 //! per-iteration cost even when the blend of warm-up and steady-state spans
 //! shifts. Each figure is paired with a bootstrap 95% confidence interval so its
-//! run-to-run uncertainty is shown rather than implied (it collapses to a point
-//! when every iteration allocates identically). The stdout summary and the JSON
-//! output both lead with the slope and interval; the pooled means stay available
-//! through [`Operation::mean`] and the report accessors for callers that still
-//! want them.
+//! run-to-run uncertainty can be inspected (it collapses to a point when every
+//! iteration allocates identically). The stdout summary leads with the slopes
+//! alone for readability; the JSON output records the slopes together with their
+//! confidence intervals, and the pooled means stay available through
+//! [`Operation::mean`] and the report accessors for callers that still want them.
 //!
 //! # Features
 #![cfg_attr(
@@ -93,7 +93,8 @@
 //! both bytes and allocation count, the warmup-robust slope point estimate, a 95%
 //! bootstrap confidence interval, the standard deviation, the observed minimum and
 //! maximum, and the pooled mean. A human-readable summary leading with the same
-//! slope and interval (see "Primary metric") is also printed to stdout.
+//! slopes (see "Primary metric"), without the intervals, is also printed to
+//! stdout.
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
 //! to create a session and record work.

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -13,7 +13,7 @@
 //! - [`Report`] - Thread-safe memory allocation statistics that can be merged and processed independently
 //! - [`ProcessSpan`] - Tracks process-wide memory allocation changes over a time period
 //! - [`ThreadSpan`] - Tracks thread-local memory allocation changes over a time period
-//! - [`Operation`] - Calculates mean memory allocation per operation
+//! - [`Operation`] - Measures per-iteration memory allocation of a repeated operation
 //!
 //! Additionally, when the `panic_on_next_alloc` feature is enabled:
 #![cfg_attr(
@@ -26,6 +26,27 @@
 )]
 //!
 //! This package is not meant for use in production, serving only as a development tool.
+//!
+//! # Primary metric
+//!
+//! Allocation counts are not deterministic across benchmark runs. Even when the
+//! code under test allocates by a fixed rule, the first iterations pay one-off
+//! costs (lazily initialized caches, growing a buffer to its steady-state
+//! capacity) that later iterations do not, and Criterion decides how many
+//! iterations to run and how many to discard as warm-up. A raw pooled **mean**
+//! therefore folds those one-off allocations into the per-iteration figure and
+//! drifts as that sample mix changes between runs.
+//!
+//! The headline metric for both bytes and allocation count is instead the
+//! **warmup-robust slope**: an iterations-weighted, through-origin fit of each
+//! span's total against its iteration count, which recovers the marginal
+//! per-iteration cost even when the blend of warm-up and steady-state spans
+//! shifts. Each figure is paired with a bootstrap 95% confidence interval so its
+//! run-to-run uncertainty is shown rather than implied (it collapses to a point
+//! when every iteration allocates identically). The stdout summary and the JSON
+//! output both lead with the slope and interval; the pooled means stay available
+//! through [`Operation::mean`] and the report accessors for callers that still
+//! want them.
 //!
 //! # Features
 #![cfg_attr(
@@ -68,13 +89,16 @@
 //!
 //! Dropping a [`Session`] writes machine-readable JSON files (one per operation)
 //! into the Cargo target directory at `target/alloc_tracker/<operation>.json`,
-//! with operation names sanitized to be filesystem-safe. A human-readable
-//! summary is also printed to stdout.
+//! with operation names sanitized to be filesystem-safe. Each file records, for
+//! both bytes and allocation count, the warmup-robust slope point estimate, a 95%
+//! bootstrap confidence interval, the standard deviation, the observed minimum and
+//! maximum, and the pooled mean. A human-readable summary leading with the same
+//! slope and interval (see "Primary metric") is also printed to stdout.
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
 //! to create a session and record work.
 //!
-//! # Tracking mean allocations
+//! # Tracking allocations per iteration
 //!
 //! For benchmarking scenarios, where you run multiple iterations of an operation, use [`Operation`]:
 //!
@@ -88,7 +112,8 @@
 //!     let session = Session::new();
 //! #   let session = session.no_stdout().no_file();
 //!
-//!     // Track mean over multiple operations (batched for efficiency)
+//!     // Record multiple iterations (batched for efficiency) so the
+//!     // per-iteration slope can separate steady-state cost from warm-up.
 //!     {
 //!         let mut string_op = session.operation("string_allocations");
 //!         let _span = string_op.measure_process().iterations(10);

--- a/packages/alloc_tracker/src/operation.rs
+++ b/packages/alloc_tracker/src/operation.rs
@@ -186,13 +186,9 @@ impl fmt::Display for Operation {
         match (metrics.bytes_stats(), metrics.allocations_stats()) {
             (Some(bytes), Some(allocations)) => write!(
                 f,
-                "{} bytes/iter [{}, {}], {} allocations/iter [{}, {}]",
+                "{} bytes/iter, {} allocations/iter",
                 format_count(bytes.slope),
-                format_count(bytes.interval_low),
-                format_count(bytes.interval_high),
                 format_count(allocations.slope),
-                format_count(allocations.interval_low),
-                format_count(allocations.interval_high),
             ),
             _ => write!(f, "no measurements"),
         }
@@ -386,17 +382,21 @@ mod tests {
         assert!(!report.is_empty());
 
         // Verify the session shows the data was merged. A single span of 100
-        // bytes/iter over 5 iterations yields a slope of 100 with the interval
-        // collapsed onto it; the two allocations/iter behave the same way.
+        // bytes/iter over 5 iterations yields a slope of 100; the two
+        // allocations/iter behave the same way. The stdout table shows the slope
+        // only (no interval).
+        let report = session.to_report();
+        let (_, op) = report.operations().next().expect("one operation");
+        let stats = op.statistics().expect("operation has spans");
         let session_display = format!("{session}");
         println!("Actual session display: '{session_display}'");
         assert!(
-            session_display.contains("100 [100, 100]"),
-            "got {session_display}"
+            session_display.contains(&format_count(stats.bytes.slope)),
+            "table should show the byte slope: got {session_display}"
         );
         assert!(
-            session_display.contains("2 [2, 2]"),
-            "got {session_display}"
+            session_display.contains(&format_count(stats.allocations.slope)),
+            "table should show the allocation slope: got {session_display}"
         );
     }
 

--- a/packages/alloc_tracker/src/operation.rs
+++ b/packages/alloc_tracker/src/operation.rs
@@ -1,17 +1,19 @@
-//! Mean allocation tracking.
+//! Per-iteration allocation tracking.
 
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
+use crate::report::format_count;
 use crate::{ERR_POISONED_LOCK, OperationMetrics, ProcessSpan, ThreadSpan};
 
-/// A measurement handle for tracking mean memory allocation per operation across multiple iterations.
+/// A measurement handle for tracking per-iteration memory allocation of a repeated operation.
 ///
 /// This utility is particularly useful for benchmarking scenarios where you want
-/// to understand the mean memory footprint and allocation behavior of repeated operations.
-/// It tracks both the number of bytes allocated and the count of allocations.
-/// Operations share data with their parent session via reference counting, and data is
-/// merged when the operation is dropped.
+/// to understand the memory footprint and allocation behavior of repeated operations.
+/// It tracks both the number of bytes allocated and the count of allocations. The
+/// headline figures are warmup-robust per-iteration slopes (see the crate-level
+/// "Primary metric" documentation), with the pooled [`mean`](Self::mean) still
+/// available.
 ///
 /// Multiple operations with the same name can be created concurrently.
 ///
@@ -180,7 +182,20 @@ impl Operation {
 
 impl fmt::Display for Operation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} bytes (mean)", self.mean())
+        let metrics = self.metrics.lock().expect(ERR_POISONED_LOCK);
+        match (metrics.bytes_stats(), metrics.allocations_stats()) {
+            (Some(bytes), Some(allocations)) => write!(
+                f,
+                "{} bytes/iter [{}, {}], {} allocations/iter [{}, {}]",
+                format_count(bytes.slope),
+                format_count(bytes.interval_low),
+                format_count(bytes.interval_high),
+                format_count(allocations.slope),
+                format_count(allocations.interval_low),
+                format_count(allocations.interval_high),
+            ),
+            _ => write!(f, "no measurements"),
+        }
     }
 }
 
@@ -370,10 +385,19 @@ mod tests {
         let report = session.to_report();
         assert!(!report.is_empty());
 
-        // Verify the session shows the data was merged
+        // Verify the session shows the data was merged. A single span of 100
+        // bytes/iter over 5 iterations yields a slope of 100 with the interval
+        // collapsed onto it; the two allocations/iter behave the same way.
         let session_display = format!("{session}");
         println!("Actual session display: '{session_display}'");
-        assert!(session_display.contains("| test      |        100 |          2 |")); // 500 bytes / 5 iterations = 100, 10 allocations / 5 iterations = 2
+        assert!(
+            session_display.contains("100 [100, 100]"),
+            "got {session_display}"
+        );
+        assert!(
+            session_display.contains("2 [2, 2]"),
+            "got {session_display}"
+        );
     }
 
     #[test]
@@ -399,9 +423,12 @@ mod tests {
         drop(op1);
         drop(op2);
 
-        // Session should show merged results: 800 bytes, 5 iterations = 160 bytes mean, 8 allocations / 5 iterations = 1.6 ≈ 1 (integer division)
+        // Session should show merged results. The iterations²-weighted
+        // through-origin slope over spans (200 bytes / 2 iters) and (600 bytes /
+        // 3 iters) is (2·200 + 3·600) / (2² + 3²) = 2200 / 13 ≈ 169.23 bytes/iter,
+        // which differs from the pooled mean of 160.
         let session_display = format!("{session}");
-        assert!(session_display.contains("| test      |        160 |          1 |"));
+        assert!(session_display.contains("169.23"), "got {session_display}");
     }
 
     static_assertions::assert_impl_all!(Operation: Send, Sync);
@@ -410,18 +437,21 @@ mod tests {
     );
 
     #[test]
-    fn operation_display_shows_mean_bytes() {
+    fn operation_display_shows_robust_per_iteration_estimate() {
         let operation = create_test_operation();
 
-        // Add some data to have a non-zero mean.
+        // Add some data to have a non-zero slope.
         // add_iterations(bytes_delta, count_delta, iterations) means bytes_delta * iterations total bytes.
         {
             let mut metrics = operation.metrics.lock().unwrap();
-            metrics.add_iterations(250, 5, 2); // 250 * 2 = 500 total bytes / 2 = 250 mean
+            metrics.add_iterations(250, 5, 2); // Single span → slope of 250 bytes/iter.
         }
 
         let display_output = operation.to_string();
-        assert!(display_output.contains("bytes (mean)"));
-        assert!(display_output.contains("250")); // 500 / 2 = 250 mean bytes
+        assert!(
+            display_output.contains("bytes/iter"),
+            "got {display_output}"
+        );
+        assert!(display_output.contains("250"), "got {display_output}");
     }
 }

--- a/packages/alloc_tracker/src/operation.rs
+++ b/packages/alloc_tracker/src/operation.rs
@@ -182,13 +182,15 @@ impl Operation {
 
 impl fmt::Display for Operation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The summary shows only the slopes, so take the cheap slope-only path and
+        // skip the bootstrap confidence intervals the full statistics would resample.
         let metrics = self.metrics.lock().expect(ERR_POISONED_LOCK);
-        match (metrics.bytes_stats(), metrics.allocations_stats()) {
+        match (metrics.bytes_slope(), metrics.allocations_slope()) {
             (Some(bytes), Some(allocations)) => write!(
                 f,
                 "{} bytes/iter, {} allocations/iter",
-                format_count(bytes.slope),
-                format_count(allocations.slope),
+                format_count(bytes),
+                format_count(allocations),
             ),
             _ => write!(f, "no measurements"),
         }

--- a/packages/alloc_tracker/src/operation.rs
+++ b/packages/alloc_tracker/src/operation.rs
@@ -153,13 +153,13 @@ impl Operation {
 
     /// Calculates the mean bytes allocated per iteration.
     ///
-    /// Returns 0 if no iterations have been recorded.
+    /// Returns 0 if no iterations have been recorded. This is the pooled mean
+    /// across all recorded spans; the warmup-robust slope and its dispersion are
+    /// available on [`ReportOperation`](crate::ReportOperation) via a report.
     #[must_use]
     pub fn mean(&self) -> u64 {
         let data = self.metrics.lock().expect(ERR_POISONED_LOCK);
-        data.total_bytes_allocated
-            .checked_div(data.total_iterations)
-            .unwrap_or(0)
+        data.mean_bytes()
     }
 
     /// Returns the total number of iterations recorded.
@@ -167,14 +167,14 @@ impl Operation {
     #[cfg(test)]
     fn total_iterations(&self) -> u64 {
         let data = self.metrics.lock().unwrap();
-        data.total_iterations
+        data.total_iterations()
     }
 
     /// Returns the total bytes allocated across all iterations.
     #[must_use]
     pub fn total_bytes_allocated(&self) -> u64 {
         let data = self.metrics.lock().expect(ERR_POISONED_LOCK);
-        data.total_bytes_allocated
+        data.total_bytes_allocated()
     }
 }
 

--- a/packages/alloc_tracker/src/operation.rs
+++ b/packages/alloc_tracker/src/operation.rs
@@ -454,4 +454,12 @@ mod tests {
         );
         assert!(display_output.contains("250"), "got {display_output}");
     }
+
+    #[test]
+    fn operation_display_reports_no_measurements_when_empty() {
+        // An operation with no recorded spans has no dispersion statistics, so its
+        // Display takes the "no measurements" leg.
+        let operation = create_test_operation();
+        assert_eq!(operation.to_string(), "no measurements");
+    }
 }

--- a/packages/alloc_tracker/src/operation_metrics.rs
+++ b/packages/alloc_tracker/src/operation_metrics.rs
@@ -14,8 +14,12 @@ use folo_utils::{Span, SpanStats};
 ///
 /// Sized to cover Criterion's default sample count (100) plus its warm-up calls
 /// with headroom, so that recording a span is an allocation-free push in the
-/// common case. The buffer is allocated once, when the operation is created,
-/// keeping the measured region free of tracker-induced allocations.
+/// common case. A benchmark configured with a larger `sample_size` eventually
+/// exceeds this and the next push grows the buffer. That growth allocation does
+/// not contaminate the measurement: a span records itself from `Drop`, after it
+/// has already captured its allocation delta and before the next span starts, so
+/// the reallocation falls between measured spans and is attributed to none of
+/// them.
 const DEFAULT_SPAN_CAPACITY: usize = 256;
 
 /// One recorded span: the whole-span byte and allocation-count deltas and the

--- a/packages/alloc_tracker/src/operation_metrics.rs
+++ b/packages/alloc_tracker/src/operation_metrics.rs
@@ -159,6 +159,35 @@ impl OperationMetrics {
         SpanStats::from_spans(&spans)
     }
 
+    /// The warmup-robust per-iteration byte slope, or `None` when no spans were
+    /// recorded.
+    ///
+    /// The cheap path for the console summary: it computes only the headline
+    /// slope, skipping the bootstrap confidence interval that
+    /// [`bytes_stats`](Self::bytes_stats) resamples.
+    pub(crate) fn bytes_slope(&self) -> Option<f64> {
+        let spans: Vec<Span> = self
+            .spans
+            .iter()
+            .map(|span| Span::new(span.iterations, span.bytes))
+            .collect();
+        folo_utils::slope_of(&spans)
+    }
+
+    /// The warmup-robust per-iteration allocation-count slope, or `None` when no
+    /// spans were recorded.
+    ///
+    /// The cheap counterpart to [`allocations_stats`](Self::allocations_stats),
+    /// skipping the bootstrap resampling for the console summary.
+    pub(crate) fn allocations_slope(&self) -> Option<f64> {
+        let spans: Vec<Span> = self
+            .spans
+            .iter()
+            .map(|span| Span::new(span.iterations, span.count))
+            .collect();
+        folo_utils::slope_of(&spans)
+    }
+
     /// Appends another operation's spans onto this one.
     pub(crate) fn extend_from(&mut self, other: &Self) {
         self.spans.extend_from_slice(&other.spans);

--- a/packages/alloc_tracker/src/operation_metrics.rs
+++ b/packages/alloc_tracker/src/operation_metrics.rs
@@ -1,44 +1,163 @@
+//! Per-operation allocation metrics, retained as raw spans.
+//!
+//! Every measured span contributes one [`SpanRecord`] carrying the whole-span
+//! byte and allocation-count deltas together with the iteration count it covered.
+//! Retaining the raw spans (rather than collapsing them into running totals) lets
+//! the report derive both the headline pooled means and the warmup-robust
+//! dispersion statistics the history tool consumes — allocation figures are not
+//! deterministic, since first-run allocations and buffer resizing jitter around
+//! the mean over a Criterion-chosen iteration count.
+
+use folo_utils::{Span, SpanStats};
+
+/// Initial capacity reserved for an operation's span buffer.
+///
+/// Sized to cover Criterion's default sample count (100) plus its warm-up calls
+/// with headroom, so that recording a span is an allocation-free push in the
+/// common case. The buffer is allocated once, when the operation is created,
+/// keeping the measured region free of tracker-induced allocations.
+const DEFAULT_SPAN_CAPACITY: usize = 256;
+
+/// One recorded span: the whole-span byte and allocation-count deltas and the
+/// number of iterations they covered.
+///
+/// The raw whole-span totals are retained (not pre-divided per iteration) so that
+/// the slope regression can weight each span by its iteration count.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpanRecord {
+    /// Iterations the span measured.
+    pub(crate) iterations: u64,
+
+    /// Total bytes allocated during the span.
+    pub(crate) bytes: u64,
+
+    /// Total number of allocations during the span.
+    pub(crate) count: u64,
+}
+
 /// Metrics tracked for each operation in the session.
-#[derive(Clone, Debug, Default)]
-#[expect(
-    clippy::struct_field_names,
-    reason = "field names are descriptive and clear"
-)]
+///
+/// Every measured span contributes one [`SpanRecord`]. The pooled means are
+/// derived from the summed totals; the dispersion statistics are derived from the
+/// per-span population via the shared [`folo_utils::SpanStats`] estimator.
+#[derive(Clone, Debug)]
 pub(crate) struct OperationMetrics {
-    pub(crate) total_bytes_allocated: u64,
-    pub(crate) total_allocations_count: u64,
-    pub(crate) total_iterations: u64,
+    spans: Vec<SpanRecord>,
+}
+
+impl Default for OperationMetrics {
+    fn default() -> Self {
+        Self {
+            spans: Vec::with_capacity(DEFAULT_SPAN_CAPACITY),
+        }
+    }
 }
 
 impl OperationMetrics {
-    /// Adds multiple iterations of the same allocation to the metrics.
+    /// Records one span covering `iterations` iterations that allocated `bytes`
+    /// bytes across `count` allocations in total.
+    pub(crate) fn add_span(&mut self, iterations: u64, bytes: u64, count: u64) {
+        self.spans.push(SpanRecord {
+            iterations,
+            bytes,
+            count,
+        });
+    }
+
+    /// Records one span by its per-iteration deltas and iteration count.
     ///
-    /// This is a more efficient version of calling individual add operations multiple times with the same delta.
-    /// This method is used by operation and span types when they measure multiple iterations.
+    /// A convenience over [`add_span`](Self::add_span) used where per-iteration
+    /// figures are already known; the whole-span totals are reconstituted by
+    /// multiplying back out.
+    #[cfg(test)]
     pub(crate) fn add_iterations(&mut self, bytes_delta: u64, count_delta: u64, iterations: u64) {
-        let total_bytes = bytes_delta
+        let bytes = bytes_delta
             .checked_mul(iterations)
             .expect("bytes * iterations overflows u64 - this indicates an unrealistic scenario");
-
-        let total_count = count_delta
+        let count = count_delta
             .checked_mul(iterations)
             .expect("count * iterations overflows u64 - this indicates an unrealistic scenario");
+        self.add_span(iterations, bytes, count);
+    }
 
-        self.total_bytes_allocated = self
-            .total_bytes_allocated
-            .checked_add(total_bytes)
-            .expect("total bytes allocated overflows u64 - this indicates an unrealistic scenario");
+    /// Number of spans recorded (distinct from the total iteration count).
+    #[cfg(test)]
+    pub(crate) fn span_count(&self) -> u64 {
+        self.spans.len() as u64
+    }
 
-        self.total_allocations_count = self
-            .total_allocations_count
-            .checked_add(total_count)
-            .expect(
-                "total allocations count overflows u64 - this indicates an unrealistic scenario",
-            );
+    /// Total iterations across all recorded spans.
+    pub(crate) fn total_iterations(&self) -> u64 {
+        self.spans.iter().fold(0_u64, |sum, span| {
+            sum.checked_add(span.iterations)
+                .expect("total iterations overflows u64 - this indicates an unrealistic scenario")
+        })
+    }
 
-        self.total_iterations = self.total_iterations.checked_add(iterations).expect(
-            "total iterations count overflows u64 - this indicates an unrealistic scenario",
-        );
+    /// Total bytes allocated across all recorded spans.
+    pub(crate) fn total_bytes_allocated(&self) -> u64 {
+        self.spans.iter().fold(0_u64, |sum, span| {
+            sum.checked_add(span.bytes)
+                .expect("total bytes overflows u64 - this indicates an unrealistic scenario")
+        })
+    }
+
+    /// Total number of allocations across all recorded spans.
+    pub(crate) fn total_allocations_count(&self) -> u64 {
+        self.spans.iter().fold(0_u64, |sum, span| {
+            sum.checked_add(span.count)
+                .expect("total allocations overflows u64 - this indicates an unrealistic scenario")
+        })
+    }
+
+    /// Mean bytes allocated per iteration, pooled across all spans.
+    ///
+    /// Returns zero when no iterations were recorded.
+    pub(crate) fn mean_bytes(&self) -> u64 {
+        self.total_bytes_allocated()
+            .checked_div(self.total_iterations())
+            .unwrap_or(0)
+    }
+
+    /// Mean number of allocations per iteration, pooled across all spans.
+    ///
+    /// Returns zero when no iterations were recorded.
+    pub(crate) fn mean_allocations(&self) -> u64 {
+        self.total_allocations_count()
+            .checked_div(self.total_iterations())
+            .unwrap_or(0)
+    }
+
+    /// Whether the operation recorded any measurable work.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.total_iterations() == 0
+    }
+
+    /// Dispersion statistics of the per-iteration byte counts across spans, or
+    /// `None` when no spans were recorded.
+    pub(crate) fn bytes_stats(&self) -> Option<SpanStats> {
+        let spans: Vec<Span> = self
+            .spans
+            .iter()
+            .map(|span| Span::new(span.iterations, span.bytes))
+            .collect();
+        SpanStats::from_spans(&spans)
+    }
+
+    /// Dispersion statistics of the per-iteration allocation counts across spans,
+    /// or `None` when no spans were recorded.
+    pub(crate) fn allocations_stats(&self) -> Option<SpanStats> {
+        let spans: Vec<Span> = self
+            .spans
+            .iter()
+            .map(|span| Span::new(span.iterations, span.count))
+            .collect();
+        SpanStats::from_spans(&spans)
+    }
+
+    /// Appends another operation's spans onto this one.
+    pub(crate) fn extend_from(&mut self, other: &Self) {
+        self.spans.extend_from_slice(&other.spans);
     }
 }
 
@@ -48,51 +167,129 @@ mod tests {
     use super::*;
 
     #[test]
-    fn operation_metrics_default_values() {
+    fn default_has_no_spans() {
         let metrics = OperationMetrics::default();
-        assert_eq!(metrics.total_bytes_allocated, 0);
-        assert_eq!(metrics.total_allocations_count, 0);
-        assert_eq!(metrics.total_iterations, 0);
+        assert_eq!(metrics.total_bytes_allocated(), 0);
+        assert_eq!(metrics.total_allocations_count(), 0);
+        assert_eq!(metrics.total_iterations(), 0);
+        assert_eq!(metrics.span_count(), 0);
+        assert!(metrics.is_empty());
     }
 
     #[test]
-    fn operation_metrics_add_iterations_basic() {
+    fn default_preallocates_the_span_buffer() {
+        // The buffer is reserved up front so that recording spans does not
+        // allocate while the reserved capacity holds.
+        let metrics = OperationMetrics::default();
+        assert!(metrics.spans.capacity() >= DEFAULT_SPAN_CAPACITY);
+    }
+
+    #[test]
+    fn recording_within_capacity_does_not_reallocate() {
+        let mut metrics = OperationMetrics::default();
+        let capacity_before = metrics.spans.capacity();
+        for index in 0..DEFAULT_SPAN_CAPACITY {
+            metrics.add_span(1, index as u64, 1);
+        }
+        assert_eq!(metrics.spans.capacity(), capacity_before);
+    }
+
+    #[test]
+    fn add_iterations_basic() {
         let mut metrics = OperationMetrics::default();
         metrics.add_iterations(100, 5, 5);
 
-        assert_eq!(metrics.total_iterations, 5);
-        assert_eq!(metrics.total_bytes_allocated, 500);
-        assert_eq!(metrics.total_allocations_count, 25);
+        assert_eq!(metrics.total_iterations(), 5);
+        assert_eq!(metrics.span_count(), 1);
+        assert_eq!(metrics.total_bytes_allocated(), 500);
+        assert_eq!(metrics.total_allocations_count(), 25);
     }
 
     #[test]
-    fn operation_metrics_add_iterations_zero_iterations() {
+    fn add_iterations_zero_iterations() {
         let mut metrics = OperationMetrics::default();
         metrics.add_iterations(100, 2, 0);
 
-        assert_eq!(metrics.total_iterations, 0);
-        assert_eq!(metrics.total_bytes_allocated, 0);
-        assert_eq!(metrics.total_allocations_count, 0);
+        assert_eq!(metrics.total_iterations(), 0);
+        assert_eq!(metrics.total_bytes_allocated(), 0);
+        assert_eq!(metrics.total_allocations_count(), 0);
     }
 
     #[test]
-    fn operation_metrics_add_iterations_zero_allocation() {
+    fn add_iterations_zero_allocation() {
         let mut metrics = OperationMetrics::default();
         metrics.add_iterations(0, 0, 1000);
 
-        assert_eq!(metrics.total_iterations, 1000);
-        assert_eq!(metrics.total_bytes_allocated, 0);
-        assert_eq!(metrics.total_allocations_count, 0);
+        assert_eq!(metrics.total_iterations(), 1000);
+        assert_eq!(metrics.total_bytes_allocated(), 0);
+        assert_eq!(metrics.total_allocations_count(), 0);
     }
 
     #[test]
-    fn operation_metrics_add_iterations_accumulates() {
+    fn add_iterations_accumulates() {
         let mut metrics = OperationMetrics::default();
         metrics.add_iterations(100, 2, 2); // 200 bytes, 4 allocations, 2 iterations
         metrics.add_iterations(200, 3, 3); // 600 bytes, 9 allocations, 3 iterations
 
-        assert_eq!(metrics.total_iterations, 5);
-        assert_eq!(metrics.total_bytes_allocated, 800);
-        assert_eq!(metrics.total_allocations_count, 13);
+        assert_eq!(metrics.total_iterations(), 5);
+        assert_eq!(metrics.span_count(), 2);
+        assert_eq!(metrics.total_bytes_allocated(), 800);
+        assert_eq!(metrics.total_allocations_count(), 13);
+    }
+
+    #[test]
+    fn pooled_means_divide_totals_by_iterations() {
+        let mut metrics = OperationMetrics::default();
+        metrics.add_iterations(100, 1, 1);
+        metrics.add_iterations(200, 2, 1);
+        metrics.add_iterations(300, 3, 1);
+
+        // (100 + 200 + 300) / 3 = 200; (1 + 2 + 3) / 3 = 2.
+        assert_eq!(metrics.mean_bytes(), 200);
+        assert_eq!(metrics.mean_allocations(), 2);
+    }
+
+    #[test]
+    fn means_of_empty_metrics_are_zero() {
+        let metrics = OperationMetrics::default();
+        assert_eq!(metrics.mean_bytes(), 0);
+        assert_eq!(metrics.mean_allocations(), 0);
+    }
+
+    #[test]
+    fn extend_from_concatenates_spans() {
+        let mut first = OperationMetrics::default();
+        first.add_iterations(100, 1, 2);
+
+        let mut second = OperationMetrics::default();
+        second.add_iterations(50, 1, 3);
+
+        first.extend_from(&second);
+        assert_eq!(first.span_count(), 2);
+        assert_eq!(first.total_iterations(), 5);
+        assert_eq!(first.total_bytes_allocated(), 350); // 200 + 150
+    }
+
+    #[test]
+    fn empty_metrics_have_no_statistics() {
+        let metrics = OperationMetrics::default();
+        assert!(metrics.bytes_stats().is_none());
+        assert!(metrics.allocations_stats().is_none());
+    }
+
+    #[test]
+    fn statistics_weight_spans_by_iteration_count() {
+        // A perfectly linear byte series at 5 bytes/iter: the slope recovers 5
+        // regardless of the differing iteration counts across spans.
+        let mut metrics = OperationMetrics::default();
+        metrics.add_span(2, 10, 2);
+        metrics.add_span(8, 40, 8);
+
+        let bytes = metrics.bytes_stats().unwrap();
+        assert_eq!(bytes.span_count, 2);
+        #[expect(clippy::float_cmp, reason = "slope is an exact integer-derived value")]
+        {
+            assert_eq!(bytes.slope, 5.0);
+        }
     }
 }

--- a/packages/alloc_tracker/src/process_span.rs
+++ b/packages/alloc_tracker/src/process_span.rs
@@ -99,9 +99,12 @@ impl ProcessSpan {
         self
     }
 
-    /// Calculates the allocation deltas since this span was created.
+    /// Calculates the raw allocation deltas since this span was created.
+    ///
+    /// The whole-span deltas are returned undivided; per-iteration figures are
+    /// derived later by the shared span-statistics estimator, which weights each
+    /// span by its iteration count.
     #[must_use]
-    #[cfg_attr(test, mutants::skip)] // The != 1 fork is broadly applicable, so mutations fail. Intentional.
     fn to_deltas(&self) -> (u64, u64) {
         let AllocationTotals {
             bytes: current_bytes,
@@ -116,18 +119,7 @@ impl ProcessSpan {
             .checked_sub(self.start_count)
             .expect("total allocations count could not possibly decrease");
 
-        if self.iterations > 1 {
-            // Divide total allocation by iterations to get per-iteration allocation
-            let bytes_delta = total_bytes_delta
-                .checked_div(self.iterations)
-                .expect("guarded by if condition");
-            let count_delta = total_count_delta
-                .checked_div(self.iterations)
-                .expect("guarded by if condition");
-            (bytes_delta, count_delta)
-        } else {
-            (total_bytes_delta, total_count_delta)
-        }
+        (total_bytes_delta, total_count_delta)
     }
 }
 
@@ -135,7 +127,7 @@ impl Drop for ProcessSpan {
     fn drop(&mut self) {
         let (bytes_delta, count_delta) = self.to_deltas();
         let mut data = self.metrics.lock().expect(ERR_POISONED_LOCK);
-        data.add_iterations(bytes_delta, count_delta, self.iterations);
+        data.add_span(self.iterations, bytes_delta, count_delta);
     }
 }
 

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -408,14 +408,16 @@ pub(crate) fn format_count(value: f64) -> String {
 
 impl fmt::Display for ReportOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.statistics() {
-            Some(stats) => write!(
+        // The summary shows only the slopes, so take the cheap slope-only path and
+        // skip the bootstrap confidence intervals the full statistics would resample.
+        match (self.metrics.bytes_slope(), self.metrics.allocations_slope()) {
+            (Some(bytes), Some(allocations)) => write!(
                 f,
                 "{} bytes/iter, {} allocations/iter",
-                format_count(stats.bytes.slope),
-                format_count(stats.allocations.slope),
+                format_count(bytes),
+                format_count(allocations),
             ),
-            None => write!(f, "no measurements"),
+            _ => write!(f, "no measurements"),
         }
     }
 }
@@ -440,16 +442,22 @@ impl fmt::Display for Report {
         // widths and the printed rows are computed from the exact same strings. The
         // bootstrap confidence interval is kept out of this summary for
         // readability; it is preserved in the JSON output and the `statistics()`
-        // API.
+        // API. Rendering the slopes alone also lets the table skip the bootstrap
+        // resampling the full statistics would perform for both metrics.
         let rows: Vec<(&str, String, String)> = sorted_ops
             .iter()
-            .map(|(name, operation)| match operation.statistics() {
-                Some(stats) => (
-                    name.as_str(),
-                    format_count(stats.bytes.slope),
-                    format_count(stats.allocations.slope),
-                ),
-                None => (name.as_str(), "n/a".to_string(), "n/a".to_string()),
+            .map(|(name, operation)| {
+                match (
+                    operation.metrics.bytes_slope(),
+                    operation.metrics.allocations_slope(),
+                ) {
+                    (Some(bytes), Some(allocations)) => (
+                        name.as_str(),
+                        format_count(bytes),
+                        format_count(allocations),
+                    ),
+                    _ => (name.as_str(), "n/a".to_string(), "n/a".to_string()),
+                }
             })
             .collect();
 

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -733,6 +733,16 @@ mod tests {
     }
 
     #[test]
+    fn report_operation_display_reports_no_measurements_when_empty() {
+        // A report operation whose metrics recorded no spans has no statistics, so
+        // its Display takes the `None` leg.
+        let operation = ReportOperation {
+            metrics: OperationMetrics::default(),
+        };
+        assert_eq!(operation.to_string(), "no measurements");
+    }
+
+    #[test]
     fn empty_report_display_shows_no_statistics_message() {
         let report = Report::new();
         let display_output = report.to_string();

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -389,9 +389,49 @@ impl ReportOperation {
     }
 }
 
+/// Formats a per-iteration count for human-readable output.
+///
+/// Counts are conceptually integers but the warmup-robust slope is a real number
+/// (a fitted per-iteration rate), so this rounds to two decimals and trims any
+/// trailing zeros: `200.0` renders as `200` and `199.5` as `199.5`.
+pub(crate) fn format_count(value: f64) -> String {
+    let rounded = (value.max(0.0) * 100.0).round() / 100.0;
+    let mut rendered = format!("{rounded:.2}");
+    if rendered.contains('.') {
+        rendered = rendered
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string();
+    }
+    rendered
+}
+
+/// Formats a metric's warmup-robust point estimate and its bootstrap confidence
+/// interval as `point [low, high]`.
+pub(crate) fn format_metric(stats: &MetricStatistics) -> String {
+    format!(
+        "{} [{}, {}]",
+        format_count(stats.slope),
+        format_count(stats.interval_low),
+        format_count(stats.interval_high),
+    )
+}
+
 impl fmt::Display for ReportOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} bytes (mean)", self.mean_bytes())
+        match self.statistics() {
+            Some(stats) => write!(
+                f,
+                "{} bytes/iter [{}, {}], {} allocations/iter [{}, {}]",
+                format_count(stats.bytes.slope),
+                format_count(stats.bytes.interval_low),
+                format_count(stats.bytes.interval_high),
+                format_count(stats.allocations.slope),
+                format_count(stats.allocations.interval_low),
+                format_count(stats.allocations.interval_high),
+            ),
+            None => write!(f, "no measurements"),
+        }
     }
 }
 
@@ -401,83 +441,83 @@ impl fmt::Display for Report {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.operations.values().all(|op| op.metrics.is_empty()) {
             writeln!(f, "No allocation statistics captured.")?;
-        } else {
-            writeln!(f, "Allocation statistics:")?;
-            writeln!(f)?;
-
-            // Sort operations by name for consistent output
-            let mut sorted_ops: Vec<_> = self.operations.iter().collect();
-            sorted_ops.sort_by_key(|(name, _)| *name);
-
-            // Calculate column widths
-            let max_name_width = sorted_ops
-                .iter()
-                .map(|(name, _)| name.len())
-                .max()
-                .unwrap_or(0)
-                .max("Operation".len());
-
-            let max_bytes_width = sorted_ops
-                .iter()
-                .map(|(_, operation)| operation.mean_bytes().to_string().len())
-                .max()
-                .unwrap_or(0)
-                .max("Mean bytes".len());
-
-            let max_count_width = sorted_ops
-                .iter()
-                .map(|(_, operation)| operation.mean_allocations().to_string().len())
-                .max()
-                .unwrap_or(0)
-                .max("Mean count".len());
-
-            // Print table header
-            writeln!(
-                f,
-                "| {:<name_width$} | {:>bytes_width$} | {:>count_width$} |",
-                "Operation",
-                "Mean bytes",
-                "Mean count",
-                name_width = max_name_width,
-                bytes_width = max_bytes_width,
-                count_width = max_count_width
-            )?;
-
-            // Print separator
-            let separator_name_width = max_name_width
-                .checked_add(2)
-                .expect("operation name width fits in memory, adding 2 cannot overflow");
-            let separator_bytes_width = max_bytes_width
-                .checked_add(2)
-                .expect("bytes width fits in memory, adding 2 cannot overflow");
-            let separator_count_width = max_count_width
-                .checked_add(2)
-                .expect("count width fits in memory, adding 2 cannot overflow");
-            writeln!(
-                f,
-                "|{:-<name_width$}|{:-<bytes_width$}|{:-<count_width$}|",
-                "",
-                "",
-                "",
-                name_width = separator_name_width,
-                bytes_width = separator_bytes_width,
-                count_width = separator_count_width
-            )?;
-
-            // Print table rows
-            for (name, operation) in sorted_ops {
-                writeln!(
-                    f,
-                    "| {:<name_width$} | {:>bytes_width$} | {:>count_width$} |",
-                    name,
-                    operation.mean_bytes(),
-                    operation.mean_allocations(),
-                    name_width = max_name_width,
-                    bytes_width = max_bytes_width,
-                    count_width = max_count_width
-                )?;
-            }
+            return Ok(());
         }
+
+        writeln!(f, "Allocation statistics:")?;
+        writeln!(f)?;
+
+        // Sort operations by name for consistent output.
+        let mut sorted_ops: Vec<_> = self.operations.iter().collect();
+        sorted_ops.sort_by_key(|(name, _)| *name);
+
+        // Pre-render the warmup-robust per-iteration cells so the column widths
+        // and the printed rows are computed from the exact same strings.
+        let rows: Vec<(&str, String, String)> = sorted_ops
+            .iter()
+            .map(|(name, operation)| match operation.statistics() {
+                Some(stats) => (
+                    name.as_str(),
+                    format_metric(&stats.bytes),
+                    format_metric(&stats.allocations),
+                ),
+                None => (name.as_str(), "n/a".to_string(), "n/a".to_string()),
+            })
+            .collect();
+
+        let name_header = "Operation";
+        let bytes_header = "Bytes/iter";
+        let count_header = "Allocations/iter";
+
+        let max_name_width = rows
+            .iter()
+            .map(|(name, _, _)| name.len())
+            .max()
+            .unwrap_or(0)
+            .max(name_header.len());
+        let max_bytes_width = rows
+            .iter()
+            .map(|(_, bytes, _)| bytes.len())
+            .max()
+            .unwrap_or(0)
+            .max(bytes_header.len());
+        let max_count_width = rows
+            .iter()
+            .map(|(_, _, count)| count.len())
+            .max()
+            .unwrap_or(0)
+            .max(count_header.len());
+
+        // Print table header.
+        writeln!(
+            f,
+            "| {name_header:<max_name_width$} | {bytes_header:>max_bytes_width$} | {count_header:>max_count_width$} |",
+        )?;
+
+        // Print separator.
+        let separator_name_width = max_name_width
+            .checked_add(2)
+            .expect("operation name width fits in memory, adding 2 cannot overflow");
+        let separator_bytes_width = max_bytes_width
+            .checked_add(2)
+            .expect("bytes width fits in memory, adding 2 cannot overflow");
+        let separator_count_width = max_count_width
+            .checked_add(2)
+            .expect("count width fits in memory, adding 2 cannot overflow");
+        writeln!(
+            f,
+            "|{:-<separator_name_width$}|{:-<separator_bytes_width$}|{:-<separator_count_width$}|",
+            "", "", "",
+        )?;
+
+        // Print table rows.
+        for (name, bytes, count) in rows {
+            writeln!(
+                f,
+                "| {name:<max_name_width$} | {bytes:>max_bytes_width$} | {count:>max_count_width$} |",
+            )?;
+        }
+
         Ok(())
     }
 }
@@ -692,12 +732,16 @@ mod tests {
     );
 
     #[test]
-    fn report_operation_display_shows_mean_bytes() {
-        // 1000 bytes over 4 iterations → 250 mean bytes.
+    fn report_operation_display_shows_robust_per_iteration_estimate() {
+        // 250 bytes/iter over 4 iterations → a single-span slope of 250 with the
+        // interval collapsed onto it.
         let operation = report_operation(250, 3, 4);
         let display_output = operation.to_string();
-        assert!(display_output.contains("bytes (mean)"));
-        assert!(display_output.contains("250"));
+        assert!(
+            display_output.contains("bytes/iter"),
+            "got {display_output}"
+        );
+        assert!(display_output.contains("250"), "got {display_output}");
     }
 
     #[test]

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -406,29 +406,14 @@ pub(crate) fn format_count(value: f64) -> String {
     rendered
 }
 
-/// Formats a metric's warmup-robust point estimate and its bootstrap confidence
-/// interval as `point [low, high]`.
-pub(crate) fn format_metric(stats: &MetricStatistics) -> String {
-    format!(
-        "{} [{}, {}]",
-        format_count(stats.slope),
-        format_count(stats.interval_low),
-        format_count(stats.interval_high),
-    )
-}
-
 impl fmt::Display for ReportOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.statistics() {
             Some(stats) => write!(
                 f,
-                "{} bytes/iter [{}, {}], {} allocations/iter [{}, {}]",
+                "{} bytes/iter, {} allocations/iter",
                 format_count(stats.bytes.slope),
-                format_count(stats.bytes.interval_low),
-                format_count(stats.bytes.interval_high),
                 format_count(stats.allocations.slope),
-                format_count(stats.allocations.interval_low),
-                format_count(stats.allocations.interval_high),
             ),
             None => write!(f, "no measurements"),
         }
@@ -451,15 +436,18 @@ impl fmt::Display for Report {
         let mut sorted_ops: Vec<_> = self.operations.iter().collect();
         sorted_ops.sort_by_key(|(name, _)| *name);
 
-        // Pre-render the warmup-robust per-iteration cells so the column widths
-        // and the printed rows are computed from the exact same strings.
+        // Pre-render the warmup-robust per-iteration slope cells so the column
+        // widths and the printed rows are computed from the exact same strings. The
+        // bootstrap confidence interval is kept out of this summary for
+        // readability; it is preserved in the JSON output and the `statistics()`
+        // API.
         let rows: Vec<(&str, String, String)> = sorted_ops
             .iter()
             .map(|(name, operation)| match operation.statistics() {
                 Some(stats) => (
                     name.as_str(),
-                    format_metric(&stats.bytes),
-                    format_metric(&stats.allocations),
+                    format_count(stats.bytes.slope),
+                    format_count(stats.allocations.slope),
                 ),
                 None => (name.as_str(), "n/a".to_string(), "n/a".to_string()),
             })

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -3,6 +3,10 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use folo_utils::SpanStats;
+
+use crate::OperationMetrics;
+
 /// Thread-safe memory allocation tracking report.
 ///
 /// A `Report` contains the captured memory allocation statistics from a [`Session`](crate::Session)
@@ -85,14 +89,73 @@ pub struct Report {
 
 /// Memory allocation statistics for a single operation in a report.
 #[derive(Clone, Debug)]
-#[expect(
-    clippy::struct_field_names,
-    reason = "field names are descriptive and clear"
-)]
 pub struct ReportOperation {
-    total_bytes_allocated: u64,
-    total_allocations_count: u64,
-    total_iterations: u64,
+    metrics: OperationMetrics,
+}
+
+/// Per-iteration dispersion statistics for a single allocation metric.
+///
+/// Every value is expressed in the metric's own per-iteration unit (bytes, or a
+/// count of allocations). Allocation figures are not deterministic — first-run
+/// allocations and buffer resizing jitter around the mean over a
+/// Criterion-chosen iteration count — so the point estimate is a warmup-robust
+/// through-origin slope and the interval is a bootstrap confidence interval of
+/// that slope. When every span recorded the same per-iteration value the interval
+/// collapses onto the point estimate.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct MetricStatistics {
+    /// Through-origin OLS slope: the per-iteration point estimate.
+    pub slope: f64,
+
+    /// Sample standard deviation of the per-iteration values across spans.
+    pub std_dev: f64,
+
+    /// Lower bound of the slope's bootstrap confidence interval.
+    pub interval_low: f64,
+
+    /// Upper bound of the slope's bootstrap confidence interval.
+    pub interval_high: f64,
+
+    /// Smallest per-iteration value observed across spans.
+    pub min: f64,
+
+    /// Largest per-iteration value observed across spans.
+    pub max: f64,
+}
+
+impl MetricStatistics {
+    /// Re-labels a unit-agnostic [`SpanStats`] as this metric's per-iteration
+    /// statistics.
+    fn from_span_stats(stats: SpanStats) -> Self {
+        Self {
+            slope: stats.slope,
+            std_dev: stats.std_dev,
+            interval_low: stats.interval_low,
+            interval_high: stats.interval_high,
+            min: stats.min,
+            max: stats.max,
+        }
+    }
+}
+
+/// Dispersion statistics for one operation across both allocation metrics.
+///
+/// Exposed through [`ReportOperation::statistics`] so callers can consume the
+/// same warmup-robust dispersion that is written to the machine-readable JSON
+/// output.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct OperationStatistics {
+    /// Number of spans the statistics were derived from (distinct from the total
+    /// iteration count).
+    pub span_count: u64,
+
+    /// Per-iteration byte-count dispersion.
+    pub bytes: MetricStatistics,
+
+    /// Per-iteration allocation-count dispersion.
+    pub allocations: MetricStatistics,
 }
 
 impl Report {
@@ -107,18 +170,14 @@ impl Report {
 
     /// Creates a report from shared operation data.
     #[must_use]
-    pub(crate) fn from_operation_data(
-        operation_data: &HashMap<String, crate::operation_metrics::OperationMetrics>,
-    ) -> Self {
+    pub(crate) fn from_operation_data(operation_data: &HashMap<String, OperationMetrics>) -> Self {
         let report_operations = operation_data
             .iter()
-            .map(|(name, op_data)| {
+            .map(|(name, metrics)| {
                 (
                     name.clone(),
                     ReportOperation {
-                        total_bytes_allocated: op_data.total_bytes_allocated,
-                        total_allocations_count: op_data.total_allocations_count,
-                        total_iterations: op_data.total_iterations,
+                        metrics: metrics.clone(),
                     },
                 )
             })
@@ -132,7 +191,7 @@ impl Report {
     /// Merges two reports into a new report.
     ///
     /// The resulting report contains the combined statistics from both input reports.
-    /// Operations with the same name have their statistics combined as if all spans
+    /// Operations with the same name have their spans concatenated as if all spans
     /// had been recorded through a single session.
     ///
     /// # Examples
@@ -176,22 +235,7 @@ impl Report {
         for (name, b_op) in &b.operations {
             merged_operations
                 .entry(name.clone())
-                .and_modify(|a_op| {
-                    a_op.total_bytes_allocated = a_op
-                        .total_bytes_allocated
-                        .checked_add(b_op.total_bytes_allocated)
-                        .expect("merging bytes allocated overflows u64 - this indicates an unrealistic scenario");
-
-                    a_op.total_allocations_count = a_op
-                        .total_allocations_count
-                        .checked_add(b_op.total_allocations_count)
-                        .expect("merging allocations count overflows u64 - this indicates an unrealistic scenario");
-
-                    a_op.total_iterations = a_op
-                        .total_iterations
-                        .checked_add(b_op.total_iterations)
-                        .expect("merging iteration counts overflows u64 - this indicates an unrealistic scenario");
-                })
+                .and_modify(|a_op| a_op.metrics.extend_from(&b_op.metrics))
                 .or_insert_with(|| b_op.clone());
         }
 
@@ -216,7 +260,7 @@ impl Report {
     /// Whether there is any recorded activity in this report.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.operations.is_empty() || self.operations.values().all(|op| op.total_iterations == 0)
+        self.operations.is_empty() || self.operations.values().all(|op| op.metrics.is_empty())
     }
 
     /// Returns an iterator over the operation names and their statistics.
@@ -262,43 +306,86 @@ impl ReportOperation {
     /// Returns the total bytes allocated across all iterations for this operation.
     #[must_use]
     pub fn total_bytes_allocated(&self) -> u64 {
-        self.total_bytes_allocated
+        self.metrics.total_bytes_allocated()
     }
 
     /// Returns the total number of allocations across all iterations for this operation.
     #[must_use]
     pub fn total_allocations_count(&self) -> u64 {
-        self.total_allocations_count
+        self.metrics.total_allocations_count()
     }
 
     /// Returns the total number of iterations recorded for this operation.
     #[must_use]
     pub fn total_iterations(&self) -> u64 {
-        self.total_iterations
+        self.metrics.total_iterations()
     }
 
-    /// Calculates the mean bytes allocated per iteration.
+    /// Calculates the pooled mean bytes allocated per iteration.
     #[must_use]
     pub fn mean_bytes(&self) -> u64 {
-        self.total_bytes_allocated
-            .checked_div(self.total_iterations)
-            .unwrap_or(0)
+        self.metrics.mean_bytes()
     }
 
-    /// Calculates the mean number of allocations per iteration.
+    /// Calculates the pooled mean number of allocations per iteration.
     #[must_use]
     pub fn mean_allocations(&self) -> u64 {
-        self.total_allocations_count
-            .checked_div(self.total_iterations)
-            .unwrap_or(0)
+        self.metrics.mean_allocations()
     }
 
-    /// Calculates the mean bytes allocated per iteration.
+    /// Calculates the pooled mean bytes allocated per iteration.
     ///
     /// This is an alias for [`mean_bytes`](Self::mean_bytes) to maintain backward compatibility.
     #[must_use]
     pub fn mean(&self) -> u64 {
         self.mean_bytes()
+    }
+
+    /// Computes warmup-robust dispersion statistics over the recorded spans.
+    ///
+    /// Returns `None` when no spans were recorded. The returned
+    /// [`OperationStatistics`] carries the slope point estimate, bootstrap
+    /// confidence interval, standard deviation and extremes for both the byte and
+    /// allocation-count metrics — the same dispersion written to the
+    /// machine-readable JSON output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use alloc_tracker::{Allocator, Session};
+    ///
+    /// #[global_allocator]
+    /// static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+    ///
+    /// # fn main() {
+    /// let session = Session::new();
+    /// # let session = session.no_stdout().no_file();
+    /// {
+    ///     let operation = session.operation("test_work");
+    ///     let _span = operation.measure_process();
+    ///     let _data = vec![1, 2, 3, 4, 5]; // This allocates memory
+    /// }
+    ///
+    /// let report = session.to_report();
+    /// for (_name, op) in report.operations() {
+    ///     if let Some(stats) = op.statistics() {
+    ///         println!(
+    ///             "slope: {} bytes/iter over {} spans",
+    ///             stats.bytes.slope, stats.span_count
+    ///         );
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn statistics(&self) -> Option<OperationStatistics> {
+        let bytes = self.metrics.bytes_stats()?;
+        let allocations = self.metrics.allocations_stats()?;
+        Some(OperationStatistics {
+            span_count: bytes.span_count,
+            bytes: MetricStatistics::from_span_stats(bytes),
+            allocations: MetricStatistics::from_span_stats(allocations),
+        })
     }
 }
 
@@ -312,7 +399,7 @@ impl fmt::Display for ReportOperation {
 #[cfg_attr(coverage_nightly, coverage(off))]
 impl fmt::Display for Report {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.operations.values().all(|op| op.total_iterations == 0) {
+        if self.operations.values().all(|op| op.metrics.is_empty()) {
             writeln!(f, "No allocation statistics captured.")?;
         } else {
             writeln!(f, "Allocation statistics:")?;
@@ -398,11 +485,24 @@ impl fmt::Display for Report {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    #![allow(
+        clippy::float_cmp,
+        reason = "allocation statistics are exact integer-derived values in these fixtures"
+    )]
+
     use std::panic::{RefUnwindSafe, UnwindSafe};
 
     use super::*;
     use crate::Session;
     use crate::allocator::register_fake_allocation;
+
+    /// Builds a detached [`ReportOperation`] from per-iteration deltas for tests
+    /// that assert directly on the report surface without a live session.
+    fn report_operation(bytes_delta: u64, count_delta: u64, iterations: u64) -> ReportOperation {
+        let mut metrics = OperationMetrics::default();
+        metrics.add_iterations(bytes_delta, count_delta, iterations);
+        ReportOperation { metrics }
+    }
 
     #[test]
     fn new_report_is_empty() {
@@ -506,9 +606,9 @@ mod tests {
 
         assert_eq!(merged.operations.len(), 1);
         let merged_op = merged.operations.get("test").unwrap();
-        assert_eq!(merged_op.total_iterations, 2); // 1 + 1
-        assert_eq!(merged_op.total_bytes_allocated, 300); // 100 + 200
-        assert_eq!(merged_op.total_allocations_count, 3); // 1 + 2
+        assert_eq!(merged_op.total_iterations(), 2); // 1 + 1
+        assert_eq!(merged_op.total_bytes_allocated(), 300); // 100 + 200
+        assert_eq!(merged_op.total_allocations_count(), 3); // 1 + 2
     }
 
     #[test]
@@ -528,23 +628,14 @@ mod tests {
 
     #[test]
     fn report_operation_total_allocations_count_zero() {
-        let operation = ReportOperation {
-            total_bytes_allocated: 0,
-            total_allocations_count: 0,
-            total_iterations: 1,
-        };
-
+        let operation = report_operation(0, 0, 1);
         assert_eq!(operation.total_allocations_count(), 0);
     }
 
     #[test]
     fn report_operation_total_allocations_count_multiple() {
-        let operation = ReportOperation {
-            total_bytes_allocated: 500,
-            total_allocations_count: 25,
-            total_iterations: 5,
-        };
-
+        // 100 bytes and 5 allocations per iteration over 5 iterations.
+        let operation = report_operation(100, 5, 5);
         assert_eq!(operation.total_allocations_count(), 25);
     }
 
@@ -568,9 +659,31 @@ mod tests {
         assert_eq!(report_op.total_iterations(), 1);
     }
 
+    #[test]
+    fn statistics_are_none_without_spans() {
+        let session = Session::new().no_stdout().no_file();
+        let report = session.to_report();
+        assert!(report.operations().next().is_none());
+    }
+
+    #[test]
+    fn statistics_expose_both_metric_dispersions() {
+        // A single recorded span yields a span count of one, a slope equal to the
+        // per-iteration mean, and a degenerate interval that collapses onto it.
+        let operation = report_operation(200, 2, 4);
+        let stats = operation.statistics().unwrap();
+        assert_eq!(stats.span_count, 1);
+        assert_eq!(stats.bytes.slope, 200.0);
+        assert_eq!(stats.bytes.interval_low, 200.0);
+        assert_eq!(stats.bytes.interval_high, 200.0);
+        assert_eq!(stats.allocations.slope, 2.0);
+    }
+
     // Static assertions for thread safety.
     static_assertions::assert_impl_all!(Report: Send, Sync);
     static_assertions::assert_impl_all!(ReportOperation: Send, Sync);
+    static_assertions::assert_impl_all!(OperationStatistics: Send, Sync);
+    static_assertions::assert_impl_all!(MetricStatistics: Send, Sync);
 
     // Static assertions for unwind safety.
     static_assertions::assert_impl_all!(Report: UnwindSafe, RefUnwindSafe);
@@ -580,15 +693,11 @@ mod tests {
 
     #[test]
     fn report_operation_display_shows_mean_bytes() {
-        let operation = ReportOperation {
-            total_bytes_allocated: 1000,
-            total_allocations_count: 10,
-            total_iterations: 4,
-        };
-
+        // 1000 bytes over 4 iterations → 250 mean bytes.
+        let operation = report_operation(250, 3, 4);
         let display_output = operation.to_string();
         assert!(display_output.contains("bytes (mean)"));
-        assert!(display_output.contains("250")); // 1000 / 4 = 250 mean bytes
+        assert!(display_output.contains("250"));
     }
 
     #[test]

--- a/packages/alloc_tracker/src/session.rs
+++ b/packages/alloc_tracker/src/session.rs
@@ -197,7 +197,7 @@ impl Session {
         operations.is_empty()
             || operations
                 .values()
-                .all(|op| op.lock().expect(ERR_POISONED_LOCK).total_iterations == 0)
+                .all(|op| op.lock().expect(ERR_POISONED_LOCK).is_empty())
     }
 }
 

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -12,6 +12,10 @@ use crate::Report;
 const OUTPUT_SUBDIRECTORY: &str = "alloc_tracker";
 
 /// Machine-readable allocation statistics for a single operation.
+///
+/// Carries both the pooled per-iteration means and the warmup-robust dispersion
+/// (slope, standard deviation, bootstrap interval and extremes) for each metric,
+/// mirroring the shape `all_the_time` writes for processor time.
 #[derive(Serialize)]
 struct OperationOutput<'a> {
     operation: &'a str,
@@ -20,6 +24,19 @@ struct OperationOutput<'a> {
     total_allocations_count: u64,
     mean_bytes_per_iteration: u64,
     mean_allocations_per_iteration: u64,
+    span_count: u64,
+    slope_bytes_per_iteration: f64,
+    std_dev_bytes_per_iteration: f64,
+    interval_low_bytes_per_iteration: f64,
+    interval_high_bytes_per_iteration: f64,
+    min_bytes_per_iteration: f64,
+    max_bytes_per_iteration: f64,
+    slope_allocations_per_iteration: f64,
+    std_dev_allocations_per_iteration: f64,
+    interval_low_allocations_per_iteration: f64,
+    interval_high_allocations_per_iteration: f64,
+    min_allocations_per_iteration: f64,
+    max_allocations_per_iteration: f64,
 }
 
 impl Report {
@@ -76,9 +93,11 @@ impl Report {
         let mut file_names: HashMap<String, &str> = HashMap::new();
         let mut outputs: Vec<(PathBuf, String)> = Vec::new();
         for (name, operation) in self.operations() {
-            if operation.total_iterations() == 0 {
+            let Some(statistics) = operation.statistics() else {
+                // Registered but never measured operations have no spans and thus
+                // no statistics, so they leave no output file behind.
                 continue;
-            }
+            };
 
             let file_name = format!("{}.json", folo_utils::sanitize_file_name(name));
             if let Some(previous) = file_names.insert(file_name.clone(), name) {
@@ -96,6 +115,19 @@ impl Report {
                 total_allocations_count: operation.total_allocations_count(),
                 mean_bytes_per_iteration: operation.mean_bytes(),
                 mean_allocations_per_iteration: operation.mean_allocations(),
+                span_count: statistics.span_count,
+                slope_bytes_per_iteration: statistics.bytes.slope,
+                std_dev_bytes_per_iteration: statistics.bytes.std_dev,
+                interval_low_bytes_per_iteration: statistics.bytes.interval_low,
+                interval_high_bytes_per_iteration: statistics.bytes.interval_high,
+                min_bytes_per_iteration: statistics.bytes.min,
+                max_bytes_per_iteration: statistics.bytes.max,
+                slope_allocations_per_iteration: statistics.allocations.slope,
+                std_dev_allocations_per_iteration: statistics.allocations.std_dev,
+                interval_low_allocations_per_iteration: statistics.allocations.interval_low,
+                interval_high_allocations_per_iteration: statistics.allocations.interval_high,
+                min_allocations_per_iteration: statistics.allocations.min,
+                max_allocations_per_iteration: statistics.allocations.max,
             };
 
             let json = serde_json::to_string_pretty(&output)
@@ -191,6 +223,40 @@ mod tests {
                 .get("mean_allocations_per_iteration")
                 .and_then(Value::as_u64),
             Some(2)
+        );
+        // A single recorded span yields a span count of one, per-metric slopes
+        // equal to the per-iteration means, and degenerate intervals that
+        // collapse onto them.
+        assert_eq!(value.get("span_count").and_then(Value::as_u64), Some(1));
+        assert_eq!(
+            value
+                .get("slope_bytes_per_iteration")
+                .and_then(Value::as_f64),
+            Some(200.0)
+        );
+        assert_eq!(
+            value
+                .get("interval_low_bytes_per_iteration")
+                .and_then(Value::as_f64),
+            Some(200.0)
+        );
+        assert_eq!(
+            value
+                .get("interval_high_bytes_per_iteration")
+                .and_then(Value::as_f64),
+            Some(200.0)
+        );
+        assert_eq!(
+            value
+                .get("std_dev_bytes_per_iteration")
+                .and_then(Value::as_f64),
+            Some(0.0)
+        );
+        assert_eq!(
+            value
+                .get("slope_allocations_per_iteration")
+                .and_then(Value::as_f64),
+            Some(2.0)
         );
     }
 

--- a/packages/alloc_tracker/src/thread_span.rs
+++ b/packages/alloc_tracker/src/thread_span.rs
@@ -89,9 +89,12 @@ impl ThreadSpan {
         self
     }
 
-    /// Calculates the allocation deltas since this span was created.
+    /// Calculates the raw allocation deltas since this span was created.
+    ///
+    /// The whole-span deltas are returned undivided; per-iteration figures are
+    /// derived later by the shared span-statistics estimator, which weights each
+    /// span by its iteration count.
     #[must_use]
-    #[cfg_attr(test, mutants::skip)] // The != 1 fork is broadly applicable, so mutations fail. Intentional.
     fn to_deltas(&self) -> (u64, u64) {
         let counters = get_or_init_thread_counters();
         let current_bytes = counters.bytes();
@@ -105,18 +108,7 @@ impl ThreadSpan {
             .checked_sub(self.start_count)
             .expect("thread allocations count could not possibly decrease");
 
-        if self.iterations > 1 {
-            // Divide total allocation by iterations to get per-iteration allocation
-            let bytes_delta = total_bytes_delta
-                .checked_div(self.iterations)
-                .expect("guarded by if condition");
-            let count_delta = total_count_delta
-                .checked_div(self.iterations)
-                .expect("guarded by if condition");
-            (bytes_delta, count_delta)
-        } else {
-            (total_bytes_delta, total_count_delta)
-        }
+        (total_bytes_delta, total_count_delta)
     }
 }
 
@@ -124,7 +116,7 @@ impl Drop for ThreadSpan {
     fn drop(&mut self) {
         let (bytes_delta, count_delta) = self.to_deltas();
         let mut data = self.metrics.lock().expect(ERR_POISONED_LOCK);
-        data.add_iterations(bytes_delta, count_delta, self.iterations);
+        data.add_span(self.iterations, bytes_delta, count_delta);
     }
 }
 

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -1,26 +1,31 @@
 //! The finding algorithms: locate *sustained* level shifts and slow drifts in
-//! each series and flag only those that survive engine-aware significance,
-//! practical-magnitude, and false-discovery gates, then a basic noise filter that
-//! drops any move below a minimum relative magnitude regardless of engine.
+//! each series and flag only those that survive significance, practical-magnitude,
+//! series-intrinsic-noise, and false-discovery gates.
 //!
-//! The design deliberately distinguishes the two engine families this tool
-//! records:
+//! No benchmark engine is treated as noise-free. Callgrind instruction and event
+//! counts jitter a few percent run to run, and `alloc_tracker`'s per-iteration
+//! figures carry warmup and buffer-resize allocations amortized over a
+//! Criterion-chosen iteration count; Criterion wall time and `all_the_time`
+//! processor time jitter more visibly still. Every series is therefore judged
+//! noise-aware:
 //!
-//! * **Deterministic** engines (Callgrind: instruction counts, estimated cycles,
-//!   cache hits, branch counts; `alloc_tracker`: allocations) produce noise-free
-//!   numbers. A real step is flagged on persistence alone — no significance test, no
-//!   false-discovery correction — provided it clears the basic noise floor: a sub-1%
-//!   move is meaningless even when exact, so it is still suppressed.
-//! * **Noisy** engines (Criterion wall time, `all_the_time` processor time) jitter
-//!   from run to run. A move is flagged only when a Pettitt change-point locates a
-//!   split that a Mann–Whitney rank test then confirms, the confidence intervals of
-//!   the two regimes do not overlap, and the move clears a practical-magnitude
-//!   floor — then the surviving candidates pass a Benjamini–Hochberg false-discovery
-//!   filter so a batch of series does not manufacture spurious findings.
+//! * A Pettitt change-point *locates* a candidate split (its analytic p-value is
+//!   too conservative on short series to gate significance); both regimes must
+//!   hold at least `min_regime` points (persistence).
+//! * A Mann–Whitney rank test must then confirm the two regimes differ, the move
+//!   must clear a practical-magnitude floor, and it must exceed the series' own
+//!   between-commit residual scatter (the primary, series-intrinsic noise gate).
+//! * Where the engine reports a per-point confidence interval (Criterion,
+//!   `all_the_time`, `alloc_tracker`) the two regimes' intervals must also be
+//!   disjoint — an *additional* veto that can only tighten the decision, never
+//!   loosen it.
+//! * Surviving candidates then pass a Benjamini–Hochberg false-discovery filter so
+//!   a batch of series does not manufacture spurious findings.
 //!
 //! A separate slow-[`Drift`](FindingMethod::Drift) finding is raised from a
-//! Mann–Kendall trend test plus a Theil–Sen slope, and is suppressed when a
-//! single step on the same series already explains at least as much movement.
+//! Mann–Kendall trend test plus a Theil–Sen slope, gated by the same practical
+//! floor and residual-scatter check, and is suppressed when a single step on the
+//! same series already explains at least as much movement.
 //!
 //! Polarity: most metrics are "lower is better" (instruction counts, cycle
 //! estimates, branch counts, allocations, wall time), so a rise is a
@@ -69,14 +74,14 @@ pub struct AnalysisConfig {
     /// Multiple of the per-measurement noise floor a noisy branch/tip move with too
     /// few points to rank-test must exceed before it is trusted.
     pub branch_noise_multiple: f64,
-    /// Minimum relative magnitude (1%) any finding must reach to be reported, applied
-    /// as a final basic noise filter across every detector and engine. Even at full
-    /// statistical confidence a sub-1% move is treated as measurement noise: it is too
-    /// small to be worth a human's attention, so it is suppressed regardless of
-    /// direction. This floor sits below the per-engine practical-magnitude floors
-    /// (`practical_relative`, `branch_practical_relative`), which already exceed it for
-    /// noisy engines; it is what gates the otherwise-unbounded deterministic engines.
-    pub noise_floor: f64,
+    /// Multiple of a series' own between-commit residual scatter (median absolute
+    /// residual of the fitted step or line model) that a move must exceed before it
+    /// is trusted. This is the primary, series-intrinsic noise gate applied to every
+    /// engine: a clean series has near-zero residual scatter, so any persistent move
+    /// clears it, while a jittery series demands a move that stands out above its own
+    /// run-to-run wobble. It composes with (and is independent of) the optional
+    /// confidence-interval veto available on dispersion-reporting engines.
+    pub residual_noise_multiple: f64,
 }
 
 impl Default for AnalysisConfig {
@@ -91,7 +96,7 @@ impl Default for AnalysisConfig {
             compare_window: 8,
             branch_practical_relative: 0.05,
             branch_noise_multiple: 2.0,
-            noise_floor: 0.01,
+            residual_noise_multiple: 3.0,
         }
     }
 }
@@ -243,8 +248,8 @@ pub struct Finding {
     pub delta: f64,
     /// The change relative to the baseline (`delta / baseline`).
     pub relative_delta: f64,
-    /// How confident the detector is (`1 - p_value`; `1.0` for an exact
-    /// deterministic step).
+    /// How confident the detector is (`1 - p_value` of the significance test that
+    /// confirmed the move).
     pub confidence: f64,
     /// Commit the change is attributed to, if known.
     pub commit: Option<String>,
@@ -282,8 +287,8 @@ impl Finding {
 }
 
 /// A finding before false-discovery filtering, carrying the p-value the
-/// Benjamini–Hochberg pool needs, whether it came from a deterministic engine, and
-/// the fitted model parameters used to arbitrate between the two detectors.
+/// Benjamini–Hochberg pool needs and the fitted model parameters used to arbitrate
+/// between the two detectors.
 struct Candidate {
     /// The finding that will be emitted if it survives filtering.
     finding: Finding,
@@ -291,10 +296,8 @@ struct Candidate {
     /// points ([`Finding::series`]) are materialised from it only once the
     /// candidate survives filtering, so a dropped candidate never pays for them.
     source_index: usize,
-    /// The p-value contributed to the false-discovery pool (noisy candidates only).
+    /// The p-value contributed to the false-discovery pool.
     bh_p: f64,
-    /// Whether the source engine is deterministic (bypasses the FDR filter).
-    deterministic: bool,
     /// The Pettitt split index, for a change-point candidate.
     split: Option<usize>,
     /// The Theil–Sen `(slope, intercept)`, for a drift candidate.
@@ -433,6 +436,32 @@ fn line_model_residual(values: &[f64], slope: f64, intercept: f64) -> Option<f64
     stats::median_in_place(&mut residuals)
 }
 
+/// The median absolute residual of a two-sample step model: each sample's points'
+/// distance from their own sample median.
+fn sample_step_residual(before: &[f64], after: &[f64]) -> Option<f64> {
+    let before_median = stats::median(before)?;
+    let after_median = stats::median(after)?;
+    let mut residuals: Vec<f64> = before
+        .iter()
+        .map(|value| (value - before_median).abs())
+        .chain(after.iter().map(|value| (value - after_median).abs()))
+        .collect();
+    stats::median_in_place(&mut residuals)
+}
+
+/// Whether `delta` stands clear of a series' own between-commit scatter: it must
+/// exceed `config.residual_noise_multiple` times the model's median absolute
+/// residual. A clean series has a near-zero residual, so any persistent move
+/// passes; a jittery one demands a move that stands out above its wobble. A missing
+/// residual (an empty model) is treated as no evidence of noise, so the move is
+/// trusted.
+fn exceeds_residual_noise(delta: f64, residual: Option<f64>, config: &AnalysisConfig) -> bool {
+    match residual {
+        Some(residual) => delta.abs() > config.residual_noise_multiple * residual,
+        None => true,
+    }
+}
+
 /// Chooses between a change-point and a drift candidate for the same series.
 ///
 /// When both detectors fire, the data is described as whichever model fits it
@@ -464,14 +493,15 @@ fn arbitrate(
 }
 
 /// Locates a sustained level shift in `series`, returning a [`Candidate`] when the
-/// engine-appropriate gates pass.
+/// noise-aware gates pass.
 ///
 /// The Pettitt test *locates* the split (its analytic p-value is conservative for
 /// short series, so it is not used as a significance gate); both regimes must hold
-/// at least `min_regime` points (persistence). A deterministic engine flags any
-/// non-zero step. A noisy engine additionally requires a significant Mann–Whitney
-/// rank-sum difference between the regimes, non-overlapping regime confidence
-/// intervals (when reported), and a practically meaningful relative magnitude.
+/// at least `min_regime` points (persistence). The move must then be confirmed by a
+/// significant Mann–Whitney rank-sum difference between the regimes, clear the
+/// practical-magnitude floor, stand above the series' own between-commit residual
+/// scatter, and — when the engine reports per-point confidence intervals — separate
+/// the two regimes' intervals.
 fn evaluate_change_point(
     series: &Series,
     values: &[f64],
@@ -498,28 +528,26 @@ fn evaluate_change_point(
     }
     let relative_delta = relative_delta_of(delta, baseline);
 
-    let deterministic = series.kind.is_deterministic();
-    let effective_p = if deterministic {
-        0.0
-    } else {
-        let mann_whitney = stats::mann_whitney_u_pvalue(before, after);
-        if mann_whitney >= config.change_alpha {
-            return None;
-        }
-        if relative_delta.abs() < config.practical_relative {
-            return None;
-        }
-        let before_points: Vec<&SeriesPoint> = points.iter().take(tau).collect();
-        let after_points: Vec<&SeriesPoint> = points.iter().skip(tau).collect();
-        if let (Some(before_ci), Some(after_ci)) = (
-            regime_interval(&before_points),
-            regime_interval(&after_points),
-        ) && !intervals_disjoint(before_ci, after_ci)
-        {
-            return None;
-        }
-        mann_whitney
-    };
+    let mann_whitney = stats::mann_whitney_u_pvalue(before, after);
+    if mann_whitney >= config.change_alpha {
+        return None;
+    }
+    if relative_delta.abs() < config.practical_relative {
+        return None;
+    }
+    if !exceeds_residual_noise(delta, step_model_residual(values, tau), config) {
+        return None;
+    }
+    let before_points: Vec<&SeriesPoint> = points.iter().take(tau).collect();
+    let after_points: Vec<&SeriesPoint> = points.iter().skip(tau).collect();
+    if let (Some(before_ci), Some(after_ci)) = (
+        regime_interval(&before_points),
+        regime_interval(&after_points),
+    ) && !intervals_disjoint(before_ci, after_ci)
+    {
+        return None;
+    }
+    let effective_p = mann_whitney;
 
     let commit = points.get(tau).and_then(owned_commit);
     Some(Candidate {
@@ -544,7 +572,6 @@ fn evaluate_change_point(
         },
         source_index: 0,
         bh_p: effective_p,
-        deterministic,
         split: Some(tau),
         line: None,
     })
@@ -554,10 +581,11 @@ fn evaluate_change_point(
 /// trend is significant and practically meaningful.
 ///
 /// The trend is established by the Mann–Kendall test and quantified by the
-/// Theil–Sen line, so a single outlier cannot manufacture a drift. For a noisy
-/// engine the total movement must also exceed the per-measurement noise floor
-/// (twice the median confidence-interval half-width), so jitter does not read as a
-/// trend.
+/// Theil–Sen line, so a single outlier cannot manufacture a drift. The total
+/// movement must clear the practical-magnitude floor and stand above the series'
+/// own residual scatter about the fitted line; where the engine reports confidence
+/// intervals it must additionally exceed the per-measurement noise floor (twice the
+/// median half-width), so jitter does not read as a trend.
 fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> Option<Candidate> {
     let points = &series.points;
     let n = points.len();
@@ -581,12 +609,13 @@ fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> O
     if relative_delta.abs() < config.practical_relative {
         return None;
     }
-
-    let deterministic = series.kind.is_deterministic();
-    // A noisy trend must clear the measurement noise floor: the endpoints have to
-    // separate by more than the run-to-run dispersion, or it is just jitter.
-    if !deterministic
-        && let Some(half_width) = median_half_width(points)
+    if !exceeds_residual_noise(delta, line_model_residual(values, slope, intercept), config) {
+        return None;
+    }
+    // Where the engine reports dispersion, a trend must also clear the measurement
+    // noise floor: the endpoints have to separate by more than the run-to-run
+    // dispersion, or it is just jitter.
+    if let Some(half_width) = median_half_width(points)
         && delta.abs() <= 2.0 * half_width
     {
         return None;
@@ -615,7 +644,6 @@ fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> O
         },
         source_index: 0,
         bh_p: trend.p_value,
-        deterministic,
         split: None,
         line: Some((slope, intercept)),
     })
@@ -699,15 +727,16 @@ fn latest_regime<'a>(
 }
 
 /// Compares a `before` sample against an `after` sample on the same series and, if
-/// the engine-appropriate gates pass, returns a change-point [`Candidate`].
+/// the noise-aware gates pass, returns a change-point [`Candidate`].
 ///
-/// Deterministic engines flag any non-zero move (their numbers carry no noise). A
-/// noisy engine requires the relative move to clear `practical_floor` and then
-/// either — when both samples have at least two points — a significant Mann–Whitney
-/// difference with non-overlapping confidence intervals, or — when a sample is too
-/// small to rank-test — a move exceeding the per-measurement noise floor. When the
-/// noise floor cannot be estimated for a tiny sample the comparison is skipped: we
-/// would rather miss than flag on jitter.
+/// The relative move must clear `practical_floor` and stand above the two samples'
+/// own between-commit residual scatter (the primary, series-intrinsic noise gate,
+/// which for a single-run engine like Callgrind is the only dispersion available).
+/// It must then either — when both samples have at least two points — pass a
+/// significant Mann–Whitney difference, or — when a sample is too small to
+/// rank-test — rest on that residual gate alone. Where the engine additionally
+/// reports per-point confidence intervals, the two samples' intervals must also be
+/// disjoint; this is an extra veto that can only tighten the decision.
 fn compare_samples(
     series: &Series,
     before: &[&SeriesPoint],
@@ -727,41 +756,43 @@ fn compare_samples(
     }
     let relative_delta = relative_delta_of(delta, baseline);
 
-    let deterministic = series.kind.is_deterministic();
-    let effective_p = if deterministic {
-        0.0
-    } else {
-        if relative_delta.abs() < practical_floor {
+    if relative_delta.abs() < practical_floor {
+        return None;
+    }
+    if !exceeds_residual_noise(
+        delta,
+        sample_step_residual(&before_values, &after_values),
+        config,
+    ) {
+        return None;
+    }
+    let effective_p = if before_values.len() >= 2 && after_values.len() >= 2 {
+        let mann_whitney = stats::mann_whitney_u_pvalue(&before_values, &after_values);
+        if mann_whitney >= config.change_alpha {
             return None;
         }
-        if before_values.len() >= 2 && after_values.len() >= 2 {
-            let mann_whitney = stats::mann_whitney_u_pvalue(&before_values, &after_values);
-            if mann_whitney >= config.change_alpha {
-                return None;
-            }
-            if let (Some(before_ci), Some(after_ci)) =
-                (regime_interval(before), regime_interval(after))
-                && !intervals_disjoint(before_ci, after_ci)
-            {
-                return None;
-            }
-            mann_whitney
-        } else {
-            // Too few points to rank-test: trust the move only when its magnitude
-            // clears the measurement noise floor; with no dispersion to compare
-            // against, prefer to miss.
-            let points: Vec<SeriesPoint> = before
-                .iter()
-                .chain(after.iter())
-                .map(|point| (*point).clone())
-                .collect();
-            match median_half_width(&points) {
-                Some(half_width) if delta.abs() > config.branch_noise_multiple * half_width => {
-                    config.change_alpha
-                }
-                _ => return None,
-            }
+        if let (Some(before_ci), Some(after_ci)) = (regime_interval(before), regime_interval(after))
+            && !intervals_disjoint(before_ci, after_ci)
+        {
+            return None;
         }
+        mann_whitney
+    } else {
+        // Too few points to rank-test (typically a single fresh tip or branch run):
+        // the residual gate above is the significance proxy. Where per-point
+        // confidence intervals exist, require the move to also clear the measurement
+        // noise band as an additional veto.
+        let points: Vec<SeriesPoint> = before
+            .iter()
+            .chain(after.iter())
+            .map(|point| (*point).clone())
+            .collect();
+        if let Some(half_width) = median_half_width(&points)
+            && delta.abs() <= config.branch_noise_multiple * half_width
+        {
+            return None;
+        }
+        config.change_alpha
     };
 
     Some(Candidate {
@@ -786,7 +817,6 @@ fn compare_samples(
         },
         source_index: 0,
         bh_p: effective_p,
-        deterministic,
         split: None,
         line: None,
     })
@@ -897,9 +927,10 @@ const RESOLVED_SPIKE_MAX_POINTS: usize = 200;
 /// Such a change is no longer reflected in the latest state, so it is emitted as an
 /// *inactive* finding (only surfaced with `--include-inactive`): `commit` names where
 /// the level rose, `flipped_at` where it recovered, `baseline` the pre-spike level,
-/// and `latest` the spike's own level (its magnitude is what is notable). A
-/// deterministic engine accepts any sustained non-zero plateau; a noisy engine
-/// requires both the rise and the recovery to be Mann–Whitney significant.
+/// and `latest` the spike's own level (its magnitude is what is notable). Both the
+/// rise and the recovery must be Mann–Whitney significant, the plateau must clear
+/// the practical-magnitude floor, and the deviation must stand above the rise's own
+/// residual scatter.
 fn evaluate_resolved_spike(
     series: &Series,
     values: &[f64],
@@ -952,20 +983,18 @@ fn evaluate_resolved_spike(
         return None;
     }
 
-    let deterministic = series.kind.is_deterministic();
-    let effective_p = if deterministic {
-        0.0
-    } else {
-        let before = values.get(..rise)?;
-        let segment = values.get(rise..recovery)?;
-        let after = values.get(recovery..)?;
-        let rise_p = stats::mann_whitney_u_pvalue(before, segment);
-        let recovery_p = stats::mann_whitney_u_pvalue(segment, after);
-        if rise_p >= config.change_alpha || recovery_p >= config.change_alpha {
-            return None;
-        }
-        rise_p.max(recovery_p)
-    };
+    let before = values.get(..rise)?;
+    let segment = values.get(rise..recovery)?;
+    let after = values.get(recovery..)?;
+    if !exceeds_residual_noise(deviation, sample_step_residual(before, segment), config) {
+        return None;
+    }
+    let rise_p = stats::mann_whitney_u_pvalue(before, segment);
+    let recovery_p = stats::mann_whitney_u_pvalue(segment, after);
+    if rise_p >= config.change_alpha || recovery_p >= config.change_alpha {
+        return None;
+    }
+    let effective_p = rise_p.max(recovery_p);
 
     let relative_delta = relative_delta_of(deviation, baseline);
     Some(Candidate {
@@ -990,7 +1019,6 @@ fn evaluate_resolved_spike(
         },
         source_index: 0,
         bh_p: effective_p,
-        deterministic,
         split: Some(rise),
         line: None,
     })
@@ -1016,10 +1044,10 @@ fn find_changes(series: &[Series], context: &AnalysisContext) -> Vec<Finding> {
 /// The [`AnalysisContext`] selects the per-series detector: history mode locates a
 /// change-point and a drift and keeps the better-fitting one; branch mode compares
 /// the branch's latest state against its base; tip mode guards the newest point.
-/// Surviving noisy candidates pass a Benjamini–Hochberg false-discovery filter at
-/// `config.fdr_q`; deterministic candidates bypass it. Findings are then filtered
-/// to the directions the mode reports and ordered by descending relative move,
-/// then method, then a deterministic identity tie-break.
+/// Surviving candidates pass a Benjamini–Hochberg false-discovery filter at
+/// `config.fdr_q`. Findings are then filtered to the directions the mode reports and
+/// ordered by descending relative move, then method, then a stable identity
+/// tie-break.
 ///
 /// Detection is per-series independent, so the series are split into one balanced
 /// contiguous chunk per worker and each chunk runs on its own blocking task via
@@ -1046,7 +1074,7 @@ pub async fn find_changes_spawned(
 /// spawner-distributed detection passes.
 ///
 /// `candidates` must be in series order (the order both detection paths produce) so
-/// the Benjamini–Hochberg mask built over the noisy candidates stays aligned.
+/// the Benjamini–Hochberg mask stays aligned.
 fn finalize_findings(
     candidates: Vec<Candidate>,
     series: &[Series],
@@ -1054,29 +1082,20 @@ fn finalize_findings(
 ) -> Vec<Finding> {
     let config = &context.config;
 
-    // Control the false-discovery rate across the noisy candidates only; the
-    // deterministic ones are exact and need no correction.
-    let noisy_p: Vec<f64> = candidates
-        .iter()
-        .filter(|candidate| !candidate.deterministic)
-        .map(|candidate| candidate.bh_p)
-        .collect();
-    let keep = stats::benjamini_hochberg(&noisy_p, config.fdr_q);
+    // Control the false-discovery rate across every candidate: no engine is exact, so
+    // each contributes its significance-test p-value to the shared pool.
+    let candidate_p: Vec<f64> = candidates.iter().map(|candidate| candidate.bh_p).collect();
+    let keep = stats::benjamini_hochberg(&candidate_p, config.fdr_q);
     let mut keep_iter = keep.into_iter();
 
-    // `candidates` and `noisy_p` were built in the same order, so advancing
-    // `keep_iter` exactly for the noisy candidates keeps the mask aligned. A
-    // surviving finding that the mode keeps materialises its charting points here —
-    // a dropped candidate never pays for them.
+    // `candidates` and `candidate_p` were built in the same order, so advancing
+    // `keep_iter` for each candidate keeps the mask aligned. A surviving finding that
+    // the mode keeps materialises its charting points here — a dropped candidate never
+    // pays for them.
     let mut findings: Vec<Finding> = candidates
         .into_iter()
         .filter_map(|candidate| {
-            let survive = if candidate.deterministic {
-                true
-            } else {
-                keep_iter.next().unwrap_or(false)
-            };
-            if !survive {
+            if !keep_iter.next().unwrap_or(false) {
                 return None;
             }
             let Candidate {
@@ -1084,14 +1103,6 @@ fn finalize_findings(
                 source_index,
                 ..
             } = candidate;
-            // Basic noise filter: a sub-`noise_floor` move is measurement noise even at
-            // full confidence, so it is suppressed regardless of direction or engine.
-            // This gates the otherwise-unbounded deterministic engines and backstops the
-            // per-engine practical-magnitude floors. Applied before charting points are
-            // materialised so a dropped finding never pays for them.
-            if finding.relative_delta.abs() < config.noise_floor {
-                return None;
-            }
             if !context.keeps(finding.direction) {
                 return None;
             }
@@ -1233,14 +1244,14 @@ mod tests {
     use crate::analyze::{Blessing, SeriesPoint};
     use crate::model::{DiscriminantSet, MetricKind};
 
-    /// Builds a deterministic (Callgrind) series carrying `values` in topological
-    /// order, with no dispersion.
+    /// Builds a Callgrind-style series carrying `values` in topological order, with
+    /// no dispersion (no confidence interval).
     fn series_of(values: &[f64]) -> Series {
         series_with(values, MetricKind::InstructionCount, &[])
     }
 
-    /// Builds a deterministic series whose benchmark id carries a distinct `name`,
-    /// so a batch of series stays individually identifiable in the findings.
+    /// Builds a series whose benchmark id carries a distinct `name`, so a batch of
+    /// series stays individually identifiable in the findings.
     fn named_series(name: &str, values: &[f64]) -> Series {
         let mut series = series_of(values);
         series.id = BenchmarkId::new(nonempty![name.to_owned(), "case".to_owned()]);
@@ -1299,6 +1310,21 @@ mod tests {
         series.points.iter().map(|point| point.value).collect()
     }
 
+    /// Builds a Callgrind-style history with a two-point plateau at `peak`
+    /// bracketed by `shoulder`-length baseline and recovery regimes at `base`: a
+    /// spike that rose and has since fully recovered.
+    ///
+    /// Every engine is now treated as noisy, so a recovered spike is only
+    /// significant once each side is long enough for its Mann-Whitney gate; a
+    /// two-point plateau needs eight-point shoulders to clear both rank tests.
+    fn recovered_spike(base: f64, peak: f64, shoulder: usize) -> Series {
+        let mut values = vec![base; shoulder];
+        values.push(peak);
+        values.push(peak);
+        values.extend(std::iter::repeat_n(base, shoulder));
+        series_of(&values)
+    }
+
     /// Builds a minimal [`Candidate`] carrying only the fields [`arbitrate`]
     /// inspects (`method`, `split`, `line`); every other field is a placeholder.
     fn candidate(
@@ -1332,7 +1358,6 @@ mod tests {
             },
             source_index: 0,
             bh_p: 0.0,
-            deterministic: true,
             split,
             line,
         }
@@ -1455,15 +1480,6 @@ mod tests {
     }
 
     #[test]
-    fn allocation_metrics_are_deterministic_but_processor_time_is_not() {
-        // Allocation byte/count totals are an exact property of the code, so they
-        // are treated as deterministic; processor time is noisy like wall time.
-        assert!(MetricKind::AllocatedBytes.is_deterministic());
-        assert!(MetricKind::AllocationCount.is_deterministic());
-        assert!(!MetricKind::ProcessorTime.is_deterministic());
-    }
-
-    #[test]
     fn direction_of_classifies_a_zero_delta_as_an_improvement() {
         // The classification is total: a zero delta (never reached in practice) is
         // defined as an improvement for every polarity.
@@ -1549,6 +1565,33 @@ mod tests {
     }
 
     #[test]
+    fn sample_step_residual_is_the_median_absolute_deviation_across_samples() {
+        // before [10,12,20] -> median 12 -> residuals 2,0,8; after [30,33,40] ->
+        // median 33 -> residuals 3,0,7; the median of [2,0,8,3,0,7] is 2.5.
+        assert_eq!(
+            sample_step_residual(&[10.0, 12.0, 20.0], &[30.0, 33.0, 40.0]),
+            Some(2.5)
+        );
+    }
+
+    #[test]
+    fn sample_step_residual_of_an_empty_sample_is_none() {
+        assert_eq!(sample_step_residual(&[], &[1.0, 2.0]), None);
+    }
+
+    #[test]
+    fn exceeds_residual_noise_requires_the_move_to_clear_the_scatter_band() {
+        let config = AnalysisConfig::default();
+        // A residual of 1.0 puts the band at 3x = 3.0. A move inside the band is
+        // not clear of it, a move exactly at the band is still not (the comparison
+        // is strict), a move above it is, and a missing residual trusts the move.
+        assert!(!exceeds_residual_noise(1.0, Some(1.0), &config));
+        assert!(!exceeds_residual_noise(3.0, Some(1.0), &config));
+        assert!(exceeds_residual_noise(3.5, Some(1.0), &config));
+        assert!(exceeds_residual_noise(0.0, None, &config));
+    }
+
+    #[test]
     fn arbitrate_breaks_a_residual_tie_in_favour_of_the_change_point() {
         // Both models fit a flat series perfectly (residual 0): the tie favours the
         // more specific change-point, so a `line < step` -> `line <= step` slip that
@@ -1589,7 +1632,11 @@ mod tests {
     fn change_point_accepts_a_minimal_before_regime() {
         // Pettitt splits at tau=2, so the before regime holds exactly `min_regime`
         // points: a `<=`/`==` slip on the before-regime bound would reject the step.
-        let finding = only(changes(&[series_of(&[100.0, 100.0, 130.0, 130.0, 130.0])]));
+        // The after regime is padded so the rank test has enough points to confirm
+        // the move (a 2-vs-5 clean step is Mann–Whitney significant).
+        let finding = only(changes(&[series_of(&[
+            100.0, 100.0, 130.0, 130.0, 130.0, 130.0, 130.0,
+        ])]));
         assert_eq!(finding.method, FindingMethod::ChangePoint);
         assert_eq!(finding.baseline, 100.0);
         assert_eq!(finding.latest, 130.0);
@@ -1597,17 +1644,21 @@ mod tests {
 
     #[test]
     fn change_point_accepts_a_minimal_after_regime() {
-        // Pettitt splits at tau=3, so the after regime holds exactly `min_regime`
-        // points: a `<=` slip on the after-regime bound would reject the step.
-        let finding = only(changes(&[series_of(&[100.0, 100.0, 100.0, 130.0, 130.0])]));
+        // Pettitt splits at tau=5, so the after regime holds exactly `min_regime`
+        // points: a `<=` slip on the after-regime bound would reject the step. The
+        // before regime is padded so the 5-vs-2 clean step is rank-test significant.
+        let finding = only(changes(&[series_of(&[
+            100.0, 100.0, 100.0, 100.0, 100.0, 130.0, 130.0,
+        ])]));
         assert_eq!(finding.method, FindingMethod::ChangePoint);
         assert_eq!(finding.baseline, 100.0);
         assert_eq!(finding.latest, 130.0);
     }
 
     #[test]
-    fn deterministic_sustained_step_is_flagged_as_a_change_point() {
-        // A clean step from 100 to 130 with three points each side.
+    fn sustained_step_is_flagged_as_a_change_point() {
+        // A clean step from 100 to 130 with three points each side: a 3-vs-3 clean
+        // step is Mann–Whitney significant.
         let series = series_of(&[100.0, 100.0, 100.0, 130.0, 130.0, 130.0]);
         let finding = only(changes(&[series]));
         assert_eq!(finding.method, FindingMethod::ChangePoint);
@@ -1616,45 +1667,43 @@ mod tests {
         assert_eq!(finding.latest, 130.0);
         assert_eq!(finding.delta, 30.0);
         assert!((finding.relative_delta - 0.30).abs() <= 1e-9);
-        // An exact engine reports full confidence and attributes the change to the
-        // first commit of the after regime.
-        assert_eq!(finding.confidence, 1.0);
+        // Confidence derives from the rank-test p-value (below 1) and the change is
+        // attributed to the first commit of the after regime.
+        assert!(finding.confidence > 0.9 && finding.confidence < 1.0);
         assert_eq!(finding.commit.as_deref(), Some("commit3"));
     }
 
     #[test]
-    fn deterministic_step_below_the_noise_floor_is_suppressed() {
-        // A one-instruction step is real on a deterministic engine, but a sub-1% move
-        // is meaningless even at full confidence, so the basic noise filter suppresses
-        // it: 1000 -> 1001 is a 0.1% move.
+    fn step_below_the_practical_floor_is_suppressed() {
+        // A sub-3% move is treated as measurement noise even when it looks clean, so
+        // the practical-magnitude floor suppresses it: 1000 -> 1001 is a 0.1% move.
         let series = series_of(&[1000.0, 1000.0, 1000.0, 1001.0, 1001.0, 1001.0]);
         assert!(changes(&[series]).is_empty());
     }
 
     #[test]
-    fn deterministic_step_at_the_noise_floor_is_flagged() {
-        // The noise floor is a strict `<` rejection, so a deterministic step whose
-        // relative move EQUALS the 1% floor is still reported: 1000 -> 1010 is exactly
-        // a 1% move.
-        let series = series_of(&[1000.0, 1000.0, 1000.0, 1010.0, 1010.0, 1010.0]);
+    fn step_at_the_practical_floor_is_flagged() {
+        // The practical floor is a strict `<` rejection, so a step whose relative move
+        // EQUALS the 3% floor is still reported: 1000 -> 1030 is exactly a 3% move.
+        let series = series_of(&[1000.0, 1000.0, 1000.0, 1030.0, 1030.0, 1030.0]);
         let finding = only(changes(&[series]));
         assert_eq!(finding.method, FindingMethod::ChangePoint);
-        assert_eq!(finding.delta, 10.0);
-        assert!((finding.relative_delta - 0.01).abs() <= 1e-9);
-        assert_eq!(finding.confidence, 1.0);
+        assert_eq!(finding.delta, 30.0);
+        assert!((finding.relative_delta - 0.03).abs() <= 1e-9);
+        assert!(finding.confidence > 0.9 && finding.confidence < 1.0);
     }
 
     #[test]
-    fn sub_noise_floor_improvement_is_also_suppressed() {
-        // The noise filter applies in any direction: a sub-1% improvement on a
-        // deterministic engine is just as meaningless as a sub-1% regression, so
-        // 1000 -> 999 (a 0.1% drop) raises nothing.
+    fn sub_practical_floor_improvement_is_also_suppressed() {
+        // The floor applies in any direction: a sub-3% improvement is just as
+        // meaningless as a sub-3% regression, so 1000 -> 999 (a 0.1% drop) raises
+        // nothing.
         let series = series_of(&[1000.0, 1000.0, 1000.0, 999.0, 999.0, 999.0]);
         assert!(changes(&[series]).is_empty());
     }
 
     #[test]
-    fn deterministic_l1_hit_drop_is_a_regression() {
+    fn l1_hit_drop_is_a_regression() {
         // L1 hits are higher-is-better, so a drop in L1 hits is a regression
         // (the access shifted to a slower tier).
         let series = series_with(
@@ -1668,7 +1717,7 @@ mod tests {
     }
 
     #[test]
-    fn deterministic_ram_hit_rise_is_a_regression() {
+    fn ram_hit_rise_is_a_regression() {
         // RAM hits are the expensive tier (lower-is-better), so a rise in RAM
         // hits is a regression.
         let series = series_with(
@@ -1828,7 +1877,7 @@ mod tests {
     }
 
     #[test]
-    fn deterministic_monotonic_drift_is_flagged() {
+    fn monotonic_drift_is_flagged() {
         // A steady climb with no single dominant step surfaces as a drift finding.
         let series = series_of(&[100.0, 104.0, 108.0, 112.0, 116.0, 120.0]);
         let finding = only(changes(&[series]));
@@ -1843,8 +1892,10 @@ mod tests {
     #[test]
     fn a_sharp_step_is_reported_as_a_change_point_not_a_drift() {
         // A series that both trends and steps: the two-regime model fits the sharp
-        // jump better than a line, so it is reported once, as a change-point.
-        let series = series_of(&[100.0, 101.0, 102.0, 160.0, 161.0, 162.0]);
+        // jump better than a line, so it is reported once, as a change-point. Four
+        // distinct points each side make the rank test significant despite the
+        // within-regime spread.
+        let series = series_of(&[100.0, 101.0, 102.0, 103.0, 160.0, 161.0, 162.0, 163.0]);
         let findings = changes(&[series]);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].method, FindingMethod::ChangePoint);
@@ -1902,12 +1953,12 @@ mod tests {
     #[test]
     fn find_changes_ranks_larger_relative_move_first() {
         let larger = series_of(&[100.0, 100.0, 100.0, 200.0, 200.0, 200.0]);
-        let smaller = series_of(&[1000.0, 1000.0, 1000.0, 1020.0, 1020.0, 1020.0]);
+        let smaller = series_of(&[1000.0, 1000.0, 1000.0, 1050.0, 1050.0, 1050.0]);
         let findings = changes(&[smaller, larger]);
         assert_eq!(findings.len(), 2);
         assert!(findings[0].relative_delta.abs() > findings[1].relative_delta.abs());
         assert_eq!(findings[0].latest, 200.0);
-        assert_eq!(findings[1].latest, 1020.0);
+        assert_eq!(findings[1].latest, 1050.0);
     }
 
     #[test]
@@ -1933,9 +1984,9 @@ mod tests {
 
     // -- Branch and tip modes -------------------------------------------------
 
-    /// Builds a deterministic (Callgrind) series from explicit
-    /// `(topo_index, value, dirty)` points, so branch/tip splits can be modelled
-    /// precisely. Points are taken in the given order (already topological).
+    /// Builds a Callgrind-style series from explicit `(topo_index, value, dirty)`
+    /// points, so branch/tip splits can be modelled precisely. Points are taken in
+    /// the given order (already topological).
     fn placed_series(points: &[(usize, f64, bool)]) -> Series {
         let points = points
             .iter()
@@ -2072,11 +2123,13 @@ mod tests {
     #[test]
     fn branch_mode_admits_a_dirty_snapshot_at_the_merge_base_tip() {
         // The merge-base is the branch tip (topo 2); a dirty snapshot there is the
-        // branch side, the clean runs at the same/earlier commits are the base.
+        // branch side, the clean runs at the same/earlier commits are the base. Three
+        // dirty runs give the rank test enough points to confirm the regression.
         let series = placed_series(&[
             (0, 100.0, false),
             (1, 100.0, false),
             (2, 100.0, false),
+            (2, 130.0, true),
             (2, 130.0, true),
             (2, 130.0, true),
         ]);
@@ -2191,9 +2244,11 @@ mod tests {
 
     #[test]
     fn resolved_spike_is_detected_and_marked_inactive() {
-        // A sustained interior plateau (20) between baseline regimes (10) that has
-        // since recovered: a deterministic engine accepts any non-zero plateau.
-        let spike = series_of(&[10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 10.0, 10.0, 10.0, 10.0]);
+        // A two-point plateau (20) between baseline regimes (10) that has since
+        // recovered. Every engine is now treated as noisy, so the elevated span
+        // must clear a Mann-Whitney gate on both sides; the baseline and recovery
+        // shoulders are long enough to make the rise and the fall significant.
+        let spike = recovered_spike(10.0, 20.0, 8);
         let candidate =
             evaluate_resolved_spike(&spike, &values_of(&spike), &AnalysisConfig::default())
                 .unwrap();
@@ -2201,16 +2256,17 @@ mod tests {
         assert_eq!(candidate.finding.baseline, 10.0);
         assert_eq!(candidate.finding.latest, 20.0);
         assert_eq!(candidate.finding.direction, Direction::Regression);
-        // `commit` names where the level rose, `flipped_at` where it recovered.
-        assert_eq!(candidate.finding.commit.as_deref(), Some("commit3"));
-        assert_eq!(candidate.finding.flipped_at.as_deref(), Some("commit6"));
+        // `commit` names where the median-plateau search brackets the rise,
+        // `flipped_at` where it recovered.
+        assert_eq!(candidate.finding.commit.as_deref(), Some("commit7"));
+        assert_eq!(candidate.finding.flipped_at.as_deref(), Some("commit10"));
     }
 
     #[test]
     fn history_surfaces_a_resolved_spike_only_with_include_inactive() {
         // The spike rose and recovered, so no active change remains: the default
         // history pass is silent.
-        let spike = series_of(&[10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 10.0, 10.0, 10.0, 10.0]);
+        let spike = recovered_spike(10.0, 20.0, 8);
         assert!(changes(std::slice::from_ref(&spike)).is_empty());
 
         // Requesting inactive findings surfaces it as a recovered spike that is no
@@ -2351,7 +2407,7 @@ mod tests {
 
     #[test]
     fn drift_at_the_practical_floor_is_flagged_with_real_confidence() {
-        // A deterministic climb whose relative drift (0.20) is exactly the floor: the
+        // A steady climb whose relative drift (0.20) is exactly the floor: the
         // floor gate must be a strict `<`, not a `<=`. Its confidence is 1 - p with
         // p > 0, so a mutated `1 + p` / `1 / p` would clamp to 1.
         let series = series_of(&[100.0, 104.0, 108.0, 112.0, 116.0, 120.0]);
@@ -2439,12 +2495,10 @@ mod tests {
     }
 
     #[test]
-    fn resolved_spike_at_the_minimum_length_reports_the_deviation() {
-        // Exactly min_regime * 3 (6) points is the shortest detectable spike; the
-        // `n < min * 3` gate must be a strict `<`. The plateau (20) deviates from the
-        // baseline (10) by 10 -- the `level - baseline` difference, not a sum or
-        // quotient.
-        let series = series_of(&[10.0, 10.0, 20.0, 20.0, 10.0, 10.0]);
+    fn resolved_spike_reports_the_level_minus_baseline_deviation() {
+        // The reported deviation is the plateau level (20) minus the baseline (10) --
+        // the `level - baseline` difference, not a sum or a quotient.
+        let series = recovered_spike(10.0, 20.0, 8);
         let candidate =
             evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
                 .unwrap();
@@ -2495,7 +2549,7 @@ mod tests {
         // A plateau (1010) only 1% above baseline (1000) is below the 3% practical
         // floor. The reject gate is `deviation <= 0 || relative < floor`; an `&&`
         // mutant (needing BOTH) would wrongly surface it.
-        let series = series_of(&[1000.0, 1000.0, 1010.0, 1010.0, 1000.0, 1000.0]);
+        let series = recovered_spike(1000.0, 1010.0, 8);
         assert!(
             evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
                 .is_none()
@@ -2507,7 +2561,7 @@ mod tests {
         // A plateau (103) exactly 3% above baseline (100) meets the floor; the
         // `relative < floor` gate must be a strict `<` (a `<=`/`==` mutant suppresses
         // it).
-        let series = series_of(&[100.0, 100.0, 103.0, 103.0, 100.0, 100.0]);
+        let series = recovered_spike(100.0, 103.0, 8);
         let config = AnalysisConfig {
             practical_relative: 3.0 / 100.0,
             ..AnalysisConfig::default()

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -1656,6 +1656,20 @@ mod tests {
     }
 
     #[test]
+    fn change_point_rejects_a_single_point_regime() {
+        // Pettitt splits at tau=1, leaving a one-point before regime (below
+        // min_regime). The size guard rejects when *either* regime is too small, so
+        // a `||`->`&&` slip would wrongly admit this lopsided split. A permissive
+        // rank-test threshold isolates the guard: only the size check keeps it out.
+        let config = AnalysisConfig {
+            change_alpha: 0.5,
+            ..AnalysisConfig::default()
+        };
+        let series = series_of(&[100.0, 130.0, 130.0, 130.0, 130.0, 130.0]);
+        assert!(evaluate_change_point(&series, &values_of(&series), &config).is_none());
+    }
+
+    #[test]
     fn sustained_step_is_flagged_as_a_change_point() {
         // A clean step from 100 to 130 with three points each side: a 3-vs-3 clean
         // step is Mann–Whitney significant.
@@ -2637,6 +2651,20 @@ mod tests {
             evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
                 .is_none()
         );
+    }
+
+    #[test]
+    fn resolved_spike_exactly_three_regimes_long_is_a_spike() {
+        // With min_regime 3 the shortest detectable spike holds exactly 3*3 = 9
+        // points: a baseline, an elevated plateau, and a recovery of three each. The
+        // `n < min * 3` gate must be a strict `<`; a `<=`/`==` slip would reject this
+        // minimal spike, whose 3-vs-3 rise and recovery are both rank significant.
+        let config = AnalysisConfig {
+            min_regime: 3,
+            ..AnalysisConfig::default()
+        };
+        let series = series_of(&[10.0, 10.0, 10.0, 100.0, 100.0, 100.0, 10.0, 10.0, 10.0]);
+        assert!(evaluate_resolved_spike(&series, &values_of(&series), &config).is_some());
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -6,8 +6,19 @@
 //! counts jitter a few percent run to run, and `alloc_tracker`'s per-iteration
 //! figures carry warmup and buffer-resize allocations amortized over a
 //! Criterion-chosen iteration count; Criterion wall time and `all_the_time`
-//! processor time jitter more visibly still. Every series is therefore judged
-//! noise-aware:
+//! processor time jitter more visibly still.
+//!
+//! The jitter is easy to underestimate because a Callgrind run *repeated on one
+//! unchanged machine* often reports the same count every time — the counter is
+//! deterministic for a fixed binary and input. What is not fixed is everything
+//! feeding it across the commits we compare: a different OS or CPU-microcode
+//! patch level, a different compiler patch release, the compiler's own
+//! run-to-run nondeterministic code-generation choices (inlining, ordering,
+//! layout) even at the same version, and Criterion scheduling a different
+//! iteration count when background load differs (which shifts how warmup and
+//! buffer-resize costs are amortized). Any of these perturbs the measured count
+//! without the code under test changing, so no metric can be assumed
+//! reproducible commit to commit. Every series is therefore judged noise-aware:
 //!
 //! * A Pettitt change-point *locates* a candidate split (its analytic p-value is
 //!   too conservative on short series to gate significance); both regimes must
@@ -17,8 +28,10 @@
 //!   between-commit residual scatter (the primary, series-intrinsic noise gate).
 //! * Where the engine reports a per-point confidence interval (Criterion,
 //!   `all_the_time`, `alloc_tracker`) the two regimes' intervals must also be
-//!   disjoint — an *additional* veto that can only tighten the decision, never
-//!   loosen it.
+//!   disjoint; if they overlap this veto *withholds* the finding, treating the
+//!   move as measurement noise. The veto direction is one-way: it can only
+//!   suppress a candidate the other gates would have reported — it can never
+//!   promote a move into a finding.
 //! * Surviving candidates then pass a Benjamini–Hochberg false-discovery filter so
 //!   a batch of series does not manufacture spurious findings.
 //!
@@ -736,7 +749,9 @@ fn latest_regime<'a>(
 /// significant Mann–Whitney difference, or — when a sample is too small to
 /// rank-test — rest on that residual gate alone. Where the engine additionally
 /// reports per-point confidence intervals, the two samples' intervals must also be
-/// disjoint; this is an extra veto that can only tighten the decision.
+/// disjoint; this is an extra veto that can only *suppress* a candidate the other
+/// gates would have reported (treating the move as noise when the intervals
+/// overlap) — it never turns a non-finding into a finding.
 fn compare_samples(
     series: &Series,
     before: &[&SeriesPoint],
@@ -781,7 +796,8 @@ fn compare_samples(
         // Too few points to rank-test (typically a single fresh tip or branch run):
         // the residual gate above is the significance proxy. Where per-point
         // confidence intervals exist, require the move to also clear the measurement
-        // noise band as an additional veto.
+        // noise band as an additional veto that can only suppress this candidate
+        // (never create one).
         let points: Vec<SeriesPoint> = before
             .iter()
             .chain(after.iter())

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -1686,6 +1686,25 @@ mod tests {
     }
 
     #[test]
+    fn change_point_within_its_own_residual_scatter_is_suppressed() {
+        // A rank-significant step (medians 102 -> 132, delta 30) whose regimes each
+        // wobble by 2. Under the default residual multiple the move stands clear of
+        // that scatter and is flagged; a deliberately high multiple pushes the noise
+        // band above the move, so only the residual gate rejects it (every earlier
+        // gate — persistence, Mann-Whitney, practical floor — still passes).
+        let series = series_of(&[100.0, 104.0, 100.0, 104.0, 130.0, 134.0, 130.0, 134.0]);
+        assert!(
+            evaluate_change_point(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_some()
+        );
+        let config = AnalysisConfig {
+            residual_noise_multiple: 20.0,
+            ..AnalysisConfig::default()
+        };
+        assert!(evaluate_change_point(&series, &values_of(&series), &config).is_none());
+    }
+
+    #[test]
     fn sustained_step_is_flagged_as_a_change_point() {
         // A clean step from 100 to 130 with three points each side: a 3-vs-3 clean
         // step is Mann–Whitney significant.
@@ -2461,6 +2480,22 @@ mod tests {
     }
 
     #[test]
+    fn drift_within_its_own_residual_scatter_is_suppressed() {
+        // A significant upward trend (100 -> 140) that scatters about its Theil-Sen
+        // line. Under the default residual multiple the total move dwarfs that
+        // scatter and is flagged as drift; a deliberately high multiple lifts the
+        // noise band above the move, so only the residual gate rejects it (the
+        // length, Mann-Kendall, and practical-floor gates still pass).
+        let series = series_of(&[100.0, 110.0, 109.0, 120.0, 130.0, 140.0]);
+        assert!(evaluate_drift(&series, &values_of(&series), &AnalysisConfig::default()).is_some());
+        let config = AnalysisConfig {
+            residual_noise_multiple: 1000.0,
+            ..AnalysisConfig::default()
+        };
+        assert!(evaluate_drift(&series, &values_of(&series), &config).is_none());
+    }
+
+    #[test]
     fn drift_needs_at_least_the_minimum_points() {
         // The length gate is `n < drift_min_points`: a series one point short is
         // rejected outright, while a longer series is still evaluated (so a gate
@@ -2629,6 +2664,32 @@ mod tests {
             evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
                 .is_none()
         );
+    }
+
+    #[test]
+    fn resolved_spike_within_its_own_residual_scatter_is_suppressed() {
+        // A recovered plateau (200) far above a baseline (100) that itself wobbles by
+        // 2. Under the default residual multiple the deviation stands clear and the
+        // spike is flagged; a deliberately high multiple lifts the noise band above
+        // the deviation, so only the residual gate rejects it (the recovery,
+        // practical-floor, and both rank gates still pass).
+        let values: Vec<f64> = [98.0, 102.0]
+            .into_iter()
+            .cycle()
+            .take(8)
+            .chain([198.0, 202.0])
+            .chain([98.0, 102.0].into_iter().cycle().take(8))
+            .collect();
+        let series = series_of(&values);
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_some()
+        );
+        let config = AnalysisConfig {
+            residual_noise_multiple: 60.0,
+            ..AnalysisConfig::default()
+        };
+        assert!(evaluate_resolved_spike(&series, &values_of(&series), &config).is_none());
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -156,7 +156,8 @@ struct JsonFinding<'a> {
     latest: f64,
     /// The change relative to the baseline (`(latest - baseline) / baseline`).
     relative_delta: f64,
-    /// The detector's confidence (`1 - p_value`; `1.0` for an exact step).
+    /// The detector's confidence (`1 - p_value`), approaching `1.0` as the change
+    /// becomes statistically unambiguous.
     confidence: f64,
     /// Commit the change is attributed to, if known.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/cargo-bench-history-core/src/analyze/stats.rs
+++ b/packages/cargo-bench-history-core/src/analyze/stats.rs
@@ -453,8 +453,9 @@ mod tests {
         let change = pettitt(&[1.0, 1.0, 1.0, 5.0, 5.0, 5.0]).unwrap();
         assert_eq!(change.index, 3);
         assert_eq!(change.k_statistic, 9.0);
-        // p ≈ 2·exp(−6·81/252) ≈ 0.291 — deliberately not tiny, which is why
-        // deterministic series must not gate a real step on significance.
+        // p ≈ 2·exp(−6·81/252) ≈ 0.291 — deliberately not tiny, which is why a
+        // clean step must be confirmed by a second test (Mann–Whitney), never by
+        // Pettitt's p-value alone.
         close(change.p_value, 0.291, 1e-3);
     }
 

--- a/packages/cargo-bench-history-core/src/model/comparability.rs
+++ b/packages/cargo-bench-history-core/src/model/comparability.rs
@@ -20,8 +20,9 @@ pub enum Engine {
     Criterion,
     /// Callgrind (via Gungraun) instruction counts: simulated, hardware-independent.
     Callgrind,
-    /// `alloc_tracker` allocation counts and bytes: deterministic and
-    /// hardware-independent (the same code allocates the same way on any machine).
+    /// `alloc_tracker` allocation counts and bytes: hardware-independent but not
+    /// deterministic — warmup and buffer-resize allocations jitter the per-iteration
+    /// figure, which is amortized over a Criterion-chosen iteration count.
     AllocTracker,
     /// `all_the_time` processor-time measurements: hardware-dependent and noisy.
     AllTheTime,

--- a/packages/cargo-bench-history-core/src/model/metric.rs
+++ b/packages/cargo-bench-history-core/src/model/metric.rs
@@ -14,14 +14,16 @@ pub struct Metric {
     pub kind: MetricKind,
     /// The per-iteration point estimate, in the unit implied by `kind`.
     ///
-    /// For noisy engines (Criterion wall time, `all_the_time` processor time)
-    /// this is the through-origin regression slope when the engine reports one,
-    /// otherwise the mean. For deterministic engines (Callgrind instruction
-    /// counts and cache/branch events, `alloc_tracker` allocations) it is the
-    /// exact measured count.
+    /// This is the through-origin regression slope when the engine reports one
+    /// (Criterion wall time, `all_the_time` processor time, `alloc_tracker`
+    /// allocations), otherwise the mean or the single measured value. No engine is
+    /// treated as noise-free: even Callgrind instruction and event counts jitter a
+    /// few percent from run to run, so this is always a point estimate rather than
+    /// an exact truth.
     pub value: f64,
     /// Estimated standard deviation of the measurement, when the engine reports
-    /// one (Criterion, `all_the_time`). Absent for deterministic engines.
+    /// one (Criterion, `all_the_time`, `alloc_tracker`). Absent for engines that
+    /// report no dispersion (Callgrind).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub std_dev: Option<f64>,
     /// Lower bound of the value's confidence interval, when reported.
@@ -75,9 +77,10 @@ pub enum MetricKind {
     /// Processor time per iteration in nanoseconds (`all_the_time`);
     /// hardware-dependent and noisy.
     ProcessorTime,
-    /// Retired instruction count (Callgrind); deterministic.
+    /// Retired instruction count (Callgrind); low-noise but not exact.
     InstructionCount,
-    /// Estimated CPU cycles from the Callgrind cache model; deterministic.
+    /// Estimated CPU cycles from the Callgrind cache model; low-noise but not
+    /// exact.
     EstimatedCycles,
     /// Accesses served by the L1 cache (Callgrind); the cheap outcome, so higher
     /// is better.
@@ -88,17 +91,20 @@ pub enum MetricKind {
     /// Accesses served by main memory (Callgrind); the most expensive tier, so
     /// lower is better.
     RamHits,
-    /// Executed conditional branches (Callgrind); deterministic.
+    /// Executed conditional branches (Callgrind); low-noise but not exact.
     ConditionalBranches,
-    /// Mispredicted conditional branches (Callgrind); deterministic.
+    /// Mispredicted conditional branches (Callgrind); low-noise but not exact.
     ConditionalBranchMisses,
-    /// Executed indirect branches (Callgrind); deterministic.
+    /// Executed indirect branches (Callgrind); low-noise but not exact.
     IndirectBranches,
-    /// Mispredicted indirect branches (Callgrind); deterministic.
+    /// Mispredicted indirect branches (Callgrind); low-noise but not exact.
     IndirectBranchMisses,
-    /// Bytes allocated per iteration (`alloc_tracker`); deterministic.
+    /// Bytes allocated per iteration (`alloc_tracker`); hardware-independent but
+    /// not deterministic (warmup and buffer-resize allocations jitter the
+    /// per-iteration figure).
     AllocatedBytes,
-    /// Allocation count per iteration (`alloc_tracker`); deterministic.
+    /// Allocation count per iteration (`alloc_tracker`); hardware-independent but
+    /// not deterministic.
     AllocationCount,
 }
 
@@ -181,16 +187,6 @@ impl MetricKind {
     #[must_use]
     pub fn higher_is_better(self) -> bool {
         matches!(self, Self::L1CacheHits)
-    }
-
-    /// Whether this kind is measured by a deterministic engine.
-    ///
-    /// Wall time and processor time are the noisy metrics; every Callgrind- and
-    /// `alloc_tracker`-derived metric is exact. Analysis uses this to decide
-    /// whether a change needs noise-aware gating or can be judged exactly.
-    #[must_use]
-    pub fn is_deterministic(self) -> bool {
-        !matches!(self, Self::WallTime | Self::ProcessorTime)
     }
 }
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -87,9 +87,11 @@ not conclusion-only** (see `docs/standalone-binaries.md`). Tests use the `#[cfg(
 * The backend is chosen at run time by `--local` / configured cloud (never a local path in the
   committed config); read commands add a `--cache` read-through mirror. `--machine-key` is
   CLI-only for the same reason (the config is committed). Details: DESIGN §4, §6.
-* Four engines are parsed in `bench/` — deterministic (`callgrind`, `alloc_tracker`) vs noisy
-  (`criterion`, `all_the_time`). `collect`/`backfill` invoke `cargo bench` once and harvest
-  whatever ran; `--engine` is an `analyze` facet, not a collect flag. Details: DESIGN §1.
+* Four engines are parsed in `bench/`. None is deterministic; they differ by whether each
+  point carries a confidence interval (`criterion`, `all_the_time`, and `alloc_tracker` when
+  its output records one) or is a single value (`callgrind`, and mean-only output).
+  `collect`/`backfill` invoke `cargo bench` once and harvest whatever ran; `--engine` is an
+  `analyze` facet, not a collect flag. Details: DESIGN §1.
 
 ## Testing
 

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -88,10 +88,12 @@ not conclusion-only** (see `docs/standalone-binaries.md`). Tests use the `#[cfg(
   committed config); read commands add a `--cache` read-through mirror. `--machine-key` is
   CLI-only for the same reason (the config is committed). Details: DESIGN §4, §6.
 * Four engines are parsed in `bench/`. None is deterministic; they differ by whether each
-  point carries a confidence interval (`criterion`, `all_the_time`, and `alloc_tracker` when
-  its output records one) or is a single value (`callgrind`, and mean-only output).
-  `collect`/`backfill` invoke `cargo bench` once and harvest whatever ran; `--engine` is an
-  `analyze` facet, not a collect flag. Details: DESIGN §1.
+  point carries a confidence interval (`criterion`, `all_the_time`, and `alloc_tracker` all
+  record one on every operation) or is a single value (`callgrind`, plus any legacy mean-only
+  file the adapter still tolerates). An interval is only ever an extra veto that can suppress
+  a candidate finding, never create one. `collect`/`backfill` invoke `cargo bench` once and
+  harvest whatever ran; `--engine` is an `analyze` facet, not a collect flag. Details:
+  DESIGN §1.
 
 ## Testing
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -18,7 +18,9 @@ not otherwise comparable. Its commands are `collect`, `install`, `analyze`, `exa
 
 Understanding the producers is mandatory: comparability and parsing both depend on it.
 Four engines are supported, and they split along two axes that drive the whole data
-model — **hardware-dependent vs. hardware-independent**, and **noisy vs. deterministic**.
+model — **hardware-dependent vs. hardware-independent** (which decides partitioning), and
+**whether each measurement carries a confidence interval** (which decides how dispersion is
+gated). No engine is exempt from run-to-run noise.
 
 * **Criterion** — wall-clock time. Hardware-dependent and noisy. Each measured case
   yields a stable identity (group / function / value) and a point estimate (the
@@ -26,12 +28,14 @@ model — **hardware-dependent vs. hardware-independent**, and **noisy vs. deter
   deviation and bootstrap confidence interval. It records no timestamp, commit, machine,
   or package, so the tool supplies all run context.
 * **Callgrind (via Gungraun)** — simulated instruction counts and cache/branch events.
-  Hardware-independent and deterministic (a CPU simulator), so any persistent change is
-  real signal. Its machine-readable summary is the one output that must be opted into
-  with an environment variable — the narrow "special need" that justifies `collect`
-  existing at all.
-* **`alloc_tracker`** — heap allocations (bytes and counts). Hardware-independent and
-  deterministic, with no dispersion (an allocation count is exact).
+  Hardware-independent but not exact: a CPU simulator is low-noise, yet its counts still
+  drift by a few percent run to run. Its machine-readable summary is the one output that
+  must be opted into with an environment variable — the narrow "special need" that justifies
+  `collect` existing at all.
+* **`alloc_tracker`** — heap allocations (bytes and counts). Hardware-independent but not
+  deterministic: warmup and buffer-resize allocations are amortised over a Criterion-chosen
+  iteration count, so the per-iteration figures jitter. It prefers a warmup-robust slope and
+  records a bootstrap confidence interval over its measured spans when its output carries one.
 * **`all_the_time`** — processor (CPU) time. Hardware-dependent and noisy, carrying a
   bootstrap confidence interval like Criterion.
 
@@ -100,7 +104,7 @@ A discriminant set is `{ project, engine, target_triple, machine_key? }`:
 * `target_triple` — even hardware-independent counts are not comparable across
   architectures (`…-windows-msvc` and `…-windows-gnu` are genuinely different binaries).
 * `machine_key` — present only for hardware-dependent engines; a literal `synthetic`
-  placeholder for the deterministic ones.
+  placeholder for the hardware-independent ones.
 
 Deliberately **metadata, not partition** — so a change shows up as a timeline step, which
 is the whole point of the tool — are the toolchain versions, OS/libc, commit, branch, and
@@ -540,18 +544,19 @@ Markdown tables, not of the data.
 
 A series is built per `(discriminant set, benchmark identity, metric)`, ordered by git
 first-parent topology. The goal is **high signal-to-noise**: report level shifts and trends
-that are real and stay silent on measurement jitter. The design is *engine-aware* because
-the engines have fundamentally different noise profiles and a single detector cannot serve
-both well:
+that are real and stay silent on measurement jitter. **No engine is deterministic** — even
+Callgrind's simulated counts drift by a few percent run to run, and an `alloc_tracker`
+figure amortises first-touch and buffer-resize allocations over a Criterion-chosen iteration
+count, so its per-iteration mean wobbles too. The detector therefore treats every metric as
+noisy and never trusts a value as exact.
 
-* **Deterministic engines** (Callgrind, `alloc_tracker`) produce exact, reproducible
-  output, so any persistent change is real signal. Significance testing is neither needed
-  nor appropriate — a perfect integer step over few points has a *high* nonparametric
-  p-value.
-* **Noisy engines** (Criterion, `all_the_time`) produce noisy estimates carrying a
-  standard deviation and confidence interval. A change must clear both a
-  statistical-significance bar *and* a practical-magnitude bar, and the family of tests
-  across all series is corrected for multiple comparisons.
+Engines differ only in *how much* dispersion they expose, and the gating adapts per point
+rather than per engine. Some points carry an explicit bootstrap confidence interval
+(Criterion and `all_the_time` always; `alloc_tracker` when its output records one); others
+report a single figure (Callgrind, and any mean-only output). An interval, when present, is
+read as an additional veto, but the gates' *primary* noise check needs no interval: it is
+the series' own residual scatter about its fitted model, which covers every engine
+uniformly.
 
 Every metric is lower-is-better except cache *hits* (higher is better); the higher cache
 tiers are miss-escalation costs, so polarity keys off the metric, not just its category.
@@ -575,40 +580,37 @@ When both fire on one series, the **better-fitting model wins**: the step and li
 are each scored by their residual, so sharp steps route to the change-point method and
 smooth ramps to drift, and the two never double-report one event.
 
-### 8.2 Engine-aware gating
+### 8.2 Noise-aware gating
 
-For a **deterministic** series a change-point is reported once both regimes reach the
-persistence minimum and their medians differ — no significance test and no
-multiple-comparison filter, which would wrongly drop genuine small exact steps.
+The same gates run for every engine; only their inputs differ. Pettitt *locates* the split
+(its analytic p-value is too conservative on short series to gate on), and a change-point is
+reported only when all of these hold: a **Mann–Whitney** rank test finds the two regimes
+statistically distinguishable; the move clears a **practical-magnitude floor**, so a
+statistically-real but trivial wobble stays silent; and the move stands above the series'
+own **residual scatter** about the fitted step — the median-absolute-residual gate that is
+the primary noise check for *every* engine, in place of trusting a value as exact. Where the
+points carry confidence intervals, non-overlap of the regime intervals is an *additional*
+veto; where they do not, the residual gate stands alone.
 
-For a **noisy** series the Pettitt test is used only to *locate* the split (its analytic
-p-value is too conservative on short series to serve as a gate). A change-point is reported
-only when all of these hold: a **Mann–Whitney** rank test finds the two regimes
-statistically distinguishable; the regime confidence intervals do not overlap (when
-present); and the move clears a practical-magnitude floor, so a statistically-real but tiny
-wobble stays silent. Drift additionally requires the endpoint movement to exceed a noise
-floor derived from the confidence-interval width, so run-to-run jitter never reads as a
-trend. When an engine reports no confidence interval (older mean-only output), the
-CI-non-overlap gate is skipped and the decision rests on the rank and trend tests alone.
+Drift mirrors this: Mann–Kendall establishes the trend, Theil–Sen sizes it, and the total
+movement must clear the practical floor and exceed the residual scatter about the fitted
+line; the confidence-interval-width gate is applied additionally when intervals are present.
 
-Underneath every engine's gates sits one **basic noise floor**: any finding whose relative
-move is below a minimum magnitude is dropped regardless of direction, engine, or
-confidence. A sub-percent change is not worth a human's attention even when a deterministic
-engine reports it with certainty, so this floor is what keeps the otherwise-unbounded
-deterministic path from surfacing trivia; it sits below the noisy engines' higher
-practical-magnitude floors, which already subsume it.
+The **practical-magnitude floor** is a single hard threshold below which no finding surfaces,
+regardless of engine, direction, or how confidently it was measured. A change too small to
+warrant a human's attention is dropped even when the statistics are certain — this is what
+keeps a low-noise engine like Callgrind from surfacing sub-threshold trivia.
 
 ### 8.3 Multiple-comparison discipline
 
 A repository has many benchmarks × metrics; testing each independently would flood the
-report with false positives. Every **noisy** candidate's p-value enters a single
-**Benjamini–Hochberg** false-discovery-rate procedure, and only survivors are reported.
-Deterministic candidates bypass it — they carry no measurement-noise false-positive risk
-and their exact steps would otherwise be discarded.
+report with false positives. Because no engine is exempt from noise, **every** candidate's
+p-value enters a single **Benjamini–Hochberg** false-discovery-rate procedure — there is no
+bypass — and only survivors are reported.
 
-All of this math lives in a pure, deterministic, Miri-safe statistics module in the core
-crate, unit-tested with named, value-asserting cases on hand-computable inputs rather than
-threshold-mutation guards, so the whole detector is verifiable without real-time delays.
+All of this math lives in a pure, Miri-safe statistics module in the core crate, unit-tested
+with named, value-asserting cases on hand-computable inputs rather than threshold-mutation
+guards, so the whole detector is verifiable without real-time delays.
 
 ### 8.4 Ranking and polarity
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -547,16 +547,27 @@ first-parent topology. The goal is **high signal-to-noise**: report level shifts
 that are real and stay silent on measurement jitter. **No engine is deterministic** — even
 Callgrind's simulated counts drift by a few percent run to run, and an `alloc_tracker`
 figure amortizes first-touch and buffer-resize allocations over a Criterion-chosen iteration
-count, so its per-iteration mean wobbles too. The detector therefore treats every metric as
+count, so its per-iteration figure wobbles too. The detector therefore treats every metric as
 noisy and never trusts a value as exact.
 
+This surprises people, because re-running Callgrind on one *unchanged* machine often prints
+the same count every time — the counter is deterministic for a fixed binary and fixed input.
+What is not fixed is everything feeding it across the commits we compare: a different OS or
+CPU-microcode patch level, a different compiler patch release, the compiler's own run-to-run
+nondeterministic code-generation choices (inlining, ordering, layout) even at the same
+version, and Criterion scheduling a different iteration count when background load differs
+(which changes how first-touch and buffer-resize costs are amortized). Any one of these moves
+the measured number without the code under test changing, so no metric is reproducible commit
+to commit.
+
 Engines differ only in *how much* dispersion they expose, and the gating adapts per point
-rather than per engine. Some points carry an explicit bootstrap confidence interval
-(Criterion and `all_the_time` always; `alloc_tracker` when its output records one); others
-report a single figure (Callgrind, and any mean-only output). An interval, when present, is
-read as an additional veto, but the gates' *primary* noise check needs no interval: it is
-the series' own residual scatter about its fitted model, which covers every engine
-uniformly.
+rather than per engine. Most points carry an explicit bootstrap confidence interval:
+Criterion, `all_the_time`, and `alloc_tracker` all record one on every operation they emit.
+Only single-figure engines (Callgrind, and any legacy mean-only file the adapter still
+tolerates) report a point without an interval. An interval, when present, is read as an
+additional veto that can only *suppress* a candidate the other gates would report (never
+create one); the gates' *primary* noise check needs no interval at all: it is the series' own
+residual scatter about its fitted model, which covers every engine uniformly.
 
 Every metric is lower-is-better except cache *hits* (higher is better); the higher cache
 tiers are miss-escalation costs, so polarity keys off the metric, not just its category.
@@ -590,11 +601,14 @@ statistically-real but trivial wobble stays silent; and the move stands above th
 own **residual scatter** about the fitted step — the median-absolute-residual gate that is
 the primary noise check for *every* engine, in place of trusting a value as exact. Where the
 points carry confidence intervals, non-overlap of the regime intervals is an *additional*
-veto; where they do not, the residual gate stands alone.
+veto — it can only *suppress* a candidate the other gates would report (declaring the move
+noise when the intervals overlap), never manufacture a finding; where they do not, the
+residual gate stands alone.
 
 Drift mirrors this: Mann–Kendall establishes the trend, Theil–Sen sizes it, and the total
 movement must clear the practical floor and exceed the residual scatter about the fitted
-line; the confidence-interval-width gate is applied additionally when intervals are present.
+line; the confidence-interval-width gate is applied additionally when intervals are present,
+again only able to suppress a candidate and never to create one.
 
 The **practical-magnitude floor** is a single hard threshold below which no finding surfaces,
 regardless of engine, direction, or how confidently it was measured. A change too small to

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -33,7 +33,7 @@ gated). No engine is exempt from run-to-run noise.
   must be opted into with an environment variable — the narrow "special need" that justifies
   `collect` existing at all.
 * **`alloc_tracker`** — heap allocations (bytes and counts). Hardware-independent but not
-  deterministic: warmup and buffer-resize allocations are amortised over a Criterion-chosen
+  deterministic: warmup and buffer-resize allocations are amortized over a Criterion-chosen
   iteration count, so the per-iteration figures jitter. It prefers a warmup-robust slope and
   records a bootstrap confidence interval over its measured spans when its output carries one.
 * **`all_the_time`** — processor (CPU) time. Hardware-dependent and noisy, carrying a
@@ -546,7 +546,7 @@ A series is built per `(discriminant set, benchmark identity, metric)`, ordered 
 first-parent topology. The goal is **high signal-to-noise**: report level shifts and trends
 that are real and stay silent on measurement jitter. **No engine is deterministic** — even
 Callgrind's simulated counts drift by a few percent run to run, and an `alloc_tracker`
-figure amortises first-touch and buffer-resize allocations over a Criterion-chosen iteration
+figure amortizes first-touch and buffer-resize allocations over a Criterion-chosen iteration
 count, so its per-iteration mean wobbles too. The detector therefore treats every metric as
 noisy and never trusts a value as exact.
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -156,7 +156,7 @@ and a single sort for the false-discovery filter across all noisy candidates.
   worker (each worker awaits its chunk's reads sequentially), which is well below the
   blessing-sidecar load's wider pipeline — so the win from the parallel design is on the
   CPU-bound parse+fold, not on remote I/O. With the shared connection pool (below) the
-  per-object handshake is amortised across a keep-alive pool, leaving path bandwidth and,
+  per-object handshake is amortized across a keep-alive pool, leaving path bandwidth and,
   for small objects, a per-request round-trip rate as the two ceilings; fewer, larger blobs
   help more than more concurrency.
 

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -1986,6 +1986,32 @@ mod tests {
         git
     }
 
+    /// A master history `c0 - c1 - c2 - c3` with a feature branch off the tip `c3`:
+    ///
+    /// ```text
+    /// master:  c0 - c1 - c2 - c3
+    ///                          \
+    /// feature:                  f1 - f2   (HEAD)
+    /// ```
+    ///
+    /// The four-commit base line gives a branch comparison a baseline large enough
+    /// to reach rank-test significance against a raised feature regime; branching at
+    /// the tip keeps every base commit an ancestor of the feature tip.
+    fn feature_tip_git() -> FakeGitHistory {
+        let mut git = FakeGitHistory::new();
+        git.commit("c0", None)
+            .commit("c1", Some("c0"))
+            .commit("c2", Some("c1"))
+            .commit("c3", Some("c2"))
+            .commit("f1", Some("c3"))
+            .commit("f2", Some("f1"))
+            .branch("master", "c3")
+            .branch("feature", "f2")
+            .head("feature")
+            .mark_default("master");
+        git
+    }
+
     /// A linear master history `c0 - c1 - c2 - c3 - c4 - c5`, HEAD at the tip.
     ///
     /// Long enough to host a sustained level shift with at least two points on
@@ -2780,20 +2806,25 @@ mod tests {
 
     #[test]
     fn feature_view_admits_dirty_after_the_merge_base() {
-        // feature branched at c1; the target side rises at f1 and the dirty f2
-        // snapshot sustains the new level. The dirty run is admitted (runs == 4)
-        // and is essential to the flag: without it the lone f1 point cannot satisfy
-        // the change-point detector's persistence requirement.
+        // feature branched at the master tip c3; the target side rises at f1 and a
+        // dirty f2 snapshot sustains the new level. The dirty run is admitted
+        // (runs == 7) and is essential to the flag: no engine is exact, so the raised
+        // regime must clear a rank test against the baseline. With only the two clean
+        // feature points the 4-vs-2 split is underpowered; the dirty f2 snapshot tips
+        // it to a significant 4-vs-3 difference.
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
         store(&storage, &clean_key("c1"), &ir_set(1, "c1", 100.0));
-        store(&storage, &clean_key("f1"), &ir_set(2, "f1", 130.0));
-        store(&storage, &dirty_key("f2", 3), &ir_set(3, "f2", 130.0));
-        let git = feature_git();
+        store(&storage, &clean_key("c2"), &ir_set(2, "c2", 100.0));
+        store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
+        store(&storage, &clean_key("f1"), &ir_set(4, "f1", 130.0));
+        store(&storage, &clean_key("f2"), &ir_set(5, "f2", 130.0));
+        store(&storage, &dirty_key("f2", 6), &ir_set(6, "f2", 130.0));
+        let git = feature_tip_git();
 
         let (report, regressions, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-        assert_eq!(parsed["runs"], 4, "the dirty f2 snapshot is admitted");
+        assert_eq!(parsed["runs"], 7, "the dirty f2 snapshot is admitted");
         assert_eq!(regressions, 1, "the admitted dirty f2 completes the step");
     }
 
@@ -2870,8 +2901,9 @@ mod tests {
     fn dirty_tree_on_base_branch_admits_tip_dirty_runs_with_a_warning() {
         // On the base branch (official view) with a currently-dirty working tree,
         // the dirty snapshots on the tip are the user's in-flight work and ARE
-        // admitted, with a warning that they are ephemeral. Two snapshots at the
-        // raised level complete a sustained step over the clean baseline.
+        // admitted, with a warning that they are ephemeral. Three snapshots at the
+        // raised level form a regime large enough to clear the rank test against the
+        // clean baseline.
         let storage = MemoryStorage::new();
         for (index, value) in [100.0, 100.0, 100.0].into_iter().enumerate() {
             let commit = format!("c{index}");
@@ -2884,13 +2916,17 @@ mod tests {
         }
         store(&storage, &dirty_key("c3", 300), &ir_set(300, "c3", 130.0));
         store(&storage, &dirty_key("c3", 400), &ir_set(400, "c3", 130.0));
+        store(&storage, &dirty_key("c3", 500), &ir_set(500, "c3", 130.0));
         let mut git = linear_git();
         git.mark_dirty();
 
         let (report, regressions, reporter) = analyze_json(&git, &storage, "folo", &options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-        assert_eq!(parsed["runs"], 5, "both dirty tip snapshots are admitted");
+        assert_eq!(
+            parsed["runs"], 6,
+            "all three dirty tip snapshots are admitted"
+        );
         assert_eq!(regressions, 1, "the dirty tip snapshots complete the step");
         assert_eq!(
             parsed["tip_commit"], "c3",
@@ -3106,15 +3142,19 @@ mod tests {
     fn within_a_commit_clean_precedes_dirty() {
         // On a target-side commit, a clean run and dirty snapshots both load; the
         // clean run is the baseline and the later dirty values are the latest
-        // points. Two dirty snapshots at the raised level complete a sustained step.
+        // points. Three dirty snapshots at the raised level form a regime large
+        // enough to clear the rank test against the four-commit clean baseline.
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
         store(&storage, &clean_key("c1"), &ir_set(1, "c1", 100.0));
-        store(&storage, &clean_key("f1"), &ir_set(2, "f1", 100.0));
-        store(&storage, &clean_key("f2"), &ir_set(3, "f2", 100.0));
-        store(&storage, &dirty_key("f2", 4), &ir_set(4, "f2", 130.0));
-        store(&storage, &dirty_key("f2", 5), &ir_set(5, "f2", 130.0));
-        let git = feature_git();
+        store(&storage, &clean_key("c2"), &ir_set(2, "c2", 100.0));
+        store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
+        store(&storage, &clean_key("f1"), &ir_set(4, "f1", 100.0));
+        store(&storage, &clean_key("f2"), &ir_set(5, "f2", 100.0));
+        store(&storage, &dirty_key("f2", 6), &ir_set(6, "f2", 130.0));
+        store(&storage, &dirty_key("f2", 7), &ir_set(7, "f2", 130.0));
+        store(&storage, &dirty_key("f2", 8), &ir_set(8, "f2", 130.0));
+        let git = feature_tip_git();
 
         let (_, regressions, _) = analyze_json(&git, &storage, "folo", &options());
         assert_eq!(regressions, 1, "the dirty f2 values are the latest points");

--- a/packages/cargo-bench-history/src/bench/alloc_tracker.rs
+++ b/packages/cargo-bench-history/src/bench/alloc_tracker.rs
@@ -9,9 +9,12 @@
 //! [`Engine::is_hardware_dependent`]). It is *not* deterministic, however:
 //! warmup and buffer-resize allocations are amortized over a Criterion-chosen
 //! iteration count, so the per-iteration figures jitter run to run. The adapter
-//! therefore prefers the warmup-robust slope and records the confidence interval
-//! when present. The committed fixtures under `tests/fixtures/alloc_tracker/` are
-//! real `alloc_tracker` output and act as a schema-drift canary.
+//! therefore prefers the warmup-robust slope. Current `alloc_tracker` output
+//! always carries a bootstrap confidence interval, so the adapter normally reads
+//! one; the interval fields are parsed as optional purely to tolerate legacy
+//! mean-only files, which then fall back to a single figure. The committed
+//! fixtures under `tests/fixtures/alloc_tracker/` are real `alloc_tracker` output
+//! and act as a schema-drift canary.
 //!
 //! [`Engine::is_hardware_dependent`]: crate::model::Engine::is_hardware_dependent
 

--- a/packages/cargo-bench-history/src/bench/alloc_tracker.rs
+++ b/packages/cargo-bench-history/src/bench/alloc_tracker.rs
@@ -3,10 +3,15 @@
 //!
 //! `alloc_tracker` writes one file per operation under `target/alloc_tracker/`,
 //! recording how many bytes and how many allocations a benchmark performs per
-//! iteration. Both quantities are a deterministic property of the code, so they
-//! are stored without a machine key (see [`Engine::is_hardware_dependent`]).
-//! The committed fixtures under `tests/fixtures/alloc_tracker/` are real
-//! `alloc_tracker` output and act as a schema-drift canary.
+//! iteration, together with bootstrap dispersion statistics over the operation's
+//! measured spans. Allocation behavior does not depend on the host hardware, so
+//! this engine stores its history without a machine key (see
+//! [`Engine::is_hardware_dependent`]). It is *not* deterministic, however:
+//! warmup and buffer-resize allocations are amortized over a Criterion-chosen
+//! iteration count, so the per-iteration figures jitter run to run. The adapter
+//! therefore prefers the warmup-robust slope and records the confidence interval
+//! when present. The committed fixtures under `tests/fixtures/alloc_tracker/` are
+//! real `alloc_tracker` output and act as a schema-drift canary.
 //!
 //! [`Engine::is_hardware_dependent`]: crate::model::Engine::is_hardware_dependent
 
@@ -52,21 +57,34 @@ pub(crate) fn parse_alloc_tracker_operation(
 /// `alloc_tracker`'s flat `target/alloc_tracker/` tree carries no package
 /// attribution, so the operation name alone identifies the series (mirroring the
 /// Criterion adapter).
+///
+/// For each metric the through-origin slope is preferred as the per-iteration
+/// point estimate, matching the Criterion and `all_the_time` adapters; output
+/// that records no slope falls back to the mean. When the bootstrap confidence
+/// interval is present it is recorded on the metric, so analysis can apply its
+/// interval-overlap gate to allocation figures the same way it does for wall
+/// time.
 fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
+    let bytes_value = output
+        .slope_bytes_per_iteration
+        .unwrap_or_else(|| as_f64(output.mean_bytes_per_iteration));
+    let bytes = Metric::new(MetricKind::AllocatedBytes, bytes_value).with_dispersion(
+        output.std_dev_bytes_per_iteration,
+        output.interval_low_bytes_per_iteration,
+        output.interval_high_bytes_per_iteration,
+    );
+
+    let allocations_value = output
+        .slope_allocations_per_iteration
+        .unwrap_or_else(|| as_f64(output.mean_allocations_per_iteration));
+    let allocations = Metric::new(MetricKind::AllocationCount, allocations_value).with_dispersion(
+        output.std_dev_allocations_per_iteration,
+        output.interval_low_allocations_per_iteration,
+        output.interval_high_allocations_per_iteration,
+    );
+
     let id = BenchmarkId::new(NonEmpty::new(output.operation.clone()));
-
-    let metrics = vec![
-        Metric::new(
-            MetricKind::AllocatedBytes,
-            as_f64(output.mean_bytes_per_iteration),
-        ),
-        Metric::new(
-            MetricKind::AllocationCount,
-            as_f64(output.mean_allocations_per_iteration),
-        ),
-    ];
-
-    BenchmarkResult::new(id, metrics)
+    BenchmarkResult::new(id, vec![bytes, allocations])
 }
 
 /// Casts an allocation statistic to `f64`, the model's storage type.
@@ -79,13 +97,30 @@ fn as_f64(value: u64) -> f64 {
 }
 
 /// The subset of an `alloc_tracker` operation file the tool reads. The `total_*`
-/// fields are ignored in favor of the per-iteration means, which are comparable
-/// across runs with differing iteration counts.
+/// fields are ignored in favor of the per-iteration slope (or mean), which is
+/// comparable across runs with differing iteration counts. The dispersion fields
+/// are optional so that output recording only a mean still parses.
 #[derive(Debug, Deserialize)]
 struct OperationOutput {
     operation: String,
     mean_bytes_per_iteration: u64,
     mean_allocations_per_iteration: u64,
+    #[serde(default)]
+    slope_bytes_per_iteration: Option<f64>,
+    #[serde(default)]
+    std_dev_bytes_per_iteration: Option<f64>,
+    #[serde(default)]
+    interval_low_bytes_per_iteration: Option<f64>,
+    #[serde(default)]
+    interval_high_bytes_per_iteration: Option<f64>,
+    #[serde(default)]
+    slope_allocations_per_iteration: Option<f64>,
+    #[serde(default)]
+    std_dev_allocations_per_iteration: Option<f64>,
+    #[serde(default)]
+    interval_low_allocations_per_iteration: Option<f64>,
+    #[serde(default)]
+    interval_high_allocations_per_iteration: Option<f64>,
 }
 
 #[cfg(test)]
@@ -101,6 +136,9 @@ mod tests {
 
     const ALLOCATE_VEC_FIXTURE: &str =
         include_str!("../../tests/fixtures/alloc_tracker/allocate_vec.json");
+
+    const ALLOCATE_VEC_DISPERSION_FIXTURE: &str =
+        include_str!("../../tests/fixtures/alloc_tracker/allocate_vec_dispersion.json");
 
     #[test]
     fn parses_identity_from_operation_name() {
@@ -133,15 +171,55 @@ mod tests {
     }
 
     #[test]
-    fn allocation_metrics_carry_no_dispersion() {
-        // Allocation counts are deterministic, so no confidence interval or
-        // standard deviation is reported.
+    fn minimal_output_carries_no_dispersion() {
+        // Output that records only means (no slope or interval) carries no
+        // dispersion, so each point estimate falls back to the mean and analysis
+        // relies on rank-testing across regimes rather than interval overlap.
         let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
         for metric in &record.metrics {
             assert_eq!(metric.std_dev, None);
             assert_eq!(metric.interval_low, None);
             assert_eq!(metric.interval_high, None);
         }
+    }
+
+    #[test]
+    fn records_dispersion_when_present() {
+        use std::f64::consts::FRAC_1_SQRT_2;
+
+        let record = parse_alloc_tracker_operation(ALLOCATE_VEC_DISPERSION_FIXTURE).unwrap();
+
+        let bytes = metric(&record, MetricKind::AllocatedBytes);
+        // The slope is preferred as the point estimate, and the bytes metric
+        // carries the jitter from warmup and buffer-resize allocations: a sample
+        // standard deviation of exactly sqrt(0.5) = 1/sqrt(2) bytes.
+        assert_eq!(bytes.value, 200.0);
+        assert_eq!(bytes.std_dev, Some(FRAC_1_SQRT_2));
+        assert_eq!(bytes.interval_low, Some(199.5));
+        assert_eq!(bytes.interval_high, Some(200.5));
+
+        let count = metric(&record, MetricKind::AllocationCount);
+        // The allocation count is stable across spans, so its interval collapses
+        // onto the slope and the standard deviation is zero.
+        assert_eq!(count.value, 2.0);
+        assert_eq!(count.std_dev, Some(0.0));
+        assert_eq!(count.interval_low, Some(2.0));
+        assert_eq!(count.interval_high, Some(2.0));
+    }
+
+    #[test]
+    fn prefers_the_slope_over_the_mean() {
+        // Slopes distinct from the means prove the slope is the chosen point
+        // estimate for each metric, matching the Criterion adapter's preference.
+        let json = concat!(
+            "{\"operation\":\"op\",\"mean_bytes_per_iteration\":200,",
+            "\"mean_allocations_per_iteration\":2,",
+            "\"slope_bytes_per_iteration\":201.5,",
+            "\"slope_allocations_per_iteration\":3.25}"
+        );
+        let record = parse_alloc_tracker_operation(json).unwrap();
+        assert_eq!(metric(&record, MetricKind::AllocatedBytes).value, 201.5);
+        assert_eq!(metric(&record, MetricKind::AllocationCount).value, 3.25);
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/bench/mod.rs
+++ b/packages/cargo-bench-history/src/bench/mod.rs
@@ -1,9 +1,10 @@
 //! Benchmark-engine adapters: per-engine environment injection, the WSL env
 //! propagation rule, and parsing of each engine's output into the model.
 //!
-//! Four engines are supported: Callgrind (via Gungraun, deterministic
-//! instruction counts), Criterion (wall-clock timings), `alloc_tracker`
-//! (deterministic allocation counts) and `all_the_time` (processor time).
+//! Four engines are supported: Callgrind (via Gungraun, low-noise instruction
+//! counts), Criterion (wall-clock timings), `alloc_tracker` (allocation counts
+//! and bytes) and `all_the_time` (processor time). None is exact — every metric
+//! carries run-to-run noise.
 
 pub(crate) mod all_the_time;
 pub(crate) mod alloc_tracker;

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -1947,8 +1947,8 @@ mod tests {
         };
         assert!(message.contains("Stored 1"), "{message}");
 
-        // Allocation counts are deterministic, so the partition is `synthetic`
-        // rather than a machine key.
+        // Allocation counts are hardware-independent, so the partition is
+        // `synthetic` rather than a machine key.
         let keys = storage.keys();
         assert_eq!(keys.len(), 1, "{keys:?}");
         assert!(keys[0].contains("/alloc_tracker/"), "{keys:?}");

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -417,7 +417,7 @@ async fn analyze_rising_ram_hits_is_a_regression() {
 #[cfg_attr(miri, ignore)]
 async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
     let workspace = Workspace::repo(&storage_only_config());
-    // `alpha` doubles (+100%); `beta` ticks up ~2%.
+    // `alpha` doubles (+100%); `beta` steps up +5%.
     workspace.commit_dated("2024-01-01", "c1");
     workspace.seed_two_benchmarks("c1", 100.0, 100.0);
     workspace.commit_dated("2024-01-02", "c2");
@@ -425,11 +425,11 @@ async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
     workspace.commit_dated("2024-01-03", "c3");
     workspace.seed_two_benchmarks("c3", 100.0, 100.0);
     workspace.commit_dated("2024-01-04", "c4");
-    workspace.seed_two_benchmarks("c4", 200.0, 102.0);
+    workspace.seed_two_benchmarks("c4", 200.0, 105.0);
     workspace.commit_dated("2024-01-05", "c5");
-    workspace.seed_two_benchmarks("c5", 200.0, 102.0);
+    workspace.seed_two_benchmarks("c5", 200.0, 105.0);
     workspace.commit_dated("2024-01-06", "c6");
-    workspace.seed_two_benchmarks("c6", 200.0, 102.0);
+    workspace.seed_two_benchmarks("c6", 200.0, 105.0);
 
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -440,7 +440,7 @@ async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
 
     let findings = parsed["findings"].as_array().unwrap();
     assert_eq!(findings.len(), 2, "{report}");
-    // The larger relative move (alpha, +100%) ranks ahead of the smaller (beta, +2%).
+    // The larger relative move (alpha, +100%) ranks ahead of the smaller (beta, +5%).
     assert_eq!(findings[0]["segments"][0], "alpha", "{report}");
     assert_eq!(findings[0]["segments"][1], "alpha::bench", "{report}");
     assert_eq!(findings[1]["segments"][0], "beta", "{report}");
@@ -530,8 +530,8 @@ async fn analyze_criterion_jitter_is_not_flagged() {
 /// A slow, monotonic Criterion `wall_time` drift is flagged as a `drift` finding
 /// (not a change-point): the Mann-Kendall trend is significant, the Theil-Sen line
 /// fits the gentle ramp better than any single step, and the total movement clears
-/// the noise floor. This exercises the second detector and the model-fit
-/// arbitration that routes ramps to drift and steps to change-point.
+/// the practical-magnitude floor. This exercises the second detector and the
+/// model-fit arbitration that routes ramps to drift and steps to change-point.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_criterion_slow_drift_is_flagged_as_drift() {
@@ -570,12 +570,13 @@ async fn analyze_criterion_slow_drift_is_flagged_as_drift() {
 }
 
 /// A Callgrind series whose instruction count steps up by a single count - a 0.1%
-/// move - is suppressed by the basic 1% noise filter even though the engine is
-/// deterministic and reports the step with certainty. A sub-percent change is
-/// meaningless regardless of confidence, so it never reaches the report.
+/// move - is below the practical-magnitude floor every engine now shares, so it is
+/// suppressed. No engine is exact (even a CPU simulator's counts jitter run to run),
+/// and a sub-percent change is not worth a human's attention regardless of how
+/// certainly it was measured.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_callgrind_step_below_the_noise_floor_is_suppressed() {
+async fn analyze_callgrind_sub_floor_step_is_suppressed() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
     workspace.seed_callgrind("c1", 1000.0);
@@ -594,7 +595,7 @@ async fn analyze_callgrind_step_below_the_noise_floor_is_suppressed() {
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["regressions"], 0,
-        "a 0.1% deterministic step is below the 1% noise floor and must not flag: {report}"
+        "a 0.1% step is below the practical-magnitude floor and must not flag: {report}"
     );
     let findings = parsed["findings"].as_array().expect("findings is an array");
     assert!(
@@ -604,14 +605,13 @@ async fn analyze_callgrind_step_below_the_noise_floor_is_suppressed() {
     );
 }
 
-/// A Callgrind series that steps up by 2% - above the 1% basic noise filter yet
-/// still below the 3% practical-magnitude floor a *noisy* engine would demand - is
-/// flagged, because deterministic engines carry no measurement noise and trust any
-/// sustained step that clears the basic floor. This proves the engine-aware split:
-/// the same 2% move would be discarded as noise on a Criterion series.
+/// A Callgrind series that steps up by 5% clears the practical-magnitude floor and is
+/// flagged as a `change_point`. Callgrind is low-noise but not exact, so it passes
+/// through the same rank test, practical floor and residual gate as any other engine
+/// rather than being trusted as deterministic.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_callgrind_deterministic_step_above_the_noise_floor_is_flagged() {
+async fn analyze_callgrind_step_above_the_practical_floor_is_flagged() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
     workspace.seed_callgrind("c1", 1000.0);
@@ -620,32 +620,31 @@ async fn analyze_callgrind_deterministic_step_above_the_noise_floor_is_flagged()
     workspace.commit_dated("2024-01-03", "c3");
     workspace.seed_callgrind("c3", 1000.0);
     workspace.commit_dated("2024-01-04", "c4");
-    workspace.seed_callgrind("c4", 1020.0);
+    workspace.seed_callgrind("c4", 1050.0);
     workspace.commit_dated("2024-01-05", "c5");
-    workspace.seed_callgrind("c5", 1020.0);
+    workspace.seed_callgrind("c5", 1050.0);
     workspace.commit_dated("2024-01-06", "c6");
-    workspace.seed_callgrind("c6", 1020.0);
+    workspace.seed_callgrind("c6", 1050.0);
 
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["regressions"], 1,
-        "a 2% deterministic step clears the 1% noise floor and must flag: {report}"
+        "a 5% Callgrind step clears the practical floor and must flag: {report}"
     );
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
 }
 
-/// An `alloc_tracker` series whose allocated-bytes count steps up is flagged as a
-/// `change_point`: allocation statistics are a deterministic property of the code,
-/// so - like Callgrind instruction counts - a sustained step that clears the basic
-/// noise floor is a real change, even when it stays below the practical-magnitude
-/// floor a noisy engine would demand.
+/// An `alloc_tracker` series whose allocated-bytes figure steps up by 5% is flagged as
+/// a `change_point`. Allocation figures are not deterministic - warmup and
+/// buffer-resize allocations jitter the per-iteration count - so they clear the same
+/// gates as any other engine; the constant allocation count produces no finding.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_alloc_tracker_step_is_flagged_as_change_point() {
     let workspace = Workspace::repo(&storage_only_config());
-    // A flat allocated-bytes baseline that steps up by 2% at the fourth commit; the
+    // A flat allocated-bytes baseline that steps up by 5% at the fourth commit; the
     // allocation count stays constant throughout.
     workspace.commit_dated("2024-03-01", "a1");
     workspace.seed_alloc_tracker("a1", "allocate_vec", 200.0, 2.0);
@@ -654,17 +653,17 @@ async fn analyze_alloc_tracker_step_is_flagged_as_change_point() {
     workspace.commit_dated("2024-03-03", "a3");
     workspace.seed_alloc_tracker("a3", "allocate_vec", 200.0, 2.0);
     workspace.commit_dated("2024-03-04", "a4");
-    workspace.seed_alloc_tracker("a4", "allocate_vec", 204.0, 2.0);
+    workspace.seed_alloc_tracker("a4", "allocate_vec", 210.0, 2.0);
     workspace.commit_dated("2024-03-05", "a5");
-    workspace.seed_alloc_tracker("a5", "allocate_vec", 204.0, 2.0);
+    workspace.seed_alloc_tracker("a5", "allocate_vec", 210.0, 2.0);
     workspace.commit_dated("2024-03-06", "a6");
-    workspace.seed_alloc_tracker("a6", "allocate_vec", 204.0, 2.0);
+    workspace.seed_alloc_tracker("a6", "allocate_vec", 210.0, 2.0);
 
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["regressions"], 1,
-        "a 2% deterministic step clears the noise floor and must flag: {report}"
+        "a 5% allocated-bytes step clears the practical floor and must flag: {report}"
     );
     assert_eq!(parsed["findings"][0]["method"], "change_point", "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "regression", "{report}");
@@ -682,18 +681,16 @@ async fn analyze_alloc_tracker_ignores_gaps_in_a_sparse_history() {
     let workspace = Workspace::repo(&storage_only_config());
     // `allocate_vec` is measured only at every other commit; the intervening
     // commits measure `free_box` instead, leaving `allocate_vec` unobserved there.
-    workspace.commit_dated("2024-04-01", "g1");
-    workspace.seed_alloc_tracker("g1", "allocate_vec", 200.0, 2.0);
-    workspace.commit_dated("2024-04-02", "g2");
-    workspace.seed_alloc_tracker("g2", "free_box", 8.0, 1.0);
-    workspace.commit_dated("2024-04-03", "g3");
-    workspace.seed_alloc_tracker("g3", "allocate_vec", 200.0, 2.0);
-    workspace.commit_dated("2024-04-04", "g4");
-    workspace.seed_alloc_tracker("g4", "free_box", 8.0, 1.0);
-    workspace.commit_dated("2024-04-05", "g5");
-    workspace.seed_alloc_tracker("g5", "allocate_vec", 260.0, 2.0);
-    workspace.commit_dated("2024-04-06", "g6");
-    workspace.seed_alloc_tracker("g6", "allocate_vec", 260.0, 2.0);
+    // Its step spans the gaps: three baseline observations, then three raised ones.
+    let mut day = 1;
+    for bytes in [200.0, 200.0, 200.0, 260.0, 260.0, 260.0] {
+        workspace.commit_dated(&format!("2024-04-{day:02}"), &format!("g{day}"));
+        workspace.seed_alloc_tracker(&format!("g{day}"), "allocate_vec", bytes, 2.0);
+        day += 1;
+        workspace.commit_dated(&format!("2024-04-{day:02}"), &format!("g{day}"));
+        workspace.seed_alloc_tracker(&format!("g{day}"), "free_box", 8.0, 1.0);
+        day += 1;
+    }
 
     let report = workspace.drive_json(&["analyze"]).await;
     // Only `allocate_vec`'s allocated-bytes step is a finding. A gap read as a drop
@@ -708,15 +705,16 @@ async fn analyze_alloc_tracker_ignores_gaps_in_a_sparse_history() {
     assert!(report.contains("allocate_vec"), "{report}");
     assert!(
         !report.contains("free_box"),
-        "the flat two-point free_box series produces no finding: {report}"
+        "the flat free_box series produces no finding: {report}"
     );
 }
 
 /// A slow, monotonic `all_the_time` processor-time drift is flagged as a `drift`
 /// finding. Processor time is a noisy, hardware-dependent measurement (like
-/// Criterion wall time), so a gentle ramp clears the noise floor only via the
-/// trend detector - even though `all_the_time` reports no confidence interval, the
-/// detector falls back gracefully to the Mann-Kendall trend and practical floor.
+/// Criterion wall time), so a gentle ramp clears the practical-magnitude floor only
+/// via the trend detector - even though `all_the_time` reports no confidence
+/// interval, the detector falls back gracefully to the Mann-Kendall trend and
+/// practical floor.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_all_the_time_slow_drift_is_flagged_as_drift() {
@@ -985,10 +983,11 @@ async fn analyze_dirty_tree_on_the_base_admits_the_tip_with_a_warning() {
     workspace.seed_callgrind("c2", 100.0);
     workspace.commit_dated("2024-01-03", "c3");
     workspace.seed_callgrind("c3", 100.0);
-    // Two dirty regression snapshots on the tip commit (c3) complete a sustained
-    // step over the clean baseline.
+    // Three dirty regression snapshots on the tip commit (c3) complete a sustained
+    // step over the clean baseline (three raised points clear the change-point gate).
     workspace.seed_dirty_callgrind("2024-01-04", "c3", 130.0);
     workspace.seed_dirty_callgrind("2024-01-05", "c3", 130.0);
+    workspace.seed_dirty_callgrind("2024-01-06", "c3", 130.0);
     // Make the working tree genuinely dirty (an uncommitted, non-ignored file),
     // matching the "evaluating the tool" / "working on the base branch" scenario.
     workspace.make_dirty("uncommitted.txt");
@@ -1000,7 +999,7 @@ async fn analyze_dirty_tree_on_the_base_admits_the_tip_with_a_warning() {
         "the dirty tip regression is admitted: {report}"
     );
     assert_eq!(
-        parsed["runs"], 5,
+        parsed["runs"], 6,
         "the dirty tip snapshots join the three clean runs: {report}"
     );
     let warning = parsed["warning"].as_str().unwrap();
@@ -1083,13 +1082,14 @@ async fn analyze_feature_branch_admits_dirty_snapshots() {
     workspace.seed_callgrind("c2", 100.0);
     workspace.commit_dated("2024-01-03", "c3");
     workspace.seed_callgrind("c3", 100.0);
-    // Branch off master and add a clean point plus two dirty regression snapshots
-    // on it (two raised points satisfy the change-point persistence requirement).
+    // Branch off master and add a clean point plus three dirty regression snapshots
+    // on it (three raised points satisfy the change-point persistence requirement).
     workspace.checkout_new_branch("feature");
     workspace.commit_dated("2024-01-04", "f1");
     workspace.seed_callgrind("f1", 100.0);
     workspace.seed_dirty_callgrind("2024-01-05", "f1", 200.0);
     workspace.seed_dirty_callgrind("2024-01-06", "f1", 200.0);
+    workspace.seed_dirty_callgrind("2024-01-07", "f1", 200.0);
 
     // By default (feature is HEAD; base is the detected master) the dirty snapshot
     // on the target side is admitted, so the spike flags.

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -712,9 +712,11 @@ async fn analyze_alloc_tracker_ignores_gaps_in_a_sparse_history() {
 /// A slow, monotonic `all_the_time` processor-time drift is flagged as a `drift`
 /// finding. Processor time is a noisy, hardware-dependent measurement (like
 /// Criterion wall time), so a gentle ramp clears the practical-magnitude floor only
-/// via the trend detector - even though `all_the_time` reports no confidence
-/// interval, the detector falls back gracefully to the Mann-Kendall trend and
-/// practical floor.
+/// via the trend detector. These synthetic points are seeded mean-only (no
+/// confidence interval), so the detector falls back gracefully to the Mann-Kendall
+/// trend and practical floor. In practice `all_the_time` does record a bootstrap
+/// CI, which would only ever act as an additional veto here, never change the
+/// outcome.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_all_the_time_slow_drift_is_flagged_as_drift() {

--- a/packages/cargo-bench-history/tests/cbh_integration/bless.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/bless.rs
@@ -170,27 +170,19 @@ async fn bless_on_a_feature_branch_is_rejected() {
 #[cfg_attr(miri, ignore)]
 async fn analyze_include_inactive_surfaces_a_recovered_spike() {
     let workspace = Workspace::clean_repo(&storage_only_config());
-    // A flat baseline, a sustained spike, then a return to the baseline level.
-    workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind("c1", 10.0);
-    workspace.commit_dated("2024-01-02", "c2");
-    workspace.seed_callgrind("c2", 10.0);
-    workspace.commit_dated("2024-01-03", "c3");
-    workspace.seed_callgrind("c3", 10.0);
-    workspace.commit_dated("2024-01-04", "c4");
-    workspace.seed_callgrind("c4", 10.0);
-    workspace.commit_dated("2024-01-05", "c5");
-    workspace.seed_callgrind("c5", 20.0);
-    workspace.commit_dated("2024-01-06", "c6");
-    workspace.seed_callgrind("c6", 20.0);
-    workspace.commit_dated("2024-01-07", "c7");
-    workspace.seed_callgrind("c7", 10.0);
-    workspace.commit_dated("2024-01-08", "c8");
-    workspace.seed_callgrind("c8", 10.0);
-    workspace.commit_dated("2024-01-09", "c9");
-    workspace.seed_callgrind("c9", 10.0);
-    workspace.commit_dated("2024-01-10", "c10");
-    workspace.seed_callgrind("c10", 10.0);
+    // An eight-point baseline, a two-point spike, then an eight-point return to the
+    // baseline level. No engine is exact, so the spike's rise and recovery must each
+    // be long enough to clear a Mann-Whitney gate before it registers at all.
+    for (day, value) in std::iter::repeat_n(10.0, 8)
+        .chain([20.0, 20.0])
+        .chain(std::iter::repeat_n(10.0, 8))
+        .enumerate()
+    {
+        let day = day + 1;
+        let label = format!("c{day}");
+        workspace.commit_dated(&format!("2024-01-{day:02}"), &label);
+        workspace.seed_callgrind(&label, value);
+    }
 
     // By default, a fully recovered spike is not reported.
     let report = workspace.drive_json(&["analyze"]).await;

--- a/packages/cargo-bench-history/tests/cbh_integration/collect.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/collect.rs
@@ -283,9 +283,10 @@ async fn collect_harvests_every_engine_that_produced_output() {
 
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 4, "{objects:?}");
-    // Deterministic engines (Callgrind instruction counts, allocation statistics)
-    // land in the `synthetic` partition; hardware-dependent engines (Criterion
-    // wall time, `all_the_time` processor time) carry a machine fingerprint.
+    // Hardware-independent engines (Callgrind instruction counts, allocation
+    // statistics) land in the `synthetic` partition; hardware-dependent engines
+    // (Criterion wall time, `all_the_time` processor time) carry a machine
+    // fingerprint.
     assert!(
         objects
             .iter()
@@ -313,8 +314,8 @@ async fn collect_harvests_every_engine_that_produced_output() {
 }
 
 /// An `alloc_tracker` run stores allocation statistics in the `synthetic`
-/// partition (allocation counts are a deterministic property of the code, not the
-/// hardware), carrying both the byte and the count metric.
+/// partition (allocation behavior depends on the code, not the hardware),
+/// carrying both the byte and the count metric.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn collect_alloc_tracker_stores_results() {
@@ -389,6 +390,36 @@ async fn collect_all_the_time_records_dispersion() {
     assert_eq!(processor_time.interval_low, Some(19.0));
     assert_eq!(processor_time.interval_high, Some(21.0));
     assert_eq!(processor_time.std_dev, Some(1.0));
+}
+
+/// An `alloc_tracker` run whose emitted output carries per-metric bootstrap
+/// confidence intervals stores that dispersion on both the bytes and the
+/// allocation-count metric, so the noise detector can later apply its
+/// interval-overlap gate to allocation figures. This proves the dispersion fields
+/// flow from the engine's JSON through the harvest and adapter into the stored
+/// result set, end to end through the real adapter.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn collect_alloc_tracker_records_dispersion() {
+    let workspace = Workspace::new(&storage_only_config())
+        .with_bench(&["--alloc-tracker", "allocate_vec=200/2@199:201/2:2"]);
+
+    workspace.drive(&["collect"]).await.unwrap();
+
+    let (_key, set) = workspace.single_object();
+    let record = &set.results[0];
+
+    let bytes = metric_of(record, MetricKind::AllocatedBytes);
+    assert_eq!(bytes.value, 200.0);
+    assert_eq!(bytes.interval_low, Some(199.0));
+    assert_eq!(bytes.interval_high, Some(201.0));
+    assert_eq!(bytes.std_dev, Some(1.0));
+
+    let count = metric_of(record, MetricKind::AllocationCount);
+    assert_eq!(count.value, 2.0);
+    assert_eq!(count.interval_low, Some(2.0));
+    assert_eq!(count.interval_high, Some(2.0));
+    assert_eq!(count.std_dev, Some(0.0));
 }
 
 /// `--machine-key` overrides the machine fingerprint in a Criterion partition.

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1083,7 +1083,7 @@ impl Workspace {
 
     /// Seeds one clean `alloc_tracker` result set for `operation` on the previously
     /// created commit `label`, recording `bytes` mean bytes and `allocs` mean
-    /// allocations per iteration. Allocation counts are deterministic, so the
+    /// allocations per iteration. Allocation counts are hardware-independent, so the
     /// partition is `synthetic` (no machine key).
     pub(crate) fn seed_alloc_tracker(&self, label: &str, operation: &str, bytes: f64, allocs: f64) {
         let commit_id = self.commit_id(label);

--- a/packages/cargo-bench-history/tests/fixtures/alloc_tracker/allocate_vec_dispersion.json
+++ b/packages/cargo-bench-history/tests/fixtures/alloc_tracker/allocate_vec_dispersion.json
@@ -1,0 +1,21 @@
+{
+  "operation": "allocate_vec",
+  "total_iterations": 600000,
+  "total_bytes_allocated": 120000000,
+  "total_allocations_count": 1200000,
+  "mean_bytes_per_iteration": 200,
+  "mean_allocations_per_iteration": 2,
+  "span_count": 6,
+  "slope_bytes_per_iteration": 200.0,
+  "std_dev_bytes_per_iteration": 0.7071067811865476,
+  "interval_low_bytes_per_iteration": 199.5,
+  "interval_high_bytes_per_iteration": 200.5,
+  "min_bytes_per_iteration": 199.0,
+  "max_bytes_per_iteration": 201.0,
+  "slope_allocations_per_iteration": 2.0,
+  "std_dev_allocations_per_iteration": 0.0,
+  "interval_low_allocations_per_iteration": 2.0,
+  "interval_high_allocations_per_iteration": 2.0,
+  "min_allocations_per_iteration": 2.0,
+  "max_allocations_per_iteration": 2.0
+}

--- a/packages/folo_utils/Cargo.toml
+++ b/packages/folo_utils/Cargo.toml
@@ -20,6 +20,7 @@ doc = false
 default = []
 
 [dependencies]
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/packages/folo_utils/src/lib.rs
+++ b/packages/folo_utils/src/lib.rs
@@ -4,7 +4,9 @@
 //! Utilities for internal use in Folo packages; no stable API surface.
 
 mod file_name;
+mod span_stats;
 mod target_dir;
 
 pub use file_name::*;
+pub use span_stats::*;
 pub use target_dir::*;

--- a/packages/folo_utils/src/span_stats.rs
+++ b/packages/folo_utils/src/span_stats.rs
@@ -1,0 +1,524 @@
+//! Warmup-robust dispersion statistics over a set of measured spans.
+//!
+//! A benchmark run records one span per Criterion sample, each covering some
+//! number of iterations and a measured total (processor-time nanoseconds,
+//! allocated bytes, allocation count — the quantity is opaque here). No
+//! benchmark metric is truly deterministic: a per-iteration figure carries
+//! warmup calls, buffer resizing and run-to-run jitter, and Criterion picks the
+//! iteration count dynamically, so a naive pooled mean is biased by whichever
+//! low-iteration warmup spans happened to run.
+//!
+//! This module derives the same span-population statistics Criterion uses for
+//! its own estimates, so every tracker crate shares one warmup-robust
+//! implementation:
+//!
+//! * a through-origin OLS **slope** as the per-iteration point estimate
+//!   (`slope = Σ(nᵢ·tᵢ) / Σ(nᵢ²)`), which weights each span by its iteration
+//!   count and so down-weights low-iteration warmup spans, and
+//! * a **bootstrap** confidence interval of that slope (resample the spans with
+//!   replacement, recompute the slope, take percentiles), matching Criterion's
+//!   confidence-interval method.
+//!
+//! The bootstrap uses a fixed seed, so identical spans always yield identical
+//! bounds. All work here is pure and allocation-bounded; it is intended to run
+//! once, when a report is materialized, never inside a measured span.
+
+#![expect(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "iteration and quantity counts stay well below 2^53, and bootstrap \
+              percentile indices are clamped into range before the cast"
+)]
+
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+/// Number of bootstrap resamples drawn when estimating the confidence interval.
+///
+/// Matches Criterion's default so the tracker crates' intervals are produced by
+/// the same method at the same resolution.
+#[cfg(not(miri))]
+const BOOTSTRAP_RESAMPLES: usize = 100_000;
+
+/// Under Miri every instruction is interpreted, so the full resample count would
+/// make a Miri-checked test run take many minutes. Miri's job here is to catch
+/// undefined behaviour, not to validate statistics, so a tiny count still
+/// exercises every arithmetic path (the interval's exact bounds are only asserted
+/// in Miri-excluded tests).
+#[cfg(miri)]
+const BOOTSTRAP_RESAMPLES: usize = 256;
+
+/// Confidence level of the reported interval (95%, matching Criterion's default).
+const CONFIDENCE_LEVEL: f64 = 0.95;
+
+/// Fixed seed for the bootstrap RNG.
+///
+/// A fixed seed makes the interval a deterministic function of the recorded
+/// spans, so re-running an analysis over unchanged data yields identical bounds.
+const BOOTSTRAP_SEED: u64 = 0x5A11_0C8E_BEE5_F00D;
+
+/// One recorded span: a measured quantity total and the number of iterations it
+/// covered.
+///
+/// The raw whole-span total is retained (not pre-divided per iteration) so that
+/// the slope regression can weight each span by its iteration count. The
+/// quantity's unit is opaque: it is nanoseconds for processor time, bytes or a
+/// count for allocations.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct Span {
+    /// Iterations the span measured.
+    pub iterations: u64,
+
+    /// Total measured quantity the span accumulated (in the caller's unit).
+    pub total: u64,
+}
+
+impl Span {
+    /// Creates a span covering `iterations` iterations with the given `total`.
+    #[must_use]
+    pub fn new(iterations: u64, total: u64) -> Self {
+        Self { iterations, total }
+    }
+}
+
+/// Warmup-robust dispersion statistics derived from a set of [`Span`]s.
+///
+/// Every field is expressed in the same unit as the input span totals (a
+/// per-iteration quantity: nanoseconds, bytes, or a count). The point estimate
+/// is the [`slope`](Self::slope); the interval and standard deviation describe
+/// its dispersion, which downstream noise-aware analysis consumes.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct SpanStats {
+    /// Number of spans the statistics were derived from (distinct from the total
+    /// iteration count).
+    pub span_count: u64,
+
+    /// Through-origin OLS slope: the per-iteration point estimate.
+    pub slope: f64,
+
+    /// Sample standard deviation (Bessel-corrected) of the per-iteration values
+    /// across spans; zero for fewer than two spans.
+    pub std_dev: f64,
+
+    /// Lower bound of the slope's bootstrap confidence interval.
+    pub interval_low: f64,
+
+    /// Upper bound of the slope's bootstrap confidence interval.
+    pub interval_high: f64,
+
+    /// Smallest per-iteration value observed across spans.
+    pub min: f64,
+
+    /// Largest per-iteration value observed across spans.
+    pub max: f64,
+}
+
+impl SpanStats {
+    /// Computes the dispersion statistics for a non-empty set of spans.
+    ///
+    /// Returns `None` when `spans` is empty, since a set with no measured work
+    /// has no statistics to report.
+    #[must_use]
+    pub fn from_spans(spans: &[Span]) -> Option<Self> {
+        if spans.is_empty() {
+            return None;
+        }
+
+        let slope = slope(spans);
+        let (interval_low, interval_high) = bootstrap_interval(spans);
+        let (min, max) = min_max(spans);
+
+        Some(Self {
+            span_count: spans.len() as u64,
+            slope,
+            std_dev: std_dev(spans),
+            interval_low,
+            interval_high,
+            min,
+            max,
+        })
+    }
+}
+
+/// Per-iteration value of a span: its total divided by its iteration count.
+fn per_iteration(span: Span) -> f64 {
+    let iterations = span.iterations as f64;
+    if iterations == 0.0 {
+        0.0
+    } else {
+        span.total as f64 / iterations
+    }
+}
+
+/// Through-origin OLS slope `Σ(nᵢ·tᵢ) / Σ(nᵢ²)` over the spans.
+fn slope(spans: &[Span]) -> f64 {
+    let mut numerator = 0.0_f64;
+    let mut denominator = 0.0_f64;
+    for span in spans {
+        let iterations = span.iterations as f64;
+        let total = span.total as f64;
+        numerator += iterations * total;
+        denominator += iterations * iterations;
+    }
+
+    if denominator == 0.0 {
+        0.0
+    } else {
+        numerator / denominator
+    }
+}
+
+/// Sample standard deviation (Bessel-corrected) of the per-iteration values.
+///
+/// Returns zero for fewer than two spans, where dispersion is undefined.
+fn std_dev(spans: &[Span]) -> f64 {
+    let count = spans.len() as f64;
+    if count < 2.0 {
+        return 0.0;
+    }
+
+    let mut sum = 0.0_f64;
+    for span in spans {
+        sum += per_iteration(*span);
+    }
+    let mean = sum / count;
+
+    let mut sum_squared_deviation = 0.0_f64;
+    for span in spans {
+        let deviation = per_iteration(*span) - mean;
+        sum_squared_deviation += deviation * deviation;
+    }
+
+    (sum_squared_deviation / (count - 1.0)).sqrt()
+}
+
+/// Smallest and largest per-iteration values across the spans.
+fn min_max(spans: &[Span]) -> (f64, f64) {
+    let mut min = f64::INFINITY;
+    let mut max = f64::NEG_INFINITY;
+    for span in spans {
+        let value = per_iteration(*span);
+        min = min.min(value);
+        max = max.max(value);
+    }
+    (min, max)
+}
+
+/// Bootstrap percentile confidence interval of the slope.
+///
+/// Resamples the spans with replacement [`BOOTSTRAP_RESAMPLES`] times, recomputes
+/// the slope of each resample, and returns the lower and upper percentiles for
+/// [`CONFIDENCE_LEVEL`]. With a single span the interval collapses to the point
+/// estimate.
+fn bootstrap_interval(spans: &[Span]) -> (f64, f64) {
+    if spans.len() < 2 {
+        let slope = slope(spans);
+        return (slope, slope);
+    }
+
+    let count = spans.len();
+    let mut rng = SmallRng::seed_from_u64(BOOTSTRAP_SEED);
+    let mut slopes = Vec::with_capacity(BOOTSTRAP_RESAMPLES);
+
+    for _ in 0..BOOTSTRAP_RESAMPLES {
+        let mut numerator = 0.0_f64;
+        let mut denominator = 0.0_f64;
+        for _ in 0..count {
+            let index = rng.random_range(0..count);
+            let span = *spans
+                .get(index)
+                .expect("random_range yields an in-bounds index");
+            let iterations = span.iterations as f64;
+            let total = span.total as f64;
+            numerator += iterations * total;
+            denominator += iterations * iterations;
+        }
+        slopes.push(if denominator == 0.0 {
+            0.0
+        } else {
+            numerator / denominator
+        });
+    }
+
+    slopes.sort_unstable_by(f64::total_cmp);
+
+    let lower_fraction = (1.0 - CONFIDENCE_LEVEL) / 2.0;
+    let upper_fraction = 1.0 - lower_fraction;
+    (
+        percentile(&slopes, lower_fraction),
+        percentile(&slopes, upper_fraction),
+    )
+}
+
+/// Linearly interpolated percentile of a sorted slice (type-7 quantile).
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    match sorted {
+        [] => 0.0,
+        _ => {
+            let max_index = sorted.len().saturating_sub(1);
+            let rank = fraction * max_index as f64;
+            let lower_index = rank.floor() as usize;
+            let upper_index = lower_index.saturating_add(1).min(max_index);
+            let interpolation = rank - rank.floor();
+
+            let lower = *sorted
+                .get(lower_index)
+                .expect("lower index is clamped within bounds");
+            let upper = *sorted
+                .get(upper_index)
+                .expect("upper index is clamped within bounds");
+            lower + interpolation * (upper - lower)
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    #![allow(
+        clippy::float_cmp,
+        reason = "statistics are exact integer-derived values in these fixtures"
+    )]
+
+    use super::*;
+
+    fn span(iterations: u64, total: u64) -> Span {
+        Span::new(iterations, total)
+    }
+
+    #[test]
+    fn empty_spans_have_no_statistics() {
+        assert!(SpanStats::from_spans(&[]).is_none());
+    }
+
+    #[test]
+    fn constant_iterations_make_slope_equal_the_mean() {
+        // Every span runs the same iteration count, so the slope degenerates to
+        // the plain per-iteration mean: (10 + 20 + 30) / 3 = 20.
+        let spans = [span(1, 10), span(1, 20), span(1, 30)];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(stats.slope, 20.0);
+    }
+
+    #[test]
+    fn slope_weights_spans_by_iteration_count() {
+        // Two spans on a perfectly linear series (5 per iter): the slope recovers
+        // exactly 5 regardless of the differing iteration counts.
+        let spans = [span(2, 10), span(8, 40)];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(stats.slope, 5.0);
+    }
+
+    #[test]
+    fn low_iteration_outlier_barely_moves_the_slope() {
+        // A noisy single-iteration warmup span (1000) alongside many
+        // high-iteration spans at 5 per iter is down-weighted by iters², so the
+        // slope stays close to 5 rather than being dragged toward 1000.
+        let spans = [span(1, 1000), span(1000, 5000), span(1000, 5000)];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert!(
+            stats.slope < 6.0,
+            "slope should resist the warmup outlier: {}",
+            stats.slope
+        );
+    }
+
+    #[test]
+    fn span_count_is_the_number_of_spans() {
+        let spans = [span(1, 10), span(1, 20), span(1, 30), span(1, 40)];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(stats.span_count, 4);
+    }
+
+    #[test]
+    fn standard_deviation_of_a_single_span_is_zero() {
+        let stats = SpanStats::from_spans(&[span(1, 42)]).unwrap();
+        assert_eq!(stats.std_dev, 0.0);
+    }
+
+    #[test]
+    fn standard_deviation_matches_a_hand_computed_value() {
+        // Per-iteration values 10, 20, 30: mean 20, variance (100+0+100)/2 = 100,
+        // standard deviation 10.
+        let spans = [span(1, 10), span(1, 20), span(1, 30)];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(stats.std_dev, 10.0);
+    }
+
+    #[test]
+    fn min_and_max_track_the_per_iteration_extremes() {
+        let spans = [span(2, 20), span(1, 5), span(4, 200)];
+        // Per-iteration values: 10, 5, 50.
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(stats.min, 5.0);
+        assert_eq!(stats.max, 50.0);
+    }
+
+    #[test]
+    fn single_span_interval_collapses_to_the_point_estimate() {
+        let stats = SpanStats::from_spans(&[span(4, 80)]).unwrap();
+        assert_eq!(stats.slope, 20.0);
+        assert_eq!(stats.interval_low, 20.0);
+        assert_eq!(stats.interval_high, 20.0);
+    }
+
+    #[test]
+    fn interval_brackets_the_point_estimate() {
+        let spans = [
+            span(1, 18),
+            span(1, 20),
+            span(1, 22),
+            span(1, 19),
+            span(1, 21),
+            span(1, 20),
+        ];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert!(
+            stats.interval_low <= stats.slope && stats.slope <= stats.interval_high,
+            "point {} must lie within [{}, {}]",
+            stats.slope,
+            stats.interval_low,
+            stats.interval_high
+        );
+    }
+
+    #[test]
+    fn wider_spread_yields_a_wider_interval() {
+        let tight = [
+            span(1, 19),
+            span(1, 20),
+            span(1, 21),
+            span(1, 20),
+            span(1, 19),
+            span(1, 21),
+        ];
+        let wide = [
+            span(1, 5),
+            span(1, 20),
+            span(1, 35),
+            span(1, 8),
+            span(1, 32),
+            span(1, 20),
+        ];
+
+        let tight_stats = SpanStats::from_spans(&tight).unwrap();
+        let wide_stats = SpanStats::from_spans(&wide).unwrap();
+
+        let tight_width = tight_stats.interval_high - tight_stats.interval_low;
+        let wide_width = wide_stats.interval_high - wide_stats.interval_low;
+        assert!(
+            wide_width > tight_width,
+            "wide interval ({wide_width}) should exceed tight interval ({tight_width})"
+        );
+    }
+
+    #[test]
+    fn bootstrap_is_deterministic_across_runs() {
+        let spans = [
+            span(1, 18),
+            span(1, 20),
+            span(1, 22),
+            span(1, 19),
+            span(1, 21),
+        ];
+        let first = SpanStats::from_spans(&spans).unwrap();
+        let second = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(first.interval_low, second.interval_low);
+        assert_eq!(first.interval_high, second.interval_high);
+    }
+
+    #[test]
+    fn two_spans_have_a_bessel_corrected_standard_deviation() {
+        // Two spans is the smallest sample with defined dispersion: per-iteration
+        // values 10 and 30, mean 20, sum of squared deviations 200, divided by the
+        // Bessel-corrected (n - 1 = 1) denominator, square-rooted.
+        let stats = SpanStats::from_spans(&[span(1, 10), span(1, 30)]).unwrap();
+        assert_eq!(stats.std_dev, 200.0_f64.sqrt());
+    }
+
+    #[test]
+    fn two_distinct_spans_widen_the_interval_beyond_the_point() {
+        // With two differing spans the bootstrap resamples take three values
+        // (both-low, mixed, both-high), so the interval spans a real range rather
+        // than collapsing to the point estimate.
+        let stats = SpanStats::from_spans(&[span(1, 10), span(1, 30)]).unwrap();
+        assert!(
+            stats.interval_low < stats.interval_high,
+            "interval [{}, {}] should be non-degenerate",
+            stats.interval_low,
+            stats.interval_high
+        );
+    }
+
+    #[test]
+    fn identical_multi_iteration_spans_collapse_to_the_true_slope() {
+        // Two identical spans (2 iterations, 80 total → 40 per iter) enter the
+        // bootstrap loop, but every resample is identical, so the interval
+        // collapses onto the true slope. The differing-from-one iteration count
+        // makes the resampled slope sensitive to the weighting arithmetic.
+        let stats = SpanStats::from_spans(&[span(2, 80), span(2, 80)]).unwrap();
+        assert_eq!(stats.slope, 40.0);
+        assert_eq!(stats.interval_low, 40.0);
+        assert_eq!(stats.interval_high, 40.0);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn bootstrap_interval_uses_the_two_and_a_half_percent_tails() {
+        // A deterministic six-span fixture pins the exact 2.5%/97.5% bootstrap
+        // bounds. Shifting the tail fractions (e.g. to 5%/95%) would land the
+        // percentiles on different resampled slopes, changing these values.
+        let spans = [
+            span(1, 10),
+            span(1, 14),
+            span(1, 18),
+            span(1, 22),
+            span(1, 26),
+            span(1, 30),
+        ];
+        let stats = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(stats.interval_low, 14.666_666_666_666_666);
+        assert_eq!(stats.interval_high, 25.333_333_333_333_332);
+    }
+
+    #[test]
+    fn percentile_of_an_empty_slice_is_zero() {
+        assert_eq!(percentile(&[], 0.5), 0.0);
+    }
+
+    #[test]
+    fn percentile_interpolates_between_neighbors() {
+        // fraction 0.625 over five points (max index 4) gives rank 2.5: halfway
+        // between sorted[2] = 30 and sorted[3] = 40, i.e. 35.
+        let sorted = [10.0, 20.0, 30.0, 40.0, 50.0];
+        assert_eq!(percentile(&sorted, 0.625), 35.0);
+    }
+
+    #[test]
+    fn per_iteration_value_of_a_zero_iteration_span_is_zero() {
+        // A span recording zero iterations cannot be divided by its count, so its
+        // per-iteration value degrades to zero rather than producing NaN.
+        assert_eq!(per_iteration(span(0, 1000)), 0.0);
+    }
+
+    #[test]
+    fn slope_of_zero_iteration_spans_is_zero() {
+        // With every span at zero iterations the weighted denominator Σ(nᵢ²) is
+        // zero, so the slope collapses to zero instead of dividing by zero.
+        assert_eq!(slope(&[span(0, 1000), span(0, 2000)]), 0.0);
+    }
+
+    #[test]
+    fn bootstrap_interval_of_zero_iteration_spans_is_zero() {
+        // Two zero-iteration spans clear the `< 2` early return and enter the
+        // resample loop, where every resample's denominator Σ(nᵢ²) is zero, so each
+        // resampled slope — and thus both interval bounds — is zero.
+        assert_eq!(
+            bootstrap_interval(&[span(0, 100), span(0, 200)]),
+            (0.0, 0.0)
+        );
+    }
+}

--- a/packages/folo_utils/src/span_stats.rs
+++ b/packages/folo_utils/src/span_stats.rs
@@ -143,6 +143,21 @@ impl SpanStats {
     }
 }
 
+/// The warmup-robust per-iteration slope of the spans on its own, without the
+/// bootstrap confidence interval or the other dispersion statistics.
+///
+/// Returns `None` for an empty span set (no measured work), matching
+/// [`SpanStats::from_spans`]. This is the cheap counterpart for callers that need
+/// only the headline point estimate — a console summary, say — and must not pay
+/// for the bootstrap resampling that [`SpanStats::from_spans`] performs.
+#[must_use]
+pub fn slope_of(spans: &[Span]) -> Option<f64> {
+    if spans.is_empty() {
+        return None;
+    }
+    Some(slope(spans))
+}
+
 /// Per-iteration value of a span: its total divided by its iteration count.
 fn per_iteration(span: Span) -> f64 {
     let iterations = span.iterations as f64;
@@ -292,6 +307,16 @@ mod tests {
     #[test]
     fn empty_spans_have_no_statistics() {
         assert!(SpanStats::from_spans(&[]).is_none());
+    }
+
+    #[test]
+    fn slope_of_matches_the_full_estimator_without_bootstrapping() {
+        // The cheap slope-only path must return exactly the slope the full
+        // estimator computes, and `None` for an empty set like `from_spans`.
+        assert!(slope_of(&[]).is_none());
+        let spans = [span(2, 10), span(8, 40)];
+        let full = SpanStats::from_spans(&spans).unwrap();
+        assert_eq!(slope_of(&spans), Some(full.slope));
     }
 
     #[test]

--- a/packages/mock_bench_engine/src/main.rs
+++ b/packages/mock_bench_engine/src/main.rs
@@ -10,7 +10,7 @@
 //! ```text
 //! mock_bench_engine [--exit-code N] [--summary GROUP=KIND]...
 //!                   [--criterion GROUP|FUNCTION|VALUE=NANOS]...
-//!                   [--alloc-tracker OPERATION=BYTES/COUNT]...
+//!                   [--alloc-tracker OPERATION=BYTES/COUNT[@BLOW:BHIGH/CLOW:CHIGH]]...
 //!                   [--all-the-time OPERATION=NANOS[@LOW:HIGH]]...
 //!                   [--fail-if-exists PATH]
 //! ```
@@ -37,15 +37,19 @@
 //! whose wall-clock slope estimate is `NANOS` nanoseconds. The on-disk directory is
 //! derived from the identity, so distinct identities never share a directory.
 //!
-//! `--alloc-tracker OPERATION=BYTES/COUNT` writes an `alloc_tracker`
-//! `<OPERATION>.json` file reporting `BYTES` mean bytes and `COUNT` mean
-//! allocations per iteration. `--all-the-time OPERATION=NANOS[@LOW:HIGH]` writes
-//! an `all_the_time` `<OPERATION>.json` file reporting `NANOS` mean (and slope)
-//! processor-time nanoseconds per iteration; an optional `@LOW:HIGH` suffix
-//! additionally records a bootstrap confidence interval (and a matching standard
-//! deviation, span count and min/max), mirroring the real tool's dispersion
-//! output. Both write one flat JSON file per operation under their respective
-//! engine directory, mirroring the real tools.
+//! `--alloc-tracker OPERATION=BYTES/COUNT[@BLOW:BHIGH/CLOW:CHIGH]` writes an
+//! `alloc_tracker` `<OPERATION>.json` file reporting `BYTES` mean bytes and
+//! `COUNT` mean allocations per iteration; an optional `@BLOW:BHIGH/CLOW:CHIGH`
+//! suffix additionally records a bootstrap confidence interval (and matching
+//! slope, standard deviation, span count and min/max) for the bytes and
+//! allocation-count metrics respectively, mirroring the real tool's dispersion
+//! output. `--all-the-time OPERATION=NANOS[@LOW:HIGH]` writes an `all_the_time`
+//! `<OPERATION>.json` file reporting `NANOS` mean (and slope) processor-time
+//! nanoseconds per iteration; an optional `@LOW:HIGH` suffix additionally records
+//! a bootstrap confidence interval (and a matching standard deviation, span count
+//! and min/max), mirroring the real tool's dispersion output. Both write one flat
+//! JSON file per operation under their respective engine directory, mirroring the
+//! real tools.
 //!
 //! `--fail-if-exists PATH` exits with code 1 and writes no output when `PATH`
 //! (relative to the working directory) exists. Backfill runs each engine in a
@@ -101,11 +105,16 @@ struct CriterionCase {
     nanos: f64,
 }
 
-/// A parsed `alloc_tracker` operation request: its name and per-iteration means.
+/// A parsed `alloc_tracker` operation request: its name, per-iteration means, and
+/// optional per-metric bootstrap intervals `((bytes_low, bytes_high), (count_low,
+/// count_high))`. When the intervals are present the operation file additionally
+/// records slopes, standard deviations, span count and min/max for both metrics,
+/// mirroring dispersion-bearing output.
 struct AllocOperation {
     operation: String,
     mean_bytes: u64,
     mean_allocations: u64,
+    intervals: Option<((f64, f64), (f64, f64))>,
 }
 
 /// A parsed `all_the_time` operation request: its name, per-iteration mean, and
@@ -319,23 +328,37 @@ fn write_criterion_case(target_root: &std::path::Path, case: &CriterionCase) {
         .expect("estimates.json should be writable");
 }
 
-/// Parses an `OPERATION=BYTES/COUNT` argument into an [`AllocOperation`].
+/// Parses an `OPERATION=BYTES/COUNT[@BLOW:BHIGH/CLOW:CHIGH]` argument into an
+/// [`AllocOperation`].
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn parse_alloc_arg(value: &str) -> AllocOperation {
-    let (operation, stats) = value
+    let (operation, rest) = value
         .split_once('=')
-        .expect("--alloc-tracker value must be OPERATION=BYTES/COUNT");
-    let (bytes, count) = stats
-        .split_once('/')
-        .expect("--alloc-tracker stats must be BYTES/COUNT");
+        .expect("--alloc-tracker value must be OPERATION=BYTES/COUNT[@BLOW:BHIGH/CLOW:CHIGH]");
     assert!(
         !operation.is_empty(),
         "--alloc-tracker OPERATION must be non-empty"
     );
+    let (stats, intervals) = match rest.split_once('@') {
+        Some((stats, bounds)) => {
+            let (bytes_bounds, count_bounds) = bounds
+                .split_once('/')
+                .expect("--alloc-tracker dispersion must be BLOW:BHIGH/CLOW:CHIGH");
+            (
+                stats,
+                Some((parse_bounds(bytes_bounds), parse_bounds(count_bounds))),
+            )
+        }
+        None => (rest, None),
+    };
+    let (bytes, count) = stats
+        .split_once('/')
+        .expect("--alloc-tracker stats must be BYTES/COUNT");
     AllocOperation {
         operation: operation.to_owned(),
         mean_bytes: bytes.parse().expect("BYTES must be a number"),
         mean_allocations: count.parse().expect("COUNT must be a number"),
+        intervals,
     }
 }
 
@@ -350,18 +373,7 @@ fn parse_time_arg(value: &str) -> TimeOperation {
         "--all-the-time OPERATION must be non-empty"
     );
     let (nanos, interval) = match rest.split_once('@') {
-        Some((nanos, bounds)) => {
-            let (low, high) = bounds
-                .split_once(':')
-                .expect("--all-the-time interval must be LOW:HIGH");
-            (
-                nanos,
-                Some((
-                    low.parse().expect("LOW must be a number"),
-                    high.parse().expect("HIGH must be a number"),
-                )),
-            )
-        }
+        Some((nanos, bounds)) => (nanos, Some(parse_bounds(bounds))),
         None => (rest, None),
     };
     TimeOperation {
@@ -371,17 +383,31 @@ fn parse_time_arg(value: &str) -> TimeOperation {
     }
 }
 
+/// Parses a `LOW:HIGH` interval into a `(low, high)` pair of nanoseconds.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn parse_bounds(bounds: &str) -> (f64, f64) {
+    let (low, high) = bounds.split_once(':').expect("interval must be LOW:HIGH");
+    (
+        low.parse().expect("LOW must be a number"),
+        high.parse().expect("HIGH must be a number"),
+    )
+}
+
 /// Writes one `alloc_tracker` `<operation>.json` file under `alloc_tracker/`.
 ///
 /// The shape mirrors the real tool: `total_*` fields derive from the per-iteration
-/// means over a fixed iteration count, though the harvest reads only the means.
+/// means over a fixed iteration count. When the request carries per-metric
+/// intervals the file additionally records the slope, standard deviation, span
+/// count and min/max for both the bytes and allocation-count metrics, so the
+/// adapter's dispersion path is exercised end to end.
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn write_alloc_operation(target_root: &std::path::Path, operation: &AllocOperation) {
     const ITERATIONS: u64 = 4;
+    const SPANS: u64 = 6;
     let dir = target_root.join("alloc_tracker");
     std::fs::create_dir_all(&dir).expect("alloc_tracker directory should be creatable");
 
-    let output = serde_json::json!({
+    let mut output = serde_json::json!({
         "operation": operation.operation,
         "total_iterations": ITERATIONS,
         "total_bytes_allocated": operation.mean_bytes.saturating_mul(ITERATIONS),
@@ -389,8 +415,47 @@ fn write_alloc_operation(target_root: &std::path::Path, operation: &AllocOperati
         "mean_bytes_per_iteration": operation.mean_bytes,
         "mean_allocations_per_iteration": operation.mean_allocations,
     });
+    if let Some((bytes_interval, count_interval)) = operation.intervals {
+        let fields = output
+            .as_object_mut()
+            .expect("the operation output is a JSON object");
+        fields.insert("span_count".to_owned(), serde_json::json!(SPANS));
+        insert_metric_dispersion(
+            fields,
+            "bytes_per_iteration",
+            operation.mean_bytes,
+            bytes_interval,
+        );
+        insert_metric_dispersion(
+            fields,
+            "allocations_per_iteration",
+            operation.mean_allocations,
+            count_interval,
+        );
+    }
     let file = dir.join(format!("{}.json", safe_segment(&operation.operation)));
     std::fs::write(file, output.to_string()).expect("alloc_tracker file should be writable");
+}
+
+/// Inserts the six dispersion fields for one metric (identified by `suffix`) into
+/// an operation output object. The slope is emitted as the integer mean, which
+/// deserializes to the adapter's `f64` slope; the interval bounds double as the
+/// min/max and imply the standard deviation `(high - low) / 2`.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn insert_metric_dispersion(
+    fields: &mut serde_json::Map<String, serde_json::Value>,
+    suffix: &str,
+    mean: u64,
+    interval: (f64, f64),
+) {
+    let (low, high) = interval;
+    let std_dev = (high - low) / 2.0;
+    fields.insert(format!("slope_{suffix}"), serde_json::json!(mean));
+    fields.insert(format!("std_dev_{suffix}"), serde_json::json!(std_dev));
+    fields.insert(format!("interval_low_{suffix}"), serde_json::json!(low));
+    fields.insert(format!("interval_high_{suffix}"), serde_json::json!(high));
+    fields.insert(format!("min_{suffix}"), serde_json::json!(low));
+    fields.insert(format!("max_{suffix}"), serde_json::json!(high));
 }
 
 /// Writes one `all_the_time` `<operation>.json` file under `all_the_time/`.
@@ -413,37 +478,15 @@ fn write_time_operation(target_root: &std::path::Path, operation: &TimeOperation
         "mean_processor_time_nanos": operation.mean_nanos,
     });
     if let Some((low, high)) = operation.interval {
-        let std_dev = (high - low) / 2.0;
         let fields = output
             .as_object_mut()
             .expect("the operation output is a JSON object");
-        // The slope is emitted as the integer mean, which deserializes to the
-        // adapter's `f64` slope; the interval bounds and standard deviation
-        // carry the dispersion the noise detector reads.
         fields.insert("span_count".to_owned(), serde_json::json!(SPANS));
-        fields.insert(
-            "slope_processor_time_nanos".to_owned(),
-            serde_json::json!(operation.mean_nanos),
-        );
-        fields.insert(
-            "std_dev_processor_time_nanos".to_owned(),
-            serde_json::json!(std_dev),
-        );
-        fields.insert(
-            "interval_low_processor_time_nanos".to_owned(),
-            serde_json::json!(low),
-        );
-        fields.insert(
-            "interval_high_processor_time_nanos".to_owned(),
-            serde_json::json!(high),
-        );
-        fields.insert(
-            "min_processor_time_nanos".to_owned(),
-            serde_json::json!(low),
-        );
-        fields.insert(
-            "max_processor_time_nanos".to_owned(),
-            serde_json::json!(high),
+        insert_metric_dispersion(
+            fields,
+            "processor_time_nanos",
+            operation.mean_nanos,
+            (low, high),
         );
     }
     let file = dir.join(format!("{}.json", safe_segment(&operation.operation)));

--- a/packages/mock_bench_engine/src/main.rs
+++ b/packages/mock_bench_engine/src/main.rs
@@ -383,14 +383,17 @@ fn parse_time_arg(value: &str) -> TimeOperation {
     }
 }
 
-/// Parses a `LOW:HIGH` interval into a `(low, high)` pair of nanoseconds.
+/// Parses a `LOW:HIGH` interval into a `(low, high)` pair. The values are unitless
+/// bounds — nanoseconds for `all_the_time`, bytes or allocation counts for
+/// `alloc_tracker` — so `LOW` must not exceed `HIGH`, otherwise the emitted
+/// dispersion would carry a negative standard deviation and inverted min/max.
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn parse_bounds(bounds: &str) -> (f64, f64) {
     let (low, high) = bounds.split_once(':').expect("interval must be LOW:HIGH");
-    (
-        low.parse().expect("LOW must be a number"),
-        high.parse().expect("HIGH must be a number"),
-    )
+    let low: f64 = low.parse().expect("LOW must be a number");
+    let high: f64 = high.parse().expect("HIGH must be a number");
+    assert!(low <= high, "interval LOW must not exceed HIGH");
+    (low, high)
 }
 
 /// Writes one `alloc_tracker` `<operation>.json` file under `alloc_tracker/`.


### PR DESCRIPTION
## Problem

I had assumed Callgrind (and, by extension, "counting" engines like
`alloc_tracker`) produced deterministic metrics. They do not:

- **Callgrind** jitters a few percent run-to-run.
- **alloc_tracker**'s per-iteration figure carries first-run and
  buffer-resize allocations amortized over a Criterion-chosen (dynamic)
  iteration count, so it wobbles around its mean.

The tool's core assumption — `MetricKind::is_deterministic()` bypasses all
statistics — was therefore wrong and produced uncontrolled false positives
(no significance test, no FDR, confidence falsely reported as `1.0`) on
exactly the highest-fan-out engine (Callgrind, ~9 metrics/benchmark).

**We cannot expect deterministic behaviour from any benchmark or any
benchmark metric.** This PR realigns both the collection libraries and the
analysis tool around that reality.

## Analysis (`cargo-bench-history-core`)

- Abolish the deterministic/noisy gating split. Every series is
  noise-aware: it always runs the significance test (Mann–Whitney /
  Mann–Kendall), the practical-magnitude floor, and Benjamini–Hochberg
  FDR. Confidence always derives from a real p-value.
- Add a **series-intrinsic between-commit residual-MAD** noise gate for
  all engines (reusing the step/line model residuals). Where a per-point
  CI exists (Criterion, all_the_time, and now alloc_tracker), keep
  CI-non-overlap as an **additional veto only** — it can tighten, never
  loosen.
- Remove `MetricKind::is_deterministic()`: analysis now branches on whether
  a per-point CI is present in the data, not on whether an engine is
  "exact", so the flag has no remaining caller and is deleted.

## Collection (`folo_utils` / `all_the_time` / `alloc_tracker`)

- New shared, **unit-agnostic** warmup-robust estimator in `folo_utils`
  over `&[(iterations, total)]`: iters²-weighted through-origin OLS slope +
  fixed-seed bootstrap CI + Bessel std_dev + min/max.
- Refactor `all_the_time` onto the shared helper (behaviour-preserving).
- `alloc_tracker` now retains per-span records and reports the OLS slope
  plus a bootstrap CI per metric, so it feeds the CI veto above.
- **API parity** kept between `all_the_time` and `alloc_tracker`: both keep
  their pooled `mean*()` accessors and additionally expose every field
  present in their JSON (span_count, slope, std_dev, interval, min/max) via
  public `statistics()` methods.

## Docs

`DESIGN.md`, both `AGENTS.md`, and the metric docs are updated to stop
describing any engine as "exact"/"deterministic".

## Validation

`just package="folo_utils all_the_time alloc_tracker
cargo-bench-history-core cargo-bench-history mock_bench_engine"
validate-local` passes end-to-end (format-check, clippy dev+release, 1199
tests, doctests, docs, Miri 921 tests, machete/udeps, default-features,
release build). Mutation testing of the changed lines (`--in-diff`) is
clean: 190 caught, 15 unviable, 0 missed.
