### PR TITLE
Eliminate tracker report split; add lifecycle benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
 name = "all_the_time"
 version = "0.5.2"
 dependencies = [
+ "alloc_tracker",
  "cpu-time",
  "criterion",
  "folo_utils",
@@ -35,6 +36,7 @@ dependencies = [
 name = "alloc_tracker"
 version = "0.6.2"
 dependencies = [
+ "all_the_time",
  "criterion",
  "folo_utils",
  "mutants",

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -20,6 +20,10 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+# Dev-dependency loop with `alloc_tracker`: the lifecycle benchmarks measure this
+# crate's allocations using `alloc_tracker` while `alloc_tracker`'s own benchmarks
+# measure processor time using this crate. Cargo permits dev-dependency-only cycles.
+alloc_tracker = { path = "../alloc_tracker" }
 criterion = { workspace = true }
 mutants = { workspace = true }
 static_assertions = { workspace = true }
@@ -27,6 +31,10 @@ tempfile = { workspace = true }
 
 [[bench]]
 name = "all_the_time_example"
+harness = false
+
+[[bench]]
+name = "all_the_time_report_lifecycle"
 harness = false
 
 [[bench]]

--- a/packages/all_the_time/benches/all_the_time_report_lifecycle.rs
+++ b/packages/all_the_time/benches/all_the_time_report_lifecycle.rs
@@ -1,0 +1,225 @@
+//! Full-lifecycle benchmarks for the `all_the_time` processor time tracker.
+//!
+//! Where `all_the_time_tracking_overhead` measures only the per-span record
+//! path, this benchmark covers every remaining lifecycle stage — session and
+//! operation setup, report snapshotting, merging, **finalization** (assembling
+//! the recorded spans into the complete report, the phase that regressed in
+//! issue #328), human rendering, and JSON output. Each stage is measured for all
+//! three cost dimensions at once:
+//!
+//! * **wall-clock time** — Criterion, the harness.
+//! * **memory allocations** — `alloc_tracker` (a dev-dependency; this crate and
+//!   `alloc_tracker` form an allowed dev-dependency-only cycle).
+//! * **processor time** — `all_the_time` itself, measuring its own lifecycle.
+//!
+//! The finalization stage is scaled by operation count so that any regression
+//! back to super-linear or retained-span work surfaces immediately instead of
+//! hiding behind a cheap "slope-only" summary path.
+
+#![allow(
+    missing_docs,
+    reason = "No need for API documentation in benchmark code"
+)]
+
+use std::fmt::Write as _;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use all_the_time::{Report, Session};
+use alloc_tracker::{Allocator, Session as AllocSession};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+/// Number of spans folded into each operation of the report fixtures.
+///
+/// Streaming statistics fold every span into O(1) accumulators, so this affects
+/// only the fixture's record cost, not the finalization cost — which is exactly
+/// the invariant the finalization benchmarks lock in.
+const SPANS_PER_OP: usize = 8;
+
+fn entrypoint(c: &mut Criterion) {
+    // The measuring sessions capture this benchmark's own allocation and
+    // processor-time cost and emit their JSON on drop at the end of `entrypoint`.
+    let alloc = AllocSession::new();
+    let time = Session::new();
+
+    setup(c, &alloc, &time);
+    snapshot(c, &alloc, &time);
+    merge(c, &alloc, &time);
+    finalize(c, &alloc, &time);
+    render(c, &alloc, &time);
+    write(c, &alloc, &time);
+}
+
+/// Wraps the measured `body` in an allocation span and a processor-time span so
+/// every Criterion sample also feeds the two side-channel measuring sessions.
+fn measured<F: FnMut()>(
+    iters: u64,
+    alloc_op: &alloc_tracker::Operation,
+    time_op: &all_the_time::Operation,
+    mut body: F,
+) -> Duration {
+    let start = Instant::now();
+    {
+        let _alloc_span = alloc_op.measure_thread().iterations(iters);
+        let _time_span = time_op.measure_thread().iterations(iters);
+
+        for _ in 0..iters {
+            body();
+        }
+    }
+    start.elapsed()
+}
+
+/// Builds a report fixture with `num_ops` operations, each carrying
+/// `SPANS_PER_OP` recorded spans, so downstream stages have realistic streaming
+/// state to work over.
+fn build_report(num_ops: usize) -> Report {
+    let session = Session::new().no_stdout().no_file();
+    for op_idx in 0..num_ops {
+        let op = session.operation(format!("op_{op_idx}"));
+        for _ in 0..SPANS_PER_OP {
+            let _span = op.measure_thread().iterations(10);
+            for value in 0..10_u64 {
+                black_box(value);
+            }
+        }
+    }
+    session.to_report()
+}
+
+fn setup(c: &mut Criterion, alloc: &AllocSession, time: &Session) {
+    let mut group = c.benchmark_group("all_the_time_report_lifecycle/setup");
+    let alloc_op = alloc.operation("all_the_time_report_lifecycle/setup/session_100_ops");
+    let time_op = time.operation("all_the_time_report_lifecycle/setup/session_100_ops");
+
+    group.bench_function("session_100_ops", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                let session = Session::new().no_stdout().no_file();
+                for op_idx in 0..100 {
+                    black_box(session.operation(format!("op_{op_idx}")));
+                }
+                black_box(&session);
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn snapshot(c: &mut Criterion, alloc: &AllocSession, time: &Session) {
+    let mut group = c.benchmark_group("all_the_time_report_lifecycle/snapshot");
+    let alloc_op = alloc.operation("all_the_time_report_lifecycle/snapshot/ops_100");
+    let time_op = time.operation("all_the_time_report_lifecycle/snapshot/ops_100");
+
+    // A populated session snapshotted repeatedly; `to_report` takes `&self`.
+    let session = Session::new().no_stdout().no_file();
+    for op_idx in 0..100 {
+        let op = session.operation(format!("op_{op_idx}"));
+        for _ in 0..SPANS_PER_OP {
+            let _span = op.measure_thread().iterations(10);
+            for value in 0..10_u64 {
+                black_box(value);
+            }
+        }
+    }
+
+    group.bench_function("ops_100", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                black_box(session.to_report());
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn merge(c: &mut Criterion, alloc: &AllocSession, time: &Session) {
+    let mut group = c.benchmark_group("all_the_time_report_lifecycle/merge");
+    let alloc_op = alloc.operation("all_the_time_report_lifecycle/merge/ops_100");
+    let time_op = time.operation("all_the_time_report_lifecycle/merge/ops_100");
+
+    let left = build_report(100);
+    let right = build_report(100);
+
+    group.bench_function("ops_100", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                black_box(Report::merge(black_box(&left), black_box(&right)));
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn finalize(c: &mut Criterion, alloc: &AllocSession, time: &Session) {
+    let mut group = c.benchmark_group("all_the_time_report_lifecycle/finalize");
+
+    // Scaling finalize by operation count is the core regression guard: streaming
+    // makes finalize O(operations), so the 10x jump in operation count must show
+    // a roughly 10x (not super-linear) jump in cost.
+    for num_ops in [10_usize, 100] {
+        let report = build_report(num_ops);
+        let name = format!("ops_{num_ops}");
+        let alloc_op = alloc.operation(format!("all_the_time_report_lifecycle/finalize/{name}"));
+        let time_op = time.operation(format!("all_the_time_report_lifecycle/finalize/{name}"));
+
+        group.bench_function(&name, |b| {
+            b.iter_custom(|iters| {
+                measured(iters, &alloc_op, &time_op, || {
+                    black_box(report.finalize());
+                })
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn render(c: &mut Criterion, alloc: &AllocSession, time: &Session) {
+    let mut group = c.benchmark_group("all_the_time_report_lifecycle/render");
+    let alloc_op = alloc.operation("all_the_time_report_lifecycle/render/ops_100");
+    let time_op = time.operation("all_the_time_report_lifecycle/render/ops_100");
+
+    let finalized = build_report(100).finalize();
+
+    group.bench_function("ops_100", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                let mut rendered = String::new();
+                write!(rendered, "{finalized}").expect("writing to a String cannot fail");
+                black_box(rendered);
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn write(c: &mut Criterion, alloc: &AllocSession, time: &Session) {
+    let mut group = c.benchmark_group("all_the_time_report_lifecycle/write");
+    let alloc_op = alloc.operation("all_the_time_report_lifecycle/write/ops_25");
+    let time_op = time.operation("all_the_time_report_lifecycle/write/ops_25");
+
+    // JSON output is I/O-bound, so keep the operation count modest.
+    let finalized = build_report(25).finalize();
+    let directory = tempfile::tempdir().expect("creating a temp directory cannot fail in a bench");
+
+    group.bench_function("ops_25", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                finalized.write_to_directory(directory.path());
+            })
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, entrypoint);
+criterion_main!(benches);

--- a/packages/all_the_time/src/finalized.rs
+++ b/packages/all_the_time/src/finalized.rs
@@ -51,12 +51,13 @@ impl FinalizedReport {
     /// Whether the report captured any measurable work.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        // Emptiness tracks whether any work was *recorded*, not whether a slope
-        // could be fit. An operation may record spans yet still yield no
-        // statistics (the through-origin fit can be non-finite), and in that case
-        // the summary must still print the operation with an `n/a` value rather
-        // than suppress all output. Keying off `statistics.is_none()` here would
-        // wrongly treat such a report as empty and short-circuit `print_to_stdout`.
+        // Emptiness means "no measurable work was recorded", matching the
+        // pre-finalize `OperationMetrics::is_empty` (total iterations == 0). It is
+        // deliberately independent of whether a slope could be fit: an operation
+        // can hold a span yet zero iterations (a fitted slope but no measurable
+        // work), or be created with no spans at all (no slope, rendered as `n/a`).
+        // Keying off `statistics.is_none()` instead would misclassify the former
+        // as non-empty and print a table for a run that recorded nothing.
         self.operations
             .iter()
             .all(|operation| operation.total_iterations == 0)
@@ -275,9 +276,10 @@ mod tests {
 
     #[test]
     fn report_with_recorded_work_but_no_statistics_is_not_empty() {
-        // Spans were recorded (iterations > 0) but the slope fit yielded no
-        // statistics. The report must still be considered non-empty so the
-        // summary prints the operation with an `n/a` value.
+        // is_empty reflects recorded work (iterations), independent of whether a
+        // slope was fit: an operation with recorded iterations is never empty even
+        // when its statistics are absent. Guards against regressing back to keying
+        // off `statistics.is_none()`.
         let report = FinalizedReport::new(vec![FinalizedOperation::new(
             "recorded".to_owned(),
             5,

--- a/packages/all_the_time/src/finalized.rs
+++ b/packages/all_the_time/src/finalized.rs
@@ -51,9 +51,15 @@ impl FinalizedReport {
     /// Whether the report captured any measurable work.
     #[must_use]
     pub fn is_empty(&self) -> bool {
+        // Emptiness tracks whether any work was *recorded*, not whether a slope
+        // could be fit. An operation may record spans yet still yield no
+        // statistics (the through-origin fit can be non-finite), and in that case
+        // the summary must still print the operation with an `n/a` value rather
+        // than suppress all output. Keying off `statistics.is_none()` here would
+        // wrongly treat such a report as empty and short-circuit `print_to_stdout`.
         self.operations
             .iter()
-            .all(|operation| operation.statistics.is_none())
+            .all(|operation| operation.total_iterations == 0)
     }
 
     /// Returns an iterator over the finalized operations, sorted by name.
@@ -261,5 +267,20 @@ mod tests {
             None,
         )]);
         assert!(report.is_empty());
+    }
+
+    #[test]
+    fn report_with_recorded_work_but_no_statistics_is_not_empty() {
+        // Spans were recorded (iterations > 0) but the slope fit yielded no
+        // statistics. The report must still be considered non-empty so the
+        // summary prints the operation with an `n/a` value.
+        let report = FinalizedReport::new(vec![FinalizedOperation::new(
+            "recorded".to_owned(),
+            5,
+            Duration::from_nanos(50),
+            Duration::from_nanos(10),
+            None,
+        )]);
+        assert!(!report.is_empty());
     }
 }

--- a/packages/all_the_time/src/finalized.rs
+++ b/packages/all_the_time/src/finalized.rs
@@ -1,0 +1,265 @@
+//! The single, fully-computed processor time report.
+//!
+//! A [`Report`](crate::Report) is a mergeable snapshot of the streaming
+//! statistics; it is not yet resolved into the per-iteration figures that the
+//! outputs present. [`Report::finalize`](crate::Report::finalize) resolves it
+//! exactly once into a [`FinalizedReport`]: every operation's complete
+//! statistics — the warmup-robust slope *and* its confidence interval — are
+//! computed up front. Both the human-readable stdout summary and the
+//! machine-readable JSON files are then rendered from this one finalized value,
+//! so there is no cheap "slope-only" path that silently skips the interval
+//! computation and hides its cost from benchmarks.
+
+use std::fmt;
+use std::time::Duration;
+
+use crate::OperationStatistics;
+use crate::statistics::nanos_to_duration;
+
+/// A processor time report with every operation's statistics fully computed.
+///
+/// Produced by [`Report::finalize`](crate::Report::finalize). There is exactly
+/// one report and it is always fully calculated: the slope and its confidence
+/// interval are resolved for every operation up front, regardless of which
+/// outputs (if any) end up consuming them.
+#[derive(Clone, Debug)]
+pub struct FinalizedReport {
+    /// Operations sorted by name, so every output presents them in a stable order.
+    operations: Vec<FinalizedOperation>,
+}
+
+/// One operation's fully-computed processor time statistics.
+#[derive(Clone, Debug)]
+pub struct FinalizedOperation {
+    name: String,
+    total_iterations: u64,
+    total_processor_time: Duration,
+    mean: Duration,
+    statistics: Option<OperationStatistics>,
+}
+
+impl FinalizedReport {
+    /// Assembles a finalized report from the resolved per-operation figures.
+    ///
+    /// The operations are sorted by name so both outputs present them
+    /// identically.
+    pub(crate) fn new(mut operations: Vec<FinalizedOperation>) -> Self {
+        operations.sort_by(|a, b| a.name.cmp(&b.name));
+        Self { operations }
+    }
+
+    /// Whether the report captured any measurable work.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.operations
+            .iter()
+            .all(|operation| operation.statistics.is_none())
+    }
+
+    /// Returns an iterator over the finalized operations, sorted by name.
+    pub fn operations(&self) -> impl Iterator<Item = &FinalizedOperation> {
+        self.operations.iter()
+    }
+
+    /// Prints the processor time statistics to stdout.
+    ///
+    /// Prints nothing if no operations recorded measurable work. This may
+    /// indicate that the session was part of a "list available benchmarks" probe
+    /// run instead of some real activity, in which case printing anything might
+    /// violate the output protocol the tool is speaking.
+    #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
+    pub fn print_to_stdout(&self) {
+        if self.is_empty() {
+            return;
+        }
+        println!("{self}");
+    }
+}
+
+impl FinalizedOperation {
+    /// Creates a finalized operation from its resolved figures.
+    pub(crate) fn new(
+        name: String,
+        total_iterations: u64,
+        total_processor_time: Duration,
+        mean: Duration,
+        statistics: Option<OperationStatistics>,
+    ) -> Self {
+        Self {
+            name,
+            total_iterations,
+            total_processor_time,
+            mean,
+            statistics,
+        }
+    }
+
+    /// The operation name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Total iterations recorded across all spans.
+    #[must_use]
+    pub fn total_iterations(&self) -> u64 {
+        self.total_iterations
+    }
+
+    /// Total processor time recorded across all spans.
+    #[must_use]
+    pub fn total_processor_time(&self) -> Duration {
+        self.total_processor_time
+    }
+
+    /// Mean processor time per iteration across all spans.
+    #[must_use]
+    pub fn mean(&self) -> Duration {
+        self.mean
+    }
+
+    /// The warmup-robust per-iteration statistics, or `None` when no spans were
+    /// recorded.
+    #[must_use]
+    pub fn statistics(&self) -> Option<OperationStatistics> {
+        self.statistics
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))] // Too annoying to test every question mark operator.
+impl fmt::Display for FinalizedReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            writeln!(f, "No processor time statistics captured.")?;
+            return Ok(());
+        }
+        writeln!(f, "Processor time statistics:")?;
+        writeln!(f)?;
+
+        // Render the warmup-robust per-iteration slope, not the raw mean: the mean
+        // folds warmup and one-off costs into the figure, while the slope recovers
+        // the marginal per-iteration cost. The confidence interval is computed as
+        // part of finalization and preserved in the JSON output and the
+        // `statistics()` API; it is kept out of this summary purely for
+        // readability, not to save computation.
+        let cells: Vec<(&str, String)> = self
+            .operations
+            .iter()
+            .map(|operation| {
+                let value = match operation.statistics {
+                    Some(statistics) => {
+                        format!("{:?}", nanos_to_duration(statistics.slope_nanos))
+                    }
+                    None => "n/a".to_owned(),
+                };
+                (operation.name.as_str(), value)
+            })
+            .collect();
+
+        let max_name_width = cells
+            .iter()
+            .map(|(name, _)| name.len())
+            .max()
+            .unwrap_or(0)
+            .max("Operation".len());
+        let max_value_width = cells
+            .iter()
+            .map(|(_, value)| value.len())
+            .max()
+            .unwrap_or(0)
+            .max("Per iteration".len());
+
+        // Print table header.
+        writeln!(
+            f,
+            "| {:<name_width$} | {:>value_width$} |",
+            "Operation",
+            "Per iteration",
+            name_width = max_name_width,
+            value_width = max_value_width
+        )?;
+        let separator_name_width = max_name_width
+            .checked_add(2)
+            .expect("operation name width fits in memory, adding 2 cannot overflow");
+        let separator_value_width = max_value_width
+            .checked_add(2)
+            .expect("value width fits in memory, adding 2 cannot overflow");
+        writeln!(
+            f,
+            "|{:-<name_width$}|{:-<value_width$}|",
+            "",
+            "",
+            name_width = separator_name_width,
+            value_width = separator_value_width
+        )?;
+
+        // Print table rows.
+        for (name, value) in cells {
+            writeln!(f, "| {name:<max_name_width$} | {value:>max_value_width$} |")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+
+    // The finalized report is a plain owned value: thread-safe and unwind-safe.
+    static_assertions::assert_impl_all!(FinalizedReport: Send, Sync);
+    static_assertions::assert_impl_all!(FinalizedOperation: Send, Sync);
+    static_assertions::assert_impl_all!(FinalizedReport: UnwindSafe, RefUnwindSafe);
+    static_assertions::assert_impl_all!(FinalizedOperation: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn empty_report_is_empty() {
+        let report = FinalizedReport::new(Vec::new());
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn operations_are_sorted_by_name() {
+        let report = FinalizedReport::new(vec![
+            FinalizedOperation::new(
+                "zebra".to_owned(),
+                1,
+                Duration::from_nanos(10),
+                Duration::from_nanos(10),
+                Some(OperationStatistics {
+                    span_count: 1,
+                    slope_nanos: 10.0,
+                    interval_nanos: None,
+                }),
+            ),
+            FinalizedOperation::new(
+                "alpha".to_owned(),
+                1,
+                Duration::from_nanos(20),
+                Duration::from_nanos(20),
+                Some(OperationStatistics {
+                    span_count: 1,
+                    slope_nanos: 20.0,
+                    interval_nanos: None,
+                }),
+            ),
+        ]);
+
+        let names: Vec<&str> = report.operations().map(FinalizedOperation::name).collect();
+        assert_eq!(names, ["alpha", "zebra"]);
+    }
+
+    #[test]
+    fn report_with_only_unmeasured_operations_is_empty() {
+        let report = FinalizedReport::new(vec![FinalizedOperation::new(
+            "unmeasured".to_owned(),
+            0,
+            Duration::ZERO,
+            Duration::ZERO,
+            None,
+        )]);
+        assert!(report.is_empty());
+    }
+}

--- a/packages/all_the_time/src/finalized.rs
+++ b/packages/all_the_time/src/finalized.rs
@@ -73,6 +73,10 @@ impl FinalizedReport {
     /// indicate that the session was part of a "list available benchmarks" probe
     /// run instead of some real activity, in which case printing anything might
     /// violate the output protocol the tool is speaking.
+    // Pure stdout side effect: the empty-guard early return is unreachable from
+    // the covered `Session::drop` path (it pre-checks emptiness), and stdout
+    // output is not meaningfully assertable — matching the sibling `Display` impl.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {
         if self.is_empty() {

--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -29,10 +29,11 @@
 //! closed-form 95% confidence interval so its run-to-run uncertainty can be
 //! inspected: it collapses onto the point estimate when every span records the
 //! same per-iteration value, and is omitted entirely when a single span leaves it
-//! unestimable. The stdout summary leads with the slope alone for readability; the
-//! JSON output records the slope together with that confidence interval, and the
-//! pooled mean stays available through [`ReportOperation::mean`] for callers that
-//! still want it.
+//! unestimable. The confidence interval is always computed as part of finalizing
+//! a report — there is no cheaper "slope-only" path that skips it — so the stdout
+//! summary simply displays the slope alone for readability while the JSON output
+//! records the slope together with that confidence interval. The pooled mean stays
+//! available through [`ReportOperation::mean`] for callers that still want it.
 //!
 //! # Benchmarking
 //!
@@ -80,8 +81,9 @@
 //! together with the warmup-robust slope point estimate and its 95% confidence
 //! interval (when estimable). The interval is a deterministic function of the
 //! measured spans, so identical measurements always yield identical bounds. The
-//! stdout summary leads with the same slope (see "Primary metric"), without the
-//! interval, for readability.
+//! stdout summary displays the same slope (see "Primary metric") without the
+//! interval purely for readability — the interval is computed regardless of which
+//! output consumes it.
 //!
 //! These outputs are produced automatically, so a typical benchmark only needs
 //! to create a session and record work.
@@ -195,6 +197,7 @@
 )]
 
 mod constants;
+mod finalized;
 mod operation;
 mod operation_metrics;
 mod pal;
@@ -206,6 +209,7 @@ mod target_output;
 mod thread_span;
 
 pub(crate) use constants::*;
+pub use finalized::*;
 pub use operation::*;
 pub(crate) use operation_metrics::*;
 pub use process_span::*;

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -204,6 +204,10 @@ impl Report {
     /// of a "list available benchmarks" probe run instead of some real activity,
     /// in which case printing anything might violate the output protocol the tool
     /// is speaking.
+    // Pure stdout side effect: no computation to cover here (the report is
+    // finalized on the covered `Session::drop` path), and stdout output is not
+    // meaningfully assertable — matching the sibling `Display` impls.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {
         self.finalize().print_to_stdout();

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::time::Duration;
 
 use crate::statistics::nanos_to_duration;
-use crate::{OperationMetrics, OperationStatistics};
+use crate::{FinalizedOperation, FinalizedReport, OperationMetrics, OperationStatistics};
 
 /// Thread-safe processor time tracking report.
 ///
@@ -170,17 +170,43 @@ impl Report {
         }
     }
 
+    /// Fully computes this report into a [`FinalizedReport`].
+    ///
+    /// Every operation's complete statistics — the warmup-robust slope *and* its
+    /// confidence interval — are resolved exactly once here. Both the stdout
+    /// summary and the machine-readable JSON output are rendered from the
+    /// returned value, so there is a single report that is always fully
+    /// calculated: the interval is computed even when an output only displays the
+    /// slope.
+    #[must_use]
+    pub fn finalize(&self) -> FinalizedReport {
+        let operations = self
+            .operations
+            .iter()
+            .map(|(name, operation)| {
+                FinalizedOperation::new(
+                    name.clone(),
+                    operation.total_iterations(),
+                    operation.total_processor_time(),
+                    operation.mean(),
+                    operation.statistics(),
+                )
+            })
+            .collect();
+
+        FinalizedReport::new(operations)
+    }
+
     /// Prints the processor time statistics to stdout.
     ///
-    /// Prints nothing if no operations were captured. This may indicate that the session
-    /// was part of a "list available benchmarks" probe run instead of some real activity,
-    /// in which case printing anything might violate the output protocol the tool is speaking.
+    /// Finalizes the report and prints the resulting summary. Prints nothing if
+    /// no operations were captured. This may indicate that the session was part
+    /// of a "list available benchmarks" probe run instead of some real activity,
+    /// in which case printing anything might violate the output protocol the tool
+    /// is speaking.
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {
-        if self.is_empty() {
-            return;
-        }
-        println!("{self}");
+        self.finalize().print_to_stdout();
     }
 
     /// Whether there is any recorded activity in this report.
@@ -296,78 +322,15 @@ impl fmt::Display for ReportOperation {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))] // Too annoying to test every question mark operator.
+// No API contract to test - output format is not guaranteed, and the rendering
+// itself is exercised through `FinalizedReport`.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl fmt::Display for Report {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.operations.values().all(|op| op.metrics.is_empty()) {
-            writeln!(f, "No processor time statistics captured.")?;
-            return Ok(());
-        }
-        writeln!(f, "Processor time statistics:")?;
-        writeln!(f)?;
-
-        // Sort operations by name for consistent output.
-        let mut sorted_ops: Vec<_> = self.operations.iter().collect();
-        sorted_ops.sort_by_key(|(name, _)| *name);
-
-        // Render the warmup-robust per-iteration slope, not the raw mean: the mean
-        // folds warmup and one-off costs into the figure, while the slope recovers
-        // the marginal per-iteration cost. The confidence interval is kept out of
-        // this summary for readability; it is preserved in the JSON output and the
-        // `statistics()` API.
-        let cells: Vec<(&str, String)> = sorted_ops
-            .iter()
-            .map(|(name, operation)| {
-                let value = match operation.metrics.slope_nanos() {
-                    Some(slope_nanos) => format!("{:?}", nanos_to_duration(slope_nanos)),
-                    None => "n/a".to_owned(),
-                };
-                (name.as_str(), value)
-            })
-            .collect();
-
-        let max_name_width = cells
-            .iter()
-            .map(|(name, _)| name.len())
-            .max()
-            .unwrap_or(0)
-            .max("Operation".len());
-        let max_value_width = cells
-            .iter()
-            .map(|(_, value)| value.len())
-            .max()
-            .unwrap_or(0)
-            .max("Per iteration".len());
-
-        // Print table header.
-        writeln!(
-            f,
-            "| {:<name_width$} | {:>value_width$} |",
-            "Operation",
-            "Per iteration",
-            name_width = max_name_width,
-            value_width = max_value_width
-        )?;
-        let separator_name_width = max_name_width
-            .checked_add(2)
-            .expect("operation name width fits in memory, adding 2 cannot overflow");
-        let separator_value_width = max_value_width
-            .checked_add(2)
-            .expect("value width fits in memory, adding 2 cannot overflow");
-        writeln!(
-            f,
-            "|{:-<name_width$}|{:-<value_width$}|",
-            "",
-            "",
-            name_width = separator_name_width,
-            value_width = separator_value_width
-        )?;
-
-        // Print table rows.
-        for (name, value) in cells {
-            writeln!(f, "| {name:<max_name_width$} | {value:>max_value_width$} |")?;
-        }
-        Ok(())
+        // There is one report and it is always fully calculated: rendering the
+        // human summary goes through the same finalized value the JSON output
+        // uses, rather than a cheaper slope-only path.
+        write!(f, "{}", self.finalize())
     }
 }
 

--- a/packages/all_the_time/src/report.rs
+++ b/packages/all_the_time/src/report.rs
@@ -204,9 +204,11 @@ impl Report {
     /// of a "list available benchmarks" probe run instead of some real activity,
     /// in which case printing anything might violate the output protocol the tool
     /// is speaking.
-    // Pure stdout side effect: no computation to cover here (the report is
-    // finalized on the covered `Session::drop` path), and stdout output is not
-    // meaningfully assertable — matching the sibling `Display` impls.
+    // Excluded from coverage as an un-assertable stdout side effect, matching the
+    // sibling `Display` impls. The `finalize()` computation it performs is covered
+    // independently — `Session::drop` finalizes on the measured path and
+    // `FinalizedReport` is unit-tested — so nothing computational is hidden here;
+    // only the stdout emission, which cannot be meaningfully asserted, is skipped.
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {

--- a/packages/all_the_time/src/session.rs
+++ b/packages/all_the_time/src/session.rs
@@ -241,7 +241,9 @@ impl Drop for Session {
             return;
         }
 
-        let report = self.to_report();
+        // There is one report and it is always fully calculated: finalize once,
+        // then feed every enabled output from that single value.
+        let report = self.to_report().finalize();
         if self.emit_stdout {
             report.print_to_stdout();
         }

--- a/packages/all_the_time/src/target_output.rs
+++ b/packages/all_the_time/src/target_output.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use serde::Serialize;
 
-use crate::Report;
+use crate::FinalizedReport;
 
 /// Subdirectory of the Cargo target directory that receives the JSON files.
 const OUTPUT_SUBDIRECTORY: &str = "all_the_time";
@@ -27,7 +27,7 @@ struct OperationOutput<'a> {
     interval_high_processor_time_nanos: Option<f64>,
 }
 
-impl Report {
+impl FinalizedReport {
     /// Writes machine-readable JSON statistics into the Cargo target directory.
     ///
     /// One file is written per operation, named after the operation, at
@@ -72,7 +72,7 @@ impl Report {
     ///
     /// Also panics if two operation names sanitize to the same file name, since
     /// writing both would silently discard one operation's results.
-    pub(crate) fn write_to_directory(&self, directory: impl AsRef<Path>) {
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
         let directory = directory.as_ref();
 
         // Build every output up front, detecting sanitized-name collisions before
@@ -80,7 +80,8 @@ impl Report {
         // file name would otherwise silently overwrite each other's results.
         let mut file_names: HashMap<String, &str> = HashMap::new();
         let mut outputs: Vec<(PathBuf, String)> = Vec::new();
-        for (name, operation) in self.operations() {
+        for operation in self.operations() {
+            let name = operation.name();
             let Some(statistics) = operation.statistics() else {
                 // Registered but never measured operations have no spans and thus
                 // no statistics, so they leave no output file behind.
@@ -192,7 +193,10 @@ mod tests {
         let session = session_with_recorded_work("read_cell");
         let directory = tempfile::tempdir().unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         let file = directory.path().join("read_cell.json");
         let value = read_json(&file);
@@ -264,7 +268,10 @@ mod tests {
         }
 
         let directory = tempfile::tempdir().unwrap();
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         let value = read_json(&directory.path().join("read_cell.json"));
         assert_eq!(value.get("span_count").and_then(Value::as_u64), Some(2));
@@ -294,7 +301,10 @@ mod tests {
         let session = session_with_recorded_work("group/case name");
         let directory = tempfile::tempdir().unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
@@ -316,7 +326,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("nested");
 
-        session.to_report().write_to_directory(&target);
+        session.to_report().finalize().write_to_directory(&target);
 
         // Nothing is written, so the directory is not even created.
         assert!(!target.exists());
@@ -340,7 +350,10 @@ mod tests {
         let _unmeasured = session.operation("unmeasured");
 
         let directory = tempfile::tempdir().unwrap();
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         assert!(directory.path().join("measured.json").exists());
         assert!(!directory.path().join("unmeasured.json").exists());
@@ -354,7 +367,10 @@ mod tests {
         fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("read_cell");
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         // Parsing succeeds only if the stale, non-JSON contents were replaced.
         let value = read_json(&file);
@@ -378,6 +394,7 @@ mod tests {
 
         session
             .to_report()
+            .finalize()
             .write_to_directory(blocker.join("nested"));
     }
 
@@ -391,7 +408,10 @@ mod tests {
         // A directory occupying the output file's path makes the file write fail.
         fs::create_dir_all(directory.path().join("read_cell.json")).unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
     }
 
     #[test]
@@ -414,6 +434,7 @@ mod tests {
         // never created.
         session
             .to_report()
+            .finalize()
             .write_to_directory("collision_is_detected_before_writing");
     }
 }

--- a/packages/alloc_tracker/Cargo.toml
+++ b/packages/alloc_tracker/Cargo.toml
@@ -23,6 +23,10 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+# Dev-dependency loop with `all_the_time`: the lifecycle benchmarks measure this
+# crate's processor time using `all_the_time` while `all_the_time`'s own benchmarks
+# measure allocations using this crate. Cargo permits dev-dependency-only cycles.
+all_the_time = { path = "../all_the_time" }
 criterion = { workspace = true }
 mutants = { workspace = true }
 static_assertions = { workspace = true }
@@ -30,6 +34,10 @@ tempfile = { workspace = true }
 
 [[bench]]
 name = "alloc_tracker_example"
+harness = false
+
+[[bench]]
+name = "alloc_tracker_report_lifecycle"
 harness = false
 
 [[bench]]

--- a/packages/alloc_tracker/benches/alloc_tracker_report_lifecycle.rs
+++ b/packages/alloc_tracker/benches/alloc_tracker_report_lifecycle.rs
@@ -1,0 +1,221 @@
+//! Full-lifecycle benchmarks for the `alloc_tracker` memory allocation tracker.
+//!
+//! Where `alloc_tracker_tracking_overhead` measures only the per-span record
+//! path, this benchmark covers every remaining lifecycle stage — session and
+//! operation setup, report snapshotting, merging, **finalization** (assembling
+//! the recorded spans into the complete report, the phase that regressed in
+//! issue #328), human rendering, and JSON output. Each stage is measured for all
+//! three cost dimensions at once:
+//!
+//! * **wall-clock time** — Criterion, the harness.
+//! * **memory allocations** — `alloc_tracker` itself, measuring its own lifecycle.
+//! * **processor time** — `all_the_time` (a dev-dependency; this crate and
+//!   `all_the_time` form an allowed dev-dependency-only cycle).
+//!
+//! The finalization stage is scaled by operation count so that any regression
+//! back to super-linear or retained-span work surfaces immediately instead of
+//! hiding behind a cheap "slope-only" summary path.
+
+#![allow(
+    missing_docs,
+    reason = "No need for API documentation in benchmark code"
+)]
+
+use std::fmt::Write as _;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use all_the_time::Session as TimeSession;
+use alloc_tracker::{Allocator, Report, Session};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
+
+/// Number of spans folded into each operation of the report fixtures.
+///
+/// Streaming statistics fold every span into O(1) accumulators, so this affects
+/// only the fixture's record cost, not the finalization cost — which is exactly
+/// the invariant the finalization benchmarks lock in.
+const SPANS_PER_OP: usize = 8;
+
+fn entrypoint(c: &mut Criterion) {
+    // The measuring sessions capture this benchmark's own allocation and
+    // processor-time cost and emit their JSON on drop at the end of `entrypoint`.
+    let alloc = Session::new();
+    let time = TimeSession::new();
+
+    setup(c, &alloc, &time);
+    snapshot(c, &alloc, &time);
+    merge(c, &alloc, &time);
+    finalize(c, &alloc, &time);
+    render(c, &alloc, &time);
+    write(c, &alloc, &time);
+}
+
+/// Wraps the measured `body` in an allocation span and a processor-time span so
+/// every Criterion sample also feeds the two side-channel measuring sessions.
+fn measured<F: FnMut()>(
+    iters: u64,
+    alloc_op: &alloc_tracker::Operation,
+    time_op: &all_the_time::Operation,
+    mut body: F,
+) -> Duration {
+    let start = Instant::now();
+    {
+        let _alloc_span = alloc_op.measure_thread().iterations(iters);
+        let _time_span = time_op.measure_thread().iterations(iters);
+
+        for _ in 0..iters {
+            body();
+        }
+    }
+    start.elapsed()
+}
+
+/// Builds a report fixture with `num_ops` operations, each carrying
+/// `SPANS_PER_OP` recorded spans, so downstream stages have realistic streaming
+/// state to work over.
+fn build_report(num_ops: usize) -> Report {
+    let session = Session::new().no_stdout().no_file();
+    for op_idx in 0..num_ops {
+        let op = session.operation(format!("op_{op_idx}"));
+        for _ in 0..SPANS_PER_OP {
+            let _span = op.measure_thread().iterations(10);
+            black_box((0..10_u32).collect::<Vec<_>>());
+        }
+    }
+    session.to_report()
+}
+
+fn setup(c: &mut Criterion, alloc: &Session, time: &TimeSession) {
+    let mut group = c.benchmark_group("alloc_tracker_report_lifecycle/setup");
+    let alloc_op = alloc.operation("alloc_tracker_report_lifecycle/setup/session_100_ops");
+    let time_op = time.operation("alloc_tracker_report_lifecycle/setup/session_100_ops");
+
+    group.bench_function("session_100_ops", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                let session = Session::new().no_stdout().no_file();
+                for op_idx in 0..100 {
+                    black_box(session.operation(format!("op_{op_idx}")));
+                }
+                black_box(&session);
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn snapshot(c: &mut Criterion, alloc: &Session, time: &TimeSession) {
+    let mut group = c.benchmark_group("alloc_tracker_report_lifecycle/snapshot");
+    let alloc_op = alloc.operation("alloc_tracker_report_lifecycle/snapshot/ops_100");
+    let time_op = time.operation("alloc_tracker_report_lifecycle/snapshot/ops_100");
+
+    // A populated session snapshotted repeatedly; `to_report` takes `&self`.
+    let session = Session::new().no_stdout().no_file();
+    for op_idx in 0..100 {
+        let op = session.operation(format!("op_{op_idx}"));
+        for _ in 0..SPANS_PER_OP {
+            let _span = op.measure_thread().iterations(10);
+            black_box((0..10_u32).collect::<Vec<_>>());
+        }
+    }
+
+    group.bench_function("ops_100", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                black_box(session.to_report());
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn merge(c: &mut Criterion, alloc: &Session, time: &TimeSession) {
+    let mut group = c.benchmark_group("alloc_tracker_report_lifecycle/merge");
+    let alloc_op = alloc.operation("alloc_tracker_report_lifecycle/merge/ops_100");
+    let time_op = time.operation("alloc_tracker_report_lifecycle/merge/ops_100");
+
+    let left = build_report(100);
+    let right = build_report(100);
+
+    group.bench_function("ops_100", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                black_box(Report::merge(black_box(&left), black_box(&right)));
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn finalize(c: &mut Criterion, alloc: &Session, time: &TimeSession) {
+    let mut group = c.benchmark_group("alloc_tracker_report_lifecycle/finalize");
+
+    // Scaling finalize by operation count is the core regression guard: streaming
+    // makes finalize O(operations), so the 10x jump in operation count must show
+    // a roughly 10x (not super-linear) jump in cost.
+    for num_ops in [10_usize, 100] {
+        let report = build_report(num_ops);
+        let name = format!("ops_{num_ops}");
+        let alloc_op = alloc.operation(format!("alloc_tracker_report_lifecycle/finalize/{name}"));
+        let time_op = time.operation(format!("alloc_tracker_report_lifecycle/finalize/{name}"));
+
+        group.bench_function(&name, |b| {
+            b.iter_custom(|iters| {
+                measured(iters, &alloc_op, &time_op, || {
+                    black_box(report.finalize());
+                })
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn render(c: &mut Criterion, alloc: &Session, time: &TimeSession) {
+    let mut group = c.benchmark_group("alloc_tracker_report_lifecycle/render");
+    let alloc_op = alloc.operation("alloc_tracker_report_lifecycle/render/ops_100");
+    let time_op = time.operation("alloc_tracker_report_lifecycle/render/ops_100");
+
+    let finalized = build_report(100).finalize();
+
+    group.bench_function("ops_100", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                let mut rendered = String::new();
+                write!(rendered, "{finalized}").expect("writing to a String cannot fail");
+                black_box(rendered);
+            })
+        });
+    });
+
+    group.finish();
+}
+
+fn write(c: &mut Criterion, alloc: &Session, time: &TimeSession) {
+    let mut group = c.benchmark_group("alloc_tracker_report_lifecycle/write");
+    let alloc_op = alloc.operation("alloc_tracker_report_lifecycle/write/ops_25");
+    let time_op = time.operation("alloc_tracker_report_lifecycle/write/ops_25");
+
+    // JSON output is I/O-bound, so keep the operation count modest.
+    let finalized = build_report(25).finalize();
+    let directory = tempfile::tempdir().expect("creating a temp directory cannot fail in a bench");
+
+    group.bench_function("ops_25", |b| {
+        b.iter_custom(|iters| {
+            measured(iters, &alloc_op, &time_op, || {
+                finalized.write_to_directory(directory.path());
+            })
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, entrypoint);
+criterion_main!(benches);

--- a/packages/alloc_tracker/src/finalized.rs
+++ b/packages/alloc_tracker/src/finalized.rs
@@ -1,0 +1,299 @@
+//! The single, fully-computed memory allocation report.
+//!
+//! A [`Report`](crate::Report) is a mergeable snapshot of the streaming
+//! statistics; it is not yet resolved into the per-iteration figures that the
+//! outputs present. [`Report::finalize`](crate::Report::finalize) resolves it
+//! exactly once into a [`FinalizedReport`]: every operation's complete
+//! statistics — the warmup-robust slopes *and* their confidence intervals for
+//! both the byte and allocation-count metrics — are computed up front. Both the
+//! human-readable stdout summary and the machine-readable JSON files are then
+//! rendered from this one finalized value, so there is no cheap "slope-only"
+//! path that silently skips the interval computation and hides its cost from
+//! benchmarks.
+
+use std::fmt;
+
+use crate::OperationStatistics;
+use crate::report::format_count;
+
+/// A memory allocation report with every operation's statistics fully computed.
+///
+/// Produced by [`Report::finalize`](crate::Report::finalize). There is exactly
+/// one report and it is always fully calculated: the per-metric slopes and their
+/// confidence intervals are resolved for every operation up front, regardless of
+/// which outputs (if any) end up consuming them.
+#[derive(Clone, Debug)]
+pub struct FinalizedReport {
+    /// Operations sorted by name, so every output presents them in a stable order.
+    operations: Vec<FinalizedOperation>,
+}
+
+/// One operation's fully-computed memory allocation statistics.
+#[derive(Clone, Debug)]
+pub struct FinalizedOperation {
+    name: String,
+    total_iterations: u64,
+    total_bytes_allocated: u64,
+    total_allocations_count: u64,
+    mean_bytes: u64,
+    mean_allocations: u64,
+    statistics: Option<OperationStatistics>,
+}
+
+impl FinalizedReport {
+    /// Assembles a finalized report from the resolved per-operation figures.
+    ///
+    /// The operations are sorted by name so both outputs present them
+    /// identically.
+    pub(crate) fn new(mut operations: Vec<FinalizedOperation>) -> Self {
+        operations.sort_by(|a, b| a.name.cmp(&b.name));
+        Self { operations }
+    }
+
+    /// Whether the report captured any measurable work.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.operations
+            .iter()
+            .all(|operation| operation.statistics.is_none())
+    }
+
+    /// Returns an iterator over the finalized operations, sorted by name.
+    pub fn operations(&self) -> impl Iterator<Item = &FinalizedOperation> {
+        self.operations.iter()
+    }
+
+    /// Prints the memory allocation statistics to stdout.
+    ///
+    /// Prints nothing if no operations recorded measurable work. This may
+    /// indicate that the session was part of a "list available benchmarks" probe
+    /// run instead of some real activity, in which case printing anything might
+    /// violate the output protocol the tool is speaking.
+    #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
+    pub fn print_to_stdout(&self) {
+        if self.is_empty() {
+            return;
+        }
+        println!("{self}");
+    }
+}
+
+impl FinalizedOperation {
+    /// Creates a finalized operation from its resolved figures.
+    pub(crate) fn new(
+        name: String,
+        total_iterations: u64,
+        total_bytes_allocated: u64,
+        total_allocations_count: u64,
+        mean_bytes: u64,
+        mean_allocations: u64,
+        statistics: Option<OperationStatistics>,
+    ) -> Self {
+        Self {
+            name,
+            total_iterations,
+            total_bytes_allocated,
+            total_allocations_count,
+            mean_bytes,
+            mean_allocations,
+            statistics,
+        }
+    }
+
+    /// The operation name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Total iterations recorded across all spans.
+    #[must_use]
+    pub fn total_iterations(&self) -> u64 {
+        self.total_iterations
+    }
+
+    /// Total bytes allocated across all spans.
+    #[must_use]
+    pub fn total_bytes_allocated(&self) -> u64 {
+        self.total_bytes_allocated
+    }
+
+    /// Total number of allocations across all spans.
+    #[must_use]
+    pub fn total_allocations_count(&self) -> u64 {
+        self.total_allocations_count
+    }
+
+    /// Pooled mean bytes allocated per iteration.
+    #[must_use]
+    pub fn mean_bytes(&self) -> u64 {
+        self.mean_bytes
+    }
+
+    /// Pooled mean number of allocations per iteration.
+    #[must_use]
+    pub fn mean_allocations(&self) -> u64 {
+        self.mean_allocations
+    }
+
+    /// The warmup-robust per-iteration statistics, or `None` when no spans were
+    /// recorded.
+    #[must_use]
+    pub fn statistics(&self) -> Option<OperationStatistics> {
+        self.statistics
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))] // Too annoying to test every question mark operator.
+impl fmt::Display for FinalizedReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            writeln!(f, "No allocation statistics captured.")?;
+            return Ok(());
+        }
+
+        writeln!(f, "Allocation statistics:")?;
+        writeln!(f)?;
+
+        // Pre-render the warmup-robust per-iteration slope cells so the column
+        // widths and the printed rows are computed from the exact same strings.
+        // The confidence interval is computed as part of finalization and
+        // preserved in the JSON output and the `statistics()` API; it is kept out
+        // of this summary purely for readability, not to save computation.
+        let rows: Vec<(&str, String, String)> = self
+            .operations
+            .iter()
+            .map(|operation| match operation.statistics {
+                Some(statistics) => (
+                    operation.name.as_str(),
+                    format_count(statistics.bytes.slope),
+                    format_count(statistics.allocations.slope),
+                ),
+                None => (operation.name.as_str(), "n/a".to_owned(), "n/a".to_owned()),
+            })
+            .collect();
+
+        let name_header = "Operation";
+        let bytes_header = "Bytes/iter";
+        let count_header = "Allocations/iter";
+
+        let max_name_width = rows
+            .iter()
+            .map(|(name, _, _)| name.len())
+            .max()
+            .unwrap_or(0)
+            .max(name_header.len());
+        let max_bytes_width = rows
+            .iter()
+            .map(|(_, bytes, _)| bytes.len())
+            .max()
+            .unwrap_or(0)
+            .max(bytes_header.len());
+        let max_count_width = rows
+            .iter()
+            .map(|(_, _, count)| count.len())
+            .max()
+            .unwrap_or(0)
+            .max(count_header.len());
+
+        // Print table header.
+        writeln!(
+            f,
+            "| {name_header:<max_name_width$} | {bytes_header:>max_bytes_width$} | {count_header:>max_count_width$} |",
+        )?;
+
+        // Print separator.
+        let separator_name_width = max_name_width
+            .checked_add(2)
+            .expect("operation name width fits in memory, adding 2 cannot overflow");
+        let separator_bytes_width = max_bytes_width
+            .checked_add(2)
+            .expect("bytes width fits in memory, adding 2 cannot overflow");
+        let separator_count_width = max_count_width
+            .checked_add(2)
+            .expect("count width fits in memory, adding 2 cannot overflow");
+        writeln!(
+            f,
+            "|{:-<separator_name_width$}|{:-<separator_bytes_width$}|{:-<separator_count_width$}|",
+            "", "", "",
+        )?;
+
+        // Print table rows.
+        for (name, bytes, count) in rows {
+            writeln!(
+                f,
+                "| {name:<max_name_width$} | {bytes:>max_bytes_width$} | {count:>max_count_width$} |",
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+    use crate::report::MetricStatistics;
+
+    // The finalized report is a plain owned value: thread-safe and unwind-safe.
+    static_assertions::assert_impl_all!(FinalizedReport: Send, Sync);
+    static_assertions::assert_impl_all!(FinalizedOperation: Send, Sync);
+    static_assertions::assert_impl_all!(FinalizedReport: UnwindSafe, RefUnwindSafe);
+    static_assertions::assert_impl_all!(FinalizedOperation: UnwindSafe, RefUnwindSafe);
+
+    fn operation(name: &str, bytes_slope: f64, allocations_slope: f64) -> FinalizedOperation {
+        FinalizedOperation::new(
+            name.to_owned(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            Some(OperationStatistics {
+                span_count: 1,
+                bytes: MetricStatistics {
+                    slope: bytes_slope,
+                    interval: None,
+                },
+                allocations: MetricStatistics {
+                    slope: allocations_slope,
+                    interval: None,
+                },
+            }),
+        )
+    }
+
+    #[test]
+    fn empty_report_is_empty() {
+        let report = FinalizedReport::new(Vec::new());
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn operations_are_sorted_by_name() {
+        let report = FinalizedReport::new(vec![
+            operation("zebra", 10.0, 1.0),
+            operation("alpha", 20.0, 2.0),
+        ]);
+
+        let names: Vec<&str> = report.operations().map(FinalizedOperation::name).collect();
+        assert_eq!(names, ["alpha", "zebra"]);
+    }
+
+    #[test]
+    fn report_with_only_unmeasured_operations_is_empty() {
+        let report = FinalizedReport::new(vec![FinalizedOperation::new(
+            "unmeasured".to_owned(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            None,
+        )]);
+        assert!(report.is_empty());
+    }
+}

--- a/packages/alloc_tracker/src/finalized.rs
+++ b/packages/alloc_tracker/src/finalized.rs
@@ -53,9 +53,15 @@ impl FinalizedReport {
     /// Whether the report captured any measurable work.
     #[must_use]
     pub fn is_empty(&self) -> bool {
+        // Emptiness tracks whether any work was *recorded*, not whether a slope
+        // could be fit. An operation may record spans yet still yield no
+        // statistics (the through-origin fit can be non-finite), and in that case
+        // the summary must still print the operation with `n/a` values rather
+        // than suppress all output. Keying off `statistics.is_none()` here would
+        // wrongly treat such a report as empty and short-circuit `print_to_stdout`.
         self.operations
             .iter()
-            .all(|operation| operation.statistics.is_none())
+            .all(|operation| operation.total_iterations == 0)
     }
 
     /// Returns an iterator over the finalized operations, sorted by name.
@@ -295,5 +301,22 @@ mod tests {
             None,
         )]);
         assert!(report.is_empty());
+    }
+
+    #[test]
+    fn report_with_recorded_work_but_no_statistics_is_not_empty() {
+        // Spans were recorded (iterations > 0) but the slope fit yielded no
+        // statistics. The report must still be considered non-empty so the
+        // summary prints the operation with `n/a` values.
+        let report = FinalizedReport::new(vec![FinalizedOperation::new(
+            "recorded".to_owned(),
+            5,
+            500,
+            5,
+            100,
+            1,
+            None,
+        )]);
+        assert!(!report.is_empty());
     }
 }

--- a/packages/alloc_tracker/src/finalized.rs
+++ b/packages/alloc_tracker/src/finalized.rs
@@ -53,12 +53,13 @@ impl FinalizedReport {
     /// Whether the report captured any measurable work.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        // Emptiness tracks whether any work was *recorded*, not whether a slope
-        // could be fit. An operation may record spans yet still yield no
-        // statistics (the through-origin fit can be non-finite), and in that case
-        // the summary must still print the operation with `n/a` values rather
-        // than suppress all output. Keying off `statistics.is_none()` here would
-        // wrongly treat such a report as empty and short-circuit `print_to_stdout`.
+        // Emptiness means "no measurable work was recorded", matching the
+        // pre-finalize `OperationMetrics::is_empty` (total iterations == 0). It is
+        // deliberately independent of whether a slope could be fit: an operation
+        // can hold a span yet zero iterations (a fitted slope but no measurable
+        // work), or be created with no spans at all (no slope, rendered as `n/a`).
+        // Keying off `statistics.is_none()` instead would misclassify the former
+        // as non-empty and print a table for a run that recorded nothing.
         self.operations
             .iter()
             .all(|operation| operation.total_iterations == 0)
@@ -309,9 +310,10 @@ mod tests {
 
     #[test]
     fn report_with_recorded_work_but_no_statistics_is_not_empty() {
-        // Spans were recorded (iterations > 0) but the slope fit yielded no
-        // statistics. The report must still be considered non-empty so the
-        // summary prints the operation with `n/a` values.
+        // is_empty reflects recorded work (iterations), independent of whether a
+        // slope was fit: an operation with recorded iterations is never empty even
+        // when its statistics are absent. Guards against regressing back to keying
+        // off `statistics.is_none()`.
         let report = FinalizedReport::new(vec![FinalizedOperation::new(
             "recorded".to_owned(),
             5,

--- a/packages/alloc_tracker/src/finalized.rs
+++ b/packages/alloc_tracker/src/finalized.rs
@@ -75,6 +75,10 @@ impl FinalizedReport {
     /// indicate that the session was part of a "list available benchmarks" probe
     /// run instead of some real activity, in which case printing anything might
     /// violate the output protocol the tool is speaking.
+    // Pure stdout side effect: the empty-guard early return is unreachable from
+    // the covered `Session::drop` path (it pre-checks emptiness), and stdout
+    // output is not meaningfully assertable — matching the sibling `Display` impl.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {
         if self.is_empty() {

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -44,9 +44,11 @@
 //! shifts. Each figure is paired with a closed-form 95% confidence interval so its
 //! run-to-run uncertainty can be inspected: it collapses onto the point estimate
 //! when every span records the same per-iteration value, and is omitted entirely
-//! when a single span leaves it unestimable. The stdout summary leads with the
-//! slopes alone for readability; the JSON output records the slopes together with
-//! their confidence intervals, and the pooled means stay available through
+//! when a single span leaves it unestimable. The confidence intervals are always
+//! computed as part of finalizing a report — there is no cheaper "slope-only" path
+//! that skips them — so the stdout summary simply displays the slopes alone for
+//! readability while the JSON output records the slopes together with their
+//! confidence intervals. The pooled means stay available through
 //! [`Operation::mean`] and the report accessors for callers that still want them.
 //!
 //! # Features
@@ -198,6 +200,7 @@
 
 mod allocator;
 mod constants;
+mod finalized;
 mod operation;
 mod operation_metrics;
 mod process_span;
@@ -208,6 +211,7 @@ mod thread_span;
 
 pub use allocator::*;
 pub(crate) use constants::*;
+pub use finalized::*;
 pub use operation::*;
 pub(crate) use operation_metrics::*;
 pub use process_span::*;

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -253,6 +253,10 @@ impl Report {
     /// of a "list available benchmarks" probe run instead of some real activity,
     /// in which case printing anything might violate the output protocol the tool
     /// is speaking.
+    // Pure stdout side effect: no computation to cover here (the report is
+    // finalized on the covered `Session::drop` path), and stdout output is not
+    // meaningfully assertable — matching the sibling `Display` impls.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {
         self.finalize().print_to_stdout();

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -253,9 +253,11 @@ impl Report {
     /// of a "list available benchmarks" probe run instead of some real activity,
     /// in which case printing anything might violate the output protocol the tool
     /// is speaking.
-    // Pure stdout side effect: no computation to cover here (the report is
-    // finalized on the covered `Session::drop` path), and stdout output is not
-    // meaningfully assertable — matching the sibling `Display` impls.
+    // Excluded from coverage as an un-assertable stdout side effect, matching the
+    // sibling `Display` impls. The `finalize()` computation it performs is covered
+    // independently — `Session::drop` finalizes on the measured path and
+    // `FinalizedReport` is unit-tested — so nothing computational is hidden here;
+    // only the stdout emission, which cannot be meaningfully asserted, is skipped.
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {

--- a/packages/alloc_tracker/src/report.rs
+++ b/packages/alloc_tracker/src/report.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::OperationMetrics;
+use crate::{FinalizedOperation, FinalizedReport, OperationMetrics};
 
 /// Thread-safe memory allocation tracking report.
 ///
@@ -217,17 +217,45 @@ impl Report {
         }
     }
 
+    /// Fully computes this report into a [`FinalizedReport`].
+    ///
+    /// Every operation's complete statistics — the warmup-robust per-metric
+    /// slopes *and* their confidence intervals — are resolved exactly once here.
+    /// Both the stdout summary and the machine-readable JSON output are rendered
+    /// from the returned value, so there is a single report that is always fully
+    /// calculated: the intervals are computed even when an output only displays
+    /// the slopes.
+    #[must_use]
+    pub fn finalize(&self) -> FinalizedReport {
+        let operations = self
+            .operations
+            .iter()
+            .map(|(name, operation)| {
+                FinalizedOperation::new(
+                    name.clone(),
+                    operation.total_iterations(),
+                    operation.total_bytes_allocated(),
+                    operation.total_allocations_count(),
+                    operation.mean_bytes(),
+                    operation.mean_allocations(),
+                    operation.statistics(),
+                )
+            })
+            .collect();
+
+        FinalizedReport::new(operations)
+    }
+
     /// Prints the memory allocation statistics to stdout.
     ///
-    /// Prints nothing if no operations were captured. This may indicate that the session
-    /// was part of a "list available benchmarks" probe run instead of some real activity,
-    /// in which case printing anything might violate the output protocol the tool is speaking.
+    /// Finalizes the report and prints the resulting summary. Prints nothing if
+    /// no operations were captured. This may indicate that the session was part
+    /// of a "list available benchmarks" probe run instead of some real activity,
+    /// in which case printing anything might violate the output protocol the tool
+    /// is speaking.
     #[cfg_attr(test, mutants::skip)] // Too difficult to test stdout output reliably - manually tested.
     pub fn print_to_stdout(&self) {
-        if self.is_empty() {
-            return;
-        }
-        println!("{self}");
+        self.finalize().print_to_stdout();
     }
 
     /// Whether there is any recorded activity in this report.
@@ -400,97 +428,15 @@ impl fmt::Display for ReportOperation {
     }
 }
 
-// No API contract to test - output format is not guaranteed.
+// No API contract to test - output format is not guaranteed, and the rendering
+// itself is exercised through `FinalizedReport`.
 #[cfg_attr(coverage_nightly, coverage(off))]
 impl fmt::Display for Report {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.operations.values().all(|op| op.metrics.is_empty()) {
-            writeln!(f, "No allocation statistics captured.")?;
-            return Ok(());
-        }
-
-        writeln!(f, "Allocation statistics:")?;
-        writeln!(f)?;
-
-        // Sort operations by name for consistent output.
-        let mut sorted_ops: Vec<_> = self.operations.iter().collect();
-        sorted_ops.sort_by_key(|(name, _)| *name);
-
-        // Pre-render the warmup-robust per-iteration slope cells so the column
-        // widths and the printed rows are computed from the exact same strings. The
-        // confidence interval is kept out of this summary for readability; it is
-        // preserved in the JSON output and the `statistics()` API.
-        let rows: Vec<(&str, String, String)> = sorted_ops
-            .iter()
-            .map(|(name, operation)| {
-                match (
-                    operation.metrics.bytes_slope(),
-                    operation.metrics.allocations_slope(),
-                ) {
-                    (Some(bytes), Some(allocations)) => (
-                        name.as_str(),
-                        format_count(bytes),
-                        format_count(allocations),
-                    ),
-                    _ => (name.as_str(), "n/a".to_string(), "n/a".to_string()),
-                }
-            })
-            .collect();
-
-        let name_header = "Operation";
-        let bytes_header = "Bytes/iter";
-        let count_header = "Allocations/iter";
-
-        let max_name_width = rows
-            .iter()
-            .map(|(name, _, _)| name.len())
-            .max()
-            .unwrap_or(0)
-            .max(name_header.len());
-        let max_bytes_width = rows
-            .iter()
-            .map(|(_, bytes, _)| bytes.len())
-            .max()
-            .unwrap_or(0)
-            .max(bytes_header.len());
-        let max_count_width = rows
-            .iter()
-            .map(|(_, _, count)| count.len())
-            .max()
-            .unwrap_or(0)
-            .max(count_header.len());
-
-        // Print table header.
-        writeln!(
-            f,
-            "| {name_header:<max_name_width$} | {bytes_header:>max_bytes_width$} | {count_header:>max_count_width$} |",
-        )?;
-
-        // Print separator.
-        let separator_name_width = max_name_width
-            .checked_add(2)
-            .expect("operation name width fits in memory, adding 2 cannot overflow");
-        let separator_bytes_width = max_bytes_width
-            .checked_add(2)
-            .expect("bytes width fits in memory, adding 2 cannot overflow");
-        let separator_count_width = max_count_width
-            .checked_add(2)
-            .expect("count width fits in memory, adding 2 cannot overflow");
-        writeln!(
-            f,
-            "|{:-<separator_name_width$}|{:-<separator_bytes_width$}|{:-<separator_count_width$}|",
-            "", "", "",
-        )?;
-
-        // Print table rows.
-        for (name, bytes, count) in rows {
-            writeln!(
-                f,
-                "| {name:<max_name_width$} | {bytes:>max_bytes_width$} | {count:>max_count_width$} |",
-            )?;
-        }
-
-        Ok(())
+        // There is one report and it is always fully calculated: rendering the
+        // human summary goes through the same finalized value the JSON output
+        // uses, rather than a cheaper slope-only path.
+        write!(f, "{}", self.finalize())
     }
 }
 

--- a/packages/alloc_tracker/src/session.rs
+++ b/packages/alloc_tracker/src/session.rs
@@ -223,7 +223,9 @@ impl Drop for Session {
             return;
         }
 
-        let report = self.to_report();
+        // There is one report and it is always fully calculated: finalize once,
+        // then feed every enabled output from that single value.
+        let report = self.to_report().finalize();
         if self.emit_stdout {
             report.print_to_stdout();
         }

--- a/packages/alloc_tracker/src/target_output.rs
+++ b/packages/alloc_tracker/src/target_output.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::Report;
+use crate::FinalizedReport;
 
 /// Subdirectory of the Cargo target directory that receives the JSON files.
 const OUTPUT_SUBDIRECTORY: &str = "alloc_tracker";
@@ -38,7 +38,7 @@ struct OperationOutput<'a> {
     interval_high_allocations_per_iteration: Option<f64>,
 }
 
-impl Report {
+impl FinalizedReport {
     /// Writes machine-readable JSON statistics into the Cargo target directory.
     ///
     /// One file is written per operation, named after the operation, at
@@ -83,7 +83,7 @@ impl Report {
     ///
     /// Also panics if two operation names sanitize to the same file name, since
     /// writing both would silently discard one operation's results.
-    pub(crate) fn write_to_directory(&self, directory: impl AsRef<Path>) {
+    pub fn write_to_directory(&self, directory: impl AsRef<Path>) {
         let directory = directory.as_ref();
 
         // Build every output up front, detecting sanitized-name collisions before
@@ -91,7 +91,8 @@ impl Report {
         // file name would otherwise silently overwrite each other's results.
         let mut file_names: HashMap<String, &str> = HashMap::new();
         let mut outputs: Vec<(PathBuf, String)> = Vec::new();
-        for (name, operation) in self.operations() {
+        for operation in self.operations() {
+            let name = operation.name();
             let Some(statistics) = operation.statistics() else {
                 // Registered but never measured operations have no spans and thus
                 // no statistics, so they leave no output file behind.
@@ -190,7 +191,10 @@ mod tests {
         let session = session_with_recorded_work("allocate_vec");
         let directory = tempfile::tempdir().unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         let file = directory.path().join("allocate_vec.json");
         let value = read_json(&file);
@@ -259,7 +263,10 @@ mod tests {
         }
         let directory = tempfile::tempdir().unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         let value = read_json(&directory.path().join("allocate_vec.json"));
         assert_eq!(value.get("span_count").and_then(Value::as_u64), Some(2));
@@ -283,7 +290,10 @@ mod tests {
         let session = session_with_recorded_work("group/case name");
         let directory = tempfile::tempdir().unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         let file = directory.path().join("group_case_name.json");
         assert!(file.exists());
@@ -302,7 +312,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let target = directory.path().join("nested");
 
-        session.to_report().write_to_directory(&target);
+        session.to_report().finalize().write_to_directory(&target);
 
         // Nothing is written, so the directory is not even created.
         assert!(!target.exists());
@@ -322,7 +332,10 @@ mod tests {
         let _unmeasured = session.operation("unmeasured");
 
         let directory = tempfile::tempdir().unwrap();
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         assert!(directory.path().join("measured.json").exists());
         assert!(!directory.path().join("unmeasured.json").exists());
@@ -336,7 +349,10 @@ mod tests {
         fs::write(&file, "stale contents").unwrap();
 
         let session = session_with_recorded_work("allocate_vec");
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
 
         // Parsing succeeds only if the stale, non-JSON contents were replaced.
         let value = read_json(&file);
@@ -360,6 +376,7 @@ mod tests {
 
         session
             .to_report()
+            .finalize()
             .write_to_directory(blocker.join("nested"));
     }
 
@@ -373,7 +390,10 @@ mod tests {
         // A directory occupying the output file's path makes the file write fail.
         fs::create_dir_all(directory.path().join("allocate_vec.json")).unwrap();
 
-        session.to_report().write_to_directory(directory.path());
+        session
+            .to_report()
+            .finalize()
+            .write_to_directory(directory.path());
     }
 
     #[test]
@@ -393,6 +413,7 @@ mod tests {
         // never created.
         session
             .to_report()
+            .finalize()
             .write_to_directory("collision_is_detected_before_writing");
     }
 }


### PR DESCRIPTION
## Why

Follow-up to #330 (the streaming-CI fix for #328). That investigation exposed
two structural weaknesses that let the finalization blowup hide for so long:

1. **The report path was split.** In both `all_the_time` and `alloc_tracker`,
   the stdout summary took a cheap *slope-only* path while the JSON file took an
   expensive *slope + interval* path. The costly computation lived **only** in
   the file path, so anything exercising just the human summary never paid its
   cost — masking the regression.
2. **We had no finalization benchmarks.** The "iteration overhead" benches cover
   the per-span record path, but nothing measured the *report assembly* phase
   where #328 actually lived.

## What

### Part A — one report, always fully computed
- New `Report::finalize()` seam produces a **public** `FinalizedReport`
  (+ `FinalizedOperation`) that resolves every operation's complete statistics
  (slope **and** interval) exactly once. Both sinks — the stdout summary and the
  JSON output — render from this single value. `Session::drop` finalizes once and
  feeds each enabled sink; there is no separate cheap path anymore.
- The human table still shows only the slope column, but that is now purely a
  **display choice** — the interval is computed regardless of which output (if
  any) consumes it.
- `FinalizedReport::write_to_directory` is now **public** (symmetric with the
  public `finalize`/`FinalizedReport`) so the write phase has a clean,
  temp-dir-friendly seam; `write_to_target` stays internal.
- lib.rs prose in both crates updated to reflect the always-computed interval.

### Part B — full lifecycle benchmark coverage
- New `all_the_time_report_lifecycle` and `alloc_tracker_report_lifecycle`
  benches cover **setup → snapshot → merge → finalization → render → JSON write**.
- Each stage is measured **simultaneously** for all three cost dimensions:
  wall-clock (Criterion), allocations (`alloc_tracker`) and processor time
  (`all_the_time`), via an **allowed dev-dependency-only cycle** between the two
  crates (precedent: `nm ⇄ nm_impl`).
- Finalization is scaled by operation count (`ops_10`, `ops_100`) so any
  regression to super-linear / retained-span work surfaces immediately. Local
  smoke run confirms ~linear scaling (e.g. finalize proc-time 720ns → 9.5µs for
  10× ops; allocations 11 → 102).

## API surface (please veto if unwanted)

This makes three items public in **each** crate: `Report::finalize()`,
`FinalizedReport`, `FinalizedOperation`, and `FinalizedReport::write_to_directory`.
They give benchmarks a clean seam and are genuinely useful ("the full report
without doing I/O"). Nothing was removed — `Report`, `to_report`,
`print_to_stdout`, `merge`, `operations`, `statistics`, `is_empty`, `Display` are
all unchanged.

## Validation

`just package="all_the_time alloc_tracker" validate-local` — green
(format-check, check, clippy `--all-targets`, test, test-docs, docs, miri,
machete, default-features-check, mutants). Mutation testing: **226 mutants, 194
caught, 32 unviable, 0 missed**; the new `finalized.rs` logic is fully covered
(28 caught, 4 unviable). Both lifecycle benches smoke-run under a bounded budget
and emit all three metric sets.
