### PR TITLE
Isolate mock_bench_engine build into a dedicated target dir

### DIFF
--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -13,10 +13,12 @@ coverage-measure:
     cargo +{{ env_var('RUST_NIGHTLY') }} llvm-cov clean --workspace
 
     # Pre-build the mock benchmark engine once and hand each per-test process its path via
-    # MOCK_BENCH_ENGINE. nextest runs every test in its own process, so without this each
-    # cargo-bench-history integration test would build the engine on demand and those
-    # concurrent `cargo build` invocations would race over the shared coverage target tree
-    # (observed as transient "No such file or directory" engine-spawn failures on macOS).
+    # MOCK_BENCH_ENGINE. nextest runs every test in its own process, so this spares each
+    # cargo-bench-history integration test a redundant on-demand Cargo freshness check. The
+    # engine builds into its own dedicated target directory (see `_mock-engine-path`), so
+    # neither this pre-build nor any residual on-demand build relinks a binary out of the
+    # shared coverage tree while another test is spawning it — the transient "No such file or
+    # directory" engine-spawn races previously seen on macOS (issue #332).
     $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
 
     # This will run tests and generate test coverage data files, to be analyzed separately.

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -172,13 +172,24 @@ test-scripts:
 # Cargo does not expose it via CARGO_BIN_EXE_* to the tests. The tests build and locate
 # it on demand, but a test runner can call this once up front and pass the path via
 # MOCK_BENCH_ENGINE so each per-test process skips a redundant Cargo freshness check.
+#
+# The build targets a dedicated `<target>/mock-engine` directory rather than the shared
+# workspace `target/` tree (matching the Rust-side `engine_target_dir`). Cargo relinks a
+# binary by unlinking it and hard-linking the replacement, so on the shared tree a
+# concurrent build could momentarily leave the engine absent under a test that is spawning
+# it; its own tree means only builds aimed here touch the file, closing that race (#332).
 [group('testing')]
 [script]
 _mock-engine-path:
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    $messages = cargo +$env:RUST_MSRV build -p mock_bench_engine --message-format=json-render-diagnostics --locked
+    # Nest under the ambient CARGO_TARGET_DIR (e.g. a coverage run's tree) when set, else the
+    # workspace `target/`, so the isolated tree stays git-ignored and cached like everything
+    # else. The Rust resolver derives the same path, so a pre-built MOCK_BENCH_ENGINE and an
+    # on-demand build resolve to the very same isolated binary.
+    $engineTargetDir = Join-Path ($env:CARGO_TARGET_DIR ?? "target") "mock-engine"
+    $messages = cargo +$env:RUST_MSRV build -p mock_bench_engine --target-dir $engineTargetDir --message-format=json-render-diagnostics --locked
     $exe = $messages |
         ForEach-Object {
             # Tolerate non-JSON lines (e.g. rendered diagnostics or blank lines), just

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -134,15 +134,27 @@ fn run_cargo_build() -> BuildOutput {
 /// `MOCK_BENCH_ENGINE` and an on-demand build resolve to the very same isolated binary. The
 /// ambient value is taken as a parameter (rather than read here) so the mapping stays
 /// unit-testable without mutating process-wide environment.
+///
+/// A *relative* ambient `CARGO_TARGET_DIR` is absolutized against the workspace root rather
+/// than the process working directory. The result is handed to `cargo build` as
+/// `--target-dir`, and some callers change the working directory before first touching the
+/// engine, so a cwd-relative value would otherwise send the build to an unexpected tree —
+/// the same reason the harvester absolutizes `CARGO_TARGET_DIR` (see
+/// `cargo-bench-history`'s `commands::collect::target_root_from`).
 fn engine_target_dir(ambient_target_dir: Option<OsString>) -> PathBuf {
+    // The workspace root, two levels above this crate's own manifest
+    // (`<root>/packages/mock_bench_engine`).
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
     let base = ambient_target_dir.map_or_else(
-        || {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("..")
-                .join("..")
-                .join("target")
+        || workspace_root.join("target"),
+        |configured| {
+            let configured = PathBuf::from(configured);
+            if configured.is_absolute() {
+                configured
+            } else {
+                workspace_root.join(configured)
+            }
         },
-        PathBuf::from,
     );
     base.join("mock-engine")
 }
@@ -310,11 +322,26 @@ mod tests {
     }
 
     #[test]
-    fn engine_target_dir_nests_under_an_ambient_target_dir() {
-        // A configured `CARGO_TARGET_DIR` (e.g. a coverage run) is honored as the base, so
-        // the isolated tree stays inside whatever tree the rest of the build uses.
-        let dir = engine_target_dir(Some(OsString::from("/some/custom/target")));
-        assert_eq!(dir, Path::new("/some/custom/target").join("mock-engine"));
+    fn engine_target_dir_uses_an_absolute_ambient_target_dir_as_is() {
+        // An absolute `CARGO_TARGET_DIR` (the normal case, e.g. a coverage run) is honored
+        // verbatim as the base, so the isolated tree stays inside that tree.
+        let ambient = Path::new(env!("CARGO_MANIFEST_DIR")).join("custom-target");
+        assert!(ambient.is_absolute());
+        let dir = engine_target_dir(Some(ambient.clone().into_os_string()));
+        assert_eq!(dir, ambient.join("mock-engine"));
+    }
+
+    #[test]
+    fn engine_target_dir_absolutizes_a_relative_ambient_target_dir_against_the_workspace() {
+        // A relative `CARGO_TARGET_DIR` is resolved against the workspace root, not the
+        // process working directory, so a later `--chdir` cannot redirect the build.
+        let dir = engine_target_dir(Some(OsString::from("rel-target")));
+        let expected = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("rel-target")
+            .join("mock-engine");
+        assert_eq!(dir, expected);
     }
 
     #[test]
@@ -322,13 +349,15 @@ mod tests {
         // With no override it anchors at the workspace `target/`, addressed absolutely from
         // this crate's manifest so it does not depend on the current working directory.
         let dir = engine_target_dir(None);
+        let expected = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("mock-engine");
+        assert_eq!(dir, expected);
         assert!(
             dir.is_absolute(),
             "the default target dir should be absolute: {dir:?}"
-        );
-        assert!(
-            dir.ends_with(Path::new("target").join("mock-engine")),
-            "the default should nest under the workspace target: {dir:?}"
         );
     }
 

--- a/packages/mock_bench_engine/src/lib.rs
+++ b/packages/mock_bench_engine/src/lib.rs
@@ -93,6 +93,17 @@ fn run_cargo_build() -> BuildOutput {
     // change before first touching the engine. `--locked` matches the
     // `just _mock-engine-path` recipe and refuses to silently rewrite the lockfile.
     let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    // Build into a dedicated target directory (see `engine_target_dir`) instead of the
+    // shared workspace `target/` tree. Cargo swaps a binary into place by unlinking the old
+    // file and then hard-linking the new one, so anything that stats the path during that
+    // window observes it momentarily absent. On the shared tree any concurrent cargo
+    // invocation — the outer test harness, a sibling test thread, another test process —
+    // can open that window under our build. Giving the engine its own tree means only builds
+    // that target *this* directory ever touch the file, and Cargo's per-directory build lock
+    // serialises those, so no reader is exposed to a partial state: not this crate's own
+    // build-seam tests, not `binary_path`, and not the integration tests that spawn the
+    // resolved binary (issue #332).
+    let target_dir = engine_target_dir(std::env::var_os("CARGO_TARGET_DIR"));
     let output = std::process::Command::new(env!("CARGO"))
         .args([
             "build",
@@ -101,6 +112,8 @@ fn run_cargo_build() -> BuildOutput {
             "--manifest-path",
         ])
         .arg(&manifest_path)
+        .arg("--target-dir")
+        .arg(&target_dir)
         .output()
         .expect("spawning `cargo build` for mock_bench_engine should succeed");
     BuildOutput {
@@ -109,6 +122,29 @@ fn run_cargo_build() -> BuildOutput {
         stdout: output.stdout,
         stderr: output.stderr,
     }
+}
+
+/// The dedicated target directory the on-demand `cargo build` writes into, isolating the
+/// engine binary from the shared workspace `target/` tree (see [`run_cargo_build`] for why).
+///
+/// It nests under the active target directory — the ambient `CARGO_TARGET_DIR` when one is
+/// set (as coverage runs do), otherwise the workspace `target/` — so it stays git-ignored,
+/// is cached in CI alongside everything else, and is removed by `cargo clean`. The
+/// `just _mock-engine-path` recipe passes the same `--target-dir`, so a pre-built
+/// `MOCK_BENCH_ENGINE` and an on-demand build resolve to the very same isolated binary. The
+/// ambient value is taken as a parameter (rather than read here) so the mapping stays
+/// unit-testable without mutating process-wide environment.
+fn engine_target_dir(ambient_target_dir: Option<OsString>) -> PathBuf {
+    let base = ambient_target_dir.map_or_else(
+        || {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("..")
+                .join("target")
+        },
+        PathBuf::from,
+    );
+    base.join("mock-engine")
 }
 
 /// Reads the built binary's path from Cargo's JSON build output, panicking with the
@@ -271,6 +307,29 @@ mod tests {
             ok_build(artifact_line("mock_bench_engine", "/tmp/mock_bench_engine"))
         });
         assert_eq!(resolved, "/tmp/mock_bench_engine");
+    }
+
+    #[test]
+    fn engine_target_dir_nests_under_an_ambient_target_dir() {
+        // A configured `CARGO_TARGET_DIR` (e.g. a coverage run) is honored as the base, so
+        // the isolated tree stays inside whatever tree the rest of the build uses.
+        let dir = engine_target_dir(Some(OsString::from("/some/custom/target")));
+        assert_eq!(dir, Path::new("/some/custom/target").join("mock-engine"));
+    }
+
+    #[test]
+    fn engine_target_dir_defaults_under_the_workspace_target() {
+        // With no override it anchors at the workspace `target/`, addressed absolutely from
+        // this crate's manifest so it does not depend on the current working directory.
+        let dir = engine_target_dir(None);
+        assert!(
+            dir.is_absolute(),
+            "the default target dir should be absolute: {dir:?}"
+        );
+        assert!(
+            dir.ends_with(Path::new("target").join("mock-engine")),
+            "the default should nest under the workspace target: {dir:?}"
+        );
     }
 
     // The remaining cases consult the filesystem (`Path::is_file`), which Miri's


### PR DESCRIPTION
## Summary

Fixes #332 — the flaky `mock_bench_engine` build-seam test (and the whole class of shared-`target/`-tree relink races it belongs to).

Cargo replaces a binary non-atomically: it unlinks the old file, then re-creates it (hard-link, or copy on some platforms). During that gap the path momentarily does not exist. On the shared `target/debug` tree that one path is a public crossroads — the workspace-wide `cargo test`/`llvm-cov` build, the `_mock-engine-path` pre-build, every on-demand `run_cargo_build`, and every integration test that spawns the resolved binary all touch it, with differing build configs that keep forcing relinks. When an unsynchronised reader `stat`s/`exec`s the path inside an unlink gap, it observes it absent:

- `tests::run_cargo_build_reports_an_existing_executable` / `binary_path_returns_an_existing_absolute_file` see `is_file() == false` (the reported flake), and
- integration tests spawning the engine hit transient "No such file or directory".

The `MOCK_BENCH_ENGINE` pre-build only partly mitigated this, because the build-seam test runs a real `cargo build` regardless and relinks the same shared path.

## Fix

Give the mock-engine build its own dedicated target directory so no unrelated cargo invocation ever relinks it, and cargo's per-directory build lock serialises the mock-engine builds against each other:

- `run_cargo_build` passes `--target-dir` at `<target>/mock-engine`, computed by a new unit-tested `engine_target_dir` helper that nests under the ambient `CARGO_TARGET_DIR` (e.g. coverage runs) or the workspace `target/` otherwise.
- `_mock-engine-path` builds into the same `<target>/mock-engine`, so a pre-built `MOCK_BENCH_ENGINE` and an on-demand build resolve to the very same isolated binary.
- Updated the `coverage-measure` and recipe comments to reflect that isolation (not just pre-building) is what closes the race.

The dir stays under `target/` → git-ignored, CI-cached, and cleaned by `cargo clean`.

## Validation

- `cargo test -p mock_bench_engine`: 15/15 pass (incl. the two new `engine_target_dir` tests and the real-build test now targeting the isolated dir).
- Recipe verified building to `target/mock-engine/…`, and nesting under `CARGO_TARGET_DIR` when set (coverage scenario).
- `cargo-bench-history` collect integration tests: 105/105 pass (mock-engine spawns + real-engine e2e).
- clippy `-D warnings` clean; format-check clean.
- `just package="mock_bench_engine" validate-local` (full CI mirror incl. Miri, machete, default-features-check) exits 0.
