### PR TITLE
Cover all three analysis modes in signal-validation suite

### DIFF
--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -73,3 +73,33 @@ ecosystem pattern (see `docs/performance.md`) and cover the numeric boundaries
 with named, value-asserting tests rather than threshold guards (see
 `docs/testing.md`). All of `analyze::stats` must stay deterministic and
 Miri-safe.
+
+## Signal-validation tests are correctness-critical — changing expectations needs human approval
+
+`src/analyze/signal_validation.rs` is the suite of hand-curated "obvious right
+answer" series (an obvious doubling, a dead-flat line, …) paired with the verdict
+each analysis mode *must* reach. It exists to catch the analysis math drifting
+into illogical territory — calling a doubling "no change", or a flat line "a
+regression". The curated expectations **are** the specification of correct
+behaviour here.
+
+**Never change a signal-validation expectation to make a failing test pass.** A
+failure in this suite is a signal that a change altered what the analysis
+concludes about an unambiguous input, which is almost always a regression in the
+analysis, not a stale test. Adjusting the expected outcome to match the new
+behaviour silently ratifies that regression and defeats the entire purpose of the
+suite.
+
+If, while maintaining this crate, you come to believe an expectation genuinely
+needs to change (e.g. a deliberate, approved change to the detection semantics):
+
+* **Stop and get explicit human approval before touching any expectation.** This
+  is a hard gate, not a courtesy. Do not commit an expectation change without it.
+* **Propose the adjustment to the user with evidence, not just a diff.** Show the
+  affected series, the old vs. new verdict per mode/polarity, and *why* the new
+  verdict is the correct answer for that input. Include illustrative material —
+  worked examples, plots of the series and the detector's decision, before/after
+  comparisons — enough for a human to judge the real-world impact without
+  re-deriving it.
+* Adding *new* curated cases (more coverage) is welcome and does not need this
+  gate; **changing or removing an existing expectation does.**

--- a/packages/cargo-bench-history-core/AGENTS.md
+++ b/packages/cargo-bench-history-core/AGENTS.md
@@ -74,7 +74,7 @@ with named, value-asserting tests rather than threshold guards (see
 `docs/testing.md`). All of `analyze::stats` must stay deterministic and
 Miri-safe.
 
-## Signal-validation tests are correctness-critical — changing expectations needs human approval
+## Signal-validation tests are correctness-critical — every change needs human approval
 
 `src/analyze/signal_validation.rs` is the suite of hand-curated "obvious right
 answer" series (an obvious doubling, a dead-flat line, …) paired with the verdict
@@ -90,16 +90,25 @@ analysis, not a stale test. Adjusting the expected outcome to match the new
 behaviour silently ratifies that regression and defeats the entire purpose of the
 suite.
 
-If, while maintaining this crate, you come to believe an expectation genuinely
-needs to change (e.g. a deliberate, approved change to the detection semantics):
+**Every change to this suite needs explicit human approval before you commit
+it** — not only editing or removing an expectation, but also *adding* a new
+curated case. Approval for additions is not a rubber stamp: a weak or
+ill-considered "trash case" dilutes the suite and, worse, normalizes casually
+approving expectation changes to it when its outcome later shifts in the regular
+course of business. Every case must earn its place as an unambiguous, obviously
+correct answer.
 
-* **Stop and get explicit human approval before touching any expectation.** This
-  is a hard gate, not a courtesy. Do not commit an expectation change without it.
-* **Propose the adjustment to the user with evidence, not just a diff.** Show the
-  affected series, the old vs. new verdict per mode/polarity, and *why* the new
-  verdict is the correct answer for that input. Include illustrative material —
-  worked examples, plots of the series and the detector's decision, before/after
-  comparisons — enough for a human to judge the real-world impact without
-  re-deriving it.
-* Adding *new* curated cases (more coverage) is welcome and does not need this
-  gate; **changing or removing an existing expectation does.**
+If, while maintaining this crate, you come to believe the suite needs to change —
+an expectation adjusted, a case removed, or a new case added:
+
+* **Stop and get explicit human approval before touching the suite.** This is a
+  hard gate, not a courtesy. Do not commit any change to the curated cases or
+  their expectations without it.
+* **Propose the change to the user with evidence, not just a diff.** For an
+  expectation change, show the affected series, the old vs. new verdict per
+  mode/polarity, and *why* the new verdict is the correct answer for that input.
+  For a new case, show the series and argue why its verdict is unambiguously
+  correct and what class of regression it guards against. Include illustrative
+  material — worked examples, plots of the series and the detector's decision,
+  before/after comparisons — enough for a human to judge the real-world impact
+  without re-deriving it.

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -118,6 +118,11 @@ impl Mode {
 
     /// The analysis context this mode is evaluated under. `merge_base_index` is consulted
     /// only by branch mode; the other modes ignore it.
+    ///
+    /// `include_improvements` is set from [`reports_improvements`](Self::reports_improvements)
+    /// so the context matches the mode's intended reporting semantics: branch (which
+    /// reports both directions) opts in, history and tip opt out. Branch mode ignores the
+    /// flag today, but pinning it consistently keeps the context correct if that changes.
     fn context(self, merge_base_index: Option<usize>) -> AnalysisContext {
         let mode = match self {
             Self::History => AnalysisMode::History,
@@ -128,7 +133,7 @@ impl Mode {
             mode,
             config: AnalysisConfig::default(),
             merge_base_index,
-            include_improvements: false,
+            include_improvements: self.reports_improvements(),
             include_inactive: false,
         }
     }

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -2,7 +2,7 @@
 //! against the analysis statistics yielding illogical results.
 //!
 //! Each case is a data series with an unambiguous shape (an obvious step, a dead-flat
-//! line) paired with the move each analysis mode's detector is expected to see. The
+//! line) paired with the outcome each analysis mode's detector is expected to see. The
 //! point is not to exercise a particular detector but to pin the end-to-end verdict of
 //! the analysis on inputs a human would answer without hesitation — so a future change
 //! to the math that starts calling a doubling "no change", or a flat line "a
@@ -22,11 +22,12 @@
 //!   latest regime against the base level across a merge-base split, and
 //!   [`Tip`](AnalysisMode::Tip) compares only the newest point against its recent
 //!   window. Because each inspects a different slice, the *same* series yields different
-//!   verdicts per mode, so mode is a curated dimension: every case states the move each
-//!   mode is expected to see. An obvious mid-series step is a rise to history and branch
-//!   but invisible to tip (whose window has already caught up); a lone final-point jump
-//!   is a rise to tip and branch but not a sustained historical trend. Branch mode also
-//!   needs a merge-base to have a base side at all — a case without one leaves it quiet.
+//!   verdicts per mode, so mode is a curated dimension: every case states the outcome
+//!   each mode is expected to see. An obvious mid-series step is a rise to history and
+//!   branch but invisible to tip (whose window has already caught up); a lone
+//!   final-point jump is a rise to tip and branch but not a sustained historical trend.
+//!   Branch mode also needs a base side to compare against at all — a case with an empty
+//!   base side leaves it quiet.
 //! * **Polarity (dimension 2).** The codebase's only polarity lever is the metric kind,
 //!   so *higher-is-worse* is modelled with a lower-is-better metric
 //!   ([`MetricKind::InstructionCount`]) and *lower-is-worse* with the one
@@ -139,7 +140,7 @@ impl Mode {
     }
 }
 
-/// The move a mode's detector is expected to see in a case — the hand-curated,
+/// The outcome a mode's detector is expected to see in a case — the hand-curated,
 /// polarity-independent judgment about the raw series shape.
 ///
 /// Combined with a [`Polarity`] and the mode's reporting contract this yields the
@@ -147,7 +148,7 @@ impl Mode {
 /// improvement by the metric's polarity, and reported only when the mode surfaces that
 /// direction.
 #[derive(Clone, Copy, Debug)]
-enum Move {
+enum Outcome {
     /// The values step up.
     Rise,
     /// The values step down.
@@ -156,7 +157,7 @@ enum Move {
     Quiet,
 }
 
-impl Move {
+impl Outcome {
     /// Whether this move surfaces as a finding under `polarity` in `mode`.
     fn is_finding(self, polarity: Polarity, mode: Mode) -> bool {
         match (self, polarity) {
@@ -172,30 +173,46 @@ impl Move {
     }
 }
 
-/// One curated series and the move each mode is expected to see in it.
+/// One curated series — its base and branch/tip sides — and the outcome each mode is
+/// expected to see in it.
 struct SignalCase {
     /// Human-readable case name, surfaced in assertion failures.
     name: &'static str,
-    /// The base (unscaled) series values, oldest-first.
-    values: Vec<f64>,
-    /// First-parent split index handed to branch mode; `None` leaves branch mode without
-    /// a base side, so it stays quiet. Ignored by history and tip.
-    merge_base_index: Option<usize>,
-    /// The move history mode's change-point detector is expected to see.
-    history: Move,
-    /// The move branch mode is expected to see (given `merge_base_index`).
-    branch: Move,
-    /// The move tip mode is expected to see.
-    tip: Move,
+    /// The base-side (unscaled) series values, oldest-first: the commits at or before
+    /// the merge-base. May be empty, which leaves branch mode without a base side to
+    /// compare against, so it stays quiet. Ignored by history and tip, which read the
+    /// whole series.
+    base: Vec<f64>,
+    /// The branch/tip-side (unscaled) series values, oldest-first: the commits past the
+    /// merge-base. May be empty.
+    branch: Vec<f64>,
+    /// The outcome history mode's change-point detector is expected to see.
+    expected_history: Outcome,
+    /// The outcome branch mode is expected to see.
+    expected_branch: Outcome,
+    /// The outcome tip mode is expected to see.
+    expected_tip: Outcome,
 }
 
 impl SignalCase {
-    /// The move `mode` is expected to see in this case.
-    fn expected_move(&self, mode: Mode) -> Move {
+    /// The whole series, the base side followed by the branch/tip side, oldest-first.
+    fn values(&self) -> Vec<f64> {
+        [self.base.as_slice(), self.branch.as_slice()].concat()
+    }
+
+    /// The first-parent merge-base split index handed to branch mode: the last base-side
+    /// point, or `None` when there is no base side (branch mode then has nothing to
+    /// compare against and stays quiet). History and tip ignore it.
+    fn merge_base_index(&self) -> Option<usize> {
+        self.base.len().checked_sub(1)
+    }
+
+    /// The outcome `mode` is expected to see in this case.
+    fn expected_outcome(&self, mode: Mode) -> Outcome {
         match mode {
-            Mode::History => self.history,
-            Mode::Branch => self.branch,
-            Mode::Tip => self.tip,
+            Mode::History => self.expected_history,
+            Mode::Branch => self.expected_branch,
+            Mode::Tip => self.expected_tip,
         }
     }
 }
@@ -213,61 +230,61 @@ fn cases() -> Vec<SignalCase> {
         // sits at the new, higher level.
         SignalCase {
             name: "doubling_step",
-            values: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
-            merge_base_index: Some(49),
-            history: Move::Rise,
-            branch: Move::Rise,
-            tip: Move::Quiet,
+            base: run_of(100.0, 50),
+            branch: run_of(200.0, 50),
+            expected_history: Outcome::Rise,
+            expected_branch: Outcome::Rise,
+            expected_tip: Outcome::Quiet,
         },
         // The mirror image: a sustained halving. Same mode geometry, opposite direction,
         // so it exercises the other polarity's finding path.
         SignalCase {
             name: "halving_step",
-            values: [run_of(200.0, 50), run_of(100.0, 50)].concat(),
-            merge_base_index: Some(49),
-            history: Move::Fall,
-            branch: Move::Fall,
-            tip: Move::Quiet,
+            base: run_of(200.0, 50),
+            branch: run_of(100.0, 50),
+            expected_history: Outcome::Fall,
+            expected_branch: Outcome::Fall,
+            expected_tip: Outcome::Quiet,
         },
         // A jump confined to the final commit. Tip and branch (split just before the
         // jump) see the rise; history does not, since one trailing point is not a
         // sustained trend.
         SignalCase {
             name: "tip_spike",
-            values: [run_of(100.0, 99), run_of(200.0, 1)].concat(),
-            merge_base_index: Some(98),
-            history: Move::Quiet,
-            branch: Move::Rise,
-            tip: Move::Rise,
+            base: run_of(100.0, 99),
+            branch: run_of(200.0, 1),
+            expected_history: Outcome::Quiet,
+            expected_branch: Outcome::Rise,
+            expected_tip: Outcome::Rise,
         },
         // The mirror image at the tip: the final commit drops.
         SignalCase {
             name: "tip_drop",
-            values: [run_of(200.0, 99), run_of(100.0, 1)].concat(),
-            merge_base_index: Some(98),
-            history: Move::Quiet,
-            branch: Move::Fall,
-            tip: Move::Fall,
+            base: run_of(200.0, 99),
+            branch: run_of(100.0, 1),
+            expected_history: Outcome::Quiet,
+            expected_branch: Outcome::Fall,
+            expected_tip: Outcome::Fall,
         },
         // A dead-flat line: nothing moved, so no mode and no polarity should ever flag it.
         SignalCase {
             name: "flat_line",
-            values: run_of(100.0, 100),
-            merge_base_index: Some(49),
-            history: Move::Quiet,
-            branch: Move::Quiet,
-            tip: Move::Quiet,
+            base: run_of(100.0, 50),
+            branch: run_of(100.0, 50),
+            expected_history: Outcome::Quiet,
+            expected_branch: Outcome::Quiet,
+            expected_tip: Outcome::Quiet,
         },
-        // The same obvious doubling as the first case, but with no merge-base. Branch
-        // mode has no base side to compare against, so it must stay quiet even though
-        // history still sees the rise.
+        // The same obvious doubling as the first case, but with no base side. Branch
+        // mode has nothing to compare the branch against, so it must stay quiet even
+        // though history still sees the rise over the whole series.
         SignalCase {
             name: "doubling_without_base",
-            values: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
-            merge_base_index: None,
-            history: Move::Rise,
-            branch: Move::Quiet,
-            tip: Move::Quiet,
+            base: Vec::new(),
+            branch: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
+            expected_history: Outcome::Rise,
+            expected_branch: Outcome::Quiet,
+            expected_tip: Outcome::Quiet,
         },
     ]
 }
@@ -316,9 +333,9 @@ fn raises_finding(values: &[f64], kind: MetricKind, context: &AnalysisContext) -
     !findings.is_empty()
 }
 
-/// The values of `case`, multiplied by `scale`.
-fn scaled(case: &SignalCase, scale: f64) -> Vec<f64> {
-    case.values.iter().map(|&value| value * scale).collect()
+/// `values`, each multiplied by `scale`.
+fn scaled(values: &[f64], scale: f64) -> Vec<f64> {
+    values.iter().map(|&value| value * scale).collect()
 }
 
 #[test]
@@ -329,15 +346,16 @@ fn curated_signals_match_expected_verdicts() {
     let scale_multiples = [1000.0_f64];
 
     for case in cases() {
+        let values = case.values();
         for mode in Mode::ALL {
-            let context = mode.context(case.merge_base_index);
+            let context = mode.context(case.merge_base_index());
             for polarity in Polarity::ALL {
-                let expected = case.expected_move(mode).is_finding(polarity, mode);
+                let expected = case.expected_outcome(mode).is_finding(polarity, mode);
                 let kind = polarity.metric_kind();
 
                 // Dimensions 1 & 2: the as-is verdict under this mode and polarity
                 // matches the hand-picked expectation.
-                let reference = raises_finding(&case.values, kind, &context);
+                let reference = raises_finding(&values, kind, &context);
                 assert_eq!(
                     reference, expected,
                     "case '{}' mode={mode:?} polarity={polarity:?}: \
@@ -349,7 +367,7 @@ fn curated_signals_match_expected_verdicts() {
                 // verdict unchanged, because every comparison the analysis makes is
                 // relative.
                 for scale in scale_multiples {
-                    let scaled_verdict = raises_finding(&scaled(&case, scale), kind, &context);
+                    let scaled_verdict = raises_finding(&scaled(&values, scale), kind, &context);
                     assert_eq!(
                         scaled_verdict, reference,
                         "case '{}' mode={mode:?} polarity={polarity:?}: scaling by {scale} \

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -2,11 +2,11 @@
 //! against the analysis statistics yielding illogical results.
 //!
 //! Each case is a data series with an unambiguous shape (an obvious step, a dead-flat
-//! line) paired with, per polarity, whether the analysis *should* report a finding.
-//! The point is not to exercise a particular detector but to pin the end-to-end
-//! verdict of the analysis on inputs a human would answer without hesitation — so a
-//! future change to the math that starts calling a doubling "no change", or a flat
-//! line "a regression", fails here loudly.
+//! line) paired with the move each analysis mode's detector is expected to see. The
+//! point is not to exercise a particular detector but to pin the end-to-end verdict of
+//! the analysis on inputs a human would answer without hesitation — so a future change
+//! to the math that starts calling a doubling "no change", or a flat line "a
+//! regression", fails here loudly.
 //!
 //! The verdict is taken through the serial detection oracle [`find_changes`], the same
 //! spawner-free entry the rest of the [`findings`](super::findings) unit tests use;
@@ -14,18 +14,28 @@
 //! findings the spawner-distributed production path
 //! ([`find_changes_spawned`](super::find_changes_spawned)) does.
 //!
-//! Every case is run through a 2×2 matrix:
+//! Every case is run through a 3 × 2 × 2 matrix:
 //!
-//! * **Polarity (dimension 1).** The codebase's only polarity lever is the metric
-//!   kind, so *higher-is-worse* is modelled with a lower-is-better metric
-//!   ([`MetricKind::InstructionCount`]: a rise is a regression) and *lower-is-worse*
-//!   with the one higher-is-better metric ([`MetricKind::L1CacheHits`]: a rise is an
-//!   improvement). The analysis is asked to report the *worse* direction only
-//!   (`include_improvements = false`), which is what makes this dimension meaningful:
-//!   an obvious doubling is a finding under higher-is-worse but a (suppressed)
-//!   improvement under lower-is-worse. The expected verdict therefore depends on the
-//!   series and is stated case by case.
-//! * **Absolute scale (dimension 2).** Every case is analysed both as-is and scaled up
+//! * **Analysis mode (dimension 1).** The three modes are *different detectors*, not
+//!   one detector with a flag: [`History`](AnalysisMode::History) locates a change-point
+//!   over the whole series, [`Branch`](AnalysisMode::Branch) compares the branch's
+//!   latest regime against the base level across a merge-base split, and
+//!   [`Tip`](AnalysisMode::Tip) compares only the newest point against its recent
+//!   window. Because each inspects a different slice, the *same* series yields different
+//!   verdicts per mode, so mode is a curated dimension: every case states the move each
+//!   mode is expected to see. An obvious mid-series step is a rise to history and branch
+//!   but invisible to tip (whose window has already caught up); a lone final-point jump
+//!   is a rise to tip and branch but not a sustained historical trend. Branch mode also
+//!   needs a merge-base to have a base side at all — a case without one leaves it quiet.
+//! * **Polarity (dimension 2).** The codebase's only polarity lever is the metric kind,
+//!   so *higher-is-worse* is modelled with a lower-is-better metric
+//!   ([`MetricKind::InstructionCount`]) and *lower-is-worse* with the one
+//!   higher-is-better metric ([`MetricKind::L1CacheHits`]). History and tip report the
+//!   worse direction only, so a move surfaces as a finding under one polarity and is a
+//!   suppressed improvement under the other; branch reports *both* directions, so a move
+//!   is a finding under either polarity (only its classification differs). The expected
+//!   verdict is derived from the per-mode move via this reporting contract.
+//! * **Absolute scale (dimension 3).** Every case is analysed both as-is and scaled up
 //!   by a large constant. All of the analysis is relative, so the absolute scale must
 //!   not change the verdict: the as-is verdict is checked against the case's
 //!   expectation, and every scaled verdict is checked against that as-is reference, so
@@ -35,6 +45,13 @@
 //! because these inputs are chosen so the *presence* of a finding is the whole
 //! question. Detector internals, confidence, and magnitude are covered by the
 //! finer-grained unit tests in [`findings`](super::findings).
+//!
+//! The analysis treats every metric as noise-aware, so the curated series carry no
+//! within-regime dispersion (each regime is a run of identical values) and every step
+//! is large and well above the practical-magnitude floors. That keeps the verdict
+//! unambiguous under the noisy gates: a step between two zero-variance regimes is
+//! maximally significant, so detection turns purely on the mode's slice and floor
+//! rather than on any noise model.
 
 #![cfg_attr(coverage_nightly, coverage(off))]
 
@@ -48,9 +65,9 @@ use crate::model::{BenchmarkId, DiscriminantSet, MetricKind};
 
 /// How a rise in the measured metric is judged.
 ///
-/// This is the suite's dimension-1 lever. Both variants map to a *deterministic*
-/// (noise-free) metric kind, so detection is exact and the two differ only in which
-/// direction of change counts as "worse".
+/// This is the suite's dimension-2 lever. Both variants map to a metric kind that
+/// differs only in polarity — which direction of change counts as "worse" — so a case's
+/// detection is identical under both and only the reported direction changes.
 #[derive(Clone, Copy, Debug)]
 enum Polarity {
     /// A rise is a regression (lower-is-better metric).
@@ -74,24 +91,106 @@ impl Polarity {
     }
 }
 
-/// One curated series and its expected verdict under each polarity.
+/// The analysis mode a case is evaluated under — the suite's dimension-1 lever.
+///
+/// The three modes are genuinely different detectors, so a case declares its expected
+/// move per mode rather than sharing one verdict across them.
+#[derive(Clone, Copy, Debug)]
+enum Mode {
+    /// Change-point analysis over the whole series.
+    History,
+    /// The branch's latest regime against the base level, across a merge-base split.
+    Branch,
+    /// The newest point against its recent window.
+    Tip,
+}
+
+impl Mode {
+    /// The three modes, for matrix expansion.
+    const ALL: [Self; 3] = [Self::History, Self::Branch, Self::Tip];
+
+    /// Whether this mode reports improvements as findings. Only branch does: history is
+    /// run here as a regressions-only drift watch (`include_improvements = false`) and
+    /// tip is a regression guard, so for those an improvement is a non-finding.
+    fn reports_improvements(self) -> bool {
+        matches!(self, Self::Branch)
+    }
+
+    /// The analysis context this mode is evaluated under. `merge_base_index` is consulted
+    /// only by branch mode; the other modes ignore it.
+    fn context(self, merge_base_index: Option<usize>) -> AnalysisContext {
+        let mode = match self {
+            Self::History => AnalysisMode::History,
+            Self::Branch => AnalysisMode::Branch,
+            Self::Tip => AnalysisMode::Tip,
+        };
+        AnalysisContext {
+            mode,
+            config: AnalysisConfig::default(),
+            merge_base_index,
+            include_improvements: false,
+            include_inactive: false,
+        }
+    }
+}
+
+/// The move a mode's detector is expected to see in a case — the hand-curated,
+/// polarity-independent judgment about the raw series shape.
+///
+/// Combined with a [`Polarity`] and the mode's reporting contract this yields the
+/// expected finding verdict: the raw rise/fall is classified as a regression or an
+/// improvement by the metric's polarity, and reported only when the mode surfaces that
+/// direction.
+#[derive(Clone, Copy, Debug)]
+enum Move {
+    /// The values step up.
+    Rise,
+    /// The values step down.
+    Fall,
+    /// Nothing notable moves.
+    Quiet,
+}
+
+impl Move {
+    /// Whether this move surfaces as a finding under `polarity` in `mode`.
+    fn is_finding(self, polarity: Polarity, mode: Mode) -> bool {
+        match (self, polarity) {
+            (Self::Quiet, _) => false,
+            // Classified a regression (worse) — every mode reports it.
+            (Self::Rise, Polarity::HigherIsWorse) | (Self::Fall, Polarity::LowerIsWorse) => true,
+            // Classified an improvement (better) — reported only where the mode reports
+            // both directions.
+            (Self::Rise, Polarity::LowerIsWorse) | (Self::Fall, Polarity::HigherIsWorse) => {
+                mode.reports_improvements()
+            }
+        }
+    }
+}
+
+/// One curated series and the move each mode is expected to see in it.
 struct SignalCase {
     /// Human-readable case name, surfaced in assertion failures.
     name: &'static str,
     /// The base (unscaled) series values, oldest-first.
     values: Vec<f64>,
-    /// Whether a finding is expected under [`Polarity::HigherIsWorse`].
-    expect_higher_is_worse: bool,
-    /// Whether a finding is expected under [`Polarity::LowerIsWorse`].
-    expect_lower_is_worse: bool,
+    /// First-parent split index handed to branch mode; `None` leaves branch mode without
+    /// a base side, so it stays quiet. Ignored by history and tip.
+    merge_base_index: Option<usize>,
+    /// The move history mode's change-point detector is expected to see.
+    history: Move,
+    /// The move branch mode is expected to see (given `merge_base_index`).
+    branch: Move,
+    /// The move tip mode is expected to see.
+    tip: Move,
 }
 
 impl SignalCase {
-    /// The expected verdict for `polarity`.
-    fn expected(&self, polarity: Polarity) -> bool {
-        match polarity {
-            Polarity::HigherIsWorse => self.expect_higher_is_worse,
-            Polarity::LowerIsWorse => self.expect_lower_is_worse,
+    /// The move `mode` is expected to see in this case.
+    fn expected_move(&self, mode: Mode) -> Move {
+        match mode {
+            Mode::History => self.history,
+            Mode::Branch => self.branch,
+            Mode::Tip => self.tip,
         }
     }
 }
@@ -104,27 +203,79 @@ fn run_of(value: f64, count: usize) -> Vec<f64> {
 /// The hand-curated cases. New "obvious answer" series are added as one row each.
 fn cases() -> Vec<SignalCase> {
     vec![
-        // An unmistakable doubling of the metric halfway through: a regression when a
-        // rise is worse, and merely an (unreported) improvement when a rise is better.
+        // An unmistakable sustained doubling halfway through. History and branch (split
+        // at the step) both see a rise; tip is quiet because its recent window already
+        // sits at the new, higher level.
         SignalCase {
             name: "doubling_step",
             values: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
-            expect_higher_is_worse: true,
-            expect_lower_is_worse: false,
+            merge_base_index: Some(49),
+            history: Move::Rise,
+            branch: Move::Rise,
+            tip: Move::Quiet,
         },
-        // A dead-flat line: nothing moved, so no polarity should ever flag it.
+        // The mirror image: a sustained halving. Same mode geometry, opposite direction,
+        // so it exercises the other polarity's finding path.
+        SignalCase {
+            name: "halving_step",
+            values: [run_of(200.0, 50), run_of(100.0, 50)].concat(),
+            merge_base_index: Some(49),
+            history: Move::Fall,
+            branch: Move::Fall,
+            tip: Move::Quiet,
+        },
+        // A jump confined to the final commit. Tip and branch (split just before the
+        // jump) see the rise; history does not, since one trailing point is not a
+        // sustained trend.
+        SignalCase {
+            name: "tip_spike",
+            values: [run_of(100.0, 99), run_of(200.0, 1)].concat(),
+            merge_base_index: Some(98),
+            history: Move::Quiet,
+            branch: Move::Rise,
+            tip: Move::Rise,
+        },
+        // The mirror image at the tip: the final commit drops.
+        SignalCase {
+            name: "tip_drop",
+            values: [run_of(200.0, 99), run_of(100.0, 1)].concat(),
+            merge_base_index: Some(98),
+            history: Move::Quiet,
+            branch: Move::Fall,
+            tip: Move::Fall,
+        },
+        // A dead-flat line: nothing moved, so no mode and no polarity should ever flag it.
         SignalCase {
             name: "flat_line",
             values: run_of(100.0, 100),
-            expect_higher_is_worse: false,
-            expect_lower_is_worse: false,
+            merge_base_index: Some(49),
+            history: Move::Quiet,
+            branch: Move::Quiet,
+            tip: Move::Quiet,
+        },
+        // The same obvious doubling as the first case, but with no merge-base. Branch
+        // mode has no base side to compare against, so it must stay quiet even though
+        // history still sees the rise.
+        SignalCase {
+            name: "doubling_without_base",
+            values: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
+            merge_base_index: None,
+            history: Move::Rise,
+            branch: Move::Quiet,
+            tip: Move::Quiet,
         },
     ]
 }
 
-/// Builds a deterministic (noise-free) series carrying `values` in topological order,
-/// tagged with `kind`.
-fn deterministic_series(values: &[f64], kind: MetricKind) -> Series {
+/// Builds a noise-free series carrying `values` in topological order, tagged with
+/// `kind`.
+///
+/// The points carry no confidence intervals and each curated regime is a run of
+/// identical values, so the series has zero within-regime dispersion. The analysis is
+/// noise-aware for every metric, but a step between two zero-variance regimes is
+/// unambiguous under those gates, so the verdict turns on the mode and the step
+/// magnitude rather than on a noise model.
+fn noise_free_series(values: &[f64], kind: MetricKind) -> Series {
     let points = values
         .iter()
         .enumerate()
@@ -152,23 +303,11 @@ fn deterministic_series(values: &[f64], kind: MetricKind) -> Series {
     }
 }
 
-/// The history-mode context the suite analyses under: the worse direction only, so an
-/// improvement is a non-finding rather than a flipped finding.
-fn history_context() -> AnalysisContext {
-    AnalysisContext {
-        mode: AnalysisMode::History,
-        config: AnalysisConfig::default(),
-        merge_base_index: None,
-        include_improvements: false,
-        include_inactive: false,
-    }
-}
-
-/// Runs the serial detection oracle on a single series and reports whether it raised
-/// any finding.
-fn raises_finding(values: &[f64], kind: MetricKind) -> bool {
-    let series = deterministic_series(values, kind);
-    let findings = find_changes(&[series], &history_context());
+/// Runs the serial detection oracle on a single series under `context` and reports
+/// whether it raised any finding.
+fn raises_finding(values: &[f64], kind: MetricKind, context: &AnalysisContext) -> bool {
+    let series = noise_free_series(values, kind);
+    let findings = find_changes(&[series], context);
     !findings.is_empty()
 }
 
@@ -185,28 +324,34 @@ fn curated_signals_match_expected_verdicts() {
     let scale_multiples = [1000.0_f64];
 
     for case in cases() {
-        for polarity in Polarity::ALL {
-            let expected = case.expected(polarity);
-            let kind = polarity.metric_kind();
+        for mode in Mode::ALL {
+            let context = mode.context(case.merge_base_index);
+            for polarity in Polarity::ALL {
+                let expected = case.expected_move(mode).is_finding(polarity, mode);
+                let kind = polarity.metric_kind();
 
-            // Dimension 1: the as-is verdict matches the hand-picked expectation.
-            let reference = raises_finding(&case.values, kind);
-            assert_eq!(
-                reference, expected,
-                "case '{}' under {polarity:?}: expected finding={expected}, got {reference}",
-                case.name,
-            );
-
-            // Dimension 2: scaling the whole series by any constant leaves the verdict
-            // unchanged, because every comparison the analysis makes is relative.
-            for scale in scale_multiples {
-                let scaled_verdict = raises_finding(&scaled(&case, scale), kind);
+                // Dimensions 1 & 2: the as-is verdict under this mode and polarity
+                // matches the hand-picked expectation.
+                let reference = raises_finding(&case.values, kind, &context);
                 assert_eq!(
-                    scaled_verdict, reference,
-                    "case '{}' under {polarity:?}: scaling by {scale} changed the verdict \
-                     (absolute scale must not matter)",
+                    reference, expected,
+                    "case '{}' mode={mode:?} polarity={polarity:?}: \
+                     expected finding={expected}, got {reference}",
                     case.name,
                 );
+
+                // Dimension 3: scaling the whole series by any constant leaves the
+                // verdict unchanged, because every comparison the analysis makes is
+                // relative.
+                for scale in scale_multiples {
+                    let scaled_verdict = raises_finding(&scaled(&case, scale), kind, &context);
+                    assert_eq!(
+                        scaled_verdict, reference,
+                        "case '{}' mode={mode:?} polarity={polarity:?}: scaling by {scale} \
+                         changed the verdict (absolute scale must not matter)",
+                        case.name,
+                    );
+                }
             }
         }
     }

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -180,8 +180,9 @@ struct SignalCase {
     name: &'static str,
     /// The base-side (unscaled) series values, oldest-first: the commits at or before
     /// the merge-base. May be empty, which leaves branch mode without a base side to
-    /// compare against, so it stays quiet. Ignored by history and tip, which read the
-    /// whole series.
+    /// compare against, so it stays quiet. The base/branch split matters only to branch
+    /// mode; history and tip see the whole concatenated series and read these values as
+    /// ordinary leading points, indifferent to which side they came from.
     base: Vec<f64>,
     /// The branch/tip-side (unscaled) series values, oldest-first: the commits past the
     /// merge-base. May be empty.


### PR DESCRIPTION
## What

Extends the signal-validation suite in `cargo-bench-history-core` to cover **all three analysis modes** (history, branch, tip), not just history.

## Why

The three analysis modes are genuinely *different detectors*, not one detector with a flag:

- **History** locates a change-point over the whole series.
- **Branch** compares the branch's latest regime against the base level across a merge-base split.
- **Tip** compares only the newest point against its recent window.

Because each inspects a different slice, the *same* series yields different verdicts per mode — so the suite could not simply reuse one series+expectation across modes. For example, a mid-series doubling is a finding in history and branch but invisible to tip (whose window has already caught up); a lone final-point jump is a finding in tip and branch but not a sustained historical trend.

## How

Mode becomes a curated third dimension. Each case declares the move each mode's detector is expected to see (`Rise` / `Fall` / `Quiet`), plus a `merge_base_index` for branch mode. The expected finding verdict is derived from the per-mode move via each mode's direction-reporting contract:

- History (regressions-only drift watch) and tip (regression guard) report the **worse direction only**.
- Branch reports **both** directions.

New cases exercise:

- `doubling_step` / `halving_step` — sustained rise/fall seen by history and branch, quiet for tip.
- `tip_spike` / `tip_drop` — a jump on the final commit seen by tip and branch, quiet for history.
- `flat_line` — quiet everywhere.
- `doubling_without_base` — the branch-needs-a-merge-base degeneracy (history sees the rise, branch has no base side so stays quiet).

The matrix is now **3 (mode) × 2 (polarity) × 2 (scale)**.

## Documentation correction

The suite's docs previously claimed the metric kinds were "deterministic", but #319 removed `MetricKind::is_deterministic` — every metric is now treated as noise-aware. The series are re-described as carrying zero within-regime dispersion (each regime is a run of identical values), so a step between two zero-variance regimes is unambiguous under the noisy gates and the verdict turns on the mode's slice and floor rather than on any noise model. `deterministic_series` is renamed to `noise_free_series` accordingly.

## Validation

`just package="cargo-bench-history-core" validate-local`-equivalent steps run locally and green: test (all-features 261, no-features), clippy (all-targets), format-check, machete, default-features-check, and Miri.
