### PR TITLE
Align install-tools with CI, remove divergent tooling paths

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,6 +1,16 @@
 name: Setup Environment
 description: Setup development environment for Folo project
 
+inputs:
+  install-azurite:
+    description: >-
+      Whether `just install-tools` should also install the Azurite blob-storage emulator.
+      Off by default because only the test-azurite job needs it and its npm install adds
+      ~3 minutes; that job opts back in by setting this to "true". azcopy is never installed
+      in CI (only the on-demand `just bench-history-stress-azure` uses it), so it has no input.
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -155,8 +165,22 @@ runs:
       run: git config --local include.path ./.gitconfig
     
     - name: Install development tools
+      # Runs the exact install-tools recipe developers run locally, so the CI and local toolsets
+      # never diverge and every tool version has a single source of truth (the recipe). Two tools
+      # are trimmed here because no ordinary CI job needs them: azcopy is always skipped (only the
+      # on-demand `just bench-history-stress-azure` uses it), and Azurite is skipped unless a job
+      # opts in via install-azurite (the test-azurite job does) — its emulator install is not worth
+      # the ~3 minutes on every other job.
       shell: bash
-      run: just install-tools
+      env:
+        INSTALL_AZURITE: ${{ inputs.install-azurite }}
+      run: |
+        if [ "$INSTALL_AZURITE" = "true" ]; then
+          SKIP_AZURITE=false
+        else
+          SKIP_AZURITE=true
+        fi
+        just skip_azcopy=true skip_azurite="$SKIP_AZURITE" install-tools
     
     - name: Verify environment setup
       shell: bash

--- a/.github/actions/start-azurite/action.yml
+++ b/.github/actions/start-azurite/action.yml
@@ -1,33 +1,26 @@
 name: Start Azurite
 description: >-
-  Installs and starts the Azurite blob storage emulator on the runner host so
-  that `azure`-feature tests can reach it at https://127.0.0.1:10000. It runs in
-  `--oauth basic` mode over HTTPS (behind a throwaway self-signed certificate),
-  because Microsoft Entra ID is the only supported auth mode and it requires TLS;
-  the tests trust the cert by disabling certificate validation. Linux-only: the
-  emulator runs directly on the host (not as a service container, which cannot
-  reliably bind Azurite to a reachable address).
-
-inputs:
-  azurite-version:
-    description: >-
-      Azurite npm version to install. Pinned by default so the `test-azurite` job
-      is reproducible and unaffected by upstream releases.
-    required: false
-    default: "3.35.0"
+  Starts the Azurite blob storage emulator on the runner host so that `azure`-feature
+  tests can reach it at https://127.0.0.1:10000. Azurite itself is installed by the
+  setup-environment composite action (run with `install-azurite: true`), which owns the
+  pinned version via `just install-tools` — this action only mints a certificate and
+  launches the already-installed emulator, so the version is never duplicated here. It runs
+  in `--oauth basic` mode over HTTPS (behind a throwaway self-signed certificate), because
+  Microsoft Entra ID is the only supported auth mode and it requires TLS; the tests trust
+  the cert by disabling certificate validation. Linux-only: the emulator runs directly on
+  the host (not as a service container, which cannot reliably bind Azurite to a reachable
+  address).
 
 runs:
   using: composite
   steps:
-    - name: Install and start Azurite
+    - name: Start Azurite
+      # Azurite is installed by setup-environment (run with install-azurite: true), so its version
+      # lives in one place — `just install-tools`. This step only mints a throwaway cert and
+      # launches the already-installed emulator.
       shell: bash
-      env:
-        AZURITE_VERSION: ${{ inputs.azurite-version }}
       run: |
         set -euo pipefail
-
-        echo "Installing Azurite ${AZURITE_VERSION}..."
-        npm install -g "azurite@${AZURITE_VERSION}"
 
         echo "Generating a throwaway self-signed certificate for the HTTPS listener..."
         openssl req -x509 -newkey rsa:2048 -nodes \

--- a/.github/actions/start-azurite/action.yml
+++ b/.github/actions/start-azurite/action.yml
@@ -22,6 +22,15 @@ runs:
       run: |
         set -euo pipefail
 
+        # This action does not install Azurite; setup-environment does (run with
+        # install-azurite: true). If a job forgot to opt in, fail here with a targeted message
+        # rather than a bare "azurite-blob: command not found" further down.
+        if ! command -v azurite-blob >/dev/null 2>&1; then
+          echo "azurite-blob not found on PATH." >&2
+          echo "Run the setup-environment action with 'install-azurite: \"true\"' before this step." >&2
+          exit 1
+        fi
+
         echo "Generating a throwaway self-signed certificate for the HTTPS listener..."
         openssl req -x509 -newkey rsa:2048 -nodes \
           -keyout "$RUNNER_TEMP/azurite-key.pem" \

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -26,38 +26,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read pinned Rust toolchain channel
-        # dtolnay/rust-toolchain cannot read rust-toolchain.toml, so extract the pinned stable
-        # channel here and hand it to the install step below (mirrors the setup-environment
-        # composite). Pinning stops @stable from rolling the toolchain forward every ~6 weeks,
-        # which — because Swatinem/rust-cache keys on every installed toolchain — would
-        # otherwise bust this job's cargo-delta cache on each upstream release. The version is
-        # never hardcoded; rust-toolchain.toml stays the single source of truth.
-        id: rust-toolchain
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $match = Select-String -Path 'rust-toolchain.toml' -Pattern '^\s*channel\s*=\s*"([^"]+)"' | Select-Object -First 1
-          if (-not $match) { throw 'Could not read the pinned channel from rust-toolchain.toml' }
-          $channel = $match.Matches[0].Groups[1].Value
-          Write-Host "Pinned Rust channel from rust-toolchain.toml: $channel"
-          "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: cargo-delta
-          # See setup-environment/action.yml for the rationale behind including
-          # the runner image version in the cache key.
-          env-vars: ImageVersion
-
-      - name: Install cargo-delta
-        run: cargo install cargo-delta --locked
+      - name: Setup environment
+        # The delta job runs before — and gates — every package-scoped job, so it uses the same
+        # setup-environment composite as they do rather than a hand-picked minimal toolchain. That
+        # keeps a single install path (cargo-delta comes from `just install-tools` like every other
+        # tool) and, on a cold cache, primes the shared `prerequisites` cache this job's dependents
+        # then restore instead of each recompiling from scratch. On a warm cache the setup is a
+        # ~30-second restore.
+        uses: ./.github/actions/setup-environment
 
       - name: Compute delta
         id: compute
@@ -744,6 +720,10 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          # Only this job needs the Azurite emulator, so it is the sole opt-in; every other job
+          # skips its ~3-minute npm install. The start-azurite step below then just launches it.
+          install-azurite: "true"
 
       - name: Start Azurite
         uses: ./.github/actions/start-azurite

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -1,3 +1,11 @@
+# Whether `install-tools` installs azcopy / Azurite. Both default to installing, for a complete
+# local setup. CI overrides them via the setup-environment composite action (which runs this exact
+# recipe): it always sets skip_azcopy=true (only the on-demand `just bench-history-stress-azure`
+# uses azcopy) and sets skip_azurite=true on every job except test-azurite, because Azurite's npm
+# install adds ~3 minutes and only that job needs the emulator.
+skip_azcopy := "false"
+skip_azurite := "false"
+
 # Installs the complete set of Rust toolchains and other tools for local PC development.
 [group('setup')]
 [script]
@@ -5,8 +13,10 @@ install-tools:
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # This "full install" logic is specific to local PC setup. The GitHub workflows reuse the same
-    # version numbers but have their own logic for what tooling needs to be installed in which jobs.
+    # This is the single source of truth for which tools — and which versions — get installed. CI
+    # runs this same recipe on nearly every job via the setup-environment composite action, so
+    # there is no separate CI install path to keep in sync. The only per-job variation is the
+    # skip_azcopy / skip_azurite flags above, which trim two tools no ordinary CI job needs.
 
     # First, we install/upgrade the stable toolchain in `rust-toolchain.toml`.
     rustup toolchain install
@@ -51,13 +61,12 @@ install-tools:
     }
 
     # azcopy drives the bulk upload in the cargo-bench-history Azure stress harness
-    # (`just bench-history-stress-azure`), which is on-demand only and never runs in
-    # CI — so, like the Azurite install below, skip the download in CI and only fetch
-    # azcopy for local PC setup. It is not a cargo crate and has no installer, so a
-    # helper script fetches the pinned official binary; see scripts/install-azcopy.ps1
-    # (including its rationale for the destination). No-op when azcopy is already present.
-    if ($env:CI) {
-        Write-Host "Skipping azcopy install in CI (only the on-demand 'just bench-history-stress-azure' needs it)."
+    # (`just bench-history-stress-azure`), which is on-demand only — no CI job needs it, so CI
+    # sets skip_azcopy=true. It is not a cargo crate and has no installer, so a helper script
+    # fetches the pinned official binary; see scripts/install-azcopy.ps1 (including its rationale
+    # for the destination). No-op when azcopy is already present.
+    if ("{{skip_azcopy}}" -eq "true") {
+        Write-Host "Skipping azcopy install (skip_azcopy=true)."
     } else {
         & "{{justfile_directory()}}/scripts/install-azcopy.ps1"
     }
@@ -65,20 +74,19 @@ install-tools:
     # Azurite is the Azure Blob storage emulator that backs the cargo-bench-history
     # Azure backend tests, exercised locally via `just test-azurite`. It is a Node
     # package, so npm is a prerequisite (see DEVELOPMENT.md). We install it on every
-    # platform because the emulator and those tests are cross-platform. Azurite is only
-    # needed for the on-demand `just test-azurite`, so its install is best-effort: any
-    # failure (npm missing, or the install itself erroring) only warns and continues, so
-    # the rest of the toolchain still installs.
+    # platform because the emulator and those tests are cross-platform. Its install is
+    # best-effort: any failure (npm missing, or the install itself erroring) only warns
+    # and continues, so the rest of the toolchain still installs.
     #
-    # The version is pinned to match the CI `start-azurite` action
-    # (.github/actions/start-azurite/action.yml) so local and CI runs target the same
-    # emulator — keep the two in sync when bumping.
-    if ($env:CI) {
-        # Skip in CI: `npm install -g azurite` takes ~3 minutes and `install-tools` runs
-        # on every CI job, but only the `test-azurite` job needs the emulator — and that
-        # job provisions its own copy via the start-azurite action. Installing it here too
-        # would add ~3 minutes of uncached work to every other CI job for no benefit.
-        Write-Host "Skipping Azurite install in CI (the test-azurite job provisions its own via the start-azurite action)."
+    # This is the single source of the pinned Azurite version. CI installs Azurite through this
+    # same recipe (the test-azurite job sets install-azurite on the setup-environment action,
+    # which clears skip_azurite) and the start-azurite action then only launches it, so there is
+    # no second copy of the version to keep in sync.
+    if ("{{skip_azurite}}" -eq "true") {
+        # CI sets skip_azurite=true on every job except test-azurite: `npm install -g azurite`
+        # takes ~3 minutes and only that job needs the emulator, so paying it on every other CI
+        # job would be uncached work for no benefit.
+        Write-Host "Skipping Azurite install (skip_azurite=true)."
     } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
         # A global npm install can fail for reasons unrelated to the rest of the toolchain
         # — most commonly an npm global prefix pointing at a root-owned directory (e.g. the


### PR DESCRIPTION
## Motivation

A comment in `just install-tools` claimed the "full install" logic was *"specific to
local PC setup"* and that *"the GitHub workflows... have their own logic for what tooling
needs to be installed in which jobs."* That was misleading: `setup-environment` already
runs `just install-tools` verbatim on nearly every job, so CI and local share one recipe.
The only real divergences were:

1. **Implicit `$env:CI` detection** inside the recipe (azcopy/Azurite skips).
2. The **`delta` job** hand-rolled its own toolchain + `cargo install cargo-delta` instead
   of using `setup-environment`.
3. The **`start-azurite`** action installed Azurite itself, **duplicating** the `3.35.0`
   version pin.

Notably, `.github/workflows/design.md` ("Shared infrastructure") already documents the
target state — *all non-trivial jobs use `setup-environment`; no version is ever duplicated
into a workflow file* — so this change brings the code into line with its own design.

## Changes

- **`justfiles/just_setup.just`** — replace both `$env:CI` checks with explicit
  `skip_azcopy` / `skip_azurite` `just` variables (default `false` = full local install);
  rewrite the misleading comment; the pinned Azurite version now lives here alone.
- **`.github/actions/setup-environment/action.yml`** — add an `install-azurite` input
  (default `false`); the install step now runs
  `just skip_azcopy=true skip_azurite=<...> install-tools`.
- **`.github/actions/start-azurite/action.yml`** — drop the `npm install` step and the
  `azurite-version` input; it now only mints a cert and launches the emulator that
  `setup-environment` installed.
- **`.github/workflows/validation.yml`** — the `delta` job now uses `setup-environment`
  (single install path; on a cold cache it primes the shared `prerequisites` cache its
  dependents restore); the `test-azurite` job passes `install-azurite: "true"`.

## Result

- One install path for local and CI; per-job trimming is now explicit `skip_*` flags rather
  than implicit environment detection.
- The Azurite version is pinned in exactly one place.

## Validation

- `just --dry-run install-tools`: default → `if ("false" -eq "true")`; with overrides →
  `if ("true" -eq "true")` (skip fires as expected).
- `just validate-workflows` (actionlint + ShellCheck): clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
