### PR TITLE
ci: cache toolchains, apt packages, lint tools + pin toolchain in setup-environment

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -4,67 +4,55 @@ description: Setup development environment for Folo project
 runs:
   using: composite
   steps:
-    - name: Install dependencies (Linux)
+    - name: Install APT packages (Linux)
+      # The GitHub-hosted Ubuntu images already ship git, git-lfs, gcc, make, curl,
+      # libssl-dev, pkg-config and PowerShell (apt reports them "already the newest"), so
+      # only build-essential, cmake and valgrind — plus their dependencies — are genuinely
+      # installed here. Package downloads are not the bottleneck (~1s for tens of MB on the
+      # Azure mirrors); the cost is the `apt-get update` index refresh and the dpkg
+      # unpack/configure. cache-apt-pkgs-action restores the already-configured files from
+      # an actions/cache entry and skips apt entirely on a hit, cutting this step from ~15s
+      # (amd64) / ~26s (arm64) to a few seconds. Its v1 line is in upstream maintenance
+      # lock, so the major tag will not shift under us.
+      #
+      # execute_install_scripts runs each package's postinst (e.g. ldconfig) on restore so
+      # valgrind's shared-library dependencies resolve. No PR-validation job runs valgrind
+      # (only the nightly bench-history workflow does), so the Verify step below actually
+      # executes valgrind to prove the restored fileset is functional before a regression
+      # could reach that workflow.
+      if: runner.os == 'Linux'
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: build-essential cmake valgrind
+        version: "1"
+        execute_install_scripts: true
+
+    - name: Install PowerShell (Linux ARM64)
+      # amd64 Ubuntu runners preinstall PowerShell, but the arm64 images do not ship a pwsh
+      # the packages.microsoft.com apt repo can satisfy — that repo only publishes amd64
+      # packages, so `apt install powershell` fails on arm64 with "Depends: libc6:amd64 but
+      # it is not installable". Microsoft instead ships arm64 PowerShell as a tarball on the
+      # PowerShell GitHub releases page, which we install here. --retry-all-errors covers
+      # transient TLS failures against GitHub during early boot.
+      if: runner.os == 'Linux' && runner.arch == 'ARM64'
+      shell: bash
+      run: |
+        set -x
+        # Pinned to a current LTS release. Bump as newer 7.4.x patches ship.
+        PWSH_VERSION="7.4.6"
+        curl --fail --silent --show-error --location \
+          --retry 5 --retry-delay 2 --retry-all-errors \
+          --output /tmp/powershell.tar.gz \
+          "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-arm64.tar.gz"
+        sudo mkdir -p /opt/microsoft/powershell/7
+        sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
+        sudo chmod +x /opt/microsoft/powershell/7/pwsh
+        sudo ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+
+    - name: Configure Git LFS (Linux)
       if: runner.os == 'Linux'
       shell: bash
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: |
-        # Print each command before executing so a future silent failure points at
-        # the offending line. The script previously used "wget -q" which masked an
-        # intermittent SSL verification failure as a context-free "exit code 5".
-        set -x
-
-        # This supposedly speeds up installation by avoiding mandb updates.
-        sudo mv /usr/bin/mandb /usr/bin/mandb.deactivated && sudo cp -p /bin/true /usr/bin/mandb
-
-        ARCH="$(dpkg --print-architecture)"
-
-        # PowerShell on Linux is distributed differently per architecture:
-        # - amd64: Microsoft's apt repo ships a powershell package, so we register the
-        #   repo and install via apt alongside our other system packages.
-        # - arm64: The packages.microsoft.com apt repo for Ubuntu only ships amd64
-        #   PowerShell packages — installing the repo and apt-getting `powershell`
-        #   fails with "Depends: libc6:amd64 but it is not installable". Microsoft
-        #   instead ships ARM64 PowerShell as a tarball on the PowerShell GitHub
-        #   releases page, which is what we use here.
-        if [ "$ARCH" = "amd64" ]; then
-          # Add Microsoft package repository (for PowerShell and any other Microsoft packages).
-          # We use curl with --retry-all-errors because the runner can transiently fail
-          # TLS verification against packages.microsoft.com during early boot — likely a
-          # race with unattended-upgrades rewriting /etc/ssl/certs/ca-certificates.crt.
-          # --show-error ensures the failure is visible if all retries are exhausted.
-          curl --fail --silent --show-error --location \
-            --retry 5 --retry-delay 2 --retry-all-errors \
-            --output packages-microsoft-prod.deb \
-            "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
-          sudo dpkg -i --force-confnew packages-microsoft-prod.deb
-
-          sudo apt update
-          sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config powershell valgrind
-        elif [ "$ARCH" = "arm64" ]; then
-          sudo apt update
-          sudo apt install -y git git-lfs build-essential cmake gcc make curl libssl-dev pkg-config valgrind
-
-          # Pinned to a current LTS release. Bump as newer 7.4.x patches ship.
-          PWSH_VERSION="7.4.6"
-          curl --fail --silent --show-error --location \
-            --retry 5 --retry-delay 2 --retry-all-errors \
-            --output /tmp/powershell.tar.gz \
-            "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-arm64.tar.gz"
-          sudo mkdir -p /opt/microsoft/powershell/7
-          sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
-          sudo chmod +x /opt/microsoft/powershell/7/pwsh
-          sudo ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
-        else
-          echo "ERROR: Unsupported Linux architecture '$ARCH'." >&2
-          echo "Extend the setup-environment action to add a PowerShell install path" >&2
-          echo "for this architecture before adding a runner of this type to CI." >&2
-          exit 1
-        fi
-
-        # Set up Git LFS
-        git lfs install
+      run: git lfs install
     
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -129,4 +117,13 @@ runs:
         cargo --version
         rustc --version
         pwsh --version
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          # Prove the APT packages restored from the cache are functional. valgrind is the
+          # one that matters: no PR-validation job runs it (only the nightly bench-history
+          # workflow does), and a fileset-only cache restore could leave its shared
+          # libraries unregistered — so actually run it against a trivial program rather
+          # than only printing a version.
+          cmake --version
+          valgrind --quiet --error-exitcode=1 /bin/true
+        fi
         echo "Environment setup complete"

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -82,7 +82,33 @@ runs:
         # toolchain are identical. ImageVersion is set automatically on every GitHub-hosted
         # runner. env-vars is additive on top of the rust-cache defaults.
         env-vars: ImageVersion
-    
+
+    - name: Cache Rust toolchains
+      # rust-cache above caches ~/.cargo and ./target but never ~/.rustup, so without this
+      # every job re-downloads all three toolchains that `just install-tools` installs:
+      # stable, the MSRV, and the pinned nightly (whose profile pulls rust-src,
+      # llvm-tools-preview and miri). That is the single largest uncached cost of this
+      # composite. Caching the installed toolchains turns the `rustup toolchain install`
+      # calls into no-ops on a hit.
+      #
+      # Placed AFTER the rust-cache step on purpose: rust-cache derives its key from the
+      # toolchains installed when it runs (here, only stable). Restoring the nightly/MSRV
+      # toolchains before it would fold their hashes into the shared `prerequisites` key
+      # and invalidate the large compilation cache for every job at once.
+      #
+      # Keyed on OS + arch + a hash of the files that pin every toolchain version
+      # (constants.env holds RUST_MSRV/RUST_NIGHTLY; rust-toolchain.toml holds the stable
+      # channel), so any version bump invalidates the cache automatically. Unlike the
+      # compiled cargo-tool binaries in ~/.cargo/bin, rustup toolchains are prebuilt,
+      # relocatable artifacts that do not link against image-specific dylibs, so the runner
+      # ImageVersion is deliberately left out of the key.
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.rustup/toolchains
+          ~/.rustup/update-hashes
+        key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('constants.env', 'rust-toolchain.toml') }}
+
     - name: Install just
       shell: bash
       run: cargo install just --locked

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -12,8 +12,9 @@ runs:
       # Azure mirrors); the cost is the `apt-get update` index refresh and the dpkg
       # unpack/configure. cache-apt-pkgs-action restores the already-configured files from
       # an actions/cache entry and skips apt entirely on a hit, cutting this step from ~15s
-      # (amd64) / ~26s (arm64) to a few seconds. Its v1 line is in upstream maintenance
-      # lock, so the major tag will not shift under us.
+      # (amd64) / ~26s (arm64) to a few seconds. The action is in upstream maintenance mode,
+      # so `@v1` only rolls forward to backward-compatible fixes within its major line —
+      # there is no breaking v2 to chase.
       #
       # execute_install_scripts runs each package's postinst (e.g. ldconfig) on restore so
       # valgrind's shared-library dependencies resolve. No PR-validation job runs valgrind

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -54,35 +54,18 @@ runs:
       shell: bash
       run: git lfs install
     
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-    
-    - name: Setup Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        # We use the same shared key for all the different workflows that use this action.
-        # This enables more reuse, e.g. the Copilot workflow can reuse artifacts from the
-        # validate workflow, which speeds up copilot executions.
-        shared-key: prerequisites
-        # Include the runner image version (e.g. macos-15-arm64 20260511.0048.1) in the
-        # cache key. Cached binaries can subtly depend on image-specific dylibs and tools,
-        # so caches must not flow across image versions even when the lockfile and rust
-        # toolchain are identical. ImageVersion is set automatically on every GitHub-hosted
-        # runner. env-vars is additive on top of the rust-cache defaults.
-        env-vars: ImageVersion
-
     - name: Cache Rust toolchains
-      # rust-cache above caches ~/.cargo and ./target but never ~/.rustup, so without this
-      # every job re-downloads all three toolchains that `just install-tools` installs:
-      # stable, the MSRV, and the pinned nightly (whose profile pulls rust-src,
-      # llvm-tools-preview and miri). That is the single largest uncached cost of this
-      # composite. Caching the installed toolchains turns the `rustup toolchain install`
-      # calls into no-ops on a hit.
+      # Restored BEFORE the toolchain is installed so the pinned stable, the MSRV and the
+      # pinned nightly (whose profile pulls rust-src, llvm-tools-preview and miri) are all
+      # served from cache, turning every `rustup toolchain install` — the dtolnay step below
+      # and the ones inside `just install-tools` — into a no-op on a hit. rust-cache below
+      # caches ~/.cargo and ./target but never ~/.rustup, so re-installing these toolchains is
+      # the single largest uncached cost of this composite.
       #
-      # Placed AFTER the rust-cache step on purpose: rust-cache derives its key from the
-      # toolchains installed when it runs (here, only stable). Restoring the nightly/MSRV
-      # toolchains before it would fold their hashes into the shared `prerequisites` key
-      # and invalidate the large compilation cache for every job at once.
+      # It also means every toolchain is already present when Swatinem/rust-cache runs, so its
+      # shared `prerequisites` key (which enumerates `rustup toolchain list`) reflects the
+      # exact toolchain set. A deliberate bump of any pin then rebuilds that cache, which is
+      # what we want.
       #
       # Keyed on OS + arch + a hash of the files that pin every toolchain version
       # (constants.env holds RUST_MSRV/RUST_NIGHTLY; rust-toolchain.toml holds the stable
@@ -96,6 +79,49 @@ runs:
           ~/.rustup/toolchains
           ~/.rustup/update-hashes
         key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('constants.env', 'rust-toolchain.toml') }}
+
+    - name: Read pinned Rust toolchain channel
+      # dtolnay/rust-toolchain cannot read rust-toolchain.toml — its channel comes from the
+      # action @rev or the `toolchain` input — so extract the pinned stable channel here and
+      # hand it to the install step below. Parsing in PowerShell keeps it portable across the
+      # Linux/macOS/Windows runners (macOS ships BSD grep, which has no -P). The version is
+      # never hardcoded; rust-toolchain.toml stays the single source of truth.
+      id: rust-toolchain
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $match = Select-String -Path 'rust-toolchain.toml' -Pattern '^\s*channel\s*=\s*"([^"]+)"' | Select-Object -First 1
+        if (-not $match) { throw 'Could not read the pinned channel from rust-toolchain.toml' }
+        $channel = $match.Matches[0].Groups[1].Value
+        Write-Host "Pinned Rust channel from rust-toolchain.toml: $channel"
+        "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Install Rust toolchain
+      # Pinned to the exact channel from rust-toolchain.toml (parsed above) via @master —
+      # dtolnay's documented ref for passing an explicit `toolchain`. Using @stable would
+      # instead install the *latest* stable and roll it forward every ~6 weeks; because
+      # Swatinem/rust-cache enumerates every installed toolchain (`rustup toolchain list`)
+      # into its key, that rolling stable would silently bust the shared compilation cache on
+      # each upstream release even though the workspace only ever builds with the pinned
+      # channel. Pinning it keeps the toolchain set — and thus the cache key — stable until we
+      # deliberately bump the pin.
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        # We use the same shared key for all the different workflows that use this action.
+        # This enables more reuse, e.g. the Copilot workflow can reuse artifacts from the
+        # validate workflow, which speeds up copilot executions.
+        shared-key: prerequisites
+        # Include the runner image version (e.g. macos-15-arm64 20260511.0048.1) in the
+        # cache key. Cached binaries can subtly depend on image-specific dylibs and tools,
+        # so caches must not flow across image versions even when the lockfile and rust
+        # toolchain are identical. ImageVersion is set automatically on every GitHub-hosted
+        # runner. env-vars is additive on top of the rust-cache defaults.
+        env-vars: ImageVersion
 
     - name: Cache actionlint and ShellCheck
       # just install-tools fetches pinned actionlint and ShellCheck as standalone binaries

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -97,6 +97,28 @@ runs:
           ~/.rustup/update-hashes
         key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('constants.env', 'rust-toolchain.toml') }}
 
+    - name: Cache actionlint and ShellCheck
+      # just install-tools fetches pinned actionlint and ShellCheck as standalone binaries
+      # (scripts/install-actionlint.ps1, scripts/install-shellcheck.ps1) into ~/.cargo/bin on
+      # every job and every platform. Unlike the cargo-installed tools that also live there,
+      # these are plain downloaded files with no cargo install-metadata, so Swatinem/rust-cache's
+      # bin caching never tracks them and they are otherwise re-downloaded and re-extracted every
+      # run. Caching the two binaries lets each script's "pinned version already present" check
+      # short-circuit the download on a hit, so this step is restored before Install development
+      # tools below (which runs install-tools).
+      #
+      # Keyed on OS + arch + a hash of the two install scripts, which embed both the pinned
+      # versions and their published checksums — so bumping either tool invalidates the cache
+      # automatically. Like rustup toolchains these are prebuilt, relocatable binaries that do not
+      # link against image-specific dylibs, so the runner ImageVersion is deliberately left out of
+      # the key.
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/actionlint*
+          ~/.cargo/bin/shellcheck*
+        key: lint-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/install-actionlint.ps1', 'scripts/install-shellcheck.ps1') }}
+
     - name: Install just
       shell: bash
       run: cargo install just --locked

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -26,8 +26,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Read pinned Rust toolchain channel
+        # dtolnay/rust-toolchain cannot read rust-toolchain.toml, so extract the pinned stable
+        # channel here and hand it to the install step below (mirrors the setup-environment
+        # composite). Pinning stops @stable from rolling the toolchain forward every ~6 weeks,
+        # which — because Swatinem/rust-cache keys on every installed toolchain — would
+        # otherwise bust this job's cargo-delta cache on each upstream release. The version is
+        # never hardcoded; rust-toolchain.toml stays the single source of truth.
+        id: rust-toolchain
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $match = Select-String -Path 'rust-toolchain.toml' -Pattern '^\s*channel\s*=\s*"([^"]+)"' | Select-Object -First 1
+          if (-not $match) { throw 'Could not read the pinned channel from rust-toolchain.toml' }
+          $channel = $match.Matches[0].Groups[1].Value
+          Write-Host "Pinned Rust channel from rust-toolchain.toml: $channel"
+          "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

Speeds up the shared `setup-environment` composite action — used by nearly every CI
job across all workflows — by adding three layers of caching plus a keying fix that keeps
the shared Rust compile cache stable. The step previously spent **~66s to run ~2s of
actual logic**; almost all of that time was re-downloading the same things on every job.

Developed as an **incremental series on this one branch**: each step was committed and
verified against this PR's own validation runs (within-run cache MISS vs. HIT) before the
next was added.

1. **Cache `~/.rustup` toolchains** — stable + MSRV + pinned nightly (with
   miri/rust-src/llvm-tools) were re-downloaded on every job.
2. **Cache Linux apt packages** (`awalsh128/cache-apt-pkgs-action`) — build-essential,
   cmake, valgrind, replacing the monolithic `apt-get` step.
3. **Cache actionlint + ShellCheck binaries** — pinned standalone downloads that
   Swatinem/rust-cache never tracked, so they were re-downloaded every job.
4. **Restore the rustup cache *before* toolchain install and pin the stable channel to
   `rust-toolchain.toml`** — so all three toolchains are cache-served *and* folded into
   `Swatinem/rust-cache`'s key, and `dtolnay/rust-toolchain` stops rolling latest-stable
   (which silently busted the shared compile cache for every job at once every ~6 weeks).

## Motivation

Validated against a real run
([run 28669360751, Linux x64](https://github.com/folo-rs/folo/actions/runs/28669360751/job/85033293152)):
`Setup environment` took **66s to run 2s of logic**. Measured breakdown:

| Phase | Duration | Cached before this PR? |
|---|---|---|
| apt `Install dependencies (Linux)` | ~16s (amd64) / ~26s (arm64) | ❌ |
| rustup toolchain downloads (stable + MSRV + nightly w/ miri/rust-src/llvm-tools) | ~27s | ❌ |
| `Setup Rust cache` restore (registry + target + bin) | ~13s | ✅ hit |
| `cargo install just` + cargo tools | ~1s | ✅ (`already installed`) |
| actionlint + ShellCheck re-download | ~9s | ❌ |

`Swatinem/rust-cache` caches `~/.cargo` and `./target` but never `~/.rustup`, and its bin
caching only tracks cargo-installed binaries — so toolchains, apt packages, and the two
downloaded lint binaries were all uncached.

A second, subtler cost: `dtolnay/rust-toolchain@stable` installs the *latest* stable and
rolls it forward on every upstream release. Because rust-cache hashes `rustc -vV` for every
installed toolchain into its key, each new stable (~every 6 weeks) silently invalidated the
large shared `prerequisites` compile cache for **all** jobs — even though the workspace only
ever builds with the pinned `1.96.1` from `rust-toolchain.toml`.

## What each step does + measured savings

| Step | Cached / fixed | Mechanism | Effect per job (on a hit) |
|---|---|---|---|
| 1 | `~/.rustup/toolchains` | `actions/cache`, key `rustup-<os>-<arch>-<hash(constants.env, rust-toolchain.toml)>` | ~9s (toolchain installs become no-ops) |
| 2 | apt: build-essential, cmake, valgrind | `awalsh128/cache-apt-pkgs-action@v1`, `execute_install_scripts: true` | ~12s (amd64) / ~22s (arm64): ~16s → ~4s |
| 3 | `~/.cargo/bin/{actionlint,shellcheck}` | `actions/cache`, key `lint-tools-<os>-<arch>-<hash(install scripts)>` | ~8s: ~9s install → ~0.4s restore + skip |
| 4 | shared rust-cache key stability | rustup cache restored before install; `dtolnay/rust-toolchain@master` pinned to the channel parsed from `rust-toolchain.toml` | no per-run time cost; removes a periodic multi-minute compile-cache rebuild (~every 6 weeks) |

## Design notes

- **Steps 1 & 4 — rustup toolchain cache + pinned stable channel.** The
  `~/.rustup/toolchains` cache is restored **before** the toolchain is installed, so the
  pinned stable (`1.96.1`), the MSRV (`1.93`) and the pinned nightly (with
  miri/rust-src/llvm-tools) are all served from cache — every `rustup toolchain install`
  becomes a no-op. Restoring before `Setup Rust cache` also folds all three toolchains into
  rust-cache's key (it hashes `rustc -vV` for every installed toolchain), which is exactly
  what we want: the shared compile cache is keyed on the *actual, pinned* toolchain set. To
  keep that key stable, `dtolnay/rust-toolchain` is pinned to the channel read from
  `rust-toolchain.toml` (via a small pwsh parse step feeding `@master`'s `toolchain` input)
  instead of `@stable` — otherwise every upstream stable release would roll the installed
  `stable` toolchain forward and silently bust the shared `prerequisites` compile cache for
  every job at once. The version is never hard-coded in the workflow; `rust-toolchain.toml`
  stays the single source of truth. The same pin is applied to the standalone `delta` job in
  `validation.yml`. `ImageVersion` is omitted from the rustup key: toolchains are prebuilt,
  relocatable artifacts that don't link image-specific dylibs.
- **Step 2 — awalsh128 apt cache.** `execute_install_scripts: true` runs each package's
  postinst (e.g. `ldconfig`) on restore, so valgrind's shared libraries resolve from a
  fileset-only restore. Because no PR-validation job otherwise runs valgrind (only the
  nightly bench-history workflow does), the `Verify environment setup` step now actually
  runs `valgrind --error-exitcode=1 /bin/true` to prove the restored fileset is functional.
  The redundant amd64 Microsoft-repo + `apt install powershell` was dropped (pwsh is
  preinstalled on amd64); the arm64 pwsh tarball install is kept (that repo has no arm64
  packages).
- **Step 3 — lint-tools cache.** actionlint and ShellCheck are plain downloaded binaries
  (not cargo-installed), so Swatinem's bin cache never tracked them. Keyed on a hash of the
  two `scripts/install-*.ps1` files, which embed both the pinned versions and their
  published checksums, so bumping either tool invalidates the cache automatically. Restored
  before `Install development tools` so each script's idempotent "pinned version already
  present" check short-circuits the download on a hit.

## Verification

Savings appear from the second run onward (the first run is the cache miss that populates
each entry). Confirmed **within-run** (MISS job vs. later HIT job) on this PR's runs:

- **apt:** `awalsh128` step ~16s (miss, installs + saves) → ~4s (hit, restore). valgrind
  smoke test passes on a hit; amd64 + arm64 Rust build/test jobs are green.
- **rustup + pin:** cross-run cache hit. The `Read pinned Rust toolchain channel` step logs
  `Pinned Rust channel from rust-toolchain.toml: 1.96.1`, and `dtolnay/rust-toolchain@master`
  installs `1.96.1` as a no-op (`unchanged - rustc 1.96.1`) served from the rustup cache —
  not a rolled latest-stable. MSRV `1.93` and the pinned nightly are likewise `unchanged`
  from cache. Confirmed in both a `setup-environment` job and the standalone `delta` job.
- **lint-tools:** on a hit, `Install development tools` logs
  `ShellCheck 0.11.0 already installed; skipping.` and
  `actionlint 1.7.12 already installed; skipping.` instead of re-downloading.

**One-time migration:** moving the rustup cache ahead of rust-cache changes the shared
compile-cache key once (it now hashes the pinned nightly + MSRV + `1.96.1` instead of a
rolling latest-stable + `1.96.1`), so the first run after this change rebuilds the
`prerequisites`/tool cache a single time; every run afterward is stable.

The always-run jobs (`validate-workflows`, `format-check`, `test-scripts`) exercise
`setup-environment` even on a workflow-only change.
