### PR TITLE
Add PowerShell linting (PSScriptAnalyzer) and extract inline pwsh

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -100,7 +100,9 @@ runs:
       id: rust-toolchain
       shell: pwsh
       run: |
+        Set-StrictMode -Version Latest
         $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         $match = Select-String -Path 'rust-toolchain.toml' -Pattern '^\s*channel\s*=\s*"([^"]+)"' | Select-Object -First 1
         if (-not $match) { throw 'Could not read the pinned channel from rust-toolchain.toml' }
         $channel = $match.Matches[0].Groups[1].Value

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -17,13 +17,13 @@ runs:
     - name: Install APT packages (Linux)
       # The GitHub-hosted Ubuntu images already ship git, git-lfs, gcc, make, curl,
       # libssl-dev, pkg-config and PowerShell (apt reports them "already the newest"), so
-      # only build-essential, cmake and valgrind — plus their dependencies — are genuinely
+      # only build-essential, cmake and valgrind - plus their dependencies - are genuinely
       # installed here. Package downloads are not the bottleneck (~1s for tens of MB on the
       # Azure mirrors); the cost is the `apt-get update` index refresh and the dpkg
       # unpack/configure. cache-apt-pkgs-action restores the already-configured files from
       # an actions/cache entry and skips apt entirely on a hit, cutting this step from ~15s
       # (amd64) / ~26s (arm64) to a few seconds. The action is in upstream maintenance mode,
-      # so `@v1` only rolls forward to backward-compatible fixes within its major line —
+      # so `@v1` only rolls forward to backward-compatible fixes within its major line -
       # there is no breaking v2 to chase.
       #
       # execute_install_scripts runs each package's postinst (e.g. ldconfig) on restore so
@@ -40,7 +40,7 @@ runs:
 
     - name: Install PowerShell (Linux ARM64)
       # amd64 Ubuntu runners preinstall PowerShell, but the arm64 images do not ship a pwsh
-      # the packages.microsoft.com apt repo can satisfy — that repo only publishes amd64
+      # the packages.microsoft.com apt repo can satisfy - that repo only publishes amd64
       # packages, so `apt install powershell` fails on arm64 with "Depends: libc6:amd64 but
       # it is not installable". Microsoft instead ships arm64 PowerShell as a tarball on the
       # PowerShell GitHub releases page, which we install here. --retry-all-errors covers
@@ -68,8 +68,8 @@ runs:
     - name: Cache Rust toolchains
       # Restored BEFORE the toolchain is installed so the pinned stable, the MSRV and the
       # pinned nightly (whose profile pulls rust-src, llvm-tools-preview and miri) are all
-      # served from cache, turning every `rustup toolchain install` — the dtolnay step below
-      # and the ones inside `just install-tools` — into a no-op on a hit. rust-cache below
+      # served from cache, turning every `rustup toolchain install` - the dtolnay step below
+      # and the ones inside `just install-tools` - into a no-op on a hit. rust-cache below
       # caches ~/.cargo and ./target but never ~/.rustup, so re-installing these toolchains is
       # the single largest uncached cost of this composite.
       #
@@ -92,8 +92,8 @@ runs:
         key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('constants.env', 'rust-toolchain.toml') }}
 
     - name: Read pinned Rust toolchain channel
-      # dtolnay/rust-toolchain cannot read rust-toolchain.toml — its channel comes from the
-      # action @rev or the `toolchain` input — so extract the pinned stable channel here and
+      # dtolnay/rust-toolchain cannot read rust-toolchain.toml - its channel comes from the
+      # action @rev or the `toolchain` input - so extract the pinned stable channel here and
       # hand it to the install step below. Parsing in PowerShell keeps it portable across the
       # Linux/macOS/Windows runners (macOS ships BSD grep, which has no -P). The version is
       # never hardcoded; rust-toolchain.toml stays the single source of truth.
@@ -110,13 +110,13 @@ runs:
         "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
     - name: Install Rust toolchain
-      # Pinned to the exact channel from rust-toolchain.toml (parsed above) via @master —
+      # Pinned to the exact channel from rust-toolchain.toml (parsed above) via @master -
       # dtolnay's documented ref for passing an explicit `toolchain`. Using @stable would
       # instead install the *latest* stable and roll it forward every ~6 weeks; because
       # Swatinem/rust-cache enumerates every installed toolchain (`rustup toolchain list`)
       # into its key, that rolling stable would silently bust the shared compilation cache on
       # each upstream release even though the workspace only ever builds with the pinned
-      # channel. Pinning it keeps the toolchain set — and thus the cache key — stable until we
+      # channel. Pinning it keeps the toolchain set - and thus the cache key - stable until we
       # deliberately bump the pin.
       uses: dtolnay/rust-toolchain@master
       with:
@@ -147,7 +147,7 @@ runs:
       # tools below (which runs install-tools).
       #
       # Keyed on OS + arch + a hash of the two install scripts, which embed both the pinned
-      # versions and their published checksums — so bumping either tool invalidates the cache
+      # versions and their published checksums - so bumping either tool invalidates the cache
       # automatically. Like rustup toolchains these are prebuilt, relocatable binaries that do not
       # link against image-specific dylibs, so the runner ImageVersion is deliberately left out of
       # the key.
@@ -171,7 +171,7 @@ runs:
       # never diverge and every tool version has a single source of truth (the recipe). Two tools
       # are trimmed here because no ordinary CI job needs them: azcopy is always skipped (only the
       # on-demand `just bench-history-stress-azure` uses it), and Azurite is skipped unless a job
-      # opts in via install-azurite (the test-azurite job does) — its emulator install is not worth
+      # opts in via install-azurite (the test-azurite job does) - its emulator install is not worth
       # the ~3 minutes on every other job.
       shell: bash
       env:
@@ -196,7 +196,7 @@ runs:
           # Prove the APT packages restored from the cache are functional. valgrind is the
           # one that matters: no PR-validation job runs it (only the nightly bench-history
           # workflow does), and a fileset-only cache restore could leave its shared
-          # libraries unregistered — so actually run it against a trivial program rather
+          # libraries unregistered - so actually run it against a trivial program rather
           # than only printing a version.
           cmake --version
           valgrind --quiet --error-exitcode=1 /bin/true

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,4 +1,4 @@
-# GitHub workflows — agent instructions
+# GitHub workflows - agent instructions
 
 Instructions for editing the workflows in this directory. For the design and its rationale,
 see [design.md](design.md). Keep this file limited to actionable instructions; put
@@ -14,14 +14,14 @@ high-level design in `design.md` and per-job mechanics in inline YAML comments.
 ## Shell
 
 - Every `run:` step uses `shell: pwsh`; prefer PowerShell over Bash. The `setup-environment`
-  composite is the only exception — it bootstraps PowerShell itself.
+  composite is the only exception - it bootstraps PowerShell itself.
 - Every `run: pwsh` step opens with the standard preamble (`Set-StrictMode -Version Latest` plus
   the two error-preference lines); see `docs/build-and-tooling.md`.
 - Keep steps thin: put non-trivial logic in a PowerShell `[script]` `just` recipe the step
   calls, so it runs and is tested locally. Logic worth unit-testing goes one level deeper
   into a module under `scripts/` covered by a Pester suite (`just test-scripts`); see
   `scripts/release/ReleaseAutomation.psm1`. This is also what makes the logic visible to
-  `just validate-scripts` (PSScriptAnalyzer) — inline YAML is invisible to both it and Pester.
+  `just validate-scripts` (PSScriptAnalyzer) - inline YAML is invisible to both it and Pester.
 
 ## Toolchain versions
 
@@ -32,6 +32,6 @@ high-level design in `design.md` and per-job mechanics in inline YAML comments.
 ## Job gating
 
 - A job whose inputs are not Cargo packages (the workflow files, or anything under
-  `scripts/`) must run unconditionally — do not gate it on the `delta` job or `skip_all`, or
+  `scripts/`) must run unconditionally - do not gate it on the `delta` job or `skip_all`, or
   a change touching only those files would be validated by nothing. Package-scoped jobs gate
   on `delta`.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -15,10 +15,13 @@ high-level design in `design.md` and per-job mechanics in inline YAML comments.
 
 - Every `run:` step uses `shell: pwsh`; prefer PowerShell over Bash. The `setup-environment`
   composite is the only exception — it bootstraps PowerShell itself.
+- Every `run: pwsh` step opens with the standard preamble (`Set-StrictMode -Version Latest` plus
+  the two error-preference lines); see `docs/build-and-tooling.md`.
 - Keep steps thin: put non-trivial logic in a PowerShell `[script]` `just` recipe the step
   calls, so it runs and is tested locally. Logic worth unit-testing goes one level deeper
   into a module under `scripts/` covered by a Pester suite (`just test-scripts`); see
-  `scripts/release/ReleaseAutomation.psm1`.
+  `scripts/release/ReleaseAutomation.psm1`. This is also what makes the logic visible to
+  `just validate-scripts` (PSScriptAnalyzer) — inline YAML is invisible to both it and Pester.
 
 ## Toolchain versions
 

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -15,7 +15,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Group by the commit SHA, not the ref. Distinct commits must collect in parallel — each is
+# Group by the commit SHA, not the ref. Distinct commits must collect in parallel - each is
 # its own history data point, and cancelling one to favour a newer commit would drop that
 # commit's measurements, defeating the per-commit goal (so the usual ref-keyed
 # cancel-in-progress from validation.yml would be wrong here). cancel-in-progress therefore
@@ -59,7 +59,7 @@ jobs:
     # (each a signed JWT proving "this run is repo folo-rs/folo on ref refs/heads/main").
     # The tool exchanges them directly with Entra, which matches each against the
     # dedicated prod managed identity's `main`-branch federated credential (created by
-    # infra/azure-bench-history-prod/) and issues an access token — so CI authenticates
+    # infra/azure-bench-history-prod/) and issues an access token - so CI authenticates
     # with no stored secret. Minting on demand (rather than once up front via
     # `azure/login`) is what keeps a multi-hour run authenticated past the ~1h
     # access-token lifetime. `contents: read` is the minimum the checkout needs.
@@ -75,8 +75,8 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       # cargo-bench-history self-federates with GitHub OIDC: given the managed identity's
-      # client id and tenant — plus the ACTIONS_ID_TOKEN_* values GitHub injects because
-      # of id-token: write — it mints a fresh OIDC assertion each time Entra needs a new
+      # client id and tenant - plus the ACTIONS_ID_TOKEN_* values GitHub injects because
+      # of id-token: write - it mints a fresh OIDC assertion each time Entra needs a new
       # access token, so a long run never re-submits an expired assertion. Export those
       # two identifiers from constants.env under the standard names the tool reads
       # (AZURE_PROD_CLIENT_ID is the prod identity's client id). The data store account
@@ -147,8 +147,8 @@ jobs:
           Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
           Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
-      # All bench-history scratch — the read-through cache and every rendered report/summary/
-      # notable/issue-body file — lives under the runner temp directory, OUTSIDE the repo
+      # All bench-history scratch - the read-through cache and every rendered report/summary/
+      # notable/issue-body file - lives under the runner temp directory, OUTSIDE the repo
       # checkout. Keeping it out of the working tree is what stops `analyze`'s own
       # `git status --porcelain` dirty-check from seeing these files (the cache is even restored
       # BELOW, before analyze runs) and wrongly annotating the analyzed tip
@@ -175,7 +175,7 @@ jobs:
       # new objects, and this run saves a fresh entry on success. The path MUST match the
       # `--cache` directory the `gh-analyze-bench-history` recipe passes (`<scratch>/cache`).
       # The cloud history is append-only (collect uses --skip-existing), so a
-      # restored-but-slightly-stale mirror is always correct — a deliberate
+      # restored-but-slightly-stale mirror is always correct - a deliberate
       # --overwrite/prune bumps the cloud marker that wipes it on the next read.
       - name: Restore benchmark-history read-through cache
         uses: actions/cache@v4
@@ -224,13 +224,13 @@ jobs:
           if-no-files-found: error
 
       # The File step passes the title and labels to the gh-file-rolling-issue recipe as `gh`
-      # flags, so this body needs NO YAML front matter — it is the pure issue body. That fixed
+      # flags, so this body needs NO YAML front matter - it is the pure issue body. That fixed
       # title is the dedup key that turns findings into one rolling issue.
       # The body carries the CONDENSED summary (not the full report) so it fits the issue
       # limit, followed by a link to the attached full reports and a footer with two parts:
       # a minimal "Issue lifecycle" summary (refreshed only on runs that still have findings,
       # never auto-closed) and a "What do I do?" section pointing at `examine` and the
-      # bless-an-intentional-change vs. fix-a-defect decision — see the File step.
+      # bless-an-intentional-change vs. fix-a-defect decision - see the File step.
       - name: Compose regression issue
         if: steps.notable.outputs.value == 'true'
         shell: pwsh
@@ -265,8 +265,8 @@ jobs:
           - **A defect to fix**: fix it as usual. A fixed finding self-clears on its own several runs after the fix, even without a blessing. This is **not** immediate: clearing it needs statistical evidence from multiple post-fix runs.
           '@
 
-          # The title and labels are NOT front matter here — the File step passes them to the
-          # gh-file-rolling-issue recipe as `gh` flags — so this file is the pure issue body.
+          # The title and labels are NOT front matter here - the File step passes them to the
+          # gh-file-rolling-issue recipe as `gh` flags - so this file is the pure issue body.
           $parts = @(
             $summary
             ''
@@ -311,12 +311,12 @@ jobs:
         uses: actions/checkout@v6
 
       # Compose the failure-alert body (interpolating the failed run's URL) into the runner temp
-      # dir, then file it with the same Publish-RollingIssue seam the regression path uses — one
+      # dir, then file it with the same Publish-RollingIssue seam the regression path uses - one
       # rolling issue keyed on $FAILURE_ISSUE_TITLE, updated rather than duplicated on each failing
       # run, and auto-closed by the `resolve` job once the workflow is green again. The ci-failure
       # label is what `resolve` narrows its close search to. The module is imported directly (not
       # via `just`) because this lightweight notifier deliberately skips the build-environment
-      # setup — the same shape (checkout + preinstalled gh CLI + module import, no build-env setup)
+      # setup - the same shape (checkout + preinstalled gh CLI + module import, no build-env setup)
       # as the sibling `resolve` job's own close step.
       - name: Open or update failure issue
         env:
@@ -382,7 +382,7 @@ jobs:
       # ci-failure label; find any still-open instance and close it with an audit trail linking the
       # green run. Close-RollingIssue lists by `--label ci-failure` (which already excludes the
       # advisory regression issue, label `regression`, closed by hand) and closes every exact-title
-      # match — the same dedup key the alert path files under, so the two stay in lockstep.
+      # match - the same dedup key the alert path files under, so the two stay in lockstep.
       - name: Close failure issue if open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -84,34 +84,16 @@ jobs:
       - name: Configure Azure federation identity from constants.env
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
-          # constants.env is a KEY=value file (with # comment lines). Read the two
-          # identifiers the tool federates with and re-export them under the standard
-          # AZURE_* names GitHub-injected steps and the tool read.
-          $values = @{}
-          foreach ($line in Get-Content constants.env) {
-            if ($line -match '^\s*([^#=]+)=(.*)$') {
-              $values[$Matches[1].Trim()] = $Matches[2].Trim()
-            }
-          }
-
-          # Fail fast if either identifier is missing or empty: an empty
-          # AZURE_CLIENT_ID / AZURE_TENANT_ID would otherwise silently break the tool's
-          # OIDC federation far later with an opaque error, whereas the previous bash
-          # step's `set -u` errored here.
-          function Get-RequiredConstant($name) {
-            $value = $values[$name]
-            if ([string]::IsNullOrWhiteSpace($value)) {
-              throw "constants.env is missing a non-empty '$name' (required for Azure federation)."
-            }
-            return $value
-          }
-          @(
-            "AZURE_CLIENT_ID=$(Get-RequiredConstant 'AZURE_PROD_CLIENT_ID')"
-            "AZURE_TENANT_ID=$(Get-RequiredConstant 'AZURE_TENANT_ID')"
-          ) | Add-Content -Path $env:GITHUB_ENV -Encoding utf8
+          # constants.env holds the two non-secret identifiers the collect/analyze jobs federate
+          # with; the module re-exports them under the standard AZURE_* names the tool reads, failing
+          # loudly if either is missing. Shared by both jobs so the two cannot drift. See
+          # scripts/bench-history/AzureFederation.psm1.
+          Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
+          Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
       # The deterministic engines (Callgrind, allocation/time counters) are
       # hardware-independent; the wall-clock engines are pinned to the fixed `github` machine
@@ -156,34 +138,14 @@ jobs:
       - name: Configure Azure federation identity from constants.env
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
-          # constants.env is a KEY=value file (with # comment lines). Read the two
-          # identifiers the tool federates with and re-export them under the standard
-          # AZURE_* names the tool reads.
-          $values = @{}
-          foreach ($line in Get-Content constants.env) {
-            if ($line -match '^\s*([^#=]+)=(.*)$') {
-              $values[$Matches[1].Trim()] = $Matches[2].Trim()
-            }
-          }
-
-          # Fail fast if either identifier is missing or empty: an empty
-          # AZURE_CLIENT_ID / AZURE_TENANT_ID would otherwise silently break the tool's
-          # OIDC federation far later with an opaque error, whereas the previous bash
-          # step's `set -u` errored here.
-          function Get-RequiredConstant($name) {
-            $value = $values[$name]
-            if ([string]::IsNullOrWhiteSpace($value)) {
-              throw "constants.env is missing a non-empty '$name' (required for Azure federation)."
-            }
-            return $value
-          }
-          @(
-            "AZURE_CLIENT_ID=$(Get-RequiredConstant 'AZURE_PROD_CLIENT_ID')"
-            "AZURE_TENANT_ID=$(Get-RequiredConstant 'AZURE_TENANT_ID')"
-          ) | Add-Content -Path $env:GITHUB_ENV -Encoding utf8
+          # Same shared seam the collect job uses: re-export the two committed identifiers under the
+          # standard AZURE_* names the tool reads. See scripts/bench-history/AzureFederation.psm1.
+          Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
+          Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
       # All bench-history scratch — the read-through cache and every rendered report/summary/
       # notable/issue-body file — lives under the runner temp directory, OUTSIDE the repo
@@ -198,7 +160,9 @@ jobs:
         id: scratch
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $dir = Join-Path $env:RUNNER_TEMP 'bench-history'
           New-Item -ItemType Directory -Path $dir -Force | Out-Null
           "dir=$dir" | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
@@ -236,7 +200,9 @@ jobs:
         env:
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $value = (Get-Content (Join-Path $env:SCRATCH_DIR 'notable.txt') -Raw).Trim()
           "value=$value" | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
 
@@ -272,7 +238,9 @@ jobs:
           REPORT_ARTIFACT_URL: ${{ steps.full_reports.outputs.artifact-url }}
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
 
           $summary = (Get-Content (Join-Path $env:SCRATCH_DIR 'summary.md') -Raw).TrimEnd()
           $fullReport = "**Full report:** the complete Markdown and JSON reports are attached to this workflow run. [Download the full report bundle]($env:REPORT_ARTIFACT_URL)."
@@ -348,15 +316,17 @@ jobs:
       # run, and auto-closed by the `resolve` job once the workflow is green again. The ci-failure
       # label is what `resolve` narrows its close search to. The module is imported directly (not
       # via `just`) because this lightweight notifier deliberately skips the build-environment
-      # setup — same raw-`gh`-in-pwsh weight as the sibling `resolve` job; only checkout + the
-      # preinstalled gh CLI are needed.
+      # setup — the same shape (checkout + preinstalled gh CLI + module import, no build-env setup)
+      # as the sibling `resolve` job's own close step.
       - name: Open or update failure issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           Import-Module ./scripts/bench-history/BenchHistoryIssue.psm1 -Force
 
           # Single-quoted here-string keeps the ``main`` inline-code backticks literal; only
@@ -397,18 +367,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # Least privilege: this job only talks to the issues API (no checkout, no contents).
+    # Minimal for the work it does: issues:write to close the alert, contents:read for the checkout
+    # that puts the shared BenchHistoryIssue module on disk (the close logic lives there so it is
+    # unit-tested against a mocked gh, mirroring how the alert job files via the same module).
     permissions:
+      contents: read
       issues: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       # The alert job files exactly one rolling issue carrying $FAILURE_ISSUE_TITLE and the
-      # ci-failure label; find any still-open instance and close it with an audit trail
-      # linking the green run. Uses the preinstalled gh CLI (GH_REPO lets it run without a
-      # checkout). Listing by `--label ci-failure` already excludes the advisory regression
-      # issue (label `regression`, closed by hand); the exact-title match mirrors the alert
-      # path's own dedup key so the two stay in lockstep. `--limit` defeats the 30-result
-      # default so a backlog of historical duplicates would all be closed.
+      # ci-failure label; find any still-open instance and close it with an audit trail linking the
+      # green run. Close-RollingIssue lists by `--label ci-failure` (which already excludes the
+      # advisory regression issue, label `regression`, closed by hand) and closes every exact-title
+      # match — the same dedup key the alert path files under, so the two stay in lockstep.
       - name: Close failure issue if open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -416,17 +390,16 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
+          Import-Module ./scripts/bench-history/BenchHistoryIssue.psm1 -Force
 
-          $issues = gh issue list --state open --label ci-failure --limit 100 --json number,title |
-            ConvertFrom-Json
-          $matching = @($issues | Where-Object { $_.title -eq $env:FAILURE_ISSUE_TITLE })
-          if ($matching.Count -eq 0) {
+          $comment = "✅ The bench-history workflow is green again. Auto-closing this alert. Successful run: $env:RUN_URL"
+          $closed = @(Close-RollingIssue -Title $env:FAILURE_ISSUE_TITLE -Label 'ci-failure' -Comment $comment -Verbose)
+          if ($closed.Count -eq 0) {
             Write-Host 'No open failure issue to close.'
-            exit 0
-          }
-          foreach ($issue in $matching) {
-            Write-Host "Closing #$($issue.number)"
-            gh issue close $issue.number --reason completed --comment "✅ The bench-history workflow is green again. Auto-closing this alert. Successful run: $env:RUN_URL"
+          } else {
+            $noun = if ($closed.Count -eq 1) { 'issue' } else { 'issues' }
+            Write-Host "Closed failure $noun $($closed -join ', ')"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ name: Release
 # created with the default GITHUB_TOKEN does not trigger downstream `on: release` /
 # `on: push: tags` workflows, so driving the binary jobs from within this same run
 # (rather than a separate tag-triggered workflow) is what lets the ambient
-# GITHUB_TOKEN suffice — no PAT or GitHub App token needed.
+# GITHUB_TOKEN suffice - no PAT or GitHub App token needed.
 #
 # The non-trivial logic lives in PowerShell `just` recipes (justfiles/just_automation.just)
 # so it can be run and tested locally; the steps here are thin `just` calls.
@@ -79,11 +79,11 @@ jobs:
     # Runs after every successful publish (including no-op pushes), NOT gated on whether
     # anything was published this run. This is what makes retries self-healing: a plain
     # re-run or a bare workflow_dispatch reconciles the actual published state against the
-    # uploaded assets and rebuilds only what is missing — no manual crate list.
+    # uploaded assets and rebuilds only what is missing - no manual crate list.
     needs: publish
     if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Fast reconcile work plus up to 90 min for a cold-cache setup-environment — which itself
+    # Fast reconcile work plus up to 90 min for a cold-cache setup-environment - which itself
     # timed out the previous 30-minute cap on a cache miss.
     timeout-minutes: 120
 
@@ -108,7 +108,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # The recipe always emits its Write-Verbose decision history, so the step log records how
-        # the missing-archive plan was derived per crate and target — not just the final count.
+        # the missing-archive plan was derived per crate and target - not just the final count.
         run: just gh-plan-release-binaries
 
   build-binaries:
@@ -160,7 +160,7 @@ jobs:
   alert:
     # File a GitHub issue unique to this run whenever any job above fails, so every failed
     # release is tracked individually (not folded into a rolling issue). `failure()` fires
-    # only on a real failure — a skipped build-binaries (nothing to build) does not count.
+    # only on a real failure - a skipped build-binaries (nothing to build) does not count.
     needs: [publish, plan-binaries, build-binaries]
     if: failure() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup environment
-        # The delta job runs before — and gates — every package-scoped job, so it uses the same
+        # The delta job runs before - and gates - every package-scoped job, so it uses the same
         # setup-environment composite as they do rather than a hand-picked minimal toolchain. That
         # keeps a single install path (cargo-delta comes from `just install-tools` like every other
         # tool) and, on a cold cache, primes the shared `prerequisites` cache this job's dependents
@@ -77,8 +77,8 @@ jobs:
 
   # PowerShell test suite for the standalone scripts under scripts/ (the release-automation and
   # binstall-validation modules), plus PSScriptAnalyzer static analysis of those scripts and the
-  # binstall-metadata check on the real workspace. Runs unconditionally — independent of the
-  # `delta` package analysis — because the scripts are not Cargo packages, so a change touching
+  # binstall-metadata check on the real workspace. Runs unconditionally - independent of the
+  # `delta` package analysis - because the scripts are not Cargo packages, so a change touching
   # only scripts/ would otherwise be validated by nothing; the static-analysis and binstall checks
   # ride along here because they reuse the same environment and are seconds long.
   test-scripts:
@@ -100,8 +100,8 @@ jobs:
       - name: Validate binstall metadata
         run: just validate-binstall
 
-  # Validates the GitHub Actions workflow files with actionlint. Runs unconditionally — independent
-  # of the `delta` package analysis — because the workflow files are not Cargo packages, so a
+  # Validates the GitHub Actions workflow files with actionlint. Runs unconditionally - independent
+  # of the `delta` package analysis - because the workflow files are not Cargo packages, so a
   # change touching only .github/workflows/ would otherwise be validated by nothing. actionlint
   # is a fast static check, so running it on every PR is cheap.
   validate-workflows:
@@ -189,7 +189,7 @@ jobs:
       - name: Run clippy dev on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" clippy dev
 
-  # The x86_64 test pass (ubuntu-latest and windows-latest — both x86_64). Runs the full
+  # The x86_64 test pass (ubuntu-latest and windows-latest - both x86_64). Runs the full
   # test suite (unit, integration and example tests) with coverage instrumentation, so the
   # coverage report is a side effect of the regular test run rather than a second,
   # separately re-executed pass. Also runs the benchmark targets once to verify they do not
@@ -667,12 +667,12 @@ jobs:
   # and BENCH_HISTORY_REQUIRE_AZURITE turns an unreachable emulator into a hard
   # failure, so a misconfigured emulator can never silently degrade into skipping
   # every test. This job also collects coverage so the azure.rs network paths
-  # reach Codecov — the multi-platform `test-x64` job runs without an emulator and
+  # reach Codecov - the multi-platform `test-x64` job runs without an emulator and
   # therefore cannot cover them; Codecov merges this azure-flagged upload with it.
   #
   # Runs on a single platform (Linux) by choice, not by limitation: the Azure Blob
   # backend is OS-agnostic network I/O (HTTP via the azure SDK), so exercising it on
-  # one platform fully covers it — also running it on Windows/macOS would only
+  # one platform fully covers it - also running it on Windows/macOS would only
   # duplicate the same coverage. Linux is picked because it is the cheapest/fastest
   # runner and because Azurite runs directly on the host there via npm (service
   # containers cannot reliably bind it to a reachable address). Package-gated: the
@@ -721,13 +721,13 @@ jobs:
   # Complements `test-azurite` by exercising the Microsoft Entra ID authentication
   # path that the emulator (account-key/SAS) never touches: a real Storage account
   # with shared-key access disabled, reached over HTTPS, authenticated through
-  # GitHub OIDC workload identity federation — no stored secret. Each test creates a
+  # GitHub OIDC workload identity federation - no stored secret. Each test creates a
   # fresh blob container and deletes it when it finishes (even on panic); the final
   # `if: always()` sweep is a backstop for a container a crashed run might leave.
   #
   # Gated two ways so it only runs when it can succeed:
   #   * package-gated to cargo-bench-history (same gate as test-azurite);
-  #   * same-repo only — a fork PR cannot mint an OIDC token for our tenant, so it
+  #   * same-repo only - a fork PR cannot mint an OIDC token for our tenant, so it
   #     would fail federation; the condition lets fork PRs skip cleanly instead.
   # The Azure identifiers it needs are committed (non-secret) in constants.env, the
   # same source `just test-azure` reads locally, so local and CI target the same
@@ -743,7 +743,7 @@ jobs:
   # round-trip end to end.
   #
   # The account, managed identity and federated credentials are scripted/Bicep'd in
-  # infra/azure-bench-history-test/ — see that directory's README to deploy or re-create.
+  # infra/azure-bench-history-test/ - see that directory's README to deploy or re-create.
   test-azure:
     needs: [delta]
     if: >-
@@ -755,7 +755,7 @@ jobs:
     # JWT proving "this run is repo folo-rs/folo on ref X"). `azure/login@v2` hands
     # that token to Azure, which matches it against the managed identity's federated
     # credentials (see infra/azure-bench-history-test/main.bicep) and issues an access
-    # token — so CI authenticates with no stored secret. The default GITHUB_TOKEN
+    # token - so CI authenticates with no stored secret. The default GITHUB_TOKEN
     # cannot request an OIDC token unless this permission is granted explicitly (and
     # fork PRs cannot get it at all, hence the same-repo gate above). `contents: read`
     # is the minimum the checkout needs.
@@ -801,8 +801,8 @@ jobs:
         run: ./infra/azure-bench-history-test/cleanup-containers.ps1 -MinAgeMinutes 180
 
   # Variant of test-azure that exercises cargo-bench-history's SELF-MINTING GitHub
-  # OIDC credential — the exact credential the prod collection (bench-history.yml)
-  # depends on — against the real test account. The unit tests in storage/github_oidc.rs
+  # OIDC credential - the exact credential the prod collection (bench-history.yml)
+  # depends on - against the real test account. The unit tests in storage/github_oidc.rs
   # stub the HTTP exchange, and test-azure above takes the local-az DeveloperToolsCredential
   # fallback, so without this job nothing would prove the self-minting path actually
   # round-trips real GitHub OIDC -> Entra -> Blob until the post-merge collection run.
@@ -879,19 +879,19 @@ jobs:
   # when cargo-bench-history is affected. The per-commit upload count is therefore
   # variable. codecov.yml sets `codecov.notify.manual_trigger: true`, so Codecov posts
   # NO coverage status or PR comment until this job runs the CLI `send-notifications`
-  # command — which it does only after every coverage-producing job has finished. That
+  # command - which it does only after every coverage-producing job has finished. That
   # way Codecov computes the status from the complete set of uploads instead of
   # reporting a misleadingly low figure off a partial set (see codecov.yml for the
   # full rationale and why this is preferred over a hardcoded `after_n_builds`).
   #
   # It depends on `test-x64` and `test-azurite` (the only coverage producers;
   # `test-azure` / `test-azure-gh` upload none). The `!cancelled()` status function lets
-  # it run even when `test-azurite` is skipped — without a status function a skipped
+  # it run even when `test-azurite` is skipped - without a status function a skipped
   # dependency would skip this job too. It releases notifications only when every expected
   # upload actually landed: `test-x64` must have succeeded, and `test-azurite` must have
   # either succeeded (its azure upload landed) or been skipped (cargo-bench-history not
   # affected, so no azure upload was expected). If `test-x64` failed, or `test-azurite`
-  # ran and failed, an expected upload is missing and the build is already red — so we do
+  # ran and failed, an expected upload is missing and the build is already red - so we do
   # NOT release a status off an incomplete set, which would post the very "coverage
   # decreased" result this gate exists to prevent. A `skip_all` run uploads no coverage at
   # all, so `test-x64` is skipped and this job does not run.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,8 +39,13 @@ jobs:
         id: compute
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
+
+          # The cargo-delta pipeline lives in the Pester-tested Delta module, shared with the local
+          # `just delta` recipe so the two cannot drift. See scripts/build/Delta.psm1.
+          Import-Module ./scripts/build/Delta.psm1 -Force
 
           if ($env:GITHUB_EVENT_NAME -eq 'push') {
             Write-Host 'Push to main detected, running full workspace validation.'
@@ -52,63 +57,30 @@ jobs:
             exit 0
           }
 
-          $configPath = Join-Path (Get-Location) 'delta.toml'
-          $worktreeDir = Join-Path ([System.IO.Path]::GetTempPath()) ('delta-baseline-' + [guid]::NewGuid().ToString('n'))
-          $baselineJson = [System.IO.Path]::GetTempFileName()
+          # Full history is already checked out (fetch-depth: 0), so -SkipFetch avoids a redundant
+          # fetch; the module analyzes origin/main in a throwaway worktree and cleans up after
+          # itself (no artifacts land in the checkout to dirty the tree).
+          $affected = @(Invoke-CargoDelta -SkipFetch)
+          $output = Get-DeltaOutput -Affected $affected
 
-          try {
-            Write-Host 'Analyzing current branch...'
-            cargo delta -c $configPath analyze | Set-Content -Path 'current.json' -Encoding utf8
-
-            Write-Host 'Analyzing baseline (origin/main)...'
-            git worktree add $worktreeDir origin/main
-            Push-Location $worktreeDir
-            try {
-              cargo delta -c $configPath analyze | Set-Content -Path $baselineJson -Encoding utf8
-            } finally {
-              Pop-Location
-            }
-
-            Write-Host 'Computing delta...'
-            cargo delta -c $configPath run --baseline $baselineJson --current current.json |
-              Set-Content -Path 'delta.json' -Encoding utf8
-
-            Get-Content 'delta.json' -Raw | Write-Host
-
-            $delta = Get-Content 'delta.json' -Raw | ConvertFrom-Json
-            $affected = @()
-            if ($delta.Affected) { $affected = @($delta.Affected) }
-            $packages = $affected -join ' '
-            $packagesJson = if ($affected.Count -eq 0) {
-              '[]'
-            } else {
-              '[' + (($affected | ForEach-Object { ConvertTo-Json $_ -Compress }) -join ',') + ']'
-            }
-
-            if ($affected.Count -eq 0) {
-              Write-Host 'No packages affected by changes.'
-              $skipAll = 'true'
-            } else {
-              Write-Host "Affected packages: $packages"
-              $skipAll = 'false'
-            }
-
-            @(
-              "packages=$packages"
-              "packages_json=$packagesJson"
-              "skip_all=$skipAll"
-            ) | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
-          } finally {
-            git worktree remove $worktreeDir --force 2>$null
-            if (Test-Path $worktreeDir) { Remove-Item -Recurse -Force $worktreeDir -ErrorAction SilentlyContinue }
-            if (Test-Path $baselineJson) { Remove-Item -Force $baselineJson -ErrorAction SilentlyContinue }
+          if ($affected.Count -eq 0) {
+            Write-Host 'No packages affected by changes.'
+          } else {
+            Write-Host "Affected packages: $($output.Packages)"
           }
 
+          @(
+            "packages=$($output.Packages)"
+            "packages_json=$($output.PackagesJson)"
+            "skip_all=$($output.SkipAll)"
+          ) | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
   # PowerShell test suite for the standalone scripts under scripts/ (the release-automation and
-  # binstall-validation modules), plus the binstall-metadata check on the real workspace. Runs
-  # unconditionally — independent of the `delta` package analysis — because the scripts are not
-  # Cargo packages, so a change touching only scripts/ would otherwise be validated by nothing;
-  # the binstall check rides along here because it reuses the same environment and is seconds long.
+  # binstall-validation modules), plus PSScriptAnalyzer static analysis of those scripts and the
+  # binstall-metadata check on the real workspace. Runs unconditionally — independent of the
+  # `delta` package analysis — because the scripts are not Cargo packages, so a change touching
+  # only scripts/ would otherwise be validated by nothing; the static-analysis and binstall checks
+  # ride along here because they reuse the same environment and are seconds long.
   test-scripts:
     runs-on: ubuntu-latest
 
@@ -121,6 +93,9 @@ jobs:
 
       - name: Run script test suites
         run: just test-scripts
+
+      - name: Validate scripts (PSScriptAnalyzer)
+        run: just validate-scripts
 
       - name: Validate binstall metadata
         run: just validate-binstall

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,28 @@
+# PSScriptAnalyzer configuration for `just validate-scripts` (and the CI script-validation
+# step). This is the single source of truth for which rules gate PowerShell in this repo; see
+# docs/build-and-tooling.md ("Scripting") for the surrounding convention.
+#
+# The repo-local custom rules under scripts/analyzer/ (e.g. the foreach case-collision rule that
+# would have caught the shadowing bug the default rules miss) are passed via -CustomRulePath by
+# the recipe rather than referenced here, so their path is unambiguous regardless of the working
+# directory. IncludeDefaultRules keeps the built-in rules running alongside them.
+@{
+    # Only Error/Warning findings gate. Info-level rules (e.g. PSProvideCommentHelp,
+    # PSUseOutputTypeCorrectly) are dropped by this filter, so there is no need to list them in
+    # ExcludeRules — this also future-proofs against a rule's default severity changing.
+    Severity = @('Error', 'Warning')
+
+    # Run the full built-in rule set in addition to the -CustomRulePath rules. Without this,
+    # supplying custom rules would run ONLY the custom rules.
+    IncludeDefaultRules = $true
+
+    ExcludeRules = @(
+        # Our scripts are developer-tooling / CLI utilities whose whole job is to print progress
+        # and results to the console, so Write-Host is a deliberate choice, not an oversight.
+        'PSAvoidUsingWriteHost'
+
+        # This repo standardizes on UTF-8 *without* a BOM (the non-ASCII content is em-dashes in
+        # comments). A BOM would be churn on every file and is undesirable cross-platform.
+        'PSUseBOMForUnicodeEncodedFile'
+    )
+}

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -21,9 +21,9 @@
         # and results to the console, so Write-Host is a deliberate choice, not an oversight.
         'PSAvoidUsingWriteHost'
 
-        # This repo standardizes on UTF-8 *without* a BOM. Scripts are kept ASCII-only (hyphens,
-        # not em-dashes), so this rule would not normally fire; the suppression is a safety net so
-        # a stray non-ASCII character can never force a churny, cross-platform-undesirable BOM.
+        # This repo standardizes on UTF-8 *without* a BOM. Scripts are kept ASCII-only, so this rule
+        # would not normally fire; the suppression is a safety net so a stray non-ASCII character can
+        # never force a churny, cross-platform-undesirable BOM.
         'PSUseBOMForUnicodeEncodedFile'
     )
 }

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -9,7 +9,7 @@
 @{
     # Only Error/Warning findings gate. Info-level rules (e.g. PSProvideCommentHelp,
     # PSUseOutputTypeCorrectly) are dropped by this filter, so there is no need to list them in
-    # ExcludeRules — this also future-proofs against a rule's default severity changing.
+    # ExcludeRules - this also future-proofs against a rule's default severity changing.
     Severity = @('Error', 'Warning')
 
     # Run the full built-in rule set in addition to the -CustomRulePath rules. Without this,
@@ -21,8 +21,9 @@
         # and results to the console, so Write-Host is a deliberate choice, not an oversight.
         'PSAvoidUsingWriteHost'
 
-        # This repo standardizes on UTF-8 *without* a BOM (the non-ASCII content is em-dashes in
-        # comments). A BOM would be churn on every file and is undesirable cross-platform.
+        # This repo standardizes on UTF-8 *without* a BOM. Scripts are kept ASCII-only (hyphens,
+        # not em-dashes), so this rule would not normally fire; the suppression is a safety net so
+        # a stray non-ASCII character can never force a churny, cross-platform-undesirable BOM.
         'PSUseBOMForUnicodeEncodedFile'
     )
 }

--- a/constants.env
+++ b/constants.env
@@ -32,6 +32,13 @@ CARGO_SORT_DERIVES_VERSION=0.13.0
 CARGO_UDEPS_VERSION=0.1.61
 RELEASE_PLZ_VERSION=0.3.159
 
+# PowerShell Gallery module (not a cargo tool) installed by `just install-tools`, pinned to an
+# exact version so `just validate-scripts` gates on a reproducible rule set — a newer PSScriptAnalyzer
+# can add or change rules, which would otherwise make CI results depend on whatever version a
+# machine happens to have. Bump deliberately and re-run `just validate-scripts` to absorb any new
+# findings.
+PSSCRIPTANALYZER_VERSION=1.25.0
+
 # gungraun-runner drives Valgrind for Callgrind instruction-count benchmarks. Unlike the tools
 # above it is NOT bumped to the latest release: it enforces strict string equality against the
 # `gungraun = "=X.Y.Z"` dependency in the root Cargo.toml, so this MUST stay equal to that pin or

--- a/constants.env
+++ b/constants.env
@@ -10,8 +10,8 @@ RUST_NIGHTLY=nightly-2026-06-19
 # Versions of the Cargo tools installed by `just install-tools`, kept in one place and injected
 # into the recipe as `cargo install <crate>@<version>` (dotenv exposes each `FOO_VERSION` as
 # `$env:FOO_VERSION`). They are pinned to explicit versions rather than left floating because a
-# plain `cargo install <crate>` never upgrades an already-installed crate — it just prints
-# "already installed" and skips — so an unpinned tool would stay frozen at whatever version first
+# plain `cargo install <crate>` never upgrades an already-installed crate - it just prints
+# "already installed" and skips - so an unpinned tool would stay frozen at whatever version first
 # landed. With a pin, an installed version that differs is replaced (and a matching one is a fast
 # no-op), so bumping a tool is simply editing its version here. These normally track the latest
 # published release; bump them deliberately. The GitHub workflows install these tools by calling
@@ -33,7 +33,7 @@ CARGO_UDEPS_VERSION=0.1.61
 RELEASE_PLZ_VERSION=0.3.159
 
 # PowerShell Gallery module (not a cargo tool) installed by `just install-tools`, pinned to an
-# exact version so `just validate-scripts` gates on a reproducible rule set — a newer PSScriptAnalyzer
+# exact version so `just validate-scripts` gates on a reproducible rule set - a newer PSScriptAnalyzer
 # can add or change rules, which would otherwise make CI results depend on whatever version a
 # machine happens to have. Bump deliberately and re-run `just validate-scripts` to absorb any new
 # findings.
@@ -42,14 +42,14 @@ PSSCRIPTANALYZER_VERSION=1.25.0
 # gungraun-runner drives Valgrind for Callgrind instruction-count benchmarks. Unlike the tools
 # above it is NOT bumped to the latest release: it enforces strict string equality against the
 # `gungraun = "=X.Y.Z"` dependency in the root Cargo.toml, so this MUST stay equal to that pin or
-# the `*_cg` benches fail at runtime with VersionMismatch. Keep the two — and the install command
-# in docs/callgrind-benchmarks.md — in lockstep when bumping.
+# the `*_cg` benches fail at runtime with VersionMismatch. Keep the two - and the install command
+# in docs/callgrind-benchmarks.md - in lockstep when bumping.
 GUNGRAUN_RUNNER_VERSION=0.19.3
 
 # Azure identifiers for the cargo-bench-history real-Azure storage tests, shared by
 # local runs (`just test-azure`) and the CI `test-azure` job so both target the same
 # deployed account (infra/azure-bench-history-test/). These are non-secret identifiers,
-# not credentials — authentication is via Microsoft Entra ID (local `az login` / CI
+# not credentials - authentication is via Microsoft Entra ID (local `az login` / CI
 # OIDC federation), so there is nothing to leak by committing them.
 #
 # These do NOT by themselves enable the real-Azure tests: those run only when

--- a/docs/build-and-tooling.md
+++ b/docs/build-and-tooling.md
@@ -74,15 +74,40 @@ standard validation on both Windows and Linux, execute:
 You can assume PowerShell 7 (`pwsh`) is available on every operating system and
 environment. Prefer PowerShell 7 commands to Bash commands.
 
-### PowerShell scripts in justfiles must consider exit codes
+### Every PowerShell snippet starts with the standard preamble
 
-Every PowerShell script in a `.just` file (i.e. every `[script]` block) must start
-with the following:
+Every PowerShell snippet — each `[script]` block in a `.just` file, each `shell: pwsh`
+`run:` step in a workflow, and every standalone `.ps1`/`.psm1` under `scripts/` — must start
+with the standard preamble:
 
 ```powershell
+Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 ```
 
-This ensures that commands that produce nonzero exit codes are correctly
-considered errors and fail the script.
+`Set-StrictMode -Version Latest` turns silent footguns (referencing an uninitialized variable,
+reading a non-existent property, indexing out of bounds) into hard errors. The two preference
+lines ensure that commands producing nonzero exit codes are treated as errors and fail the
+script. (Standalone scripts additionally set `$VerbosePreference = 'Continue'`; module files set
+strict mode once at the top rather than per function.)
+
+### PowerShell linting
+
+`just validate-scripts` runs [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer)
+over everything under `scripts/`, gating on Error/Warning findings. The rule set lives in
+`PSScriptAnalyzerSettings.psd1`, supplemented by repo-local custom rules in
+`scripts/analyzer/FoloAnalyzerRules.psm1` — which catch classes the built-in rules (and strict
+mode) miss, such as a `foreach` whose loop variable case-insensitively collides with the
+collection it enumerates. It runs as part of `just validate-local` and the CI `test-scripts` job.
+Silence a genuine false positive with a justified
+`[Diagnostics.CodeAnalysis.SuppressMessageAttribute(...)]`, never by relaxing the gate; the tree
+is expected to be finding-free.
+
+PSScriptAnalyzer can only see `.ps1`/`.psm1` files, so **nontrivial** inline PowerShell is not
+linted where it sits. Keep inline snippets (justfile `[script]` blocks and workflow `pwsh` steps)
+thin: anything with real logic — branching, loops, parsing, error handling, non-trivial data
+manipulation — belongs in a module under `scripts/`, covered by a Pester suite
+(`just test-scripts`) and thus by the linter, with the recipe or workflow step reduced to a thin
+wrapper that imports the module and calls it. A snippet that is just the preamble plus a command
+or two may stay inline.

--- a/docs/build-and-tooling.md
+++ b/docs/build-and-tooling.md
@@ -11,17 +11,17 @@ We use the [`just`](https://github.com/casey/just) command runner for many commo
 commands. Look inside `*.just` files in `justfiles/` to see the list of available
 commands. Some relevant ones are:
 
-* `just build` — build the entire workspace.
-* `just package="cpulist many_cpus" build` — target specific packages with a command.
-* `just test` — test the entire workspace; this does **not** run doctests, use
+* `just build` - build the entire workspace.
+* `just package="cpulist many_cpus" build` - target specific packages with a command.
+* `just test` - test the entire workspace; this does **not** run doctests, use
   `just test-docs` for that.
-* `just docs` — build API documentation.
+* `just docs` - build API documentation.
 
 The `package` argument must be the first argument to any `just` command, if used.
 
 Avoid running `just bench` (wall-clock Criterion benchmarks) without explicit
 confirmation: they take a lot of time, and the numbers are also noisy and
-machine-dependent — running them on a shared machine produces results that should
+machine-dependent - running them on a shared machine produces results that should
 not be acted on. `just test` already runs a single iteration of every Criterion
 benchmark to validate that they still execute.
 
@@ -29,12 +29,12 @@ benchmark to validate that they still execute.
 under Valgrind's CPU simulator, so the instruction counts and simulated cache
 numbers are deterministic and unaffected by other processes on the machine. It is
 safe to run `just bench-cg` (or `just package=foo bench-cg`) any time without
-asking — including as a smoke test of a new Callgrind benchmark.
+asking - including as a smoke test of a new Callgrind benchmark.
 
 We generally prefer using Just commands over raw Cargo commands if there is a
 suitable Just command defined in one of the `*.just` files.
 
-Do **not** execute `just release` — this is a critical tool reserved for human
+Do **not** execute `just release` - this is a critical tool reserved for human
 use.
 
 Do **not** use VS Code tasks, relying instead on `just` and, if necessary, `cargo`
@@ -53,7 +53,7 @@ slowest step, so it runs last (after the cheaper checks have had a chance to fai
 fast); scope it with `package="foo bar"` to keep it tractable. To run just the
 mutation step on its own, use `just package="foo bar" mutants`.
 
-We operate under a **zero warnings allowed** requirement — fix all warnings that
+We operate under a **zero warnings allowed** requirement - fix all warnings that
 validation generates.
 
 ## Multiplatform codebase
@@ -76,8 +76,8 @@ environment. Prefer PowerShell 7 commands to Bash commands.
 
 ### Every PowerShell snippet starts with the standard preamble
 
-Every PowerShell snippet — each `[script]` block in a `.just` file, each `shell: pwsh`
-`run:` step in a workflow, and every standalone `.ps1`/`.psm1` under `scripts/` — must start
+Every PowerShell snippet - each `[script]` block in a `.just` file, each `shell: pwsh`
+`run:` step in a workflow, and every standalone `.ps1`/`.psm1` under `scripts/` - must start
 with the standard preamble:
 
 ```powershell
@@ -97,7 +97,7 @@ strict mode once at the top rather than per function.)
 `just validate-scripts` runs [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer)
 over everything under `scripts/`, gating on Error/Warning findings. The rule set lives in
 `PSScriptAnalyzerSettings.psd1`, supplemented by repo-local custom rules in
-`scripts/analyzer/FoloAnalyzerRules.psm1` — which catch classes the built-in rules (and strict
+`scripts/analyzer/FoloAnalyzerRules.psm1` - which catch classes the built-in rules (and strict
 mode) miss, such as a `foreach` whose loop variable case-insensitively collides with the
 collection it enumerates. It runs as part of `just validate-local` and the CI `test-scripts` job.
 Silence a genuine false positive with a justified
@@ -106,8 +106,8 @@ is expected to be finding-free.
 
 PSScriptAnalyzer can only see `.ps1`/`.psm1` files, so **nontrivial** inline PowerShell is not
 linted where it sits. Keep inline snippets (justfile `[script]` blocks and workflow `pwsh` steps)
-thin: anything with real logic — branching, loops, parsing, error handling, non-trivial data
-manipulation — belongs in a module under `scripts/`, covered by a Pester suite
+thin: anything with real logic - branching, loops, parsing, error handling, non-trivial data
+manipulation - belongs in a module under `scripts/`, covered by a Pester suite
 (`just test-scripts`) and thus by the linter, with the recipe or workflow step reduced to a thin
 wrapper that imports the module and calls it. A snippet that is just the preamble plus a command
 or two may stay inline.

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -50,6 +50,7 @@ gh-collect-bench-history:
 [group('automation')]
 [script]
 gh-analyze-bench-history dir:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -66,7 +67,7 @@ gh-analyze-bench-history dir:
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
-    $notable = if ($json.notable) { 'true' } else { 'false' }
+    $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }
     Set-Content -Path $notablePath -Value $notable -Encoding utf8
     Write-Verbose "Analysis complete: notable=$notable (full report at $reportPath, condensed summary at $summaryPath)." -Verbose
 
@@ -83,6 +84,7 @@ gh-analyze-bench-history dir:
 [group('automation')]
 [script]
 gh-file-rolling-issue title label body_file:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/bench-history/BenchHistoryIssue.psm1 -Force
@@ -112,6 +114,7 @@ gh-file-rolling-issue title label body_file:
 [group('automation')]
 [script]
 gh-compose-release-config output:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
@@ -136,6 +139,7 @@ gh-compose-release-config output:
 [group('automation')]
 [script]
 gh-release config:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
@@ -151,6 +155,7 @@ gh-release config:
 [group('automation')]
 [script]
 gh-plan-release-binaries:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -16,14 +16,14 @@
 # ignore the key. `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
 # already-stored object is skipped, not overwritten), so a re-triggered run of an
 # already-collected commit never bumps the cache-invalidation marker the `analyze` job's
-# read-through cache depends on — a re-run of the same commit is not "better" data, so there is
+# read-through cache depends on - a re-run of the same commit is not "better" data, so there is
 # nothing to replace.
 [group('automation')]
 gh-collect-bench-history:
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- collect --workspace --exclude benchmarks --machine-key github --skip-existing --verbose
 
 # Analyzes the collected history for regressions across ALL engines and target triples, but
-# only the `github` machine key — the fixed key `gh-collect-bench-history` stamps on the
+# only the `github` machine key - the fixed key `gh-collect-bench-history` stamps on the
 # GitHub runner pool's data. Restricting it here (rather than `--machine-key all`) keeps this
 # job surveying only GitHub-pool history and never mixes in a stray key some other machine may
 # have inserted into the shared store. It writes four artefacts INTO the given {{dir}}:
@@ -45,7 +45,7 @@ gh-collect-bench-history:
 # downloaded at most once across runs instead of in full every run. The bench-history.yml
 # `analyze` job persists that directory between runs via `actions/cache`; its `path:` and the
 # report/summary/notable filenames its steps read MUST match the names written here. The cloud
-# history is append-only (collection uses `--skip-existing`), so the cache only ever tops up —
+# history is append-only (collection uses `--skip-existing`), so the cache only ever tops up -
 # a stale mirror is wiped via the cloud-side marker only after a deliberate `--overwrite`/`prune`.
 [group('automation')]
 [script]
@@ -76,8 +76,8 @@ gh-analyze-bench-history dir:
 # scripts/bench-history/BenchHistoryIssue.psm1 (Pester-tested via `just test-scripts`), the one
 # way this workflow opens issues now that JasonEtco/create-an-issue is gone: `gh` reads the body
 # from any path (--body-file), so it can live in the runner temp dir, outside the repo checkout.
-# The title is the dedup key — a persisting condition updates one rolling issue instead of opening
-# a new one each run — so both the regression alert ('Benchmark regressions detected') and the
+# The title is the dedup key - a persisting condition updates one rolling issue instead of opening
+# a new one each run - so both the regression alert ('Benchmark regressions detected') and the
 # workflow-failure alert route through here with their own title/label. `label` is the
 # comma-separated label list applied on creation. Needs GH_TOKEN in the environment (the workflow
 # supplies it).
@@ -132,8 +132,8 @@ gh-compose-release-config output:
 
 # Publishes changed crates to crates.io via release-plz using the composed CI config, with
 # bounded retries (3 attempts, 15 minutes apart) to ride out crates.io rate limits and the
-# short-lived OIDC token. release-plz is idempotent — it re-checks the registry and skips
-# already-published versions — so a retry (or a whole re-run) safely resumes a partially
+# short-lived OIDC token. release-plz is idempotent - it re-checks the registry and skips
+# already-published versions - so a retry (or a whole re-run) safely resumes a partially
 # published release, and each attempt mints a fresh OIDC token. NOT for local use: it
 # performs real publishes. See docs/release-automation.md.
 [group('automation')]
@@ -150,7 +150,7 @@ gh-release config:
 # published binary crate's GitHub release, and emits the matrix of missing (crate, target)
 # pairs still to build as the `matrix` / `has_binaries` step outputs (also printed). This is
 # what makes retries self-healing: a re-run rebuilds only whatever is still missing, with no
-# hardcoded crate list. Safe to run locally — with no releases yet it reports an empty
+# hardcoded crate list. Safe to run locally - with no releases yet it reports an empty
 # matrix. See .github/workflows/release.yml and docs/release-automation.md.
 [group('automation')]
 [script]

--- a/justfiles/just_basics.just
+++ b/justfiles/just_basics.just
@@ -11,7 +11,7 @@ check PROFILE='dev':
 check-frozen:
     # `cargo freeze-deps` rewrites every workspace dependency requirement in Cargo.toml to
     # its declared minimum (`=X.Y.Z`) in place. Regenerating Cargo.lock then makes the
-    # resolver select those minimums, and `check` compiles against them — a failure means a
+    # resolver select those minimums, and `check` compiles against them - a failure means a
     # published minimum-version promise is too low to actually compile. This rewrites
     # Cargo.toml and Cargo.lock in place, so run it on a throwaway checkout (e.g. CI).
     cargo freeze-deps

--- a/justfiles/just_basics.just
+++ b/justfiles/just_basics.just
@@ -25,6 +25,7 @@ clean:
 [group('basics')]
 [script]
 docs:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -34,6 +35,7 @@ docs:
 [group('basics')]
 [script]
 docs-default-features:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -43,6 +45,7 @@ docs-default-features:
 [group('basics')]
 [script]
 docs-open:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 

--- a/justfiles/just_delta.just
+++ b/justfiles/just_delta.just
@@ -3,121 +3,66 @@
 [group('delta')]
 [script]
 delta:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # We need the full history of both branches to compare them. If we are in a shallow clone
-    # (e.g. in CI), we need to unshallow first.
-    $is_shallow = git rev-parse --is-shallow-repository
-    if ($is_shallow -eq "true") {
-        git fetch --unshallow origin main
+    # The analyze-current / analyze-baseline-via-worktree / run / parse pipeline lives in the
+    # Pester-tested Delta module, shared with the CI `delta` job so the two cannot drift apart.
+    # See scripts/build/Delta.psm1.
+    Import-Module "{{ justfile_directory() }}/scripts/build/Delta.psm1" -Force
+
+    $affected = @(Invoke-CargoDelta)
+
+    Write-Host ""
+    if ($affected.Count -gt 0) {
+        Write-Host "Affected packages ($($affected.Count)):"
+        foreach ($pkg in $affected) {
+            Write-Host "  - $pkg"
+        }
+        Write-Host ""
+        Write-Host "DELTA_PACKAGES=$($affected -join ' ')"
     } else {
-        git fetch origin main
-    }
-
-    # Use a temporary directory for analysis artifacts.
-    $temp_dir = Join-Path ([System.IO.Path]::GetTempPath()) "cargo-delta-$(Get-Random)"
-    New-Item -ItemType Directory -Path $temp_dir -Force | Out-Null
-
-    try {
-        $baseline_json = Join-Path $temp_dir "baseline.json"
-        $current_json = Join-Path $temp_dir "current.json"
-        $delta_json = Join-Path $temp_dir "delta.json"
-        $config_path = (Resolve-Path "delta.toml").Path
-
-        # Analyze the current branch first (we are already on it).
-        Write-Host "Analyzing current branch..."
-        cargo delta -c $config_path analyze | Out-File -FilePath $current_json -Encoding utf8
-
-        # Use a git worktree to analyze origin/main without switching branches.
-        $worktree_dir = Join-Path $temp_dir "main-worktree"
-        git worktree add --quiet $worktree_dir origin/main
-
-        try {
-            Write-Host "Analyzing baseline (origin/main)..."
-            Push-Location $worktree_dir
-            cargo delta -c $config_path analyze | Out-File -FilePath $baseline_json -Encoding utf8
-            Pop-Location
-        } finally {
-            git worktree remove $worktree_dir --force
-        }
-
-        # Compare to find impacted crates.
-        Write-Host "Computing delta..."
-        cargo delta -c $config_path run --baseline $baseline_json --current $current_json | Out-File -FilePath $delta_json -Encoding utf8
-
-        # Parse the delta output to extract the "Affected" package list.
-        $delta = Get-Content $delta_json -Raw | ConvertFrom-Json
-        $affected = $delta.Affected
-
-        if ($affected -and $affected.Count -gt 0) {
-            $package_list = $affected -join " "
-            Write-Host ""
-            Write-Host "Affected packages ($($affected.Count)):"
-            foreach ($pkg in $affected) {
-                Write-Host "  - $pkg"
-            }
-            Write-Host ""
-            Write-Host "DELTA_PACKAGES=$package_list"
-        } else {
-            Write-Host ""
-            Write-Host "No packages affected by changes."
-            Write-Host "DELTA_PACKAGES="
-        }
-    } finally {
-        Remove-Item -Path $temp_dir -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Host "No packages affected by changes."
+        Write-Host "DELTA_PACKAGES="
     }
 
 # Runs delta analysis and then validates only the affected packages.
 [group('delta')]
 [script]
 delta-validate:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # Capture delta output and extract the package list.
-    $output = just delta 2>&1 | Out-String
-    Write-Host $output
+    Import-Module "{{ justfile_directory() }}/scripts/build/Delta.psm1" -Force
 
-    $match = [regex]::Match($output, "DELTA_PACKAGES=(.*)")
-    if (-not $match.Success) {
-        Write-Error "Failed to parse delta output."
-        exit 1
-    }
-
-    $packages = $match.Groups[1].Value.Trim()
-
-    if ($packages -eq "") {
+    $packages = @(Invoke-CargoDelta)
+    if ($packages.Count -eq 0) {
         Write-Host "No packages affected. Nothing to validate."
         exit 0
     }
 
-    Write-Host "Running validate-local for: $packages"
-    just package="$packages" validate-local
+    $packageList = $packages -join " "
+    Write-Host "Running validate-local for: $packageList"
+    just package="$packageList" validate-local
 
 # Runs delta analysis and then performs extended validation on the affected packages.
 [group('delta')]
 [script]
 delta-validate-extra:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # Capture delta output and extract the package list.
-    $output = just delta 2>&1 | Out-String
-    Write-Host $output
+    Import-Module "{{ justfile_directory() }}/scripts/build/Delta.psm1" -Force
 
-    $match = [regex]::Match($output, "DELTA_PACKAGES=(.*)")
-    if (-not $match.Success) {
-        Write-Error "Failed to parse delta output."
-        exit 1
-    }
-
-    $packages = $match.Groups[1].Value.Trim()
-
-    if ($packages -eq "") {
+    $packages = @(Invoke-CargoDelta)
+    if ($packages.Count -eq 0) {
         Write-Host "No packages affected. Nothing to validate."
         exit 0
     }
 
-    Write-Host "Running validate-extra-local for: $packages"
-    just package="$packages" validate-extra-local
+    $packageList = $packages -join " "
+    Write-Host "Running validate-extra-local for: $packageList"
+    just package="$packageList" validate-extra-local

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -5,6 +5,7 @@ clippy PROFILE='dev':
 [group('quality')]
 [script]
 coverage-measure:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -63,6 +64,7 @@ format-check:
 [group('quality')]
 [script]
 validate-workflows:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -75,11 +77,47 @@ validate-workflows:
 [group('quality')]
 [script]
 validate-binstall:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/release/BinstallValidation.psm1 -Force
 
     Invoke-BinstallValidation
+
+# Statically analyzes every PowerShell script and module under scripts/ with PSScriptAnalyzer
+# (installed and version-pinned by `just install-tools`). It runs the built-in rule set filtered by
+# the curated PSScriptAnalyzerSettings.psd1 PLUS the repo-local custom rules in
+# scripts/analyzer/FoloAnalyzerRules.psm1 — which catch classes the built-in rules miss, notably the
+# case-insensitive foreach variable-shadowing bug that once shipped a broken release. Any Error/
+# Warning finding fails the recipe; the ruleset is tuned so a clean tree has zero findings (a
+# genuine false positive is silenced with a justified SuppressMessageAttribute, not by relaxing the
+# gate). Repo-wide, not package-scoped.
+[group('quality')]
+[script]
+validate-scripts:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $root = "{{justfile_directory()}}"
+    Import-Module PSScriptAnalyzer -RequiredVersion $env:PSSCRIPTANALYZER_VERSION -Force
+
+    $results = @(Invoke-ScriptAnalyzer `
+            -Path (Join-Path $root 'scripts') `
+            -Recurse `
+            -Settings (Join-Path $root 'PSScriptAnalyzerSettings.psd1') `
+            -CustomRulePath (Join-Path $root 'scripts/analyzer/FoloAnalyzerRules.psm1') `
+            -IncludeDefaultRules)
+
+    if ($results.Count -gt 0) {
+        foreach ($finding in $results) {
+            $relative = $finding.ScriptName.Substring($root.Length).TrimStart('\', '/')
+            Write-Host ("{0}:{1} [{2}] {3}: {4}" -f $relative, $finding.Line, $finding.Severity, $finding.RuleName, $finding.Message)
+        }
+        throw "PSScriptAnalyzer reported $($results.Count) issue(s). Fix them (or add a justified SuppressMessageAttribute) so the tree stays clean."
+    }
+
+    Write-Host "PSScriptAnalyzer: no issues in scripts/."
 
 [group('quality')]
 hack:
@@ -98,6 +136,7 @@ default-features-check:
 [group('quality')]
 [script]
 careful FILTER="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -131,6 +170,7 @@ validate-local:
     just package="{{ package }}" format-check
     just package="{{ package }}" validate-workflows
     just package="{{ package }}" validate-binstall
+    just package="{{ package }}" validate-scripts
     just package="{{ package }}" check dev
     just package="{{ package }}" clippy dev
     just package="{{ package }}" test

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -18,7 +18,7 @@ coverage-measure:
     # cargo-bench-history integration test a redundant on-demand Cargo freshness check. The
     # engine builds into its own dedicated target directory (see `_mock-engine-path`), so
     # neither this pre-build nor any residual on-demand build relinks a binary out of the
-    # shared coverage tree while another test is spawning it — the transient "No such file or
+    # shared coverage tree while another test is spawning it - the transient "No such file or
     # directory" engine-spawn races previously seen on macOS (issue #332).
     $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
 
@@ -87,7 +87,7 @@ validate-binstall:
 # Statically analyzes every PowerShell script and module under scripts/ with PSScriptAnalyzer
 # (installed and version-pinned by `just install-tools`). It runs the built-in rule set filtered by
 # the curated PSScriptAnalyzerSettings.psd1 PLUS the repo-local custom rules in
-# scripts/analyzer/FoloAnalyzerRules.psm1 — which catch classes the built-in rules miss, notably the
+# scripts/analyzer/FoloAnalyzerRules.psm1 - which catch classes the built-in rules miss, notably the
 # case-insensitive foreach variable-shadowing bug that once shipped a broken release. Any Error/
 # Warning finding fails the recipe; the ruleset is tuned so a clean tree has zero findings (a
 # genuine false positive is silenced with a justified SuppressMessageAttribute, not by relaxing the
@@ -163,7 +163,7 @@ validate-linux:
 
 # Full validation of primary factors, as you would do in a build pipeline before a release.
 # Includes package-scoped mutation testing as its final (and by far slowest) step, since
-# uncaught mutations are a very common cause of CI failures — we catch them before pushing.
+# uncaught mutations are a very common cause of CI failures - we catch them before pushing.
 # Performs validation on the current platform, whatever that may be.
 [group('quality')]
 validate-local:
@@ -195,7 +195,7 @@ validate-extra-linux:
     wsl -e bash -l -c "just package='{{ package }}' validate-extra-local"
 
 # Validation of extra factors that take potentially too long to run in regular validation.
-# Mutation testing is intentionally not here — it runs as part of `validate-local`.
+# Mutation testing is intentionally not here - it runs as part of `validate-local`.
 # Performs validation on the current platform, whatever that may be.
 [group('quality')]
 validate-extra-local:

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -1,26 +1,22 @@
 [group('quality')]
 [script]
 mutants SHARD="" CAREFUL='false':
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
+    # The fiddly, easy-to-break parts of this recipe - the long platform-dependent exclusion set
+    # and the 1-based -> 0-based shard translation - live in the Pester-tested Mutants module so a
+    # stray edit is caught by a test, not by a wasted CI mutation run. See
+    # scripts/build/Mutants.psm1. The recipe keeps only the orchestration with real side effects
+    # (environment tweaks and the cargo-mutants invocation).
+    Import-Module "{{ justfile_directory() }}/scripts/build/Mutants.psm1" -Force
+
     $careful = '{{ CAREFUL }}' -eq 'true'
 
-    function Escape-Wildcards ($s) {
-        if ($IsWindows) {
-            return $s
-        }
-
-        # On Linux, PowerShell has built-in globbing that expands wildcards. Unfortunately,
-        # cargo mutants requires literal input values, globbing just breaks it. We convince
-        # PowerShell to turn off globbing by single-quoting the arguments we fear may be
-        # interpreted as wildcard glob expressions.
-        "'" + $s + "'"
-    }
-
     # Two mechanisms keep mutation runs fast and meaningful:
-    #   * Path/package exclusions (the `-e` args below) drop whole files cargo-mutants
-    #     should never mutate.
+    #   * Path/package exclusions (the `-e` args from Get-MutantsExcludeArgument) drop whole files
+    #     cargo-mutants should never mutate.
     #   * Individual tests that carry no mutation signal opt out at the test site with
     #     `#[cfg_attr(mutants, ignore = "<why>")]`. This keeps them running under normal
     #     `cargo test`/coverage while skipping them under mutation - see
@@ -28,140 +24,27 @@ mutants SHARD="" CAREFUL='false':
     #     real-engine end-to-end test). cargo-mutants defines no cfg of its own, so this
     #     recipe ensures `RUSTFLAGS` contains `--cfg mutants` below (preserving any
     #     existing flags) to drive that opt-out.
+    $mutantArgs = @(Get-MutantsExcludeArgument -IsWindowsPlatform $IsWindows -IsLinuxPlatform $IsLinux)
 
-    # Note: while cargo-mutants does theoretically support specifying these via config file, it
-    # does not support merging that static set of entries with the dynamic set of entries we
-    # determine based on the platform. So we have to specify them all here.
-    # https://github.com/sourcefrog/cargo-mutants/issues/527
-    $args = @(
-        # Parts of this package require Criterion to work and other parts are currently not tested
-        # as there is no public way to simulate a system topology for `many_cpus`.
-        "-e"
-        "many_cpus_benchmarking",
-
-        # Macros are tested via the impl package, mutations in the middle layer might not be detected.
-        "-e"
-        "linked_macros"
-
-        # We do not test facades, as they are just trivial code that forwards calls to real impls.
-        "-e"
-        (Escape-Wildcards "**/*facade.rs")
-        "-e"
-        "facade"
-
-        # We have limited coverage of platform bindings because it can be difficult to set up the
-        # right scenarios for each, given they are platform-dependent. Instead, we test higher
-        # level code using a mock platform.
-        "-e"
-        "bindings"
-
-        # This is just a different type of bindings, skipped for same reason as `bindings` above.
-        "-e"
-        (Escape-Wildcards "packages/many_cpus_impl/src/pal/linux/filesystem/**")
-
-        # These packages are literally full of synchronization primitives, so 95% of mutations
-        # will just cause tests to time out and never complete - pointless to try mutate this stuff.
-        "-e"
-        "events_once",
-        "-e"
-        "awaiter_set",
-        "-e"
-        "events"
-        
-        # All this is code only used in tests/benchmarks - we do not test this code itself.
-        "-e"
-        (Escape-Wildcards "packages/testing/**")
-        "-e"
-        (Escape-Wildcards "packages/benchmarks/**")
-
-        # The mock benchmark engine is a test-support binary (its own never-published
-        # `mock_bench_engine` package, which the integration tests spawn). It is scaffolding,
-        # not shipped code, so mutating it yields no production coverage signal - it only spawns
-        # extra subprocess-heavy test runs that time out on slower runners. Its own behavior is
-        # covered by the integration tests.
-        "-e"
-        (Escape-Wildcards "packages/mock_bench_engine/**")
-
-        # `testing.rs` is an in-workspace test utility (gated behind the `private-test-util`
-        # feature, consumed only by the shell crate's tests). It is scaffolding with no public
-        # API contract, so mutating it yields no production coverage signal. A source-level
-        # `mutants::skip` cannot apply to a file module (inner/file-module proc-macro attributes
-        # are unstable Rust), so it is excluded here instead.
-        "-e"
-        (Escape-Wildcards "packages/cargo-bench-history-core/src/testing.rs")
-
-        # Some of our systems are single-processor, yet the code may only be meaningfully testable
-        # on multi-processor systems. As a "good enough" approximation, we skip mutation testing
-        # of code that is only testable in a multi-processor system.
-        "-e",
-        (Escape-Wildcards "packages/par_bench/src/resource_usage_ext.rs")
-    )
-
-    if (!$IsWindows) {
-        $args += "-e"
-        $args += (Escape-Wildcards "**/*windows.rs")
-
-        $args += "-e"
-        $args += "windows"
-    }
-    
-    if (!$IsLinux) {
-        $args += "-e"
-        $args += (Escape-Wildcards "**/*linux.rs")
-
-        $args += "-e"
-        $args += "linux"
-    }
-
-    $args += "--jobs"
+    $mutantArgs += "--jobs"
     if ($careful) {
         # In careful mode, only one mutation is tested at a time. Combined with
         # `RUST_TEST_THREADS=1` set below, this ensures that exactly one test runs at any
         # given moment across the entire mutation testing run.
-        $args += "1"
+        $mutantArgs += "1"
     } else {
         # Experimentally determined heuristics.
-        $args += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
+        $mutantArgs += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
     }
 
-    # Optional sharding lets CI split mutation testing across multiple parallel runners.
-    # We accept the same 1-based "N/M" format as `miri-harder` for consistency with the
-    # existing workspace convention (so `1/8 .. 8/8` for 8 shards), and convert to
-    # cargo-mutants' native 0-based form (`0/N .. (N-1)/N`) before invoking the tool.
-    # Without a SHARD argument, cargo-mutants runs every mutant in a single job (the
-    # original behavior).
-    $shard = "{{ SHARD }}"
-    if ($shard -ne "") {
-        $parts = $shard -split "/"
-
-        if ($parts.Length -ne 2) {
-            Write-Error "Invalid SHARD value '$shard'. Expected format 'N/M'."
-            exit 1
-        }
-
-        $shardIndex = 0
-        $shardCount = 0
-        if (-not [int]::TryParse($parts[0], [ref]$shardIndex) -or -not [int]::TryParse($parts[1], [ref]$shardCount)) {
-            Write-Error "Invalid SHARD value '$shard'. N and M must be integers in 'N/M'."
-            exit 1
-        }
-
-        if ($shardCount -le 0) {
-            Write-Error "Invalid SHARD value '$shard'. M must be a positive integer in 'N/M'."
-            exit 1
-        }
-
-        if ($shardIndex -lt 1 -or $shardIndex -gt $shardCount) {
-            Write-Error "Invalid SHARD value '$shard'. N must satisfy 1 <= N <= M in 'N/M'."
-            exit 1
-        }
-
-        $args += "--shard"
-        $args += ("{0}/{1}" -f ($shardIndex - 1), $shardCount)
-    }
+    # Optional sharding lets CI split mutation testing across multiple parallel runners. We accept
+    # the same 1-based "N/M" format as `miri-harder` (so `1/8 .. 8/8` for 8 shards); the module
+    # converts it to cargo-mutants' native 0-based form. Without a SHARD argument, cargo-mutants
+    # runs every mutant in a single job (the original behavior).
+    $mutantArgs += Get-MutantsShardArgument -Spec "{{ SHARD }}"
 
     # We must use Invoke-Expression to preserve the quotes around the wildcarded arguments on Linux.
-    $expanded_args = [String]::join(" ", $args)
+    $expanded_args = [String]::join(" ", $mutantArgs)
 
     # If the user has overridden `CARGO_TARGET_DIR`, we need to un-override it here because it is
     # critical that different mutations be emitted into different target directories, otherwise
@@ -214,7 +97,7 @@ mutants SHARD="" CAREFUL='false':
     #     understand what is covered by mutation testing and how successfully.
     # --timeout - as we skip the baseline tests, we need to manually define a timeout.
     #     This needs to be long enough to run a full package test suite (for all jobs in parallel)
-    #     but short enough to call a timeout and timeout and avoid things going on forever.
+    #     but short enough to call a timeout and avoid things going on forever.
     #     This should only be reached if a mutation causes a serious issue (and may need to be
     #     skipped or the test improved).
     Invoke-Expression "cargo mutants {{ target_package }} --baseline=skip --timeout=60 --no-shuffle --caught --unviable $expanded_args"

--- a/justfiles/just_release.just
+++ b/justfiles/just_release.just
@@ -15,9 +15,9 @@ prepare-release: verify-semver-checks && check-never-published
 # Preflight for `just prepare-release`: proves that `cargo semver-checks` can actually run on
 # this machine before `release-plz update` starts trusting it. release-plz runs
 # cargo-semver-checks to decide whether a bumped version needs to be a *major* bump, but when the
-# tool fails to *run* — most commonly because the installed cargo-semver-checks is too old for the
+# tool fails to *run* - most commonly because the installed cargo-semver-checks is too old for the
 # current toolchain's rustdoc JSON format (e.g. "unsupported rustdoc format v57 ... supported
-# formats are v53, v55, v56") — release-plz silently swallows the error and treats it as "no
+# formats are v53, v55, v56") - release-plz silently swallows the error and treats it as "no
 # breaking changes". That turns a broken tool into an undetected breaking release. This canary
 # runs cargo-semver-checks on one small, fast-to-build package, comparing it against its own `HEAD`
 # so the two sides are byte-identical and the *only* way the check can fail is the tool itself
@@ -32,7 +32,7 @@ verify-semver-checks:
     $PSNativeCommandUseErrorActionPreference = $true
 
     # A tiny published crate that builds quickly, keeping this preflight cheap. Its own API is
-    # irrelevant here — it is only a vehicle for exercising the rustdoc build+parse path that
+    # irrelevant here - it is only a vehicle for exercising the rustdoc build+parse path that
     # release-plz relies on.
     $package = "folo_utils"
 

--- a/justfiles/just_release.just
+++ b/justfiles/just_release.just
@@ -5,6 +5,7 @@ audit:
 [group('release')]
 [script]
 prepare-release: verify-semver-checks && check-never-published
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -26,6 +27,7 @@ prepare-release: verify-semver-checks && check-never-published
 [group('release')]
 [script]
 verify-semver-checks:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -64,6 +66,7 @@ verify-semver-checks:
 [group('release')]
 [script]
 check-never-published:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -14,7 +14,7 @@ install-tools:
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # This is the single source of truth for which tools — and which versions — get installed. CI
+    # This is the single source of truth for which tools - and which versions - get installed. CI
     # runs this same recipe on nearly every job via the setup-environment composite action, so
     # there is no separate CI install path to keep in sync. The only per-job variation is the
     # skip_azcopy / skip_azurite flags above, which trim two tools no ordinary CI job needs.
@@ -28,8 +28,8 @@ install-tools:
 
     # Every tool is pinned to an explicit version from constants.env (dotenv, configured in the
     # root justfile, exposes each `FOO_VERSION` as `$env:FOO_VERSION`). This is deliberate: a plain
-    # `cargo install <crate>` never upgrades an already-installed crate — it prints "already
-    # installed" and skips — so an unpinned tool would freeze at whatever version first landed. With
+    # `cargo install <crate>` never upgrades an already-installed crate - it prints "already
+    # installed" and skips - so an unpinned tool would freeze at whatever version first landed. With
     # a pin, `cargo install <crate>@<version>` replaces an installed version that differs from the
     # pin and is a fast no-op when it already matches, so bumping a tool is just editing its version
     # in constants.env. (cargo-mutants is installed further down because it is skipped on ARM.)
@@ -84,7 +84,7 @@ install-tools:
     }
 
     # azcopy drives the bulk upload in the cargo-bench-history Azure stress harness
-    # (`just bench-history-stress-azure`), which is on-demand only — no CI job needs it, so CI
+    # (`just bench-history-stress-azure`), which is on-demand only - no CI job needs it, so CI
     # sets skip_azcopy=true. It is not a cargo crate and has no installer, so a helper script
     # fetches the pinned official binary; see scripts/install-azcopy.ps1 (including its rationale
     # for the destination). No-op when azcopy is already present.
@@ -112,7 +112,7 @@ install-tools:
         Write-Host "Skipping Azurite install (skip_azurite=true)."
     } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
         # A global npm install can fail for reasons unrelated to the rest of the toolchain
-        # — most commonly an npm global prefix pointing at a root-owned directory (e.g. the
+        # - most commonly an npm global prefix pointing at a root-owned directory (e.g. the
         # default /usr/local on a system Node), which yields EACCES without sudo. Since the
         # cargo tools above have already installed, treat such a failure as non-fatal: warn
         # and continue rather than aborting the whole recipe over an optional emulator.
@@ -121,7 +121,7 @@ install-tools:
         } catch {
             Write-Warning (
                 "Failed to install Azurite via 'npm install -g azurite@3.35.0': $_. " +
-                "Skipping it — the rest of the toolchain is unaffected and Azurite is only " +
+                "Skipping it - the rest of the toolchain is unaffected and Azurite is only " +
                 "needed for 'just test-azurite'. This is usually an npm global-prefix " +
                 "permission issue (a root-owned prefix like /usr/local yields EACCES); fix it " +
                 "with 'npm config set prefix ~/.npm-global' or use a user-owned Node (nvm), " +

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -10,6 +10,7 @@ skip_azurite := "false"
 [group('setup')]
 [script]
 install-tools:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -138,6 +139,19 @@ install-tools:
         Write-Host "Pester 5+ already available; skipping install."
     } else {
         Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser -Force -SkipPublisherCheck
+    }
+
+    # PSScriptAnalyzer powers `just validate-scripts`, the PowerShell static-analysis gate for the
+    # standalone scripts under scripts/ (curated ruleset in PSScriptAnalyzerSettings.psd1 plus the
+    # repo-local custom rules in scripts/analyzer/). Unlike Pester it is pinned to an EXACT version
+    # (PSSCRIPTANALYZER_VERSION in constants.env): a newer analyzer can add or change rules, which
+    # would make which findings gate depend on whatever version a machine happens to have, so the
+    # pin keeps `validate-scripts` reproducible across local PCs and CI. Install the pinned version
+    # only when a matching one is not already present.
+    if (Get-Module -ListAvailable PSScriptAnalyzer | Where-Object { $_.Version -eq [version]$env:PSSCRIPTANALYZER_VERSION }) {
+        Write-Host "PSScriptAnalyzer $env:PSSCRIPTANALYZER_VERSION already available; skipping install."
+    } else {
+        Install-Module PSScriptAnalyzer -RequiredVersion $env:PSSCRIPTANALYZER_VERSION -Scope CurrentUser -Force -SkipPublisherCheck
     }
 
     # ShellCheck is what actionlint delegates to for linting embedded shell (`run:`) steps. GitHub's

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -431,7 +431,8 @@ run-examples:
     # Pre-compile each package's examples up front so first-time compilation does not eat into the
     # per-example execution timeout (on slow CI runners a cold compile can exceed it). A package
     # whose examples fail to build is recorded and its examples skipped, so one broken package does
-    # not mask the others' results.
+    # not mask the others' results. Each affected example is recorded as its own failure so the
+    # summary's total, successful and failed counts stay consistent (total = successful + failed).
     $env:IS_TESTING = "1"
     $buildFailed = @{}
     foreach ($pkg in ($targets | ForEach-Object { $_.Package } | Sort-Object -Unique)) {
@@ -441,7 +442,9 @@ run-examples:
         } catch {
             Write-Host "Building examples for package '$pkg' failed" -ForegroundColor Red
             $buildFailed[$pkg] = $true
-            $failures += "${pkg}::* (build failed)"
+            foreach ($failedTarget in @($targets | Where-Object { $_.Package -eq $pkg })) {
+                $failures += "$($failedTarget.Package)::$($failedTarget.Example) (build failed)"
+            }
         }
     }
 

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -182,7 +182,7 @@ bench-history-stress *ARGS:
 # against cloud storage.
 #
 # Requires `az login` (the harness and azcopy authenticate as your Entra user via
-# the Azure CLI) and the `azcopy` binary on PATH for the bulk upload — both are
+# the Azure CLI) and the `azcopy` binary on PATH for the bulk upload - both are
 # installed by `just install-tools`. The account defaults to
 # BENCH_HISTORY_TEST_AZURE_ACCOUNT from constants.env (shared with the test-azure job);
 # override it by passing a name as the first argument. Any further harness flags
@@ -223,7 +223,7 @@ bench-history-stress-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_
 # trust that cert by disabling certificate validation. If an emulator is already listening on
 # 127.0.0.1:10000 this recipe reuses it (which must therefore also be an HTTPS
 # `--oauth basic` emulator); otherwise it starts one (in-memory, no persisted state)
-# and stops it again when the tests finish — even on failure. BENCH_HISTORY_REQUIRE_AZURITE
+# and stops it again when the tests finish - even on failure. BENCH_HISTORY_REQUIRE_AZURITE
 # is set so an unreachable emulator is a hard error rather than a silent skip, mirroring
 # the CI job. The `azure azurite` test filter selects the Azure-backend tests by the
 # naming convention (the `storage::azure` unit tests and the `*_in_azurite` integration
@@ -324,7 +324,7 @@ test-azurite:
 #
 # Requires `az login` (the tests authenticate as your Entra user via the Azure
 # CLI) and a deployed storage account that grants your user the `Storage Blob
-# Data Contributor` role — see infra/azure-bench-history-test/ to deploy one. The
+# Data Contributor` role - see infra/azure-bench-history-test/ to deploy one. The
 # account defaults to BENCH_HISTORY_TEST_AZURE_ACCOUNT from constants.env (shared with
 # CI); override it by passing a name: `just test-azure <account>`.
 #
@@ -358,7 +358,7 @@ test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', ''):
 #
 # Benches go through `cargo test --benches` (not nextest): this invokes each bench binary's
 # main() once with `--test`, which Criterion treats as "run each bench once" and Gungraun
-# treats as its normal one-shot Valgrind run — exactly the smoke check we want here.
+# treats as its normal one-shot Valgrind run - exactly the smoke check we want here.
 [group('testing')]
 [script]
 test-benches FILTER="":

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -1,6 +1,7 @@
 [group('testing')]
 [script]
 bench TARGET="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -21,8 +22,11 @@ bench TARGET="":
 [group('testing')]
 [script]
 bench-cg TARGET="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module "{{ justfile_directory() }}/scripts/build/CallgrindBench.psm1" -Force
 
     if (-not $IsLinux) {
         Write-Error "bench-cg requires Linux (Valgrind). On Windows, invoke through WSL from the repo root: wsl -e bash -l -c 'just bench-cg'"
@@ -37,31 +41,21 @@ bench-cg TARGET="":
     $package_filter = "{{ package }}"
     $target_filter = "{{ TARGET }}"
 
-    $packages = if ($package_filter -eq "") {
-        Get-ChildItem packages -Directory | ForEach-Object { $_.Name }
-    } else {
-        # Support space-separated package lists (e.g. from cargo-delta output).
-        $package_filter -split " " | Where-Object { $_ -ne "" }
+    $targets = @(Get-CallgrindBenchTarget -PackagesRoot "packages" -PackageFilter $package_filter -TargetFilter $target_filter)
+
+    foreach ($benchTarget in $targets) {
+        Write-Host "Running $($benchTarget.Package)::$($benchTarget.Bench)" -ForegroundColor Cyan
+        cargo bench -p $($benchTarget.Package) --bench $($benchTarget.Bench) --all-features --locked
     }
 
-    $any_run = $false
-    foreach ($pkg in $packages) {
-        $benches_dir = Join-Path "packages" $pkg "benches"
-        if (-not (Test-Path $benches_dir)) { continue }
-
-        $bench_files = Get-ChildItem $benches_dir -Filter "*_cg.rs"
-        foreach ($bench_file in $bench_files) {
-            $bench_name = $bench_file.BaseName
-            if ($target_filter -ne "" -and $bench_name -ne $target_filter) { continue }
-
-            Write-Host "Running ${pkg}::${bench_name}" -ForegroundColor Cyan
-            cargo bench -p $pkg --bench $bench_name --all-features --locked
-            $any_run = $true
+    if ($targets.Count -eq 0) {
+        $scope = if ($package_filter -eq "") {
+            "the workspace"
+        } else {
+            $names = @($package_filter -split " " | Where-Object { $_ -ne "" })
+            $noun = if ($names.Count -eq 1) { "package" } else { "packages" }
+            "$noun '$package_filter'"
         }
-    }
-
-    if (-not $any_run) {
-        $scope = if ($package_filter -eq "") { "the workspace" } else { "package(s) '$package_filter'" }
         $target_clause = if ($target_filter -eq "") { "" } else { " matching target '$target_filter'" }
         Write-Host "No Callgrind benchmarks found in $scope$target_clause." -ForegroundColor Yellow
     }
@@ -74,55 +68,16 @@ miri FILTER="":
 [group('testing')]
 [script]
 miri-harder SHARD="" FILTER="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    $totalSeeds = 64
-    $shard = "{{ SHARD }}"
+    # The seed-range arithmetic (splitting the seed budget across CI shards, the final shard
+    # absorbing the remainder) lives in the Pester-tested Miri module, which shares the "N/M"
+    # shard-spec parsing with `just mutants`. See scripts/build/Miri.psm1.
+    Import-Module "{{ justfile_directory() }}/scripts/build/Miri.psm1" -Force
 
-    if ($shard -eq "") {
-        $seedRange = "..$totalSeeds"
-    } else {
-        $parts = $shard -split "/"
-
-        if ($parts.Length -ne 2) {
-            Write-Error "Invalid SHARD value '$shard'. Expected format 'N/M'."
-            exit 1
-        }
-
-        $shardIndex = 0
-        $shardCount = 0
-        if (-not [int]::TryParse($parts[0], [ref]$shardIndex) -or -not [int]::TryParse($parts[1], [ref]$shardCount)) {
-            Write-Error "Invalid SHARD value '$shard'. N and M must be integers in 'N/M'."
-            exit 1
-        }
-
-        if ($shardCount -le 0) {
-            Write-Error "Invalid SHARD value '$shard'. M must be a positive integer in 'N/M'."
-            exit 1
-        }
-
-        if ($shardIndex -lt 1 -or $shardIndex -gt $shardCount) {
-            Write-Error "Invalid SHARD value '$shard'. N must satisfy 1 <= N <= M in 'N/M'."
-            exit 1
-        }
-
-        $seedsPerShard = [math]::Floor($totalSeeds / $shardCount)
-        if ($seedsPerShard -lt 1) {
-            Write-Error "Invalid SHARD value '$shard'. Too many shards for $totalSeeds seeds."
-            exit 1
-        }
-
-        $start = ($shardIndex - 1) * $seedsPerShard
-        if ($shardIndex -eq $shardCount) {
-            # Last shard picks up any remainder from uneven division.
-            $end = $totalSeeds
-        } else {
-            $end = $shardIndex * $seedsPerShard
-        }
-        $seedRange = "$start..$end"
-    }
-
+    $seedRange = Get-MiriSeedRange -Spec "{{ SHARD }}"
     $env:MIRIFLAGS = "-Zmiri-many-seeds=$seedRange"
     Write-Host "Running miri-harder with seed range: $seedRange"
     cargo +$env:RUST_NIGHTLY miri test {{ target_package }} --no-fail-fast --all-features --lib {{ FILTER }} --locked -- --quiet
@@ -130,6 +85,7 @@ miri-harder SHARD="" FILTER="":
 [group('testing')]
 [script]
 miri-example EXAMPLE:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -142,6 +98,7 @@ miri-example EXAMPLE:
 [group('testing')]
 [script]
 test FILTER="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -156,6 +113,7 @@ test FILTER="":
 [group('testing')]
 [script]
 test-scripts:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -181,8 +139,11 @@ test-scripts:
 [group('testing')]
 [script]
 _mock-engine-path:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module "{{ justfile_directory() }}/scripts/build/MockBenchEngine.psm1" -Force
 
     # Nest under the ambient CARGO_TARGET_DIR (e.g. a coverage run's tree) when set, else the
     # workspace `target/`, so the isolated tree stays git-ignored and cached like everything
@@ -190,17 +151,7 @@ _mock-engine-path:
     # on-demand build resolve to the very same isolated binary.
     $engineTargetDir = Join-Path ($env:CARGO_TARGET_DIR ?? "target") "mock-engine"
     $messages = cargo +$env:RUST_MSRV build -p mock_bench_engine --target-dir $engineTargetDir --message-format=json-render-diagnostics --locked
-    $exe = $messages |
-        ForEach-Object {
-            # Tolerate non-JSON lines (e.g. rendered diagnostics or blank lines), just
-            # as the Rust-side resolver does; only parsed objects flow downstream.
-            if ([string]::IsNullOrWhiteSpace($_)) { return }
-            try { $_ | ConvertFrom-Json -ErrorAction Stop } catch { return }
-        } |
-        Where-Object { $_.reason -eq "compiler-artifact" -and $_.target.name -eq "mock_bench_engine" -and $_.executable } |
-        Select-Object -Last 1 -ExpandProperty executable
-    if (-not $exe) { throw "could not resolve the mock_bench_engine executable from cargo output" }
-    Write-Output $exe
+    Write-Output (Resolve-MockBenchEngineExecutable -CargoMessage $messages)
 
 # Run the cargo-bench-history "stress analyze" harness against LOCAL filesystem
 # storage: it seeds a giant synthetic benchmark history (default 1000 benchmarks ×
@@ -218,6 +169,7 @@ _mock-engine-path:
 [group('testing')]
 [script]
 bench-history-stress *ARGS:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -240,6 +192,7 @@ bench-history-stress *ARGS:
 [group('testing')]
 [script]
 bench-history-stress-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', '') *ARGS:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -278,75 +231,21 @@ bench-history-stress-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_
 [group('testing')]
 [script]
 test-azurite:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
+    Import-Module "{{ justfile_directory() }}/scripts/build/Azurite.psm1" -Force
+
     $blobHost = "127.0.0.1"
     $blobPort = 10000
-
-    # True when something is already accepting connections on the Azurite blob port.
-    function Test-AzuriteReachable {
-        $client = [System.Net.Sockets.TcpClient]::new()
-        try {
-            $client.Connect($blobHost, $blobPort)
-            return $true
-        } catch {
-            return $false
-        } finally {
-            $client.Dispose()
-        }
-    }
-
-    # Stop a process and (on Windows) its descendants. The Windows `.cmd` shim spawns
-    # node as a child, so killing only the shim would orphan the emulator.
-    function Stop-AzuriteProcessTree {
-        param([Parameter(Mandatory)][int] $ProcessId)
-
-        if ($IsWindows) {
-            Get-CimInstance Win32_Process -Filter "ParentProcessId = $ProcessId" -ErrorAction SilentlyContinue |
-                ForEach-Object { Stop-AzuriteProcessTree -ProcessId $_.ProcessId }
-        }
-        Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
-    }
-
-    # Generate a self-signed certificate for Azurite's HTTPS listener, written as a
-    # password-protected PFX (the cross-platform format .NET exports). Entra auth
-    # requires TLS, so `--oauth basic` only runs over HTTPS; the tests trust this cert
-    # by disabling certificate validation, so its contents (beyond being a valid cert
-    # for 127.0.0.1) do not matter. It is given a 10-year lifetime so the cached copy
-    # never needs rolling.
-    function New-AzuriteCertificate {
-        param([Parameter(Mandatory)][string] $PfxPath, [Parameter(Mandatory)][string] $Password)
-
-        $rsa = [System.Security.Cryptography.RSA]::Create(2048)
-        try {
-            $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
-                "CN=127.0.0.1",
-                $rsa,
-                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
-                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
-            $sanBuilder = [System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder]::new()
-            $sanBuilder.AddIpAddress([System.Net.IPAddress]::Loopback)
-            $sanBuilder.AddDnsName("localhost")
-            $request.CertificateExtensions.Add($sanBuilder.Build())
-            $notBefore = [System.DateTimeOffset]::UtcNow.AddDays(-1)
-            $notAfter = [System.DateTimeOffset]::UtcNow.AddYears(10)
-            $certificate = $request.CreateSelfSigned($notBefore, $notAfter)
-            $pfxBytes = $certificate.Export(
-                [System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx,
-                $Password)
-            [System.IO.File]::WriteAllBytes($PfxPath, $pfxBytes)
-        } finally {
-            $rsa.Dispose()
-        }
-    }
 
     $startedByUs = $false
     $launcher = $null
     $emulatorPid = 0
     $certPassword = "azurite"
     try {
-        if (Test-AzuriteReachable) {
+        if (Test-AzuriteReachable -BlobHost $blobHost -BlobPort $blobPort) {
             Write-Host "Azurite already reachable at ${blobHost}:${blobPort}; reusing the running emulator."
         } else {
             $shim = if ($IsWindows) { "azurite-blob.cmd" } else { "azurite-blob" }
@@ -355,9 +254,9 @@ test-azurite:
                 throw "Azurite is not installed. Install it with: npm install -g azurite"
             }
 
-            # Cache the certificate under the Cargo target directory (honoring
-            # CARGO_TARGET_DIR and any `build.target-dir` config) so it is generated
-            # once and reused, and cleaned up whenever `target/` is removed.
+            # Cache the certificate under the Cargo target directory (honoring CARGO_TARGET_DIR and
+            # any `build.target-dir` config) so it is generated once and reused, and cleaned up
+            # whenever `target/` is removed.
             $targetDir = (cargo metadata --no-deps --format-version 1 | ConvertFrom-Json).target_directory
             $certPath = Join-Path $targetDir "azurite/selfsigned.pfx"
             if (Test-Path $certPath) {
@@ -368,17 +267,7 @@ test-azurite:
                 New-AzuriteCertificate -PfxPath $certPath -Password $certPassword
             }
 
-            $azuriteArgs = @(
-                "--blobHost", $blobHost,
-                "--blobPort", "$blobPort",
-                "--cert", $certPath,
-                "--pwd", $certPassword,
-                "--oauth", "basic",
-                "--inMemoryPersistence",
-                "--skipApiVersionCheck",
-                "--silent",
-                "--loose"
-            )
+            $azuriteArgs = Get-AzuriteArgument -BlobHost $blobHost -BlobPort $blobPort -CertPath $certPath -Password $certPassword
 
             Write-Host "Starting Azurite blob emulator on ${blobHost}:${blobPort} (in-memory, HTTPS + OAuth)."
             $startParams = @{
@@ -392,15 +281,15 @@ test-azurite:
 
             $ready = $false
             foreach ($attempt in 1..30) {
-                if (Test-AzuriteReachable) { $ready = $true; break }
+                if (Test-AzuriteReachable -BlobHost $blobHost -BlobPort $blobPort) { $ready = $true; break }
                 Start-Sleep -Seconds 1
             }
             if (-not $ready) {
                 throw "Azurite did not become ready on ${blobHost}:${blobPort} within 30 seconds."
             }
 
-            # The launcher may be a shim that spawns the real emulator as a child, so
-            # resolve the process actually holding the port to stop it directly later.
+            # The launcher may be a shim that spawns the real emulator as a child, so resolve the
+            # process actually holding the port to stop it directly later.
             $emulatorPid = $launcher.Id
             if ($IsWindows) {
                 $listener = Get-NetTCPConnection -LocalPort $blobPort -State Listen -ErrorAction SilentlyContinue |
@@ -412,8 +301,8 @@ test-azurite:
 
         $env:BENCH_HISTORY_REQUIRE_AZURITE = "1"
         # Pin the endpoint to the emulator this recipe manages so a developer's pre-existing
-        # AZURITE_BLOB_ENDPOINT cannot redirect the tests to a different target (the recipe
-        # would then start/reuse one emulator while the tests hit another — non-hermetic).
+        # AZURITE_BLOB_ENDPOINT cannot redirect the tests to a different target (the recipe would
+        # then start/reuse one emulator while the tests hit another - non-hermetic).
         $env:AZURITE_BLOB_ENDPOINT = "https://${blobHost}:${blobPort}/devstoreaccount1"
         $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
         Write-Host "Running Azurite-backed tests against ${blobHost}:${blobPort}."
@@ -446,6 +335,7 @@ test-azurite:
 [group('testing')]
 [script]
 test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', ''):
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -472,6 +362,7 @@ test-azure ACCOUNT=env_var_or_default('BENCH_HISTORY_TEST_AZURE_ACCOUNT', ''):
 [group('testing')]
 [script]
 test-benches FILTER="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -480,6 +371,7 @@ test-benches FILTER="":
 [group('testing')]
 [script]
 test-docs FILTER="":
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
@@ -515,182 +407,90 @@ test-docs FILTER="":
 [group('testing')]
 [script]
 run-examples:
+    Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # Discover and run all stand-alone example binaries
-    $failures = @()
-    $total_count = 0
-    $success_count = 0
-    $timeout_seconds = 30
-    
-    # Determine which packages to process
-    $packages_to_process = @()
-    if ("{{ package }}" -eq "") {
-        # Get all workspace members
-        $workspace_members = Get-ChildItem -Path "packages" -Directory | Where-Object { Test-Path (Join-Path $_.FullName "Cargo.toml") }
-        $packages_to_process = $workspace_members | ForEach-Object { $_.Name }
-    } else {
-        # Support space-separated package lists (e.g. from cargo-delta output).
-        $packages_to_process = "{{ package }}".Split(" ", [StringSplitOptions]::RemoveEmptyEntries)
-    }
-    
-    Write-Host "Running examples for packages: $($packages_to_process -join ', ')"
-    Write-Host "Timeout per example: $timeout_seconds seconds"
-    Write-Host ""
-    
-    foreach ($pkg in $packages_to_process) {
-        $examples_dir = Join-Path "packages" $pkg "examples"
-        
-        # Skip packages without examples directory (early continue pattern)
-        if (-not (Test-Path $examples_dir)) {
-            Write-Host "No examples directory found for package '$pkg'" -ForegroundColor DarkGray
-            continue
-        }
-        
-        # Pre-compile all examples for this package so compilation time does not eat into the
-        # per-example execution timeout. On slow CI runners, first-time compilation can exceed the
-        # timeout even though the example itself exits instantly.
-        Write-Host "Building examples for package '$pkg'..." -ForegroundColor DarkGray
-        $env:IS_TESTING = "1"
-        cargo build --package $pkg --examples --all-features --locked
-        if ($LASTEXITCODE -ne 0) {
-            $failures += "$pkg::* (build failed)"
-            continue
-        }
+    Import-Module "{{ justfile_directory() }}/scripts/build/Examples.psm1" -Force
 
-        # Find .rs files directly in examples directory
-        $example_files = Get-ChildItem -Path $examples_dir -Filter "*.rs" | Where-Object { $_.Name -ne "mod.rs" }
-        
-        # Find subdirectories with main.rs files
-        $example_subdirs = Get-ChildItem -Path $examples_dir -Directory | Where-Object { 
-            Test-Path (Join-Path $_.FullName "main.rs") 
+    $timeoutSeconds = 30
+    $failures = @()
+    $successCount = 0
+
+    $targets = @(Get-ExampleTarget -PackagesRoot "packages" -PackageFilter "{{ package }}")
+
+    if ($targets.Count -eq 0) {
+        Write-Host "No examples found."
+        return
+    }
+
+    $exampleWord = if ($targets.Count -eq 1) { "example" } else { "examples" }
+    Write-Host "Running $($targets.Count) $exampleWord (timeout ${timeoutSeconds}s each)"
+    Write-Host ""
+
+    # Pre-compile each package's examples up front so first-time compilation does not eat into the
+    # per-example execution timeout (on slow CI runners a cold compile can exceed it). A package
+    # whose examples fail to build is recorded and its examples skipped, so one broken package does
+    # not mask the others' results.
+    $env:IS_TESTING = "1"
+    $buildFailed = @{}
+    foreach ($pkg in ($targets | ForEach-Object { $_.Package } | Sort-Object -Unique)) {
+        Write-Host "Building examples for package '$pkg'..." -ForegroundColor DarkGray
+        try {
+            cargo build --package $pkg --examples --all-features --locked
+        } catch {
+            Write-Host "Building examples for package '$pkg' failed" -ForegroundColor Red
+            $buildFailed[$pkg] = $true
+            $failures += "${pkg}::* (build failed)"
         }
-        
-        # Examples that are expected to panic or fail and should be excluded from run-examples
-        $excluded_examples = @(
-            "nm_otel_console"     # This example runs an infinite loop by design
-            "nm_otel_readme"      # This example runs an infinite loop by design
-            "alloc_tracker_panic_on_alloc_demo"  # This example intentionally panics to demonstrate functionality
-        )
-        
-        # Process .rs files
-        foreach ($example_file in $example_files) {
-            $example_name = $example_file.BaseName
-            
-            # Skip excluded examples
-            if ($excluded_examples -contains $example_name) {
-                Write-Host "Skipping excluded example '$example_name' in package '$pkg'" -ForegroundColor DarkGray
-                continue
+    }
+
+    # Runs one example in a child job so the parent can enforce a timeout; the final pipeline value
+    # is the process exit code, which Invoke-ExampleRun peels off the captured output.
+    $cargoRunner = {
+        param($pkg, $exampleName)
+        $env:IS_TESTING = "1"
+        & cargo run --package $pkg --example $exampleName --all-features --locked 2>&1
+        return $LASTEXITCODE
+    }
+
+    foreach ($target in $targets) {
+        if ($buildFailed.ContainsKey($target.Package)) { continue }
+
+        Write-Host "Running example '$($target.Example)' in package '$($target.Package)'..." -ForegroundColor Cyan
+        $result = Invoke-ExampleRun -Package $target.Package -Example $target.Example -Command $cargoRunner -TimeoutSeconds $timeoutSeconds
+
+        switch ($result.Status) {
+            "Success" {
+                Write-Host "  OK: '$($target.Example)' in package '$($target.Package)'" -ForegroundColor Green
+                $successCount++
             }
-            
-            $total_count++
-            
-            Write-Host "Running example '$example_name' in package '$pkg'..." -ForegroundColor Cyan
-            
-            try {
-                # Run the example with a timeout to prevent hanging
-                $job = Start-Job -ScriptBlock {
-                    param($pkg, $example_name)
-                    $env:IS_TESTING = "1"
-                    & cargo run --package $pkg --example $example_name --all-features --locked 2>&1
-                    return $LASTEXITCODE
-                } -ArgumentList $pkg, $example_name
-                
-                $completed = Wait-Job -Job $job -Timeout $timeout_seconds
-                
-                if ($completed) {
-                    $result = Receive-Job -Job $job
-                    $exit_code = $result[-1]  # Last item should be the exit code
-                    $output = $result[0..($result.Length-2)] -join "`n"  # All output except exit code
-                    
-                    if ($exit_code -eq 0) {
-                        Write-Host "✓ Example '$example_name' in package '$pkg' completed successfully" -ForegroundColor Green
-                        $success_count++
-                    } else {
-                        Write-Host "✗ Example '$example_name' in package '$pkg' failed with exit code $exit_code" -ForegroundColor Red
-                        if ($output.Trim() -ne "") {
-                            Write-Host "Output:" -ForegroundColor Yellow
-                            Write-Host $output -ForegroundColor DarkYellow
-                        }
-                        $failures += "$pkg::$example_name (exit code $exit_code)"
-                    }
-                } else {
-                    Write-Host "✗ Example '$example_name' in package '$pkg' timed out after $timeout_seconds seconds" -ForegroundColor Red
-                    $failures += "$pkg::$example_name (timeout)"
-                    Stop-Job -Job $job
+            "Failed" {
+                Write-Host "  FAIL: '$($target.Example)' in package '$($target.Package)' (exit code $($result.ExitCode))" -ForegroundColor Red
+                if (-not [string]::IsNullOrWhiteSpace($result.Output)) {
+                    Write-Host "Output:" -ForegroundColor Yellow
+                    Write-Host $result.Output -ForegroundColor DarkYellow
                 }
-                
-                Remove-Job -Job $job -Force
-                
-            } catch {
-                Write-Host "✗ Example '$example_name' in package '$pkg' failed with exception: $($_.Exception.Message)" -ForegroundColor Red
-                $failures += "$pkg::$example_name (exception: $($_.Exception.Message))"
+                $failures += "$($target.Package)::$($target.Example) (exit code $($result.ExitCode))"
             }
-        }
-        
-        # Process subdirectory examples
-        foreach ($example_subdir in $example_subdirs) {
-            $example_name = $example_subdir.Name
-            
-            # Skip excluded examples
-            if ($excluded_examples -contains $example_name) {
-                Write-Host "Skipping excluded example '$example_name' in package '$pkg'" -ForegroundColor DarkGray
-                continue
+            "Timeout" {
+                Write-Host "  TIMEOUT: '$($target.Example)' in package '$($target.Package)' after ${timeoutSeconds}s" -ForegroundColor Red
+                $failures += "$($target.Package)::$($target.Example) (timeout)"
             }
-            
-            $total_count++
-            
-            Write-Host "Running example '$example_name' in package '$pkg'..." -ForegroundColor Cyan
-            
-            try {
-                # Run the example with a timeout to prevent hanging
-                $job = Start-Job -ScriptBlock {
-                    param($pkg, $example_name)
-                    $env:IS_TESTING = "1"
-                    & cargo run --package $pkg --example $example_name --all-features --locked 2>&1
-                    return $LASTEXITCODE
-                } -ArgumentList $pkg, $example_name
-                
-                $completed = Wait-Job -Job $job -Timeout $timeout_seconds
-                
-                if ($completed) {
-                    $result = Receive-Job -Job $job
-                    $exit_code = $result[-1]  # Last item should be the exit code
-                    $output = $result[0..($result.Length-2)] -join "`n"  # All output except exit code
-                    
-                    if ($exit_code -eq 0) {
-                        Write-Host "✓ Example '$example_name' in package '$pkg' completed successfully" -ForegroundColor Green
-                        $success_count++
-                    } else {
-                        Write-Host "✗ Example '$example_name' in package '$pkg' failed with exit code $exit_code" -ForegroundColor Red
-                        if ($output.Trim() -ne "") {
-                            Write-Host "Output:" -ForegroundColor Yellow
-                            Write-Host $output -ForegroundColor DarkYellow
-                        }
-                        $failures += "$pkg::$example_name (exit code $exit_code)"
-                    }
-                } else {
-                    Write-Host "✗ Example '$example_name' in package '$pkg' timed out after $timeout_seconds seconds" -ForegroundColor Red
-                    $failures += "$pkg::$example_name (timeout)"
-                    Stop-Job -Job $job
-                }
-                
-                Remove-Job -Job $job -Force
-                
-            } catch {
-                Write-Host "✗ Example '$example_name' in package '$pkg' failed with exception: $($_.Exception.Message)" -ForegroundColor Red
-                $failures += "$pkg::$example_name (exception: $($_.Exception.Message))"
+            "Exception" {
+                Write-Host "  ERROR: '$($target.Example)' in package '$($target.Package)': $($result.Message)" -ForegroundColor Red
+                $failures += "$($target.Package)::$($target.Example) (exception: $($result.Message))"
             }
         }
     }
-    
+
     Write-Host ""
     Write-Host "Summary:" -ForegroundColor White
-    Write-Host "  Total examples: $total_count" -ForegroundColor White
-    Write-Host "  Successful: $success_count" -ForegroundColor Green
-    Write-Host "  Failed: $($failures.Count)" -ForegroundColor $(if ($failures.Count -eq 0) { "Green" } else { "Red" })
-    
+    Write-Host "  Total examples: $($targets.Count)" -ForegroundColor White
+    Write-Host "  Successful: $successCount" -ForegroundColor Green
+    $failedColor = if ($failures.Count -eq 0) { "Green" } else { "Red" }
+    Write-Host "  Failed: $($failures.Count)" -ForegroundColor $failedColor
+
     if ($failures.Count -gt 0) {
         Write-Host ""
         Write-Host "Failed examples:" -ForegroundColor Red

--- a/scripts/analyzer/FoloAnalyzerRules.Tests.ps1
+++ b/scripts/analyzer/FoloAnalyzerRules.Tests.ps1
@@ -5,7 +5,7 @@ Set-StrictMode -Version Latest
 # Pester suite for the repo-local PSScriptAnalyzer custom rules in FoloAnalyzerRules.psm1. Each
 # case runs the real analyzer over a script snippet with only our custom rule enabled, so the
 # tests exercise the rule exactly as `just validate-scripts` invokes it. The headline guarantee is
-# that the foreach case-collision that shipped a broken release is now flagged as an Error — and
+# that the foreach case-collision that shipped a broken release is now flagged as an Error - and
 # that legitimately-distinct loop variables stay clean (no false positives).
 
 BeforeAll {

--- a/scripts/analyzer/FoloAnalyzerRules.Tests.ps1
+++ b/scripts/analyzer/FoloAnalyzerRules.Tests.ps1
@@ -1,0 +1,71 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+Set-StrictMode -Version Latest
+
+# Pester suite for the repo-local PSScriptAnalyzer custom rules in FoloAnalyzerRules.psm1. Each
+# case runs the real analyzer over a script snippet with only our custom rule enabled, so the
+# tests exercise the rule exactly as `just validate-scripts` invokes it. The headline guarantee is
+# that the foreach case-collision that shipped a broken release is now flagged as an Error — and
+# that legitimately-distinct loop variables stay clean (no false positives).
+
+BeforeAll {
+    Import-Module PSScriptAnalyzer -ErrorAction Stop
+
+    $script:RuleModule = Join-Path $PSScriptRoot 'FoloAnalyzerRules.psm1'
+    $script:RuleName = 'Measure-ForeachVariableShadowsSource'
+
+    function Invoke-Rule {
+        param([Parameter(Mandatory)][string]$Script)
+        # Streams the analyzer's DiagnosticRecord objects. Callers wrap the result in @(...) so that
+        # `.Count`/indexing is safe under Set-StrictMode even for zero or one finding (a function
+        # return unwraps a single-element result to a scalar and an empty one to $null).
+        Invoke-ScriptAnalyzer -ScriptDefinition $Script `
+            -CustomRulePath $script:RuleModule `
+            -IncludeRule $script:RuleName
+    }
+}
+
+Describe 'Measure-ForeachVariableShadowsSource' {
+    It 'flags a foreach whose loop variable only differs in case from the collection' {
+        $findings = @(Invoke-Rule -Script 'foreach ($target in $Target) { $target }')
+        $findings.Count | Should -Be 1
+        $findings[0].Severity | Should -Be 'Error'
+        $findings[0].RuleName | Should -Be 'FoloAvoidForeachVariableShadowsSource'
+        $findings[0].Message | Should -Match 'clobbered to its last element'
+    }
+
+    It 'flags a foreach whose loop variable is identical to the collection' {
+        @(Invoke-Rule -Script 'foreach ($Target in $Target) { $Target }').Count | Should -Be 1
+    }
+
+    It 'reports each occurrence exactly once (no per-scope duplication)' {
+        $script = @'
+function Outer {
+    param([string[]]$Target)
+    foreach ($target in $Target) { $target }
+}
+'@
+        @(Invoke-Rule -Script $script).Count | Should -Be 1
+    }
+
+    It 'flags every colliding loop, and only those' {
+        $script = @'
+foreach ($item in $Items) { $item }
+foreach ($target in $Target) { $target }
+foreach ($node in $Nodes) { $node }
+'@
+        @(Invoke-Rule -Script $script).Count | Should -Be 1
+    }
+
+    It 'does not flag distinct loop and collection variable names' {
+        @(Invoke-Rule -Script 'foreach ($releaseTarget in $Target) { $releaseTarget }').Count | Should -Be 0
+    }
+
+    It 'does not flag enumeration over an array literal' {
+        @(Invoke-Rule -Script 'foreach ($x in @(1, 2, 3)) { $x }').Count | Should -Be 0
+    }
+
+    It 'does not flag enumeration over a method or command result' {
+        @(Invoke-Rule -Script 'foreach ($line in (Get-Content $path)) { $line }').Count | Should -Be 0
+    }
+}

--- a/scripts/analyzer/FoloAnalyzerRules.psm1
+++ b/scripts/analyzer/FoloAnalyzerRules.psm1
@@ -1,0 +1,70 @@
+Set-StrictMode -Version Latest
+
+# Repo-local PSScriptAnalyzer custom rules. PSScriptAnalyzer discovers each rule by convention:
+# an advanced function named `Measure-*` that takes a typed AST parameter and returns
+# DiagnosticRecord objects. The recipe `just validate-scripts` passes this module via
+# -CustomRulePath -IncludeDefaultRules, so these rules run alongside the built-in rules.
+#
+# This module exists because the built-in rule set (and Set-StrictMode) miss whole classes of
+# real bugs specific to how we write PowerShell — most notably the case-insensitive variable
+# collision that shipped a broken release (a `foreach` whose loop variable name only differed in
+# case from the collection it enumerated, silently clobbering the collection to its last
+# element). Grow this module as we discover new footguns worth catching mechanically.
+
+<#
+.SYNOPSIS
+    Flags a `foreach` whose loop variable case-insensitively collides with the variable it
+    enumerates (e.g. `foreach ($target in $Target)`).
+.DESCRIPTION
+    PowerShell variable names are case-insensitive, so `$target` and `$Target` are the SAME
+    variable. Writing `foreach ($target in $Target) { ... }` therefore overwrites the collection
+    on every iteration; after the loop the collection variable holds only its last element. This
+    is a silent, high-impact bug that no built-in PSScriptAnalyzer rule catches, so we catch it
+    here as an Error.
+
+    The parameter is typed as [ForEachStatementAst] so PSScriptAnalyzer invokes the rule once per
+    matching node — typing it as the broad [ScriptBlockAst] and recursing with FindAll would
+    report the same statement multiple times (once per enclosing scope).
+#>
+function Measure-ForeachVariableShadowsSource {
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.Language.ForEachStatementAst]$ForEachStatementAst
+    )
+
+    $loopVariableName = $ForEachStatementAst.Variable.VariablePath.UserPath
+
+    # The condition is the enumerated expression. Unwrap the common `pipeline -> command
+    # expression -> variable` nesting to reach a bare `$Foo` source; anything more complex (a
+    # method call, an array literal, a sub-expression) cannot be a plain variable collision, so we
+    # only act on a simple VariableExpressionAst.
+    $sourceExpression = $ForEachStatementAst.Condition
+    if ($sourceExpression -is [System.Management.Automation.Language.PipelineAst] -and
+        $sourceExpression.PipelineElements.Count -eq 1) {
+        $sourceExpression = $sourceExpression.PipelineElements[0]
+    }
+    if ($sourceExpression -is [System.Management.Automation.Language.CommandExpressionAst]) {
+        $sourceExpression = $sourceExpression.Expression
+    }
+
+    if ($sourceExpression -isnot [System.Management.Automation.Language.VariableExpressionAst]) {
+        return
+    }
+
+    $sourceVariableName = $sourceExpression.VariablePath.UserPath
+    if ($loopVariableName -and $sourceVariableName -and ($loopVariableName -ieq $sourceVariableName)) {
+        [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+            Message  = "foreach loop variable '`$$loopVariableName' case-insensitively collides " +
+                "with the enumerated variable '`$$sourceVariableName' — they are the SAME " +
+                "variable, so the collection is clobbered to its last element. Rename the loop " +
+                "variable (e.g. '`$item')."
+            Extent   = $ForEachStatementAst.Extent
+            RuleName = 'FoloAvoidForeachVariableShadowsSource'
+            Severity = 'Error'
+        }
+    }
+}
+
+Export-ModuleMember -Function Measure-ForeachVariableShadowsSource

--- a/scripts/analyzer/FoloAnalyzerRules.psm1
+++ b/scripts/analyzer/FoloAnalyzerRules.psm1
@@ -6,7 +6,7 @@ Set-StrictMode -Version Latest
 # -CustomRulePath -IncludeDefaultRules, so these rules run alongside the built-in rules.
 #
 # This module exists because the built-in rule set (and Set-StrictMode) miss whole classes of
-# real bugs specific to how we write PowerShell — most notably the case-insensitive variable
+# real bugs specific to how we write PowerShell - most notably the case-insensitive variable
 # collision that shipped a broken release (a `foreach` whose loop variable name only differed in
 # case from the collection it enumerated, silently clobbering the collection to its last
 # element). Grow this module as we discover new footguns worth catching mechanically.
@@ -23,7 +23,7 @@ Set-StrictMode -Version Latest
     here as an Error.
 
     The parameter is typed as [ForEachStatementAst] so PSScriptAnalyzer invokes the rule once per
-    matching node — typing it as the broad [ScriptBlockAst] and recursing with FindAll would
+    matching node - typing it as the broad [ScriptBlockAst] and recursing with FindAll would
     report the same statement multiple times (once per enclosing scope).
 #>
 function Measure-ForeachVariableShadowsSource {
@@ -57,7 +57,7 @@ function Measure-ForeachVariableShadowsSource {
     if ($loopVariableName -and $sourceVariableName -and ($loopVariableName -ieq $sourceVariableName)) {
         [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
             Message  = "foreach loop variable '`$$loopVariableName' case-insensitively collides " +
-                "with the enumerated variable '`$$sourceVariableName' — they are the SAME " +
+                "with the enumerated variable '`$$sourceVariableName' - they are the SAME " +
                 "variable, so the collection is clobbered to its last element. Rename the loop " +
                 "variable (e.g. '`$item')."
             Extent   = $ForEachStatementAst.Extent

--- a/scripts/bench-history/AzureFederation.Tests.ps1
+++ b/scripts/bench-history/AzureFederation.Tests.ps1
@@ -1,0 +1,111 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for AzureFederation.psm1. The dotenv parse, the required-constant fail-fast and the
+# AZURE_PROD_CLIENT_ID -> AZURE_CLIENT_ID mapping are exercised against fixture files under TestDrive
+# (no real constants.env, no real GITHUB_ENV), so the logic the collect/analyze jobs depend on is
+# proven without a workflow run.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'AzureFederation.psm1') -Force
+}
+
+Describe 'Read-DotEnvFile' {
+    It 'parses KEY=value pairs, skipping comments and blank lines' {
+        $path = Join-Path $TestDrive 'constants.env'
+        Set-Content -LiteralPath $path -Encoding utf8 -Value @(
+            '# a comment'
+            ''
+            'AZURE_TENANT_ID=tenant-123'
+            '  AZURE_PROD_CLIENT_ID = client-456  '
+        )
+        $values = Read-DotEnvFile -Path $path
+        $values['AZURE_TENANT_ID'] | Should -Be 'tenant-123'
+        $values['AZURE_PROD_CLIENT_ID'] | Should -Be 'client-456'
+    }
+
+    It 'keeps everything after the first = so values may contain =' {
+        $path = Join-Path $TestDrive 'constants.env'
+        Set-Content -LiteralPath $path -Encoding utf8 -Value 'CONNECTION=a=b=c'
+        (Read-DotEnvFile -Path $path)['CONNECTION'] | Should -Be 'a=b=c'
+    }
+
+    It 'lets a later duplicate key win' {
+        $path = Join-Path $TestDrive 'constants.env'
+        Set-Content -LiteralPath $path -Encoding utf8 -Value @('K=first', 'K=second')
+        (Read-DotEnvFile -Path $path)['K'] | Should -Be 'second'
+    }
+
+    It 'returns an absent key as $null rather than throwing under strict mode' {
+        $path = Join-Path $TestDrive 'constants.env'
+        Set-Content -LiteralPath $path -Encoding utf8 -Value 'K=v'
+        (Read-DotEnvFile -Path $path)['NOPE'] | Should -BeNullOrEmpty
+    }
+
+    It 'throws when the file does not exist' {
+        { Read-DotEnvFile -Path (Join-Path $TestDrive 'missing.env') } | Should -Throw '*does not exist*'
+    }
+}
+
+Describe 'Get-RequiredConstant' {
+    It 'returns the value when present' {
+        Get-RequiredConstant -Values @{ K = 'v' } -Name 'K' | Should -Be 'v'
+    }
+
+    It 'throws, naming the constant, when the key is absent' {
+        { Get-RequiredConstant -Values @{ } -Name 'AZURE_TENANT_ID' } | Should -Throw "*AZURE_TENANT_ID*"
+    }
+
+    It 'throws when the value is blank' {
+        { Get-RequiredConstant -Values @{ AZURE_TENANT_ID = '   ' } -Name 'AZURE_TENANT_ID' } |
+            Should -Throw "*AZURE_TENANT_ID*"
+    }
+}
+
+Describe 'Set-AzureFederationEnv' {
+    BeforeEach {
+        $script:ConstantsPath = Join-Path $TestDrive 'constants.env'
+        $script:EnvFilePath = Join-Path $TestDrive 'github.env'
+        Set-Content -LiteralPath $script:EnvFilePath -Encoding utf8 -Value @()
+    }
+
+    It 'maps the prod client id and tenant to the standard AZURE_* names in the env file' {
+        Set-Content -LiteralPath $script:ConstantsPath -Encoding utf8 -Value @(
+            'AZURE_PROD_CLIENT_ID=client-456'
+            'AZURE_TENANT_ID=tenant-123'
+            'UNRELATED=ignored'
+        )
+        Set-AzureFederationEnv -ConstantsPath $script:ConstantsPath -EnvFilePath $script:EnvFilePath | Out-Null
+
+        $written = Get-Content -LiteralPath $script:EnvFilePath
+        $written | Should -Contain 'AZURE_CLIENT_ID=client-456'
+        $written | Should -Contain 'AZURE_TENANT_ID=tenant-123'
+        # The unrelated constant is not leaked into the job env.
+        ($written | Where-Object { $_ -like 'UNRELATED=*' }) | Should -BeNullOrEmpty
+    }
+
+    It 'returns the exported mapping' {
+        Set-Content -LiteralPath $script:ConstantsPath -Encoding utf8 -Value @(
+            'AZURE_PROD_CLIENT_ID=client-456'
+            'AZURE_TENANT_ID=tenant-123'
+        )
+        $exported = Set-AzureFederationEnv -ConstantsPath $script:ConstantsPath -EnvFilePath $script:EnvFilePath
+        $exported['AZURE_CLIENT_ID'] | Should -Be 'client-456'
+        $exported['AZURE_TENANT_ID'] | Should -Be 'tenant-123'
+    }
+
+    It 'appends rather than overwriting existing env-file content' {
+        Set-Content -LiteralPath $script:EnvFilePath -Encoding utf8 -Value 'PREEXISTING=kept'
+        Set-Content -LiteralPath $script:ConstantsPath -Encoding utf8 -Value @(
+            'AZURE_PROD_CLIENT_ID=client-456'
+            'AZURE_TENANT_ID=tenant-123'
+        )
+        Set-AzureFederationEnv -ConstantsPath $script:ConstantsPath -EnvFilePath $script:EnvFilePath | Out-Null
+        Get-Content -LiteralPath $script:EnvFilePath | Should -Contain 'PREEXISTING=kept'
+    }
+
+    It 'fails loudly when a required identifier is missing' {
+        Set-Content -LiteralPath $script:ConstantsPath -Encoding utf8 -Value 'AZURE_TENANT_ID=tenant-123'
+        { Set-AzureFederationEnv -ConstantsPath $script:ConstantsPath -EnvFilePath $script:EnvFilePath } |
+            Should -Throw '*AZURE_PROD_CLIENT_ID*'
+    }
+}

--- a/scripts/bench-history/AzureFederation.psm1
+++ b/scripts/bench-history/AzureFederation.psm1
@@ -1,0 +1,87 @@
+#requires -Version 7
+
+# Azure OIDC federation identity plumbing for the benchmark-history workflow
+# (.github/workflows/bench-history.yml).
+#
+# The `collect` and `analyze` jobs both federate into Azure with the SAME two identifiers, which
+# live (non-secret) in constants.env. Two jobs re-exporting those under the standard AZURE_* names
+# is exactly the kind of copy-pasted inline snippet that drifts — and where the recent
+# case-collision footgun hid — so the parse-and-map logic lives here, behind small seams the Pester
+# suite (AzureFederation.Tests.ps1) exercises, and each job's workflow step is a thin import + call.
+#
+# constants.env is read directly (not via `just`'s dotenv) because these steps re-export under
+# different names (AZURE_PROD_CLIENT_ID -> AZURE_CLIENT_ID) and must fail loudly when an identifier
+# is missing rather than federate later with an empty value and an opaque error.
+
+Set-StrictMode -Version Latest
+
+function Read-DotEnvFile {
+    # Parses a KEY=value dotenv file (constants.env) into an ordered hashtable. Blank lines and
+    # `#` comment lines are skipped; keys and values are trimmed. A later duplicate key wins, matching
+    # dotenv semantics. Isolated so the tests can feed a fixture file without touching the real one.
+    [CmdletBinding()]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    param([Parameter(Mandatory)][string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Dotenv file '$Path' does not exist."
+    }
+
+    $values = [ordered]@{}
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        # KEY=value, where KEY has no '#' or '=' (so a leading-# comment line never matches). The
+        # value is everything after the first '=', so values may themselves contain '='.
+        if ($line -match '^\s*([^#=]+)=(.*)$') {
+            $values[$Matches[1].Trim()] = $Matches[2].Trim()
+        }
+    }
+    return $values
+}
+
+function Get-RequiredConstant {
+    # Returns $Values[$Name], throwing when it is absent or blank. Federation with an empty
+    # AZURE_CLIENT_ID / AZURE_TENANT_ID would otherwise fail far later with an opaque error; failing
+    # here names the exact missing constant. Accessing a missing hashtable key returns $null under
+    # strict mode (it does not throw), so the explicit blank check is what catches an absent key.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary] $Values,
+        [Parameter(Mandatory)][string] $Name
+    )
+
+    $value = $Values[$Name]
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw "constants.env is missing a non-empty '$Name' (required for Azure federation)."
+    }
+    return $value
+}
+
+function Set-AzureFederationEnv {
+    # Reads the two federation identifiers from $ConstantsPath and appends them, under the standard
+    # AZURE_* names the tool and azure/login read, to the GitHub step-env file at $EnvFilePath
+    # (normally $env:GITHUB_ENV). The mapping is deliberate: constants.env names them
+    # AZURE_PROD_CLIENT_ID / AZURE_TENANT_ID, the consumers expect AZURE_CLIENT_ID / AZURE_TENANT_ID.
+    # Returns the mapping it wrote so a caller (and the tests) can inspect it.
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    param(
+        [Parameter(Mandatory)][string] $ConstantsPath,
+        [Parameter(Mandatory)][string] $EnvFilePath
+    )
+
+    $constants = Read-DotEnvFile -Path $ConstantsPath
+    $exported = [ordered]@{
+        AZURE_CLIENT_ID = Get-RequiredConstant -Values $constants -Name 'AZURE_PROD_CLIENT_ID'
+        AZURE_TENANT_ID = Get-RequiredConstant -Values $constants -Name 'AZURE_TENANT_ID'
+    }
+
+    $lines = foreach ($entry in $exported.GetEnumerator()) { "$($entry.Key)=$($entry.Value)" }
+    if ($PSCmdlet.ShouldProcess($EnvFilePath, 'Append AZURE_CLIENT_ID and AZURE_TENANT_ID')) {
+        $lines | Add-Content -Path $EnvFilePath -Encoding utf8
+    }
+    Write-Verbose "Exported AZURE_CLIENT_ID and AZURE_TENANT_ID from '$ConstantsPath' to '$EnvFilePath' so the collect/analyze jobs federate into Azure with the same committed, non-secret identifiers."
+    return $exported
+}
+
+Export-ModuleMember -Function Read-DotEnvFile, Get-RequiredConstant, Set-AzureFederationEnv

--- a/scripts/bench-history/AzureFederation.psm1
+++ b/scripts/bench-history/AzureFederation.psm1
@@ -5,8 +5,8 @@
 #
 # The `collect` and `analyze` jobs both federate into Azure with the SAME two identifiers, which
 # live (non-secret) in constants.env. Two jobs re-exporting those under the standard AZURE_* names
-# is exactly the kind of copy-pasted inline snippet that drifts — and where the recent
-# case-collision footgun hid — so the parse-and-map logic lives here, behind small seams the Pester
+# is exactly the kind of copy-pasted inline snippet that drifts - and where the recent
+# case-collision footgun hid - so the parse-and-map logic lives here, behind small seams the Pester
 # suite (AzureFederation.Tests.ps1) exercises, and each job's workflow step is a thin import + call.
 #
 # constants.env is read directly (not via `just`'s dotenv) because these steps re-export under

--- a/scripts/bench-history/BenchHistoryIssue.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryIssue.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         BeforeEach {
             # Reproduce the real gotcha: gh emits a note on stderr (deprecation, rate-limit, etc.)
             # while returning valid JSON on stdout and exiting 0. Write-Error lands on PowerShell's
-            # error stream (stream 2) — where a native gh's stderr also goes — so a naive `2>&1`
+            # error stream (stream 2) - where a native gh's stderr also goes - so a naive `2>&1`
             # merge would corrupt the JSON; the module must parse stdout only. `-ErrorAction
             # Continue` keeps the note non-terminating even under the suite's `$ErrorActionPreference
             # = 'Stop'`, so it stays a stream-2 write the module redirects away rather than a throw.

--- a/scripts/bench-history/BenchHistoryIssue.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryIssue.Tests.ps1
@@ -218,3 +218,122 @@ Describe 'Publish-RollingIssue (mocked gh)' {
         }
     }
 }
+
+Describe 'Close-RollingIssue (mocked gh)' {
+    Context 'when open issues with the exact title exist' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryIssue {
+                switch ("$($args[0]) $($args[1])") {
+                    'issue list' {
+                        $global:LASTEXITCODE = 0
+                        '[{"number":7,"title":"Something else"},{"number":42,"title":"bench-history workflow failed"},{"number":43,"title":"bench-history workflow failed"}]'
+                    }
+                    'issue close' { $global:LASTEXITCODE = 0; '' }
+                    default { $global:LASTEXITCODE = 1; "unexpected: $args" }
+                }
+            }
+        }
+
+        It 'closes every matching issue and only those' {
+            Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again' | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
+                ($args[1] -eq 'close') -and ($args -contains 42)
+            }
+            Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
+                ($args[1] -eq 'close') -and ($args -contains 43)
+            }
+            # The non-matching issue #7 is never touched.
+            Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
+                ($args[1] -eq 'close') -and ($args -contains 7)
+            } -Times 0 -Exactly
+        }
+
+        It 'closes with reason completed and the given audit comment' {
+            Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again' | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
+                ($args[1] -eq 'close') -and ($args -contains '--reason') -and ($args -contains 'completed') -and
+                ($args -contains '--comment') -and ($args -contains 'green again')
+            }
+        }
+
+        It 'narrows the list to the given label and open state' {
+            Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again' | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
+                ($args[1] -eq 'list') -and ($args -contains '--label') -and ($args -contains 'ci-failure') -and
+                ($args -contains '--state') -and ($args -contains 'open')
+            }
+        }
+
+        It 'returns the closed issue numbers' {
+            $closed = @(Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again')
+            $closed.Count | Should -Be 2
+            $closed | Should -Contain 42
+            $closed | Should -Contain 43
+        }
+    }
+
+    Context 'when no open issue has a matching title' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryIssue {
+                switch ("$($args[0]) $($args[1])") {
+                    'issue list' { $global:LASTEXITCODE = 0; '[{"number":7,"title":"Something else"}]' }
+                    'issue close' { $global:LASTEXITCODE = 0; '' }
+                    default { $global:LASTEXITCODE = 1; "unexpected: $args" }
+                }
+            }
+        }
+
+        It 'closes nothing and returns an empty array' {
+            $closed = @(Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again')
+            $closed.Count | Should -Be 0
+            Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter { $args[1] -eq 'close' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when the open-issue list is empty' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryIssue {
+                switch ("$($args[0]) $($args[1])") {
+                    'issue list' { $global:LASTEXITCODE = 0; '[]' }
+                    'issue close' { $global:LASTEXITCODE = 0; '' }
+                    default { $global:LASTEXITCODE = 1; "unexpected: $args" }
+                }
+            }
+        }
+
+        It 'closes nothing and returns an empty array' {
+            @(Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again').Count | Should -Be 0
+        }
+    }
+
+    Context 'when gh list fails' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryIssue { $global:LASTEXITCODE = 1; 'HTTP 503: Service Unavailable' }
+        }
+
+        It 'throws, surfacing the gh output' {
+            { Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again' } |
+                Should -Throw '*503*'
+        }
+    }
+
+    Context 'when gh close fails' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryIssue {
+                switch ("$($args[0]) $($args[1])") {
+                    'issue list' {
+                        $global:LASTEXITCODE = 0
+                        '[{"number":42,"title":"bench-history workflow failed"}]'
+                    }
+                    'issue close' { $global:LASTEXITCODE = 1; 'could not close issue' }
+                    default { $global:LASTEXITCODE = 1; "unexpected: $args" }
+                }
+            }
+        }
+
+        It 'throws, surfacing the gh output' {
+            { Close-RollingIssue -Title 'bench-history workflow failed' -Label 'ci-failure' -Comment 'green again' } |
+                Should -Throw '*could not close issue*'
+        }
+    }
+}

--- a/scripts/bench-history/BenchHistoryIssue.psm1
+++ b/scripts/bench-history/BenchHistoryIssue.psm1
@@ -18,12 +18,12 @@ Set-StrictMode -Version Latest
 
 function Invoke-GhCapture {
     # Runs `gh` with the given arguments, capturing stdout and stderr SEPARATELY. stderr is
-    # redirected to a temp file so it never contaminates stdout: `gh` can print warnings — e.g.
-    # deprecation or rate-limit notes — to stderr while still exiting 0, and folding those into
+    # redirected to a temp file so it never contaminates stdout: `gh` can print warnings - e.g.
+    # deprecation or rate-limit notes - to stderr while still exiting 0, and folding those into
     # stdout (a bare `2>&1`) would break the JSON/URL parsing the callers do. Returns the captured
     # stdout as a single string on success; on a non-zero exit, throws with whatever `gh` wrote
     # (stderr first, then any stdout) so the failure is never swallowed. Inspecting the exit code
-    # ourselves — rather than letting a non-zero `gh` abort — is why the native-error toggle is off.
+    # ourselves - rather than letting a non-zero `gh` abort - is why the native-error toggle is off.
     # This is the single seam the Pester suite mocks (via `Mock gh`).
     [CmdletBinding()]
     param([Parameter(Mandatory)][object[]] $Arguments)
@@ -51,7 +51,7 @@ function Invoke-GhCapture {
 function Get-OpenIssueByTitle {
     # Returns the first OPEN issue whose title equals $Title exactly, or $null when none matches.
     # The list is narrowed to $Label so only a handful of issues come back, then the exact-title
-    # match is done client-side — the same list-then-match approach the workflow's `resolve` job
+    # match is done client-side - the same list-then-match approach the workflow's `resolve` job
     # uses to find the failure-alert issue, which avoids the eventual-consistency lag of the GitHub
     # search index that a `gh issue list --search`/`gh search issues` query would hit. Isolates the
     # real `gh issue list` call so the tests can mock it.
@@ -81,7 +81,7 @@ function Publish-RollingIssue {
     # Files exactly ONE rolling issue: when an open issue with the exact $Title already exists its
     # body is updated in place (so a persisting condition never spams duplicates), otherwise a new
     # issue is created with $Label. The body is read by `gh` from $BodyFile, which may be any path
-    # (for example the runner temp dir) — this is what frees the workflow from writing scratch files
+    # (for example the runner temp dir) - this is what frees the workflow from writing scratch files
     # into the repo checkout. $Label is the comma-separated label list applied on creation; the
     # dedup search is narrowed to the first of those labels. Returns the issue URL.
     [CmdletBinding()]
@@ -121,7 +121,7 @@ function Close-RollingIssue {
     # with an audit $Comment. The mirror image of Publish-RollingIssue: the workflow's `resolve` job
     # calls this once the pipeline is green again so a fixed run does not leave the rolling
     # failure-alert issue rotting open. Closing ALL matches (not just the first) sweeps any backlog
-    # of historical duplicates in one pass — the same list-then-exact-title approach
+    # of historical duplicates in one pass - the same list-then-exact-title approach
     # Get-OpenIssueByTitle uses, which sidesteps the search-index lag a `gh search` would hit.
     # Returns the numbers it closed (an empty array when none were open). The real `gh` calls go
     # through Invoke-GhCapture so the Pester suite can mock them.

--- a/scripts/bench-history/BenchHistoryIssue.psm1
+++ b/scripts/bench-history/BenchHistoryIssue.psm1
@@ -14,7 +14,7 @@
 # (BenchHistoryIssue.Tests.ps1) exercise it against a mocked `gh` rather than only via a push to
 # `main`. The one real GitHub-touching tool (`gh`) is isolated behind small seams the tests mock.
 
-Set-StrictMode -Version 3.0
+Set-StrictMode -Version Latest
 
 function Invoke-GhCapture {
     # Runs `gh` with the given arguments, capturing stdout and stderr SEPARATELY. stderr is
@@ -116,4 +116,47 @@ function Publish-RollingIssue {
     return $text
 }
 
-Export-ModuleMember -Function Get-OpenIssueByTitle, Publish-RollingIssue
+function Close-RollingIssue {
+    # Closes EVERY open issue whose title equals $Title exactly among those carrying $Label, each
+    # with an audit $Comment. The mirror image of Publish-RollingIssue: the workflow's `resolve` job
+    # calls this once the pipeline is green again so a fixed run does not leave the rolling
+    # failure-alert issue rotting open. Closing ALL matches (not just the first) sweeps any backlog
+    # of historical duplicates in one pass — the same list-then-exact-title approach
+    # Get-OpenIssueByTitle uses, which sidesteps the search-index lag a `gh search` would hit.
+    # Returns the numbers it closed (an empty array when none were open). The real `gh` calls go
+    # through Invoke-GhCapture so the Pester suite can mock them.
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][string] $Title,
+        [Parameter(Mandatory)][string] $Label,
+        [Parameter(Mandatory)][string] $Comment,
+        [int] $Limit = 100
+    )
+
+    # `--limit` defeats the 30-result default so a backlog of historical duplicates all come back.
+    $output = Invoke-GhCapture -Arguments @(
+        'issue', 'list', '--state', 'open', '--label', $Label, '--limit', $Limit, '--json', 'number,title'
+    )
+
+    # A no-match list is the literal `[]`, which ConvertFrom-Json yields as an empty array; the
+    # @() wrappers keep a single-object result enumerable and .Count-safe under strict mode.
+    $issues = $output | ConvertFrom-Json
+    $matching = @(@($issues) | Where-Object { $_.title -eq $Title })
+
+    if ($matching.Count -eq 0) {
+        Write-Verbose "No open issue titled '$Title' labelled '$Label' to close; nothing to do."
+        return @()
+    }
+
+    $closed = foreach ($issue in $matching) {
+        Write-Verbose "Closing issue #$($issue.number) ('$Title') because the tracked condition has cleared; leaving comment: $Comment"
+        Invoke-GhCapture -Arguments @(
+            'issue', 'close', $issue.number, '--reason', 'completed', '--comment', $Comment
+        ) | Out-Null
+        $issue.number
+    }
+    return @($closed)
+}
+
+Export-ModuleMember -Function Get-OpenIssueByTitle, Publish-RollingIssue, Close-RollingIssue

--- a/scripts/build/Azurite.Tests.ps1
+++ b/scripts/build/Azurite.Tests.ps1
@@ -1,0 +1,82 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Azurite.psm1. Test-AzuriteReachable is exercised against a real ephemeral
+# TcpListener (up) and a closed port (down); New-AzuriteCertificate is asked to produce a PFX which
+# is then loaded back and inspected; Get-AzuriteArgument is asserted flag-for-flag; and
+# Stop-AzuriteProcessTree is driven with -WhatIf so it classifies without killing anything.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Azurite.psm1') -Force
+}
+
+Describe 'Test-AzuriteReachable' {
+    It 'returns $true when a listener is accepting connections' {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        try {
+            $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+            Test-AzuriteReachable -BlobHost '127.0.0.1' -BlobPort $port | Should -BeTrue
+        } finally {
+            $listener.Stop()
+        }
+    }
+
+    It 'returns $false when nothing is listening' {
+        # Port 1 is effectively never open on a loopback interface, so the connect is refused.
+        Test-AzuriteReachable -BlobHost '127.0.0.1' -BlobPort 1 | Should -BeFalse
+    }
+}
+
+Describe 'New-AzuriteCertificate' {
+    It 'writes a loadable PFX for CN=127.0.0.1 with a long lifetime' {
+        $pfxPath = Join-Path $TestDrive 'selfsigned.pfx'
+        New-AzuriteCertificate -PfxPath $pfxPath -Password 'test-pass'
+
+        Test-Path -LiteralPath $pfxPath | Should -BeTrue
+
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($pfxPath, 'test-pass')
+        try {
+            $cert.Subject | Should -Be 'CN=127.0.0.1'
+            ($cert.NotAfter - $cert.NotBefore).TotalDays | Should -BeGreaterThan 3000
+        } finally {
+            $cert.Dispose()
+        }
+    }
+
+    It 'does nothing under -WhatIf' {
+        $pfxPath = Join-Path $TestDrive 'whatif.pfx'
+        New-AzuriteCertificate -PfxPath $pfxPath -Password 'test-pass' -WhatIf
+        Test-Path -LiteralPath $pfxPath | Should -BeFalse
+    }
+}
+
+Describe 'Get-AzuriteArgument' {
+    It 'builds the HTTPS + OAuth in-memory emulator argument vector' {
+        $argv = Get-AzuriteArgument -BlobHost '127.0.0.1' -BlobPort 10000 -CertPath '/tmp/c.pfx' -Password 'pw'
+        $expected = @(
+            '--blobHost', '127.0.0.1',
+            '--blobPort', '10000',
+            '--cert', '/tmp/c.pfx',
+            '--pwd', 'pw',
+            '--oauth', 'basic',
+            '--inMemoryPersistence',
+            '--skipApiVersionCheck',
+            '--silent',
+            '--loose'
+        )
+        ($argv -join ' ') | Should -Be ($expected -join ' ')
+    }
+
+    It 'stringifies the port number' {
+        $argv = Get-AzuriteArgument -BlobHost 'localhost' -BlobPort 12345 -CertPath 'c' -Password 'pw'
+        $portIndex = [array]::IndexOf($argv, '--blobPort')
+        $argv[$portIndex + 1] | Should -BeOfType [string]
+        $argv[$portIndex + 1] | Should -Be '12345'
+    }
+}
+
+Describe 'Stop-AzuriteProcessTree' {
+    It 'does not throw for an unknown process id under -WhatIf' {
+        { Stop-AzuriteProcessTree -ProcessId 2147483647 -WhatIf } | Should -Not -Throw
+    }
+}

--- a/scripts/build/Azurite.Tests.ps1
+++ b/scripts/build/Azurite.Tests.ps1
@@ -3,7 +3,9 @@
 # Pester suite for Azurite.psm1. Test-AzuriteReachable is exercised against a real ephemeral
 # TcpListener (up) and a closed port (down); New-AzuriteCertificate is asked to produce a PFX which
 # is then loaded back and inspected; Get-AzuriteArgument is asserted flag-for-flag; and
-# Stop-AzuriteProcessTree is driven with -WhatIf so it classifies without killing anything.
+# Stop-AzuriteProcessTree is driven with -WhatIf (including a mocked child process on Windows) so it
+# classifies the whole tree without killing anything, and once without -WhatIf to confirm it stops
+# both the root and its descendant.
 
 BeforeAll {
     Import-Module (Join-Path $PSScriptRoot 'Azurite.psm1') -Force
@@ -78,5 +80,40 @@ Describe 'Get-AzuriteArgument' {
 Describe 'Stop-AzuriteProcessTree' {
     It 'does not throw for an unknown process id under -WhatIf' {
         { Stop-AzuriteProcessTree -ProcessId 2147483647 -WhatIf } | Should -Not -Throw
+    }
+
+    It 'never stops any process in the tree under -WhatIf' -Skip:(-not $IsWindows) {
+        # The child-enumeration recursion is Windows-only (Get-CimInstance is a CIM cmdlet that does
+        # not exist on Linux), so this runs only on Windows. Hand it one synthetic child and assert
+        # -WhatIf reaches all the way down the tree: no Stop-Process anywhere.
+        InModuleScope Azurite {
+            Mock Get-CimInstance {
+                if ($Filter -eq 'ParentProcessId = 4242') {
+                    [pscustomobject]@{ ProcessId = 9191 }
+                }
+            }
+            Mock Stop-Process { }
+
+            Stop-AzuriteProcessTree -ProcessId 4242 -WhatIf
+
+            Should -Invoke Stop-Process -Times 0 -Exactly
+            Should -Invoke Get-CimInstance -Times 2 -Exactly
+        }
+    }
+
+    It 'stops every process in the tree without -WhatIf' -Skip:(-not $IsWindows) {
+        InModuleScope Azurite {
+            Mock Get-CimInstance {
+                if ($Filter -eq 'ParentProcessId = 4242') {
+                    [pscustomobject]@{ ProcessId = 9191 }
+                }
+            }
+            Mock Stop-Process { }
+
+            Stop-AzuriteProcessTree -ProcessId 4242
+
+            Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 4242 }
+            Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 9191 }
+        }
     }
 }

--- a/scripts/build/Azurite.psm1
+++ b/scripts/build/Azurite.psm1
@@ -74,6 +74,7 @@ function New-AzuriteCertificate {
     if (-not $PSCmdlet.ShouldProcess($PfxPath, 'Create self-signed certificate')) { return }
 
     $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+    $certificate = $null
     try {
         $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
             'CN=127.0.0.1',
@@ -92,6 +93,9 @@ function New-AzuriteCertificate {
             $Password)
         [System.IO.File]::WriteAllBytes($PfxPath, $pfxBytes)
     } finally {
+        # X509Certificate2 holds a native key handle, so dispose it (alongside the RSA key) rather
+        # than waiting on the finalizer; test-azurite may generate this repeatedly in one session.
+        if ($certificate) { $certificate.Dispose() }
         $rsa.Dispose()
     }
 }

--- a/scripts/build/Azurite.psm1
+++ b/scripts/build/Azurite.psm1
@@ -1,0 +1,124 @@
+#requires -Version 7
+
+# Helpers for the `test-azurite` recipe, which runs the cargo-bench-history Azure-storage tests
+# against a local Azurite blob emulator over HTTPS + OAuth.
+#
+# The recipe itself is imperative I/O (probe the port, maybe launch the emulator, wait, run tests,
+# tear down in a finally). These helpers carve out the pieces worth isolating and testing: the
+# TCP reachability probe, the recursive process-tree kill (the Windows `.cmd` shim spawns node as a
+# child, so killing only the shim orphans the emulator), the self-signed certificate generation
+# (Entra auth requires TLS, so `--oauth basic` only runs over HTTPS), and the emulator argument
+# vector.
+
+Set-StrictMode -Version Latest
+
+function Test-AzuriteReachable {
+    # True when something is already accepting TCP connections on the Azurite blob endpoint, used
+    # both to decide whether to launch an emulator and to poll a freshly-launched one until ready.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string] $BlobHost,
+        [Parameter(Mandatory)][int] $BlobPort
+    )
+
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $client.Connect($BlobHost, $BlobPort)
+        return $true
+    } catch {
+        return $false
+    } finally {
+        $client.Dispose()
+    }
+}
+
+function Stop-AzuriteProcessTree {
+    # Stop a process and (on Windows) its descendants. The Windows `.cmd` shim spawns node as a
+    # child, so killing only the shim would orphan the emulator that actually holds the port.
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][int] $ProcessId
+    )
+
+    if ($IsWindows) {
+        Get-CimInstance Win32_Process -Filter "ParentProcessId = $ProcessId" -ErrorAction SilentlyContinue |
+            ForEach-Object { Stop-AzuriteProcessTree -ProcessId $_.ProcessId }
+    }
+    if ($PSCmdlet.ShouldProcess("process $ProcessId", 'Stop-Process')) {
+        Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function New-AzuriteCertificate {
+    # Generate a self-signed certificate for Azurite's HTTPS listener, written as a
+    # password-protected PFX (the cross-platform format .NET exports). Entra auth requires TLS, so
+    # `--oauth basic` only runs over HTTPS; the tests trust this cert by disabling certificate
+    # validation, so its contents (beyond being a valid cert for 127.0.0.1) do not matter. It is
+    # given a 10-year lifetime so the cached copy never needs rolling.
+    [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '',
+        Justification = 'Throwaway password for an ephemeral self-signed localhost test certificate whose contents are deliberately untrusted; not a secret.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUsePSCredentialType', '',
+        Justification = 'The .NET PFX export API takes a plain string; a PSCredential would add no protection for a throwaway test certificate password.')]
+    param(
+        [Parameter(Mandatory)][string] $PfxPath,
+        [Parameter(Mandatory)][string] $Password
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($PfxPath, 'Create self-signed certificate')) { return }
+
+    $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+    try {
+        $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            'CN=127.0.0.1',
+            $rsa,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+        $sanBuilder = [System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder]::new()
+        $sanBuilder.AddIpAddress([System.Net.IPAddress]::Loopback)
+        $sanBuilder.AddDnsName('localhost')
+        $request.CertificateExtensions.Add($sanBuilder.Build())
+        $notBefore = [System.DateTimeOffset]::UtcNow.AddDays(-1)
+        $notAfter = [System.DateTimeOffset]::UtcNow.AddYears(10)
+        $certificate = $request.CreateSelfSigned($notBefore, $notAfter)
+        $pfxBytes = $certificate.Export(
+            [System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx,
+            $Password)
+        [System.IO.File]::WriteAllBytes($PfxPath, $pfxBytes)
+    } finally {
+        $rsa.Dispose()
+    }
+}
+
+function Get-AzuriteArgument {
+    # Build the Azurite blob-emulator argument vector: an in-memory HTTPS listener with OAuth
+    # (`basic`) enabled, bound to the given host/port and using the given certificate. Isolated so
+    # the exact flag set is asserted by tests rather than buried in the launch call.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '',
+        Justification = 'Throwaway password protecting an ephemeral self-signed localhost test certificate; not a secret.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUsePSCredentialType', '',
+        Justification = 'The value is forwarded verbatim as an Azurite `--pwd` CLI argument, which takes a plain string.')]
+    param(
+        [Parameter(Mandatory)][string] $BlobHost,
+        [Parameter(Mandatory)][int] $BlobPort,
+        [Parameter(Mandatory)][string] $CertPath,
+        [Parameter(Mandatory)][string] $Password
+    )
+
+    return @(
+        '--blobHost', $BlobHost,
+        '--blobPort', "$BlobPort",
+        '--cert', $CertPath,
+        '--pwd', $Password,
+        '--oauth', 'basic',
+        '--inMemoryPersistence',
+        '--skipApiVersionCheck',
+        '--silent',
+        '--loose'
+    )
+}
+
+Export-ModuleMember -Function Test-AzuriteReachable, Stop-AzuriteProcessTree, New-AzuriteCertificate, Get-AzuriteArgument

--- a/scripts/build/Azurite.psm1
+++ b/scripts/build/Azurite.psm1
@@ -42,8 +42,13 @@ function Stop-AzuriteProcessTree {
     )
 
     if ($IsWindows) {
+        # Forward -WhatIf explicitly so the whole tree is classified, not just this node. Preference
+        # inheritance ($WhatIfPreference/$ConfirmPreference) already flows into the recursion, but
+        # making -WhatIf explicit keeps the intent unmistakable and independent of that subtlety.
         Get-CimInstance Win32_Process -Filter "ParentProcessId = $ProcessId" -ErrorAction SilentlyContinue |
-            ForEach-Object { Stop-AzuriteProcessTree -ProcessId $_.ProcessId }
+            ForEach-Object {
+                Stop-AzuriteProcessTree -ProcessId $_.ProcessId -WhatIf:$WhatIfPreference
+            }
     }
     if ($PSCmdlet.ShouldProcess("process $ProcessId", 'Stop-Process')) {
         Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue

--- a/scripts/build/CallgrindBench.Tests.ps1
+++ b/scripts/build/CallgrindBench.Tests.ps1
@@ -1,0 +1,77 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for CallgrindBench.psm1. Get-CallgrindBenchTarget walks the filesystem, so each test
+# builds a small `packages/<pkg>/benches/` fixture under Pester's TestDrive and asserts which
+# (package, bench) pairs it discovers under the various filter combinations.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'CallgrindBench.psm1') -Force
+}
+
+Describe 'Get-CallgrindBenchTarget' {
+    BeforeEach {
+        $script:Root = Join-Path $TestDrive 'packages'
+
+        # alpha: one Callgrind bench + one plain (non-_cg) bench that must be ignored.
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'alpha' 'benches') -Force | Out-Null
+        Set-Content -Path (Join-Path $script:Root 'alpha' 'benches' 'alpha_cg.rs') -Value '// cg'
+        Set-Content -Path (Join-Path $script:Root 'alpha' 'benches' 'alpha.rs') -Value '// plain'
+
+        # beta: two Callgrind benches.
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'beta' 'benches') -Force | Out-Null
+        Set-Content -Path (Join-Path $script:Root 'beta' 'benches' 'beta_one_cg.rs') -Value '// cg'
+        Set-Content -Path (Join-Path $script:Root 'beta' 'benches' 'beta_two_cg.rs') -Value '// cg'
+
+        # gamma: has a benches dir but no Callgrind benches.
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'gamma' 'benches') -Force | Out-Null
+        Set-Content -Path (Join-Path $script:Root 'gamma' 'benches' 'gamma.rs') -Value '// plain'
+
+        # delta: no benches dir at all (must be skipped without error).
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'delta') -Force | Out-Null
+    }
+
+    It 'discovers every *_cg.rs bench across all packages when no filters are given' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root)
+        $pairs = $targets | ForEach-Object { "$($_.Package)::$($_.Bench)" }
+        ($pairs -join ',') | Should -Be 'alpha::alpha_cg,beta::beta_one_cg,beta::beta_two_cg'
+    }
+
+    It 'ignores plain (non-_cg) bench files' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root)
+        ($targets | Where-Object { $_.Bench -eq 'alpha' }) | Should -BeNullOrEmpty
+    }
+
+    It 'restricts to a space-separated package allow-list' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root -PackageFilter 'beta')
+        $pairs = $targets | ForEach-Object { "$($_.Package)::$($_.Bench)" }
+        ($pairs -join ',') | Should -Be 'beta::beta_one_cg,beta::beta_two_cg'
+    }
+
+    It 'supports multiple space-separated packages' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root -PackageFilter 'alpha beta')
+        $targets.Count | Should -Be 3
+    }
+
+    It 'restricts to a single target name' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root -TargetFilter 'beta_two_cg')
+        $targets.Count | Should -Be 1
+        $targets[0].Package | Should -Be 'beta'
+        $targets[0].Bench | Should -Be 'beta_two_cg'
+    }
+
+    It 'returns nothing for a package without Callgrind benches' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root -PackageFilter 'gamma')
+        $targets | Should -BeNullOrEmpty
+    }
+
+    It 'skips a package that has no benches directory without error' {
+        { Get-CallgrindBenchTarget -PackagesRoot $script:Root -PackageFilter 'delta' } | Should -Not -Throw
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root -PackageFilter 'delta')
+        $targets | Should -BeNullOrEmpty
+    }
+
+    It 'returns nothing when the target filter matches no bench' {
+        $targets = @(Get-CallgrindBenchTarget -PackagesRoot $script:Root -TargetFilter 'does_not_exist_cg')
+        $targets | Should -BeNullOrEmpty
+    }
+}

--- a/scripts/build/CallgrindBench.psm1
+++ b/scripts/build/CallgrindBench.psm1
@@ -1,0 +1,49 @@
+#requires -Version 7
+
+# Discovers Callgrind instruction-count benchmark targets for the `bench-cg` recipe.
+#
+# Callgrind benches live in `packages/<pkg>/benches/*_cg.rs` (the `_cg` suffix is the naming
+# convention that pairs a Callgrind file with its Criterion counterpart). Turning a package filter
+# and an optional target filter into the concrete list of (package, bench) pairs to run involves
+# directory walking and filtering that is easy to get wrong and worth covering with tests, so it
+# lives here. The recipe keeps only the platform/tool guards and the actual `cargo bench` calls.
+
+Set-StrictMode -Version Latest
+
+function Get-CallgrindBenchTarget {
+    # Returns the Callgrind benchmark targets under $PackagesRoot as objects with `Package` and
+    # `Bench` properties, sorted for deterministic ordering. An empty $PackageFilter scans every
+    # package directory; otherwise it is a space-separated allow-list (e.g. cargo-delta output).
+    # A non-empty $TargetFilter restricts results to a single bench name. Packages without a
+    # `benches/` directory are skipped silently.
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $PackagesRoot,
+        [string] $PackageFilter = '',
+        [string] $TargetFilter = ''
+    )
+
+    $packages = if ([string]::IsNullOrWhiteSpace($PackageFilter)) {
+        Get-ChildItem -LiteralPath $PackagesRoot -Directory | ForEach-Object { $_.Name } | Sort-Object
+    } else {
+        # Support space-separated package lists (e.g. from cargo-delta output).
+        $PackageFilter -split ' ' | Where-Object { $_ -ne '' }
+    }
+
+    $targets = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($package in $packages) {
+        $benchesDir = Join-Path $PackagesRoot $package 'benches'
+        if (-not (Test-Path -LiteralPath $benchesDir)) { continue }
+
+        $benchFiles = Get-ChildItem -LiteralPath $benchesDir -Filter '*_cg.rs' | Sort-Object Name
+        foreach ($benchFile in $benchFiles) {
+            $benchName = $benchFile.BaseName
+            if (-not [string]::IsNullOrWhiteSpace($TargetFilter) -and $benchName -ne $TargetFilter) { continue }
+            $targets.Add([pscustomobject]@{ Package = $package; Bench = $benchName })
+        }
+    }
+    return $targets.ToArray()
+}
+
+Export-ModuleMember -Function Get-CallgrindBenchTarget

--- a/scripts/build/Delta.Tests.ps1
+++ b/scripts/build/Delta.Tests.ps1
@@ -1,0 +1,88 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Delta.psm1. The two pure functions carry the parsing/shaping logic both the
+# `just delta*` recipes and the CI `delta` job depend on, so they are exercised directly here:
+# Read-DeltaAffectedPackage against realistic `cargo delta run` JSON (including the "nothing
+# affected" and malformed-but-tolerated shapes that must not throw under strict mode), and
+# Get-DeltaOutput against the three CI step outputs it produces. Invoke-CargoDelta drives real
+# cargo/git, so it is covered by the recipes running in CI rather than unit-tested here.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Delta.psm1') -Force
+}
+
+Describe 'Read-DeltaAffectedPackage' {
+    It 'returns the affected package names' {
+        $json = '{"Affected":["events_once","infinity_pool"]}'
+        $result = Read-DeltaAffectedPackage -DeltaJson $json
+        $result | Should -Be @('events_once', 'infinity_pool')
+    }
+
+    It 'returns a single affected package as a one-element array' {
+        $result = @(Read-DeltaAffectedPackage -DeltaJson '{"Affected":["events"]}')
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be 'events'
+    }
+
+    It 'returns an empty array when the affected list is empty' {
+        Read-DeltaAffectedPackage -DeltaJson '{"Affected":[]}' | Should -BeNullOrEmpty
+    }
+
+    It 'returns an empty array when there is no Affected field (strict-mode safe)' {
+        Read-DeltaAffectedPackage -DeltaJson '{"Other":1}' | Should -BeNullOrEmpty
+    }
+
+    It 'returns an empty array for a null Affected field' {
+        Read-DeltaAffectedPackage -DeltaJson '{"Affected":null}' | Should -BeNullOrEmpty
+    }
+
+    It 'ignores unrelated fields in the report' {
+        $json = '{"Affected":["par_bench"],"Summary":"whatever","Count":1}'
+        Read-DeltaAffectedPackage -DeltaJson $json | Should -Be @('par_bench')
+    }
+}
+
+Describe 'Get-DeltaOutput' {
+    Context 'when packages are affected' {
+        BeforeAll {
+            $script:Output = Get-DeltaOutput -Affected @('events_once', 'infinity_pool')
+        }
+
+        It 'joins packages with spaces' {
+            $script:Output.Packages | Should -Be 'events_once infinity_pool'
+        }
+
+        It 'emits a JSON array of the package names' {
+            $script:Output.PackagesJson | Should -Be '["events_once","infinity_pool"]'
+        }
+
+        It 'does not skip when something is affected' {
+            $script:Output.SkipAll | Should -Be 'false'
+        }
+    }
+
+    Context 'when nothing is affected' {
+        BeforeAll {
+            $script:Output = Get-DeltaOutput -Affected @()
+        }
+
+        It 'produces an empty package string' {
+            $script:Output.Packages | Should -Be ''
+        }
+
+        It 'produces an empty JSON array' {
+            $script:Output.PackagesJson | Should -Be '[]'
+        }
+
+        It 'signals skip_all' {
+            $script:Output.SkipAll | Should -Be 'true'
+        }
+    }
+
+    It 'produces valid JSON that round-trips to the original list' {
+        $affected = @('a-b', 'c_d', 'e')
+        $json = (Get-DeltaOutput -Affected $affected).PackagesJson
+        $roundTripped = @($json | ConvertFrom-Json)
+        ($roundTripped -join ',') | Should -Be ($affected -join ',')
+    }
+}

--- a/scripts/build/Delta.psm1
+++ b/scripts/build/Delta.psm1
@@ -1,0 +1,125 @@
+#requires -Version 7
+
+# cargo-delta orchestration shared by the local `just delta*` recipes and the CI `delta` job.
+#
+# cargo-delta answers "which workspace packages are affected by this branch's changes vs.
+# origin/main", so the whole validation matrix can be scoped to just those packages. The same
+# analyze-current / analyze-baseline-via-worktree / run / parse pipeline was previously copied both
+# into the justfile and into .github/workflows/validation.yml, which is exactly how the two drift
+# apart. It lives here once now: the fragile parsing (Read-DeltaAffectedPackage) and the CI output
+# shaping (Get-DeltaOutput) are pure and Pester-tested, and the orchestration (Invoke-CargoDelta)
+# is the single seam both callers use. The only intentional difference between callers is baseline
+# freshness: the local recipe fetches origin/main first, whereas CI checks out with full history
+# (fetch-depth: 0) and passes -SkipFetch.
+
+Set-StrictMode -Version Latest
+
+function Read-DeltaAffectedPackage {
+    # Parses the JSON emitted by `cargo delta run` and returns its list of affected package names
+    # as a string array (empty when nothing is affected). Tolerates a missing or null `Affected`
+    # field so a well-formed "nothing changed" report is not mistaken for an error - which also
+    # keeps it safe under Set-StrictMode, where blindly reading an absent property would throw.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $DeltaJson
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DeltaJson)) { return @() }
+
+    $delta = $DeltaJson | ConvertFrom-Json
+    if ($null -eq $delta) { return @() }
+    if (-not ($delta.PSObject.Properties.Name -contains 'Affected')) { return @() }
+    if ($null -eq $delta.Affected) { return @() }
+    return @($delta.Affected)
+}
+
+function Get-DeltaOutput {
+    # Shapes an affected-package list into the three step outputs the CI `delta` job publishes:
+    # `packages` (space-separated, the form `just package="..."` expects), `packages_json` (a JSON
+    # array the matrix `contains(fromJson(...))` checks consume), and `skip_all` ('true' when
+    # nothing is affected, so dependent jobs can short-circuit). Pure so the exact JSON shaping is
+    # test-covered independently of the cargo/git orchestration.
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $Affected
+    )
+
+    $packagesJson = if ($Affected.Count -eq 0) {
+        '[]'
+    } else {
+        '[' + (($Affected | ForEach-Object { ConvertTo-Json $_ -Compress }) -join ',') + ']'
+    }
+
+    return [pscustomobject]@{
+        Packages     = $Affected -join ' '
+        PackagesJson = $packagesJson
+        SkipAll      = if ($Affected.Count -eq 0) { 'true' } else { 'false' }
+    }
+}
+
+function Invoke-CargoDelta {
+    # Runs the full cargo-delta pipeline and returns the affected package names as a string array.
+    # Analyzes the current checkout, then analyzes origin/main in a throwaway git worktree (so the
+    # branch is never switched), runs the comparison, and parses the result. Unless -SkipFetch is
+    # given, origin/main is refreshed first (unshallowing a shallow clone) so the baseline is
+    # current; CI passes -SkipFetch because it already checks out full history. All intermediate
+    # artifacts go in a temp directory that is always cleaned up.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [string] $ConfigPath = (Resolve-Path 'delta.toml').Path,
+        [switch] $SkipFetch
+    )
+
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    if (-not $SkipFetch) {
+        # We need the full history of both branches to compare them. A shallow clone (e.g. a
+        # default CI checkout) must be unshallowed first; a full clone just fetches origin/main.
+        $isShallow = git rev-parse --is-shallow-repository
+        if ($isShallow -eq 'true') {
+            git fetch --unshallow origin main | Out-Null
+        } else {
+            git fetch origin main | Out-Null
+        }
+    }
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "cargo-delta-$([guid]::NewGuid().ToString('n'))"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    try {
+        $baselineJson = Join-Path $tempDir 'baseline.json'
+        $currentJson = Join-Path $tempDir 'current.json'
+
+        # Analyze the current branch first (we are already on it).
+        Write-Host 'Analyzing current branch...'
+        cargo delta -c $ConfigPath analyze | Set-Content -Path $currentJson -Encoding utf8
+
+        # Use a git worktree to analyze origin/main without switching branches.
+        $worktreeDir = Join-Path $tempDir 'main-worktree'
+        git worktree add --quiet $worktreeDir origin/main | Out-Null
+        try {
+            Write-Host 'Analyzing baseline (origin/main)...'
+            Push-Location $worktreeDir
+            try {
+                cargo delta -c $ConfigPath analyze | Set-Content -Path $baselineJson -Encoding utf8
+            } finally {
+                Pop-Location
+            }
+        } finally {
+            git worktree remove $worktreeDir --force | Out-Null
+        }
+
+        Write-Host 'Computing delta...'
+        # Capture stdout directly: when nothing changed, cargo-delta writes its "quitting" notice
+        # to stderr and emits no stdout, which the parser treats as "nothing affected".
+        $deltaJson = cargo delta -c $ConfigPath run --baseline $baselineJson --current $currentJson | Out-String
+
+        return Read-DeltaAffectedPackage -DeltaJson $deltaJson
+    } finally {
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Export-ModuleMember -Function Read-DeltaAffectedPackage, Get-DeltaOutput, Invoke-CargoDelta

--- a/scripts/build/Examples.Tests.ps1
+++ b/scripts/build/Examples.Tests.ps1
@@ -1,0 +1,105 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Examples.psm1.
+#
+# Get-ExampleTarget walks the filesystem, so tests build a `packages/<pkg>/examples/` fixture under
+# TestDrive covering both example shapes plus the mod.rs and skip-list exclusions. Invoke-ExampleRun
+# takes an injected scriptblock in place of cargo, so its timeout/exit-code/output classification is
+# tested with fast fake commands (one short real timeout to exercise the watchdog).
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Examples.psm1') -Force
+}
+
+Describe 'Get-ExampleTarget' {
+    BeforeEach {
+        $script:Root = Join-Path $TestDrive 'packages'
+
+        # alpha: two .rs examples, a mod.rs to ignore, and a subdir example.
+        $alpha = Join-Path $script:Root 'alpha' 'examples'
+        New-Item -ItemType Directory -Path $alpha -Force | Out-Null
+        Set-Content -Path (Join-Path $script:Root 'alpha' 'Cargo.toml') -Value '[package]'
+        Set-Content -Path (Join-Path $alpha 'a_one.rs') -Value '// ex'
+        Set-Content -Path (Join-Path $alpha 'a_two.rs') -Value '// ex'
+        Set-Content -Path (Join-Path $alpha 'mod.rs') -Value '// shared'
+        New-Item -ItemType Directory -Path (Join-Path $alpha 'a_dir') -Force | Out-Null
+        Set-Content -Path (Join-Path $alpha 'a_dir' 'main.rs') -Value '// ex'
+
+        # beta: one example plus an excluded-by-design example.
+        $beta = Join-Path $script:Root 'beta' 'examples'
+        New-Item -ItemType Directory -Path $beta -Force | Out-Null
+        Set-Content -Path (Join-Path $script:Root 'beta' 'Cargo.toml') -Value '[package]'
+        Set-Content -Path (Join-Path $beta 'b_one.rs') -Value '// ex'
+        Set-Content -Path (Join-Path $beta 'nm_otel_console.rs') -Value '// infinite loop'
+
+        # gamma: a package with no examples directory (must be skipped).
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'gamma') -Force | Out-Null
+        Set-Content -Path (Join-Path $script:Root 'gamma' 'Cargo.toml') -Value '[package]'
+
+        # noise: a directory that is not a package (no Cargo.toml) must be ignored.
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'noise') -Force | Out-Null
+    }
+
+    It 'discovers both .rs-file and subdirectory examples across all packages' {
+        $targets = @(Get-ExampleTarget -PackagesRoot $script:Root)
+        $pairs = $targets | ForEach-Object { "$($_.Package)::$($_.Example)" }
+        ($pairs -join ',') | Should -Be 'alpha::a_dir,alpha::a_one,alpha::a_two,beta::b_one'
+    }
+
+    It 'ignores mod.rs' {
+        $targets = @(Get-ExampleTarget -PackagesRoot $script:Root -PackageFilter 'alpha')
+        ($targets | Where-Object { $_.Example -eq 'mod' }) | Should -BeNullOrEmpty
+    }
+
+    It 'drops examples on the default skip-list' {
+        $targets = @(Get-ExampleTarget -PackagesRoot $script:Root -PackageFilter 'beta')
+        ($targets | Where-Object { $_.Example -eq 'nm_otel_console' }) | Should -BeNullOrEmpty
+        ($targets | ForEach-Object { $_.Example }) | Should -Be 'b_one'
+    }
+
+    It 'honours a caller-supplied exclusion list' {
+        $targets = @(Get-ExampleTarget -PackagesRoot $script:Root -PackageFilter 'alpha' -ExcludedExample @('a_two'))
+        ($targets | ForEach-Object { $_.Example }) -join ',' | Should -Be 'a_dir,a_one'
+    }
+
+    It 'restricts to a space-separated package allow-list' {
+        $targets = @(Get-ExampleTarget -PackagesRoot $script:Root -PackageFilter 'beta')
+        ($targets | ForEach-Object { $_.Package } | Sort-Object -Unique) | Should -Be 'beta'
+    }
+
+    It 'skips packages without an examples directory' {
+        $targets = @(Get-ExampleTarget -PackagesRoot $script:Root -PackageFilter 'gamma')
+        $targets | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-ExampleRun' {
+    It 'reports Success and captures output when the command exits 0' {
+        $command = { Write-Output 'line one'; Write-Output 'line two'; return 0 }
+        $result = Invoke-ExampleRun -Package 'pkg' -Example 'ex' -Command $command -TimeoutSeconds 30
+        $result.Status | Should -Be 'Success'
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Be "line one`nline two"
+    }
+
+    It 'reports Success with empty output when the command emits only an exit code' {
+        $command = { return 0 }
+        $result = Invoke-ExampleRun -Package 'pkg' -Example 'ex' -Command $command -TimeoutSeconds 30
+        $result.Status | Should -Be 'Success'
+        $result.Output | Should -Be ''
+    }
+
+    It 'reports Failed and preserves the non-zero exit code and output' {
+        $command = { Write-Output 'boom'; return 7 }
+        $result = Invoke-ExampleRun -Package 'pkg' -Example 'ex' -Command $command -TimeoutSeconds 30
+        $result.Status | Should -Be 'Failed'
+        $result.ExitCode | Should -Be 7
+        $result.Output | Should -Be 'boom'
+    }
+
+    It 'reports Timeout when the command outlasts the watchdog' {
+        $command = { Start-Sleep -Seconds 30; return 0 }
+        $result = Invoke-ExampleRun -Package 'pkg' -Example 'ex' -Command $command -TimeoutSeconds 1
+        $result.Status | Should -Be 'Timeout'
+    }
+}

--- a/scripts/build/Examples.psm1
+++ b/scripts/build/Examples.psm1
@@ -1,0 +1,134 @@
+#requires -Version 7
+
+# Backs the `run-examples` recipe: discovers stand-alone example binaries and runs each one under a
+# timeout, classifying the outcome.
+#
+# `run-examples` executes every example in the workspace to prove they complete without panicking.
+# Two parts are easy to get subtly wrong and worth testing in isolation: (1) discovering the example
+# targets, which come in two shapes - `examples/<name>.rs` files and `examples/<name>/main.rs`
+# directories - with a hard-coded skip-list of examples that loop forever or panic by design; and
+# (2) running an example under a timeout and turning the job's mixed output-plus-exit-code stream
+# into a clean result (the exit-code-is-the-last-item slicing is a classic off-by-one). Extracting
+# both also collapses the recipe's two near-identical run blocks (files vs. subdirectories) into one.
+
+Set-StrictMode -Version Latest
+
+function Get-ExampleTarget {
+    # Returns the runnable example targets under $PackagesRoot as objects with `Package` and
+    # `Example` properties, sorted for deterministic ordering. An empty $PackageFilter scans every
+    # package that has a Cargo.toml; otherwise it is a space-separated allow-list (e.g. cargo-delta
+    # output). Both example shapes are discovered: `examples/<name>.rs` files (excluding `mod.rs`)
+    # and `examples/<name>/main.rs` subdirectories. Names in $ExcludedExample are dropped.
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $PackagesRoot,
+        [string] $PackageFilter = '',
+        # Examples that are expected to loop forever or panic by design, so `run-examples` must not
+        # try to run them to completion.
+        [string[]] $ExcludedExample = @(
+            'nm_otel_console',                    # runs an infinite loop by design
+            'nm_otel_readme',                     # runs an infinite loop by design
+            'alloc_tracker_panic_on_alloc_demo'   # intentionally panics to demonstrate functionality
+        )
+    )
+
+    $packages = if ([string]::IsNullOrWhiteSpace($PackageFilter)) {
+        Get-ChildItem -LiteralPath $PackagesRoot -Directory |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'Cargo.toml') } |
+            ForEach-Object { $_.Name } |
+            Sort-Object
+    } else {
+        # Support space-separated package lists (e.g. from cargo-delta output).
+        $PackageFilter -split ' ' | Where-Object { $_ -ne '' }
+    }
+
+    $targets = [System.Collections.Generic.List[pscustomobject]]::new()
+    foreach ($package in $packages) {
+        $examplesDir = Join-Path $PackagesRoot $package 'examples'
+        if (-not (Test-Path -LiteralPath $examplesDir)) { continue }
+
+        $names = [System.Collections.Generic.List[string]]::new()
+
+        # `examples/<name>.rs` files, excluding a `mod.rs` shared module.
+        Get-ChildItem -LiteralPath $examplesDir -Filter '*.rs' |
+            Where-Object { $_.Name -ne 'mod.rs' } |
+            ForEach-Object { $names.Add($_.BaseName) }
+
+        # `examples/<name>/main.rs` subdirectories.
+        Get-ChildItem -LiteralPath $examplesDir -Directory |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'main.rs') } |
+            ForEach-Object { $names.Add($_.Name) }
+
+        foreach ($name in ($names | Sort-Object)) {
+            if ($ExcludedExample -contains $name) { continue }
+            $targets.Add([pscustomobject]@{ Package = $package; Example = $name })
+        }
+    }
+    return $targets.ToArray()
+}
+
+function Invoke-ExampleRun {
+    # Runs a single example via $Command (a scriptblock receiving $Package and $Example whose final
+    # pipeline value is the process exit code) under a $TimeoutSeconds watchdog, and returns a result
+    # object with `Status` ('Success' | 'Failed' | 'Timeout' | 'Exception'), `ExitCode`, `Output`
+    # (captured stdout/stderr minus the exit code) and `Message`. Injecting $Command keeps the
+    # timeout/classification logic testable without invoking cargo.
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $Package,
+        [Parameter(Mandatory)][string] $Example,
+        [Parameter(Mandatory)][scriptblock] $Command,
+        [int] $TimeoutSeconds = 30
+    )
+
+    $job = $null
+    try {
+        $job = Start-Job -ScriptBlock $Command -ArgumentList $Package, $Example
+        $completed = Wait-Job -Job $job -Timeout $TimeoutSeconds
+
+        if (-not $completed) {
+            Stop-Job -Job $job
+            return [pscustomobject]@{
+                Status   = 'Timeout'
+                ExitCode = $null
+                Output   = ''
+                Message  = "timed out after $TimeoutSeconds seconds"
+            }
+        }
+
+        $items = @(Receive-Job -Job $job)
+        if ($items.Count -eq 0) {
+            $exitCode = $null
+            $output = ''
+        } elseif ($items.Count -eq 1) {
+            $exitCode = $items[0]
+            $output = ''
+        } else {
+            $exitCode = $items[-1]
+            $output = ($items[0..($items.Count - 2)] -join "`n")
+        }
+
+        if ($exitCode -eq 0) {
+            return [pscustomobject]@{ Status = 'Success'; ExitCode = 0; Output = $output; Message = '' }
+        }
+        return [pscustomobject]@{
+            Status   = 'Failed'
+            ExitCode = $exitCode
+            Output   = $output
+            Message  = "failed with exit code $exitCode"
+        }
+    } catch {
+        return [pscustomobject]@{
+            Status   = 'Exception'
+            ExitCode = $null
+            Output   = ''
+            Message  = $_.Exception.Message
+        }
+    } finally {
+        if ($null -ne $job) { Remove-Job -Job $job -Force }
+    }
+}
+
+Export-ModuleMember -Function Get-ExampleTarget, Invoke-ExampleRun

--- a/scripts/build/Miri.Tests.ps1
+++ b/scripts/build/Miri.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Miri.psm1. Get-MiriSeedRange is pure, so the seed arithmetic is checked
+# directly: the unsharded full range, an even split, the remainder-absorbing final shard, and the
+# "more shards than seeds" guard. Malformed specs are covered by Sharding.Tests.ps1; here we only
+# confirm they still propagate as failures.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Miri.psm1') -Force
+}
+
+Describe 'Get-MiriSeedRange' {
+    It 'returns the full range when no shard is given' {
+        Get-MiriSeedRange -Spec '' | Should -Be '..64'
+    }
+
+    It 'honours a custom total seed budget for the full range' {
+        Get-MiriSeedRange -Spec '' -TotalSeeds 32 | Should -Be '..32'
+    }
+
+    It 'splits evenly when the count divides the total' {
+        Get-MiriSeedRange -Spec '1/8' | Should -Be '0..8'
+        Get-MiriSeedRange -Spec '2/8' | Should -Be '8..16'
+        Get-MiriSeedRange -Spec '8/8' | Should -Be '56..64'
+    }
+
+    It 'gives the final shard the remainder of an uneven split' {
+        # 64 / 6 = 10 per shard; shards 1..5 cover 0..50, and shard 6 absorbs 50..64.
+        Get-MiriSeedRange -Spec '5/6' | Should -Be '40..50'
+        Get-MiriSeedRange -Spec '6/6' | Should -Be '50..64'
+    }
+
+    It 'covers the whole budget with no gaps or overlaps across all shards' {
+        $count = 7
+        $ranges = 1..$count | ForEach-Object { Get-MiriSeedRange -Spec "$_/$count" }
+        # First shard starts at 0, last ends at the total, and each shard resumes where the prior ended.
+        ($ranges[0] -split '\.\.')[0] | Should -Be '0'
+        ($ranges[-1] -split '\.\.')[1] | Should -Be '64'
+        for ($i = 1; $i -lt $count; $i++) {
+            $prevEnd = ($ranges[$i - 1] -split '\.\.')[1]
+            $thisStart = ($ranges[$i] -split '\.\.')[0]
+            $thisStart | Should -Be $prevEnd
+        }
+    }
+
+    It 'rejects a spec with more shards than seeds' {
+        { Get-MiriSeedRange -Spec '1/65' } | Should -Throw '*Too many shards*'
+    }
+
+    It 'propagates a malformed spec as a failure' {
+        { Get-MiriSeedRange -Spec 'x/8' } | Should -Throw '*must be integers*'
+    }
+}

--- a/scripts/build/Miri.psm1
+++ b/scripts/build/Miri.psm1
@@ -1,0 +1,51 @@
+#requires -Version 7
+
+# Seed-range computation for `just miri-harder`, the sharded many-seeds Miri run.
+#
+# miri-harder exercises the workspace under a range of Miri PRNG seeds (`-Zmiri-many-seeds`), and
+# CI splits that range across parallel runners via the shared 1-based "N/M" shard spec. Turning a
+# shard into a concrete `start..end` seed range is fiddly integer arithmetic (floor division plus a
+# remainder that the final shard absorbs), so it lives here with Pester coverage rather than inline
+# in the recipe. The generic "N/M" parse/validate is delegated to Sharding.psm1; only the
+# miri-specific seed slicing (including the "too many shards for the seed budget" guard) is here.
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot 'Sharding.psm1') -Force
+
+function Get-MiriSeedRange {
+    # Computes the `-Zmiri-many-seeds` range string for a shard spec. With no spec (an empty
+    # string) the full `..$TotalSeeds` range is returned, which Miri reads as seeds 0..TotalSeeds.
+    # Otherwise the total seed budget is split evenly across the shards, the final shard absorbing
+    # any remainder from uneven division, and the returned "start..end" selects this shard's slice.
+    # Throws when the spec is malformed (via Sharding) or when there are more shards than seeds.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Spec,
+        [int] $TotalSeeds = 64
+    )
+
+    if ($Spec -eq '') {
+        return "..$TotalSeeds"
+    }
+
+    $shard = ConvertFrom-ShardSpec -Spec $Spec
+
+    $seedsPerShard = [math]::Floor($TotalSeeds / $shard.Count)
+    if ($seedsPerShard -lt 1) {
+        throw "Invalid SHARD value '$Spec'. Too many shards for $TotalSeeds seeds."
+    }
+
+    $start = ($shard.Index - 1) * $seedsPerShard
+    if ($shard.Index -eq $shard.Count) {
+        # The last shard picks up any remainder left by the uneven floor division above.
+        $end = $TotalSeeds
+    } else {
+        $end = $shard.Index * $seedsPerShard
+    }
+
+    return "$start..$end"
+}
+
+Export-ModuleMember -Function Get-MiriSeedRange

--- a/scripts/build/MockBenchEngine.Tests.ps1
+++ b/scripts/build/MockBenchEngine.Tests.ps1
@@ -1,0 +1,56 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for MockBenchEngine.psm1. Resolve-MockBenchEngineExecutable is pure, so it is fed
+# hand-built `cargo build --message-format=json` streams: the happy path, streams that also contain
+# dependency artifacts and non-artifact messages (build-finished, which has no target/executable
+# and must not throw under strict mode), interleaved rendered-diagnostic noise, the "last match
+# wins" ordering, and the "no engine built" failure.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'MockBenchEngine.psm1') -Force
+
+    $script:EngineArtifact = '{"reason":"compiler-artifact","target":{"name":"mock_bench_engine","kind":["bin"]},"executable":"/tmp/target/mock-engine/debug/mock_bench_engine"}'
+    $script:DepArtifact = '{"reason":"compiler-artifact","target":{"name":"serde","kind":["lib"]},"executable":null}'
+    $script:BuildFinished = '{"reason":"build-finished","success":true}'
+}
+
+Describe 'Resolve-MockBenchEngineExecutable' {
+    It 'returns the executable path from the engine artifact' {
+        $exe = Resolve-MockBenchEngineExecutable -CargoMessage @($script:EngineArtifact)
+        $exe | Should -Be '/tmp/target/mock-engine/debug/mock_bench_engine'
+    }
+
+    It 'ignores dependency artifacts and non-artifact messages' {
+        $messages = @($script:DepArtifact, $script:EngineArtifact, $script:BuildFinished)
+        $exe = Resolve-MockBenchEngineExecutable -CargoMessage $messages
+        $exe | Should -Be '/tmp/target/mock-engine/debug/mock_bench_engine'
+    }
+
+    It 'does not throw on a build-finished message that lacks target/executable (strict-mode safe)' {
+        $messages = @($script:BuildFinished, $script:EngineArtifact)
+        { Resolve-MockBenchEngineExecutable -CargoMessage $messages } | Should -Not -Throw
+    }
+
+    It 'tolerates interleaved non-JSON rendered-diagnostic lines' {
+        $messages = @('warning: unused variable', '', $script:EngineArtifact, 'Compiling mock_bench_engine v0.1.0')
+        $exe = Resolve-MockBenchEngineExecutable -CargoMessage $messages
+        $exe | Should -Be '/tmp/target/mock-engine/debug/mock_bench_engine'
+    }
+
+    It 'returns the last matching engine artifact when several are present' {
+        $first = '{"reason":"compiler-artifact","target":{"name":"mock_bench_engine","kind":["bin"]},"executable":"/first/mock_bench_engine"}'
+        $last = '{"reason":"compiler-artifact","target":{"name":"mock_bench_engine","kind":["bin"]},"executable":"/last/mock_bench_engine"}'
+        $exe = Resolve-MockBenchEngineExecutable -CargoMessage @($first, $last)
+        $exe | Should -Be '/last/mock_bench_engine'
+    }
+
+    It 'ignores an engine artifact whose executable is null' {
+        $nullExe = '{"reason":"compiler-artifact","target":{"name":"mock_bench_engine","kind":["lib"]},"executable":null}'
+        { Resolve-MockBenchEngineExecutable -CargoMessage @($nullExe) } | Should -Throw '*could not resolve*'
+    }
+
+    It 'throws when no engine artifact is present' {
+        $messages = @($script:DepArtifact, $script:BuildFinished)
+        { Resolve-MockBenchEngineExecutable -CargoMessage $messages } | Should -Throw '*could not resolve the mock_bench_engine executable*'
+    }
+}

--- a/scripts/build/MockBenchEngine.psm1
+++ b/scripts/build/MockBenchEngine.psm1
@@ -1,0 +1,68 @@
+#requires -Version 7
+
+# Resolves the built `mock_bench_engine` test-support binary from `cargo build` JSON output.
+#
+# The mock benchmark engine lives in its own never-published package (packages/mock_bench_engine),
+# so Cargo does not expose it to the cargo-bench-history integration tests via CARGO_BIN_EXE_*.
+# A test runner builds it once up front and passes the path via MOCK_BENCH_ENGINE so each per-test
+# process skips a redundant freshness check. Picking the executable path out of the streamed
+# `--message-format=json` records is easy to get subtly wrong - especially under strict mode, where
+# a message that lacks a `target` or `executable` field would throw if accessed blindly - so the
+# parsing lives here with Pester coverage. The recipe keeps only the actual `cargo build`.
+
+Set-StrictMode -Version Latest
+
+function Resolve-MockBenchEngineExecutable {
+    # Scans the JSON lines emitted by `cargo build --message-format=json` and returns the path to
+    # the `mock_bench_engine` binary (the last matching compiler-artifact, mirroring cargo's own
+    # "last one wins" ordering). Non-JSON lines (e.g. rendered diagnostics) and messages that carry
+    # no target/executable are skipped without error, so it is safe under Set-StrictMode. Throws
+    # when no matching executable is found, so a silently-missing build surfaces immediately.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $CargoMessage
+    )
+
+    $exe = $null
+    foreach ($line in $CargoMessage) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+        $message = $null
+        try {
+            $message = $line | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            # Tolerate non-JSON lines (rendered diagnostics, blank lines) just as the Rust-side
+            # resolver does; only parsed objects flow downstream.
+            continue
+        }
+
+        if (-not (Test-HasProperty $message 'reason') -or $message.reason -ne 'compiler-artifact') { continue }
+        if (-not (Test-HasProperty $message 'executable') -or [string]::IsNullOrEmpty($message.executable)) { continue }
+        if (-not (Test-HasProperty $message 'target') -or $null -eq $message.target) { continue }
+        if (-not (Test-HasProperty $message.target 'name') -or $message.target.name -ne 'mock_bench_engine') { continue }
+
+        $exe = $message.executable
+    }
+
+    if (-not $exe) {
+        throw 'could not resolve the mock_bench_engine executable from cargo output'
+    }
+    return $exe
+}
+
+function Test-HasProperty {
+    # Strict-mode-safe presence check for a property on a (possibly $null) object, so callers can
+    # probe optional fields of heterogeneous cargo messages without tripping StrictMode.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [AllowNull()] $InputObject,
+        [Parameter(Mandatory)][string] $Name
+    )
+
+    if ($null -eq $InputObject) { return $false }
+    return $InputObject.PSObject.Properties.Name -contains $Name
+}
+
+Export-ModuleMember -Function Resolve-MockBenchEngineExecutable

--- a/scripts/build/Mutants.Tests.ps1
+++ b/scripts/build/Mutants.Tests.ps1
@@ -1,0 +1,86 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Mutants.psm1. Both functions are pure, so the exclusion set and the shard
+# translation are asserted directly across platforms. The exclusions are position-sensitive
+# (`-e` immediately precedes its value), so the tests check that pairing as well as the
+# platform-conditional entries and the Linux-only single-quoting.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Mutants.psm1') -Force
+
+    function Get-ExcludeValue($arguments) {
+        # Extract the value that follows each `-e` flag so tests can assert on the exclusion set
+        # independently of quoting.
+        $values = @()
+        for ($i = 0; $i -lt $arguments.Length; $i++) {
+            if ($arguments[$i] -eq '-e') { $values += $arguments[$i + 1] }
+        }
+        return $values
+    }
+}
+
+Describe 'Get-MutantsExcludeArgument' {
+    It 'pairs every -e flag with a following value' {
+        $excludeArgs = Get-MutantsExcludeArgument -IsWindowsPlatform $true -IsLinuxPlatform $false
+        # Even count, and no two -e flags are adjacent.
+        ($excludeArgs.Count % 2) | Should -Be 0
+        for ($i = 0; $i -lt $excludeArgs.Count; $i += 2) {
+            $excludeArgs[$i] | Should -Be '-e'
+            $excludeArgs[$i + 1] | Should -Not -Be '-e'
+        }
+    }
+
+    It 'always excludes the core package/path set' {
+        $values = Get-ExcludeValue (Get-MutantsExcludeArgument -IsWindowsPlatform $true -IsLinuxPlatform $true)
+        $values | Should -Contain 'many_cpus_benchmarking'
+        $values | Should -Contain 'facade'
+        $values | Should -Contain 'events'
+    }
+
+    It 'does not exclude windows sources when running on Windows' {
+        $values = Get-ExcludeValue (Get-MutantsExcludeArgument -IsWindowsPlatform $true -IsLinuxPlatform $false)
+        $values | Should -Not -Contain 'windows'
+        ($values -join ' ') | Should -Not -Match 'windows\.rs'
+    }
+
+    It 'excludes windows and linux sources on a third platform (e.g. macOS)' {
+        $values = Get-ExcludeValue (Get-MutantsExcludeArgument -IsWindowsPlatform $false -IsLinuxPlatform $false)
+        $values | Should -Contain 'windows'
+        $values | Should -Contain 'linux'
+    }
+
+    It 'excludes linux sources but not windows sources when running on Windows' {
+        $values = Get-ExcludeValue (Get-MutantsExcludeArgument -IsWindowsPlatform $true -IsLinuxPlatform $false)
+        $values | Should -Contain 'linux'
+        $values | Should -Not -Contain 'windows'
+    }
+
+    It 'does not single-quote glob patterns on Windows' {
+        $values = Get-ExcludeValue (Get-MutantsExcludeArgument -IsWindowsPlatform $true -IsLinuxPlatform $false)
+        $values | Should -Contain '**/*facade.rs'
+        $values | ForEach-Object { $_ | Should -Not -Match "^'" }
+    }
+
+    It 'single-quotes glob patterns off Windows so PowerShell does not expand them' {
+        $values = Get-ExcludeValue (Get-MutantsExcludeArgument -IsWindowsPlatform $false -IsLinuxPlatform $true)
+        $values | Should -Contain "'**/*facade.rs'"
+        $values | Should -Contain "'packages/testing/**'"
+        # Plain package names are still passed literally, without quoting.
+        $values | Should -Contain 'many_cpus_benchmarking'
+    }
+}
+
+Describe 'Get-MutantsShardArgument' {
+    It 'returns no shard argument for an empty spec' {
+        Get-MutantsShardArgument -Spec '' | Should -BeNullOrEmpty
+    }
+
+    It 'converts a 1-based spec to cargo-mutants 0-based --shard' {
+        Get-MutantsShardArgument -Spec '1/8' | Should -Be @('--shard', '0/8')
+        Get-MutantsShardArgument -Spec '8/8' | Should -Be @('--shard', '7/8')
+    }
+
+    It 'propagates a malformed spec as a failure' {
+        { Get-MutantsShardArgument -Spec '9/8' } | Should -Throw '*1 <= N <= M*'
+    }
+}

--- a/scripts/build/Mutants.psm1
+++ b/scripts/build/Mutants.psm1
@@ -1,0 +1,123 @@
+#requires -Version 7
+
+# Argument construction for `just mutants`, the cargo-mutants mutation-testing recipe.
+#
+# The recipe's fiddly, easy-to-break parts are the long list of platform-dependent path/package
+# exclusions and the shard-spec conversion; both live here with Pester coverage so a stray edit to
+# the exclusion set (or the exact 1-based -> 0-based shard translation cargo-mutants wants) is
+# caught by a test rather than by a wasted CI mutation run. The recipe keeps only the orchestration
+# that has real side effects (environment tweaks and the final cargo-mutants invocation).
+#
+# cargo-mutants can theoretically read exclusions from a config file, but it cannot merge that
+# static set with the dynamic, platform-derived set below, so every exclusion is specified as a
+# command-line `-e` argument here (see cargo-mutants issue #527).
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot 'Sharding.psm1') -Force
+
+function Get-MutantsExcludeArgument {
+    # Builds the ordered list of `-e <glob-or-name>` exclusion arguments for cargo-mutants, given
+    # the current platform. On non-Windows PowerShell, values that look like wildcard globs are
+    # single-quoted so PowerShell's native globbing does not expand them before cargo-mutants sees
+    # the literal pattern; on Windows there is no such globbing, so they are passed through as-is.
+    # The Windows- and Linux-only source files are excluded on the OTHER platforms (there is no
+    # point mutating code that is not even compiled here).
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)][bool] $IsWindowsPlatform,
+        [Parameter(Mandatory)][bool] $IsLinuxPlatform
+    )
+
+    function protect([string] $value) {
+        if ($IsWindowsPlatform) {
+            return $value
+        }
+        # Single-quote so PowerShell on Linux does not glob-expand the literal pattern.
+        return "'" + $value + "'"
+    }
+
+    $exclude = @(
+        # Parts of this package require Criterion to work and other parts are currently not tested
+        # as there is no public way to simulate a system topology for `many_cpus`.
+        '-e', 'many_cpus_benchmarking',
+
+        # Macros are tested via the impl package; mutations in the middle layer might not be detected.
+        '-e', 'linked_macros',
+
+        # We do not test facades, as they are just trivial code that forwards calls to real impls.
+        '-e', (protect '**/*facade.rs'),
+        '-e', 'facade',
+
+        # We have limited coverage of platform bindings because it can be difficult to set up the
+        # right scenarios for each, given they are platform-dependent. Instead, we test higher
+        # level code using a mock platform.
+        '-e', 'bindings',
+
+        # This is just a different type of bindings, skipped for the same reason as `bindings` above.
+        '-e', (protect 'packages/many_cpus_impl/src/pal/linux/filesystem/**'),
+
+        # These packages are literally full of synchronization primitives, so 95% of mutations
+        # will just cause tests to time out and never complete - pointless to try mutate this stuff.
+        '-e', 'events_once',
+        '-e', 'awaiter_set',
+        '-e', 'events',
+
+        # All this is code only used in tests/benchmarks - we do not test this code itself.
+        '-e', (protect 'packages/testing/**'),
+        '-e', (protect 'packages/benchmarks/**'),
+
+        # The mock benchmark engine is a test-support binary (its own never-published
+        # `mock_bench_engine` package, which the integration tests spawn). It is scaffolding,
+        # not shipped code, so mutating it yields no production coverage signal.
+        '-e', (protect 'packages/mock_bench_engine/**'),
+
+        # `testing.rs` is an in-workspace test utility (gated behind the `private-test-util`
+        # feature, consumed only by the shell crate's tests). It is scaffolding with no public
+        # API contract, so mutating it yields no production coverage signal.
+        '-e', (protect 'packages/cargo-bench-history-core/src/testing.rs'),
+
+        # Some of our systems are single-processor, yet the code may only be meaningfully testable
+        # on multi-processor systems. As a "good enough" approximation, we skip mutation testing
+        # of code that is only testable in a multi-processor system.
+        '-e', (protect 'packages/par_bench/src/resource_usage_ext.rs')
+    )
+
+    if (-not $IsWindowsPlatform) {
+        $exclude += '-e'
+        $exclude += (protect '**/*windows.rs')
+        $exclude += '-e'
+        $exclude += 'windows'
+    }
+
+    if (-not $IsLinuxPlatform) {
+        $exclude += '-e'
+        $exclude += (protect '**/*linux.rs')
+        $exclude += '-e'
+        $exclude += 'linux'
+    }
+
+    return $exclude
+}
+
+function Get-MutantsShardArgument {
+    # Converts the shared 1-based "N/M" shard spec into cargo-mutants' native 0-based `--shard`
+    # argument (`@('--shard', '0/M') .. @('--shard', '(M-1)/M')`). An empty spec means "no
+    # sharding" and yields an empty array so every mutant runs in one job. Throws (via Sharding)
+    # for a malformed spec.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Spec
+    )
+
+    if ($Spec -eq '') {
+        return @()
+    }
+
+    $shard = ConvertFrom-ShardSpec -Spec $Spec
+    return @('--shard', ('{0}/{1}' -f ($shard.Index - 1), $shard.Count))
+}
+
+Export-ModuleMember -Function Get-MutantsExcludeArgument, Get-MutantsShardArgument

--- a/scripts/build/Sharding.Tests.ps1
+++ b/scripts/build/Sharding.Tests.ps1
@@ -1,0 +1,68 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Sharding.psm1. ConvertFrom-ShardSpec is pure, so every case is exercised
+# directly: the happy path returns the 1-based index/count, and each malformed spec throws its
+# specific, actionable message. These are the checks both `just mutants` and `just miri-harder`
+# rely on, so a regression here would silently mis-shard a CI matrix.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Sharding.psm1') -Force
+}
+
+Describe 'ConvertFrom-ShardSpec' {
+    Context 'valid specs' {
+        It 'returns the 1-based index and count for a mid-range shard' {
+            $result = ConvertFrom-ShardSpec -Spec '3/8'
+            $result.Index | Should -Be 3
+            $result.Count | Should -Be 8
+        }
+
+        It 'accepts the first shard' {
+            $result = ConvertFrom-ShardSpec -Spec '1/8'
+            $result.Index | Should -Be 1
+            $result.Count | Should -Be 8
+        }
+
+        It 'accepts the last shard (index equal to count)' {
+            $result = ConvertFrom-ShardSpec -Spec '8/8'
+            $result.Index | Should -Be 8
+            $result.Count | Should -Be 8
+        }
+
+        It 'accepts a single-shard spec' {
+            $result = ConvertFrom-ShardSpec -Spec '1/1'
+            $result.Index | Should -Be 1
+            $result.Count | Should -Be 1
+        }
+    }
+
+    Context 'malformed specs' {
+        It 'rejects a spec with the wrong number of parts' {
+            { ConvertFrom-ShardSpec -Spec '3' } | Should -Throw "*Expected format 'N/M'*"
+            { ConvertFrom-ShardSpec -Spec '1/2/3' } | Should -Throw "*Expected format 'N/M'*"
+        }
+
+        It 'rejects an empty spec (the caller must handle "no sharding" first)' {
+            # An empty string is not a valid shard spec; the mandatory parameter rejects it.
+            { ConvertFrom-ShardSpec -Spec '' } | Should -Throw
+        }
+
+        It 'rejects non-integer components' {
+            { ConvertFrom-ShardSpec -Spec 'a/8' } | Should -Throw '*must be integers*'
+            { ConvertFrom-ShardSpec -Spec '3/x' } | Should -Throw '*must be integers*'
+        }
+
+        It 'rejects a non-positive shard count' {
+            { ConvertFrom-ShardSpec -Spec '1/0' } | Should -Throw '*M must be a positive integer*'
+            { ConvertFrom-ShardSpec -Spec '1/-2' } | Should -Throw '*M must be a positive integer*'
+        }
+
+        It 'rejects an index below 1' {
+            { ConvertFrom-ShardSpec -Spec '0/8' } | Should -Throw '*1 <= N <= M*'
+        }
+
+        It 'rejects an index above the count' {
+            { ConvertFrom-ShardSpec -Spec '9/8' } | Should -Throw '*1 <= N <= M*'
+        }
+    }
+}

--- a/scripts/build/Sharding.psm1
+++ b/scripts/build/Sharding.psm1
@@ -1,0 +1,52 @@
+#requires -Version 7
+
+# Shared shard-spec parsing for the CI-sharded recipes (`just mutants`, `just miri-harder`).
+#
+# Both recipes accept the same 1-based "N/M" shard spec (so `1/8 .. 8/8` selects one of eight
+# shards) and used to carry a byte-for-byte copy of the same parse-and-validate block. That
+# duplication is exactly the kind of place a copy-paste bug (or a strict-mode landmine) hides
+# unnoticed, so the parsing lives here once, is exercised by Pester (Sharding.Tests.ps1), and is
+# consumed by both the mutants and miri-harder helper modules. What each recipe does with the
+# parsed shard differs (cargo-mutants wants a 0-based `--shard`, miri-harder slices a seed range),
+# so only the parsing is shared; those conversions live in the respective consumer modules.
+
+Set-StrictMode -Version Latest
+
+function ConvertFrom-ShardSpec {
+    # Parses and validates a 1-based "N/M" shard spec, returning the shard index and count as a
+    # [pscustomobject] with integer Index and Count properties (both 1-based, exactly as written).
+    # Throws a descriptive terminating error for any malformed spec so the calling recipe aborts.
+    # The caller is responsible for handling the "no sharding" case (an empty spec) BEFORE calling
+    # this: an empty string is not a valid shard spec and is rejected here like any other garbage.
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string] $Spec
+    )
+
+    $parts = $Spec -split '/'
+    if ($parts.Length -ne 2) {
+        throw "Invalid SHARD value '$Spec'. Expected format 'N/M'."
+    }
+
+    $index = 0
+    $count = 0
+    if (-not [int]::TryParse($parts[0], [ref] $index) -or -not [int]::TryParse($parts[1], [ref] $count)) {
+        throw "Invalid SHARD value '$Spec'. N and M must be integers in 'N/M'."
+    }
+
+    if ($count -le 0) {
+        throw "Invalid SHARD value '$Spec'. M must be a positive integer in 'N/M'."
+    }
+
+    if ($index -lt 1 -or $index -gt $count) {
+        throw "Invalid SHARD value '$Spec'. N must satisfy 1 <= N <= M in 'N/M'."
+    }
+
+    return [pscustomobject]@{
+        Index = $index
+        Count = $count
+    }
+}
+
+Export-ModuleMember -Function ConvertFrom-ShardSpec

--- a/scripts/install-actionlint.ps1
+++ b/scripts/install-actionlint.ps1
@@ -44,6 +44,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The pinned actionlint release. Keep $ActionlintVersion and the per-platform digests in

--- a/scripts/install-actionlint.ps1
+++ b/scripts/install-actionlint.ps1
@@ -19,7 +19,7 @@
 
     The default destination is the cargo bin directory. That is a deliberate, if pragmatic,
     choice: actionlint has no standard home to prefer instead, and the cargo bin directory is
-    the one location this repository's developer environment guarantees is already on PATH —
+    the one location this repository's developer environment guarantees is already on PATH -
     every other tool `just install-tools` fetches lands there too.
 
     Idempotent: if the pinned actionlint already resolves on PATH the script does nothing
@@ -48,7 +48,7 @@ Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The pinned actionlint release. Keep $ActionlintVersion and the per-platform digests in
-# $ActionlintBuilds in sync — both come from one GitHub release of rhysd/actionlint.
+# $ActionlintBuilds in sync - both come from one GitHub release of rhysd/actionlint.
 $script:ActionlintVersion = '1.7.12'
 
 # One entry per supported OS/architecture: the release asset name, the archive format it

--- a/scripts/install-azcopy.ps1
+++ b/scripts/install-azcopy.ps1
@@ -46,6 +46,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The pinned azcopy release. Keep $AzCopyVersion and the per-platform digests in

--- a/scripts/install-azcopy.ps1
+++ b/scripts/install-azcopy.ps1
@@ -20,7 +20,7 @@
     The default destination is the cargo bin directory. That is a deliberate, if
     pragmatic, choice: azcopy has no standard home to prefer instead, and the cargo bin
     directory is the one location this repository's developer environment guarantees is
-    already on PATH — every other tool `just install-tools` fetches lands there too.
+    already on PATH - every other tool `just install-tools` fetches lands there too.
     Override -Destination to install elsewhere, but that location must be on PATH for
     `just bench-history-stress-azure` to find azcopy.
 
@@ -50,7 +50,7 @@ Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The pinned azcopy release. Keep $AzCopyVersion and the per-platform digests in
-# $AzCopyBuilds in sync — both come from one GitHub release of azure-storage-azcopy.
+# $AzCopyBuilds in sync - both come from one GitHub release of azure-storage-azcopy.
 $script:AzCopyVersion = '10.32.4'
 
 # One entry per supported OS/architecture: the release asset name, the archive format

--- a/scripts/install-shellcheck.ps1
+++ b/scripts/install-shellcheck.ps1
@@ -50,6 +50,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The pinned ShellCheck release. Keep $ShellcheckVersion and the per-platform digests in

--- a/scripts/install-shellcheck.ps1
+++ b/scripts/install-shellcheck.ps1
@@ -20,12 +20,12 @@
     is baked in below and verified after download, so a tampered or corrupted archive is rejected.
     Bump the version and the digests together when upgrading; the digests are the `digest` fields of
     the pinned release's assets (visible via `gh api repos/koalaman/shellcheck/releases/tags/v<version>`,
-    where `<version>` matches $script:ShellcheckVersion — not `releases/latest`, which would show the
+    where `<version>` matches $script:ShellcheckVersion - not `releases/latest`, which would show the
     digests of whatever the newest release happens to be rather than the one this script pins).
 
     The default destination is the cargo bin directory. That is a deliberate, if pragmatic, choice:
     ShellCheck has no standard home to prefer instead, and the cargo bin directory is the one
-    location this repository's developer environment guarantees is already on PATH — every other
+    location this repository's developer environment guarantees is already on PATH - every other
     tool `just install-tools` fetches lands there too.
 
     Idempotent: if the pinned ShellCheck already resolves on PATH the script does nothing (pass
@@ -54,7 +54,7 @@ Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The pinned ShellCheck release. Keep $ShellcheckVersion and the per-platform digests in
-# $ShellcheckBuilds in sync — both come from one GitHub release of koalaman/shellcheck.
+# $ShellcheckBuilds in sync - both come from one GitHub release of koalaman/shellcheck.
 $script:ShellcheckVersion = '0.11.0'
 
 # One entry per supported OS/architecture: the release asset name, the archive format it ships as,

--- a/scripts/release/BinstallValidation.psm1
+++ b/scripts/release/BinstallValidation.psm1
@@ -9,7 +9,7 @@
 # recipe) and covered by a Pester suite (BinstallValidation.Tests.ps1) so it can be exercised
 # locally against fixtures rather than only in CI.
 
-Set-StrictMode -Version 3.0
+Set-StrictMode -Version Latest
 
 # The exact binstall contract the release workflow publishes. Keep in lockstep with
 # .github/workflows/release.yml (`zip: all`, archive root) and docs/release-automation.md.
@@ -45,6 +45,8 @@ function Test-BinstallMetadata {
     # Validates a single `cargo metadata` package's `[package.metadata.binstall]` against the
     # release workflow's asset-naming contract. Returns the list of human-readable problems for
     # the package; an empty list means the package is compliant.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification = '"Metadata" is a mass noun (the cargo term), not a plural of "metadatum".')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][object] $Package

--- a/scripts/release/ReleaseAutomation.Tests.ps1
+++ b/scripts/release/ReleaseAutomation.Tests.ps1
@@ -330,7 +330,7 @@ Describe 'Get-MissingBinaryMatrix (mocked gh release view)' {
     }
 
     It 'rethrows a gh failure that is not a missing release' {
-        # An auth/network/API error must propagate, not be treated as "no release" — otherwise
+        # An auth/network/API error must propagate, not be treated as "no release" - otherwise
         # the workflow could build an empty matrix and look successful while binaries are missing.
         $crate = [pscustomobject]@{ Name = 'api-error'; Version = '5.0.0' }
         { Get-MissingBinaryMatrix -Crate $crate -Target $script:TwoTargets } | Should -Throw '*503*'

--- a/scripts/release/ReleaseAutomation.Tests.ps1
+++ b/scripts/release/ReleaseAutomation.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Add-GitReleaseEnableFlag (pure line-based injection)' {
     It 'is idempotent: a second pass does not duplicate the flag' {
         $once = Add-GitReleaseEnableFlag -Line $script:SourceLines -CrateName 'demo-tool'
         $twice = Add-GitReleaseEnableFlag -Line $once -CrateName 'demo-tool'
-        ($twice | Where-Object { $_ -eq 'git_release_enable = true' }).Count | Should -Be 1
+        @($twice | Where-Object { $_ -eq 'git_release_enable = true' }).Count | Should -Be 1
     }
 
     It 'forces an existing git_release_enable = false to true' {
@@ -91,13 +91,13 @@ Describe 'Add-GitReleaseEnableFlag (pure line-based injection)' {
         $result | Should -Contain 'git_release_enable = true'
         $result | Should -Not -Contain 'git_release_enable = false'
         # Replaced in place, not duplicated, and the sibling key is preserved.
-        ($result | Where-Object { $_ -match '^git_release_enable' }).Count | Should -Be 1
+        @($result | Where-Object { $_ -match '^git_release_enable' }).Count | Should -Be 1
         $result | Should -Contain 'version_group = "demo"'
     }
 
     It 'enables every requested crate in one pass' {
         $result = Add-GitReleaseEnableFlag -Line $script:SourceLines -CrateName @('demo-tool', 'pub-bin')
-        ($result | Where-Object { $_ -eq 'git_release_enable = true' }).Count | Should -Be 2
+        @($result | Where-Object { $_ -eq 'git_release_enable = true' }).Count | Should -Be 2
     }
 }
 
@@ -345,7 +345,7 @@ Describe 'Get-MissingBinaryMatrix (mocked gh release view)' {
     It 'defaults to the full target set from Get-ReleaseTarget' {
         $crate = [pscustomobject]@{ Name = 'empty-release'; Version = '4.0.0' }
         $rows = Get-MissingBinaryMatrix -Crate $crate
-        $rows.Count | Should -Be (Get-ReleaseTarget).Count
+        @($rows).Count | Should -Be @(Get-ReleaseTarget).Count
     }
 
     It 'reconciles several crates in one pass' {

--- a/scripts/release/ReleaseAutomation.psm1
+++ b/scripts/release/ReleaseAutomation.psm1
@@ -12,7 +12,7 @@
 # I/O) and isolate the ones that would touch crates.io / GitHub for real (`release-plz`, `gh`)
 # behind small seams the tests mock.
 
-Set-StrictMode -Version 3.0
+Set-StrictMode -Version Latest
 
 function Get-ReleaseTarget {
     # The single source of truth for the triple -> runner mapping. The workflow's build matrix
@@ -115,7 +115,7 @@ function New-ReleasePlzConfig {
     # BOM and uses LF line endings with a trailing newline, deterministically on every platform,
     # so the artifact does not vary with the runner OS. The caller writes this outside the
     # working tree so `cargo publish` never sees a dirty repo.
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)][string] $SourcePath,
         [Parameter(Mandatory)][string] $OutputPath,
@@ -125,7 +125,9 @@ function New-ReleasePlzConfig {
     $sourceLines = [System.IO.File]::ReadAllText($SourcePath) -split "`r?`n"
     $newLines = Add-GitReleaseEnableFlag -Line $sourceLines -CrateName $CrateName
     $content = ($newLines -join "`n").TrimEnd("`n") + "`n"
-    [System.IO.File]::WriteAllText($OutputPath, $content, [System.Text.UTF8Encoding]::new($false))
+    if ($PSCmdlet.ShouldProcess($OutputPath, 'write CI release-plz config')) {
+        [System.IO.File]::WriteAllText($OutputPath, $content, [System.Text.UTF8Encoding]::new($false))
+    }
 }
 
 function Get-BinaryReleaseAsset {
@@ -266,6 +268,8 @@ function Invoke-ReleasePublish {
     # versions), so a retry or a whole re-run safely resumes a partially-published release. NOT
     # for local use: it performs real publishes. The native-error preference is disabled locally
     # so a non-zero exit is handled here (turned into a retryable failure) rather than aborting.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ConfigPath',
+        Justification = 'Consumed inside the -Action retry closure (release-plz --config), which the rule does not trace into.')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string] $ConfigPath,
@@ -374,14 +378,14 @@ function Test-NeverPublishedCrate {
 function Set-GitHubOutput {
     # Emits a `name=value` step output for the workflow (and echoes it for the run log). No-ops
     # the file append when GITHUB_OUTPUT is unset, so the recipes are runnable locally.
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)][string] $Name,
         [Parameter(Mandatory)][string] $Value
     )
 
     Write-Host "$Name=$Value"
-    if ($env:GITHUB_OUTPUT) {
+    if ($env:GITHUB_OUTPUT -and $PSCmdlet.ShouldProcess($env:GITHUB_OUTPUT, "append output '$Name'")) {
         Add-Content -Path $env:GITHUB_OUTPUT -Value "$Name=$Value" -Encoding utf8
     }
 }

--- a/scripts/release/ReleaseAutomation.psm1
+++ b/scripts/release/ReleaseAutomation.psm1
@@ -177,15 +177,15 @@ function Get-MissingBinaryMatrix {
         [object[]] $Target = (Get-ReleaseTarget)
     )
 
-    # Verbose emits the full decision history — every crate, its expected tag, whether the
-    # release exists, and the per-target present/missing verdict — so a CI run's log explains
+    # Verbose emits the full decision history - every crate, its expected tag, whether the
+    # release exists, and the per-target present/missing verdict - so a CI run's log explains
     # exactly how the plan (and its emptiness or non-emptiness) was derived, not just the total.
     Write-Verbose "Reconciling desired vs. uploaded binary archives. Crates: $($Crate.Name -join ', '). Target triples: $(($Target.Triple) -join ', ')."
 
     # The loop variables must not differ from the collection parameters ($Crate, $Target) by
     # case alone: PowerShell variable names are case-insensitive, so `foreach ($target in $Target)`
     # would make `$target` and `$Target` the same variable and leave `$Target` holding only its
-    # last element after the loop — so every crate after the first would reconcile against a single
+    # last element after the loop - so every crate after the first would reconcile against a single
     # leftover target (the last one) instead of the full set. Hence $crateInfo / $releaseTarget.
     $rows = [System.Collections.Generic.List[object]]::new()
     foreach ($crateInfo in $Crate) {
@@ -203,10 +203,10 @@ function Get-MissingBinaryMatrix {
         foreach ($releaseTarget in $Target) {
             $archive = "$($crateInfo.Name)-v$($crateInfo.Version)-$($releaseTarget.Triple).zip"
             if ($assets -contains $archive) {
-                Write-Verbose "  Target $($releaseTarget.Triple): '$archive' already uploaded — skipping."
+                Write-Verbose "  Target $($releaseTarget.Triple): '$archive' already uploaded - skipping."
                 continue
             }
-            Write-Verbose "  Target $($releaseTarget.Triple): '$archive' missing — queuing a build on runner '$($releaseTarget.Os)'."
+            Write-Verbose "  Target $($releaseTarget.Triple): '$archive' missing - queuing a build on runner '$($releaseTarget.Os)'."
             $rows.Add([pscustomobject]@{
                     name    = $crateInfo.Name
                     version = $crateInfo.Version


### PR DESCRIPTION
## Why

A recent variable-shadowing bug — `foreach ($target in $Target)`, a case-only collision that PowerShell silently clobbers to the collection's last element — shipped a broken release. Nothing lints our PowerShell, so this whole class of "silly" script bug is caught by luck, not mechanically.

## What

Introduce **PSScriptAnalyzer** as a first-class validation gate and move all **nontrivial** inline PowerShell out of justfile `[script]` blocks and workflow `run:` steps into standalone, linted, Pester-tested modules — so the linter and tests can actually *see* our PowerShell.

### Linting foundation
- **`just validate-scripts`** — PSScriptAnalyzer over `scripts/**` with a curated ruleset (`PSScriptAnalyzerSettings.psd1`) **plus a repo-local custom AST rule** (`scripts/analyzer/FoloAnalyzerRules.psm1`) that flags the exact foreach case-collision that caused the bad release.
- **`just test-scripts`** — the Pester suites. Both gates are wired into `validate-local` and CI (`validation.yml` `test-scripts` job, runs unconditionally since scripts aren't Cargo packages).
- PSScriptAnalyzer pinned via `PSSCRIPTANALYZER_VERSION` in `constants.env`, installed by `just install-tools`.
- Universal `Set-StrictMode -Version Latest` in every module, recipe preamble, and inline workflow pwsh block.

### Inline extraction (each module has a Pester suite)
- **Justfile recipes** → `scripts/build/*.psm1`: cargo-delta, miri shard range, mutants args, shard-spec parsing, mock-engine resolver, callgrind bench discovery, `run-examples`, `test-azurite` helpers.
- **Workflows**:
  - The Azure-federation `constants.env` parsing (duplicated verbatim in `bench-history.yml`'s `collect` + `analyze` jobs) → one shared `scripts/bench-history/AzureFederation.psm1`.
  - The `resolve`-job close loop → `Close-RollingIssue` in `BenchHistoryIssue.psm1` (reuses the mockable `Invoke-GhCapture` seam). The `resolve` job gains a checkout + `contents:read` so it uses the tested module, mirroring how `alert` files via it.
  - `Set-StrictMode` added to every remaining inline workflow pwsh block (bench-history thin steps, release alert, setup-environment toolchain parse). The `validation.yml` Azure-load steps and `start-azurite` are bash (ShellCheck-covered, out of PS scope).

Net ~150 fewer lines of duplicated inline logic despite the added tests.

## Validation

Green on **Windows and under WSL Linux** (these scripts run on Linux in CI):
- `just validate-scripts` — clean
- `just test-scripts` — **184 pass / 0 fail**
- `just validate-workflows` — clean
- `Set-AzureFederationEnv` smoke-tested against the real `constants.env` (produces the identical `AZURE_*` mapping the inline code did).
