### PR TITLE
Remove the vestigial tip analysis mode from cargo-bench-history

### DIFF
--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -118,9 +118,9 @@ impl Default for AnalysisConfig {
 /// The mode is auto-detected by the caller from git topology and the admitted data
 /// set (a base branch whose tip is its own merge-base with no dirty run admitted on
 /// that tip is [`History`](AnalysisMode::History); commits — or an admitted dirty run
-/// — on top of the base make it [`Branch`](AnalysisMode::Branch)) and may be
-/// overridden with `--mode`. The working tree affects the choice only indirectly,
-/// through the exception that admits a base-tip dirty run while the tree is dirty.
+/// — on top of the base make it [`Branch`](AnalysisMode::Branch)). The working tree
+/// affects the choice only indirectly, through the exception that admits a base-tip
+/// dirty run while the tree is dirty.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnalysisMode {
@@ -138,17 +138,6 @@ impl AnalysisMode {
         match self {
             Self::History => "history",
             Self::Branch => "branch",
-        }
-    }
-
-    /// Parses an explicit `--mode` name, if recognized (`auto` is resolved by the
-    /// caller and is not a mode of its own).
-    #[must_use]
-    pub fn from_name(name: &str) -> Option<Self> {
-        match name {
-            "history" => Some(Self::History),
-            "branch" => Some(Self::Branch),
-            _ => None,
         }
     }
 }
@@ -2422,14 +2411,9 @@ mod tests {
     }
 
     #[test]
-    fn analysis_mode_names_round_trip() {
-        for mode in [AnalysisMode::History, AnalysisMode::Branch] {
-            assert_eq!(AnalysisMode::from_name(mode.as_str()), Some(mode));
-        }
+    fn analysis_mode_wire_names() {
         assert_eq!(AnalysisMode::History.as_str(), "history");
         assert_eq!(AnalysisMode::Branch.as_str(), "branch");
-        assert_eq!(AnalysisMode::from_name("auto"), None);
-        assert_eq!(AnalysisMode::from_name("nonsense"), None);
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/findings.rs
+++ b/packages/cargo-bench-history-core/src/analyze/findings.rs
@@ -77,14 +77,13 @@ pub struct AnalysisConfig {
     /// practice, regardless of statistical significance.
     pub practical_relative: f64,
     /// How many recent base-side points form the level a branch's latest state is
-    /// compared against (branch mode), and the recent base-branch window the newest
-    /// point is compared against (tip mode).
+    /// compared against (branch mode).
     pub compare_window: usize,
     /// Minimum relative magnitude a noisy *branch* move must reach. Raised above the
     /// history floor: a feature-branch signal must be high-confidence, since we
     /// would rather miss a small move than cry wolf on a pull request.
     pub branch_practical_relative: f64,
-    /// Multiple of the per-measurement noise floor a noisy branch/tip move with too
+    /// Multiple of the per-measurement noise floor a noisy branch move with too
     /// few points to rank-test must exceed before it is trusted.
     pub branch_noise_multiple: f64,
     /// Multiple of a series' own between-commit residual scatter (median absolute
@@ -122,7 +121,6 @@ impl Default for AnalysisConfig {
 /// — on top of the base make it [`Branch`](AnalysisMode::Branch)) and may be
 /// overridden with `--mode`. The working tree affects the choice only indirectly,
 /// through the exception that admits a base-tip dirty run while the tree is dirty.
-/// [`Tip`](AnalysisMode::Tip) is never auto-selected; it is an explicit guard mode.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnalysisMode {
@@ -131,8 +129,6 @@ pub enum AnalysisMode {
     /// Latest-state comparison of a feature branch against its base, ignoring the
     /// intermediate stages the branch passed through.
     Branch,
-    /// Guard check of the newest point against the recent base-branch level.
-    Tip,
 }
 
 impl AnalysisMode {
@@ -142,7 +138,6 @@ impl AnalysisMode {
         match self {
             Self::History => "history",
             Self::Branch => "branch",
-            Self::Tip => "tip",
         }
     }
 
@@ -153,7 +148,6 @@ impl AnalysisMode {
         match name {
             "history" => Some(Self::History),
             "branch" => Some(Self::Branch),
-            "tip" => Some(Self::Tip),
             _ => None,
         }
     }
@@ -175,13 +169,11 @@ pub struct AnalysisContext {
     /// treated as branch-side). Consulted only in [`AnalysisMode::Branch`].
     pub merge_base_index: Option<usize>,
     /// Whether improvements are reported. History mode defaults to regressions only
-    /// (scheduled drift watch); branch mode always reports both; tip mode reports
-    /// regressions only.
+    /// (scheduled drift watch); branch mode always reports both.
     pub include_improvements: bool,
     /// Whether *inactive* (recovered) findings are reported. History mode hides a
     /// change whose level has since returned to baseline unless this is set; branch
-    /// and tip modes only ever look at the latest state, so they have no inactive
-    /// findings.
+    /// mode only ever looks at the latest state, so it has no inactive findings.
     pub include_inactive: bool,
 }
 
@@ -193,13 +185,12 @@ impl AnalysisContext {
                 direction == Direction::Regression || self.include_improvements
             }
             AnalysisMode::Branch => true,
-            AnalysisMode::Tip => direction == Direction::Regression,
         }
     }
 
     /// Whether this analysis reports improvements at all. `false` for the
-    /// regressions-only cases (history mode's default drift watch, and tip mode),
-    /// where an always-zero improvement tally is noise the report omits.
+    /// regressions-only case (history mode's default drift watch), where an
+    /// always-zero improvement tally is noise the report omits.
     #[must_use]
     pub fn reports_improvements(&self) -> bool {
         self.keeps(Direction::Improvement)
@@ -274,8 +265,8 @@ pub struct Finding {
     pub flipped_at: Option<String>,
     /// Whether the change is still reflected in the latest measured state. An active
     /// finding's current level still differs from baseline; an inactive one has
-    /// since recovered (history mode only — branch and tip always look at the latest
-    /// state, so their findings are always active).
+    /// since recovered (history mode only — branch always looks at the latest
+    /// state, so its findings are always active).
     pub active: bool,
     /// Index into `series` at which the active (post-blessing) window begins; points
     /// before it are pre-blessing history, retained for charting but excluded from
@@ -866,29 +857,6 @@ fn evaluate_branch(
     )
 }
 
-/// Evaluates a series in *tip* mode: compares the newest point against the recent
-/// base-branch level. A guard for "did the latest commit regress?".
-fn evaluate_tip(series: &Series, config: &AnalysisConfig) -> Option<Candidate> {
-    let points = &series.points;
-    let n = points.len();
-    if n < 2 {
-        return None;
-    }
-    let all: Vec<&SeriesPoint> = points.iter().collect();
-    let (preceding, tip) = all.split_at(n.saturating_sub(1));
-    let before = recent(preceding, config.compare_window);
-    let commit = tip.first().and_then(|&point| owned_commit(point));
-    compare_samples(
-        series,
-        &before,
-        tip,
-        config,
-        config.practical_relative,
-        commit,
-        None,
-    )
-}
-
 /// The post-blessing window of `series` as a standalone series for detection.
 ///
 /// History-mode detection runs on this view so a blessed (re-baselined) series is
@@ -1060,7 +1028,7 @@ pub(super) fn find_changes(series: &[Series], context: &AnalysisContext) -> Vec<
 ///
 /// The [`AnalysisContext`] selects the per-series detector: history mode locates a
 /// change-point and a drift and keeps the better-fitting one; branch mode compares
-/// the branch's latest state against its base; tip mode guards the newest point.
+/// the branch's latest state against its base.
 /// Surviving candidates pass a Benjamini–Hochberg false-discovery filter at
 /// `config.fdr_q`. Findings are then filtered to the directions the mode reports and
 /// ordered by descending relative move, then method, then a stable identity
@@ -1210,7 +1178,7 @@ fn detect_range(
 /// This is pure and depends on no other series, which is what lets
 /// [`find_changes_spawned`] evaluate the series across workers. History mode locates a
 /// change-point and a drift and keeps the better-fitting one (optionally surfacing a
-/// recovered spike); branch and tip modes delegate to their dedicated detectors.
+/// recovered spike); branch mode delegates to its dedicated detector.
 /// `index` is the series' position in the analysed slice, stamped onto the candidate so
 /// the finalize tail can materialise its charting points only if it survives filtering.
 fn detect_one(index: usize, one: &Series, context: &AnalysisContext) -> Option<Candidate> {
@@ -1235,7 +1203,6 @@ fn detect_one(index: usize, one: &Series, context: &AnalysisContext) -> Option<C
             })
         }
         AnalysisMode::Branch => evaluate_branch(one, config, context.merge_base_index),
-        AnalysisMode::Tip => evaluate_tip(one, config),
     };
     candidate.map(|mut candidate| {
         candidate.source_index = index;
@@ -2032,10 +1999,10 @@ mod tests {
         assert_eq!(findings[1].latest, 150.0);
     }
 
-    // -- Branch and tip modes -------------------------------------------------
+    // -- Branch mode ----------------------------------------------------------
 
     /// Builds a Callgrind-style series from explicit `(topo_index, value, dirty)`
-    /// points, so branch/tip splits can be modelled precisely. Points are taken in
+    /// points, so branch splits can be modelled precisely. Points are taken in
     /// the given order (already topological).
     fn placed_series(points: &[(usize, f64, bool)]) -> Series {
         let points = points
@@ -2072,20 +2039,6 @@ mod tests {
                 mode: AnalysisMode::Branch,
                 config: AnalysisConfig::default(),
                 merge_base_index,
-                include_improvements: false,
-                include_inactive: false,
-            },
-        )
-    }
-
-    /// Runs the tip-mode guard with default config.
-    fn tip_changes(series: &[Series]) -> Vec<Finding> {
-        find_changes(
-            series,
-            &AnalysisContext {
-                mode: AnalysisMode::Tip,
-                config: AnalysisConfig::default(),
-                merge_base_index: None,
                 include_improvements: false,
                 include_inactive: false,
             },
@@ -2186,40 +2139,6 @@ mod tests {
         let finding = only(branch_changes(&[series], Some(2)));
         assert_eq!(finding.direction, Direction::Regression);
         assert_eq!(finding.latest, 130.0);
-    }
-
-    #[test]
-    fn tip_mode_flags_a_regression_at_the_newest_point() {
-        let series = placed_series(&[
-            (0, 100.0, false),
-            (1, 100.0, false),
-            (2, 100.0, false),
-            (3, 100.0, false),
-            (4, 130.0, false),
-        ]);
-        let finding = only(tip_changes(&[series]));
-        assert_eq!(finding.direction, Direction::Regression);
-        assert_eq!(finding.latest, 130.0);
-        assert_eq!(finding.commit.as_deref(), Some("commit4"));
-    }
-
-    #[test]
-    fn tip_mode_suppresses_an_improvement_at_the_newest_point() {
-        // Tip mode is a regression guard only; a faster tip is not reported.
-        let series = placed_series(&[
-            (0, 100.0, false),
-            (1, 100.0, false),
-            (2, 100.0, false),
-            (3, 100.0, false),
-            (4, 70.0, false),
-        ]);
-        assert!(tip_changes(&[series]).is_empty());
-    }
-
-    #[test]
-    fn tip_mode_needs_at_least_two_points() {
-        let series = placed_series(&[(0, 100.0, false)]);
-        assert!(tip_changes(&[series]).is_empty());
     }
 
     // -- Blessing (re-baselining) and recovered spikes ------------------------
@@ -2420,15 +2339,6 @@ mod tests {
     }
 
     #[test]
-    fn tip_mode_flags_a_two_point_regression() {
-        // Two points is the minimum for a tip comparison; `n < 2` must be a strict
-        // `<` (a `<=`/`==` mutant would bail on the two-point case).
-        let series = series_of(&[100.0, 130.0]);
-        let candidate = evaluate_tip(&series, &AnalysisConfig::default()).unwrap();
-        assert_eq!(candidate.finding.direction, Direction::Regression);
-    }
-
-    #[test]
     fn latest_regime_splits_a_three_point_branch_at_a_real_flip() {
         // Three points is the minimum to split; `branch.len() < 3` must be a strict
         // `<` (a `<=`/`==` mutant would keep the branch whole). The 100 -> 130 jump
@@ -2513,16 +2423,11 @@ mod tests {
 
     #[test]
     fn analysis_mode_names_round_trip() {
-        for mode in [
-            AnalysisMode::History,
-            AnalysisMode::Branch,
-            AnalysisMode::Tip,
-        ] {
+        for mode in [AnalysisMode::History, AnalysisMode::Branch] {
             assert_eq!(AnalysisMode::from_name(mode.as_str()), Some(mode));
         }
         assert_eq!(AnalysisMode::History.as_str(), "history");
         assert_eq!(AnalysisMode::Branch.as_str(), "branch");
-        assert_eq!(AnalysisMode::Tip.as_str(), "tip");
         assert_eq!(AnalysisMode::from_name("auto"), None);
         assert_eq!(AnalysisMode::from_name("nonsense"), None);
     }
@@ -2552,12 +2457,11 @@ mod tests {
             include_inactive: false,
         };
         // History reports improvements only when opted in; branch always compares
-        // both directions; tip (regressions-only) never reports them. Pinning both a
-        // true and a false case keeps the flag from collapsing to a constant.
+        // both directions. Pinning both a true and a false case keeps the flag from
+        // collapsing to a constant.
         assert!(!context(AnalysisMode::History, false).reports_improvements());
         assert!(context(AnalysisMode::History, true).reports_improvements());
         assert!(context(AnalysisMode::Branch, false).reports_improvements());
-        assert!(!context(AnalysisMode::Tip, false).reports_improvements());
     }
 
     #[test]

--- a/packages/cargo-bench-history-core/src/analyze/report.rs
+++ b/packages/cargo-bench-history-core/src/analyze/report.rs
@@ -82,7 +82,7 @@ pub struct ReportInput<'a> {
     /// checkout differs from the committed tip. False for a clean tree (the CI
     /// collection case).
     pub tip_dirty: bool,
-    /// The analysis mode the report was produced in (`history`/`branch`/`tip`).
+    /// The analysis mode the report was produced in (`history`/`branch`).
     pub mode: &'a str,
     /// Whether any finding survived — the at-a-glance signal a downstream
     /// automation reads to decide whether the report is worth surfacing.
@@ -97,7 +97,7 @@ pub struct ReportInput<'a> {
     /// entered the analysis.
     pub commit_span: Option<(&'a str, &'a str)>,
     /// Whether this analysis reports improvements. When `false` (history mode's
-    /// default regressions-only watch, and tip mode) the text and Markdown reports
+    /// default regressions-only watch) the text and Markdown reports
     /// omit the improvement tally, which would always be zero. The JSON report always
     /// carries it.
     pub report_improvements: bool,
@@ -217,7 +217,7 @@ struct JsonReport<'a> {
     tip_commit: &'a str,
     /// Whether the working tree carried uncommitted changes when the analysis ran.
     tip_dirty: bool,
-    /// The analysis mode (`history`/`branch`/`tip`).
+    /// The analysis mode (`history`/`branch`).
     mode: &'a str,
     /// Whether any finding survived — the downstream automation signal.
     notable: bool,
@@ -375,7 +375,7 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
     }
 
     // A per-commit chart is meaningful only for a history (`master`) timeline; the
-    // branch/tip modes compare against a baseline rather than walking a series.
+    // branch mode compares against a baseline rather than walking a series.
     let chart_enabled = input.mode == "history";
     for summary in input.sets {
         if summary.findings.is_empty() {
@@ -619,7 +619,7 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
     }
 
     // A per-commit chart is meaningful only for a history timeline, matching the
-    // text report; branch/tip modes compare against a baseline.
+    // text report; branch mode compares against a baseline.
     let chart_enabled = input.mode == "history";
     for summary in input.sets {
         if summary.findings.is_empty() {
@@ -710,7 +710,7 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -
     }
 
     // A per-commit chart is meaningful only for a history timeline, matching the full
-    // reports; branch/tip modes compare against a baseline.
+    // reports; branch mode compares against a baseline.
     let chart_enabled = input.mode == "history";
     for finding in input.findings.iter().take(limit.get()) {
         push_finding_markdown(&mut lines, finding, "##", chart_enabled);

--- a/packages/cargo-bench-history-core/src/analyze/series.rs
+++ b/packages/cargo-bench-history-core/src/analyze/series.rs
@@ -477,7 +477,7 @@ impl SeriesBuilder {
 /// series' `active_start` is set to the first point at or after that commit, so the
 /// detector only sees the post-blessing window while the full series is retained
 /// for charting. A series with no matching blessing is left untouched
-/// (`active_start = 0`). Branch and tip modes pass an empty map and so are
+/// (`active_start = 0`). Branch mode passes an empty map and so is
 /// unaffected.
 ///
 /// Each blessing carries the committer date of its commit (resolved from git

--- a/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
+++ b/packages/cargo-bench-history-core/src/analyze/signal_validation.rs
@@ -14,24 +14,23 @@
 //! findings the spawner-distributed production path
 //! ([`find_changes_spawned`](super::find_changes_spawned)) does.
 //!
-//! Every case is run through a 3 × 2 × 2 matrix:
+//! Every case is run through a 2 × 2 × 2 matrix:
 //!
-//! * **Analysis mode (dimension 1).** The three modes are *different detectors*, not
+//! * **Analysis mode (dimension 1).** The two modes are *different detectors*, not
 //!   one detector with a flag: [`History`](AnalysisMode::History) locates a change-point
-//!   over the whole series, [`Branch`](AnalysisMode::Branch) compares the branch's
-//!   latest regime against the base level across a merge-base split, and
-//!   [`Tip`](AnalysisMode::Tip) compares only the newest point against its recent
-//!   window. Because each inspects a different slice, the *same* series yields different
+//!   over the whole series, and [`Branch`](AnalysisMode::Branch) compares the branch's
+//!   latest regime against the base level across a merge-base split. Because each
+//!   inspects a different slice, the *same* series yields different
 //!   verdicts per mode, so mode is a curated dimension: every case states the outcome
-//!   each mode is expected to see. An obvious mid-series step is a rise to history and
-//!   branch but invisible to tip (whose window has already caught up); a lone
-//!   final-point jump is a rise to tip and branch but not a sustained historical trend.
+//!   each mode is expected to see. An obvious mid-series step is a rise to both history
+//!   and branch; a lone final-point jump is a rise to branch (a single elevated regime
+//!   past the split) but not a sustained historical trend to history.
 //!   Branch mode also needs a base side to compare against at all — a case with an empty
 //!   base side leaves it quiet.
 //! * **Polarity (dimension 2).** The codebase's only polarity lever is the metric kind,
 //!   so *higher-is-worse* is modelled with a lower-is-better metric
 //!   ([`MetricKind::InstructionCount`]) and *lower-is-worse* with the one
-//!   higher-is-better metric ([`MetricKind::L1CacheHits`]). History and tip report the
+//!   higher-is-better metric ([`MetricKind::L1CacheHits`]). History reports the
 //!   worse direction only, so a move surfaces as a finding under one polarity and is a
 //!   suppressed improvement under the other; branch reports *both* directions, so a move
 //!   is a finding under either polarity (only its classification differs). The expected
@@ -94,7 +93,7 @@ impl Polarity {
 
 /// The analysis mode a case is evaluated under — the suite's dimension-1 lever.
 ///
-/// The three modes are genuinely different detectors, so a case declares its expected
+/// The two modes are genuinely different detectors, so a case declares its expected
 /// move per mode rather than sharing one verdict across them.
 #[derive(Clone, Copy, Debug)]
 enum Mode {
@@ -102,33 +101,30 @@ enum Mode {
     History,
     /// The branch's latest regime against the base level, across a merge-base split.
     Branch,
-    /// The newest point against its recent window.
-    Tip,
 }
 
 impl Mode {
-    /// The three modes, for matrix expansion.
-    const ALL: [Self; 3] = [Self::History, Self::Branch, Self::Tip];
+    /// The two modes, for matrix expansion.
+    const ALL: [Self; 2] = [Self::History, Self::Branch];
 
     /// Whether this mode reports improvements as findings. Only branch does: history is
-    /// run here as a regressions-only drift watch (`include_improvements = false`) and
-    /// tip is a regression guard, so for those an improvement is a non-finding.
+    /// run here as a regressions-only drift watch (`include_improvements = false`), so
+    /// for it an improvement is a non-finding.
     fn reports_improvements(self) -> bool {
         matches!(self, Self::Branch)
     }
 
     /// The analysis context this mode is evaluated under. `merge_base_index` is consulted
-    /// only by branch mode; the other modes ignore it.
+    /// only by branch mode; history ignores it.
     ///
     /// `include_improvements` is set from [`reports_improvements`](Self::reports_improvements)
     /// so the context matches the mode's intended reporting semantics: branch (which
-    /// reports both directions) opts in, history and tip opt out. Branch mode ignores the
+    /// reports both directions) opts in, history opts out. Branch mode ignores the
     /// flag today, but pinning it consistently keeps the context correct if that changes.
     fn context(self, merge_base_index: Option<usize>) -> AnalysisContext {
         let mode = match self {
             Self::History => AnalysisMode::History,
             Self::Branch => AnalysisMode::Branch,
-            Self::Tip => AnalysisMode::Tip,
         };
         AnalysisContext {
             mode,
@@ -173,7 +169,7 @@ impl Outcome {
     }
 }
 
-/// One curated series — its base and branch/tip sides — and the outcome each mode is
+/// One curated series — its base and branch sides — and the outcome each mode is
 /// expected to see in it.
 struct SignalCase {
     /// Human-readable case name, surfaced in assertion failures.
@@ -181,29 +177,27 @@ struct SignalCase {
     /// The base-side (unscaled) series values, oldest-first: the commits at or before
     /// the merge-base. May be empty, which leaves branch mode without a base side to
     /// compare against, so it stays quiet. The base/branch split matters only to branch
-    /// mode; history and tip see the whole concatenated series and read these values as
+    /// mode; history sees the whole concatenated series and reads these values as
     /// ordinary leading points, indifferent to which side they came from.
     base: Vec<f64>,
-    /// The branch/tip-side (unscaled) series values, oldest-first: the commits past the
+    /// The branch-side (unscaled) series values, oldest-first: the commits past the
     /// merge-base. May be empty.
     branch: Vec<f64>,
     /// The outcome history mode's change-point detector is expected to see.
     expected_history: Outcome,
     /// The outcome branch mode is expected to see.
     expected_branch: Outcome,
-    /// The outcome tip mode is expected to see.
-    expected_tip: Outcome,
 }
 
 impl SignalCase {
-    /// The whole series, the base side followed by the branch/tip side, oldest-first.
+    /// The whole series, the base side followed by the branch side, oldest-first.
     fn values(&self) -> Vec<f64> {
         [self.base.as_slice(), self.branch.as_slice()].concat()
     }
 
     /// The first-parent merge-base split index handed to branch mode: the last base-side
     /// point, or `None` when there is no base side (branch mode then has nothing to
-    /// compare against and stays quiet). History and tip ignore it.
+    /// compare against and stays quiet). History ignores it.
     fn merge_base_index(&self) -> Option<usize> {
         self.base.len().checked_sub(1)
     }
@@ -213,7 +207,6 @@ impl SignalCase {
         match mode {
             Mode::History => self.expected_history,
             Mode::Branch => self.expected_branch,
-            Mode::Tip => self.expected_tip,
         }
     }
 }
@@ -227,15 +220,13 @@ fn run_of(value: f64, count: usize) -> Vec<f64> {
 fn cases() -> Vec<SignalCase> {
     vec![
         // An unmistakable sustained doubling halfway through. History and branch (split
-        // at the step) both see a rise; tip is quiet because its recent window already
-        // sits at the new, higher level.
+        // at the step) both see a rise.
         SignalCase {
             name: "doubling_step",
             base: run_of(100.0, 50),
             branch: run_of(200.0, 50),
             expected_history: Outcome::Rise,
             expected_branch: Outcome::Rise,
-            expected_tip: Outcome::Quiet,
         },
         // The mirror image: a sustained halving. Same mode geometry, opposite direction,
         // so it exercises the other polarity's finding path.
@@ -245,18 +236,15 @@ fn cases() -> Vec<SignalCase> {
             branch: run_of(100.0, 50),
             expected_history: Outcome::Fall,
             expected_branch: Outcome::Fall,
-            expected_tip: Outcome::Quiet,
         },
-        // A jump confined to the final commit. Tip and branch (split just before the
-        // jump) see the rise; history does not, since one trailing point is not a
-        // sustained trend.
+        // A jump confined to the final commit. Branch (split just before the jump) sees
+        // the rise; history does not, since one trailing point is not a sustained trend.
         SignalCase {
             name: "tip_spike",
             base: run_of(100.0, 99),
             branch: run_of(200.0, 1),
             expected_history: Outcome::Quiet,
             expected_branch: Outcome::Rise,
-            expected_tip: Outcome::Rise,
         },
         // The mirror image at the tip: the final commit drops.
         SignalCase {
@@ -265,7 +253,6 @@ fn cases() -> Vec<SignalCase> {
             branch: run_of(100.0, 1),
             expected_history: Outcome::Quiet,
             expected_branch: Outcome::Fall,
-            expected_tip: Outcome::Fall,
         },
         // A dead-flat line: nothing moved, so no mode and no polarity should ever flag it.
         SignalCase {
@@ -274,7 +261,6 @@ fn cases() -> Vec<SignalCase> {
             branch: run_of(100.0, 50),
             expected_history: Outcome::Quiet,
             expected_branch: Outcome::Quiet,
-            expected_tip: Outcome::Quiet,
         },
         // The same obvious doubling as the first case, but with no base side. Branch
         // mode has nothing to compare the branch against, so it must stay quiet even
@@ -285,7 +271,6 @@ fn cases() -> Vec<SignalCase> {
             branch: [run_of(100.0, 50), run_of(200.0, 50)].concat(),
             expected_history: Outcome::Rise,
             expected_branch: Outcome::Quiet,
-            expected_tip: Outcome::Quiet,
         },
     ]
 }

--- a/packages/cargo-bench-history-stress/README.md
+++ b/packages/cargo-bench-history-stress/README.md
@@ -2,7 +2,7 @@
 
 An **on-demand** stress harness for [`cargo-bench-history`](../cargo-bench-history)'s
 `analyze` command. It fabricates a giant synthetic benchmark history, seeds it into a
-storage backend, then times each analysis mode (`history`, `branch`, `tip`) over it.
+storage backend, then times each analysis mode (`history`, `branch`) over it.
 
 The dataset is *invented*, not measured. The point is to put the real `analyze`
 data-loading and detection path under a realistic, large-scale load so the per-mode
@@ -54,7 +54,7 @@ store the same shape plus a tight confidence band — kept well below the inject
 magnitudes — so the seeded findings still surface while the noise-aware detection path is
 exercised too. Each benchmark belongs to a *family* (`index % 5`) that fixes its
 timeline shape (gradual drift, mid-step up, step down, blessable step, stable), and a
-couple of cross-cutting rules inject `tip`-only and `branch`-only changes. The result
+cross-cutting rule injects a `branch`-only change. The result
 is that each mode reports a sensible, explainable *mix* of regressions and
 improvements rather than flagging everything or nothing. See the module docs in
 `src/scenario.rs` for the exact family/divisor math.
@@ -111,7 +111,7 @@ distorts the timings badly.
 | `--dir <PATH>` | temp dir | Local-storage root (local only). |
 | `--account <NAME>` | `$BENCH_HISTORY_TEST_AZURE_ACCOUNT` | Azure storage account (Azure only). |
 | `--container <NAME>` | `bh-stress-<unix>` | Azure container (Azure only). |
-| `--modes <list>` | `history,branch,tip` | Modes to measure (comma-separated). |
+| `--modes <list>` | `history,branch` | Modes to measure (comma-separated). |
 | `--repeat <N>` | `1` | Runs per mode (fastest is reported). |
 | `--keep` | off | Keep the seeded data instead of cleaning up. |
 | `--verbose` | off | Explanatory diagnostics on stderr. |
@@ -135,5 +135,4 @@ mode        duration   objects   series  regressions  improvements  notable
 ----        --------   -------   ------  -----------  ------------  -------
 history     240.400s     20040    20000        11400          4000      yes
 branch       81.164s     20220    20000         8119             0      yes
-tip         126.255s     20040    20000         4228             0      yes
 ```

--- a/packages/cargo-bench-history-stress/src/cli.rs
+++ b/packages/cargo-bench-history-stress/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use clap::{Parser, ValueEnum};
 
 /// Seeds a giant synthetic benchmark history into a `cargo-bench-history` storage
-/// backend, then times each analysis mode (`history`, `branch`, `tip`) over it.
+/// backend, then times each analysis mode (`history`, `branch`) over it.
 ///
 /// The dataset is fabricated, not measured: it exists purely to put the `analyze`
 /// data-loading and detection path under a realistic, large-scale load so the
@@ -64,7 +64,7 @@ pub(crate) struct Cli {
         long,
         value_enum,
         value_delimiter = ',',
-        default_value = "history,branch,tip"
+        default_value = "history,branch"
     )]
     pub(crate) modes: Vec<ModeArg>,
 
@@ -103,8 +103,6 @@ pub(crate) enum ModeArg {
     History,
     /// Feature-branch comparison of the branch tip against the base branch.
     Branch,
-    /// Fast single-commit guard comparing the latest commit to the recent level.
-    Tip,
 }
 
 impl ModeArg {
@@ -113,7 +111,6 @@ impl ModeArg {
         match self {
             Self::History => "history",
             Self::Branch => "branch",
-            Self::Tip => "tip",
         }
     }
 }

--- a/packages/cargo-bench-history-stress/src/cli.rs
+++ b/packages/cargo-bench-history-stress/src/cli.rs
@@ -106,7 +106,7 @@ pub(crate) enum ModeArg {
 }
 
 impl ModeArg {
-    /// The `--mode` keyword the analyze command expects.
+    /// The lowercase label for this analysis mode, used in logs and the report.
     pub(crate) fn keyword(self) -> &'static str {
         match self {
             Self::History => "history",

--- a/packages/cargo-bench-history-stress/src/lib.rs
+++ b/packages/cargo-bench-history-stress/src/lib.rs
@@ -8,7 +8,7 @@
 //! (Callgrind on Linux only; Criterion, `alloc_tracker`, and `all_the_time` on
 //! all of {windows, linux, macos} × {x64, arm}), plus a short feature branch with
 //! dirty snapshots and a few blessings — seeds it into a configured storage
-//! backend, then times each analysis mode (`history`, `branch`, `tip`) over it.
+//! backend, then times each analysis mode (`history`, `branch`) over it.
 //! The dataset is invented, not measured: its only purpose is to put the real
 //! `analyze` data-loading and detection path under a realistic, large-scale load
 //! so the per-mode wall-clock cost can be observed against either

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -248,7 +248,6 @@ fn build_options(
             Some(FULL_HISTORY_SINCE.to_owned()),
         ),
         ModeArg::Branch => (BRANCH_FEATURE, BRANCH_MAIN, None),
-        ModeArg::Tip => (BRANCH_MAIN, BRANCH_MAIN, None),
     };
     AnalyzeOptions {
         config_path: Some(config_path(workspace)),

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -271,7 +271,6 @@ fn build_options(
         markdown: None,
         json: Some(PathBuf::from(ANALYZE_REPORT_FILE)),
         markdown_summary: None,
-        mode: Some(mode.keyword().to_owned()),
         include_improvements: true,
         include_inactive: false,
         verbose: false,

--- a/packages/cargo-bench-history-stress/src/scenario.rs
+++ b/packages/cargo-bench-history-stress/src/scenario.rs
@@ -25,10 +25,8 @@
 //!   flagged elsewhere),
 //! * family 4 — stable.
 //!
-//! Two cross-cutting steps drive the other modes: a single-point step on the
-//! latest `main` commit for `b % TIP_DIVISOR == 0` (a `tip`-mode regression that
-//! is too short-lived to confirm in `history` mode), and an elevation on the
-//! feature branch for `b % BRANCH_DIVISOR == 0` (a `branch`-mode regression).
+//! One cross-cutting step drives the other mode: an elevation on the feature
+//! branch for `b % BRANCH_DIVISOR == 0` (a `branch`-mode regression).
 
 // The synthetic values are illustrative magnitudes, not real measurements:
 // bounded small-integer index arithmetic and lossy integer/f64 conversions here
@@ -72,11 +70,6 @@ const BLESSABLE_FAMILY: usize = 3;
 /// rest keep the un-blessed step, so the two cases contrast in one run.
 const BLESSED_SET_LIMIT: usize = 3;
 
-/// Every benchmark whose index is a multiple of this gets a single-point step on
-/// the latest `main` commit — a `tip`-mode regression too short to confirm in
-/// `history` mode.
-const TIP_DIVISOR: usize = 7;
-
 /// Every benchmark whose index is a multiple of this is elevated on the feature
 /// branch — a `branch`-mode regression.
 const BRANCH_DIVISOR: usize = 3;
@@ -108,9 +101,6 @@ const STEP_IMPROVEMENT: f64 = 0.10;
 
 /// Relative size of the family-3 blessable step.
 const BLESSABLE_STEP: f64 = 0.12;
-
-/// Relative size of the single-point tip regression.
-const TIP_REGRESSION: f64 = 0.25;
 
 /// Relative size of the feature-branch regression.
 const BRANCH_REGRESSION: f64 = 0.20;
@@ -248,7 +238,7 @@ impl Scenario {
     /// Roughly half the commits do — every even index — so the analysis walks a
     /// git topology in which many commits have no stored result, exercising the
     /// "commit with no run" path that a real, sparsely-benchmarked history hits.
-    /// The tip and the blessed commit are always populated so `tip`/`branch`
+    /// The tip and the blessed commit are always populated so `history`/`branch`
     /// detection and blessing stay well-defined regardless of where the parity
     /// falls.
     pub(crate) fn commit_has_run(&self, index: usize) -> bool {
@@ -273,9 +263,8 @@ impl Scenario {
     }
 
     /// The clean instruction count for benchmark `b` in set `s` at `main` commit
-    /// index `i`. `apply_tip` includes the single-point tip step (present only on
-    /// the latest commit of the base branch, absent from a branch baseline).
-    pub(crate) fn main_clean_value(&self, b: usize, s: usize, i: usize, apply_tip: bool) -> f64 {
+    /// index `i`.
+    pub(crate) fn main_clean_value(&self, b: usize, s: usize, i: usize) -> f64 {
         let base = self.base_value(b, s);
         let count = self.commits;
         let position = if count > 1 {
@@ -295,18 +284,15 @@ impl Scenario {
             3 if i >= self.bless_index() => value += base * BLESSABLE_STEP,
             _ => {}
         }
-        if apply_tip && i + 1 == count && b.is_multiple_of(TIP_DIVISOR) {
-            value += base * TIP_REGRESSION;
-        }
         value
     }
 
     /// The clean instruction count for benchmark `b` in set `s` on the feature
-    /// branch. The baseline is the family's settled end-of-history level (without
-    /// the base branch's tip-only step); `b % BRANCH_DIVISOR == 0` benchmarks are
-    /// elevated to introduce a branch regression.
+    /// branch. The baseline is the family's settled end-of-history level;
+    /// `b % BRANCH_DIVISOR == 0` benchmarks are elevated to introduce a branch
+    /// regression.
     pub(crate) fn feature_clean_value(&self, b: usize, s: usize) -> f64 {
-        let baseline = self.main_clean_value(b, s, self.commits.saturating_sub(1), false);
+        let baseline = self.main_clean_value(b, s, self.commits.saturating_sub(1));
         if b.is_multiple_of(BRANCH_DIVISOR) {
             baseline + self.base_value(b, s) * BRANCH_REGRESSION
         } else {
@@ -491,10 +477,10 @@ mod tests {
     #[test]
     fn family_zero_drifts_monotonically_upward() {
         let s = scenario();
-        // b = 5 is family 0 (5 % 5) and not a tip benchmark (5 % 7 != 0), so the
-        // value rises purely from drift across the whole history.
+        // b = 5 is family 0 (5 % 5), so the value rises purely from drift across
+        // the whole history.
         let series: Vec<f64> = (0..s.commits)
-            .map(|i| s.main_clean_value(5, 0, i, true))
+            .map(|i| s.main_clean_value(5, 0, i))
             .collect();
         for pair in series.windows(2) {
             assert!(pair[1] > pair[0], "expected rising drift, got {series:?}");
@@ -509,9 +495,9 @@ mod tests {
         let s = scenario();
         let base = s.base_value(1, 0);
         // commits = 4 -> step when 2*i >= 4, i.e. i >= 2.
-        assert!(close(s.main_clean_value(1, 0, 1, false), base));
+        assert!(close(s.main_clean_value(1, 0, 1), base));
         assert!(close(
-            s.main_clean_value(1, 0, 2, false),
+            s.main_clean_value(1, 0, 2),
             base * (1.0 + STEP_REGRESSION)
         ));
     }
@@ -521,9 +507,9 @@ mod tests {
         let s = scenario();
         let base = s.base_value(2, 0);
         // commits = 4 -> step when 10*i >= 28, i.e. i >= 3.
-        assert!(close(s.main_clean_value(2, 0, 2, false), base));
+        assert!(close(s.main_clean_value(2, 0, 2), base));
         assert!(close(
-            s.main_clean_value(2, 0, 3, false),
+            s.main_clean_value(2, 0, 3),
             base * (1.0 - STEP_IMPROVEMENT)
         ));
     }
@@ -534,9 +520,9 @@ mod tests {
         let base = s.base_value(3, 0);
         let bless = s.bless_index();
         assert_eq!(bless, 2);
-        assert!(close(s.main_clean_value(3, 0, bless - 1, false), base));
+        assert!(close(s.main_clean_value(3, 0, bless - 1), base));
         assert!(close(
-            s.main_clean_value(3, 0, bless, false),
+            s.main_clean_value(3, 0, bless),
             base * (1.0 + BLESSABLE_STEP)
         ));
     }
@@ -546,30 +532,8 @@ mod tests {
         let s = scenario();
         let base = s.base_value(4, 0);
         for i in 0..s.commits {
-            assert!(close(s.main_clean_value(4, 0, i, true), base));
+            assert!(close(s.main_clean_value(4, 0, i), base));
         }
-    }
-
-    #[test]
-    fn tip_step_only_lands_on_the_last_commit_of_tip_benchmarks() {
-        let s = scenario();
-        // b = 0: family 0 AND a tip benchmark (0 % 7 == 0). The tip step is the
-        // gap between the apply_tip and no-tip value on the final commit only.
-        let last = s.commits - 1;
-        let base = s.base_value(0, 0);
-        let with_tip = s.main_clean_value(0, 0, last, true);
-        let without_tip = s.main_clean_value(0, 0, last, false);
-        assert!(close(with_tip - without_tip, base * TIP_REGRESSION));
-        // No tip step before the final commit.
-        assert!(close(
-            s.main_clean_value(0, 0, last - 1, true),
-            s.main_clean_value(0, 0, last - 1, false)
-        ));
-        // A non-tip benchmark (b = 1, 1 % 7 != 0) sees no tip step at all.
-        assert!(close(
-            s.main_clean_value(1, 0, last, true),
-            s.main_clean_value(1, 0, last, false)
-        ));
     }
 
     #[test]
@@ -577,12 +541,12 @@ mod tests {
         let s = scenario();
         // b = 3 is a multiple of BRANCH_DIVISOR (3); b = 1 is not.
         let base3 = s.base_value(3, 0);
-        let settled3 = s.main_clean_value(3, 0, s.commits - 1, false);
+        let settled3 = s.main_clean_value(3, 0, s.commits - 1);
         assert!(close(
             s.feature_clean_value(3, 0),
             settled3 + base3 * BRANCH_REGRESSION
         ));
-        let settled1 = s.main_clean_value(1, 0, s.commits - 1, false);
+        let settled1 = s.main_clean_value(1, 0, s.commits - 1);
         assert!(close(s.feature_clean_value(1, 0), settled1));
     }
 
@@ -668,7 +632,7 @@ mod tests {
             seed: 7,
         };
         let base = s.base_value(0, 0);
-        assert!(close(s.main_clean_value(0, 0, 0, false), base));
+        assert!(close(s.main_clean_value(0, 0, 0), base));
         let anchor = Timestamp::from_second(1_750_000_000).unwrap();
         let (main, feature) = commit_times(anchor, 1, 1);
         assert_eq!(main.len(), 1);
@@ -785,9 +749,9 @@ mod tests {
             seed: 99,
         };
         let base = s.base_value(1, 0);
-        assert!(close(s.main_clean_value(1, 0, 2, false), base));
+        assert!(close(s.main_clean_value(1, 0, 2), base));
         assert!(close(
-            s.main_clean_value(1, 0, 3, false),
+            s.main_clean_value(1, 0, 3),
             base * (1.0 + STEP_REGRESSION)
         ));
     }

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -231,7 +231,7 @@ fn write_one(
             time,
         } => {
             let run = clean_run(scenario, set, *time, commit_id, BRANCH_MAIN, false, |b| {
-                scenario.main_clean_value(b, *s, *index, true)
+                scenario.main_clean_value(b, *s, *index)
             });
             (set.clean_key(PROJECT, commit_id), run.to_json()?)
         }

--- a/packages/cargo-bench-history-stress/tests/stress_smoke.rs
+++ b/packages/cargo-bench-history-stress/tests/stress_smoke.rs
@@ -45,7 +45,7 @@ fn deterministic_columns(stdout: &str) -> BTreeMap<String, Vec<String>> {
         .lines()
         .filter_map(|line| {
             let columns: Vec<&str> = line.split_whitespace().collect();
-            if columns.len() == 9 && ["history", "branch", "tip"].contains(&columns[0]) {
+            if columns.len() == 9 && ["history", "branch"].contains(&columns[0]) {
                 // Skip columns 1-3 (duration, cpu, cpu%); keep the rest.
                 let kept = columns[4..].iter().map(|c| (*c).to_owned()).collect();
                 Some((columns[0].to_owned(), kept))
@@ -58,7 +58,7 @@ fn deterministic_columns(stdout: &str) -> BTreeMap<String, Vec<String>> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn runs_all_three_modes_and_reports_a_table() {
+fn runs_all_modes_and_reports_a_table() {
     let output = run_stress(&[]);
     assert!(
         output.status.success(),
@@ -74,7 +74,6 @@ fn runs_all_three_modes_and_reports_a_table() {
     let rows = deterministic_columns(&stdout);
     assert!(rows.contains_key("history"), "{stdout}");
     assert!(rows.contains_key("branch"), "{stdout}");
-    assert!(rows.contains_key("tip"), "{stdout}");
 
     // Every mode loaded a non-zero number of objects and series, proving the
     // replicated key layout is what analyze actually reads.

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -50,8 +50,8 @@ New per-series logic must be side-effect-free. Flow and rationale: [`docs/analyz
 `resolve_history`/`select_dataset`), and all four live inside the `analyze` module tree
 (`list.rs`, `prune.rs`, `examine.rs`, each `pub(crate) mod`; `bless`/`unbless` in `bless.rs`
 reuse the same facet selection). **A selection parameter added to one must be added to all
-four** unless genuinely inapplicable. The analysis-only flags (`--mode`,
-`--include-improvements`, `--include-inactive`) and the analyze-only condensed
+four** unless genuinely inapplicable. The analysis-only flags
+(`--include-improvements`, `--include-inactive`) and the analyze-only condensed
 `--markdown-summary` output are **not** part of the lockstep — only `analyze` detects;
 `list`/`prune`/`examine` reuse the selection but never analyze. Each is
 generic over the `GitHistory` + `Storage` ports so tests drive it with fakes + `block_on`.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -539,7 +539,7 @@ pointing at the unmatched benchmark id or metric name.
 blessings. It shows every selected point exactly as the chart would plot it (a commit
 carrying both a clean run and dirty snapshots contributes a row each, ordered
 clean-before-dirty and flagged, so a value's provenance is unambiguous), which is why the
-analysis-only flags (mode, improvements, inactive findings) are not part of its surface. The
+analysis-only flags (improvements, inactive findings) are not part of its surface. The
 three output renderings compose from one pass as everywhere else: the per-commit table on
 stdout by default, the same table in Markdown, and a machine-readable JSON form that carries,
 per discriminant set, the ordered points with full-precision values and each commit's full
@@ -642,10 +642,10 @@ judgement rather than an automatic tier.
 ### 8.5 Analysis modes
 
 The same stored history answers two very different questions, so `analyze` runs in one of
-two **modes**, auto-detected from git topology and the recorded runs it admits, or forced
-explicitly. Working-tree state feeds in only through the base-tip dirty exception (below),
-which admits a base-tip dirty run — and, by admitting it, selects branch mode — only while
-the tree is currently dirty.
+two **modes**, auto-detected from git topology and the recorded runs it admits. There is no
+flag to force a mode; the topology alone decides. Working-tree state feeds in only through
+the base-tip dirty exception (below), which admits a base-tip dirty run — and, by admitting
+it, selects branch mode — only while the tree is currently dirty.
 
 * **history** — the base-branch view: auto-selected when the analyzed tip *is* the
   merge-base with the base and no dirty run is recorded on top of it. It applies the
@@ -672,8 +672,8 @@ or two branch points, which is why the techniques differ by mode:
 | Resolved (inactive) findings reported | opt-in | — |
 
 Modes apply to `analyze` only; `list`, `prune`, and `examine` reuse the same data-set
-*selection* but never analyze, so the mode and improvement/inactive flags are analyze-only
-and not part of the selection lockstep.
+*selection* but never analyze, so the mode selection and improvement/inactive flags are
+analyze-only and not part of the selection lockstep.
 
 ### 8.6 Re-baselining: blessings and resolved spikes
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -642,7 +642,7 @@ judgement rather than an automatic tier.
 ### 8.5 Analysis modes
 
 The same stored history answers two very different questions, so `analyze` runs in one of
-three **modes**, auto-detected from git topology and the recorded runs it admits, or forced
+two **modes**, auto-detected from git topology and the recorded runs it admits, or forced
 explicitly. Working-tree state feeds in only through the base-tip dirty exception (below),
 which admits a base-tip dirty run — and, by admitting it, selects branch mode — only while
 the tree is currently dirty.
@@ -657,22 +657,19 @@ the tree is currently dirty.
   regime** against the base — a branch may improve then regress, and we report where it
   *ended up* rather than mask a late regression behind an early gain — reporting both
   directions.
-* **tip** — never auto-selected; an explicit fast guard comparing only the last point
-  against a bounded window of recent points, regressions only.
 
 The two driving scenarios are a scheduled base-branch regression watch (history) and a
 per-PR feature-branch evaluation (branch). Long-range trend analysis is meaningless on one
 or two branch points, which is why the techniques differ by mode:
 
-| Technique | history | branch | tip |
-|---|---|---|---|
-| Change-point (Pettitt + engine gating) | ✅ | — | — |
-| Monotonic drift (Mann–Kendall + Theil–Sen) | ✅ | — | — |
-| Benjamini–Hochberg false-discovery filter | ✅ | — | — |
-| Latest-regime vs. base | — | ✅ | — |
-| Tip-vs-recent guard | — | — | ✅ |
-| Improvements reported | opt-in | ✅ | — |
-| Resolved (inactive) findings reported | opt-in | — | — |
+| Technique | history | branch |
+|---|---|---|
+| Change-point (Pettitt + engine gating) | ✅ | — |
+| Monotonic drift (Mann–Kendall + Theil–Sen) | ✅ | — |
+| Benjamini–Hochberg false-discovery filter | ✅ | — |
+| Latest-regime vs. base | — | ✅ |
+| Improvements reported | opt-in | ✅ |
+| Resolved (inactive) findings reported | opt-in | — |
 
 Modes apply to `analyze` only; `list`, `prune`, and `examine` reuse the same data-set
 *selection* but never analyze, so the mode and improvement/inactive flags are analyze-only
@@ -692,8 +689,8 @@ Every history-mode finding therefore carries an active flag and an active-from b
 * **Blessings** — a blessing (see `bless`) re-baselines a series from the blessed commit
   forward: the detectors run on the **active segment only**, so the pre-blessing step is no
   longer re-flagged, while the earlier points still feed the chart and any long-range
-  technique that needs context. Blessings are honoured **only in history mode** — branch and
-  tip judge the latest state against the base, which is treated as fully blessed by
+  technique that needs context. Blessings are honoured **only in history mode** — branch
+  mode judges the latest state against the base, which is treated as fully blessed by
   construction. A re-baselined finding records the blessing's commit and time for
   provenance.
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -34,7 +34,7 @@ flowchart TD
 ```
 
 The cost is overwhelmingly in the **load** and secondarily in the **detect**; everything
-else is bookkeeping. Each analysis mode (`history`, `branch`, `tip`) is a separate
+else is bookkeeping. Each analysis mode (`history`, `branch`) is a separate
 invocation with its own load — there is no dataset cache across modes — and the mode is
 auto-detected once per run from git topology.
 
@@ -125,8 +125,7 @@ Detection has no cross-series state, so the series split into one balanced chunk
 identical to a sequential pass. A single available CPU (as Miri reports) yields a single
 worker over the whole input. Per series the mode selects the detector: history runs both a
 change-point and a drift detector and keeps the better fit (plus an optional recovered-spike
-pass); branch compares the branch tip's level against its base; tip guards only the newest
-point.
+pass); branch compares the branch tip's level against its base.
 
 The statistical kernels are chosen to keep the tens-of-millions-of-points path affordable —
 an in-place unstable sort for the median (no scratch buffer, and ties are bit-identical so

--- a/packages/cargo-bench-history/src/analyze/dataset.rs
+++ b/packages/cargo-bench-history/src/analyze/dataset.rs
@@ -57,7 +57,7 @@ pub(crate) struct SelectedDataSet {
     /// Whether the working tree carried uncommitted changes when the analysis ran;
     /// the report annotates the tip `+ uncommitted changes` when set.
     pub(crate) tip_dirty: bool,
-    /// The resolved analysis mode (auto-detected from topology, or overridden).
+    /// The resolved analysis mode, auto-detected from the git topology.
     pub(crate) mode: AnalysisMode,
     /// First-parent topological index of the merge-base, used by branch mode to
     /// split base-side history from the branch's own commits.
@@ -163,36 +163,23 @@ where
                 .unwrap_or(false)
     });
 
-    // The mode steers the analysis and the default `--since`. An explicit `--mode`
-    // overrides the auto-detection.
-    let mode =
-        match selection.mode_override {
-            Some(mode) => {
-                reporter.note_with(|| {
-                    format!(
-                        "analysis mode: {} (set explicitly via --mode, overriding auto-detection)",
-                        mode.as_str()
-                    )
-                });
-                mode
-            }
-            None => {
-                let mode = auto_mode(tip_is_merge_base, dirty_tip_run_present);
-                reporter.note_with(|| format!(
-                "analysis mode: {} (auto-detected because the target tip {} its own merge-base \
-                 with the base branch and {} admitted on top of it; a base-tip dirty run is \
-                 admitted only while the working tree is currently dirty)",
-                mode.as_str(),
-                if tip_is_merge_base { "is" } else { "is not" },
-                if dirty_tip_run_present {
-                    "a dirty run is"
-                } else {
-                    "no dirty run is"
-                },
-            ));
-                mode
-            }
-        };
+    // The mode steers the analysis and the default `--since`; it is auto-detected
+    // from the git topology and the recorded data.
+    let mode = auto_mode(tip_is_merge_base, dirty_tip_run_present);
+    reporter.note_with(|| {
+        format!(
+            "analysis mode: {} (auto-detected because the target tip {} its own merge-base \
+             with the base branch and {} admitted on top of it; a base-tip dirty run is \
+             admitted only while the working tree is currently dirty)",
+            mode.as_str(),
+            if tip_is_merge_base { "is" } else { "is not" },
+            if dirty_tip_run_present {
+                "a dirty run is"
+            } else {
+                "no dirty run is"
+            },
+        )
+    });
     let since = resolve_since(selection.since, mode, now)?;
     reporter.note_with(|| {
         format!(

--- a/packages/cargo-bench-history/src/analyze/dataset.rs
+++ b/packages/cargo-bench-history/src/analyze/dataset.rs
@@ -33,7 +33,7 @@ use crate::text::count_noun;
 pub(crate) struct SelectedDataSet {
     /// The reconstructed series for the in-window runs, built with the caller's
     /// series filter and ordered by git topology. Pre-blessing: the caller applies
-    /// blessings (history mode) or leaves them unapplied (branch/tip, listings).
+    /// blessings (history mode) or leaves them unapplied (branch, listings).
     pub(crate) series: Vec<Series>,
     /// Compact per-set, per-commit run tallies, standing in for a retained copy of
     /// every loaded object (which a large history cannot afford to keep resident).
@@ -66,7 +66,7 @@ pub(crate) struct SelectedDataSet {
     /// entry pairs the blessed commit's first-parent topological index and its
     /// committer date (from topology, for the report anchor) with the record;
     /// history-mode re-baselining picks, per series, the latest matching blessing.
-    /// Empty in branch and tip modes (they ignore blessings).
+    /// Empty in branch mode (it ignores blessings).
     pub(crate) blessings: HashMap<DiscriminantSet, Vec<BlessingPlacement>>,
 }
 
@@ -360,7 +360,7 @@ where
 
     // Load the blessing sidecars on in-window commits into a per-set map. A
     // blessing on a commit outside the analyzed history (or that fails to parse) is
-    // irrelevant and skipped. Branch and tip modes ignore blessings entirely, so
+    // irrelevant and skipped. Branch mode ignores blessings entirely, so
     // only history mode pays the load.
     let mut blessings: HashMap<DiscriminantSet, Vec<BlessingPlacement>> = HashMap::new();
     if mode == AnalysisMode::History {

--- a/packages/cargo-bench-history/src/analyze/pipeline.rs
+++ b/packages/cargo-bench-history/src/analyze/pipeline.rs
@@ -182,7 +182,7 @@ where
         options.json.as_deref(),
         options.markdown_summary.as_deref(),
     )?;
-    let selection = Selection::from_analyze(options)?;
+    let selection = Selection::from_analyze(options);
     let filter = SeriesFilter {
         prefixes: &options.prefixes,
     };

--- a/packages/cargo-bench-history/src/analyze/pipeline.rs
+++ b/packages/cargo-bench-history/src/analyze/pipeline.rs
@@ -197,8 +197,8 @@ where
     );
 
     let mut series = dataset.series;
-    // Re-baseline blessed series before detection (history mode only; branch and
-    // tip modes carry an empty blessing map).
+    // Re-baseline blessed series before detection (history mode only; branch
+    // mode carries an empty blessing map).
     let rebaseline_started = Instant::now();
     apply_blessings(&mut series, &dataset.blessings);
     reporter.timing(

--- a/packages/cargo-bench-history/src/analyze/selection.rs
+++ b/packages/cargo-bench-history/src/analyze/selection.rs
@@ -1,12 +1,8 @@
 //! The data-set `Selection` the analyze/list/prune/examine/bless query commands
 //! share, built from each command's options.
 
-use cargo_bench_history_core::analyze::AnalysisMode;
-
-use super::window::parse_mode;
 use crate::{
-    AnalyzeOptions, BlessOptions, ExamineOptions, ListOptions, PruneOptions, RunError,
-    UnblessOptions,
+    AnalyzeOptions, BlessOptions, ExamineOptions, ListOptions, PruneOptions, UnblessOptions,
 };
 
 /// The data-set selection parameters shared by the query commands: which stored
@@ -29,13 +25,11 @@ pub(crate) struct Selection<'a> {
     pub(crate) engine: &'a [String],
     pub(crate) target_triple: &'a [String],
     pub(crate) machine_key: &'a [String],
-    /// Explicit `--mode` override; `None` lets the mode auto-detect from topology.
-    pub(crate) mode_override: Option<AnalysisMode>,
 }
 
 impl<'a> Selection<'a> {
-    pub(crate) fn from_analyze(options: &'a AnalyzeOptions) -> Result<Self, RunError> {
-        Ok(Self {
+    pub(crate) fn from_analyze(options: &'a AnalyzeOptions) -> Self {
+        Self {
             context: options.context.as_deref(),
             base: options.base.as_deref(),
             no_dirty: options.no_dirty,
@@ -44,8 +38,7 @@ impl<'a> Selection<'a> {
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
-            mode_override: parse_mode(options.mode.as_deref())?,
-        })
+        }
     }
 
     pub(crate) fn from_list(options: &'a ListOptions) -> Self {
@@ -58,7 +51,6 @@ impl<'a> Selection<'a> {
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
-            mode_override: None,
         }
     }
 
@@ -72,7 +64,6 @@ impl<'a> Selection<'a> {
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
-            mode_override: None,
         }
     }
 
@@ -90,7 +81,6 @@ impl<'a> Selection<'a> {
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
-            mode_override: None,
         }
     }
 
@@ -107,7 +97,6 @@ impl<'a> Selection<'a> {
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
-            mode_override: None,
         }
     }
 
@@ -122,7 +111,6 @@ impl<'a> Selection<'a> {
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
-            mode_override: None,
         }
     }
 }

--- a/packages/cargo-bench-history/src/analyze/window.rs
+++ b/packages/cargo-bench-history/src/analyze/window.rs
@@ -19,7 +19,6 @@ use crate::RunError;
 /// signals; the working tree enters only indirectly, since a base-tip dirty run
 /// counts as feature-branch data only while the tree is currently dirty — a dirty
 /// checkout with no admitted dirty run still analyzes as history.
-/// [`AnalysisMode::Tip`] is never auto-selected.
 pub(crate) fn auto_mode(tip_is_merge_base: bool, dirty_tip_run_present: bool) -> AnalysisMode {
     if tip_is_merge_base && !dirty_tip_run_present {
         AnalysisMode::History
@@ -41,8 +40,8 @@ pub(crate) fn since_cutoff_reason(explicit_since: bool, mode: AnalysisMode) -> &
 
 /// Resolves the effective `--since` cutoff: an explicit value always wins;
 /// otherwise history mode applies a default look-back so a scheduled trend watch
-/// does not silently widen as history accumulates, while branch and tip modes have
-/// no default (a feature branch's whole history is in scope).
+/// does not silently widen as history accumulates, while branch mode has no default
+/// (a feature branch's whole history is in scope).
 pub(crate) fn resolve_since(
     value: Option<&str>,
     mode: AnalysisMode,
@@ -74,7 +73,7 @@ fn default_history_since(now: Timestamp) -> Result<Timestamp, RunError> {
 /// Parses the `--mode` option into an explicit [`AnalysisMode`] override.
 ///
 /// `auto` (the default when omitted) resolves to `None` so the mode is detected
-/// from topology; `history`, `branch`, and `tip` force that mode.
+/// from topology; `history` and `branch` force that mode.
 pub(crate) fn parse_mode(value: Option<&str>) -> Result<Option<AnalysisMode>, RunError> {
     match value {
         None | Some("auto") => Ok(None),
@@ -82,7 +81,7 @@ pub(crate) fn parse_mode(value: Option<&str>) -> Result<Option<AnalysisMode>, Ru
             .map(Some)
             .ok_or_else(|| RunError::Analyze {
                 message: format!(
-                    "unknown analysis mode {name:?}; expected auto, history, branch, or tip"
+                    "unknown analysis mode {name:?}; expected auto, history, or branch"
                 ),
             }),
     }
@@ -263,7 +262,6 @@ mod tests {
             parse_mode(Some("branch")).unwrap(),
             Some(AnalysisMode::Branch)
         );
-        assert_eq!(parse_mode(Some("tip")).unwrap(), Some(AnalysisMode::Tip));
         let error = parse_mode(Some("weekly")).unwrap_err();
         assert!(
             error.to_string().contains("unknown analysis mode"),
@@ -282,12 +280,11 @@ mod tests {
             history,
             "2023-12-01T00:00:00Z".parse::<Timestamp>().unwrap()
         );
-        // Branch and tip modes have no default cutoff.
+        // Branch mode has no default cutoff.
         assert_eq!(
             resolve_since(None, AnalysisMode::Branch, now).unwrap(),
             None
         );
-        assert_eq!(resolve_since(None, AnalysisMode::Tip, now).unwrap(), None);
         // An explicit value always wins, even in branch mode.
         let explicit = resolve_since(Some("2024-01-01"), AnalysisMode::Branch, now)
             .unwrap()

--- a/packages/cargo-bench-history/src/analyze/window.rs
+++ b/packages/cargo-bench-history/src/analyze/window.rs
@@ -1,6 +1,6 @@
-//! `--since` / `--until` window and `--mode` resolution: parsing the edges,
-//! deciding the history-mode default look-back, and testing each committer time
-//! against the resolved window.
+//! `--since` / `--until` window resolution: parsing the edges, deciding the
+//! history-mode default look-back, and testing each committer time against the
+//! resolved window.
 
 use cargo_bench_history_core::analyze::AnalysisMode;
 use jiff::civil::Date;
@@ -68,23 +68,6 @@ fn default_history_since(now: Timestamp) -> Result<Timestamp, RunError> {
         .map_err(|error| RunError::Analyze {
             message: format!("default --since window is out of the representable range: {error}"),
         })
-}
-
-/// Parses the `--mode` option into an explicit [`AnalysisMode`] override.
-///
-/// `auto` (the default when omitted) resolves to `None` so the mode is detected
-/// from topology; `history` and `branch` force that mode.
-pub(crate) fn parse_mode(value: Option<&str>) -> Result<Option<AnalysisMode>, RunError> {
-    match value {
-        None | Some("auto") => Ok(None),
-        Some(name) => AnalysisMode::from_name(name)
-            .map(Some)
-            .ok_or_else(|| RunError::Analyze {
-                message: format!(
-                    "unknown analysis mode {name:?}; expected auto, history, or branch"
-                ),
-            }),
-    }
 }
 
 /// Parses the `--since` option into an absolute lower-bound instant, if set.
@@ -247,25 +230,6 @@ mod tests {
         assert_eq!(
             since_cutoff_reason(false, AnalysisMode::Branch),
             "no default look-back window outside history mode"
-        );
-    }
-
-    #[test]
-    fn parse_mode_resolves_auto_to_none_and_rejects_unknown() {
-        assert_eq!(parse_mode(None).unwrap(), None);
-        assert_eq!(parse_mode(Some("auto")).unwrap(), None);
-        assert_eq!(
-            parse_mode(Some("history")).unwrap(),
-            Some(AnalysisMode::History)
-        );
-        assert_eq!(
-            parse_mode(Some("branch")).unwrap(),
-            Some(AnalysisMode::Branch)
-        );
-        let error = parse_mode(Some("weekly")).unwrap_err();
-        assert!(
-            error.to_string().contains("unknown analysis mode"),
-            "{error}"
         );
     }
 

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -449,13 +449,6 @@ struct AnalyzeCommand {
     #[arg(long, help_heading = HEADING_FILTER)]
     no_dirty: bool,
 
-    /// Analysis mode: auto, history, or branch (default: auto). `auto` infers
-    /// history mode (long-range base-branch trends) from a clean base-branch
-    /// checkout, and branch mode (this branch's latest state vs the base)
-    /// otherwise.
-    #[arg(long, value_name = "MODE", help_heading = HEADING_ANALYSIS)]
-    mode: Option<String>,
-
     /// In history mode, also report sustained improvements (by default only
     /// regressions are reported, since improvement over time is expected). Branch
     /// mode always reports all findings, so this flag has no effect there.
@@ -497,7 +490,6 @@ impl AnalyzeCommand {
             markdown: self.output.markdown,
             json: self.output.json,
             markdown_summary: self.markdown_summary,
-            mode: self.mode,
             include_improvements: self.include_improvements,
             include_inactive: self.include_inactive,
             verbose: self.env.verbose,
@@ -1384,12 +1376,11 @@ mod tests {
 
     #[test]
     fn analyze_collects_switches() {
-        let command = parse(&["analyze", "--include-improvements", "--mode", "history"]);
+        let command = parse(&["analyze", "--include-improvements"]);
         let Command::Analyze(options) = command else {
             panic!("expected analyze command");
         };
         assert!(options.include_improvements);
-        assert_eq!(options.mode.as_deref(), Some("history"));
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/cli.rs
+++ b/packages/cargo-bench-history/src/cli.rs
@@ -449,24 +449,22 @@ struct AnalyzeCommand {
     #[arg(long, help_heading = HEADING_FILTER)]
     no_dirty: bool,
 
-    /// Analysis mode: auto, history, branch, or tip (default: auto). `auto` infers
+    /// Analysis mode: auto, history, or branch (default: auto). `auto` infers
     /// history mode (long-range base-branch trends) from a clean base-branch
     /// checkout, and branch mode (this branch's latest state vs the base)
-    /// otherwise. Use `tip` as a fast post-merge guard that only checks whether the
-    /// base-branch tip just regressed against its recently established level,
-    /// skipping the full-history scan.
+    /// otherwise.
     #[arg(long, value_name = "MODE", help_heading = HEADING_ANALYSIS)]
     mode: Option<String>,
 
     /// In history mode, also report sustained improvements (by default only
     /// regressions are reported, since improvement over time is expected). Branch
-    /// and tip modes always report all findings, so this flag has no effect there.
+    /// mode always reports all findings, so this flag has no effect there.
     #[arg(long, help_heading = HEADING_ANALYSIS)]
     include_improvements: bool,
 
     /// In history mode, also report inactive findings: a change the current state
     /// no longer reflects (a regression that has since recovered). Hidden by
-    /// default since they need no action. Branch and tip modes always report all
+    /// default since they need no action. Branch mode always reports all
     /// findings, so this flag has no effect there.
     #[arg(long, help_heading = HEADING_ANALYSIS)]
     include_inactive: bool,

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -176,9 +176,6 @@ pub struct AnalyzeOptions {
     /// against the working directory. Analyze-only, so a large analysis still fits
     /// within a GitHub issue body.
     pub markdown_summary: Option<PathBuf>,
-    /// Analysis-mode selector (`auto`, `history`, or `branch`), if set.
-    /// `auto` (the default) infers history vs branch mode from the git topology.
-    pub mode: Option<String>,
     /// In history mode, also report sustained improvements (regressions only by
     /// default, since improvement over time on the base branch is expected).
     pub include_improvements: bool,

--- a/packages/cargo-bench-history/src/command.rs
+++ b/packages/cargo-bench-history/src/command.rs
@@ -176,7 +176,7 @@ pub struct AnalyzeOptions {
     /// against the working directory. Analyze-only, so a large analysis still fits
     /// within a GitHub issue body.
     pub markdown_summary: Option<PathBuf>,
-    /// Analysis-mode selector (`auto`, `history`, `branch`, or `tip`), if set.
+    /// Analysis-mode selector (`auto`, `history`, or `branch`), if set.
     /// `auto` (the default) infers history vs branch mode from the git topology.
     pub mode: Option<String>,
     /// In history mode, also report sustained improvements (regressions only by

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -193,8 +193,8 @@
 //!
 //! # Analyze modes
 //!
-//! `analyze` runs in one of three modes, chosen automatically (`--mode auto`, the
-//! default) or forced with `--mode`:
+//! `analyze` runs in one of two modes, chosen automatically from the git topology
+//! (there is no flag to force a mode):
 //!
 //! * **history** — long-range trend watch over the base branch (selected when you
 //!   analyze a clean checkout of the base branch). It detects sustained
@@ -206,8 +206,6 @@
 //!   a dirty base checkout). It judges the branch by its **latest** state versus the
 //!   base, reporting both regressions and improvements; the finding's `flipped_at`
 //!   names the commit a regime began at.
-//! * **tip** — a fast guard that compares only the latest commit against the
-//!   recently established level, reporting regressions only.
 //!
 //! # Configuration
 //!

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1379,54 +1379,6 @@ async fn analyze_history_mode_suppresses_improvements_by_default() {
     );
 }
 
-/// `--mode tip` overrides auto-detection (which would pick history on a clean base
-/// checkout) and runs the fast tip guard: it flags a regression at the latest
-/// commit but stays silent on an improvement, since the guard cares only about
-/// the level getting worse.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn analyze_tip_mode_flags_only_a_tip_regression() {
-    let regressing = Workspace::repo(&storage_only_config());
-    regressing.commit_dated("2024-01-01", "c1");
-    regressing.seed_callgrind("c1", 100.0);
-    regressing.commit_dated("2024-01-02", "c2");
-    regressing.seed_callgrind("c2", 100.0);
-    regressing.commit_dated("2024-01-03", "c3");
-    regressing.seed_callgrind("c3", 100.0);
-    regressing.commit_dated("2024-01-04", "c4");
-    regressing.seed_callgrind("c4", 100.0);
-    regressing.commit_dated("2024-01-05", "c5");
-    regressing.seed_callgrind("c5", 130.0);
-
-    let report = regressing.drive_json(&["analyze", "--mode", "tip"]).await;
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-    assert_eq!(
-        parsed["regressions"], 1,
-        "the tip step up must flag: {report}"
-    );
-    assert_eq!(parsed["mode"], "tip", "the override must win: {report}");
-
-    let improving = Workspace::repo(&storage_only_config());
-    improving.commit_dated("2024-01-01", "c1");
-    improving.seed_callgrind("c1", 100.0);
-    improving.commit_dated("2024-01-02", "c2");
-    improving.seed_callgrind("c2", 100.0);
-    improving.commit_dated("2024-01-03", "c3");
-    improving.seed_callgrind("c3", 100.0);
-    improving.commit_dated("2024-01-04", "c4");
-    improving.seed_callgrind("c4", 100.0);
-    improving.commit_dated("2024-01-05", "c5");
-    improving.seed_callgrind("c5", 70.0);
-
-    let report = improving.drive_json(&["analyze", "--mode", "tip"]).await;
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-    assert_eq!(
-        parsed["regressions"], 0,
-        "tip mode reports regressions only, so a drop stays silent: {report}"
-    );
-    assert_eq!(parsed["improvements"], 0, "{report}");
-}
-
 /// An unrecognized `--mode` is a clear up-front error, not a silent fallback.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1379,21 +1379,6 @@ async fn analyze_history_mode_suppresses_improvements_by_default() {
     );
 }
 
-/// An unrecognized `--mode` is a clear up-front error, not a silent fallback.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn analyze_rejects_an_unknown_mode() {
-    let workspace = Workspace::repo(&storage_only_config());
-    let error = workspace
-        .drive(&["analyze", "--mode", "weekly"])
-        .await
-        .unwrap_err();
-    assert!(
-        error.to_string().contains("unknown analysis mode"),
-        "the error should name the problem: {error}"
-    );
-}
-
 /// A `--target-triple` filter restricts analysis to the matching set: the same
 /// commits host a regressing Linux series and a flat Windows series, and each
 /// triple selection sees only its own.


### PR DESCRIPTION
## What

Two cleanups to `cargo-bench-history`'s analysis-mode handling:

1. Removes the vestigial **`Tip`** analysis mode, leaving only the two
   meaningful modes: **History** and **Branch**.
2. Removes the now-redundant **`--mode` flag** on `analyze` entirely. With only
   History and Branch left, the mode is fully determined by git topology, so
   there is nothing left for the flag to override.

> **User-visible CLI change:** `analyze` no longer accepts `--mode`. The mode is
> auto-detected from the `base`/`context` relationship plus the base-tip dirty
> exception. Passing `--mode ...` now produces an unknown-argument error from
> clap. There is no config or stored-data migration (no persisted data ever
> carried a mode).

## Why

**Removing `Tip`:** the `Tip` detector was a leftover that got confused with a
separate, unrelated mechanism. Two things shared the word "tip":

- **The base-tip dirty exception** (`DirtyTipPolicy` / `dirty_tip_exception`) — a
  *data-admission* rule that admits a base-side tip's dirty runs and thereby
  auto-selects **branch** mode. **This stays.**
- **`AnalysisMode::Tip`** — a *detector* that compared the single newest point
  against a recent window (regressions only), never auto-selected. **This is
  removed.**

`Tip` mode served no scenario that branch mode doesn't already cover better:

- `analyze` always loads the full dataset (load dominates cost, not detect), so
  Tip's "skip the full-history scan" benefit was illusory.
- A single-point-vs-window check is strictly less robust than history mode's
  sustained change-point detector, which auto-selects on a linear base branch
  anyway.
- `auto_mode` only ever returned `History` or `Branch`; `Tip` was reachable only
  via an explicit `--mode tip`.

**Removing `--mode`:** once `Tip` is gone, both remaining modes are decided by
topology alone (History when the analyzed tip is its own merge-base with the base
and no dirty run sits on it; Branch otherwise). Forcing a mode could not express
anything the `--base`/`--context` selection could not already express, and every
subcommand other than `analyze` already ran on pure auto-detection.

## Changes

**cargo-bench-history-core**
- Removed the `AnalysisMode::Tip` variant, the `evaluate_tip` function, and all
  `Tip` match arms; the enum is now `History` | `Branch`.
- Removed `AnalysisMode::from_name` (dead once `--mode` parsing is gone).
- Dropped the `Tip` dimension from the curated `signal_validation.rs` suite.
- Removed obsolete tip unit tests; updated affected docs/comments.

**cargo-bench-history (shell)**
- Removed the `--mode` CLI arg, `AnalyzeOptions.mode`, `Selection::mode_override`,
  and `window::parse_mode`. Mode is now always auto-detected; dataset resolution
  and its verbose note collapse to a single auto path.
- Deleted the tip-mode and unknown-mode integration tests.

**cargo-bench-history-stress**
- Dropped the `tip` mode from the harness and relies on topology-based
  auto-detection (its seeded history/branch topologies already select the right
  mode; it no longer passes `--mode`).

**docs**
- `DESIGN.md`, `analyze.md`, `lib.rs` module docs, and `AGENTS.md` updated for
  two auto-detected modes and no `--mode` flag (fixes stale "three modes"/tip
  text the first pass missed).

## Validation

`cargo test` (unit + integration + azure + core), clippy (dev + release),
`just format-check`, and docs all pass. The tip-removal commit also ran the full
`validate-local` including mutants (1407 tested, 0 missed).

## Notes

- No schema-version bump: no stored data carries `mode`, and the report's `mode`
  field can only be `"history"` or `"branch"`.
- The base-tip dirty exception is untouched.
- Deferred: a warning for the "merge-base unknown (e.g. shallow clone) → History
  auto-selected on a real feature branch" case. The report has a single `warning`
  slot today, so a second orthogonal warning needs a warnings-list refactor —
  left as a possible follow-up.
