### PR TITLE
Condense long cargo-bench-history regression issues (#309)

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -97,9 +97,21 @@ jobs:
               $values[$Matches[1].Trim()] = $Matches[2].Trim()
             }
           }
+
+          # Fail fast if either identifier is missing or empty: an empty
+          # AZURE_CLIENT_ID / AZURE_TENANT_ID would otherwise silently break the tool's
+          # OIDC federation far later with an opaque error, whereas the previous bash
+          # step's `set -u` errored here.
+          function Get-RequiredConstant($name) {
+            $value = $values[$name]
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              throw "constants.env is missing a non-empty '$name' (required for Azure federation)."
+            }
+            return $value
+          }
           @(
-            "AZURE_CLIENT_ID=$($values['AZURE_PROD_CLIENT_ID'])"
-            "AZURE_TENANT_ID=$($values['AZURE_TENANT_ID'])"
+            "AZURE_CLIENT_ID=$(Get-RequiredConstant 'AZURE_PROD_CLIENT_ID')"
+            "AZURE_TENANT_ID=$(Get-RequiredConstant 'AZURE_TENANT_ID')"
           ) | Add-Content -Path $env:GITHUB_ENV -Encoding utf8
 
       # The deterministic engines (Callgrind, allocation/time counters) are
@@ -155,9 +167,21 @@ jobs:
               $values[$Matches[1].Trim()] = $Matches[2].Trim()
             }
           }
+
+          # Fail fast if either identifier is missing or empty: an empty
+          # AZURE_CLIENT_ID / AZURE_TENANT_ID would otherwise silently break the tool's
+          # OIDC federation far later with an opaque error, whereas the previous bash
+          # step's `set -u` errored here.
+          function Get-RequiredConstant($name) {
+            $value = $values[$name]
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              throw "constants.env is missing a non-empty '$name' (required for Azure federation)."
+            }
+            return $value
+          }
           @(
-            "AZURE_CLIENT_ID=$($values['AZURE_PROD_CLIENT_ID'])"
-            "AZURE_TENANT_ID=$($values['AZURE_TENANT_ID'])"
+            "AZURE_CLIENT_ID=$(Get-RequiredConstant 'AZURE_PROD_CLIENT_ID')"
+            "AZURE_TENANT_ID=$(Get-RequiredConstant 'AZURE_TENANT_ID')"
           ) | Add-Content -Path $env:GITHUB_ENV -Encoding utf8
 
       # Persist the read-through cache (cargo-bench-history's --cache directory) across

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -83,14 +83,24 @@ jobs:
       # (AZURE_PROD_CLIENT_ID is the prod identity's client id). The data store account
       # name is NOT needed here: it is baked into the committed .cargo/bench_history.toml.
       - name: Configure Azure federation identity from constants.env
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          source constants.env
-          {
-            echo "AZURE_CLIENT_ID=$AZURE_PROD_CLIENT_ID"
-            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
-          } >> "$GITHUB_ENV"
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          # constants.env is a KEY=value file (with # comment lines). Read the two
+          # identifiers the tool federates with and re-export them under the standard
+          # AZURE_* names GitHub-injected steps and the tool read.
+          $values = @{}
+          foreach ($line in Get-Content constants.env) {
+            if ($line -match '^\s*([^#=]+)=(.*)$') {
+              $values[$Matches[1].Trim()] = $Matches[2].Trim()
+            }
+          }
+          @(
+            "AZURE_CLIENT_ID=$($values['AZURE_PROD_CLIENT_ID'])"
+            "AZURE_TENANT_ID=$($values['AZURE_TENANT_ID'])"
+          ) | Add-Content -Path $env:GITHUB_ENV -Encoding utf8
 
       # The deterministic engines (Callgrind, allocation/time counters) are
       # hardware-independent; the wall-clock engines auto-detect a per-machine partition.
@@ -131,14 +141,24 @@ jobs:
       # under the standard names cargo-bench-history reads, then let the tool mint OIDC
       # assertions on demand (no azure/login). The account name is baked into config.
       - name: Configure Azure federation identity from constants.env
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          source constants.env
-          {
-            echo "AZURE_CLIENT_ID=$AZURE_PROD_CLIENT_ID"
-            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
-          } >> "$GITHUB_ENV"
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          # constants.env is a KEY=value file (with # comment lines). Read the two
+          # identifiers the tool federates with and re-export them under the standard
+          # AZURE_* names the tool reads.
+          $values = @{}
+          foreach ($line in Get-Content constants.env) {
+            if ($line -match '^\s*([^#=]+)=(.*)$') {
+              $values[$Matches[1].Trim()] = $Matches[2].Trim()
+            }
+          }
+          @(
+            "AZURE_CLIENT_ID=$($values['AZURE_PROD_CLIENT_ID'])"
+            "AZURE_TENANT_ID=$($values['AZURE_TENANT_ID'])"
+          ) | Add-Content -Path $env:GITHUB_ENV -Encoding utf8
 
       # Persist the read-through cache (cargo-bench-history's --cache directory) across
       # runs so the bulk history is downloaded at most once instead of in full every
@@ -158,34 +178,79 @@ jobs:
           restore-keys: |
             bench-history-cache-
 
-      # Renders bench-history-report.md and bench-history-notable.txt. Findings never
-      # fail the recipe (the tool always exits 0); the issue is advisory, not a gate.
+      # Renders bench-history-report.md (full Markdown), bench-history-report.json (full
+      # JSON), bench-history-summary.md (the condensed top-findings Markdown) and
+      # bench-history-notable.txt. Findings never fail the recipe (the tool always exits
+      # 0); the issue is advisory, not a gate.
       - name: Analyze benchmark history
         run: just gh-analyze-bench-history
 
       - name: Read notable flag
         id: notable
-        shell: bash
-        run: echo "value=$(cat bench-history-notable.txt)" >> "$GITHUB_OUTPUT"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $value = (Get-Content bench-history-notable.txt -Raw).Trim()
+          "value=$value" | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
+      # Attach the full Markdown and JSON reports to the run as a single artifact, so the
+      # rolling issue can carry only the condensed summary (staying under GitHub's
+      # 65,536-character issue-body limit) while a reader can still download the complete
+      # reports. upload-artifact@v4 always produces a zip, so both files share one
+      # artifact and one download URL; that URL stays valid while the run and artifact
+      # exist. Uploaded only when notable, matching the rolling issue.
+      - name: Upload full benchmark reports
+        id: full_reports
+        if: steps.notable.outputs.value == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-history-full-report
+          path: |
+            bench-history-report.md
+            bench-history-report.json
+          if-no-files-found: error
 
       # JasonEtco/create-an-issue derives the issue title/labels from the file's YAML
-      # front matter; the report the tool renders has none, so prepend a fixed header.
+      # front matter; the summary the tool renders has none, so prepend a fixed header.
       # The fixed title is also the dedup key that turns findings into one rolling issue.
-      # A lifecycle footer is appended so a reader understands the issue is refreshed
-      # only on runs that still have findings, is never auto-closed, and that an
-      # accepted regression must be blessed (not merely closed) — see the File step.
+      # The body carries the CONDENSED summary (not the full report) so it fits the issue
+      # limit, followed by a link to the attached full reports and a lifecycle footer
+      # explaining that the issue is refreshed only on runs that still have findings, is
+      # never auto-closed, and that an accepted regression must be blessed (not merely
+      # closed) — see the File step.
       - name: Compose regression issue
         if: steps.notable.outputs.value == 'true'
-        shell: bash
+        shell: pwsh
+        env:
+          REPORT_ARTIFACT_URL: ${{ steps.full_reports.outputs.artifact-url }}
         run: |
-          # The lifecycle note printed below is literal Markdown: its backticks delimit inline
-          # code spans, not shell command substitutions, and the single quotes keep them literal.
-          # shellcheck disable=SC2016
-          {
-            printf -- '---\ntitle: Benchmark regressions detected\nlabels: bench-history, regression\n---\n\n'
-            cat bench-history-report.md
-            printf -- '\n\n---\n\n**Issue lifecycle:** This issue is maintained automatically by the `bench-history` workflow. Its body is refreshed on every push to `main` whose analysis still reports findings, so it always reflects the **latest run that had findings** — a run that finds nothing leaves it untouched rather than closing it. This issue is **not** closed automatically, and closing it by hand does **not** accept the regression: unless the change is blessed, the next analysis that still finds it just files a fresh issue. To accept an intentional change, bless the affected benchmarks at the commit named above, e.g. `cargo bench-history bless <benchmark-id-prefix> --context <commit>` (or `cargo bench-history bless --all --context <commit>` to accept every benchmark at that commit), then close the issue.\n'
-          } > bench-history-issue.md
+          $ErrorActionPreference = 'Stop'
+
+          $summary = (Get-Content bench-history-summary.md -Raw).TrimEnd()
+          $fullReport = "**Full report:** the complete Markdown and JSON reports are attached to this workflow run. [Download the full report bundle]($env:REPORT_ARTIFACT_URL)."
+          # Literal Markdown: the backticks are inline code spans, kept verbatim by the
+          # single-quoted here-string.
+          $lifecycle = @'
+          **Issue lifecycle:** This issue is maintained automatically by the `bench-history` workflow. Its body is refreshed on every push to `main` whose analysis still reports findings, so it always reflects the **latest run that had findings** — a run that finds nothing leaves it untouched rather than closing it. This issue is **not** closed automatically, and closing it by hand does **not** accept the regression: unless the change is blessed, the next analysis that still finds it just files a fresh issue. To accept an intentional change, bless the affected benchmarks at the commit named above, e.g. `cargo bench-history bless <benchmark-id-prefix> --context <commit>` (or `cargo bench-history bless --all --context <commit>` to accept every benchmark at that commit), then close the issue.
+          '@
+
+          $parts = @(
+            '---'
+            'title: Benchmark regressions detected'
+            'labels: bench-history, regression'
+            '---'
+            ''
+            $summary
+            ''
+            '---'
+            ''
+            $fullReport
+            ''
+            '---'
+            ''
+            $lifecycle
+          )
+          Set-Content -Path bench-history-issue.md -Value ($parts -join "`n") -Encoding utf8
 
       # One rolling issue, updated rather than duplicated each run (the fixed title is
       # the dedup key), so a regression that persists does not spam new issues. Opened
@@ -251,7 +316,7 @@ jobs:
       # ci-failure label; find any still-open instance and close it with an audit trail
       # linking the green run. Uses the preinstalled gh CLI (GH_REPO lets it run without a
       # checkout). Listing by `--label ci-failure` already excludes the advisory regression
-      # issue (label `regression`, closed by hand); the exact-title jq match (the search the
+      # issue (label `regression`, closed by hand); the exact-title match (the search the
       # alert path dedups on is substring/word-based) is a further guard. `--limit` defeats
       # the 30-result default so a backlog of historical duplicates would all be closed.
       - name: Close failure issue if open
@@ -259,22 +324,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          numbers=$(gh issue list \
-            --state open \
-            --label ci-failure \
-            --limit 100 \
-            --json number,title \
-            | jq -r --arg title "$FAILURE_ISSUE_TITLE" '.[] | select(.title == $title) | .number')
-          if [ -z "$numbers" ]; then
-            echo "No open failure issue to close."
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $issues = gh issue list --state open --label ci-failure --limit 100 --json number,title |
+            ConvertFrom-Json
+          $matching = @($issues | Where-Object { $_.title -eq $env:FAILURE_ISSUE_TITLE })
+          if ($matching.Count -eq 0) {
+            Write-Host 'No open failure issue to close.'
             exit 0
-          fi
-          for n in $numbers; do
-            echo "Closing #$n"
-            gh issue close "$n" \
-              --reason completed \
-              --comment "✅ The bench-history workflow is green again — auto-closing this alert. Successful run: $RUN_URL"
-          done
+          }
+          foreach ($issue in $matching) {
+            Write-Host "Closing #$($issue.number)"
+            gh issue close $issue.number --reason completed --comment "✅ The bench-history workflow is green again — auto-closing this alert. Successful run: $env:RUN_URL"
+          }

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -84,7 +84,10 @@ use, so the long-lived data store never depends on test infrastructure. Collecti
 append-only and idempotent, which is what makes a re-run safe and lets a read-through cache
 of the bulk history persist between runs. A downstream analysis job reads the accumulated
 history and files a single rolling, advisory issue when it detects a notable regression;
-regressions never fail the run.
+regressions never fail the run. Because a GitHub issue body is size-capped and a large
+analysis can exceed it, the issue carries a **condensed summary** (the top findings) and
+links to the **full Markdown and JSON reports**, which the job uploads as a run artifact — so
+the issue always fits while the complete data stays one click away.
 
 ## Failure alerting
 

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -18,12 +18,16 @@ gh-collect-bench-history:
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- collect --workspace --exclude benchmarks --skip-existing --verbose
 
 # Analyzes the collected history for regressions across ALL engines, target triples and
-# machine keys, writing two working-directory artefacts: bench-history-report.md (the
-# Markdown report) and bench-history-notable.txt (`true`/`false`, the JSON `notable`
-# flag). Findings never fail the recipe (the tool always exits 0); the workflow files a
-# rolling issue when notable. `auto` mode on a clean `main` checkout resolves to
-# long-range history-trend detection. A single analyze pass emits both the Markdown and
-# JSON reports via the per-format output toggles (`--no-text --markdown --json`).
+# machine keys, writing three working-directory artefacts: bench-history-report.md (the
+# full Markdown report), bench-history-report.json (the full JSON report) and
+# bench-history-summary.md (the Markdown report condensed to the top findings by
+# magnitude, so the rolling regression issue's body stays under GitHub's 65,536-character
+# limit) plus bench-history-notable.txt (`true`/`false`, the JSON `notable` flag). Findings
+# never fail the recipe (the tool always exits 0); the workflow files a rolling issue when
+# notable, posting the summary as the body and attaching the two full reports as run
+# artifacts. `auto` mode on a clean `main` checkout resolves to long-range history-trend
+# detection. A single analyze pass emits every report via the per-format output toggles
+# (`--no-text --markdown --json --markdown-summary`).
 #
 # `--cache` mirrors fetched cloud objects under `bench-history-cache/` (relative to the
 # repo root, the working directory here) so the bulk history is downloaded at most once
@@ -40,16 +44,17 @@ gh-analyze-bench-history:
 
     $reportPath = Join-Path (Get-Location) "bench-history-report.md"
     $jsonPath = Join-Path (Get-Location) "bench-history-report.json"
+    $summaryPath = Join-Path (Get-Location) "bench-history-summary.md"
     $notablePath = Join-Path (Get-Location) "bench-history-notable.txt"
     $common = @('--engine', 'all', '--target-triple', 'all', '--machine-key', 'all')
 
-    Write-Verbose "Analyzing benchmark history in a single pass; writing Markdown to $reportPath and JSON to $jsonPath, mirroring fetched cloud objects under bench-history-cache/ so the history is downloaded at most once across runs." -Verbose
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --cache=bench-history-cache --no-text --markdown $reportPath --json $jsonPath
+    Write-Verbose "Analyzing benchmark history in a single pass; writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, mirroring fetched cloud objects under bench-history-cache/ so the history is downloaded at most once across runs." -Verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --cache=bench-history-cache --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
     $notable = if ($json.notable) { 'true' } else { 'false' }
     Set-Content -Path $notablePath -Value $notable -Encoding utf8
-    Write-Verbose "Analysis complete: notable=$notable (report at $reportPath)." -Verbose
+    Write-Verbose "Analysis complete: notable=$notable (full report at $reportPath, condensed summary at $summaryPath)." -Verbose
 
 # The release-automation logic lives in scripts/release/ReleaseAutomation.psm1, with a Pester
 # suite (scripts/release/ReleaseAutomation.Tests.ps1) that exercises it against fixtures via

--- a/packages/cargo-bench-history-core/src/analyze/mod.rs
+++ b/packages/cargo-bench-history-core/src/analyze/mod.rs
@@ -23,7 +23,10 @@ pub use findings::{
     find_changes_spawned,
 };
 pub use parallel::{balanced_chunk_sizes, worker_count};
-pub use report::{ReportFormat, ReportInput, SetSummary, format_value, render};
+pub use report::{
+    DEFAULT_SUMMARY_LIMIT, ReportFormat, ReportInput, SetSummary, format_value, render,
+    render_markdown_summary,
+};
 pub use run_points::{MetricPoint, ResultPoints, RunPoints};
 pub use selection::{SelectedCommit, select_commits};
 pub use series::{

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -22,6 +22,13 @@ const CHART_HEIGHT: u32 = 4;
 /// Width, in columns, of a history-mode finding chart.
 const CHART_WIDTH: u32 = 48;
 
+/// The number of findings a Markdown summary retains by default.
+///
+/// Enough to convey the most significant movers while keeping the rendered report
+/// comfortably within a GitHub issue body's size limit even when an analysis flags
+/// many changes.
+pub const DEFAULT_SUMMARY_LIMIT: usize = 20;
+
 /// The selectable output format of an analysis report.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReportFormat {
@@ -622,6 +629,77 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
     finish(&lines)
 }
 
+/// Renders a condensed Markdown report carrying only the `limit` most significant
+/// findings, so a large analysis still fits within a downstream size limit (a GitHub
+/// issue body caps at 65,536 characters).
+///
+/// The header repeats the full Markdown report's totals — computed from *every*
+/// finding, not the retained subset — then a flat, globally-ranked list of the top
+/// `limit` findings follows. The per-set breakdown the full Markdown report groups by
+/// is deliberately dropped: a summary is a single ranked list, and that grouping is the
+/// main length driver. When findings were dropped, a note states how many of the
+/// total are shown so a reader knows the report is partial and to consult the full
+/// report for the rest.
+#[must_use]
+pub fn render_markdown_summary(input: &ReportInput<'_>, limit: usize) -> String {
+    // Charts embed ANSI color when `colored` is active; force it off so the fenced
+    // blocks carry plain characters, matching `render_markdown`. The guard restores
+    // ambient auto-detection on return.
+    let _color = ColorOverride::force(false);
+
+    let regressions = count_top(input.findings, Direction::Regression);
+
+    let mut lines = vec![
+        format!("# Benchmark history analysis: {}", input.project),
+        String::new(),
+        format!("- Commit: {}", tip_label(input.tip_commit, input.tip_dirty)),
+        format!("- Mode: {}", input.mode),
+        format!(
+            "- Runs analyzed: {}",
+            runs_with_span(input.runs, input.commit_span)
+        ),
+        format!("- Regressions: {regressions}"),
+    ];
+    if input.report_improvements {
+        lines.push(format!(
+            "- Improvements: {}",
+            count_top(input.findings, Direction::Improvement)
+        ));
+    }
+
+    if input.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("No notable changes detected.".to_owned());
+        if let Some(hint) = input.hint {
+            lines.push(String::new());
+            lines.push(hint.to_owned());
+        }
+        push_warning(&mut lines, input.warning);
+        return finish(&lines);
+    }
+
+    // The findings are already globally ranked by descending magnitude, so the leading
+    // `limit` are the top movers. When any were dropped, name the total so a reader
+    // knows to reach for the full report (`limit` and the total are both > 1 here, so
+    // "findings" is unconditionally plural).
+    if input.findings.len() > limit {
+        lines.push(String::new());
+        lines.push(format!(
+            "> Showing the top {limit} of {} findings by magnitude.",
+            input.findings.len()
+        ));
+    }
+
+    // A per-commit chart is meaningful only for a history timeline, matching the full
+    // reports; branch/tip modes compare against a baseline.
+    let chart_enabled = input.mode == "history";
+    for finding in input.findings.iter().take(limit) {
+        push_finding_markdown(&mut lines, finding, chart_enabled);
+    }
+    push_warning(&mut lines, input.warning);
+    finish(&lines)
+}
+
 /// Appends one finding as a Markdown block mirroring the text report: a bold
 /// percentage headline naming the benchmark and metric, the shared detail line, an
 /// optional blessing note, and — in history mode — the metric chart in a fenced
@@ -858,6 +936,124 @@ mod tests {
             hint: None,
             warning: None,
         }
+    }
+
+    /// Wraps a findings slice into a report with no per-set breakdown, for the
+    /// summary tests (which render a flat, globally-ranked list and never read
+    /// `sets`). Regressions only, so the header carries a single tally.
+    fn flat_input(findings: &[Finding]) -> ReportInput<'_> {
+        ReportInput {
+            project: "folo",
+            tip_commit: "1234567890abcdef1234",
+            tip_dirty: false,
+            mode: "history",
+            notable: !findings.is_empty(),
+            runs: findings.len().saturating_add(3),
+            series: findings.len().max(1),
+            commit_span: None,
+            report_improvements: false,
+            findings,
+            sets: &[],
+            hint: None,
+            warning: None,
+        }
+    }
+
+    /// A regression finding named `name` (a single-segment id) with the given
+    /// relative move, so a summary test can tell which findings the render kept by
+    /// their distinctive ids and magnitudes.
+    fn named_regression(name: &str, relative_delta: f64) -> Finding {
+        Finding {
+            id: BenchmarkId::new(nonempty![name.to_owned()]),
+            relative_delta,
+            ..regression()
+        }
+    }
+
+    /// Five regressions in the descending-magnitude order the ranking produces, so a
+    /// summary render can cap the leading few and drop the tail.
+    fn ranked_five() -> Vec<Finding> {
+        vec![
+            named_regression("mover_a", 0.50),
+            named_regression("mover_b", 0.40),
+            named_regression("mover_c", 0.30),
+            named_regression("dropped_d", 0.20),
+            named_regression("dropped_e", 0.10),
+        ]
+    }
+
+    #[test]
+    fn markdown_summary_caps_to_the_limit_and_keeps_full_totals() {
+        let findings = ranked_five();
+        let input = flat_input(&findings);
+
+        let report = render_markdown_summary(&input, 3);
+
+        // The header tally counts every finding, not the retained subset.
+        assert!(report.contains("- Regressions: 5"), "{report}");
+        // The truncation note names how many of the total are shown.
+        assert!(
+            report.contains("> Showing the top 3 of 5 findings by magnitude."),
+            "{report}"
+        );
+        // The three largest movers are kept; the two smallest are dropped.
+        assert!(report.contains("mover_a"), "{report}");
+        assert!(report.contains("mover_b"), "{report}");
+        assert!(report.contains("mover_c"), "{report}");
+        assert!(!report.contains("dropped_d"), "{report}");
+        assert!(!report.contains("dropped_e"), "{report}");
+        // The per-set breakdown the full Markdown report groups by is dropped: a
+        // summary is a single flat list, so no `## engine/triple/machine` heading.
+        assert!(!report.contains("## callgrind"), "{report}");
+    }
+
+    #[test]
+    fn markdown_summary_omits_the_note_when_within_the_limit() {
+        let findings = ranked_five();
+        let input = flat_input(&findings);
+
+        // A limit at or above the finding count keeps every finding and shows no
+        // truncation note.
+        let report = render_markdown_summary(&input, 5);
+
+        assert!(!report.contains("Showing the top"), "{report}");
+        assert!(report.contains("mover_a"), "{report}");
+        assert!(report.contains("dropped_e"), "{report}");
+
+        // A limit beyond the count behaves the same as an exact fit.
+        let generous = render_markdown_summary(&input, 20);
+        assert_eq!(generous, report);
+    }
+
+    #[test]
+    fn markdown_summary_with_no_findings_matches_the_empty_message() {
+        let input = ReportInput {
+            hint: Some("Found 2 stored runs ... dirty snapshots"),
+            ..flat_input(&[])
+        };
+
+        let report = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
+
+        assert!(report.contains("No notable changes detected."), "{report}");
+        assert!(report.contains("Found 2 stored runs"), "{report}");
+        assert!(!report.contains("Showing the top"), "{report}");
+    }
+
+    #[test]
+    fn markdown_summary_draws_a_fenced_chart_in_history_mode() {
+        // `flat_input` fixes the mode to `history`, where a retained finding with a
+        // series is rendered with its per-commit chart — so the summary reuses the full
+        // report's chart-in-history behaviour rather than dropping it.
+        let findings = vec![regression_with_series()];
+        let input = flat_input(&findings);
+
+        let report = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
+
+        // The chart sits inside a fenced `text` block (its axis marker proves a chart was
+        // drawn) and carries no ANSI escapes.
+        assert!(report.contains("```text"), "{report}");
+        assert!(report.contains('┤') || report.contains('┼'), "{report}");
+        assert!(!report.contains('\u{1b}'), "{report}");
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -9,6 +9,8 @@
 //! ranked findings, and a per-set breakdown follows so each comparable partition
 //! reads as its own section.
 
+use std::num::NonZero;
+
 use colored::{Color, Colorize};
 use rasciigraph::{Config, plot_colored, plot_many_colored};
 use serde::Serialize;
@@ -27,7 +29,7 @@ const CHART_WIDTH: u32 = 48;
 /// Enough to convey the most significant movers while keeping the rendered report
 /// comfortably within a GitHub issue body's size limit even when an analysis flags
 /// many changes.
-pub const DEFAULT_SUMMARY_LIMIT: usize = 20;
+pub const DEFAULT_SUMMARY_LIMIT: NonZero<usize> = NonZero::new(20).expect("20 is non-zero");
 
 /// The selectable output format of an analysis report.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -641,7 +643,7 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
 /// total are shown so a reader knows the report is partial and to consult the full
 /// report for the rest.
 #[must_use]
-pub fn render_markdown_summary(input: &ReportInput<'_>, limit: usize) -> String {
+pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -> String {
     // Charts embed ANSI color when `colored` is active; force it off so the fenced
     // blocks carry plain characters, matching `render_markdown`. The guard restores
     // ambient auto-detection on return.
@@ -680,9 +682,9 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: usize) -> String 
 
     // The findings are already globally ranked by descending magnitude, so the leading
     // `limit` are the top movers. When any were dropped, name the total so a reader
-    // knows to reach for the full report (`limit` and the total are both > 1 here, so
-    // "findings" is unconditionally plural).
-    if input.findings.len() > limit {
+    // knows to reach for the full report (the total exceeds `limit`, which is at least
+    // one, so the total is at least two and "findings" is unconditionally plural).
+    if input.findings.len() > limit.get() {
         lines.push(String::new());
         lines.push(format!(
             "> Showing the top {limit} of {} findings by magnitude.",
@@ -693,7 +695,7 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: usize) -> String 
     // A per-commit chart is meaningful only for a history timeline, matching the full
     // reports; branch/tip modes compare against a baseline.
     let chart_enabled = input.mode == "history";
-    for finding in input.findings.iter().take(limit) {
+    for finding in input.findings.iter().take(limit.get()) {
         push_finding_markdown(&mut lines, finding, chart_enabled);
     }
     push_warning(&mut lines, input.warning);
@@ -987,7 +989,7 @@ mod tests {
         let findings = ranked_five();
         let input = flat_input(&findings);
 
-        let report = render_markdown_summary(&input, 3);
+        let report = render_markdown_summary(&input, NonZero::new(3).unwrap());
 
         // The header tally counts every finding, not the retained subset.
         assert!(report.contains("- Regressions: 5"), "{report}");
@@ -1014,14 +1016,14 @@ mod tests {
 
         // A limit at or above the finding count keeps every finding and shows no
         // truncation note.
-        let report = render_markdown_summary(&input, 5);
+        let report = render_markdown_summary(&input, NonZero::new(5).unwrap());
 
         assert!(!report.contains("Showing the top"), "{report}");
         assert!(report.contains("mover_a"), "{report}");
         assert!(report.contains("dropped_e"), "{report}");
 
         // A limit beyond the count behaves the same as an exact fit.
-        let generous = render_markdown_summary(&input, 20);
+        let generous = render_markdown_summary(&input, NonZero::new(20).unwrap());
         assert_eq!(generous, report);
     }
 

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -972,6 +972,18 @@ mod tests {
         }
     }
 
+    /// An improvement finding named `name` with the given (negative) relative move, so
+    /// a summary test can exercise the optional improvements tally alongside
+    /// regressions.
+    fn named_improvement(name: &str, relative_delta: f64) -> Finding {
+        Finding {
+            id: BenchmarkId::new(nonempty![name.to_owned()]),
+            direction: Direction::Improvement,
+            relative_delta,
+            ..regression()
+        }
+    }
+
     /// Five regressions in the descending-magnitude order the ranking produces, so a
     /// summary render can cap the leading few and drop the tail.
     fn ranked_five() -> Vec<Finding> {
@@ -1056,6 +1068,34 @@ mod tests {
         assert!(report.contains("```text"), "{report}");
         assert!(report.contains('┤') || report.contains('┼'), "{report}");
         assert!(!report.contains('\u{1b}'), "{report}");
+    }
+
+    #[test]
+    fn markdown_summary_reports_improvements_only_when_enabled() {
+        // Magnitudes descend so the list already reads as globally ranked; two
+        // regressions and three improvements are interleaved.
+        let findings = vec![
+            named_regression("reg_a", 0.50),
+            named_improvement("imp_b", -0.40),
+            named_regression("reg_c", 0.30),
+            named_improvement("imp_d", -0.20),
+            named_improvement("imp_e", -0.10),
+        ];
+
+        // Disabled (the `flat_input` default): the header carries no improvements tally.
+        let without = render_markdown_summary(&flat_input(&findings), NonZero::new(2).unwrap());
+        assert!(!without.contains("Improvements:"), "{without}");
+
+        // Enabled: the header carries an improvements tally counted from *every*
+        // finding — like the regressions tally — even though the cap of two drops
+        // `imp_d` and `imp_e` from the rendered list.
+        let input = ReportInput {
+            report_improvements: true,
+            ..flat_input(&findings)
+        };
+        let with = render_markdown_summary(&input, NonZero::new(2).unwrap());
+        assert!(with.contains("- Regressions: 2"), "{with}");
+        assert!(with.contains("- Improvements: 3"), "{with}");
     }
 
     #[test]

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -271,6 +271,7 @@ fn build_options(
         no_text: true,
         markdown: None,
         json: Some(PathBuf::from(ANALYZE_REPORT_FILE)),
+        markdown_summary: None,
         mode: Some(mode.keyword().to_owned()),
         include_improvements: true,
         include_inactive: false,

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -51,8 +51,9 @@ New per-series logic must be side-effect-free. Flow and rationale: [`docs/analyz
 (`list.rs`, `prune.rs`, `examine.rs`, each `pub(crate) mod`; `bless`/`unbless` in `bless.rs`
 reuse the same facet selection). **A selection parameter added to one must be added to all
 four** unless genuinely inapplicable. The analysis-only flags (`--mode`,
-`--include-improvements`, `--include-inactive`) are **not** part of the lockstep — only
-`analyze` detects; `list`/`prune`/`examine` reuse the selection but never analyze. Each is
+`--include-improvements`, `--include-inactive`) and the analyze-only condensed
+`--markdown-summary` output are **not** part of the lockstep — only `analyze` detects;
+`list`/`prune`/`examine` reuse the selection but never analyze. Each is
 generic over the `GitHistory` + `Storage` ports so tests drive it with fakes + `block_on`.
 Semantics and per-command behaviour: DESIGN §7–§8.
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -407,8 +407,14 @@ detail users are not expected to know.
 
 Output toggles select which renderings one analysis pass emits — text to stdout by default,
 with file toggles that compose so a single pass can emit text, Markdown, and JSON at once;
-requesting no output at all is an error. **Findings never affect the exit code**: the
-process exits non-zero only when the analysis fails to *run*. A finding is advisory, and
+requesting no output at all is an error. Beyond those three canonical renderings, `analyze`
+offers one **derived** output — a condensed Markdown *summary* — for a downstream consumer
+whose body has a hard size limit (the workflow posts it as a rolling GitHub issue, capped at
+65,536 characters). The summary keeps only the most significant findings and drops the
+per-facet grouping, so it is intentionally lossy; it is analyze-only because truncating a
+ranked list is meaningless for the enumerating commands, and it never displaces the full
+reports, which the workflow attaches alongside it. **Findings never affect the exit code**:
+the process exits non-zero only when the analysis fails to *run*. A finding is advisory, and
 the machine-readable signal lives in the JSON report. Downstream automation (a scheduled
 regression watch, a PR comment bot) reads that rather than the exit status. When
 facet-matching runs were stored but none entered the analysis, the report carries a plain
@@ -712,6 +718,14 @@ human reports draw from internally, not data a consumer reconstructs); the text 
 Markdown values round to four significant figures. A consumer keys off a top-level
 "notable" flag (post or stay silent) and reads each finding's direction, magnitude, and
 attribution.
+
+Separate from those three canonical formats, `analyze` can also render a condensed Markdown
+**summary** — a single derived view for a size-limited consumer. It reuses the Markdown
+finding blocks but keeps only the top findings by magnitude and drops the per-facet grouping,
+so it is deliberately **not** "same data": it is a lossy excerpt that names how many of the
+total it shows and leaves the full reports to be consulted separately. Because it exists to
+fit a downstream cap rather than to present the analysis, it is offered only by `analyze`,
+never by the enumerating commands, and the retained-count is a fixed policy of the renderer.
 
 ## 9. Architecture
 

--- a/packages/cargo-bench-history/src/analyze/mod.rs
+++ b/packages/cargo-bench-history/src/analyze/mod.rs
@@ -25,10 +25,11 @@ use std::time::Instant;
 
 use anyspawn::Spawner;
 pub(crate) use cargo_bench_history_core::analyze::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DiscriminantSetQuery,
-    FacetFilter, ReportFormat, ReportInput, RunPoints, Series, SeriesBuilder, SeriesFilter,
-    SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes, find_changes_spawned,
-    format_value, parse_key, render, select_commits, worker_count,
+    AnalysisConfig, AnalysisContext, AnalysisMode, BlessingPlacement, DEFAULT_SUMMARY_LIMIT,
+    DiscriminantSetQuery, FacetFilter, ReportFormat, ReportInput, RunPoints, Series, SeriesBuilder,
+    SeriesFilter, SetSummary, StorageKey, apply_blessings, balanced_chunk_sizes,
+    find_changes_spawned, format_value, parse_key, render, render_markdown_summary, select_commits,
+    worker_count,
 };
 use futures::{StreamExt as _, TryStreamExt as _};
 use jiff::civil::Date;
@@ -43,7 +44,9 @@ use crate::machine::resolve_machine_key;
 use crate::model::{
     BenchmarkIdPrefix, BlessingRecord, DiscriminantSet, Engine, STORAGE_VERSION, sanitize_segment,
 };
-use crate::output::{OutputSelection, OutputWriter, TokioOutputWriter, emit};
+use crate::output::{
+    OutputSelection, OutputWriter, TokioOutputWriter, emit, emit_markdown_summary,
+};
 use crate::probe::{EnvironmentProbe, SystemProbe};
 use crate::report::{Reporter, ReporterExt, StderrReporter};
 use crate::storage::{Storage, StorageFacade, project_objects_prefix, resolve_storage};
@@ -196,10 +199,11 @@ where
     S: Storage + Clone + 'static,
     W: OutputWriter,
 {
-    let output = OutputSelection::resolve(
+    let output = OutputSelection::resolve_analyze(
         options.no_text,
         options.markdown.as_deref(),
         options.json.as_deref(),
+        options.markdown_summary.as_deref(),
     )?;
     let selection = Selection::from_analyze(options)?;
     let filter = SeriesFilter {
@@ -298,6 +302,12 @@ where
     let render_started = Instant::now();
     let report = emit(&output, writer, reporter, |format| {
         render(&input, format, color)
+    })
+    .await?;
+    // The condensed summary is analyze-only and not one of the three shared formats,
+    // so it renders and writes through its own edge alongside the full reports.
+    emit_markdown_summary(&output, writer, reporter, || {
+        render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT)
     })
     .await?;
     reporter.timing("report render", render_started.elapsed());

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -470,6 +470,13 @@ struct AnalyzeCommand {
     /// findings, so this flag has no effect there.
     #[arg(long, help_heading = HEADING_ANALYSIS)]
     include_inactive: bool,
+
+    /// Also write a condensed Markdown summary — only the most significant findings
+    /// — to this path (a relative path resolves against the working directory). The
+    /// full `--markdown` report carries every finding; this summary is capped so a
+    /// large analysis still fits within a GitHub issue body.
+    #[arg(long, value_name = "PATH", help_heading = HEADING_OUTPUT)]
+    markdown_summary: Option<PathBuf>,
 }
 
 impl AnalyzeCommand {
@@ -491,6 +498,7 @@ impl AnalyzeCommand {
             no_text: self.output.no_text,
             markdown: self.output.markdown,
             json: self.output.json,
+            markdown_summary: self.markdown_summary,
             mode: self.mode,
             include_improvements: self.include_improvements,
             include_inactive: self.include_inactive,

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -171,6 +171,11 @@ pub struct AnalyzeOptions {
     /// Write the JSON report to this path, if set (`--json <path>`). A relative
     /// path resolves against the working directory.
     pub json: Option<PathBuf>,
+    /// Write the condensed Markdown summary (the most significant findings only) to
+    /// this path, if set (`--markdown-summary <path>`). A relative path resolves
+    /// against the working directory. Analyze-only, so a large analysis still fits
+    /// within a GitHub issue body.
+    pub markdown_summary: Option<PathBuf>,
     /// Analysis-mode selector (`auto`, `history`, `branch`, or `tip`), if set.
     /// `auto` (the default) infers history vs branch mode from the git topology.
     pub mode: Option<String>,

--- a/packages/cargo-bench-history/src/output.rs
+++ b/packages/cargo-bench-history/src/output.rs
@@ -8,9 +8,16 @@
 //! used by `install`) so the orchestrators stay storage- and filesystem-agnostic:
 //! production uses [`TokioOutputWriter`], while tests drive an in-memory fake.
 //!
-//! A relative `--markdown`/`--json` path resolves against the working directory
-//! (the same base as `--config`), so the resolution happens at the IO edge inside
-//! [`TokioOutputWriter`].
+//! `analyze` additionally offers `--markdown-summary <path>`: a condensed Markdown
+//! report carrying only the most significant findings, so a large analysis still
+//! fits within a GitHub issue body. It is analyze-only (the other commands do not
+//! rank findings), so it is not one of the three shared formats — it resolves and
+//! writes through [`OutputSelection::resolve_analyze`] and [`emit_markdown_summary`]
+//! rather than the shared [`emit`].
+//!
+//! A relative `--markdown`/`--markdown-summary`/`--json` path resolves against the
+//! working directory (the same base as `--config`), so the resolution happens at the
+//! IO edge inside [`TokioOutputWriter`].
 //!
 //! [`ConfigWriter`]: crate::config_writer::ConfigWriter
 
@@ -36,10 +43,15 @@ pub(crate) struct OutputSelection<'a> {
     markdown: Option<&'a Path>,
     /// Where to write the JSON report, if requested (`--json <path>`).
     json: Option<&'a Path>,
+    /// Where to write the condensed Markdown summary, if requested
+    /// (`--markdown-summary <path>`). Only `analyze` sets this; the other reporting
+    /// commands leave it `None` (they do not rank findings).
+    markdown_summary: Option<&'a Path>,
 }
 
 impl<'a> OutputSelection<'a> {
-    /// Resolves and validates the requested outputs.
+    /// Resolves and validates the requested outputs for the commands that emit only
+    /// the three shared formats (`list`, `prune`, `examine`).
     ///
     /// # Errors
     ///
@@ -63,6 +75,38 @@ impl<'a> OutputSelection<'a> {
             no_text,
             markdown,
             json,
+            markdown_summary: None,
+        })
+    }
+
+    /// Resolves and validates the requested outputs for `analyze`, which additionally
+    /// offers `--markdown-summary <path>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunError::Analyze`] when nothing would be emitted — `--no-text`
+    /// suppresses the text report and none of `--markdown`, `--markdown-summary`, or
+    /// `--json` was requested — so a run that would produce nothing is rejected up
+    /// front rather than completing silently.
+    pub(crate) fn resolve_analyze(
+        no_text: bool,
+        markdown: Option<&'a Path>,
+        json: Option<&'a Path>,
+        markdown_summary: Option<&'a Path>,
+    ) -> Result<Self, RunError> {
+        if no_text && markdown.is_none() && json.is_none() && markdown_summary.is_none() {
+            return Err(RunError::Analyze {
+                message: "no output selected: --no-text suppresses the text report, so request at \
+                          least one of --markdown <path>, --markdown-summary <path>, or --json \
+                          <path>"
+                    .to_owned(),
+            });
+        }
+        Ok(Self {
+            no_text,
+            markdown,
+            json,
+            markdown_summary,
         })
     }
 }
@@ -145,6 +189,34 @@ where
     } else {
         render(ReportFormat::Text)
     })
+}
+
+/// Writes the condensed Markdown summary to its requested path, if one was selected.
+///
+/// This is `analyze`'s companion to [`emit`]: the top-N summary is not one of the
+/// three shared report formats (it is a truncated, derived view), so it renders
+/// through its own `render_summary` closure and writes via the same [`OutputWriter`]
+/// edge, announcing the result on the verbose trail like every other written report.
+/// A no-op when `--markdown-summary` was not requested.
+///
+/// # Errors
+///
+/// Returns [`RunError::Io`] if writing the summary file fails.
+pub(crate) async fn emit_markdown_summary<W, F>(
+    selection: &OutputSelection<'_>,
+    writer: &W,
+    reporter: &dyn Reporter,
+    render_summary: F,
+) -> Result<(), RunError>
+where
+    W: OutputWriter,
+    F: FnOnce() -> String,
+{
+    if let Some(path) = selection.markdown_summary {
+        let contents = render_summary();
+        write_report(writer, reporter, path, &contents, "Markdown summary").await?;
+    }
+    Ok(())
 }
 
 /// Writes one rendered report to `path` and records the result on the verbose
@@ -315,6 +387,94 @@ mod tests {
         let reporter = RecordingReporter::new();
 
         let error = block_on(emit(&selection, &writer, &reporter, render_label)).unwrap_err();
+
+        assert!(matches!(error, RunError::Io(_)), "{error:?}");
+    }
+
+    #[test]
+    fn resolve_analyze_allows_only_the_summary() {
+        let summary = PathBuf::from("summary.md");
+        OutputSelection::resolve_analyze(true, None, None, Some(&summary)).unwrap();
+    }
+
+    #[test]
+    fn resolve_analyze_rejects_a_run_that_would_emit_nothing() {
+        let error = OutputSelection::resolve_analyze(true, None, None, None).unwrap_err();
+        match error {
+            RunError::Analyze { message } => {
+                assert!(message.contains("no output selected"), "{message}");
+                // The analyze variant names its extra format in the guidance.
+                assert!(message.contains("--markdown-summary"), "{message}");
+            }
+            other => panic!("expected an analyze error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn emit_markdown_summary_writes_the_file_and_announces_it() {
+        let summary = PathBuf::from("summary.md");
+        let selection = OutputSelection::resolve_analyze(true, None, None, Some(&summary)).unwrap();
+        let writer = MemoryOutputWriter::new();
+        let reporter = RecordingReporter::new();
+
+        block_on(emit_markdown_summary(
+            &selection,
+            &writer,
+            &reporter,
+            || "SUMMARY".to_owned(),
+        ))
+        .unwrap();
+
+        assert_eq!(writer.written(&summary).as_deref(), Some("SUMMARY"));
+        assert!(
+            reporter.contains("wrote the Markdown summary report"),
+            "{:?}",
+            reporter.notes()
+        );
+    }
+
+    #[test]
+    fn emit_markdown_summary_is_a_noop_without_a_requested_path() {
+        let json = PathBuf::from("report.json");
+        // A selection with the summary unset: the renderer must not run and nothing
+        // is written or announced.
+        let selection = OutputSelection::resolve_analyze(true, None, Some(&json), None).unwrap();
+        let writer = MemoryOutputWriter::new();
+        let reporter = RecordingReporter::new();
+
+        let mut rendered = false;
+        block_on(emit_markdown_summary(
+            &selection,
+            &writer,
+            &reporter,
+            || {
+                rendered = true;
+                "SUMMARY".to_owned()
+            },
+        ))
+        .unwrap();
+
+        assert!(
+            !rendered,
+            "the summary renderer must not run when no path is set"
+        );
+        assert!(reporter.notes().is_empty(), "{:?}", reporter.notes());
+    }
+
+    #[test]
+    fn emit_markdown_summary_maps_a_write_failure_to_an_io_error() {
+        let summary = PathBuf::from("summary.md");
+        let selection = OutputSelection::resolve_analyze(true, None, None, Some(&summary)).unwrap();
+        let writer = FailingOutputWriter;
+        let reporter = RecordingReporter::new();
+
+        let error = block_on(emit_markdown_summary(
+            &selection,
+            &writer,
+            &reporter,
+            || "SUMMARY".to_owned(),
+        ))
+        .unwrap_err();
 
         assert!(matches!(error, RunError::Io(_)), "{error:?}");
     }

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -172,6 +172,92 @@ async fn analyze_writes_markdown_and_json_from_one_suppressed_text_pass() {
     assert_eq!(parsed["project"], "testproj");
 }
 
+/// `--markdown-summary <path>` renders a flat, ungrouped condensed report that omits
+/// the per-set headings the full Markdown report carries. With few findings there is
+/// no truncation note.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_markdown_summary_renders_a_flat_report() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+
+    let summary = workspace.drive_markdown_summary(&["analyze"]).await;
+
+    assert!(
+        summary.contains("# Benchmark history analysis: testproj"),
+        "{summary}"
+    );
+    // The condensed report leads each finding with the same bold-percentage headline
+    // the full report uses.
+    assert!(summary.contains("%** — `"), "{summary}");
+    // A single seeded regression is well within the top-20 cap, so no truncation note
+    // is added.
+    assert!(
+        !summary.contains("Showing the top"),
+        "an untruncated summary must not claim it is partial: {summary}"
+    );
+    // The per-set `## engine/triple/machine` grouping is deliberately dropped from the
+    // summary, unlike the full Markdown report.
+    assert!(
+        !summary.contains("\n## "),
+        "the summary must be flat, without per-set headings: {summary}"
+    );
+}
+
+/// When an analysis produces more findings than the summary cap, `--markdown-summary`
+/// keeps only the top 20 by magnitude and states the total, while a full `--markdown`
+/// report from the same run still lists every finding.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_markdown_summary_caps_findings_and_names_the_total() {
+    let workspace = Workspace::repo(&storage_only_config());
+    // Seed more distinct rising benchmarks than the top-20 cap so truncation engages.
+    workspace.seed_many_rising_callgrind_history(25);
+
+    let outcome = workspace
+        .drive(&[
+            "analyze",
+            "--no-text",
+            "--markdown",
+            "full.md",
+            "--markdown-summary",
+            "summary.md",
+        ])
+        .await
+        .unwrap();
+    let RunOutcome::Analyzed { regressions, .. } = outcome else {
+        panic!("expected an analyzed outcome, got {outcome:?}");
+    };
+    assert_eq!(regressions, 25, "every seeded benchmark should regress");
+
+    let summary = workspace
+        .read("summary.md")
+        .expect("the Markdown summary should be written");
+    let full = workspace
+        .read("full.md")
+        .expect("the full Markdown report should be written");
+
+    // The header carries the *true* total (all 25), not the retained subset.
+    assert!(summary.contains("- Regressions: 25"), "{summary}");
+    // The truncation note names how many of the total are shown.
+    assert!(
+        summary.contains("Showing the top 20 of 25 findings by magnitude."),
+        "{summary}"
+    );
+    // Exactly the cap of finding headlines survives in the summary.
+    let summary_blocks = summary.matches("%** — `").count();
+    assert_eq!(
+        summary_blocks, 20,
+        "summary should keep only the cap: {summary}"
+    );
+    // The full report from the same run still lists every finding.
+    let full_blocks = full.matches("%** — `").count();
+    assert_eq!(
+        full_blocks, 25,
+        "full report should keep every finding: {full}"
+    );
+}
+
 /// `--no-text` suppresses stdout text while still writing a JSON report.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -885,6 +885,21 @@ impl Workspace {
             .expect("the Markdown report was written to the requested path")
     }
 
+    /// Drives `analyze` requesting the condensed Markdown summary into a file and
+    /// returns its contents. Appends `--no-text --markdown-summary <unique path>`,
+    /// so the summary file is the only rendered output. Panics if the command fails.
+    pub(crate) async fn drive_markdown_summary(&self, args: &[&str]) -> String {
+        let name = format!(
+            "cbh-summary-{}.md",
+            OUTPUT_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut full: Vec<&str> = args.to_vec();
+        full.extend_from_slice(&["--no-text", "--markdown-summary", &name]);
+        self.drive(&full).await.unwrap();
+        self.read(&name)
+            .expect("the Markdown summary was written to the requested path")
+    }
+
     /// All stored objects as `(object key, parsed result set)` pairs, sorted by key.
     pub(crate) fn stored_objects(&self) -> Vec<(String, Run)> {
         let store = self.root().join("store");
@@ -1005,6 +1020,55 @@ impl Workspace {
         self.seed_callgrind("c5", 130.0);
         self.commit_dated("2024-01-06", "c6");
         self.seed_callgrind("c6", 130.0);
+    }
+
+    /// Seeds a rising Callgrind history for `count` distinct benchmarks sharing one
+    /// partition, so a single analysis pass yields `count` regression findings of
+    /// distinct magnitudes. Each benchmark holds a flat baseline of 100 across the
+    /// first three commits, then steps to a benchmark-specific higher value across
+    /// the last three — a sustained regression the change-point detector flags.
+    /// Benchmark `i` steps to `120 + i`, so magnitudes are distinct and strictly
+    /// increasing, giving the global ranking a deterministic order.
+    pub(crate) fn seed_many_rising_callgrind_history(&self, count: usize) {
+        let baseline = vec![100.0; count];
+        // `count` is a small test parameter; a u16 cast keeps the value exact and
+        // avoids a lossy `usize as f64` conversion.
+        let raised: Vec<f64> = (0..count)
+            .map(|index| {
+                120.0 + f64::from(u16::try_from(index).expect("benchmark count fits in u16"))
+            })
+            .collect();
+        for (date, label) in [
+            ("2024-01-01", "c1"),
+            ("2024-01-02", "c2"),
+            ("2024-01-03", "c3"),
+        ] {
+            self.commit_dated(date, label);
+            self.seed_many_callgrind(label, &baseline);
+        }
+        for (date, label) in [
+            ("2024-01-04", "c4"),
+            ("2024-01-05", "c5"),
+            ("2024-01-06", "c6"),
+        ] {
+            self.commit_dated(date, label);
+            self.seed_many_callgrind(label, &raised);
+        }
+    }
+
+    /// Seeds one Callgrind result set carrying one `Ir` benchmark per entry in
+    /// `values` for the previously created commit `label`, all in the shared
+    /// `x86_64`/`synthetic` partition.
+    fn seed_many_callgrind(&self, label: &str, values: &[f64]) {
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
+        let key = format!(
+            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit_id}/clean.json"
+        );
+        self.seed(
+            &key,
+            &many_benchmark_result_set(observed.as_second(), &commit_id, values),
+        );
     }
 
     /// Seeds one Criterion `wall_time` result set on the previously created commit
@@ -1205,6 +1269,37 @@ pub(crate) fn two_benchmark_result_set(effective: i64, commit: &str, alpha: f64,
             ir(beta),
         ),
     ];
+    Run::new(context, records)
+}
+
+/// Builds a Callgrind result set carrying one `Ir` benchmark per entry in
+/// `values`, each under a distinct, zero-padded benchmark id so a single
+/// partition can host many independent series. Stamped with the effective second
+/// and `commit`.
+pub(crate) fn many_benchmark_result_set(effective: i64, commit: &str, values: &[f64]) -> Run {
+    let time = Timestamp::from_second(effective).unwrap();
+    let git = git_info(commit);
+    let context = RunContext::new(
+        time,
+        git,
+        EnvironmentInfo::default(),
+        ToolchainInfo::default(),
+        TOOL_VERSION.to_owned(),
+    );
+    let records = values
+        .iter()
+        .enumerate()
+        .map(|(index, &value)| {
+            BenchmarkResult::new(
+                BenchmarkId::new(nonempty![
+                    "many".to_owned(),
+                    format!("many::bench_{index:03}"),
+                    "wide".to_owned(),
+                ]),
+                vec![Metric::new(MetricKind::InstructionCount, value)],
+            )
+        })
+        .collect();
     Run::new(context, records)
 }
 


### PR DESCRIPTION
Closes #309.

## Problem

When `cargo-bench-history analyze` reports many findings, the Markdown report can exceed GitHub's issue-body limit (65,536 characters), so the rolling regression issue fails to post.

## Solution

**1. Analyze-only `--markdown-summary <path>` output**

A condensed Markdown report capped to the top findings by magnitude:

- `DEFAULT_SUMMARY_LIMIT = 20`, `render_markdown_summary` in `cargo-bench-history-core`.
- Header repeats the **true totals** (counted from every finding, not the retained subset); a flat, globally-ranked top-20 list; the per-set `## engine/triple/machine` grouping (the main length driver) is dropped.
- When truncated, a `> Showing the top 20 of N findings by magnitude.` note tells the reader it is partial.
- It is a deliberately-**lossy derived view**, so it is analyze-only (the enumerating commands do not rank findings) and is **not** one of the three same-data formats (text/markdown/json). It resolves/writes through `OutputSelection::resolve_analyze` + `emit_markdown_summary`, separate from the shared `emit`.

**2. Workflow posting**

- The rolling regression issue body now carries the **condensed summary** (so it always fits), followed by a link to the **full Markdown + JSON reports**, which are uploaded as a single run artifact (`actions/upload-artifact@v4`).
- All `bench-history.yml` steps converted from `shell: bash` to `shell: pwsh`, per the `.github/workflows` convention.

## Docs

`packages/cargo-bench-history/docs/DESIGN.md` (§7.3, §8.7), `.github/workflows/design.md`, and `packages/cargo-bench-history/AGENTS.md`.

## Tests

- Core unit tests for the cap, the truncation note, the empty case, and history-mode chart rendering.
- Shell `output.rs` tests for `resolve_analyze` and `emit_markdown_summary`.
- Integration tests, including a >20-finding truncation case (new multi-benchmark seed helper) asserting the summary keeps exactly 20 blocks + the note while a full `--markdown` report from the same run keeps all 25.

## Validation

`just package="cargo-bench-history cargo-bench-history-core cargo-bench-history-stress" validate-local` is green (incl. `mutants`: all `render_markdown_summary` mutants caught) and `just validate-workflows` passes.
