### PR TITLE
Add signal-validation suite to cargo-bench-history-core

### DIFF
--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -1001,11 +1001,12 @@ fn evaluate_resolved_spike(
 ///
 /// Exists only as test scaffolding — the independent oracle for
 /// `find_changes_spawned_matches_the_serial_pass` (the spawned path chunks and
-/// recombines; this one never chunks) and a synchronous convenience for the unit
-/// tests below. Production detection goes through [`find_changes_spawned`].
+/// recombines; this one never chunks) and a spawner-free convenience for the crate's
+/// unit tests (the tests below and the `signal_validation` suite). Production
+/// detection goes through [`find_changes_spawned`].
 #[cfg(test)]
 #[must_use]
-fn find_changes(series: &[Series], context: &AnalysisContext) -> Vec<Finding> {
+pub(super) fn find_changes(series: &[Series], context: &AnalysisContext) -> Vec<Finding> {
     let candidates = detect_all(series, context);
     finalize_findings(candidates, series, context)
 }

--- a/packages/cargo-bench-history-core/src/analyze/mod.rs
+++ b/packages/cargo-bench-history-core/src/analyze/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod report;
 pub(crate) mod run_points;
 pub(crate) mod selection;
 pub(crate) mod series;
+#[cfg(all(test, feature = "private-test-util"))]
+mod signal_validation;
 pub(crate) mod stats;
 
 pub use discriminant::{DiscriminantSetQuery, FacetFilter, StorageKey, parse_key};

--- a/packages/cargo-bench-history-core/src/analyze/mod.rs
+++ b/packages/cargo-bench-history-core/src/analyze/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod report;
 pub(crate) mod run_points;
 pub(crate) mod selection;
 pub(crate) mod series;
-#[cfg(all(test, feature = "private-test-util"))]
+#[cfg(test)]
 mod signal_validation;
 pub(crate) mod stats;
 

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -180,8 +180,9 @@ fn scaled(case: &SignalCase, scale: f64) -> Vec<f64> {
 
 #[test]
 fn curated_signals_match_expected_verdicts() {
-    // Absolute-scale multiples the reference (as-is) verdict must survive. Relative
-    // analysis means none of these may change the outcome.
+    // Scale multiples applied on top of each as-is series; the as-is verdict is the
+    // reference every scaled verdict must match. The analysis is relative, so no
+    // multiple may change the outcome.
     let scale_multiples = [1000.0_f64];
 
     for case in cases() {

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -1,0 +1,213 @@
+//! Signal-validation suite: hand-curated "obvious right answer" series that guard
+//! against the analysis statistics yielding illogical results.
+//!
+//! Each case is a data series with an unambiguous shape (an obvious step, a dead-flat
+//! line) paired with, per polarity, whether the analysis *should* report a finding.
+//! The point is not to exercise a particular detector but to pin the end-to-end
+//! verdict of the real production entry point ([`find_changes_spawned`]) on inputs a
+//! human would answer without hesitation — so a future change to the math that starts
+//! calling a doubling "no change", or a flat line "a regression", fails here loudly.
+//!
+//! Every case is run through a 2×2 matrix:
+//!
+//! * **Polarity (dimension 1).** The codebase's only polarity lever is the metric
+//!   kind, so *higher-is-worse* is modelled with a lower-is-better metric
+//!   ([`MetricKind::InstructionCount`]: a rise is a regression) and *lower-is-worse*
+//!   with the one higher-is-better metric ([`MetricKind::L1CacheHits`]: a rise is an
+//!   improvement). The analysis is asked to report the *worse* direction only
+//!   (`include_improvements = false`), which is what makes this dimension meaningful:
+//!   an obvious doubling is a finding under higher-is-worse but a (suppressed)
+//!   improvement under lower-is-worse. The expected verdict therefore depends on the
+//!   series and is stated case by case.
+//! * **Absolute scale (dimension 2).** Every case is analysed both as-is and scaled up
+//!   by a large constant. All of the analysis is relative, so the absolute scale must
+//!   not change the verdict: the as-is verdict is checked against the case's
+//!   expectation, and every scaled verdict is checked against that as-is reference, so
+//!   a scale-sensitivity regression fails here.
+//!
+//! The check itself is deliberately coarse — "did the analysis report any finding?" —
+//! because these inputs are chosen so the *presence* of a finding is the whole
+//! question. Detector internals, confidence, and magnitude are covered by the
+//! finer-grained unit tests in [`findings`](super::findings).
+
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use std::sync::Arc;
+
+use futures::executor::block_on;
+use nonempty::nonempty;
+
+use crate::analyze::{
+    AnalysisConfig, AnalysisContext, AnalysisMode, Series, SeriesPoint, find_changes_spawned,
+};
+use crate::model::{BenchmarkId, DiscriminantSet, MetricKind};
+use crate::testing::synchronous_spawner;
+
+/// How a rise in the measured metric is judged.
+///
+/// This is the suite's dimension-1 lever. Both variants map to a *deterministic*
+/// (noise-free) metric kind, so detection is exact and the two differ only in which
+/// direction of change counts as "worse".
+#[derive(Clone, Copy, Debug)]
+enum Polarity {
+    /// A rise is a regression (lower-is-better metric).
+    HigherIsWorse,
+    /// A rise is an improvement (higher-is-better metric).
+    LowerIsWorse,
+}
+
+impl Polarity {
+    /// The two polarities, for matrix expansion.
+    const ALL: [Self; 2] = [Self::HigherIsWorse, Self::LowerIsWorse];
+
+    /// The metric kind that realises this polarity.
+    fn metric_kind(self) -> MetricKind {
+        match self {
+            // Lower-is-better: a rise is a regression.
+            Self::HigherIsWorse => MetricKind::InstructionCount,
+            // The sole higher-is-better metric: a rise is an improvement.
+            Self::LowerIsWorse => MetricKind::L1CacheHits,
+        }
+    }
+}
+
+/// One curated series and its expected verdict under each polarity.
+struct SignalCase {
+    /// Human-readable case name, surfaced in assertion failures.
+    name: &'static str,
+    /// The base (unscaled) series values, oldest-first.
+    values: Vec<f64>,
+    /// Whether a finding is expected under [`Polarity::HigherIsWorse`].
+    expect_higher_is_worse: bool,
+    /// Whether a finding is expected under [`Polarity::LowerIsWorse`].
+    expect_lower_is_worse: bool,
+}
+
+impl SignalCase {
+    /// The expected verdict for `polarity`.
+    fn expected(&self, polarity: Polarity) -> bool {
+        match polarity {
+            Polarity::HigherIsWorse => self.expect_higher_is_worse,
+            Polarity::LowerIsWorse => self.expect_lower_is_worse,
+        }
+    }
+}
+
+/// `count` copies of `value`, as a run of series points.
+fn run_of(value: f64, count: usize) -> Vec<f64> {
+    vec![value; count]
+}
+
+/// The hand-curated cases. New "obvious answer" series are added as one row each.
+fn cases() -> Vec<SignalCase> {
+    vec![
+        // An unmistakable doubling of the metric halfway through: a regression when a
+        // rise is worse, and merely an (unreported) improvement when a rise is better.
+        SignalCase {
+            name: "doubling_step",
+            values: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
+            expect_higher_is_worse: true,
+            expect_lower_is_worse: false,
+        },
+        // A dead-flat line: nothing moved, so no polarity should ever flag it.
+        SignalCase {
+            name: "flat_line",
+            values: run_of(100.0, 100),
+            expect_higher_is_worse: false,
+            expect_lower_is_worse: false,
+        },
+    ]
+}
+
+/// Builds a deterministic (noise-free) series carrying `values` in topological order,
+/// tagged with `kind`.
+fn deterministic_series(values: &[f64], kind: MetricKind) -> Series {
+    let points = values
+        .iter()
+        .enumerate()
+        .map(|(index, &value)| SeriesPoint {
+            topo_index: index,
+            dirty: false,
+            object_ordinal: u32::try_from(index).unwrap(),
+            commit: Some(Arc::from(format!("commit{index}"))),
+            value,
+            interval_low: None,
+            interval_high: None,
+        })
+        .collect();
+    Series {
+        set: DiscriminantSet {
+            engine: "callgrind".to_owned(),
+            target_triple: "t".to_owned(),
+            machine_key: "synthetic".to_owned(),
+        },
+        id: BenchmarkId::new(nonempty!["signal".to_owned(), "case".to_owned()]),
+        kind,
+        points,
+        active_start: 0,
+        blessing: None,
+    }
+}
+
+/// The history-mode context the suite analyses under: the worse direction only, so an
+/// improvement is a non-finding rather than a flipped finding.
+fn history_context() -> AnalysisContext {
+    AnalysisContext {
+        mode: AnalysisMode::History,
+        config: AnalysisConfig::default(),
+        merge_base_index: None,
+        include_improvements: false,
+        include_inactive: false,
+    }
+}
+
+/// Runs the real detection entry point on a single series and reports whether it
+/// raised any finding.
+fn raises_finding(values: &[f64], kind: MetricKind) -> bool {
+    let series = deterministic_series(values, kind);
+    let findings = block_on(find_changes_spawned(
+        Arc::from(vec![series]),
+        history_context(),
+        &synchronous_spawner(),
+    ));
+    !findings.is_empty()
+}
+
+/// The values of `case`, multiplied by `scale`.
+fn scaled(case: &SignalCase, scale: f64) -> Vec<f64> {
+    case.values.iter().map(|&value| value * scale).collect()
+}
+
+#[test]
+fn curated_signals_match_expected_verdicts() {
+    // Absolute-scale multiples the reference (as-is) verdict must survive. Relative
+    // analysis means none of these may change the outcome.
+    let scale_multiples = [1000.0_f64];
+
+    for case in cases() {
+        for polarity in Polarity::ALL {
+            let expected = case.expected(polarity);
+            let kind = polarity.metric_kind();
+
+            // Dimension 1: the as-is verdict matches the hand-picked expectation.
+            let reference = raises_finding(&case.values, kind);
+            assert_eq!(
+                reference, expected,
+                "case '{}' under {polarity:?}: expected finding={expected}, got {reference}",
+                case.name,
+            );
+
+            // Dimension 2: scaling the whole series by any constant leaves the verdict
+            // unchanged, because every comparison the analysis makes is relative.
+            for scale in scale_multiples {
+                let scaled_verdict = raises_finding(&scaled(&case, scale), kind);
+                assert_eq!(
+                    scaled_verdict, reference,
+                    "case '{}' under {polarity:?}: scaling by {scale} changed the verdict \
+                     (absolute scale must not matter)",
+                    case.name,
+                );
+            }
+        }
+    }
+}

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -4,9 +4,15 @@
 //! Each case is a data series with an unambiguous shape (an obvious step, a dead-flat
 //! line) paired with, per polarity, whether the analysis *should* report a finding.
 //! The point is not to exercise a particular detector but to pin the end-to-end
-//! verdict of the real production entry point ([`find_changes_spawned`]) on inputs a
-//! human would answer without hesitation — so a future change to the math that starts
-//! calling a doubling "no change", or a flat line "a regression", fails here loudly.
+//! verdict of the analysis on inputs a human would answer without hesitation — so a
+//! future change to the math that starts calling a doubling "no change", or a flat
+//! line "a regression", fails here loudly.
+//!
+//! The verdict is taken through the serial detection oracle [`find_changes`], the same
+//! spawner-free entry the rest of the [`findings`](super::findings) unit tests use;
+//! `find_changes_spawned_matches_the_serial_pass` proves it produces exactly the
+//! findings the spawner-distributed production path
+//! ([`find_changes_spawned`](super::find_changes_spawned)) does.
 //!
 //! Every case is run through a 2×2 matrix:
 //!
@@ -34,14 +40,11 @@
 
 use std::sync::Arc;
 
-use futures::executor::block_on;
 use nonempty::nonempty;
 
-use crate::analyze::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Series, SeriesPoint, find_changes_spawned,
-};
+use crate::analyze::findings::find_changes;
+use crate::analyze::{AnalysisConfig, AnalysisContext, AnalysisMode, Series, SeriesPoint};
 use crate::model::{BenchmarkId, DiscriminantSet, MetricKind};
-use crate::testing::synchronous_spawner;
 
 /// How a rise in the measured metric is judged.
 ///
@@ -161,15 +164,11 @@ fn history_context() -> AnalysisContext {
     }
 }
 
-/// Runs the real detection entry point on a single series and reports whether it
-/// raised any finding.
+/// Runs the serial detection oracle on a single series and reports whether it raised
+/// any finding.
 fn raises_finding(values: &[f64], kind: MetricKind) -> bool {
     let series = deterministic_series(values, kind);
-    let findings = block_on(find_changes_spawned(
-        Arc::from(vec![series]),
-        history_context(),
-        &synchronous_spawner(),
-    ));
+    let findings = find_changes(&[series], &history_context());
     !findings.is_empty()
 }
 


### PR DESCRIPTION
## What

Adds a **signal-validation** test suite to `cargo-bench-history-core`: a
hand-curated set of "obvious right answer" data series that pin the end-to-end
verdict of the real analysis entry point (`find_changes_spawned`), guarding
against the statistics yielding illogical results.

## How it works

Each curated case is a series plus a per-polarity expected boolean, run through a
**2×2 matrix**:

- **Polarity (dimension 1).** The codebase's only polarity lever is the metric
  kind, so *higher-is-worse* is modelled with `InstructionCount` (a rise is a
  regression) and *lower-is-worse* with `L1CacheHits` (a rise is an improvement).
  The analysis reports the *worse* direction only (`include_improvements = false`),
  which is what makes this dimension meaningful — an obvious doubling is a finding
  under higher-is-worse but a suppressed improvement under lower-is-worse. The
  expected verdict is therefore stated case by case.
- **Absolute scale (dimension 2).** Each case is analysed as-is and scaled up by a
  large constant. All analysis is relative, so the scaled verdict must match the
  as-is reference.

## Starting cases

| case | higher-is-worse | lower-is-worse |
|---|---|---|
| `doubling_step` `[100;50] + [200;50]` | finding | no finding |
| `flat_line` `[100;100]` | no finding | no finding |

New "obvious answer" series are added as one table row in `cases()`.

## Placement

Test-only module `src/analyze/signal_validation.rs`, gated on plain `#[cfg(test)]`.
It takes each verdict through the serial `find_changes` oracle that the rest of the
`findings` unit tests already use, so it needs no `Spawner` and no feature — the
`find_changes_spawned_matches_the_serial_pass` test proves that oracle produces
exactly the findings the spawner-distributed production `find_changes_spawned` path
does. `find_changes` is widened to `pub(super)` (still `#[cfg(test)]`) so the sibling
module can reach it. Kept as a unit-test module rather than an integration test so no
extra dev-dependencies or `pub` exports are needed, and it stays coverage-excluded.

## Validation

- New suite passes under plain `cargo test` (no features) and under `--all-features`
- Full package test suite green (254 tests)
- `cargo clippy --tests` and `cargo clippy --all-features --tests` clean
- `cargo +nightly fmt --all --check` clean
- Miri clean (`just package="cargo-bench-history-core" miri signal_validation`)
- Default-features build unaffected
