### PR TITLE
Drop root Cargo.toml/Cargo.lock from delta trip wires

### DIFF
--- a/delta.toml
+++ b/delta.toml
@@ -8,9 +8,14 @@ file_exclude_patterns = ["target", "mutants.out", "mutants.out.old", "**/.*"]
 # all crates in the workspace are considered impacted. This is used
 # for files that affect the entire workspace, such as configuration
 # files, workflow definitions and the build system itself.
+#
+# The workspace-root Cargo.toml and Cargo.lock are deliberately omitted: ordinary
+# dependency-management edits touch them constantly yet rarely affect every crate, so
+# treating them as trip wires would force a full-workspace run on almost every PR and
+# defeat delta scoping. Genuinely cross-cutting manifest changes (e.g. a shared
+# [workspace.dependencies] bump) are still caught by the push-to-main backstop, which
+# always validates the full workspace regardless of delta.
 trip_wire_patterns = [
-    "Cargo.toml",
-    "Cargo.lock",
     "rust-toolchain.toml",
     "clippy.toml",
     "unstable-rustfmt.toml",

--- a/docs/cargo-delta.md
+++ b/docs/cargo-delta.md
@@ -13,8 +13,15 @@ Only those packages are validated.
 
 Certain files are designated as "trip wires" (see `delta.toml`). If any trip wire file is
 changed, all packages are validated regardless. Trip wires include workspace-wide configuration
-files (`Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, etc.), workflow definitions and the
-build system itself.
+files (`rust-toolchain.toml`, `clippy.toml`, etc.), workflow definitions and the build system
+itself.
+
+The workspace-root `Cargo.toml` and `Cargo.lock` are intentionally *not* trip wires: routine
+dependency edits touch them constantly but rarely affect every package, so tripping the whole
+workspace on each one would defeat delta scoping. Genuinely cross-cutting manifest changes are
+still caught by the push-to-main backstop, which always validates the full workspace. (Per-package
+`Cargo.toml` files were never trip wires - the pattern only matched the root manifest - and
+continue to scope to their own package.)
 
 ## Local usage
 


### PR DESCRIPTION
## What

Removes the workspace-root `Cargo.toml` and `Cargo.lock` from `delta.toml`'s `trip_wire_patterns`, so routine dependency-management edits no longer force a full-workspace cargo-delta run on every PR.

## Why

Ordinary dependency edits touch the root `Cargo.toml`/`Cargo.lock` constantly but rarely affect every crate. Treating them as trip wires meant almost every PR reported "everything is affected", defeating the point of delta scoping.

Key facts that make this safe and sufficient:

- **Push-to-main never runs cargo-delta.** The `delta` job in `validation.yml` short-circuits on `push` and validates the full workspace regardless. So `delta.toml` trip wires only ever apply to **PR** builds (and local `just delta`) — there's no main-branch behavior to preserve, hence no need for a second config file or on-the-fly config generation.
- **The backstop still covers cross-cutting changes.** A genuinely workspace-wide manifest change (e.g. a shared `[workspace.dependencies]` bump) is still caught by the push-to-main full-workspace validation.
- **Per-package manifests are unaffected.** The trip-wire glob matched against the full repo-relative path, so `"Cargo.toml"`/`"Cargo.lock"` (no wildcards) only ever matched the root files; `packages/*/Cargo.toml` were never trip wires and continue to scope to their own crate.

## Changes

- `delta.toml`: drop the two entries, with a comment explaining the deliberate omission.
- `docs/cargo-delta.md`: update the trip-wire description accordingly.

## Verification

`cargo delta -c delta.toml analyze` parses the config and reports the trip-wire list without `Cargo.toml`/`Cargo.lock`; all other trip wires (`rust-toolchain.toml`, `clippy.toml`, `justfiles/**`, `.github/**`, etc.) are retained.