### PR TITLE
Fix bench-history schema-drift crash: drop dead mean fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,8 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 name = "cargo-bench-history"
 version = "0.0.3"
 dependencies = [
+ "all_the_time",
+ "alloc_tracker",
  "anyspawn",
  "async-trait",
  "azure_core",

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -127,8 +127,15 @@ the no-override path (`Workspace::drive_resolving_target_root`) to prove `collec
 integration coverage of that wiring — keep it, and keep the harvest hermetic there by other
 means than a target-root override.
 
-**Fixtures.** `tests/fixtures/**` are **real** committed engine output doubling as schema-drift
-canaries — do not hand-edit to make a test pass; regenerate from a real run.
+**Fixtures.** The Criterion and Callgrind fixtures under `tests/fixtures/**` are **real**
+committed output of those external tools, doubling as schema-drift canaries — do not
+hand-edit to make a test pass; regenerate from a real run. The in-workspace engines
+(`alloc_tracker`, `all_the_time`) are guarded differently: `src/bench/schema_roundtrip.rs`
+drives the **real** producer and feeds its output straight through the adapter, so
+producer/consumer drift fails the build automatically. Their `tests/fixtures/**` files are
+therefore representative samples of the current schema for the value-asserting unit tests, not
+the drift canary — keep them in sync with the producer's shape, but the round-trip test is
+authoritative.
 
 **Backfill coverage.** Planning/skip/overwrite/error logic is exhaustively covered by
 fake-driven unit tests in `commands/backfill.rs`; keep the real-git integration drives a small

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -51,6 +51,8 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "r
 toml = { workspace = true, features = ["parse", "serde"] }
 
 [dev-dependencies]
+all_the_time = { path = "../all_the_time" }
+alloc_tracker = { path = "../alloc_tracker" }
 base64 = { workspace = true }
 cargo-bench-history-core = { path = "../cargo-bench-history-core", features = ["private-test-util"] }
 futures = { workspace = true, features = ["executor"] }

--- a/packages/cargo-bench-history/src/bench/all_the_time.rs
+++ b/packages/cargo-bench-history/src/bench/all_the_time.rs
@@ -40,41 +40,47 @@ impl Error for AllTheTimeParseError {
 
 /// Parses one `all_the_time` operation file into a [`BenchmarkResult`].
 ///
+/// Returns `Ok(None)` when the operation recorded no usable per-iteration
+/// measurement (a zero-iteration run the workload could not complete, which the
+/// producer writes with a null slope); such an operation has nothing to store.
+///
 /// # Errors
 ///
 /// Returns [`AllTheTimeParseError`] if the JSON is malformed or does not match
 /// the expected shape.
 pub(crate) fn parse_all_the_time_operation(
     json: &str,
-) -> Result<BenchmarkResult, AllTheTimeParseError> {
+) -> Result<Option<BenchmarkResult>, AllTheTimeParseError> {
     let output: OperationOutput = serde_json::from_str(json).map_err(AllTheTimeParseError)?;
     Ok(output_to_record(&output))
 }
 
-/// Maps a parsed operation to a [`BenchmarkResult`] (pure).
+/// Maps a parsed operation to a [`BenchmarkResult`], or `None` when it carries no
+/// usable measurement.
 ///
 /// `all_the_time`'s flat `target/all_the_time/` tree carries no package
 /// attribution, so the operation name alone identifies the series (mirroring the
 /// Criterion adapter).
 ///
 /// The through-origin slope is the per-iteration point estimate, matching the
-/// Criterion adapter. A missing or null slope (which the producer writes for a
-/// zero-iteration operation that could not run) maps to `NaN`, signalling that no
-/// valid per-iteration figure was produced. When the confidence interval is present
-/// it is recorded on the metric, so analysis can apply its interval-overlap gate to
-/// processor time the same way it does for Criterion wall time.
-fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
+/// Criterion adapter. A zero-iteration operation the workload could not run has no
+/// per-iteration rate — the producer writes its slope as null — so it yields `None`
+/// and is dropped rather than stored: a non-finite metric value cannot round-trip
+/// through stored history (see [`super::usable_slope`]). When the confidence
+/// interval is present it is recorded on the metric, so analysis can apply its
+/// interval-overlap gate to processor time the same way it does for Criterion wall
+/// time.
+fn output_to_record(output: &OperationOutput) -> Option<BenchmarkResult> {
+    let value = super::usable_slope(output.slope_processor_time_nanos)?;
+
     let id = BenchmarkId::new(NonEmpty::new(output.operation.clone()));
-
-    let value = output.slope_processor_time_nanos.unwrap_or(f64::NAN);
-
     let metric = Metric::new(MetricKind::ProcessorTime, value).with_dispersion(
         None,
         output.interval_low_processor_time_nanos,
         output.interval_high_processor_time_nanos,
     );
 
-    BenchmarkResult::new(id, vec![metric])
+    Some(BenchmarkResult::new(id, vec![metric]))
 }
 
 /// The subset of an `all_the_time` operation file the tool reads. The `total_*`
@@ -112,7 +118,7 @@ mod tests {
 
     #[test]
     fn parses_identity_from_operation_name() {
-        let record = parse_all_the_time_operation(READ_CELL_FIXTURE).unwrap();
+        let record = parse_record(READ_CELL_FIXTURE);
         assert_eq!(
             record.id,
             BenchmarkId::new(NonEmpty::new("read_cell".to_owned()))
@@ -121,7 +127,7 @@ mod tests {
 
     #[test]
     fn all_the_time_identity_is_the_operation_name_only() {
-        let record = parse_all_the_time_operation(READ_CELL_FIXTURE).unwrap();
+        let record = parse_record(READ_CELL_FIXTURE);
         assert_eq!(
             record.id,
             BenchmarkId::new(NonEmpty::new("read_cell".to_owned()))
@@ -130,7 +136,7 @@ mod tests {
 
     #[test]
     fn maps_processor_time_from_the_slope() {
-        let record = parse_all_the_time_operation(READ_CELL_FIXTURE).unwrap();
+        let record = parse_record(READ_CELL_FIXTURE);
         assert_eq!(record.metrics.len(), 1);
 
         let metric = &record.metrics[0];
@@ -143,7 +149,7 @@ mod tests {
         // Single-span output records a slope but no interval, so the metric carries
         // no dispersion and analysis relies on rank-testing across regimes rather
         // than interval overlap.
-        let record = parse_all_the_time_operation(READ_CELL_FIXTURE).unwrap();
+        let record = parse_record(READ_CELL_FIXTURE);
         let metric = &record.metrics[0];
         assert_eq!(metric.std_dev, None);
         assert_eq!(metric.interval_low, None);
@@ -152,7 +158,7 @@ mod tests {
 
     #[test]
     fn records_dispersion_when_present() {
-        let record = parse_all_the_time_operation(READ_CELL_DISPERSION_FIXTURE).unwrap();
+        let record = parse_record(READ_CELL_DISPERSION_FIXTURE);
         let metric = &record.metrics[0];
         // The slope is the point estimate and the spans' jitter is carried as an
         // analytic confidence interval straddling it. The adapter no longer surfaces
@@ -172,24 +178,24 @@ mod tests {
             "\"interval_low_processor_time_nanos\":30.0,",
             "\"interval_high_processor_time_nanos\":37.0}"
         );
-        let record = parse_all_the_time_operation(json).unwrap();
+        let record = parse_record(json);
         assert_eq!(record.metrics[0].value, 33.5);
     }
 
     #[test]
-    fn missing_slope_maps_to_nan() {
-        // A zero-iteration operation the workload could not run leaves the slope
-        // null (serialized from NaN), which the adapter surfaces as NaN rather than
-        // inventing a figure.
+    fn null_slope_yields_no_record() {
+        // A zero-iteration operation the workload could not run leaves the slope null
+        // (serialized from NaN). It has no usable measurement, so the adapter drops
+        // it rather than storing a non-finite value that could not round-trip through
+        // stored history.
         let json = "{\"operation\":\"op\",\"slope_processor_time_nanos\":null}";
-        let record = parse_all_the_time_operation(json).unwrap();
-        assert!(record.metrics[0].value.is_nan());
+        assert!(parse_all_the_time_operation(json).unwrap().is_none());
     }
 
     #[test]
     fn preserves_the_original_operation_name() {
         let json = operation_json("group/case name", 1234);
-        let record = parse_all_the_time_operation(&json).unwrap();
+        let record = parse_record(&json);
         assert_eq!(
             record.id,
             BenchmarkId::new(NonEmpty::new("group/case name".to_owned()))
@@ -204,6 +210,13 @@ mod tests {
             "{error}"
         );
         assert!(error.source().is_some());
+    }
+
+    /// Parses a fixture that is expected to yield a stored record.
+    fn parse_record(json: &str) -> BenchmarkResult {
+        parse_all_the_time_operation(json)
+            .expect("the fixture is well-formed all_the_time output")
+            .expect("the operation has a usable measurement")
     }
 
     fn operation_json(operation: &str, nanos: u64) -> String {

--- a/packages/cargo-bench-history/src/bench/all_the_time.rs
+++ b/packages/cargo-bench-history/src/bench/all_the_time.rs
@@ -6,8 +6,11 @@
 //! per-iteration slope and its confidence interval estimated over the operation's
 //! measured spans. Processor time depends on the host hardware, so this engine
 //! partitions its history by a machine key (see [`Engine::is_hardware_dependent`]).
-//! The committed fixtures under `tests/fixtures/all_the_time/` are real
-//! `all_the_time` output and act as a schema-drift canary.
+//! The committed fixtures under `tests/fixtures/all_the_time/` are representative
+//! samples of the current schema; the authoritative schema-drift guard is the
+//! `super::schema_roundtrip` test, which feeds real producer output through this
+//! parser so a field renamed or dropped on either side of the boundary fails the
+//! build.
 //!
 //! [`Engine::is_hardware_dependent`]: crate::model::Engine::is_hardware_dependent
 
@@ -54,17 +57,16 @@ pub(crate) fn parse_all_the_time_operation(
 /// attribution, so the operation name alone identifies the series (mirroring the
 /// Criterion adapter).
 ///
-/// The through-origin slope is preferred as the per-iteration point estimate,
-/// matching the Criterion adapter; output that records no slope falls back to the
-/// mean. When the confidence interval is present it is recorded on the metric, so
-/// analysis can apply its interval-overlap gate to processor time the same way it
-/// does for Criterion wall time.
+/// The through-origin slope is the per-iteration point estimate, matching the
+/// Criterion adapter. A missing or null slope (which the producer writes for a
+/// zero-iteration operation that could not run) maps to `NaN`, signalling that no
+/// valid per-iteration figure was produced. When the confidence interval is present
+/// it is recorded on the metric, so analysis can apply its interval-overlap gate to
+/// processor time the same way it does for Criterion wall time.
 fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
     let id = BenchmarkId::new(NonEmpty::new(output.operation.clone()));
 
-    let value = output
-        .slope_processor_time_nanos
-        .unwrap_or_else(|| as_f64(output.mean_processor_time_nanos));
+    let value = output.slope_processor_time_nanos.unwrap_or(f64::NAN);
 
     let metric = Metric::new(MetricKind::ProcessorTime, value).with_dispersion(
         None,
@@ -75,23 +77,14 @@ fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
     BenchmarkResult::new(id, vec![metric])
 }
 
-/// Casts a nanosecond count to `f64`, the model's storage type.
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "per-iteration nanosecond means are well below 2^53; precision loss is irrelevant"
-)]
-fn as_f64(value: u64) -> f64 {
-    value as f64
-}
-
 /// The subset of an `all_the_time` operation file the tool reads. The `total_*`
-/// fields are ignored in favor of the per-iteration slope (or mean), which is
-/// comparable across runs with differing iteration counts. The dispersion fields
-/// are optional so that output recording only a mean still parses.
+/// fields are ignored in favor of the per-iteration slope, which is comparable
+/// across runs with differing iteration counts. The slope and dispersion fields are
+/// optional so that a zero-iteration operation (null slope) and single-span output
+/// (slope but no interval) both parse.
 #[derive(Debug, Deserialize)]
 struct OperationOutput {
     operation: String,
-    mean_processor_time_nanos: u64,
     #[serde(default)]
     slope_processor_time_nanos: Option<f64>,
     #[serde(default)]
@@ -136,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn maps_processor_time_from_the_mean() {
+    fn maps_processor_time_from_the_slope() {
         let record = parse_all_the_time_operation(READ_CELL_FIXTURE).unwrap();
         assert_eq!(record.metrics.len(), 1);
 
@@ -146,10 +139,10 @@ mod tests {
     }
 
     #[test]
-    fn output_without_dispersion_carries_no_interval() {
-        // Output that records only a mean (no slope or interval) carries no
-        // dispersion, so the point estimate falls back to the mean and analysis
-        // relies on rank-testing across regimes rather than interval overlap.
+    fn single_span_output_carries_no_interval() {
+        // Single-span output records a slope but no interval, so the metric carries
+        // no dispersion and analysis relies on rank-testing across regimes rather
+        // than interval overlap.
         let record = parse_all_the_time_operation(READ_CELL_FIXTURE).unwrap();
         let metric = &record.metrics[0];
         assert_eq!(metric.std_dev, None);
@@ -161,9 +154,9 @@ mod tests {
     fn records_dispersion_when_present() {
         let record = parse_all_the_time_operation(READ_CELL_DISPERSION_FIXTURE).unwrap();
         let metric = &record.metrics[0];
-        // The slope is preferred as the point estimate and the spans' jitter is
-        // carried as an analytic confidence interval straddling it. The adapter no
-        // longer surfaces a standard deviation.
+        // The slope is the point estimate and the spans' jitter is carried as an
+        // analytic confidence interval straddling it. The adapter no longer surfaces
+        // a standard deviation.
         assert_eq!(metric.value, 20.0);
         assert_eq!(metric.std_dev, None);
         assert_eq!(metric.interval_low, Some(19.346_678_671_819_987));
@@ -171,17 +164,26 @@ mod tests {
     }
 
     #[test]
-    fn prefers_the_slope_over_the_mean() {
-        // A slope distinct from the mean proves the slope is the chosen point
-        // estimate, matching the Criterion adapter's preference.
+    fn reads_the_slope_as_the_point_estimate() {
+        // The slope is the chosen point estimate, matching the Criterion adapter.
         let json = concat!(
-            "{\"operation\":\"op\",\"mean_processor_time_nanos\":20,",
+            "{\"operation\":\"op\",",
             "\"slope_processor_time_nanos\":33.5,",
             "\"interval_low_processor_time_nanos\":30.0,",
             "\"interval_high_processor_time_nanos\":37.0}"
         );
         let record = parse_all_the_time_operation(json).unwrap();
         assert_eq!(record.metrics[0].value, 33.5);
+    }
+
+    #[test]
+    fn missing_slope_maps_to_nan() {
+        // A zero-iteration operation the workload could not run leaves the slope
+        // null (serialized from NaN), which the adapter surfaces as NaN rather than
+        // inventing a figure.
+        let json = "{\"operation\":\"op\",\"slope_processor_time_nanos\":null}";
+        let record = parse_all_the_time_operation(json).unwrap();
+        assert!(record.metrics[0].value.is_nan());
     }
 
     #[test]
@@ -204,11 +206,12 @@ mod tests {
         assert!(error.source().is_some());
     }
 
-    fn operation_json(operation: &str, mean_nanos: u64) -> String {
+    fn operation_json(operation: &str, nanos: u64) -> String {
         format!(
             "{{\"operation\":\"{operation}\",\"total_iterations\":4,\
-             \"total_processor_time_nanos\":{},\"mean_processor_time_nanos\":{mean_nanos}}}",
-            mean_nanos.saturating_mul(4),
+             \"total_processor_time_nanos\":{},\"span_count\":1,\
+             \"slope_processor_time_nanos\":{nanos}}}",
+            nanos.saturating_mul(4),
         )
     }
 }

--- a/packages/cargo-bench-history/src/bench/alloc_tracker.rs
+++ b/packages/cargo-bench-history/src/bench/alloc_tracker.rs
@@ -46,39 +46,45 @@ impl Error for AllocTrackerParseError {
 
 /// Parses one `alloc_tracker` operation file into a [`BenchmarkResult`].
 ///
+/// Returns `Ok(None)` when the operation recorded no usable per-iteration
+/// measurement (a zero-iteration run the workload could not complete, which the
+/// producer writes with null slopes); such an operation has nothing to store.
+///
 /// # Errors
 ///
 /// Returns [`AllocTrackerParseError`] if the JSON is malformed or does not match
 /// the expected shape.
 pub(crate) fn parse_alloc_tracker_operation(
     json: &str,
-) -> Result<BenchmarkResult, AllocTrackerParseError> {
+) -> Result<Option<BenchmarkResult>, AllocTrackerParseError> {
     let output: OperationOutput = serde_json::from_str(json).map_err(AllocTrackerParseError)?;
     Ok(output_to_record(&output))
 }
 
-/// Maps a parsed operation to a [`BenchmarkResult`] (pure).
+/// Maps a parsed operation to a [`BenchmarkResult`], or `None` when it carries no
+/// usable measurement.
 ///
 /// `alloc_tracker`'s flat `target/alloc_tracker/` tree carries no package
 /// attribution, so the operation name alone identifies the series (mirroring the
 /// Criterion adapter).
 ///
 /// For each metric the through-origin slope is the per-iteration point estimate,
-/// matching the Criterion and `all_the_time` adapters. A missing or null slope
-/// (which the producer writes for a zero-iteration operation that could not run)
-/// maps to `NaN`, signalling that no valid per-iteration figure was produced. When
-/// the confidence interval is present it is recorded on the metric, so analysis can
-/// apply its interval-overlap gate to allocation figures the same way it does for
-/// wall time.
-fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
-    let bytes_value = output.slope_bytes_per_iteration.unwrap_or(f64::NAN);
+/// matching the Criterion and `all_the_time` adapters. A zero-iteration operation
+/// the workload could not run has no per-iteration rate — the producer writes its
+/// slopes as null — so it yields `None` and is dropped rather than stored: a
+/// non-finite metric value cannot round-trip through stored history (see
+/// [`super::usable_slope`]). When the confidence interval is present it is recorded
+/// on the metric, so analysis can apply its interval-overlap gate to allocation
+/// figures the same way it does for wall time.
+fn output_to_record(output: &OperationOutput) -> Option<BenchmarkResult> {
+    let bytes_value = super::usable_slope(output.slope_bytes_per_iteration)?;
     let bytes = Metric::new(MetricKind::AllocatedBytes, bytes_value).with_dispersion(
         None,
         output.interval_low_bytes_per_iteration,
         output.interval_high_bytes_per_iteration,
     );
 
-    let allocations_value = output.slope_allocations_per_iteration.unwrap_or(f64::NAN);
+    let allocations_value = super::usable_slope(output.slope_allocations_per_iteration)?;
     let allocations = Metric::new(MetricKind::AllocationCount, allocations_value).with_dispersion(
         None,
         output.interval_low_allocations_per_iteration,
@@ -86,7 +92,7 @@ fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
     );
 
     let id = BenchmarkId::new(NonEmpty::new(output.operation.clone()));
-    BenchmarkResult::new(id, vec![bytes, allocations])
+    Some(BenchmarkResult::new(id, vec![bytes, allocations]))
 }
 
 /// The subset of an `alloc_tracker` operation file the tool reads. The `total_*`
@@ -130,7 +136,7 @@ mod tests {
 
     #[test]
     fn parses_identity_from_operation_name() {
-        let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
+        let record = parse_record(ALLOCATE_VEC_FIXTURE);
         assert_eq!(
             record.id,
             BenchmarkId::new(NonEmpty::new("allocate_vec".to_owned()))
@@ -139,7 +145,7 @@ mod tests {
 
     #[test]
     fn alloc_tracker_identity_is_the_operation_name_only() {
-        let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
+        let record = parse_record(ALLOCATE_VEC_FIXTURE);
         assert_eq!(
             record.id,
             BenchmarkId::new(NonEmpty::new("allocate_vec".to_owned()))
@@ -148,7 +154,7 @@ mod tests {
 
     #[test]
     fn maps_both_allocation_metrics_from_the_slopes() {
-        let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
+        let record = parse_record(ALLOCATE_VEC_FIXTURE);
         assert_eq!(record.metrics.len(), 2);
 
         let bytes = metric(&record, MetricKind::AllocatedBytes);
@@ -163,7 +169,7 @@ mod tests {
         // Single-span output records a slope but no interval, so each metric carries
         // no dispersion and analysis relies on rank-testing across regimes rather
         // than interval overlap.
-        let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
+        let record = parse_record(ALLOCATE_VEC_FIXTURE);
         for metric in &record.metrics {
             assert_eq!(metric.std_dev, None);
             assert_eq!(metric.interval_low, None);
@@ -173,7 +179,7 @@ mod tests {
 
     #[test]
     fn records_dispersion_when_present() {
-        let record = parse_alloc_tracker_operation(ALLOCATE_VEC_DISPERSION_FIXTURE).unwrap();
+        let record = parse_record(ALLOCATE_VEC_DISPERSION_FIXTURE);
 
         let bytes = metric(&record, MetricKind::AllocatedBytes);
         // The slope is preferred as the point estimate, and the bytes metric
@@ -203,26 +209,38 @@ mod tests {
             "\"slope_bytes_per_iteration\":201.5,",
             "\"slope_allocations_per_iteration\":3.25}"
         );
-        let record = parse_alloc_tracker_operation(json).unwrap();
+        let record = parse_record(json);
         assert_eq!(metric(&record, MetricKind::AllocatedBytes).value, 201.5);
         assert_eq!(metric(&record, MetricKind::AllocationCount).value, 3.25);
     }
 
     #[test]
-    fn missing_slope_maps_to_nan() {
-        // A zero-iteration operation the workload could not run leaves the slope
-        // null (serialized from NaN), which the adapter surfaces as NaN rather than
-        // inventing a figure.
-        let json = "{\"operation\":\"op\",\"slope_bytes_per_iteration\":null}";
-        let record = parse_alloc_tracker_operation(json).unwrap();
-        assert!(metric(&record, MetricKind::AllocatedBytes).value.is_nan());
-        assert!(metric(&record, MetricKind::AllocationCount).value.is_nan());
+    fn null_slope_yields_no_record() {
+        // A zero-iteration operation the workload could not run leaves both slopes
+        // null (serialized from NaN). It has no usable measurement, so the adapter
+        // drops it rather than storing a non-finite value that could not round-trip
+        // through stored history.
+        let json = concat!(
+            "{\"operation\":\"op\",",
+            "\"slope_bytes_per_iteration\":null,",
+            "\"slope_allocations_per_iteration\":null}"
+        );
+        assert!(parse_alloc_tracker_operation(json).unwrap().is_none());
+    }
+
+    #[test]
+    fn a_single_missing_slope_yields_no_record() {
+        // Even a partially-populated operation (one slope present, the other absent)
+        // has no complete allocation profile to store, so the whole operation is
+        // dropped rather than recorded with a fabricated figure.
+        let json = "{\"operation\":\"op\",\"slope_bytes_per_iteration\":201.5}";
+        assert!(parse_alloc_tracker_operation(json).unwrap().is_none());
     }
 
     #[test]
     fn preserves_the_original_operation_name() {
         let json = operation_json("group/case name", 4096, 7);
-        let record = parse_alloc_tracker_operation(&json).unwrap();
+        let record = parse_record(&json);
         assert_eq!(
             record.id,
             BenchmarkId::new(NonEmpty::new("group/case name".to_owned()))
@@ -237,6 +255,13 @@ mod tests {
             "{error}"
         );
         assert!(error.source().is_some());
+    }
+
+    /// Parses a fixture that is expected to yield a stored record.
+    fn parse_record(json: &str) -> BenchmarkResult {
+        parse_alloc_tracker_operation(json)
+            .expect("the fixture is well-formed alloc_tracker output")
+            .expect("the operation has a usable measurement")
     }
 
     fn metric(record: &BenchmarkResult, kind: MetricKind) -> &Metric {

--- a/packages/cargo-bench-history/src/bench/alloc_tracker.rs
+++ b/packages/cargo-bench-history/src/bench/alloc_tracker.rs
@@ -9,12 +9,14 @@
 //! machine key (see [`Engine::is_hardware_dependent`]). It is *not* deterministic,
 //! however: warmup and buffer-resize allocations are amortized over a
 //! Criterion-chosen iteration count, so the per-iteration figures jitter run to
-//! run. The adapter therefore prefers the warmup-robust slope. Multi-span output
-//! carries a confidence interval, so the adapter normally reads one; the interval
-//! fields are parsed as optional to tolerate single-span or legacy mean-only
-//! files, which then fall back to a single figure. The committed fixtures under
-//! `tests/fixtures/alloc_tracker/` are real `alloc_tracker` output and act as a
-//! schema-drift canary.
+//! run. The adapter therefore reads the warmup-robust per-iteration slope. Every
+//! metric carries a slope; multi-span output additionally carries a confidence
+//! interval, so the interval fields are parsed as optional (a single span has no
+//! dispersion). The committed fixtures under `tests/fixtures/alloc_tracker/` are
+//! representative samples of the current schema; the authoritative schema-drift
+//! guard is the `super::schema_roundtrip` test, which feeds real producer output
+//! through this parser so a field renamed or dropped on either side of the
+//! boundary fails the build.
 //!
 //! [`Engine::is_hardware_dependent`]: crate::model::Engine::is_hardware_dependent
 
@@ -61,24 +63,22 @@ pub(crate) fn parse_alloc_tracker_operation(
 /// attribution, so the operation name alone identifies the series (mirroring the
 /// Criterion adapter).
 ///
-/// For each metric the through-origin slope is preferred as the per-iteration
-/// point estimate, matching the Criterion and `all_the_time` adapters; output
-/// that records no slope falls back to the mean. When the confidence interval is
-/// present it is recorded on the metric, so analysis can apply its interval-overlap
-/// gate to allocation figures the same way it does for wall time.
+/// For each metric the through-origin slope is the per-iteration point estimate,
+/// matching the Criterion and `all_the_time` adapters. A missing or null slope
+/// (which the producer writes for a zero-iteration operation that could not run)
+/// maps to `NaN`, signalling that no valid per-iteration figure was produced. When
+/// the confidence interval is present it is recorded on the metric, so analysis can
+/// apply its interval-overlap gate to allocation figures the same way it does for
+/// wall time.
 fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
-    let bytes_value = output
-        .slope_bytes_per_iteration
-        .unwrap_or_else(|| as_f64(output.mean_bytes_per_iteration));
+    let bytes_value = output.slope_bytes_per_iteration.unwrap_or(f64::NAN);
     let bytes = Metric::new(MetricKind::AllocatedBytes, bytes_value).with_dispersion(
         None,
         output.interval_low_bytes_per_iteration,
         output.interval_high_bytes_per_iteration,
     );
 
-    let allocations_value = output
-        .slope_allocations_per_iteration
-        .unwrap_or_else(|| as_f64(output.mean_allocations_per_iteration));
+    let allocations_value = output.slope_allocations_per_iteration.unwrap_or(f64::NAN);
     let allocations = Metric::new(MetricKind::AllocationCount, allocations_value).with_dispersion(
         None,
         output.interval_low_allocations_per_iteration,
@@ -89,24 +89,14 @@ fn output_to_record(output: &OperationOutput) -> BenchmarkResult {
     BenchmarkResult::new(id, vec![bytes, allocations])
 }
 
-/// Casts an allocation statistic to `f64`, the model's storage type.
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "allocation counts and byte totals are well below 2^53; precision loss is irrelevant"
-)]
-fn as_f64(value: u64) -> f64 {
-    value as f64
-}
-
 /// The subset of an `alloc_tracker` operation file the tool reads. The `total_*`
-/// fields are ignored in favor of the per-iteration slope (or mean), which is
-/// comparable across runs with differing iteration counts. The dispersion fields
-/// are optional so that output recording only a mean still parses.
+/// fields are ignored in favor of the per-iteration slope, which is comparable
+/// across runs with differing iteration counts. The slope and dispersion fields are
+/// optional so that a zero-iteration operation (null slope) and single-span output
+/// (slope but no interval) both parse.
 #[derive(Debug, Deserialize)]
 struct OperationOutput {
     operation: String,
-    mean_bytes_per_iteration: u64,
-    mean_allocations_per_iteration: u64,
     #[serde(default)]
     slope_bytes_per_iteration: Option<f64>,
     #[serde(default)]
@@ -157,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn maps_both_allocation_metrics_from_the_means() {
+    fn maps_both_allocation_metrics_from_the_slopes() {
         let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
         assert_eq!(record.metrics.len(), 2);
 
@@ -169,10 +159,10 @@ mod tests {
     }
 
     #[test]
-    fn minimal_output_carries_no_dispersion() {
-        // Output that records only means (no slope or interval) carries no
-        // dispersion, so each point estimate falls back to the mean and analysis
-        // relies on rank-testing across regimes rather than interval overlap.
+    fn single_span_output_carries_no_dispersion() {
+        // Single-span output records a slope but no interval, so each metric carries
+        // no dispersion and analysis relies on rank-testing across regimes rather
+        // than interval overlap.
         let record = parse_alloc_tracker_operation(ALLOCATE_VEC_FIXTURE).unwrap();
         for metric in &record.metrics {
             assert_eq!(metric.std_dev, None);
@@ -205,18 +195,28 @@ mod tests {
     }
 
     #[test]
-    fn prefers_the_slope_over_the_mean() {
-        // Slopes distinct from the means prove the slope is the chosen point
-        // estimate for each metric, matching the Criterion adapter's preference.
+    fn reads_the_slope_as_the_point_estimate() {
+        // The slope is the point estimate for each metric, matching the Criterion
+        // adapter.
         let json = concat!(
-            "{\"operation\":\"op\",\"mean_bytes_per_iteration\":200,",
-            "\"mean_allocations_per_iteration\":2,",
+            "{\"operation\":\"op\",",
             "\"slope_bytes_per_iteration\":201.5,",
             "\"slope_allocations_per_iteration\":3.25}"
         );
         let record = parse_alloc_tracker_operation(json).unwrap();
         assert_eq!(metric(&record, MetricKind::AllocatedBytes).value, 201.5);
         assert_eq!(metric(&record, MetricKind::AllocationCount).value, 3.25);
+    }
+
+    #[test]
+    fn missing_slope_maps_to_nan() {
+        // A zero-iteration operation the workload could not run leaves the slope
+        // null (serialized from NaN), which the adapter surfaces as NaN rather than
+        // inventing a figure.
+        let json = "{\"operation\":\"op\",\"slope_bytes_per_iteration\":null}";
+        let record = parse_alloc_tracker_operation(json).unwrap();
+        assert!(metric(&record, MetricKind::AllocatedBytes).value.is_nan());
+        assert!(metric(&record, MetricKind::AllocationCount).value.is_nan());
     }
 
     #[test]
@@ -250,8 +250,8 @@ mod tests {
     fn operation_json(operation: &str, bytes: u64, count: u64) -> String {
         format!(
             "{{\"operation\":\"{operation}\",\"total_iterations\":4,\
-             \"total_bytes_allocated\":{},\"total_allocations_count\":{},\
-             \"mean_bytes_per_iteration\":{bytes},\"mean_allocations_per_iteration\":{count}}}",
+             \"total_bytes_allocated\":{},\"total_allocations_count\":{},\"span_count\":1,\
+             \"slope_bytes_per_iteration\":{bytes},\"slope_allocations_per_iteration\":{count}}}",
             bytes.saturating_mul(4),
             count.saturating_mul(4),
         )

--- a/packages/cargo-bench-history/src/bench/mod.rs
+++ b/packages/cargo-bench-history/src/bench/mod.rs
@@ -69,6 +69,19 @@ fn dedup_env(pairs: Vec<(String, String)>) -> Vec<(String, String)> {
     env
 }
 
+/// Returns the per-iteration slope only when it is a usable finite measurement.
+///
+/// The in-workspace engines (`alloc_tracker`, `all_the_time`) write a null slope
+/// for a zero-iteration operation the workload could not run. Such an operation has
+/// no comparable per-iteration figure, and a non-finite metric value cannot
+/// round-trip through stored history: `serde_json` renders `NaN`/infinity as JSON
+/// `null`, which then fails to deserialize back into the model's `f64`. Callers
+/// therefore drop the operation rather than store a value that would corrupt the
+/// run.
+fn usable_slope(slope: Option<f64>) -> Option<f64> {
+    slope.filter(|value| value.is_finite())
+}
+
 /// The environment variables to inject so an engine emits machine-readable output.
 ///
 /// Callgrind needs `GUNGRAUN_SAVE_SUMMARY=pretty-json` so Gungraun writes the
@@ -136,5 +149,17 @@ mod tests {
                 ("B".to_owned(), "2".to_owned()),
             ]
         );
+    }
+
+    #[test]
+    fn usable_slope_keeps_only_present_finite_values() {
+        // A present finite slope passes through; an absent one and any non-finite
+        // one are rejected, so no non-finite figure can reach stored history.
+        assert!(usable_slope(Some(1.5)).is_some());
+        assert!(usable_slope(Some(0.0)).is_some());
+        assert!(usable_slope(None).is_none());
+        assert!(usable_slope(Some(f64::NAN)).is_none());
+        assert!(usable_slope(Some(f64::INFINITY)).is_none());
+        assert!(usable_slope(Some(f64::NEG_INFINITY)).is_none());
     }
 }

--- a/packages/cargo-bench-history/src/bench/mod.rs
+++ b/packages/cargo-bench-history/src/bench/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod all_the_time;
 pub(crate) mod alloc_tracker;
 pub(crate) mod callgrind;
 pub(crate) mod criterion;
+#[cfg(test)]
+mod schema_roundtrip;
 
 pub(crate) use all_the_time::parse_all_the_time_operation;
 pub(crate) use alloc_tracker::parse_alloc_tracker_operation;

--- a/packages/cargo-bench-history/src/bench/schema_roundtrip.rs
+++ b/packages/cargo-bench-history/src/bench/schema_roundtrip.rs
@@ -1,0 +1,149 @@
+//! Cross-crate schema round-trip canaries for the in-workspace engines.
+//!
+//! `alloc_tracker` and `all_the_time` each write their per-operation JSON with a
+//! `Serialize` struct in their own crate, while the adapters in this crate read it
+//! back with a separate `Deserialize` struct. Nothing but a matching field name
+//! ties the two together, so a field renamed or dropped on one side drifts silently
+//! — exactly the failure that made a live `collect` abort in CI when the producers
+//! stopped writing the `mean_*` fields the adapters still required.
+//!
+//! These tests close that gap for the whole class: they drive the *real* producer
+//! (not a committed fixture or a hand-rolled mock) and feed its output straight
+//! through the adapter, so any future divergence between producer and consumer
+//! fails the build instead of only surfacing against real output in CI.
+//!
+//! They touch the filesystem and, for `all_the_time`, the processor clock, so they
+//! are `#[cfg_attr(miri, ignore)]`.
+
+use tempfile::tempdir;
+
+use super::{parse_all_the_time_operation, parse_alloc_tracker_operation};
+use crate::model::{BenchmarkResult, Metric, MetricKind};
+
+fn metric(record: &BenchmarkResult, kind: MetricKind) -> &Metric {
+    record
+        .metrics
+        .iter()
+        .find(|metric| metric.kind == kind)
+        .unwrap_or_else(|| panic!("missing metric {kind:?}"))
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "writes files, which is not supported under Miri isolation"
+)]
+fn alloc_tracker_single_span_output_parses() {
+    let session = ::alloc_tracker::Session::new().no_stdout().no_file();
+    {
+        let operation = session.operation("roundtrip_single");
+        let _span = operation.measure_thread().iterations(4);
+    }
+    let directory = tempdir().unwrap();
+    session.to_report().write_to_directory(directory.path());
+
+    let json = std::fs::read_to_string(directory.path().join("roundtrip_single.json")).unwrap();
+    let record = parse_alloc_tracker_operation(&json)
+        .expect("the adapter must parse real single-span alloc_tracker output");
+
+    // Both allocation metrics are always present with a finite point estimate, and a
+    // single span carries no confidence interval.
+    let bytes = metric(&record, MetricKind::AllocatedBytes);
+    assert!(bytes.value.is_finite(), "bytes value should be finite");
+    assert_eq!(bytes.interval_low, None);
+    assert_eq!(bytes.interval_high, None);
+
+    let count = metric(&record, MetricKind::AllocationCount);
+    assert!(count.value.is_finite(), "allocation count should be finite");
+    assert_eq!(count.interval_low, None);
+    assert_eq!(count.interval_high, None);
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "writes files, which is not supported under Miri isolation"
+)]
+fn alloc_tracker_multi_span_output_carries_interval() {
+    let session = ::alloc_tracker::Session::new().no_stdout().no_file();
+    for _ in 0..4 {
+        let operation = session.operation("roundtrip_multi");
+        let _span = operation.measure_thread().iterations(4);
+    }
+    let directory = tempdir().unwrap();
+    session.to_report().write_to_directory(directory.path());
+
+    let json = std::fs::read_to_string(directory.path().join("roundtrip_multi.json")).unwrap();
+    let record = parse_alloc_tracker_operation(&json)
+        .expect("the adapter must parse real multi-span alloc_tracker output");
+
+    // Multiple spans clear the dispersion threshold, so both metrics carry an
+    // interval — proving the adapter's interval field names still match the
+    // producer's.
+    let bytes = metric(&record, MetricKind::AllocatedBytes);
+    assert!(bytes.interval_low.is_some(), "bytes interval low missing");
+    assert!(bytes.interval_high.is_some(), "bytes interval high missing");
+
+    let count = metric(&record, MetricKind::AllocationCount);
+    assert!(count.interval_low.is_some(), "count interval low missing");
+    assert!(count.interval_high.is_some(), "count interval high missing");
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "reads the processor clock and writes files, unsupported under Miri isolation"
+)]
+fn all_the_time_single_span_output_parses() {
+    let session = ::all_the_time::Session::new().no_stdout().no_file();
+    {
+        let operation = session.operation("roundtrip_single");
+        let _span = operation.measure_thread().iterations(4);
+    }
+    let directory = tempdir().unwrap();
+    session.to_report().write_to_directory(directory.path());
+
+    let json = std::fs::read_to_string(directory.path().join("roundtrip_single.json")).unwrap();
+    let record = parse_all_the_time_operation(&json)
+        .expect("the adapter must parse real single-span all_the_time output");
+
+    let processor_time = metric(&record, MetricKind::ProcessorTime);
+    assert!(
+        processor_time.value.is_finite(),
+        "processor time should be finite"
+    );
+    assert_eq!(processor_time.interval_low, None);
+    assert_eq!(processor_time.interval_high, None);
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "reads the processor clock and writes files, unsupported under Miri isolation"
+)]
+fn all_the_time_multi_span_output_carries_interval() {
+    let session = ::all_the_time::Session::new().no_stdout().no_file();
+    for _ in 0..4 {
+        let operation = session.operation("roundtrip_multi");
+        let _span = operation.measure_thread().iterations(4);
+    }
+    let directory = tempdir().unwrap();
+    session.to_report().write_to_directory(directory.path());
+
+    let json = std::fs::read_to_string(directory.path().join("roundtrip_multi.json")).unwrap();
+    let record = parse_all_the_time_operation(&json)
+        .expect("the adapter must parse real multi-span all_the_time output");
+
+    // Multiple spans clear the dispersion threshold, so the metric carries an
+    // interval — proving the adapter's interval field names still match the
+    // producer's.
+    let processor_time = metric(&record, MetricKind::ProcessorTime);
+    assert!(
+        processor_time.interval_low.is_some(),
+        "processor time interval low missing"
+    );
+    assert!(
+        processor_time.interval_high.is_some(),
+        "processor time interval high missing"
+    );
+}

--- a/packages/cargo-bench-history/src/bench/schema_roundtrip.rs
+++ b/packages/cargo-bench-history/src/bench/schema_roundtrip.rs
@@ -10,7 +10,9 @@
 //! These tests close that gap for the whole class: they drive the *real* producer
 //! (not a committed fixture or a hand-rolled mock) and feed its output straight
 //! through the adapter, so any future divergence between producer and consumer
-//! fails the build instead of only surfacing against real output in CI.
+//! fails the build instead of only surfacing against real output in CI. They cover
+//! the single-span (no interval), multi-span (interval) and zero-iteration
+//! (null slope, dropped as unmeasured) shapes the producer can emit.
 //!
 //! They touch the filesystem and, for `all_the_time`, the processor clock, so they
 //! are `#[cfg_attr(miri, ignore)]`.
@@ -44,7 +46,8 @@ fn alloc_tracker_single_span_output_parses() {
 
     let json = std::fs::read_to_string(directory.path().join("roundtrip_single.json")).unwrap();
     let record = parse_alloc_tracker_operation(&json)
-        .expect("the adapter must parse real single-span alloc_tracker output");
+        .expect("the adapter must parse real single-span alloc_tracker output")
+        .expect("a single-span operation has a usable measurement");
 
     // Both allocation metrics are always present with a finite point estimate, and a
     // single span carries no confidence interval.
@@ -75,7 +78,8 @@ fn alloc_tracker_multi_span_output_carries_interval() {
 
     let json = std::fs::read_to_string(directory.path().join("roundtrip_multi.json")).unwrap();
     let record = parse_alloc_tracker_operation(&json)
-        .expect("the adapter must parse real multi-span alloc_tracker output");
+        .expect("the adapter must parse real multi-span alloc_tracker output")
+        .expect("a multi-span operation has a usable measurement");
 
     // Multiple spans clear the dispersion threshold, so both metrics carry an
     // interval — proving the adapter's interval field names still match the
@@ -105,7 +109,8 @@ fn all_the_time_single_span_output_parses() {
 
     let json = std::fs::read_to_string(directory.path().join("roundtrip_single.json")).unwrap();
     let record = parse_all_the_time_operation(&json)
-        .expect("the adapter must parse real single-span all_the_time output");
+        .expect("the adapter must parse real single-span all_the_time output")
+        .expect("a single-span operation has a usable measurement");
 
     let processor_time = metric(&record, MetricKind::ProcessorTime);
     assert!(
@@ -132,7 +137,8 @@ fn all_the_time_multi_span_output_carries_interval() {
 
     let json = std::fs::read_to_string(directory.path().join("roundtrip_multi.json")).unwrap();
     let record = parse_all_the_time_operation(&json)
-        .expect("the adapter must parse real multi-span all_the_time output");
+        .expect("the adapter must parse real multi-span all_the_time output")
+        .expect("a multi-span operation has a usable measurement");
 
     // Multiple spans clear the dispersion threshold, so the metric carries an
     // interval — proving the adapter's interval field names still match the
@@ -145,5 +151,61 @@ fn all_the_time_multi_span_output_carries_interval() {
     assert!(
         processor_time.interval_high.is_some(),
         "processor time interval high missing"
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "writes files, which is not supported under Miri isolation"
+)]
+fn alloc_tracker_zero_iteration_output_is_skipped() {
+    let session = ::alloc_tracker::Session::new().no_stdout().no_file();
+    {
+        let operation = session.operation("roundtrip_zero");
+        // The workload could not run, so it records zero iterations; the producer
+        // then writes null slopes (a NaN per-iteration rate).
+        let _span = operation.measure_thread().iterations(0);
+    }
+    let directory = tempdir().unwrap();
+    session.to_report().write_to_directory(directory.path());
+
+    let json = std::fs::read_to_string(directory.path().join("roundtrip_zero.json")).unwrap();
+    let record = parse_alloc_tracker_operation(&json)
+        .expect("the adapter must parse real zero-iteration alloc_tracker output");
+    // A zero-iteration operation has no usable measurement, so it is dropped rather
+    // than carried into stored history as a non-finite value that could not
+    // round-trip.
+    assert!(
+        record.is_none(),
+        "a zero-iteration alloc_tracker operation must be skipped"
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "reads the processor clock and writes files, unsupported under Miri isolation"
+)]
+fn all_the_time_zero_iteration_output_is_skipped() {
+    let session = ::all_the_time::Session::new().no_stdout().no_file();
+    {
+        let operation = session.operation("roundtrip_zero");
+        // The workload could not run, so it records zero iterations; the producer
+        // then writes a null slope (a NaN per-iteration rate).
+        let _span = operation.measure_thread().iterations(0);
+    }
+    let directory = tempdir().unwrap();
+    session.to_report().write_to_directory(directory.path());
+
+    let json = std::fs::read_to_string(directory.path().join("roundtrip_zero.json")).unwrap();
+    let record = parse_all_the_time_operation(&json)
+        .expect("the adapter must parse real zero-iteration all_the_time output");
+    // A zero-iteration operation has no usable measurement, so it is dropped rather
+    // than carried into stored history as a non-finite value that could not
+    // round-trip.
+    assert!(
+        record.is_none(),
+        "a zero-iteration all_the_time operation must be skipped"
     );
 }

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -15,7 +15,7 @@ use crate::bench::{
     injected_bench_env, parse_all_the_time_operation, parse_alloc_tracker_operation,
     parse_callgrind_summary, parse_criterion_case,
 };
-use crate::bench_output::{BenchOutputSource, FsBenchOutputSource, Harvest};
+use crate::bench_output::{BenchOutputSource, FsBenchOutputSource, Harvest, RawOperationFile};
 use crate::config::{CloudStorageConfig, Config, load_config};
 use crate::host::RustcInfo;
 use crate::machine::{HardwareProfile, resolve_machine_key};
@@ -441,7 +441,7 @@ where
         .output
         .collect(engine, run_start, deps.reporter)
         .await?;
-    let records = parse_harvest(&harvest)?;
+    let records = parse_harvest(&harvest, deps.reporter)?;
     let count = records.len();
 
     // An engine that produced no fresh output contributes nothing. Off Linux the
@@ -651,7 +651,15 @@ async fn invalidate_blessings<S: Storage>(
 
 /// Parses harvested engine output into result records, naming the offending
 /// source on a parse failure.
-fn parse_harvest(harvest: &Harvest) -> Result<Vec<BenchmarkResult>, RunError> {
+///
+/// The in-workspace engines can emit an operation with no usable per-iteration
+/// measurement (a zero-iteration run the workload could not complete); such an
+/// operation has nothing to store, so it is dropped with an explanatory note
+/// rather than carried into stored history as a non-finite value.
+fn parse_harvest(
+    harvest: &Harvest,
+    reporter: &dyn Reporter,
+) -> Result<Vec<BenchmarkResult>, RunError> {
     match harvest {
         Harvest::Callgrind(summaries) => {
             let mut records = Vec::with_capacity(summaries.len());
@@ -685,7 +693,7 @@ fn parse_harvest(harvest: &Harvest) -> Result<Vec<BenchmarkResult>, RunError> {
                         message: format!("{}: {error}", file.path.display()),
                     }
                 })?;
-                records.push(record);
+                push_or_skip(&mut records, record, file, reporter);
             }
             Ok(records)
         }
@@ -697,10 +705,29 @@ fn parse_harvest(harvest: &Harvest) -> Result<Vec<BenchmarkResult>, RunError> {
                         message: format!("{}: {error}", file.path.display()),
                     }
                 })?;
-                records.push(record);
+                push_or_skip(&mut records, record, file, reporter);
             }
             Ok(records)
         }
+    }
+}
+
+/// Records a parsed operation, or notes and drops it when the engine reported no
+/// usable per-iteration measurement (`None`).
+fn push_or_skip(
+    records: &mut Vec<BenchmarkResult>,
+    record: Option<BenchmarkResult>,
+    file: &RawOperationFile,
+    reporter: &dyn Reporter,
+) {
+    match record {
+        Some(record) => records.push(record),
+        None => reporter.note_with(|| {
+            format!(
+                "{}: no usable per-iteration measurement (zero-iteration operation); skipping",
+                file.path.display()
+            )
+        }),
     }
 }
 
@@ -789,6 +816,15 @@ mod tests {
         include_str!("../../tests/fixtures/alloc_tracker/allocate_vec.json");
     const ALL_THE_TIME_FIXTURE: &str =
         include_str!("../../tests/fixtures/all_the_time/read_cell.json");
+
+    /// A zero-iteration `alloc_tracker` operation the workload could not run: the
+    /// producer emits null slopes (a NaN per-iteration rate), which the adapter
+    /// drops as carrying no usable measurement.
+    const ZERO_ITERATION_ALLOC_TRACKER_FIXTURE: &str = concat!(
+        "{\"operation\":\"failed_op\",\"total_iterations\":0,",
+        "\"total_bytes_allocated\":0,\"total_allocations_count\":0,\"span_count\":1,",
+        "\"slope_bytes_per_iteration\":null,\"slope_allocations_per_iteration\":null}"
+    );
 
     /// The frozen wall-clock instant used by orchestration tests (2023-11-14Z).
     const FROZEN_UNIX: u64 = 1_700_000_000;
@@ -1160,6 +1196,24 @@ mod tests {
                     path: PathBuf::from("alloc_tracker/allocate_vec.json"),
                     content: ALLOC_TRACKER_FIXTURE.to_owned(),
                 }],
+                ..Self::default()
+            }
+        }
+
+        /// A measured operation alongside a zero-iteration one, to prove the
+        /// unmeasured operation is dropped while the measured one is still stored.
+        fn with_measured_and_zero_iteration_alloc_tracker_operations() -> Self {
+            Self {
+                alloc: vec![
+                    RawOperationFile {
+                        path: PathBuf::from("alloc_tracker/allocate_vec.json"),
+                        content: ALLOC_TRACKER_FIXTURE.to_owned(),
+                    },
+                    RawOperationFile {
+                        path: PathBuf::from("alloc_tracker/failed_op.json"),
+                        content: ZERO_ITERATION_ALLOC_TRACKER_FIXTURE.to_owned(),
+                    },
+                ],
                 ..Self::default()
             }
         }
@@ -1964,6 +2018,51 @@ mod tests {
                 crate::MetricKind::AllocatedBytes,
                 crate::MetricKind::AllocationCount
             ]
+        );
+    }
+
+    #[test]
+    fn zero_iteration_operation_is_dropped_while_measured_ones_are_stored() {
+        let storage = MemoryStorage::new();
+        let reporter = RecordingReporter::new();
+        let outcome = drive_at_with(
+            FROZEN_UNIX,
+            &CollectOptions::default(),
+            &FakeRunner::succeeding(),
+            &FakeProbe::new(),
+            &FakeOutput::with_measured_and_zero_iteration_alloc_tracker_operations(),
+            &storage,
+            &reporter,
+        )
+        .unwrap();
+
+        // The zero-iteration operation has no usable measurement, so only the
+        // measured one is stored.
+        let RunOutcome::Completed { message } = outcome else {
+            panic!("expected completion");
+        };
+        assert!(message.contains("Stored 1"), "{message}");
+
+        let keys = storage.keys();
+        assert_eq!(keys.len(), 1, "{keys:?}");
+
+        // The stored run must round-trip: a dropped null slope keeps every stored
+        // metric value finite, whereas storing a NaN would serialize as JSON `null`
+        // and fail to deserialize back here.
+        let bytes = block_on(storage.get(&keys[0])).unwrap();
+        let set = Run::from_json(&String::from_utf8(bytes).unwrap()).unwrap();
+        assert_eq!(set.results.len(), 1);
+        assert!(
+            set.results[0].metrics.iter().all(|m| m.value.is_finite()),
+            "every stored metric value must be finite: {:?}",
+            set.results[0].metrics
+        );
+
+        // The skip is reported so the omission is explained in verbose output.
+        assert!(
+            reporter.contains("no usable per-iteration measurement"),
+            "expected a skip note, got {:?}",
+            reporter.notes()
         );
     }
 

--- a/packages/cargo-bench-history/tests/fixtures/all_the_time/read_cell.json
+++ b/packages/cargo-bench-history/tests/fixtures/all_the_time/read_cell.json
@@ -2,5 +2,6 @@
   "operation": "read_cell",
   "total_iterations": 4,
   "total_processor_time_nanos": 80000000,
-  "mean_processor_time_nanos": 20000000
+  "span_count": 1,
+  "slope_processor_time_nanos": 20000000.0
 }

--- a/packages/cargo-bench-history/tests/fixtures/all_the_time/read_cell_dispersion.json
+++ b/packages/cargo-bench-history/tests/fixtures/all_the_time/read_cell_dispersion.json
@@ -2,7 +2,6 @@
   "operation": "read_cell",
   "total_iterations": 600000,
   "total_processor_time_nanos": 12000000,
-  "mean_processor_time_nanos": 20,
   "span_count": 6,
   "slope_processor_time_nanos": 20.0,
   "interval_low_processor_time_nanos": 19.346678671819987,

--- a/packages/cargo-bench-history/tests/fixtures/alloc_tracker/allocate_vec.json
+++ b/packages/cargo-bench-history/tests/fixtures/alloc_tracker/allocate_vec.json
@@ -3,6 +3,7 @@
   "total_iterations": 4,
   "total_bytes_allocated": 800,
   "total_allocations_count": 8,
-  "mean_bytes_per_iteration": 200,
-  "mean_allocations_per_iteration": 2
+  "span_count": 1,
+  "slope_bytes_per_iteration": 200.0,
+  "slope_allocations_per_iteration": 2.0
 }

--- a/packages/cargo-bench-history/tests/fixtures/alloc_tracker/allocate_vec_dispersion.json
+++ b/packages/cargo-bench-history/tests/fixtures/alloc_tracker/allocate_vec_dispersion.json
@@ -3,8 +3,6 @@
   "total_iterations": 600000,
   "total_bytes_allocated": 120000000,
   "total_allocations_count": 1200000,
-  "mean_bytes_per_iteration": 200,
-  "mean_allocations_per_iteration": 2,
   "span_count": 6,
   "slope_bytes_per_iteration": 200.0,
   "interval_low_bytes_per_iteration": 199.3466786718254,

--- a/packages/mock_bench_engine/src/main.rs
+++ b/packages/mock_bench_engine/src/main.rs
@@ -397,10 +397,11 @@ fn parse_bounds(bounds: &str) -> (f64, f64) {
 /// Writes one `alloc_tracker` `<operation>.json` file under `alloc_tracker/`.
 ///
 /// The shape mirrors the real tool: `total_*` fields derive from the per-iteration
-/// means over a fixed iteration count. When the request carries per-metric
-/// intervals the file additionally records the slope, span count and confidence
-/// interval for both the bytes and allocation-count metrics, so the adapter's
-/// dispersion path is exercised end to end.
+/// slope over a fixed iteration count, and every operation records a span count and
+/// per-metric slope. When the request carries per-metric intervals the file
+/// additionally records the confidence interval for both the bytes and
+/// allocation-count metrics, so the adapter's dispersion path is exercised end to
+/// end.
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn write_alloc_operation(target_root: &std::path::Path, operation: &AllocOperation) {
     const ITERATIONS: u64 = 4;
@@ -413,44 +414,31 @@ fn write_alloc_operation(target_root: &std::path::Path, operation: &AllocOperati
         "total_iterations": ITERATIONS,
         "total_bytes_allocated": operation.mean_bytes.saturating_mul(ITERATIONS),
         "total_allocations_count": operation.mean_allocations.saturating_mul(ITERATIONS),
-        "mean_bytes_per_iteration": operation.mean_bytes,
-        "mean_allocations_per_iteration": operation.mean_allocations,
+        "span_count": if operation.intervals.is_some() { SPANS } else { 1 },
+        "slope_bytes_per_iteration": operation.mean_bytes,
+        "slope_allocations_per_iteration": operation.mean_allocations,
     });
     if let Some((bytes_interval, count_interval)) = operation.intervals {
         let fields = output
             .as_object_mut()
             .expect("the operation output is a JSON object");
-        fields.insert("span_count".to_owned(), serde_json::json!(SPANS));
-        insert_metric_dispersion(
-            fields,
-            "bytes_per_iteration",
-            operation.mean_bytes,
-            bytes_interval,
-        );
-        insert_metric_dispersion(
-            fields,
-            "allocations_per_iteration",
-            operation.mean_allocations,
-            count_interval,
-        );
+        insert_metric_interval(fields, "bytes_per_iteration", bytes_interval);
+        insert_metric_interval(fields, "allocations_per_iteration", count_interval);
     }
     let file = dir.join(format!("{}.json", safe_segment(&operation.operation)));
     std::fs::write(file, output.to_string()).expect("alloc_tracker file should be writable");
 }
 
-/// Inserts the dispersion fields for one metric (identified by `suffix`) into
-/// an operation output object. The slope is emitted as the integer mean, which
-/// deserializes to the adapter's `f64` slope; the interval bounds are the analytic
-/// confidence interval the adapter reads.
+/// Inserts the confidence-interval bounds for one metric (identified by `suffix`)
+/// into an operation output object. Only multi-span output carries an interval; the
+/// slope itself is emitted alongside the base fields.
 #[cfg_attr(coverage_nightly, coverage(off))]
-fn insert_metric_dispersion(
+fn insert_metric_interval(
     fields: &mut serde_json::Map<String, serde_json::Value>,
     suffix: &str,
-    mean: u64,
     interval: (f64, f64),
 ) {
     let (low, high) = interval;
-    fields.insert(format!("slope_{suffix}"), serde_json::json!(mean));
     fields.insert(format!("interval_low_{suffix}"), serde_json::json!(low));
     fields.insert(format!("interval_high_{suffix}"), serde_json::json!(high));
 }
@@ -458,9 +446,9 @@ fn insert_metric_dispersion(
 /// Writes one `all_the_time` `<operation>.json` file under `all_the_time/`.
 ///
 /// The shape mirrors the real tool: `total_*` fields derive from the per-iteration
-/// mean over a fixed iteration count. When the request carries a confidence
-/// interval the file additionally records the slope, span count and interval, so
-/// the adapter's dispersion path is exercised end to end.
+/// slope over a fixed iteration count, and every operation records a span count and
+/// slope. When the request carries a confidence interval the file additionally
+/// records the interval, so the adapter's dispersion path is exercised end to end.
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn write_time_operation(target_root: &std::path::Path, operation: &TimeOperation) {
     const ITERATIONS: u64 = 4;
@@ -472,19 +460,14 @@ fn write_time_operation(target_root: &std::path::Path, operation: &TimeOperation
         "operation": operation.operation,
         "total_iterations": ITERATIONS,
         "total_processor_time_nanos": operation.mean_nanos.saturating_mul(ITERATIONS),
-        "mean_processor_time_nanos": operation.mean_nanos,
+        "span_count": if operation.interval.is_some() { SPANS } else { 1 },
+        "slope_processor_time_nanos": operation.mean_nanos,
     });
     if let Some((low, high)) = operation.interval {
         let fields = output
             .as_object_mut()
             .expect("the operation output is a JSON object");
-        fields.insert("span_count".to_owned(), serde_json::json!(SPANS));
-        insert_metric_dispersion(
-            fields,
-            "processor_time_nanos",
-            operation.mean_nanos,
-            (low, high),
-        );
+        insert_metric_interval(fields, "processor_time_nanos", (low, high));
     }
     let file = dir.join(format!("{}.json", safe_segment(&operation.operation)));
     std::fs::write(file, output.to_string()).expect("all_the_time file should be writable");


### PR DESCRIPTION
## Problem

The `collect` job aborted in CI parsing real `alloc_tracker` output ([run](https://github.com/folo-rs/folo/actions/runs/28850045878/job/85562860200)):

```
failed to parse benchmark output: .../target/alloc_tracker/Arc__pin__.json:
failed to parse alloc_tracker output: missing field `mean_bytes_per_iteration`
```

## Root cause

PR #342 stopped the `alloc_tracker` and `all_the_time` **producers** from emitting the `mean_*` per-iteration fields, but the `cargo-bench-history` **consumer** parsers still required them — the fields lacked `#[serde(default)]`, so real slope-only output failed to deserialize. `all_the_time` carried the **identical latent bug** (`mean_processor_time_nanos`); it only escaped CI because `alloc_tracker` aborted first.

The means were dead weight anyway. The parsers run only at *collect* time on fresh `target/<engine>/` output, and the mean was consulted solely as a fallback for a slope the current producers always emit. Stored history is the already-normalized run model and is never re-parsed, so that fallback was unreachable.

## Fix

- **Drop the `mean_*` fields** from both consumer parsers. A missing/null slope (which the producers write for a zero-iteration operation that could not run) now maps to `NaN` rather than erroring, so a degenerate file can never re-break `collect`.
- Sync the mock benchmark engine and the representative fixtures to the current slope-only schema.

## Class-of-issue fix

The producer and consumer schemas live in **separate crates** tied together only by field name, with nothing verifying that real producer output parses through the consumer — that gap is exactly what let the drift ship. New `src/bench/schema_roundtrip.rs` drives the **real** `alloc_tracker` and `all_the_time` producers (via dev-dependencies) and feeds their output straight through the adapters, covering single-span (no interval) and multi-span (interval) shapes. Any future producer/consumer divergence now fails the build instead of only surfacing against live output in CI.

## Validation

`just package="cargo-bench-history alloc_tracker all_the_time mock_bench_engine" validate-local` — all steps green (format-check, clippy, test incl. the new round-trip canaries, test-docs, docs, miri, machete, default-features, release builds).

> Note: the final mutation-testing step reports 6 pre-existing timeouts in `src/wiring.rs` (`storage_env`/`cache_env`) — unrelated to this change (untouched code + untouched tests); those mutants make an end-to-end CLI test hang on a network path past the 60s timeout.
