### PR TITLE
Make cargo-bench-history collect tests hermetic against CARGO_TARGET_DIR

### DIFF
--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -112,12 +112,20 @@ suite under nextest pre-builds it once and passes `MOCK_BENCH_ENGINE` (avoids pe
 output on demand via repeatable flags (`--summary`/`--criterion`/`--alloc-tracker`/
 `--all-the-time`) and `--fail-if-exists` to simulate a failing commit.
 
-**CWD & target root.** The real-adapter e2e test changes CWD, so it is `#[serial]`; on Windows
-restore the original CWD **before** the `TempDir` drops. Each test pins its own tempdir target
-root through the `run_with_overrides` entry (injected as `CARGO_TARGET_DIR` for the engine) —
-**do not** reintroduce a `set_var("CARGO_TARGET_DIR", …)` guard. `tests/cbh_real_engine.rs` is
-the one true e2e (real `cargo bench` + Criterion) and the only exercise of
-`resolve_target_root`; keep it and its `resolve_target_root` guard test.
+**CWD & target root.** Almost every test — including the real-adapter e2e — pins its own
+tempdir workspace and target root through the `run_with_overrides` entry (`workspace_dir` +
+`target_root`, the latter injected as `CARGO_TARGET_DIR` for the engine), so it neither reads
+the ambient environment nor mutates the process CWD. **Do not** reintroduce a
+`set_var("CARGO_TARGET_DIR", …)` guard or a CWD-changing `#[serial]` e2e: an ambient
+`CARGO_TARGET_DIR` (a shared or per-worktree target dir) would point the harvest at foreign
+engine output. `tests/cbh_real_engine.rs` is the one true e2e (real `cargo bench` + Criterion).
+Production `resolve_target_root` is covered by its unit tests in `commands::collect`. The one
+deliberate exception to the pin rule is the mock
+`collect_harvests_output_when_the_engine_runs_in_a_package_directory` regression, which drives
+the no-override path (`Workspace::drive_resolving_target_root`) to prove `collect` calls
+`resolve_target_root` and injects an *absolute* `CARGO_TARGET_DIR`; it is therefore the sole
+integration coverage of that wiring — keep it, and keep the harvest hermetic there by other
+means than a target-root override.
 
 **Fixtures.** `tests/fixtures/**` are **real** committed engine output doubling as schema-drift
 canaries — do not hand-edit to make a test pass; regenerate from a real run.

--- a/packages/cargo-bench-history/tests/cbh_integration/collect.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/collect.rs
@@ -1,4 +1,4 @@
-use crate::harness::*;
+use crate::harness::{serial, *};
 
 /// End-to-end happy path: a successful no-op engine command, one harvested
 /// summary, and a stored set with the expected object key and context.
@@ -49,7 +49,12 @@ async fn collect_callgrind_end_to_end_stores_results() {
 /// exact symptom this guards against. Driving without a target-root override
 /// exercises the real `resolve_target_root`, and the mock changes into a package
 /// subdirectory before writing, standing in for cargo's per-package cwd.
+///
+/// [`Workspace::drive_resolving_target_root`] clears the ambient `CARGO_TARGET_DIR`
+/// so resolution deterministically falls back to `<workspace>/target`; the test is
+/// therefore `#[serial]` to keep that process-wide mutation from racing peers.
 #[tokio::test]
+#[serial]
 #[cfg_attr(miri, ignore)]
 async fn collect_harvests_output_when_the_engine_runs_in_a_package_directory() {
     let workspace = Workspace::new(&storage_only_config()).with_bench(&[

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -828,7 +828,17 @@ impl Workspace {
     }
 
     /// Like [`drive`], but leaves the target root unset so the harvester resolves
-    /// it the default way, exercising the no-override target-root path.
+    /// it the default way, exercising the production `resolve_target_root` wiring
+    /// (`collect`'s `target_root.unwrap_or_else(|| resolve_target_root_in(base))`).
+    ///
+    /// The ambient `CARGO_TARGET_DIR` is cleared for the duration of the run so the
+    /// resolution deterministically falls back to `<workspace>/target` (a fresh
+    /// tempdir tree). Without this, a developer's shared or per-worktree
+    /// `CARGO_TARGET_DIR` would send the harvest into a directory already holding
+    /// *other* engines' output, silently storing foreign result sets. `drive`
+    /// stays hermetic by pinning `target_root` instead; this method cannot, since
+    /// its whole purpose is the no-override path, so it clears the variable and
+    /// restores it on drop. Callers must therefore be `#[serial]`.
     ///
     /// [`drive`]: Self::drive
     pub(crate) async fn drive_resolving_target_root(
@@ -841,6 +851,7 @@ impl Workspace {
 
         let effective = self.effective_args(args);
         let refs: Vec<&str> = effective.iter().map(String::as_str).collect();
+        let _cleared = ClearedTargetDir::enter();
         run_with_overrides(
             &command_from(&refs),
             Overrides {
@@ -1213,6 +1224,44 @@ impl Workspace {
     }
 }
 
+/// Clears `CARGO_TARGET_DIR` from the process environment for its lifetime,
+/// restoring the previous value on drop.
+///
+/// [`Workspace::drive_resolving_target_root`] uses this so the production
+/// `resolve_target_root` deterministically falls back to `<workspace>/target`
+/// rather than picking up whatever shared target directory the developer's
+/// environment happens to point at.
+struct ClearedTargetDir {
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ClearedTargetDir {
+    fn enter() -> Self {
+        let previous = std::env::var_os("CARGO_TARGET_DIR");
+        // SAFETY: The one caller is `#[serial]`, and the suite runs under nextest
+        // (a separate process per test), so no other thread reads or writes the
+        // environment concurrently with this mutation.
+        unsafe {
+            std::env::remove_var("CARGO_TARGET_DIR");
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for ClearedTargetDir {
+    fn drop(&mut self) {
+        let Some(previous) = self.previous.take() else {
+            return;
+        };
+        // SAFETY: The one caller is `#[serial]`, and the suite runs under nextest
+        // (a separate process per test), so no other thread reads or writes the
+        // environment concurrently with this mutation.
+        unsafe {
+            std::env::set_var("CARGO_TARGET_DIR", previous);
+        }
+    }
+}
+
 /// A fixed clock anchor for `analyze`/`list`'s history-mode default `--since`
 /// window. Seed data lands across 2024; anchoring "now" at 2024-06-01 keeps the
 /// default six-month look-back (cutoff 2023-12-01) inclusive of that data, so the
@@ -1221,6 +1270,7 @@ pub(crate) fn analysis_now() -> Timestamp {
     "2024-06-01T00:00:00Z".parse::<Timestamp>().unwrap()
 }
 
+/// Parses CLI arguments into the typed [`Command`], exactly as the binary does.
 pub(crate) fn command_from(args: &[&str]) -> Command {
     Cli::from_args(&["cargo-bench-history"], args)
         .unwrap()

--- a/packages/cargo-bench-history/tests/cbh_real_engine.rs
+++ b/packages/cargo-bench-history/tests/cbh_real_engine.rs
@@ -2,12 +2,19 @@
 //! Criterion benchmark and harvests the output the genuine engine writes.
 //!
 //! Every other integration test drives `collect` against a mock engine through the
-//! `run_with_overrides` entry, pinning an absolute target root and launching the
-//! mock from the workspace-root current directory. That is fast and hermetic, but
-//! it cannot exercise the production `resolve_target_root`, real cargo argument
-//! passing, Criterion's actual on-disk layout, or the working directory cargo
-//! gives a benchmark binary. This test closes that gap with the smallest possible
-//! real benchmark.
+//! `run_with_overrides` entry. That is fast and hermetic, but it cannot exercise
+//! real cargo argument passing, Criterion's actual on-disk layout, or the working
+//! directory cargo gives a benchmark binary. This test closes that gap with the
+//! smallest possible real benchmark.
+//!
+//! Like the mock-engine tests, it pins its own tempdir workspace and target root
+//! through `run_with_overrides` rather than reading the ambient environment: the
+//! production `resolve_target_root` honours a `CARGO_TARGET_DIR` override (so a
+//! real `cargo llvm-cov`-style target directory is respected), which means an
+//! ambient value — a shared or per-worktree target directory set while
+//! benchmarking — would point the harvest at a tree already holding *other*
+//! engines' output and store foreign result sets. Pinning keeps the run hermetic;
+//! `resolve_target_root` itself is covered by its unit tests in `commands::collect`.
 //!
 //! It is deliberately heavyweight: it compiles Criterion and runs an actual
 //! benchmark process, so it is gated off under Miri (no real subprocesses) and
@@ -26,10 +33,10 @@
 
 use std::path::{Path, PathBuf};
 
-use cargo_bench_history::{Cli, Command, MetricKind, Run, RunOutcome, run};
+use cargo_bench_history::{
+    Cli, Command, MetricKind, Overrides, Run, RunOutcome, run_with_overrides,
+};
 use cargo_bench_history_core::codec;
-use serial_test::serial;
-use testing::CwdGuard;
 
 /// Parses CLI arguments into the typed [`Command`], exactly as the binary does.
 fn command_from(args: &[&str]) -> Command {
@@ -124,7 +131,6 @@ const FIXTURE_CONFIG: &str = "[project]\nid = \"e2e\"\n";
 /// `cargo bench` + Criterion build and asserts the genuine wall-time output is
 /// harvested and stored.
 #[tokio::test]
-#[serial]
 #[cfg_attr(miri, ignore)] // Spawns a real `cargo bench`, which Miri cannot run.
 #[cfg_attr(coverage_nightly, ignore)] // Heavy real build; llvm-cov shares one target dir.
 #[cfg_attr(
@@ -147,16 +153,23 @@ async fn collect_against_real_criterion_bench_stores_wall_time() {
     )
     .unwrap();
 
-    // Drive the production entry (no overrides) with the fixture as the current
-    // directory, so the real `resolve_target_root` injects `<root>/target` and
-    // `cargo bench` builds and runs Criterion there. Restore the directory before
-    // assertions and before the tempdir is dropped (required on Windows).
-    let outcome = {
-        let _cwd = CwdGuard::enter(root);
-        run(&command_from(&["collect", "--local=./store"]))
-            .await
-            .unwrap()
-    };
+    // Pin the fixture as the workspace and `<root>/target` as the target root,
+    // exactly as the mock-engine tests do, so the run never reads the ambient
+    // environment. This keeps `cargo bench` (run in the workspace) building and
+    // harvesting inside the fixture's own tempdir tree regardless of any ambient
+    // `CARGO_TARGET_DIR` — a shared target directory would otherwise expose the
+    // harvest to foreign engine output. The benchmark command and clock are left
+    // at their defaults (real `cargo bench`, real wall clock).
+    let outcome = run_with_overrides(
+        &command_from(&["collect", "--local=./store"]),
+        Overrides {
+            workspace_dir: Some(root.to_path_buf()),
+            target_root: Some(root.join("target")),
+            ..Overrides::default()
+        },
+    )
+    .await
+    .unwrap();
 
     let RunOutcome::Completed { message } = outcome else {
         panic!("expected completion, got {outcome:?}");


### PR DESCRIPTION
## Problem

`collect_against_real_criterion_bench_stores_wall_time` intermittently failed with:

```
Stored 2 result sets covering 2 benchmark cases. [callgrind: 1 stored; criterion: 1 stored]
```

The e2e test drove the production `run` entry, whose `resolve_target_root` reads the ambient `CARGO_TARGET_DIR`. When that variable points at a shared or per-worktree target directory that already holds another engine's fresh output, the harvest scans that tree and stores a **foreign** result set — a second, unexpected set. The test assumed a pristine environment, which we cannot guarantee.

## Fix

- **`cbh_real_engine.rs`** — drive `collect` through `run_with_overrides`, pinning `workspace_dir` + `target_root` to the fixture's own tempdir (exactly as the mock-engine tests do). The run no longer reads the ambient environment. Removed the now-unnecessary `#[serial]` and `CwdGuard`. `resolve_target_root` itself remains covered by its unit tests in `commands::collect`.
- **`cbh_integration/harness.rs`** — `drive_resolving_target_root` is the *sole* integration coverage of the no-override `resolve_target_root` path, so it cannot pin `target_root`. Instead it now enters a `ClearedTargetDir` guard that removes ambient `CARGO_TARGET_DIR` for the run (restored on drop), forcing the deterministic `<workspace>/target` fallback.
- **`cbh_integration/collect.rs`** — marked `collect_harvests_output_when_the_engine_runs_in_a_package_directory` `#[serial]` to guard the process-global env mutation.
- **`AGENTS.md`** — documented the pin-don't-read-env rule and its one deliberate exception.

## Validation

- Reproduced the **exact** original panic by disabling the guard under future-dated valid Criterion contamination in an ambient `CARGO_TARGET_DIR`.
- Confirmed the guard eliminates the failure and restores the env var on drop.
- Confirmed the real-engine e2e passes even with a contaminated ambient `CARGO_TARGET_DIR`.
- `cargo +nightly fmt --all --check`, `cargo clippy -p cargo-bench-history --tests`, the full 137-test `cbh_integration` suite, and the `cbh_real_engine` e2e all pass.

All changes are test-only plus package documentation.
