### PR TITLE
Read legacy metric kinds leniently in the analyze projection

### DIFF
--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -41,6 +41,42 @@ async fn analyze_detects_regression_in_seeded_history() {
     assert!(report.contains("instruction_count"), "{report}");
 }
 
+/// History written by an older tool can carry metric kinds since dropped (the
+/// build-layout-volatile Callgrind events). `analyze` must skip those kinds and keep
+/// folding the retained ones rather than aborting the whole run on an unknown-variant
+/// parse error — the exact failure a stored `conditional_branch_misses` metric caused
+/// on the real history. The `instruction_count` regression must still surface.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_tolerates_legacy_metric_kinds_in_stored_history() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind_with_legacy_metric("c1", 100.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.seed_callgrind_with_legacy_metric("c2", 100.0);
+    workspace.commit_dated("2024-01-03", "c3");
+    workspace.seed_callgrind_with_legacy_metric("c3", 100.0);
+    workspace.commit_dated("2024-01-04", "c4");
+    workspace.seed_callgrind_with_legacy_metric("c4", 130.0);
+    workspace.commit_dated("2024-01-05", "c5");
+    workspace.seed_callgrind_with_legacy_metric("c5", 130.0);
+    workspace.commit_dated("2024-01-06", "c6");
+    workspace.seed_callgrind_with_legacy_metric("c6", 130.0);
+
+    let outcome = workspace.drive(&["analyze"]).await.unwrap();
+    let RunOutcome::Analyzed {
+        report,
+        regressions,
+        ..
+    } = outcome
+    else {
+        panic!("expected an analyzed outcome, got {outcome:?}");
+    };
+    assert_eq!(regressions, 1);
+    assert!(report.contains("nm::observe/pull"), "{report}");
+    assert!(report.contains("instruction_count"), "{report}");
+}
+
 /// A rising Criterion `wall_time` history is flagged as a regression, proving the
 /// analyzer reconstructs series across a machine-keyed partition too.
 #[tokio::test]

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -976,18 +976,23 @@ impl Workspace {
     }
 
     /// Seeds a Callgrind result set for commit `label` that carries a valid `Ir`
-    /// metric plus a `conditional_branch_misses` metric — one of the
+    /// metric at `ir_value` plus a `conditional_branch_misses` metric — one of the
     /// build-layout-volatile kinds dropped from the tool. A current [`Run`] cannot
     /// represent that kind, so the object is planted as raw JSON, reproducing history
     /// written by an older tool.
-    pub(crate) fn seed_callgrind_with_legacy_metric(&self, label: &str, value: f64) {
+    pub(crate) fn seed_callgrind_with_legacy_metric(&self, label: &str, ir_value: f64) {
+        // The dropped metric's value is irrelevant to the read path under test (it is
+        // discarded on parse), so any fixed figure standing in for real Callgrind
+        // output serves.
+        const LEGACY_METRIC_VALUE: f64 = 3.0;
+
         let commit_id = self.commit_id(label);
         let observed = self.committer_time(&commit_id);
         let key = format!(
             "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit_id}/clean.json"
         );
         let mut object: serde_json::Value = serde_json::from_str(
-            &ir_result_set(observed.as_second(), &commit_id, value)
+            &ir_result_set(observed.as_second(), &commit_id, ir_value)
                 .to_json()
                 .unwrap(),
         )
@@ -995,7 +1000,10 @@ impl Workspace {
         object["results"][0]["metrics"]
             .as_array_mut()
             .unwrap()
-            .push(serde_json::json!({ "kind": "conditional_branch_misses", "value": 3.0 }));
+            .push(serde_json::json!({
+                "kind": "conditional_branch_misses",
+                "value": LEGACY_METRIC_VALUE,
+            }));
         self.seed_raw_json(&key, &serde_json::to_string(&object).unwrap());
     }
 

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1,5 +1,6 @@
 pub(crate) use std::cell::RefCell;
 pub(crate) use std::collections::HashMap;
+use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 pub(crate) use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Stdio};
@@ -97,14 +98,14 @@ fn build_base_template() -> tempfile::TempDir {
     let template = tempfile::tempdir().unwrap();
     let root = template.path();
     run_git(root, &["init", "-b", "master"]);
-    std::fs::write(
+    fs::write(
         root.join(".git").join("info").join("exclude"),
         "/.cargo/\n/store/\n/target/\n",
     )
     .unwrap();
     run_git(root, &["commit", "--allow-empty", "-m", "root"]);
     let git_dir = root.join(".git");
-    if let Ok(entries) = std::fs::read_dir(git_dir.join("hooks")) {
+    if let Ok(entries) = fs::read_dir(git_dir.join("hooks")) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "sample") {
@@ -120,7 +121,7 @@ fn build_base_template() -> tempfile::TempDir {
 /// an optimization: a file that cannot be removed (already absent on some git version,
 /// say) only leaves the copy marginally larger and is never an error.
 fn remove_best_effort(path: &Path) {
-    match std::fs::remove_file(path) {
+    match fs::remove_file(path) {
         Ok(()) | Err(_) => {}
     }
 }
@@ -128,15 +129,15 @@ fn remove_best_effort(path: &Path) {
 /// Recursively copies the directory tree at `src` into `dst`, creating `dst` and any
 /// missing parents. Used to clone the base template's `.git` into a fresh workspace.
 fn copy_dir_all(src: &Path, dst: &Path) {
-    std::fs::create_dir_all(dst).unwrap();
-    for entry in std::fs::read_dir(src).unwrap() {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
         let entry = entry.unwrap();
         let from = entry.path();
         let to = dst.join(entry.file_name());
         if entry.file_type().unwrap().is_dir() {
             copy_dir_all(&from, &to);
         } else {
-            std::fs::copy(&from, &to).unwrap();
+            fs::copy(&from, &to).unwrap();
         }
     }
 }
@@ -420,8 +421,8 @@ impl Workspace {
             inject_local: true,
         };
         let cargo_dir = workspace.root().join(".cargo");
-        std::fs::create_dir_all(&cargo_dir).unwrap();
-        std::fs::write(cargo_dir.join("bench_history.toml"), config).unwrap();
+        fs::create_dir_all(&cargo_dir).unwrap();
+        fs::write(cargo_dir.join("bench_history.toml"), config).unwrap();
         workspace
     }
 
@@ -469,8 +470,8 @@ impl Workspace {
             inject_local: true,
         };
         let path = workspace.root().join(relative);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, config).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, config).unwrap();
         workspace
     }
 
@@ -599,11 +600,11 @@ impl Workspace {
     pub(crate) fn head_commit_id(&self) -> String {
         self.flush_git();
         let git_dir = self.root().join(".git");
-        if let Ok(head) = std::fs::read_to_string(git_dir.join("HEAD")) {
+        if let Ok(head) = fs::read_to_string(git_dir.join("HEAD")) {
             let head = head.trim();
             if let Some(reference) = head.strip_prefix("ref: ") {
                 // `refs/heads/<branch>` uses `/`, which the Windows path APIs accept.
-                if let Ok(commit_id) = std::fs::read_to_string(git_dir.join(reference)) {
+                if let Ok(commit_id) = fs::read_to_string(git_dir.join(reference)) {
                     let commit_id = commit_id.trim();
                     if commit_id.len() == 40 {
                         return commit_id.to_owned();
@@ -747,7 +748,7 @@ impl Workspace {
     /// takes the next synthetic committer date, keeping the timeline monotonic and
     /// in-window like the surrounding empty commits.
     pub(crate) fn commit_with_file(&self, message: &str, relative: &str, contents: &str) -> String {
-        std::fs::write(self.root().join(relative), contents).unwrap();
+        fs::write(self.root().join(relative), contents).unwrap();
         self.git(&["add", relative]);
         let second = self.graph.borrow_mut().next_undated_second();
         self.git_at(&["commit", "-m", message], second);
@@ -788,12 +789,12 @@ impl Workspace {
     /// Writes an untracked file at `relative`, leaving the working tree dirty (it
     /// is neither committed nor git-ignored).
     pub(crate) fn make_dirty(&self, relative: &str) {
-        std::fs::write(self.root().join(relative), "uncommitted\n").unwrap();
+        fs::write(self.root().join(relative), "uncommitted\n").unwrap();
     }
 
     /// Reads a file relative to the workspace root, if it exists.
     pub(crate) fn read(&self, relative: &str) -> Option<String> {
-        std::fs::read_to_string(self.root().join(relative)).ok()
+        fs::read_to_string(self.root().join(relative)).ok()
     }
 
     /// Drives a command with `args` against this workspace.
@@ -927,7 +928,7 @@ impl Workspace {
                     .map(|component| component.as_os_str().to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
                     .join("/");
-                let raw = std::fs::read(&path).unwrap();
+                let raw = fs::read(&path).unwrap();
                 let json = String::from_utf8(codec::decompress(&raw).unwrap()).unwrap();
                 let set = Run::from_json(&json).unwrap();
                 (key, set)
@@ -957,8 +958,45 @@ impl Workspace {
         for part in key.split('/') {
             path.push(part);
         }
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, codec::compress(set.to_json().unwrap().as_bytes())).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, codec::compress(set.to_json().unwrap().as_bytes())).unwrap();
+    }
+
+    /// Writes arbitrary `json` to `key`, compressed exactly as [`seed`](Self::seed)
+    /// does. Used to plant objects a current [`Run`] can no longer express — notably
+    /// a run carrying a metric kind the tool has since dropped — so the read path is
+    /// exercised against legacy on-disk data.
+    pub(crate) fn seed_raw_json(&self, key: &str, json: &str) {
+        let mut path = self.root().join("store");
+        for part in key.split('/') {
+            path.push(part);
+        }
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, codec::compress(json.as_bytes())).unwrap();
+    }
+
+    /// Seeds a Callgrind result set for commit `label` that carries a valid `Ir`
+    /// metric plus a `conditional_branch_misses` metric — one of the
+    /// build-layout-volatile kinds dropped from the tool. A current [`Run`] cannot
+    /// represent that kind, so the object is planted as raw JSON, reproducing history
+    /// written by an older tool.
+    pub(crate) fn seed_callgrind_with_legacy_metric(&self, label: &str, value: f64) {
+        let commit_id = self.commit_id(label);
+        let observed = self.committer_time(&commit_id);
+        let key = format!(
+            "v1/testproj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit_id}/clean.json"
+        );
+        let mut object: serde_json::Value = serde_json::from_str(
+            &ir_result_set(observed.as_second(), &commit_id, value)
+                .to_json()
+                .unwrap(),
+        )
+        .unwrap();
+        object["results"][0]["metrics"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({ "kind": "conditional_branch_misses", "value": 3.0 }));
+        self.seed_raw_json(&key, &serde_json::to_string(&object).unwrap());
     }
 
     /// Seeds one Callgrind result set with an `Ir` value for the previously created
@@ -1537,7 +1575,7 @@ pub(crate) fn storage_only_config_with_id(id: &str) -> String {
 }
 
 pub(crate) fn collect_json_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {

--- a/packages/cbh_detect/src/detect/run_points.rs
+++ b/packages/cbh_detect/src/detect/run_points.rs
@@ -13,7 +13,12 @@
 //! the run payload, so the projection carries no git fields at all. Serde ignores
 //! the unmentioned JSON fields, so a run still parses unchanged; only the discarded
 //! parts are never
-//! materialized. (The leaner element trims overall peak only marginally — peak is
+//! materialized. Metric kinds the tool no longer tracks (the build-layout-volatile
+//! Callgrind events dropped in the metric cull) are skipped rather than failing the
+//! parse, matching [`cbh_model`'s lenient run read](cbh_model::MetricList) — the
+//! same stored files feed both paths, so a single legacy object must not abort the
+//! whole history analysis. (The leaner element trims overall peak only marginally —
+//! peak is
 //! set by the per-worker builders coexisting during the merge — but the lighter
 //! parse is still worth keeping; see the load section of `cargo-bench-history`'s
 //! `docs/analyze.md`.)
@@ -78,7 +83,70 @@ pub struct ResultPoints {
     /// The fold-relevant projection of each captured metric. Inline up to two, as
     /// the noisy single-metric engines are the common case, matching
     /// [`MetricList`](cbh_model::MetricList).
+    #[serde(deserialize_with = "deserialize_metric_points")]
     pub metrics: SmallVec<[MetricPoint; 2]>,
+}
+
+/// Deserializes the metric-point list, silently dropping any metric whose `kind`
+/// is not one of the kinds the tool tracks.
+///
+/// This mirrors [`cbh_model`'s lenient run read][run]: stored history predates the
+/// removal of the build-layout-volatile Callgrind metrics (cache hits per tier,
+/// estimated cycles, branch misses), so run files written by an older tool can
+/// still carry those kinds. The lean analyze/examine projection parses those same
+/// files, so it must drop the unknown kinds too — failing the whole run parse on an
+/// unknown-variant error would abort the entire history analysis over any such data.
+///
+/// The raw list is kept inline in a `SmallVec` matching the projection's capacity so
+/// the common one- or two-metric case stays allocation-free on this hot read path.
+///
+/// [run]: cbh_model::MetricList
+fn deserialize_metric_points<'de, D>(
+    deserializer: D,
+) -> Result<SmallVec<[MetricPoint; 2]>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = SmallVec::<[RawMetricPoint<'de>; 2]>::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(RawMetricPoint::into_point)
+        .collect())
+}
+
+/// A metric point as it appears on disk, with the kind left as its raw wire name so
+/// an unknown kind can be recognized and dropped rather than aborting the parse.
+///
+/// The kind is borrowed straight from the input JSON (a `&str` tied to the
+/// deserializer input): it is only needed transiently to resolve a [`MetricKind`]
+/// before this raw form is discarded, so borrowing avoids a `String` allocation per
+/// metric on the read path. The stored kind names are a fixed vocabulary of unescaped
+/// identifiers, so the borrow always succeeds against the [`from_json`] input backing
+/// every run decode. The persisted `std_dev` the fold never reads is left unmentioned
+/// and thus ignored.
+///
+/// [`from_json`]: RunPoints::from_json
+#[derive(Deserialize)]
+struct RawMetricPoint<'a> {
+    kind: &'a str,
+    value: f64,
+    #[serde(default)]
+    interval_low: Option<f64>,
+    #[serde(default)]
+    interval_high: Option<f64>,
+}
+
+impl RawMetricPoint<'_> {
+    /// Converts to a [`MetricPoint`], or `None` when the kind is not one of the
+    /// kinds the tool tracks.
+    fn into_point(self) -> Option<MetricPoint> {
+        Some(MetricPoint {
+            kind: MetricKind::from_name(self.kind)?,
+            value: self.value,
+            interval_low: self.interval_low,
+            interval_high: self.interval_high,
+        })
+    }
 }
 
 /// A metric reduced to the fields the series fold reads.
@@ -195,6 +263,33 @@ mod tests {
         // A payload that is not a serialized run must surface a parse error rather
         // than silently yielding an empty or partial projection.
         RunPoints::from_json("not valid json").unwrap_err();
+    }
+
+    #[test]
+    fn from_json_drops_unknown_metric_kinds() {
+        // Legacy history can still carry metric kinds the tool no longer tracks (the
+        // build-layout-volatile Callgrind events removed in the metric cull). The
+        // lean analyze/examine projection must skip them rather than fail the whole
+        // run parse, matching the full-`Run` read path — otherwise a single old
+        // object aborts the entire history analysis.
+        let mut value: serde_json::Value =
+            serde_json::from_str(&sample_run().to_json().unwrap()).unwrap();
+        value["results"][0]["metrics"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({ "kind": "conditional_branch_misses", "value": 5.0 }));
+
+        let json = serde_json::to_string(&value).unwrap();
+        let points = RunPoints::from_json(&json).unwrap();
+        let kinds: Vec<MetricKind> = points.results()[0]
+            .metrics
+            .iter()
+            .map(|metric| metric.kind)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![MetricKind::WallTime, MetricKind::InstructionCount]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

PR #359 dropped six build-volatile Callgrind metrics and made stored runs read leniently so history written by an older tool keeps parsing. That leniency was only applied to the **full `Run` parse** in `cbh_model` (`BenchmarkResult::metrics`, via `deserialize_metrics`/`RawMetric`).

But `analyze`/`examine`/`list` never parse the full `Run`. The hot object loader in `cbh_analyze/src/load.rs` deserializes the **lean `RunPoints` projection** (`cbh_detect`), whose `MetricPoint.kind: MetricKind` derived `Deserialize` directly and still rejected unknown variants. A stored `conditional_branch_misses` metric therefore aborted the entire history analysis on `main`:

```
Error: failed to analyze history: stored object v1/folo/objects/callgrind/aarch64-unknown-linux-gnu/synthetic/.../clean.json is not a valid result set: unknown variant `conditional_branch_misses`, expected one of `wall_time`, `processor_time`, `instruction_count`, `conditional_branches`, `indirect_branches`, `allocated_bytes`, `allocation_count`
```

The lenient-read regression test added in #359 only exercised the full-`Run` path, so the projection's gap had no coverage — which is why this slipped through.

## What

- **`cbh_detect/src/detect/run_points.rs`**: `ResultPoints.metrics` now deserializes via `deserialize_metric_points` + a `RawMetricPoint` that borrows the raw kind name and drops any kind `MetricKind::from_name` does not recognize — mirroring `cbh_model`'s policy. This fixes `analyze`, `examine`, and `list` at once, since they share the loader. `DESIGN.md` already documents this lenient-read intent, so no doc change is needed — the implementation now matches the documented design.
- **Regression coverage** (the gap that let this through):
  - a unit test feeding a legacy kind through `RunPoints::from_json`;
  - an end-to-end `analyze` integration test over history carrying `conditional_branch_misses`, plus harness helpers (`seed_raw_json`, `seed_callgrind_with_legacy_metric`) to plant legacy JSON a current `Run` cannot express.
- **`harness.rs` tidy**: import `std::fs` and use `fs::` throughout, matching how the file already imports its other `std` modules.

## Validation

- Reproduced the exact CI error against unfixed code; the fix makes it pass.
- `cbh_detect` (117), `cbh_model` (51), `cbh_analyze` (143) lib tests and the full `cargo-bench-history` integration suite (133) all green.
- `cargo clippy` on the changed crates: zero warnings. `cargo +nightly fmt --check`: clean. Docs build clean under `-D warnings`.