### PR TITLE
Pre-build mock engine in mutants recipe to fix flaky timeouts (#349)

### DIFF
--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -72,6 +72,17 @@ mutants SHARD="" CAREFUL='false':
     # This allows mutations that cause infinite loops to hang as expected.
     $env:MUTATION_TESTING = "1"
 
+    # Mirror the `just test*` recipes: pre-build the `mock_bench_engine` test-support binary
+    # and hand its absolute path to the cargo-bench-history integration tests via
+    # MOCK_BENCH_ENGINE. Without this, those tests build the engine on demand inside every
+    # mutant's fresh target tree, and under the CPU contention of a full parallel mutation run
+    # that per-mutant build can push an otherwise-fast test past the `--timeout` ceiling and
+    # report a spurious TIMEOUT (issue #349). The engine is excluded from mutation (see
+    # Get-MutantsExcludeArgument), so a pre-built binary masks no mutant. Build it before
+    # RUSTFLAGS gains `--cfg mutants` below so the artifact matches the one `just test`
+    # produces and neither run churns the other's cache.
+    $env:MOCK_BENCH_ENGINE = just _mock-engine-path | Select-Object -Last 1
+
     # Enable the `mutants` cfg so tests carrying `#[cfg_attr(mutants, ignore = "<why>")]`
     # opt out of mutation runs. cargo-mutants defines no cfg of its own, but it preserves
     # an existing RUSTFLAGS (chaining its own `--cap-lints=warn` onto it), so the flag we


### PR DESCRIPTION
Fixes #349.

## Problem

`just validate-local` runs the `mutants` recipe with a fixed `--timeout=60` and
`--jobs=floor(ncpus/6)+1`. The two `escape_cell` mutants in
`packages/cargo-bench-history/src/analyze/examine.rs` intermittently **timed
out** rather than being caught, failing the run with no real coverage gap.

## Root cause

The `mutants` recipe was the only test-running `just` recipe that did **not**
set `MOCK_BENCH_ENGINE`. cargo-bench-history's integration tests therefore built
the `mock_bench_engine` test-support binary on demand inside every mutant's
fresh target tree. Under the CPU contention of a full parallel mutation run,
those redundant concurrent `cargo build -p mock_bench_engine` invocations
(each spawning rustc) pushed otherwise-fast tests past the 60s ceiling.

## Fix

Mirror the `just test*` recipes: pre-build the engine once and hand its absolute
path to the tests via `MOCK_BENCH_ENGINE`, matching the documented convention
(every recipe that runs the suite pre-builds the engine to avoid per-process
build races). Details:

- The engine is **excluded from mutation** (`Get-MutantsExcludeArgument`), so a
  pre-built binary masks no mutant.
- Built **after** `CARGO_TARGET_DIR` is un-set (lands in the workspace
  `target/mock-engine`, matching `just test`) and **before** `RUSTFLAGS` gains
  `--cfg mutants`, so the artifact matches the one `just test` produces and
  neither run churns the other's cache.

## Verification

- `just --list` parses; `just _mock-engine-path` resolves to an existing
  absolute path.
- Ran both `escape_cell` mutants under the recipe's exact environment
  (`MOCK_BENCH_ENGINE` set, `MUTATION_TESTING=1`, `RUSTFLAGS=--cfg mutants`):
  both **caught**.
