### PR TITLE
Make regression issue report blocks nicer

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -258,7 +258,7 @@ jobs:
           **Issue lifecycle**
 
           - Filed and refreshed automatically by the `bench-history` workflow; the body always reflects the latest `main` run that still had findings.
-          - A run that finds nothing leaves it untouched: the issue is **never** closed automatically.
+          - A run that finds nothing leaves it untouched; the issue is **never** closed automatically.
           - Closing it by hand does **not** accept the regression. A closed issue is never reopened; instead, the next run that still finds the regression files a new one.
 
           **What do I do?**

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -258,7 +258,7 @@ jobs:
           **Issue lifecycle**
 
           - Filed and refreshed automatically by the `bench-history` workflow; the body always reflects the latest `main` run that still had findings.
-          - A run that finds nothing leaves it untouched — the issue is **never** closed automatically.
+          - A run that finds nothing leaves it untouched: the issue is **never** closed automatically.
           - Closing it by hand does **not** accept the regression. A closed issue is never reopened; instead, the next run that still finds the regression files a new one.
 
           **What do I do?**
@@ -269,8 +269,8 @@ jobs:
 
           Then decide what the change is:
 
-          - **An intentional tradeoff** — accept it by blessing the affected benchmarks at the named commit, e.g. `cargo bench-history bless <benchmark-id-prefix> --context <commit>` (or `cargo bench-history bless --all --context <commit>` to accept every benchmark at that commit), then close the issue.
-          - **A defect to fix** — fix it as usual. A fixed finding self-clears on its own several runs after the fix, even without a blessing. This is **not** immediate: clearing it needs statistical evidence from multiple post-fix runs.
+          - **An intentional tradeoff**: accept it by blessing the affected benchmarks at the named commit, e.g. `cargo bench-history bless <benchmark-id-prefix> --context <commit>` (or `cargo bench-history bless --all --context <commit>` to accept every benchmark at that commit), then close the issue.
+          - **A defect to fix**: fix it as usual. A fixed finding self-clears on its own several runs after the fix, even without a blessing. This is **not** immediate: clearing it needs statistical evidence from multiple post-fix runs.
           '@
 
           $parts = @(
@@ -377,5 +377,5 @@ jobs:
           }
           foreach ($issue in $matching) {
             Write-Host "Closing #$($issue.number)"
-            gh issue close $issue.number --reason completed --comment "✅ The bench-history workflow is green again — auto-closing this alert. Successful run: $env:RUN_URL"
+            gh issue close $issue.number --reason completed --comment "✅ The bench-history workflow is green again. Auto-closing this alert. Successful run: $env:RUN_URL"
           }

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -381,11 +381,16 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
     finish(&lines)
 }
 
-/// Appends one finding as a paragraph: a leading, direction-colored percentage
-/// headline, a dimmed detail line, an optional blessing/recovery note, and — in
-/// history mode — a chart of the metric over commits.
+/// Appends one finding as a paragraph: the benchmark id on its own line as a
+/// chapter title, then a direction-colored `percentage metric (confidence)`
+/// headline, a dimmed detail line, an optional blessing/recovery note, and (in
+/// history mode) a chart of the metric over commits.
 fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled: bool) {
     lines.push(String::new());
+
+    // Lead with the benchmark id on its own line, like a chapter title: some ids are
+    // long, so a dedicated line keeps the change headline that follows readable.
+    lines.push(describe_id(&finding.id).bold().to_string());
 
     let percent = format_percent(finding.relative_delta);
     let headline = match finding.direction {
@@ -398,9 +403,9 @@ fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled:
         format!(" {}", "(recovered)".dimmed())
     };
     lines.push(format!(
-        "{headline}  {} · {}{status}",
-        describe_id(&finding.id).bold(),
-        finding.kind.as_str()
+        "  {headline} {} ({} confidence){status}",
+        finding.kind.as_str(),
+        format_confidence(finding.confidence),
     ));
 
     lines.push(format!("    {}", detail_text(finding)).dimmed().to_string());
@@ -453,15 +458,14 @@ fn runs_with_span(runs: usize, span: Option<(&str, &str)>) -> String {
 }
 
 /// The plain-text detail body shared by the text and Markdown reports: the
-/// direction, detector, confidence, the `baseline → latest` move, the attributed
-/// commit, and — when located — the flip/recovery commit. Carries no styling and no
-/// leading indent; each format applies its own.
+/// direction, detector, the `baseline → latest` move, the attributed commit, and
+/// (when located) the flip/recovery commit. Confidence rides on the headline line
+/// instead. Carries no styling and no leading indent; each format applies its own.
 fn detail_text(finding: &Finding) -> String {
     let mut detail = format!(
-        "{} via {} · {} confidence · {} → {} · @ {}",
+        "{} via {} · {} → {} · @ {}",
         direction_label(finding.direction),
         method_label(finding.method),
-        format_confidence(finding.confidence),
         format_value(finding.baseline),
         format_value(finding.latest),
         finding.commit.as_deref().unwrap_or("unknown"),
@@ -624,7 +628,7 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
             ));
         }
         for finding in &summary.findings {
-            push_finding_markdown(&mut lines, finding, chart_enabled);
+            push_finding_markdown(&mut lines, finding, "###", chart_enabled);
         }
     }
     push_warning(&mut lines, input.warning);
@@ -696,18 +700,29 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -
     // reports; branch/tip modes compare against a baseline.
     let chart_enabled = input.mode == "history";
     for finding in input.findings.iter().take(limit.get()) {
-        push_finding_markdown(&mut lines, finding, chart_enabled);
+        push_finding_markdown(&mut lines, finding, "##", chart_enabled);
     }
     push_warning(&mut lines, input.warning);
     finish(&lines)
 }
 
-/// Appends one finding as a Markdown block mirroring the text report: a bold
-/// percentage headline naming the benchmark and metric, the shared detail line, an
-/// optional blessing note, and — in history mode — the metric chart in a fenced
-/// `text` block so it survives Markdown rendering.
-fn push_finding_markdown(lines: &mut Vec<String>, finding: &Finding, chart_enabled: bool) {
+/// Appends one finding as a Markdown block mirroring the text report: the benchmark
+/// id as a `heading` (a chapter title), then a bold `percentage metric (confidence)`
+/// line, the shared detail line, an optional blessing note, and (in history mode) the
+/// metric chart in a fenced `text` block so it survives Markdown rendering. `heading`
+/// carries the ATX prefix (`##`/`###`) so the block nests correctly — top-level in the
+/// summary, one level under the set heading in the full report.
+fn push_finding_markdown(
+    lines: &mut Vec<String>,
+    finding: &Finding,
+    heading: &str,
+    chart_enabled: bool,
+) {
     lines.push(String::new());
+
+    // The benchmark id is a heading of its own, so a long id reads as a chapter title
+    // rather than crowding the change headline that follows.
+    lines.push(format!("{heading} `{}`", describe_id(&finding.id)));
 
     let status = if finding.active {
         String::new()
@@ -715,10 +730,10 @@ fn push_finding_markdown(lines: &mut Vec<String>, finding: &Finding, chart_enabl
         " _(recovered)_".to_owned()
     };
     lines.push(format!(
-        "**{}** — `{}` · `{}`{status}",
+        "**{}** `{}` ({} confidence){status}",
         format_percent(finding.relative_delta),
-        describe_id(&finding.id),
         finding.kind.as_str(),
+        format_confidence(finding.confidence),
     ));
 
     lines.push(String::new());
@@ -1170,14 +1185,19 @@ mod tests {
         // The percentage leads the finding paragraph; severity is gone.
         assert!(report.contains("+30.00%"), "{report}");
         assert!(!report.contains("[major]"), "{report}");
+        // The benchmark id leads on its own chapter-title line; the change headline
+        // that follows carries the metric and confidence, no longer the id.
+        assert!(report.contains("nm/nm::observe/pull"), "{report}");
         assert!(
-            report.contains("nm/nm::observe/pull · instruction_count"),
+            report.contains("+30.00% instruction_count (100% confidence)"),
             "{report}"
         );
+        // Confidence rides on the headline now, so the detail line drops it.
         assert!(
-            report.contains("regression via change point · 100% confidence · 100 → 130"),
+            report.contains("regression via change point · 100 → 130"),
             "{report}"
         );
+        assert!(!report.contains("100% confidence · 100"), "{report}");
     }
 
     #[test]
@@ -1322,18 +1342,25 @@ mod tests {
         );
         // The per-set tally mirrors the JSON metadata and the text header.
         assert!(report.contains("- Regressions: 1"), "{report}");
-        // Findings render as bold-headline blocks, not a table.
+        // Findings render as heading + bold-headline blocks, not a table.
         assert!(!report.contains("| Change | Direction |"), "{report}");
+        // The benchmark id is its own heading, nested one level under the set heading
+        // (`##`), so it reads as a chapter title; the change headline follows.
+        assert!(report.contains("### `nm/nm::observe/pull`"), "{report}");
         assert!(
-            report.contains("**+30.00%** — `nm/nm::observe/pull` · `instruction_count`"),
+            report.contains("**+30.00%** `instruction_count` (100% confidence)"),
             "{report}"
         );
+        // The old inline em-dash headline is gone.
+        assert!(!report.contains("—"), "{report}");
         // An active finding carries no recovered suffix.
         assert!(!report.contains("_(recovered)_"), "{report}");
+        // Confidence rides on the headline now, so the detail line drops it.
         assert!(
-            report.contains("regression via change point · 100% confidence · 100 → 130"),
+            report.contains("regression via change point · 100 → 130"),
             "{report}"
         );
+        assert!(!report.contains("100% confidence · 100"), "{report}");
     }
 
     #[test]
@@ -1349,7 +1376,7 @@ mod tests {
         // The headline suffix flags a recovered finding; the shared detail line names
         // the recovery commit.
         assert!(
-            report.contains("· `instruction_count` _(recovered)_"),
+            report.contains("`instruction_count` (100% confidence) _(recovered)_"),
             "{report}"
         );
         assert!(report.contains("recovers at c4"), "{report}");
@@ -1987,10 +2014,16 @@ mod tests {
         // The metric name is a keyword-like identifier, so Markdown renders it as inline
         // code (backticks) rather than bare prose. The text report carries no such markup.
         let markdown = render(&input, ReportFormat::Markdown, false);
-        assert!(markdown.contains("· `instruction_count`"), "{markdown}");
+        assert!(
+            markdown.contains("`instruction_count` (100% confidence)"),
+            "{markdown}"
+        );
 
         let text = render(&input, ReportFormat::Text, false);
-        assert!(text.contains("· instruction_count"), "{text}");
+        assert!(
+            text.contains("instruction_count (100% confidence)"),
+            "{text}"
+        );
         assert!(!text.contains("`instruction_count`"), "{text}");
     }
 }

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -705,11 +705,13 @@ The three report formats carry the **same data** and differ only in presentation
 layout is canonical. Each report names the **analyzed tip commit** — the commit whose line
 of history the findings describe — annotated `+ uncommitted changes` when the working tree
 was dirty, so a reader (or the auto-filed regression issue) can tie the report to an exact
-commit. Text goes to stdout as one paragraph per finding (a
-direction-coloured headline leading with the relative-change percent, a dimmed detail line,
-and — in history mode only — a small line chart of the series), with colour enabled only
+commit. Text goes to stdout as one paragraph per finding — the benchmark id on its own
+line as a chapter title, then a direction-coloured headline pairing the relative-change
+percent with the metric and its confidence, a dimmed detail line, and (in history mode
+only) a small line chart of the series — with colour enabled only
 when stdout is a terminal and not disabled by environment. Markdown is that data with
-Markdown formatting (per-finding blocks, not a table; charts as fenced code blocks without
+Markdown formatting (the id as a heading with the per-finding block nested beneath it, not
+a table; charts as fenced code blocks without
 ANSI). JSON is the machine-readable form: a flat, globally-ranked findings list where each
 finding is **self-describing** (it inlines its discriminant set and benchmark segments), so
 findings are never duplicated under the per-set breakdown, which carries only identity and

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -126,11 +126,12 @@ async fn analyze_markdown_output_renders_blocks() {
     // The header names the analyzed tip commit so the reader knows which commit the
     // findings describe.
     assert!(report.contains("- Commit: "), "{report}");
-    // A bold percentage headline leads each finding block; there is no table.
+    // Findings render as heading + bold-headline blocks; there is no table.
     assert!(!report.contains("| Change | Direction |"), "{report}");
-    // The headline format is a bold signed percentage joined to the benchmark id —
-    // far more specific than a bare `**` that any unrelated bold text would match.
-    assert!(report.contains("%** — `"), "{report}");
+    // Each finding leads with its benchmark id as a `###` chapter title (nested under
+    // the set `##`), then a bold percentage headline carrying the confidence.
+    assert!(report.contains("\n### `"), "{report}");
+    assert!(report.contains("% confidence)"), "{report}");
     assert!(report.contains("via change point"), "{report}");
 }
 
@@ -187,9 +188,11 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
         summary.contains("# Benchmark history analysis: testproj"),
         "{summary}"
     );
-    // The condensed report leads each finding with the same bold-percentage headline
-    // the full report uses.
-    assert!(summary.contains("%** — `"), "{summary}");
+    // Each finding leads with its benchmark id as a `##` chapter title, then a bold
+    // percentage headline carrying the confidence — the same block the full report
+    // uses, one heading level up.
+    assert!(summary.contains("\n## `"), "{summary}");
+    assert!(summary.contains("% confidence)"), "{summary}");
     // A single seeded regression is well within the top-20 cap, so no truncation note
     // is added.
     assert!(
@@ -197,9 +200,9 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
         "an untruncated summary must not claim it is partial: {summary}"
     );
     // The per-set `## engine/triple/machine` grouping is deliberately dropped from the
-    // summary, unlike the full Markdown report.
+    // summary, unlike the full Markdown report; only the flat finding headings remain.
     assert!(
-        !summary.contains("\n## "),
+        !summary.contains("## callgrind"),
         "the summary must be flat, without per-set headings: {summary}"
     );
 }
@@ -244,14 +247,15 @@ async fn analyze_markdown_summary_caps_findings_and_names_the_total() {
         summary.contains("Showing the top 20 of 25 findings by magnitude."),
         "{summary}"
     );
-    // Exactly the cap of finding headlines survives in the summary.
-    let summary_blocks = summary.matches("%** — `").count();
+    // Exactly the cap of finding headlines survives in the summary. Each finding
+    // headline carries the confidence, which appears nowhere else, so it counts blocks.
+    let summary_blocks = summary.matches("% confidence)").count();
     assert_eq!(
         summary_blocks, 20,
         "summary should keep only the cap: {summary}"
     );
     // The full report from the same run still lists every finding.
-    let full_blocks = full.matches("%** — `").count();
+    let full_blocks = full.matches("% confidence)").count();
     assert_eq!(
         full_blocks, 25,
         "full report should keep every finding: {full}"


### PR DESCRIPTION
## Summary

Makes the auto-filed **"Benchmark regressions detected"** issue nicer looking. The
issue body comes from the Markdown-summary rendering of `analyze`, so this reshapes the
per-finding blocks there — and keeps the text (canonical) and full Markdown renderings
in lockstep.

## Changes

- **Drop the em dashes** (`—`) from finding output. They were "all over the place" (one
  per finding) and ugly.
- **Benchmark id becomes a chapter-title heading** on its own line, so long ids stay
  readable instead of crowding the headline:
  - Markdown summary/issue: `## \`id\``
  - Full Markdown report: `### \`id\`` (nested under the set `##`)
  - Text: a bold line
- **Compact change headline** follows: `**+X%** \`metric\` (Y% confidence)`. Confidence
  moves up from the shared detail line (no longer duplicated).
- Update `docs/DESIGN.md` §8.7 to describe the new block shape.

### Before

```
**+100.00%** — `async_poll_ready/events_listener/Event (listener!)` · `allocated_bytes`

increased via change-point · 100% confidence · 100 → 200 · @ abc123
```

### After

```
## `async_poll_ready/events_listener/Event (listener!)`
**+100.00%** `allocated_bytes` (100% confidence)

increased via change-point · 100 → 200 · @ abc123
```

## Validation

- `just package="cargo-bench-history-core cargo-bench-history" validate-local` — all steps
  green (format-check, check/clippy dev+release, test, test-docs, docs,
  docs-default-features, miri, machete, default-features-check).
- Targeted mutation testing on `analyze/report.rs`: 86 caught, 5 unviable, **0 missed**.
