### PR TITLE
cargo-bench-history: skip mutating thin env-read IO wrappers (#346)

### DIFF
--- a/packages/cargo-bench-history/src/wiring.rs
+++ b/packages/cargo-bench-history/src/wiring.rs
@@ -58,6 +58,15 @@ pub(crate) fn resolve_repo(workspace_dir: &Path, repo: Option<&Path>) -> PathBuf
 /// so the pure [`resolve_local_path`] resolver stays testable and Miri-safe. An
 /// unset variable yields `None`; a set-but-empty value yields `Some("")`, leaving
 /// the empty/non-empty distinction to the resolver.
+///
+/// Not mutation-tested: like the `entra_credential` env read in the storage
+/// layer it is a bare `std::env::var` read whose behaviour cannot be pinned
+/// without mutating the global process environment (which the suite avoids). All
+/// the meaningful logic lives in [`resolve_local_path`], which stays fully under
+/// mutation; the only coverage of the reader itself is a subprocess-spawning
+/// end-to-end test, and forcing the parallel mutation run to reach that slow test
+/// just to kill a no-signal IO edge is what times it out.
+#[cfg_attr(test, mutants::skip)]
 pub(crate) fn storage_env() -> Option<String> {
     std::env::var(STORAGE_ENV_VAR).ok()
 }
@@ -97,6 +106,11 @@ pub(crate) fn resolve_local_path(
 /// The cache-side counterpart of [`storage_env`]: the single environment read
 /// behind a bare `--cache`, kept at the IO edge so the pure [`resolve_cache_path`]
 /// resolver stays testable and Miri-safe.
+///
+/// Not mutation-tested, for the same reason as [`storage_env`]: it is a bare
+/// `std::env::var` read with no signal beyond the IO edge, and
+/// [`resolve_cache_path`] carries all the logic that stays under mutation.
+#[cfg_attr(test, mutants::skip)]
 pub(crate) fn cache_env() -> Option<String> {
     std::env::var(CACHE_ENV_VAR).ok()
 }


### PR DESCRIPTION
## Summary

Fixes #346 — the 6 mutation **timeouts** on `storage_env` / `cache_env` in `src/wiring.rs`.

## Root cause

These are timeouts, not hangs. `storage_env()` / `cache_env()` are bare `std::env::var(X).ok()` reads whose only end-to-end coverage is the subprocess-spawning `cli.rs` tests, which live in the `cbh_integration` binary (~25s solo).

`cargo test` runs the **lib** unittests binary *before* integration binaries and **stops after the first failing binary**. A mutant caught by a fast lib test therefore stops `cargo test` before the slow integration binary ever runs. These 6 mutants have **no lib-level catcher**, so `cargo test` must run the whole ~25s integration binary to kill them. Under the full `just mutants` run (`--jobs 6` on a 32-CPU box, `--timeout=60`), six concurrent copies of that subprocess-heavy binary saturate the machine and exceed 60s → reported as timeouts. In isolation cargo-mutants catches all 6 (~27s each); there is no infinite loop.

## Fix

Mark both thin readers `#[cfg_attr(test, mutants::skip)]`, mirroring the existing convention for no-signal IO edges:
- `entra_credential` (`storage/azure.rs` — a `|key| env::var(key).ok()` wrapper)
- `detect_cpu_brand` (`machine.rs` — "Reads an environment variable; nothing further to assert.")

The pure resolvers `resolve_local_path` / `resolve_cache_path` take the env value as a parameter, are exhaustively unit-tested, and **stay fully under mutation** (including their `!value.is_empty()` guards). The suite also deliberately avoids mutating the global process environment in tests, so a global-env-mutating unit test was not the right tool here.

## Verification

- `cargo mutants --list -f .../wiring.rs` no longer emits the 6 `storage_env` / `cache_env` mutants; all other wiring mutants remain.
- `cargo clippy -p cargo-bench-history --all-targets` clean.
- `cargo doc -p cargo-bench-history --no-deps` clean under `-D warnings`.
- wiring lib tests pass.
