### PR TITLE
Attach discriminant-set filter flags to analyze reports

### DIFF
--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -290,6 +290,17 @@ fn set_label(set: &DiscriminantSet) -> String {
     set.to_string()
 }
 
+/// The `analyze` facet flags that select exactly this discriminant set, ready to
+/// paste into a follow-up query. Naming every facet explicitly pins the one set, so a
+/// reader who spots a finding can drill into that partition without having to guess
+/// which engine / triple / machine it came from.
+fn set_filter_flags(set: &DiscriminantSet) -> String {
+    format!(
+        "--engine {} --target-triple {} --machine-key {}",
+        set.engine, set.target_triple, set.machine_key
+    )
+}
+
 /// The commit label shared by the text and Markdown headers: the analyzed tip
 /// commit, annotated `+ uncommitted changes` when the working tree carried
 /// uncommitted changes so a reader knows the analyzed checkout differed from the
@@ -373,6 +384,7 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
         lines.push(String::new());
         lines.push(set_label(summary.set));
         lines.push(set_counts_line(summary, input.report_improvements));
+        lines.push(format!("  filter: {}", set_filter_flags(summary.set)));
         for finding in &summary.findings {
             push_finding_block(&mut lines, finding, chart_enabled);
         }
@@ -627,6 +639,7 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
                 count_direction(&summary.findings, Direction::Improvement)
             ));
         }
+        lines.push(format!("- Filter: `{}`", set_filter_flags(summary.set)));
         for finding in &summary.findings {
             push_finding_markdown(&mut lines, finding, "###", chart_enabled);
         }
@@ -701,9 +714,21 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -
     let chart_enabled = input.mode == "history";
     for finding in input.findings.iter().take(limit.get()) {
         push_finding_markdown(&mut lines, finding, "##", chart_enabled);
+        push_set_filter_footer(&mut lines, &finding.set);
     }
     push_warning(&mut lines, input.warning);
     finish(&lines)
+}
+
+/// Appends the discriminant-set filter flags as a de-emphasized footer on a summary
+/// finding, after its chart. The summary drops the per-set grouping to stay within a
+/// downstream size cap, so without this a reader could not tell which partition a
+/// finding came from — or, when the same benchmark moved in several sets, tell the
+/// otherwise near-identical blocks apart. The flags trail the block rather than lead
+/// it because they are reference material for a follow-up query, not the headline.
+fn push_set_filter_footer(lines: &mut Vec<String>, set: &DiscriminantSet) {
+    lines.push(String::new());
+    lines.push(format!("_Filter:_ `{}`", set_filter_flags(set)));
 }
 
 /// Appends one finding as a Markdown block mirroring the text report: the benchmark
@@ -1083,6 +1108,68 @@ mod tests {
         assert!(report.contains("```text"), "{report}");
         assert!(report.contains('┤') || report.contains('┼'), "{report}");
         assert!(!report.contains('\u{1b}'), "{report}");
+        // The set-filter footer trails the fenced chart, not precedes it: it is
+        // reference material for a follow-up query, not the headline.
+        let chart_close = report.rfind("```").expect("fenced chart present");
+        let footer_at = report.find("_Filter:_").expect("filter footer present");
+        assert!(
+            footer_at > chart_close,
+            "the filter footer must follow the chart: {report}"
+        );
+    }
+
+    #[test]
+    fn markdown_summary_footers_each_finding_with_its_set_filter() {
+        // The summary drops the per-set grouping, so each finding carries the facet
+        // flags that isolate its partition as a trailing footer — enough to query that
+        // exact set without leading the block.
+        let findings = vec![named_regression("mover_a", 0.50)];
+        let input = flat_input(&findings);
+
+        let report = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
+
+        let footer = "_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`";
+        assert!(report.contains(footer), "{report}");
+        // The footer trails the finding headline rather than leading it.
+        let headline_at = report.find("mover_a").expect("headline present");
+        let footer_at = report.find(footer).expect("footer present");
+        assert!(
+            footer_at > headline_at,
+            "footer must follow the finding: {report}"
+        );
+    }
+
+    #[test]
+    fn markdown_summary_distinguishes_the_same_benchmark_across_sets() {
+        // The same benchmark id regresses in two discriminant sets. Without the set
+        // footer their flat summary blocks would be indistinguishable; with it, each
+        // names the filter that isolates its own partition.
+        let linux = named_regression("shared", 0.50);
+        let windows = Finding {
+            set: DiscriminantSet {
+                engine: "criterion".to_owned(),
+                target_triple: "x86_64-pc-windows-msvc".to_owned(),
+                machine_key: "m1".to_owned(),
+            },
+            ..named_regression("shared", 0.40)
+        };
+        let findings = vec![linux, windows];
+        let input = flat_input(&findings);
+
+        let report = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
+
+        assert!(
+            report.contains(
+                "--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic"
+            ),
+            "{report}"
+        );
+        assert!(
+            report.contains(
+                "--engine criterion --target-triple x86_64-pc-windows-msvc --machine-key m1"
+            ),
+            "{report}"
+        );
     }
 
     #[test]
@@ -1182,7 +1269,14 @@ mod tests {
             report.contains("callgrind/x86_64-unknown-linux-gnu/synthetic"),
             "the set heading drops the redundant `Set ` prefix: {report}"
         );
-        // The percentage leads the finding paragraph; severity is gone.
+        // The set header names the facet flags that reproduce exactly this partition,
+        // so a reader who spots a finding knows how to query it directly.
+        assert!(
+            report.contains(
+                "  filter: --engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic"
+            ),
+            "{report}"
+        );
         assert!(report.contains("+30.00%"), "{report}");
         assert!(!report.contains("[major]"), "{report}");
         // The benchmark id leads on its own chapter-title line; the change headline
@@ -1342,6 +1436,13 @@ mod tests {
         );
         // The per-set tally mirrors the JSON metadata and the text header.
         assert!(report.contains("- Regressions: 1"), "{report}");
+        // The set header names the facet flags that reproduce exactly this partition.
+        assert!(
+            report.contains(
+                "- Filter: `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`"
+            ),
+            "{report}"
+        );
         // Findings render as heading + bold-headline blocks, not a table.
         assert!(!report.contains("| Change | Direction |"), "{report}");
         // The benchmark id is its own heading, nested one level under the set heading

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -709,7 +709,10 @@ commit. Text goes to stdout as one paragraph per finding — the benchmark id on
 line as a chapter title, then a direction-coloured headline pairing the relative-change
 percent with the metric and its confidence, a dimmed detail line, and (in history mode
 only) a small line chart of the series — with colour enabled only
-when stdout is a terminal and not disabled by environment. Markdown is that data with
+when stdout is a terminal and not disabled by environment. The text and Markdown reports
+group findings under a per-set header, which also states the **facet-filter flags** that
+reproduce exactly that partition, so a reader who spots a change can drill into it without
+reconstructing the query by hand. Markdown is that data with
 Markdown formatting (the id as a heading with the per-finding block nested beneath it, not
 a table; charts as fenced code blocks without
 ANSI). JSON is the machine-readable form: a flat, globally-ranked findings list where each
@@ -725,7 +728,11 @@ Separate from those three canonical formats, `analyze` can also render a condens
 **summary** — a single derived view for a size-limited consumer. It reuses the Markdown
 finding blocks but keeps only the top findings by magnitude and drops the per-facet grouping,
 so it is deliberately **not** "same data": it is a lossy excerpt that names how many of the
-total it shows and leaves the full reports to be consulted separately. Because it exists to
+total it shows and leaves the full reports to be consulted separately. Because it drops the
+grouping, each retained finding instead carries its set's facet-filter flags as a trailing
+footer — reference material for a follow-up query rather than a headline — so the summary
+stays investigable and blocks for the same benchmark in different sets remain distinguishable.
+Because it exists to
 fit a downstream cap rather than to present the analysis, it is offered only by `analyze`,
 never by the enumerating commands, and the retained-count is a fixed policy of the renderer.
 

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -205,6 +205,14 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
         !summary.contains("## callgrind"),
         "the summary must be flat, without per-set headings: {summary}"
     );
+    // Each flat finding instead carries the facet flags of its partition as a footer,
+    // so a reader who loses the per-set grouping still knows how to query the exact set.
+    assert!(
+        summary.contains(
+            "_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`"
+        ),
+        "{summary}"
+    );
 }
 
 /// When an analysis produces more findings than the summary cap, `--markdown-summary`


### PR DESCRIPTION
## Problem

The condensed Markdown summary emitted by `cargo-bench-history analyze` no longer names the **discriminant set** (engine / target triple / machine) each finding belongs to. Dropping the per-set grouping keeps the summary within its downstream size cap, but it also means:

- A reader cannot tell **which facet filters** (`--engine` / `--target-triple` / `--machine-key`) to use to investigate a finding.
- When the **same benchmark regresses in multiple sets**, each finding renders as a **near-identical, indistinguishable block** — looking like an accidental duplicate, with no way to tell the partitions apart.

## Change

Attach the copy-pasteable facet-filter flags that reproduce exactly one set, in two places:

- **Full text + Markdown reports** — once per set, in the set header (`  filter: …` / `- Filter: \`…\``), so a reader who spots a change can drill straight into that partition.
- **Condensed summary** — as a de-emphasized `_Filter:_ \`…\`` footer on each finding, **after the chart**. The flags trail the block (reference material for a follow-up query, not the headline), and make same-benchmark-across-sets blocks distinguishable again.

Example summary footer:

```
_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`
```

Naming all three facets explicitly pins a single set unambiguously (an explicit `--machine-key synthetic` still matches synthetic sets via the machine-key exemption).

## Tests

- New/extended unit tests in `report.rs`: text + Markdown set-header flags, the summary footer placement (after the chart), and a **same benchmark id across two sets** case proving the footers distinguish them.
- Extended the end-to-end `analyze_markdown_summary_renders_a_flat_report` integration test to assert the footer with real seeded data.

Validated: core report unit tests, full `cbh_integration` suite (137 tests), clippy, and rustfmt all green.

Docs: `packages/cargo-bench-history/docs/DESIGN.md` §8.7 updated to describe both the set-header flags and the summary footer.
