### PR TITLE
Fail on an undeterminable merge-base instead of silently picking History

### DIFF
--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -389,6 +389,15 @@ base baseline plus the branch's own clean and dirty snapshots). Membership is pu
 topological, so a dirty snapshot taken on a shared base commit is excluded from an official
 view until it is committed.
 
+Because that split is topological, the merge-base must be knowable. If the base ref cannot
+be resolved (no `--base`, no configured or detected default branch), or it shares no common
+ancestor with the target — typically a **shallow clone** whose fetched depth stops short of
+the branch point, or a checkout that never fetched the base branch — `analyze` **errors**
+and points at the fix (deepen the clone with `git fetch --unshallow` / `fetch-depth: 0`, or
+pass an explicit `--base`) rather than silently treating the incomplete history as a
+base-branch view. The tool has no requirement to support shallow or otherwise anomalous
+history; an unknown topology is reported, not guessed around.
+
 There is one carve-out to the clean-only base rule, for the common "first impressions"
 case where a user runs `analyze` on the base branch with uncommitted changes (for instance
 an untracked config file, so every stored run landed as a dirty snapshot on the base tip).
@@ -645,7 +654,9 @@ The same stored history answers two very different questions, so `analyze` runs 
 two **modes**, auto-detected from git topology and the recorded runs it admits. There is no
 flag to force a mode; the topology alone decides. Working-tree state feeds in only through
 the base-tip dirty exception (below), which admits a base-tip dirty run — and, by admitting
-it, selects branch mode — only while the tree is currently dirty.
+it, selects branch mode — only while the tree is currently dirty. Auto-detection relies on a
+known merge-base: an undeterminable one is a hard error (see the base-resolution rule above),
+never a silent fall-through to history.
 
 * **history** — the base-branch view: auto-selected when the analyzed tip *is* the
   merge-base with the base and no dirty run is recorded on top of it. It applies the

--- a/packages/cargo-bench-history/src/analyze/history.rs
+++ b/packages/cargo-bench-history/src/analyze/history.rs
@@ -153,14 +153,32 @@ where
     // a checkout that never fetched the base branch.
     let Some(merge_base) = merge_base else {
         let message = match base_commit_id.as_deref() {
-            Some(base) => format!(
-                "could not determine the merge-base of the target {target_ref} \
-                 ({target_commit_id}) and the base ({base}): they share no common ancestor in \
-                 the available history. This is usually a shallow clone whose depth stops short \
-                 of the branch point — fetch the full history (`git fetch --unshallow`, or set \
-                 fetch-depth: 0 on actions/checkout) or pass an explicit --base that shares \
-                 history with the target."
-            ),
+            // The base resolved, but shares no common ancestor with the target. By
+            // far the usual cause is a shallow clone whose depth stops short of the
+            // branch point, so the primary remedy is to deepen the clone — not to
+            // pick a different base. Only once the history is known-complete is a
+            // genuinely disjoint base worth calling out, and even then the deliberate
+            // `--base` a user passed is theirs to reconsider, not ours to second-guess.
+            Some(base) => {
+                let remedy = match selection.base {
+                    Some(explicit) => format!(
+                        " If the history is already complete, {explicit} is genuinely unrelated \
+                         to the target and cannot serve as its base."
+                    ),
+                    None => " If the history is already complete, the detected default branch is \
+                             unrelated to the target; name the intended base with --base or \
+                             project.default_branch."
+                        .to_owned(),
+                };
+                format!(
+                    "could not determine the merge-base of the target {target_ref} \
+                     ({target_commit_id}) and the base ({base}): they share no common ancestor \
+                     in the available history. This is almost always a shallow clone whose depth \
+                     stops short of the branch point — fetch the full history (`git fetch \
+                     --unshallow`, or set fetch-depth: 0 on actions/checkout) so the branch point \
+                     is present.{remedy}"
+                )
+            }
             None => format!(
                 "could not determine the base branch to compare {target_ref} against: no \
                  --base was given and no default branch could be resolved. Pass an explicit \

--- a/packages/cargo-bench-history/src/analyze/history.rs
+++ b/packages/cargo-bench-history/src/analyze/history.rs
@@ -165,18 +165,18 @@ where
                         " If the history is already complete, {explicit} is genuinely unrelated \
                          to the target and cannot serve as its base."
                     ),
-                    None => " If the history is already complete, the detected default branch is \
-                             unrelated to the target; name the intended base with --base or \
+                    None => " If the history is already complete, the base branch is unrelated to \
+                             the target; name the intended base with --base or \
                              project.default_branch."
                         .to_owned(),
                 };
                 format!(
                     "could not determine the merge-base of the target {target_ref} \
-                     ({target_commit_id}) and the base ({base}): they share no common ancestor \
-                     in the available history. This is almost always a shallow clone whose depth \
-                     stops short of the branch point — fetch the full history (`git fetch \
-                     --unshallow`, or set fetch-depth: 0 on actions/checkout) so the branch point \
-                     is present.{remedy}"
+                     ({target_commit_id}) and the base commit {base}: they share no common \
+                     ancestor in the available history. This is almost always a shallow clone \
+                     whose depth stops short of the branch point — fetch the full history (`git \
+                     fetch --unshallow`, or set fetch-depth: 0 on actions/checkout) so the branch \
+                     point is present.{remedy}"
                 )
             }
             None => format!(

--- a/packages/cargo-bench-history/src/analyze/history.rs
+++ b/packages/cargo-bench-history/src/analyze/history.rs
@@ -61,18 +61,22 @@ pub(crate) struct ResolvedHistory {
     /// dirty-tree exception, which triggers the ephemeral-data warning.
     pub(crate) dirty_base_exception: HashMap<String, bool>,
     /// First-parent topological index of the merge-base, used by branch mode to
-    /// split base-side history from the branch's own commits. `None` when no base
-    /// is known or the merge-base is off the analyzed chain.
+    /// split base-side history from the branch's own commits. `None` when the
+    /// merge-base is off the target's first-parent line (an off-chain merge-base);
+    /// a merge-base that cannot be determined at all is a hard error, not `None`.
     pub(crate) merge_base_index: Option<usize>,
-    /// Whether the target's tip *is* its own merge-base with the base (or no base
-    /// is known): the signal that this is an official base-branch view.
+    /// Whether the target's tip *is* its own merge-base with the base: the signal
+    /// that this is an official base-branch view rather than a feature branch.
     pub(crate) tip_is_merge_base: bool,
 }
 
 /// Resolves the git topology for a selection: the target ref's first-parent
 /// ancestry, the merge-base with the base ref, and the per-commit dirty-admission
 /// flags. Requires a repository — an unresolvable target ref is an error rather
-/// than an empty success.
+/// than an empty success, and so is a merge-base that cannot be determined (the
+/// base ref does not resolve, or it shares no common ancestor with the target),
+/// rather than silently falling back to a base-branch (history) view of the
+/// incomplete topology.
 pub(crate) async fn resolve_history<G>(
     git: &G,
     config: &Config,
@@ -141,6 +145,33 @@ where
         ));
     });
 
+    // The analysis is a comparison against the base branch: it splits the target's
+    // first-parent line at the merge-base. A merge-base we cannot determine leaves
+    // no topology to split on, and guessing a mode from the incomplete history would
+    // silently mislead — so refuse and say how to supply the missing history. The
+    // usual cause is a shallow clone whose depth stops short of the branch point, or
+    // a checkout that never fetched the base branch.
+    let Some(merge_base) = merge_base else {
+        let message = match base_commit_id.as_deref() {
+            Some(base) => format!(
+                "could not determine the merge-base of the target {target_ref} \
+                 ({target_commit_id}) and the base ({base}): they share no common ancestor in \
+                 the available history. This is usually a shallow clone whose depth stops short \
+                 of the branch point — fetch the full history (`git fetch --unshallow`, or set \
+                 fetch-depth: 0 on actions/checkout) or pass an explicit --base that shares \
+                 history with the target."
+            ),
+            None => format!(
+                "could not determine the base branch to compare {target_ref} against: no \
+                 --base was given and no default branch could be resolved. Pass an explicit \
+                 --base, set project.default_branch, or make the default branch available \
+                 (a shallow clone or a checkout that never fetched the base branch is the \
+                 usual cause)."
+            ),
+        };
+        return Err(RunError::Analyze { message });
+    };
+
     // The base-branch dirty-tip exception: `analyze`/`list` admit a base-side tip's
     // dirty runs only when the working tree is currently dirty (`--no-dirty` skips
     // both the probe and the exception); `prune` admits them unconditionally so it
@@ -167,7 +198,7 @@ where
 
     let selected = select_commits(
         &ancestry,
-        merge_base.as_deref(),
+        Some(merge_base.as_str()),
         !selection.no_dirty,
         dirty_tip_exception,
     );
@@ -186,15 +217,12 @@ where
         .collect();
 
     // The merge-base's topological position (when it is on the analyzed chain)
-    // splits base-side history from the branch's own commits in branch mode.
-    let merge_base_index = merge_base
-        .as_deref()
-        .and_then(|base| order.get(base).copied());
-    // The target's tip is its own merge-base (or no base is known) exactly when
-    // this is an official base-branch view rather than a feature branch.
-    let tip_is_merge_base = merge_base
-        .as_deref()
-        .is_none_or(|base| base == target_commit_id);
+    // splits base-side history from the branch's own commits in branch mode. It is
+    // absent only when the merge-base is off the target's first-parent line.
+    let merge_base_index = order.get(&merge_base).copied();
+    // The target's tip is its own merge-base exactly when this is an official
+    // base-branch view rather than a feature branch.
+    let tip_is_merge_base = merge_base == target_commit_id;
 
     Ok(ResolvedHistory {
         target_ref: target_ref.to_owned(),

--- a/packages/cargo-bench-history/src/analyze/pipeline.rs
+++ b/packages/cargo-bench-history/src/analyze/pipeline.rs
@@ -1541,13 +1541,14 @@ mod tests {
     }
 
     #[test]
-    fn analyze_without_a_resolvable_base_branch_loads_the_whole_history() {
+    fn analyze_without_a_resolvable_base_branch_is_an_error() {
         let storage = MemoryStorage::new();
         seed_linear_step(&storage);
         // HEAD resolves, but there is no advertised default branch and no --base /
-        // config default, so resolve_base_ref yields None and there is no
-        // merge-base to split the timeline on. The analysis still loads the
-        // history rather than erroring.
+        // config default, so the base branch cannot be determined and there is no
+        // merge-base to split the timeline on. Rather than silently analyze the
+        // incomplete topology as a base-branch (history) view, this is an error
+        // that tells the user how to supply the missing history.
         let mut git = FakeGitHistory::new();
         git.commit("c0", None)
             .commit("c1", Some("c0"))
@@ -1557,12 +1558,69 @@ mod tests {
             .commit("c5", Some("c4"))
             .branch("master", "c5")
             .head("master"); // No `.mark_default(...)`.
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
-        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-        assert_eq!(
-            parsed["runs"], 6,
-            "the full history loads without a merge-base: {report}"
+        let error = block_on(analyze_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &options(),
+            &auto(),
+            now_anchor(),
+            &RecordingReporter::new(),
+            false,
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap_err();
+        assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
+        let message = error.to_string();
+        assert!(
+            message.contains("could not determine the base branch"),
+            "{message}"
         );
+        assert!(message.contains("--base"), "{message}");
+    }
+
+    #[test]
+    fn analyze_without_a_common_ancestor_is_an_error() {
+        let storage = MemoryStorage::new();
+        seed_linear_step(&storage);
+        // The base branch resolves, but it shares no history with the target — the
+        // shallow-clone case, where the fetched depth stops short of the branch
+        // point. `git merge-base` finds no common ancestor, so the timeline cannot
+        // be split; this errors and points at the shallow-clone fix rather than
+        // guessing a base-branch view.
+        let mut git = FakeGitHistory::new();
+        git.commit("c0", None)
+            .commit("c1", Some("c0"))
+            .commit("c2", Some("c1"))
+            .commit("c3", Some("c2"))
+            .commit("c4", Some("c3"))
+            .commit("c5", Some("c4"))
+            // A disjoint base history with no common ancestor with the target.
+            .commit("m0", None)
+            .branch("master", "m0")
+            .branch("feature", "c5")
+            .head("feature")
+            .mark_default("master");
+        let error = block_on(analyze_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &options(),
+            &auto(),
+            now_anchor(),
+            &RecordingReporter::new(),
+            false,
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap_err();
+        assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
+        let message = error.to_string();
+        assert!(message.contains("no common ancestor"), "{message}");
+        assert!(message.contains("--unshallow"), "{message}");
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/analyze/pipeline.rs
+++ b/packages/cargo-bench-history/src/analyze/pipeline.rs
@@ -1588,8 +1588,9 @@ mod tests {
         // The base branch resolves, but it shares no history with the target — the
         // shallow-clone case, where the fetched depth stops short of the branch
         // point. `git merge-base` finds no common ancestor, so the timeline cannot
-        // be split; this errors and points at the shallow-clone fix rather than
-        // guessing a base-branch view.
+        // be split; this errors and leads with the deepen-the-clone fix rather than
+        // guessing a base-branch view. The base was auto-detected here, so the
+        // message also offers --base as the way to name a different one.
         let mut git = FakeGitHistory::new();
         git.commit("c0", None)
             .commit("c1", Some("c0"))
@@ -1621,6 +1622,54 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("no common ancestor"), "{message}");
         assert!(message.contains("--unshallow"), "{message}");
+        // Auto-detected base: offer --base as the way to name the intended one.
+        assert!(message.contains("--base"), "{message}");
+    }
+
+    #[test]
+    fn analyze_with_an_explicit_disjoint_base_does_not_suggest_a_different_base() {
+        let storage = MemoryStorage::new();
+        seed_linear_step(&storage);
+        // The user deliberately chose `--base master`, which resolves but shares no
+        // history with the target. The remedy is still to deepen the clone; we must
+        // not glibly tell them to pass some other --base, since they picked this one
+        // on purpose. Only if the history is complete is the chosen base called out
+        // as genuinely unrelated.
+        let mut git = FakeGitHistory::new();
+        git.commit("c0", None)
+            .commit("c1", Some("c0"))
+            .commit("c2", Some("c1"))
+            .commit("c3", Some("c2"))
+            .commit("c4", Some("c3"))
+            .commit("c5", Some("c4"))
+            .commit("m0", None)
+            .branch("master", "m0")
+            .branch("feature", "c5")
+            .head("feature")
+            .mark_default("master");
+        let mut options = options();
+        options.base = Some("master".to_owned());
+        let error = block_on(analyze_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            now_anchor(),
+            &RecordingReporter::new(),
+            false,
+            &writer(),
+            &spawner(),
+        ))
+        .unwrap_err();
+        assert!(matches!(error, RunError::Analyze { .. }), "{error:?}");
+        let message = error.to_string();
+        assert!(message.contains("--unshallow"), "{message}");
+        // The deliberately chosen base is named and reported as unrelated, without
+        // suggesting the user pick a different --base value.
+        assert!(message.contains("master is genuinely unrelated"), "{message}");
+        assert!(!message.contains("name the intended base"), "{message}");
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/analyze/pipeline.rs
+++ b/packages/cargo-bench-history/src/analyze/pipeline.rs
@@ -1668,7 +1668,10 @@ mod tests {
         assert!(message.contains("--unshallow"), "{message}");
         // The deliberately chosen base is named and reported as unrelated, without
         // suggesting the user pick a different --base value.
-        assert!(message.contains("master is genuinely unrelated"), "{message}");
+        assert!(
+            message.contains("master is genuinely unrelated"),
+            "{message}"
+        );
         assert!(!message.contains("name the intended base"), "{message}");
     }
 

--- a/packages/cargo-bench-history/src/analyze/prune.rs
+++ b/packages/cargo-bench-history/src/analyze/prune.rs
@@ -369,8 +369,9 @@ where
 /// removal. When pruning the base branch itself (`tip_is_merge_base`), every
 /// selected commit is eligible. Otherwise only the context branch's own commits —
 /// those strictly after the merge-base — are eligible, so base-branch history is
-/// preserved. A `None` merge-base means no base ancestry is shared, so every
-/// commit is the context branch's own.
+/// preserved. A `None` merge-base index means the merge-base is off the target's
+/// first-parent line (an off-chain merge-base), so no first-parent commit is
+/// base-side and every one is the context branch's own.
 fn commit_is_eligible(
     index: usize,
     merge_base_index: Option<usize>,
@@ -1535,7 +1536,8 @@ mod tests {
         // On the base branch (tip is its own merge-base), every commit is eligible.
         assert!(commit_is_eligible(0, Some(3), true));
         assert!(commit_is_eligible(3, Some(3), true));
-        // With no shared base ancestry, every commit is the context's own.
+        // An off-chain merge-base (no first-parent split point) leaves every
+        // first-parent commit as the context's own.
         assert!(commit_is_eligible(0, None, false));
         assert!(commit_is_eligible(5, None, false));
     }

--- a/packages/cargo-bench-history/src/analyze/window.rs
+++ b/packages/cargo-bench-history/src/analyze/window.rs
@@ -11,14 +11,16 @@ use crate::RunError;
 
 /// Auto-detects the analysis mode from the resolved topology and recorded data.
 ///
-/// An official base-branch view — the target's tip *is* its own merge-base (or no
-/// base is known) and no dirty run is recorded on that tip — is
+/// An official base-branch view — the target's tip *is* its own merge-base with
+/// the base and no dirty run is recorded on that tip — is
 /// [`AnalysisMode::History`]. Anything else (commits past the merge-base, or a
 /// dirty run actually recorded on top of the base tip) is treated as an unnamed
 /// feature branch: [`AnalysisMode::Branch`]. `auto_mode` reads only these two
 /// signals; the working tree enters only indirectly, since a base-tip dirty run
 /// counts as feature-branch data only while the tree is currently dirty — a dirty
-/// checkout with no admitted dirty run still analyzes as history.
+/// checkout with no admitted dirty run still analyzes as history. The merge-base
+/// is always known here: an undeterminable one is a hard error in `resolve_history`,
+/// never a silent fallback to this mode.
 pub(crate) fn auto_mode(tip_is_merge_base: bool, dirty_tip_run_present: bool) -> AnalysisMode {
     if tip_is_merge_base && !dirty_tip_run_present {
         AnalysisMode::History


### PR DESCRIPTION
## Summary

Fixes #353. `analyze` (and the shared list/prune/examine topology resolution) auto-detected its mode from `tip_is_merge_base`, which `is_none_or` set to `true` whenever the merge-base was **unknown** — the base ref could not be resolved, or it shared no common ancestor with the target (the shallow-clone / `fetch-depth: 1` case). An unknown topology was therefore indistinguishable from a genuine base-branch checkout and silently fell into **History** mode, giving a base-branch trend instead of the branch comparison the user expected.

Per the issue discussion, rather than emitting a warning and proceeding on incomplete history, we **fail hard**: there is no requirement to support shallow clones or other anomalous history, so an unknown topology is reported, not guessed around.

## Changes

- `resolve_history` now returns an error when the merge-base cannot be determined, with a cause-specific, actionable message:
  - **Base ref unresolved** → "could not determine the base branch… pass an explicit `--base`, set `project.default_branch`, or make the default branch available."
  - **No common ancestor** → "…they share no common ancestor… usually a shallow clone… fetch the full history (`git fetch --unshallow` / `fetch-depth: 0`) or pass an explicit `--base`."
- With the merge-base always known past that guard, `tip_is_merge_base` and `merge_base_index` drop their `Option`-guessing (`merge_base == target_commit_id` / `order.get(&merge_base)`). This also makes prune's `--prune-base` guard fire only for a genuine base-branch checkout.
- This applies uniformly across the shared analyze / list / prune / examine topology path.

## Tests

- Replaced the test that codified the old silent fallback (`analyze_without_a_resolvable_base_branch_loads_the_whole_history`) with `analyze_without_a_resolvable_base_branch_is_an_error`.
- Added `analyze_without_a_common_ancestor_is_an_error` for the disjoint/shallow case. The two error arms assert distinct substrings, so the branch is mutation-resistant.

## Docs

- Updated `docs/DESIGN.md` §7 (base resolution) and §8.5 (analysis modes), plus the field/function doc comments in `history.rs`, `window.rs`, and `prune.rs`.

## Validation

`cargo build`, the full `--lib` suite (608 passed), and `cargo clippy --all-targets` all clean.

## Note

I deliberately did **not** implement the "generalize the `warning` slot to a warnings list" refactor the issue floated — that was for the warn-and-proceed approach, which this PR replaces with a hard failure.