### PR TITLE
Reduce workload of different_actions benchmarking example (fixes #320)

### DIFF
--- a/packages/many_cpus_benchmarking/examples/many_cpus_benchmarking_shared_data_different_actions.rs
+++ b/packages/many_cpus_benchmarking/examples/many_cpus_benchmarking_shared_data_different_actions.rs
@@ -73,7 +73,7 @@ impl Payload for ProducerConsumerChannels {
     fn prepare(&mut self) {
         // Pre-seed the channels with some initial messages to avoid deadlocks
         // and create a steady flow of data for benchmarking
-        const INITIAL_MESSAGE_COUNT: usize = 5000;
+        const INITIAL_MESSAGE_COUNT: usize = 1000;
 
         for i in 0..INITIAL_MESSAGE_COUNT {
             // Both workers send some initial messages
@@ -82,7 +82,7 @@ impl Payload for ProducerConsumerChannels {
     }
 
     fn process(&mut self) {
-        const OPERATION_COUNT: usize = 25000;
+        const OPERATION_COUNT: usize = 5000;
 
         if self.is_primary_producer {
             // Primary producer: mostly sends, occasionally receives


### PR DESCRIPTION
## Problem

`many_cpus_benchmarking_shared_data_different_actions` intermittently exceeded the `run-examples` harness's **30s per-example timeout** on the `windows-latest` runner (issue #320).

It is a Criterion benchmark example. Under `cargo run --example` it runs in Criterion *test mode* (one iteration per benchmark), so `measurement_time(30s)` does not apply — but it still spins up worker-thread pairs and runs a heavy producer/consumer channel workload (blocking `recv()`) for **every hardware-compatible `WorkDistribution` mode**. Because it uses `all_with_unique_processors()` it includes the three `*Self` modes (unlike its `same_action` sibling, which uses `..._without_self()`), so more modes actually execute on a single-memory-region runner. On a small, loaded runner the blocking-channel work is sensitive to scheduler contention, and the combined per-mode cost occasionally crossed 30s and was killed.

There is no logic deadlock: the producer always supplies more channel messages than the consumer blocks for, so `process()` always completes.

## Change

Cut the per-iteration workload ~5x:

- `INITIAL_MESSAGE_COUNT`: 5000 → 1000
- `OPERATION_COUNT`: 25000 → 5000

The invariant is preserved — the producer supplies `1000 + 5000 = 6000` messages into the channel while the consumer performs only `5000` blocking receives, so there is no starvation. All five hardware-compatible distribution modes still run and report `Success`.

## Validation

- `just package="many_cpus_benchmarking" run-examples` → all 3 examples pass in ~4.9s (previously killed at 30s).
- Confirmed all 5 compatible modes still execute (`PinnedSameMemoryRegion`, `PinnedSelf`, `ConstrainedSameMemoryRegion`, `UnpinnedSelf`, `UnpinnedPerMemoryRegionSelf`).

Fixes #320
