### PR TITLE
Relax workflow timeouts for cold-cache setup-environment

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -126,9 +126,9 @@ jobs:
     needs: collect
     if: always() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Analysis loads the whole store and reduces it; generous like collect, though it is
-    # far faster than benchmarking.
-    timeout-minutes: 60
+    # Analysis loads the whole store and reduces it; far faster than benchmarking, but the cap
+    # must still clear a cold-cache setup-environment (up to ~90 min) on top of the analysis.
+    timeout-minutes: 150
 
     # id-token to self-federate with Entra (reads the history; see collect's note),
     # contents for checkout, issues to file the rolling regression issue.

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -16,7 +16,9 @@ jobs:
         platform: [ubuntu-latest, windows-latest, macos-latest, ubuntu-24.04-arm, windows-11-arm]
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 90
+    # This job's whole purpose is the cold-cache setup-environment, which can take up to
+    # ~90 min; keep margin over that so a slightly-slower-than-usual warmup is not killed.
+    timeout-minutes: 120
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -123,3 +123,17 @@ deviating from it to hand-pick a minimal per-job toolchain costs more in mainten
 the mostly-cached setup time it would save. Toolchain versions are defined once in
 `constants.env` and `rust-toolchain.toml` and reach the workflows through the `just`
 commands they call, so no version is ever duplicated into a workflow file.
+
+## Job timeouts
+
+Every job that runs `setup-environment` must budget for a *cold* cache. When the shared
+dependency and toolchain caches miss — the warmup workflow lapses, a runner image rolls, or a
+version pin changes — that step recompiles everything from scratch and can take up to ~90
+minutes (which is why the warmup job, whose only work *is* that setup, is itself capped
+generously). A job-level `timeout-minutes` bounds the whole job, setup included, so any
+explicit cap is sized as the job's own work budget *plus* that ~90-minute cold-setup
+allowance; sizing a cap to the warm-cache setup time alone would make a cache miss spuriously
+fail the job. Jobs whose work is comfortably bounded carry no explicit cap and rely on
+GitHub's default ceiling, which already clears a cold setup with room to spare. Explicit caps
+exist only to stop a genuinely stuck run, never to bound the expected duration.
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,9 @@ jobs:
     if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Generous ceiling: covers up to 3 publish attempts (release-plz publish_timeout is
-    # 45m) with 15-minute waits between retries, comfortably under this cap.
-    timeout-minutes: 180
+    # 45m) with 15-minute waits between retries (~165m), plus up to 90 min for a cold-cache
+    # setup-environment, comfortably under this cap.
+    timeout-minutes: 270
 
     permissions:
       # release-plz pushes the git tags and creates the GitHub releases.
@@ -82,7 +83,9 @@ jobs:
     needs: publish
     if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Fast reconcile work plus up to 90 min for a cold-cache setup-environment — which itself
+    # timed out the previous 30-minute cap on a cache miss.
+    timeout-minutes: 120
 
     permissions:
       # `gh release view` reads releases; checkout needs read.
@@ -119,7 +122,8 @@ jobs:
         # One entry per missing (crate, target) pair: {name, version, tag, triple, os}.
         include: ${{ fromJSON(needs.plan-binaries.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    # Release build/package/upload budget plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 150
 
     permissions:
       # Upload the archive + checksum as assets on the crate's release.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -431,7 +431,8 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
-    timeout-minutes: 90
+    # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     runs-on: windows-latest
 
     steps:
@@ -453,7 +454,8 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
-    timeout-minutes: 90
+    # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     runs-on: windows-latest
 
     steps:
@@ -475,7 +477,8 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/2, 2/2]
-    timeout-minutes: 90
+    # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     runs-on: windows-latest
 
     steps:
@@ -497,7 +500,8 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1/2, 2/2]
-    timeout-minutes: 90
+    # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     runs-on: windows-latest
 
     steps:
@@ -620,7 +624,8 @@ jobs:
   mutants:
     needs: [delta, test-x64]
     if: needs.delta.outputs.skip_all != 'true'
-    timeout-minutes: 90
+    # Sharded mutation-testing work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -642,7 +647,8 @@ jobs:
   run-examples:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
-    timeout-minutes: 90
+    # Work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -663,7 +669,8 @@ jobs:
   hack:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
-    timeout-minutes: 90
+    # Work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

A recent Release workflow run failed: the `plan-binaries` job's **Setup environment** step timed out after 30 minutes. `setup-environment` is usually quick, but on a *cold* cache (warmup lapse, runner-image roll, or a toolchain/version-pin change) it recompiles everything from scratch and can take up to ~90 minutes — more than that job's 30-minute cap.

## Change

Every job that runs `setup-environment` now budgets for a cold cache: its explicit `timeout-minutes` is sized as the job's own work budget **plus** the ~90-minute cold-setup allowance. A job-level timeout bounds the whole job (setup included), so a cap sized only for warm-cache setup makes a cache miss spuriously fail.

| Workflow | Job | Before → After |
|---|---|---|
| release | `plan-binaries` (the failure) | 30 → 120 |
| release | `build-binaries` | 60 → 150 |
| release | `publish` | 180 → 270 |
| bench-history | `analyze` | 60 → 150 |
| cache-warmup | `warmup` | 90 → 120 |
| validation | `miri-harder-*` (×4), `mutants`, `run-examples`, `hack` | 90 → 180 |

## Deliberately unchanged

- `alert` / `resolve` jobs (10 min) — they skip `setup-environment` (checkout + `gh` only, or no checkout).
- `collect` (360 min) — already a generous stuck-run ceiling.
- ~20 jobs with no explicit cap — they inherit GitHub's 360-minute default, which clears a cold setup with room to spare.

Step-level and workflow-level timeouts are not applicable (no step-level timeouts exist; composite-action steps can't carry one, and GitHub has no workflow-level timeout).

## Docs

Added a **"Job timeouts"** section to `.github/workflows/design.md` capturing the cross-cutting rationale, plus concise inline comments on each changed cap.

Validated with `just validate-workflows` (actionlint, green).
