### PR TITLE
Document measurement overhead in alloc_tracker, align all_the_time

### DIFF
--- a/packages/all_the_time/src/lib.rs
+++ b/packages/all_the_time/src/lib.rs
@@ -150,7 +150,9 @@
 //! Capturing a single measurement by calling `measure_xyz()` incurs an overhead of
 //! approximately 500 nanoseconds on an arbitrary sample machine. You are recommended to batch
 //! your measurements over a whole Criterion sample (via `.iterations(iters)` from
-//! `iter_custom`) to amortize this overhead.
+//! `iter_custom`) to amortize this overhead. Operating without batching, on individual
+//! iterations, is only viable for macrobenchmarks for which a single iteration is a
+//! large unit of work (e.g. an HTTP request).
 //!
 //! # Session management
 //!

--- a/packages/alloc_tracker/src/lib.rs
+++ b/packages/alloc_tracker/src/lib.rs
@@ -99,6 +99,16 @@
 //! }
 //! ```
 //!
+//! # Overhead
+//!
+//! Capturing a single measurement by calling `measure_xyz()` incurs an overhead of
+//! approximately 50 nanoseconds on an arbitrary sample machine. While small, this can
+//! still be considerable for tiny benchmarks. You are recommended to batch your
+//! measurements over a whole Criterion sample (via `.iterations(iters)` from
+//! `iter_custom`) to amortize this overhead. Operating without batching, on individual
+//! iterations, is only viable for macrobenchmarks for which a single iteration is a
+//! large unit of work (e.g. an HTTP request).
+//!
 //! # Machine-readable output
 //!
 //! Dropping a [`Session`] writes machine-readable JSON files (one per operation)


### PR DESCRIPTION
Adds an `# Overhead` section to `alloc_tracker`'s crate docs, mirroring the existing warning in `all_the_time`.

## What

- **alloc_tracker**: New `# Overhead` section noting that capturing a single measurement costs ~50 ns. While small, this can still be considerable for tiny benchmarks, so batching iterations over a whole Criterion sample (via `.iterations(iters)` from `iter_custom`) is recommended. Unbatched, per-iteration use is only viable for macrobenchmarks where a single iteration is a large unit of work (e.g. an HTTP request).
- **all_the_time**: Aligned its existing overhead note with the same macrobenchmark caveat so both crates give consistent batching guidance. Its ~500 ns figure is unchanged.

## Why

The two crates offer the same benchmarking pattern and should give aligned guidance on why batching matters and when unbatched measurement is acceptable.

Docs-only change; `just package="alloc_tracker" docs` and `just package="all_the_time" docs` both pass.
