### PR TITLE
Fix binary-release plan clobbering targets after the first crate

### DIFF
--- a/scripts/release/ReleaseAutomation.Tests.ps1
+++ b/scripts/release/ReleaseAutomation.Tests.ps1
@@ -358,6 +358,23 @@ Describe 'Get-MissingBinaryMatrix (mocked gh release view)' {
         $rows.Count | Should -Be 1
     }
 
+    It 'reconciles a later crate against the full target set, not just the last target' {
+        # Regression: the per-crate target loop must see every target for every crate. A loop
+        # variable that case-collides with the $Target parameter would leave $Target holding only
+        # its last element after the first crate, so a later empty release would be reconciled
+        # against a single leftover target instead of all of them. Put the empty release LAST so a
+        # per-crate loop that lost its targets would emit one row (the last target) instead of two.
+        $crates = @(
+            [pscustomobject]@{ Name = 'have-all'; Version = '1.0.0' }
+            [pscustomobject]@{ Name = 'empty-release'; Version = '4.0.0' }
+        )
+        $rows = Get-MissingBinaryMatrix -Crate $crates -Target $script:TwoTargets
+        $emptyRows = @($rows | Where-Object { $_.name -eq 'empty-release' })
+        $emptyRows.Count | Should -Be $script:TwoTargets.Count
+        $emptyRows.triple | Should -Contain 'x86_64-unknown-linux-gnu'
+        $emptyRows.triple | Should -Contain 'aarch64-apple-darwin'
+    }
+
     Context 'verbose decision history (-Verbose)' {
         BeforeAll {
             function Get-VerboseMessage {

--- a/scripts/release/ReleaseAutomation.psm1
+++ b/scripts/release/ReleaseAutomation.psm1
@@ -180,10 +180,15 @@ function Get-MissingBinaryMatrix {
     # exactly how the plan (and its emptiness or non-emptiness) was derived, not just the total.
     Write-Verbose "Reconciling desired vs. uploaded binary archives. Crates: $($Crate.Name -join ', '). Target triples: $(($Target.Triple) -join ', ')."
 
+    # The loop variables must not differ from the collection parameters ($Crate, $Target) by
+    # case alone: PowerShell variable names are case-insensitive, so `foreach ($target in $Target)`
+    # would make `$target` and `$Target` the same variable and leave `$Target` holding only its
+    # last element after the loop — so every crate after the first would reconcile against a single
+    # leftover target (the last one) instead of the full set. Hence $crateInfo / $releaseTarget.
     $rows = [System.Collections.Generic.List[object]]::new()
-    foreach ($crate in $Crate) {
-        $tag = "$($crate.Name)-v$($crate.Version)"
-        Write-Verbose "Crate '$($crate.Name)' v$($crate.Version): expected release tag '$tag'."
+    foreach ($crateInfo in $Crate) {
+        $tag = "$($crateInfo.Name)-v$($crateInfo.Version)"
+        Write-Verbose "Crate '$($crateInfo.Name)' v$($crateInfo.Version): expected release tag '$tag'."
         $assets = Get-BinaryReleaseAsset -Tag $tag
         if ($null -eq $assets) {
             Write-Verbose "  No GitHub release '$tag' found yet; skipping this crate (nothing to reconcile until its release exists)."
@@ -193,19 +198,19 @@ function Get-MissingBinaryMatrix {
         $uploaded = if ($assets.Count -gt 0) { $assets -join ', ' } else { '(none)' }
         Write-Verbose "  Release '$tag' found; already-uploaded archives: $uploaded."
 
-        foreach ($target in $Target) {
-            $archive = "$($crate.Name)-v$($crate.Version)-$($target.Triple).zip"
+        foreach ($releaseTarget in $Target) {
+            $archive = "$($crateInfo.Name)-v$($crateInfo.Version)-$($releaseTarget.Triple).zip"
             if ($assets -contains $archive) {
-                Write-Verbose "  Target $($target.Triple): '$archive' already uploaded — skipping."
+                Write-Verbose "  Target $($releaseTarget.Triple): '$archive' already uploaded — skipping."
                 continue
             }
-            Write-Verbose "  Target $($target.Triple): '$archive' missing — queuing a build on runner '$($target.Os)'."
+            Write-Verbose "  Target $($releaseTarget.Triple): '$archive' missing — queuing a build on runner '$($releaseTarget.Os)'."
             $rows.Add([pscustomobject]@{
-                    name    = $crate.Name
-                    version = $crate.Version
+                    name    = $crateInfo.Name
+                    version = $crateInfo.Version
                     tag     = $tag
-                    triple  = $target.Triple
-                    os      = $target.Os
+                    triple  = $releaseTarget.Triple
+                    os      = $releaseTarget.Os
                 })
         }
     }


### PR DESCRIPTION
## Problem

The `plan-binaries` step of the release workflow only published prebuilt binaries for **`aarch64-apple-darwin`** for every crate *except the first*. In the run that surfaced this, `cargo-detect-package` and `cargo-freeze-deps` each got only the macOS Apple-silicon archive, while `cargo-bench-history` (first crate) correctly got all five targets.

The verbose log looked contradictory: it reported `already-uploaded archives: (none)` yet queued only the last target — the assets really were empty, but the target list had been silently truncated.

## Root cause

`Get-MissingBinaryMatrix` in `scripts/release/ReleaseAutomation.psm1` used `foreach ($target in $Target)`. PowerShell variable names are **case-insensitive**, so the loop variable `$target` and the parameter `$Target` are the *same* variable. `foreach` captures its enumerator once (so the first crate iterates all five targets), but after the loop `$Target` holds only its **last element** (`aarch64-apple-darwin`). Every subsequent crate then reconciles against that single leftover target.

The outer `foreach ($crate in $Crate)` had the same latent collision (harmless only because nothing reads `$Crate` after the loop).

## Fix

- Rename the loop variables to `$crateInfo` / `$releaseTarget` so they cannot case-collide with the `$Crate` / `$Target` parameters, with a comment explaining why.
- Add a regression test — *"reconciles a later crate against the full target set, not just the last target"* — that puts an empty release **after** a fully-uploaded one and asserts it still receives every target. It fails on the old code (got 1, expected 2) and passes on the fixed code.

## Verification

- Reproduced the 5 + 1 + 1 truncation, then confirmed the fix yields all targets for every crate.
- Confirmed the new test fails on the buggy module and passes on the fixed module.
- Full Pester suite green (85 tests) via `just test-scripts`.
- Ran the real `just gh-plan-release-binaries` against current release state: now correctly reports the **8 missing** non-darwin archives for `cargo-detect-package` and `cargo-freeze-deps`.

The release workflow is self-healing, so the missing Linux/Windows binaries will be backfilled automatically on the next run to `main`.
