### PR TITLE
Pin Cargo tool versions in constants.env; bump gungraun to 0.19.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "either-or-both"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717164c227120ba9ddf3e2b32305fc0122741d3ee41a54968eae7573ee01933"
+dependencies = [
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,9 +1298,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gungraun"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd6043b1ff8096c10cdd5c59930139b52ba63cbd1a3452bc3ff95d996f9334"
+checksum = "42dad80904253d053d82f31c739a304715174f3483a8ce7f4db187c47c1588ee"
 dependencies = [
  "bincode-next",
  "derive_more",
@@ -1316,10 +1326,11 @@ dependencies = [
 
 [[package]]
 name = "gungraun-runner"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6965c4e60026245b5600b05ab4c4af5ae1eaf72b8ec5da86c9cc6af01258d8cc"
+checksum = "9ae33525418129fba64b34a1bfa91f157282559d805ac2bf444736de969dd61a"
 dependencies = [
+ "either-or-both",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,15 +45,15 @@ frozen-collections = { version = "0.9.1", default-features = false }
 future_deque = { version = "0.1.12", path = "packages/future_deque", default-features = false }
 futures = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-core = { version = "0.3.32", default-features = false }
-# Keep this version in lockstep with the `gungraun-runner` install line in
-# `justfiles/just_setup.just` and the install command in `docs/callgrind-benchmarks.md`.
+# Keep this version in lockstep with `GUNGRAUN_RUNNER_VERSION` in `constants.env` (which the
+# `just install-tools` recipe installs) and the install command in `docs/callgrind-benchmarks.md`.
 # The runner is invoked by the Callgrind bench binaries via an encoded payload and
 # `gungraun-runner` enforces strict string equality on the version (see
 # `gungraun-runner::runner::compare_versions`), so any patch-level drift between the library
 # and the installed runner causes `*_cg` benches to fail at runtime with VersionMismatch.
 # Pinned with `=` to prevent `cargo update` from drifting Cargo.lock away from the installed
 # runner version. When bumping, update all three locations together.
-gungraun = { version = "=0.19.2", default-features = false }
+gungraun = { version = "=0.19.3", default-features = false }
 hash_hasher = { version = "2.0.0", default-features = false }
 hashbrown = { version = "0.17.1", default-features = false }
 heapless = { version = "0.9.1", default-features = false }

--- a/constants.env
+++ b/constants.env
@@ -7,6 +7,38 @@ RUST_MSRV=1.93
 # clean"). Bump this deliberately (and verify the miri component exists for the date).
 RUST_NIGHTLY=nightly-2026-06-19
 
+# Versions of the Cargo tools installed by `just install-tools`, kept in one place and injected
+# into the recipe as `cargo install <crate>@<version>` (dotenv exposes each `FOO_VERSION` as
+# `$env:FOO_VERSION`). They are pinned to explicit versions rather than left floating because a
+# plain `cargo install <crate>` never upgrades an already-installed crate — it just prints
+# "already installed" and skips — so an unpinned tool would stay frozen at whatever version first
+# landed. With a pin, an installed version that differs is replaced (and a matching one is a fast
+# no-op), so bumping a tool is simply editing its version here. These normally track the latest
+# published release; bump them deliberately. The GitHub workflows install these tools by calling
+# `just install-tools`, so the same numbers flow through automatically.
+CARGO_AUDIT_VERSION=0.22.2
+CARGO_CAREFUL_VERSION=0.4.10
+CARGO_DELTA_VERSION=0.3.1
+CARGO_ENSURE_NO_DEFAULT_FEATURES_VERSION=1.1.0
+CARGO_FREEZE_DEPS_VERSION=0.1.2
+CARGO_HACK_VERSION=0.6.45
+CARGO_LLVM_COV_VERSION=0.8.7
+CARGO_MACHETE_VERSION=0.9.2
+CARGO_MUTANTS_VERSION=27.1.0
+CARGO_NEXTEST_VERSION=0.9.140
+CARGO_SEMVER_CHECKS_VERSION=0.48.0
+CARGO_SORT_VERSION=2.1.4
+CARGO_SORT_DERIVES_VERSION=0.13.0
+CARGO_UDEPS_VERSION=0.1.61
+RELEASE_PLZ_VERSION=0.3.159
+
+# gungraun-runner drives Valgrind for Callgrind instruction-count benchmarks. Unlike the tools
+# above it is NOT bumped to the latest release: it enforces strict string equality against the
+# `gungraun = "=X.Y.Z"` dependency in the root Cargo.toml, so this MUST stay equal to that pin or
+# the `*_cg` benches fail at runtime with VersionMismatch. Keep the two — and the install command
+# in docs/callgrind-benchmarks.md — in lockstep when bumping.
+GUNGRAUN_RUNNER_VERSION=0.19.3
+
 # Azure identifiers for the cargo-bench-history real-Azure storage tests, shared by
 # local runs (`just test-azure`) and the CI `test-azure` job so both target the same
 # deployed account (infra/azure-bench-history-test/). These are non-secret identifiers,

--- a/docs/callgrind-benchmarks.md
+++ b/docs/callgrind-benchmarks.md
@@ -309,7 +309,7 @@ Install once:
 
 ```bash
 sudo apt install -y valgrind
-cargo install gungraun-runner --version 0.19.2 --locked
+cargo install gungraun-runner --version 0.19.3 --locked
 ```
 
 The `gungraun-runner` version must match the `gungraun` library version

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -25,7 +25,29 @@ install-tools:
     rustup toolchain install $env:RUST_MSRV
     rustup toolchain install $env:RUST_NIGHTLY --component miri --component rustfmt --component rust-src --component llvm-tools-preview
 
-    cargo install cargo-machete cargo-nextest release-plz cargo-semver-checks cargo-audit cargo-hack cargo-llvm-cov cargo-sort cargo-sort-derives cargo-udeps cargo-careful cargo-ensure-no-default-features cargo-delta cargo-freeze-deps --locked
+    # Every tool is pinned to an explicit version from constants.env (dotenv, configured in the
+    # root justfile, exposes each `FOO_VERSION` as `$env:FOO_VERSION`). This is deliberate: a plain
+    # `cargo install <crate>` never upgrades an already-installed crate — it prints "already
+    # installed" and skips — so an unpinned tool would freeze at whatever version first landed. With
+    # a pin, `cargo install <crate>@<version>` replaces an installed version that differs from the
+    # pin and is a fast no-op when it already matches, so bumping a tool is just editing its version
+    # in constants.env. (cargo-mutants is installed further down because it is skipped on ARM.)
+    cargo install `
+        cargo-audit@$env:CARGO_AUDIT_VERSION `
+        cargo-careful@$env:CARGO_CAREFUL_VERSION `
+        cargo-delta@$env:CARGO_DELTA_VERSION `
+        cargo-ensure-no-default-features@$env:CARGO_ENSURE_NO_DEFAULT_FEATURES_VERSION `
+        cargo-freeze-deps@$env:CARGO_FREEZE_DEPS_VERSION `
+        cargo-hack@$env:CARGO_HACK_VERSION `
+        cargo-llvm-cov@$env:CARGO_LLVM_COV_VERSION `
+        cargo-machete@$env:CARGO_MACHETE_VERSION `
+        cargo-nextest@$env:CARGO_NEXTEST_VERSION `
+        cargo-semver-checks@$env:CARGO_SEMVER_CHECKS_VERSION `
+        cargo-sort@$env:CARGO_SORT_VERSION `
+        cargo-sort-derives@$env:CARGO_SORT_DERIVES_VERSION `
+        cargo-udeps@$env:CARGO_UDEPS_VERSION `
+        release-plz@$env:RELEASE_PLZ_VERSION `
+        --locked
 
     # cargo-mutants transitively depends on `winapi 0.2.8`, which only defines its
     # types for `target_arch = "x86"` / `"x86_64"` and fails to compile on aarch64
@@ -35,7 +57,7 @@ install-tools:
     # ARM machines (where running mutation testing locally is not supported).
     $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
     if ($arch -ne [System.Runtime.InteropServices.Architecture]::Arm64) {
-        cargo install cargo-mutants --locked
+        cargo install cargo-mutants@$env:CARGO_MUTANTS_VERSION --locked
     } else {
         Write-Host "Skipping cargo-mutants install on ARM64 (winapi 0.2.8 has no aarch64 support)."
     }
@@ -50,14 +72,14 @@ install-tools:
     # any invocation of a `*_cg` bench binary fails with "Failed to run benchmarks: No such
     # file or directory", including the harmless --list call that nextest issues for `--benches`.
     #
-    # The version is pinned to the exact patch matching the `gungraun = "=0.19.2"` workspace
-    # entry in the root Cargo.toml. gungraun-runner enforces strict string equality on the
-    # version (see `gungraun-runner::runner::compare_versions`), so any drift between the
-    # installed runner and the library causes `*_cg` benches to fail at runtime with
-    # VersionMismatch. Keep this line, the workspace Cargo.toml entry, and the install command
-    # in `docs/callgrind-benchmarks.md` in sync when bumping.
+    # The version lives in constants.env (GUNGRAUN_RUNNER_VERSION) and must match the exact patch of
+    # the `gungraun = "=X.Y.Z"` workspace entry in the root Cargo.toml. gungraun-runner enforces
+    # strict string equality on the version (see `gungraun-runner::runner::compare_versions`), so
+    # any drift between the installed runner and the library causes `*_cg` benches to fail at
+    # runtime with VersionMismatch. Keep GUNGRAUN_RUNNER_VERSION, the workspace Cargo.toml entry,
+    # and the install command in `docs/callgrind-benchmarks.md` in sync when bumping.
     if ($IsLinux) {
-        cargo install gungraun-runner --version 0.19.2 --locked
+        cargo install gungraun-runner@$env:GUNGRAUN_RUNNER_VERSION --locked
     }
 
     # azcopy drives the bulk upload in the cargo-bench-history Azure stress harness


### PR DESCRIPTION
## Problem

`just install-tools` never upgraded already-installed cargo tools. A plain `cargo install <crate>` (even with `--locked`) is a no-op when the crate is already present at *any* version — it prints `already installed, use --force to override` and skips. So unpinned tools froze at whatever version first landed (e.g. `cargo-semver-checks` stuck at 0.45.0 while 0.48.0 was latest).

`--force` would upgrade, but it *always* recompiles from scratch even when the version is unchanged — wasteful for CI, which runs this recipe on nearly every job.

## Fix

Pin every tool to an explicit version in `constants.env` and inject it into the recipe as `cargo install <crate>@$env:<VAR>`. An exact `@version` pin **replaces** a mismatched install and is a **fast no-op** when it already matches — so bumping a tool is now just editing its version in `constants.env`. This mirrors the version-pinning pattern already used in the oxidizer workspace.

- `constants.env`: added `CARGO_*_VERSION` / `RELEASE_PLZ_VERSION` pins + `GUNGRAUN_RUNNER_VERSION`.
- `justfiles/just_setup.just`: the install batch, `cargo-mutants`, and `gungraun-runner` all now install `@$env:<VAR>` pinned versions.

## Also: bump gungraun 0.19.2 → 0.19.3

Bumped in lockstep across all four locations that must agree (the runner enforces strict version-string equality against the library):

- `Cargo.toml` — `gungraun = { version = "=0.19.3" }`
- `constants.env` — `GUNGRAUN_RUNNER_VERSION=0.19.3`
- `docs/callgrind-benchmarks.md` — install command
- `Cargo.lock`

## Verification

- Ran the `ss-cargo-deps-tidy` skill (dependency modified): style/centralization stages all clean.
- Compiled `fast_time`'s `*_cg` bench on Linux (WSL) against gungraun 0.19.3 — `gungraun`, `gungraun-macros`, `gungraun-runner`, and the bench all check green.
- `just --show install-tools` parses; version injection and the recipe's `skip_azcopy`/`skip_azurite` flags both render correctly.

## Notes

- The only remaining raw `cargo install` in CI is the `just` bootstrap in `setup-environment/action.yml` — an inherent chicken-and-egg (you need `just` before the dotenv-loading recipe can run), so it can't easily read `constants.env`.
- `azurite@3.35.0` stays inline in the recipe, per the earlier "single source of truth" decision in #339.
