### PR TITLE
Add `--best-of <N>` min-of-N noise reduction to cargo-bench-history

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -50,9 +50,13 @@ jobs:
         platform: [ubuntu-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
 
     runs-on: ${{ matrix.platform }}
-    # Generous ceiling: the suite already takes a while and grows as benchmarks are
-    # added; the matrix runs in parallel, so a high cap only bounds a genuinely stuck
-    # run rather than the expected duration.
+    # 360 minutes is GitHub's hard per-job ceiling for hosted runners, so this is as
+    # high as the cap can go. `--best-of 3` (see the gh-collect-bench-history recipe)
+    # runs the suite three times, roughly tripling the benchmark portion; a single run
+    # sits around 60-75 min, so even the ~3x worst case stays well under the ceiling.
+    # The matrix runs in parallel, so the cap only bounds a genuinely stuck run rather
+    # than the expected duration. If the suite ever grows enough that 3x approaches six
+    # hours, shard the benchmarks across jobs rather than trying to raise this further.
     timeout-minutes: 360
 
     # `id-token: write` lets cargo-bench-history mint short-lived GitHub OIDC tokens

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -88,6 +88,11 @@ and analysis reads only that key: the GitHub-hosted runner pool may hold differe
 machines, so fingerprinting would fork the series on every SKU change and let unrelated
 machines pollute the data set, whereas one fixed key keeps a single series (accepting the
 pool's jitter) that a deliberate blessing absorbs across a genuine hardware migration.
+To blunt that jitter rather than merely accept it, collection runs the whole suite several
+times per commit and keeps, per metric, the minimum sample: runner interference is one-sided
+(a contended host only ever makes a benchmark slower) and the repeats are spaced apart in
+time, so the minimum is the reading least perturbed by transient noise. This trades a
+proportionally longer collection job for a more stable series.
 A downstream analysis job reads the accumulated
 history and files a single rolling, advisory issue when it detects a notable regression;
 regressions never fail the run. Because a GitHub issue body is size-capped and a large

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -13,14 +13,19 @@
 # a different SKU. Pinning keeps every push on one series (accepting the jitter a heterogeneous
 # pool causes); a genuine hardware migration is absorbed by blessing the resulting step change.
 # Deterministic engines (Callgrind, allocation/time counters) are hardware-independent and
-# ignore the key. `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
+# ignore the key. `--best-of 3` counteracts the same runner noise from the other direction: the
+# suite runs three times and each metric keeps its minimum sample, since benchmark interference
+# on a shared runner is one-sided (it only ever makes a case slower) and the runs are spaced far
+# enough apart in time that a transient slowdown is unlikely to hit every one. This roughly
+# triples the wall-clock benchmark portion of the collect job (see bench-history.yml's
+# `timeout-minutes`). `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
 # already-stored object is skipped, not overwritten), so a re-triggered run of an
 # already-collected commit never bumps the cache-invalidation marker the `analyze` job's
 # read-through cache depends on - a re-run of the same commit is not "better" data, so there is
 # nothing to replace.
 [group('automation')]
 gh-collect-bench-history:
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- collect --workspace --exclude benchmarks --machine-key github --skip-existing --verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- collect --workspace --exclude benchmarks --machine-key github --best-of 3 --skip-existing --verbose
 
 # Analyzes the collected history for regressions across ALL engines and target triples, but
 # only the `github` machine key - the fixed key `gh-collect-bench-history` stamps on the

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -94,9 +94,9 @@ not conclusion-only** (see `docs/standalone-binaries.md`). Tests use the `#[cfg(
   point carries a confidence interval (`criterion`, `all_the_time`, and `alloc_tracker` all
   record one on every operation) or is a single value (`callgrind`, plus any legacy mean-only
   file the adapter still tolerates). An interval is only ever an extra veto that can suppress
-  a candidate finding, never create one. `collect`/`backfill` invoke `cargo bench` once and
-  harvest whatever ran; `--engine` is an `analyze` facet, not a collect flag. Details:
-  DESIGN §1.
+  a candidate finding, never create one. `collect`/`backfill` invoke `cargo bench` (once, or
+  `--best-of N` times keeping the per-metric minimum) and harvest whatever ran; `--engine` is
+  an `analyze` facet, not a collect flag. Details: DESIGN §1, §7.1.
 
 ## Testing
 

--- a/packages/cargo-bench-history/README.md
+++ b/packages/cargo-bench-history/README.md
@@ -32,6 +32,10 @@ cargo bench-history install
 # locally. Drop --local to store in the cloud backend from the config file.
 cargo bench-history collect --local=./bench-history
 
+# On a noisy runner, run the suite a few times and keep the best (minimum) value
+# per metric, since benchmark interference only ever makes a case slower.
+cargo bench-history collect --local=./bench-history --best-of 3
+
 # Bootstrap history by benching a range of past commits, so analysis has a
 # trend to work with (a single run on its own has nothing to compare against).
 cargo bench-history backfill --local=./bench-history <from-commit> <to-commit>

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -339,7 +339,7 @@ that names the three.
 
 ### 7.1 `collect`
 
-`collect` invokes the workspace's benches once with `cargo bench` and harvests whichever
+`collect` invokes the workspace's benches with `cargo bench` and harvests whichever
 engines produced output — there is no engine configuration. It enables the combined
 environment every supported engine needs (only Callgrind needs an opt-in variable; the
 others auto-emit) and then inspects each output tree to see which engines actually ran.
@@ -352,6 +352,23 @@ relative target path would be resolved there by an engine that honours it and sc
 output away from the workspace-rooted harvest. Harvest is scoped to files modified at or
 after the run start, so stale cases from earlier runs are never re-ingested and whatever
 subset actually ran is exactly what is stored.
+
+`--best-of N` reruns the whole suite `N` times (default `1`) and stores, per metric, the
+**minimum** observed value. Benchmark interference on a shared CI runner is one-sided — it
+only ever makes a case *slower* — and the runs are spaced apart in wall-clock time (each
+`cargo bench` takes many seconds), so a transient slowdown is unlikely to hit the same case
+in every run; the minimum discards it. The winning sample is stored **wholesale** (its own
+confidence interval travels with it), so a stored result may blend metrics selected from
+different physical runs — accepted, since each metric is judged on its own timeline. Because
+the runs must be reducible metric-by-metric, every run must measure the **same set of cases
+and the same metrics per case**; any cross-run mismatch is a hard error that fails the whole
+collection rather than being papered over. The stored run takes its observation time and
+dirty-snapshot key from the **first** run's start (the git/toolchain/hardware context is
+probed once, after the runs, and does not change between them), and any non-zero `cargo
+bench` exit still aborts fail-fast. `N == 1` reproduces a plain single run. Two caveats
+remain: a runner that is slow for the *entire* job is not corrected by the minimum, and
+Callgrind's deterministic counts make min-of-N a (costly) no-op for that engine — but the
+single `cargo bench` interface cannot select engines, so both are accepted.
 
 `collect` always persists — there is no separate publish step (`--no-store` runs without
 writing, for dry runs). A clean point writes the deterministic clean key, refused by
@@ -454,7 +471,8 @@ commits that already have a stored result are listed once up front and **skipped
 their benches run**, making backfill resumable and cheap to re-issue; overwrite regenerates
 them. A build or bench failure stops by default (or, with a flag, is recorded and skipped
 with an end-of-run summary), while infrastructure failures always abort since continuing
-cannot produce correct data.
+cannot produce correct data. `--best-of N` carries through to each commit's `collect`, so a
+backfill can apply the same min-of-N noise reduction (§7.1) uniformly across the range.
 
 ### 7.5 `list`
 

--- a/packages/cargo-bench-history/src/commands/backfill.rs
+++ b/packages/cargo-bench-history/src/commands/backfill.rs
@@ -541,6 +541,7 @@ impl<S: Storage> CommitRunner for SystemCommitRunner<'_, S> {
             skip_existing: false,
             passthrough: self.options.passthrough.clone(),
             verbose: self.options.verbose,
+            best_of: self.options.best_of,
         };
         let deps = CollectDeps {
             runner: &runner,

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -26,7 +26,7 @@ use tick::Clock;
 
 use crate::model::{
     BenchmarkResult, DiscriminantSet, Engine, EnvironmentInfo, GitInfo, Run, RunContext,
-    ToolchainInfo, detect_environment,
+    ToolchainInfo, detect_environment, min_per_metric,
 };
 use crate::{CollectOptions, LocalStorageSelection, RunError, RunOutcome, finish_with_flush};
 
@@ -265,15 +265,24 @@ where
     Ok(RunOutcome::Completed { message })
 }
 
-/// Runs the benchmark command once and harvests every engine's output.
+/// Runs the benchmark command `--best-of` times and harvests every engine's output.
 ///
 /// This is the storage-aware core shared by the `collect` command and `backfill`:
 /// the former wraps the summary in a human-readable message, the latter maps it
-/// to a per-commit outcome. The benchmark command (`cargo bench` in production)
-/// is run a single time with the union of every engine's injected environment;
-/// each engine is then identified by which output tree it populated. An engine
-/// that produced no output (for example Callgrind off Linux, where its benches
-/// compile to no-ops) simply contributes nothing.
+/// to a per-commit outcome. The benchmark command (`cargo bench` in production) is
+/// run `options.best_of` times, each time with the union of every engine's
+/// injected environment; each engine is identified by which output tree it
+/// populated. An engine that produced no output (for example Callgrind off Linux,
+/// where its benches compile to no-ops) simply contributes nothing.
+///
+/// With `--best-of N` the whole suite runs `N` times and each metric is reduced to
+/// its minimum across the runs (see [`min_per_metric`]), so a transient slowdown
+/// on one run is discarded rather than stored. Every run must measure the same set
+/// of cases and metrics; a mismatch fails the collection ([`RunError::Inconsistent`]).
+/// The stored run takes its timeline position and dirty-snapshot key from the
+/// first run's start, and the git/toolchain/hardware context is probed once after
+/// the runs finish (it does not change between them). `N == 1` reproduces a plain
+/// single run.
 pub(crate) async fn run_engines<R, P, O, S>(
     options: &CollectOptions,
     deps: &CollectDeps<'_, R, P, O, S>,
@@ -286,7 +295,7 @@ where
 {
     let argv = build_bench_argv(deps.bench_command, options)?;
 
-    // The benchmark command runs once with the union of every engine's injected
+    // The benchmark command runs with the union of every engine's injected
     // environment plus `CARGO_TARGET_DIR` pinned to the directory the harvest
     // scans, so engine output always lands where it is collected from — notably
     // when an ambient `CARGO_TARGET_DIR` (such as the one `cargo llvm-cov` sets)
@@ -308,21 +317,63 @@ where
         format!("injected environment: {rendered_env}")
     });
 
-    let run_start = deps.clock.system_time();
-    let status = deps.runner.run_benches(&argv, &env).await?;
-    if !status.success {
-        return Err(RunError::Engine {
-            engine: BENCH_COMMAND_LABEL.to_owned(),
-            code: status.code,
+    let runs = options.best_of.get();
+    if runs > 1 {
+        deps.reporter.note_with(|| {
+            format!(
+                "best-of collection: running the suite {runs} times and keeping the minimum \
+                 value per metric, so a transient slowdown on any single run is discarded"
+            )
         });
     }
-    deps.reporter.note_with(|| {
-        format!(
-            "benchmark command finished; harvesting output modified at or after {} \
-         (older files are treated as stale leftovers)",
-            timestamp_from(run_start)
-        )
-    });
+
+    // One bucket per engine (parallel to `Engine::ALL`), each collecting that
+    // engine's harvested records from every run so they can be reduced together.
+    let mut per_engine: Vec<Vec<Vec<BenchmarkResult>>> = Engine::ALL
+        .iter()
+        .map(|_| Vec::with_capacity(runs))
+        .collect();
+    let mut first_run_start: Option<SystemTime> = None;
+
+    for run_number in 1..=runs {
+        let run_start = deps.clock.system_time();
+        if first_run_start.is_none() {
+            first_run_start = Some(run_start);
+        }
+        if runs > 1 {
+            deps.reporter.note_with(|| {
+                format!(
+                    "best-of run {run_number}/{runs}: invoking {}",
+                    argv.join(" ")
+                )
+            });
+        }
+
+        let status = deps.runner.run_benches(&argv, &env).await?;
+        if !status.success {
+            return Err(RunError::Engine {
+                engine: BENCH_COMMAND_LABEL.to_owned(),
+                code: status.code,
+            });
+        }
+        deps.reporter.note_with(|| {
+            format!(
+                "benchmark command finished; harvesting output modified at or after {} \
+             (older files are treated as stale leftovers)",
+                timestamp_from(run_start)
+            )
+        });
+
+        for (bucket, engine) in per_engine.iter_mut().zip(Engine::ALL) {
+            let records = harvest_records(deps, engine, run_start).await?;
+            bucket.push(records);
+        }
+    }
+
+    // At least one run always executes (`best_of` is non-zero), so a first start
+    // was recorded. It stamps the stored run's observation time and dirty-snapshot
+    // second; later runs share the same commit, so their starts do not matter.
+    let run_start = first_run_start.expect("best-of runs the suite at least once");
 
     let rustc = deps.probe.toolchain().await?;
     let shared = SharedContext {
@@ -337,8 +388,15 @@ where
     let mut harvested = 0_usize;
     let mut labels = Vec::new();
 
-    for engine in Engine::ALL {
-        let summary = harvest_engine(options, deps, &shared, engine, run_start).await?;
+    for (bucket, engine) in per_engine.iter().zip(Engine::ALL) {
+        let combined = min_per_metric(bucket).map_err(|error| RunError::Inconsistent {
+            engine: engine.to_string(),
+            message: error.to_string(),
+        })?;
+        note_best_of_selections(deps.reporter, engine, runs, &combined.selections);
+
+        let summary =
+            store_engine(options, deps, &shared, engine, combined.results, run_start).await?;
         if summary.stored {
             stored = stored.saturating_add(1);
         }
@@ -353,6 +411,45 @@ where
         harvested,
         labels,
     })
+}
+
+/// Emits the per-metric best-of provenance: the samples seen and which run won.
+///
+/// Only meaningful when more than one run was taken, so it is a no-op for a plain
+/// single run. The chosen sample is bracketed so the reasoning behind each stored
+/// value can be reconstructed from the verbose log.
+fn note_best_of_selections(
+    reporter: &dyn Reporter,
+    engine: Engine,
+    runs: usize,
+    selections: &[crate::model::Selection],
+) {
+    if runs <= 1 {
+        return;
+    }
+    for selection in selections {
+        reporter.note_with(|| {
+            let samples = selection
+                .samples
+                .iter()
+                .enumerate()
+                .map(|(index, value)| {
+                    if index == selection.chosen_run {
+                        format!("[{value}]")
+                    } else {
+                        value.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "{engine} {}/{}: best-of samples {samples} (kept run {})",
+                selection.id,
+                selection.kind.as_str(),
+                selection.chosen_run.saturating_add(1),
+            )
+        });
+    }
 }
 
 /// Builds the benchmark command line: the base command followed by the cargo
@@ -419,25 +516,44 @@ fn build_bench_argv(
     Ok(argv)
 }
 
-/// Harvests one engine's output and (unless suppressed) stores the result set.
-async fn harvest_engine<R, P, O, S>(
-    options: &CollectOptions,
+/// Harvests and parses one engine's output for a single run.
+///
+/// The front half of storing an engine's results, split out so the `--best-of`
+/// loop can gather each run's records before they are reduced together. Producing
+/// no fresh output yields an empty vector (the steady state for an engine that
+/// does not apply here).
+async fn harvest_records<R, P, O, S>(
     deps: &CollectDeps<'_, R, P, O, S>,
-    shared: &SharedContext,
     engine: Engine,
     run_start: SystemTime,
-) -> Result<EngineSummary, RunError>
+) -> Result<Vec<BenchmarkResult>, RunError>
 where
-    R: BenchRunner,
-    P: EnvironmentProbe,
     O: BenchOutputSource,
-    S: Storage,
 {
     let harvest = deps
         .output
         .collect(engine, run_start, deps.reporter)
         .await?;
-    let records = parse_harvest(&harvest, deps.reporter)?;
+    parse_harvest(&harvest, deps.reporter)
+}
+
+/// Stores one engine's reduced result set (unless suppressed).
+///
+/// The back half of collecting an engine: given the records to persist (already
+/// reduced across the `--best-of` runs), it builds the run context and storage
+/// key and writes the object. `run_start` is the first run's start, which stamps
+/// the observation time and any dirty-snapshot second.
+async fn store_engine<R, P, O, S>(
+    options: &CollectOptions,
+    deps: &CollectDeps<'_, R, P, O, S>,
+    shared: &SharedContext,
+    engine: Engine,
+    records: Vec<BenchmarkResult>,
+    run_start: SystemTime,
+) -> Result<EngineSummary, RunError>
+where
+    S: Storage,
+{
     let count = records.len();
 
     // An engine that produced no fresh output contributes nothing. Off Linux the
@@ -784,8 +900,14 @@ fn target_root_from(configured: Option<std::ffi::OsString>, base: &Path) -> Path
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
+    #![allow(
+        clippy::float_cmp,
+        reason = "best-of stores exact input values, so comparisons are exact"
+    )]
 
+    use std::collections::HashMap;
     use std::io;
+    use std::num::NonZeroUsize;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -2359,5 +2481,431 @@ mod tests {
             }
             other => panic!("expected command error, got {other:?}"),
         }
+    }
+
+    // --- best-of-N orchestration ---------------------------------------------
+
+    /// Builds a `NonZeroUsize` for a test `--best-of` count.
+    fn best_of(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).expect("test best-of counts are non-zero")
+    }
+
+    /// A single-operation `all_the_time` harvest whose stored value is `slope`.
+    ///
+    /// The adapter maps `slope_processor_time_nanos` straight to the metric value,
+    /// so authoring a slope lets a test pin exactly what value a run contributes.
+    fn all_the_time_output(slope: f64) -> FakeOutput {
+        FakeOutput {
+            time: vec![RawOperationFile {
+                path: PathBuf::from("all_the_time/read_cell.json"),
+                content: format!(
+                    "{{\"operation\":\"read_cell\",\"total_iterations\":4,\
+                     \"total_processor_time_nanos\":80000000,\"span_count\":1,\
+                     \"slope_processor_time_nanos\":{slope}}}"
+                ),
+            }],
+            ..FakeOutput::default()
+        }
+    }
+
+    /// An output source that hands out a different [`FakeOutput`] per invocation,
+    /// so `--best-of` runs can be given distinct per-run measurements.
+    ///
+    /// Each engine advances its own cursor through `runs`, mirroring how the real
+    /// harvest scans the freshly produced tree once per engine per run. Requesting
+    /// more runs than were supplied is a test-author error and panics.
+    struct SequencedOutput {
+        runs: Vec<FakeOutput>,
+        cursors: Arc<Mutex<HashMap<Engine, usize>>>,
+    }
+
+    impl SequencedOutput {
+        fn new(runs: Vec<FakeOutput>) -> Self {
+            Self {
+                runs,
+                cursors: Arc::default(),
+            }
+        }
+    }
+
+    impl BenchOutputSource for SequencedOutput {
+        async fn collect(
+            &self,
+            engine: Engine,
+            since: SystemTime,
+            reporter: &dyn Reporter,
+        ) -> io::Result<Harvest> {
+            let index = {
+                let mut cursors = self.cursors.lock().unwrap();
+                let cursor = cursors.entry(engine).or_insert(0);
+                let index = *cursor;
+                *cursor = cursor.saturating_add(1);
+                index
+            };
+            let output = self
+                .runs
+                .get(index)
+                .expect("a sequenced test must supply one output per requested run");
+            output.collect(engine, since, reporter).await
+        }
+    }
+
+    /// A runner that succeeds until a chosen 1-based invocation, then reports a
+    /// non-zero exit, to prove `--best-of` aborts fail-fast on any failing run.
+    struct FailOnNthRunner {
+        fail_on: usize,
+        calls: Arc<Mutex<usize>>,
+    }
+
+    impl FailOnNthRunner {
+        fn new(fail_on: usize) -> Self {
+            Self {
+                fail_on,
+                calls: Arc::default(),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    impl BenchRunner for FailOnNthRunner {
+        async fn run_benches(
+            &self,
+            _argv: &[String],
+            _env: &[(String, String)],
+        ) -> io::Result<EngineStatus> {
+            let mut calls = self.calls.lock().unwrap();
+            *calls = calls.saturating_add(1);
+            let this_call = *calls;
+            Ok(EngineStatus {
+                success: this_call != self.fail_on,
+                code: (this_call == self.fail_on).then_some(101),
+            })
+        }
+    }
+
+    /// Drives `execute_collect` over arbitrary runner and output doubles.
+    ///
+    /// The other `drive*` helpers pin the concrete [`FakeRunner`]/[`FakeOutput`];
+    /// the best-of tests need a per-run runner or output, so this variant is
+    /// generic over both ports while keeping the rest of the wiring fixed. The
+    /// frozen clock hands every run the same start, which is fine because the fake
+    /// output ignores the harvest cutoff.
+    fn drive_best_of<R, O>(
+        options: &CollectOptions,
+        runner: &R,
+        probe: &FakeProbe,
+        output: &O,
+        storage: &MemoryStorage,
+        reporter: &dyn Reporter,
+    ) -> Result<RunOutcome, RunError>
+    where
+        R: BenchRunner,
+        O: BenchOutputSource,
+    {
+        let now = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_secs(FROZEN_UNIX))
+            .unwrap();
+        let clock = Clock::new_frozen_at(now);
+        let env = |_name: &str| None::<String>;
+        let bench_command = mock_bench_command();
+        let deps = CollectDeps {
+            runner,
+            probe,
+            output,
+            storage: Some(storage),
+            clock: &clock,
+            env: &env,
+            project_id: "folo",
+            tool_version: "0.0.1",
+            target_root: Path::new("target"),
+            bench_command: &bench_command,
+            reporter,
+        };
+        block_on(execute_collect(options, &deps))
+    }
+
+    /// Reads the single stored object back as a [`Run`], failing if there is not
+    /// exactly one.
+    fn only_stored_run(storage: &MemoryStorage) -> Run {
+        let keys = storage.keys();
+        assert_eq!(
+            keys.len(),
+            1,
+            "expected exactly one stored object: {keys:?}"
+        );
+        let bytes = block_on(storage.get(&keys[0])).unwrap();
+        Run::from_json(&String::from_utf8(bytes).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn best_of_runs_the_suite_n_times_and_stores_the_minimum_value() {
+        // Three runs measure the same case at 30, 10 and 20 ns; the stored value is
+        // the minimum (10), discarding the two slower, interference-perturbed runs.
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = SequencedOutput::new(vec![
+            all_the_time_output(30.0),
+            all_the_time_output(10.0),
+            all_the_time_output(20.0),
+        ]);
+        let storage = MemoryStorage::new();
+        let reporter = StderrReporter::new(false);
+        let options = CollectOptions {
+            best_of: best_of(3),
+            ..CollectOptions::default()
+        };
+
+        drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap();
+
+        assert_eq!(
+            runner.calls.lock().unwrap().len(),
+            3,
+            "the suite must run once per best-of count"
+        );
+
+        let run = only_stored_run(&storage);
+        assert_eq!(run.results.len(), 1);
+        assert_eq!(run.results[0].metrics.len(), 1);
+        assert_eq!(run.results[0].metrics[0].value, 10.0);
+    }
+
+    #[test]
+    fn best_of_selects_each_metric_independently() {
+        // Two cases, each minimized on its own: read_cell wins on run 2 (5 < 30),
+        // write_cell wins on run 1 (7 < 40), so a stored result blends metrics from
+        // different physical runs.
+        fn two_ops(read: f64, write: f64) -> FakeOutput {
+            FakeOutput {
+                time: vec![
+                    RawOperationFile {
+                        path: PathBuf::from("all_the_time/read_cell.json"),
+                        content: format!(
+                            "{{\"operation\":\"read_cell\",\
+                             \"slope_processor_time_nanos\":{read}}}"
+                        ),
+                    },
+                    RawOperationFile {
+                        path: PathBuf::from("all_the_time/write_cell.json"),
+                        content: format!(
+                            "{{\"operation\":\"write_cell\",\
+                             \"slope_processor_time_nanos\":{write}}}"
+                        ),
+                    },
+                ],
+                ..FakeOutput::default()
+            }
+        }
+
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = SequencedOutput::new(vec![two_ops(30.0, 7.0), two_ops(5.0, 40.0)]);
+        let storage = MemoryStorage::new();
+        let reporter = StderrReporter::new(false);
+        let options = CollectOptions {
+            best_of: best_of(2),
+            ..CollectOptions::default()
+        };
+
+        drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap();
+
+        let run = only_stored_run(&storage);
+        let mut values: Vec<(String, f64)> = run
+            .results
+            .iter()
+            .map(|result| (result.id.to_string(), result.metrics[0].value))
+            .collect();
+        values.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            values,
+            vec![
+                ("read_cell".to_owned(), 5.0),
+                ("write_cell".to_owned(), 7.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn best_of_reports_provenance_of_the_kept_sample() {
+        // The verbose log must explain each choice: that a best-of pass is running,
+        // each invocation, and — per metric — the samples seen and which run
+        // supplied the kept minimum, with the winner bracketed.
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output =
+            SequencedOutput::new(vec![all_the_time_output(30.0), all_the_time_output(10.0)]);
+        let storage = MemoryStorage::new();
+        let reporter = RecordingReporter::new();
+        let options = CollectOptions {
+            best_of: best_of(2),
+            ..CollectOptions::default()
+        };
+
+        drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap();
+
+        assert!(
+            reporter.contains("best-of collection: running the suite 2 times"),
+            "expected an announcement of the best-of pass, got {:?}",
+            reporter.notes()
+        );
+        assert!(
+            reporter.contains("best-of run 1/2"),
+            "expected a per-run note, got {:?}",
+            reporter.notes()
+        );
+        assert!(
+            reporter.contains("best-of samples 30, [10] (kept run 2)"),
+            "expected a provenance note naming the kept sample, got {:?}",
+            reporter.notes()
+        );
+    }
+
+    #[test]
+    fn a_single_run_emits_no_best_of_notes() {
+        // With the default single run there is nothing to choose, so none of the
+        // best-of verbose notes appear — the guards that suppress them at `N == 1`
+        // must hold.
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = all_the_time_output(20.0);
+        let storage = MemoryStorage::new();
+        let reporter = RecordingReporter::new();
+
+        drive_best_of(
+            &CollectOptions::default(),
+            &runner,
+            &probe,
+            &output,
+            &storage,
+            &reporter,
+        )
+        .unwrap();
+
+        assert!(
+            !reporter.contains("best-of collection"),
+            "a single run must not announce a best-of pass, got {:?}",
+            reporter.notes()
+        );
+        assert!(
+            !reporter.contains("best-of run"),
+            "a single run must not emit per-run best-of notes, got {:?}",
+            reporter.notes()
+        );
+        assert!(
+            !reporter.contains("best-of samples"),
+            "a single run has no samples to choose between, got {:?}",
+            reporter.notes()
+        );
+    }
+
+    #[test]
+    fn best_of_fails_fast_when_any_run_fails() {
+        // The second of three runs exits non-zero, so collection aborts there
+        // (never reaching a third run) and stores nothing.
+        let runner = FailOnNthRunner::new(2);
+        let probe = FakeProbe::new();
+        let output = SequencedOutput::new(vec![
+            all_the_time_output(30.0),
+            all_the_time_output(10.0),
+            all_the_time_output(20.0),
+        ]);
+        let storage = MemoryStorage::new();
+        let reporter = StderrReporter::new(false);
+        let options = CollectOptions {
+            best_of: best_of(3),
+            ..CollectOptions::default()
+        };
+
+        let error =
+            drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap_err();
+
+        match error {
+            RunError::Engine { engine, code } => {
+                assert_eq!(engine, "cargo bench");
+                assert_eq!(code, Some(101));
+            }
+            other => panic!("expected an engine failure, got {other:?}"),
+        }
+        assert_eq!(
+            runner.call_count(),
+            2,
+            "the run after the failure must not start"
+        );
+        assert!(storage.keys().is_empty());
+    }
+
+    #[test]
+    fn best_of_rejects_a_case_missing_from_a_later_run() {
+        // Run 1 measures read_cell but run 2 does not, so the runs did not exercise
+        // the same work: a hard error that stores nothing.
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = SequencedOutput::new(vec![all_the_time_output(10.0), FakeOutput::default()]);
+        let storage = MemoryStorage::new();
+        let reporter = StderrReporter::new(false);
+        let options = CollectOptions {
+            best_of: best_of(2),
+            ..CollectOptions::default()
+        };
+
+        let error =
+            drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap_err();
+
+        match error {
+            RunError::Inconsistent { engine, message } => {
+                assert_eq!(engine, Engine::AllTheTime.to_string());
+                assert!(message.contains("read_cell"), "{message}");
+            }
+            other => panic!("expected an inconsistency error, got {other:?}"),
+        }
+        assert!(storage.keys().is_empty());
+    }
+
+    #[test]
+    fn best_of_with_no_store_runs_every_time_but_stores_nothing() {
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output =
+            SequencedOutput::new(vec![all_the_time_output(30.0), all_the_time_output(10.0)]);
+        let storage = MemoryStorage::new();
+        let reporter = StderrReporter::new(false);
+        let options = CollectOptions {
+            best_of: best_of(2),
+            no_store: true,
+            ..CollectOptions::default()
+        };
+
+        let outcome =
+            drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap();
+
+        assert_eq!(runner.calls.lock().unwrap().len(), 2);
+        assert!(storage.keys().is_empty());
+        let RunOutcome::Completed { message } = outcome else {
+            panic!("expected completion");
+        };
+        assert!(message.contains("nothing stored"), "{message}");
+    }
+
+    #[test]
+    fn best_of_one_stores_the_single_run_unchanged() {
+        // `--best-of 1` is the default single run: the lone sample is stored as-is,
+        // with no minimization to perform.
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = all_the_time_output(20.0);
+        let storage = MemoryStorage::new();
+        let reporter = StderrReporter::new(false);
+        let options = CollectOptions {
+            best_of: best_of(1),
+            ..CollectOptions::default()
+        };
+
+        drive_best_of(&options, &runner, &probe, &output, &storage, &reporter).unwrap();
+
+        assert_eq!(runner.calls.lock().unwrap().len(), 1);
+        let run = only_stored_run(&storage);
+        assert_eq!(run.results[0].metrics[0].value, 20.0);
     }
 }

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -427,8 +427,8 @@ fn note_best_of_selections(
     if runs <= 1 {
         return;
     }
-    for selection in selections {
-        reporter.note_with(|| {
+    reporter.if_enabled(|notes| {
+        for selection in selections {
             let samples = selection
                 .samples
                 .iter()
@@ -442,14 +442,14 @@ fn note_best_of_selections(
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!(
+            notes.note(&format!(
                 "{engine} {}/{}: best-of samples {samples} (kept run {})",
                 selection.id,
                 selection.kind.as_str(),
                 selection.chosen_run.saturating_add(1),
-            )
-        });
-    }
+            ));
+        }
+    });
 }
 
 /// Builds the benchmark command line: the base command followed by the cargo

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -70,16 +70,19 @@
 //!
 //! ## `collect`
 //!
-//! Executes the workspace benches once with `cargo bench`, harvests every
-//! supported engine's machine-readable output, and stores one result set per
-//! engine. There is nothing to configure about engines: the run enables the
-//! combined environment the engines need and detects each engine from the output
+//! Executes the workspace benches with `cargo bench`, harvests every supported
+//! engine's machine-readable output, and stores one result set per engine. There
+//! is nothing to configure about engines: the run enables the combined
+//! environment the engines need and detects each engine from the output
 //! it produces (off Linux the Callgrind benches compile to no-ops, so only the
 //! host-runnable engines are stored). Re-running the same clean commit is refused
 //! as a duplicate unless `--overwrite` replaces the stored result; `--no-store`
-//! harvests and reports without writing. A run is positioned on the timeline by
-//! where its commit sits in git history (first-parent topology), resolved live at
-//! analyze time — never by when the benchmarks happened to execute.
+//! harvests and reports without writing. `--best-of N` reruns the whole suite `N`
+//! times and keeps the minimum value per metric — a noise-reduction pass for
+//! jittery runners, where interference only ever makes a case slower. A run is
+//! positioned on the timeline by where its commit sits in git history
+//! (first-parent topology), resolved live at analyze time — never by when the
+//! benchmarks happened to execute.
 //!
 //! ## `install`
 //!

--- a/packages/cargo-bench-history/src/outcome.rs
+++ b/packages/cargo-bench-history/src/outcome.rs
@@ -90,6 +90,14 @@ pub enum RunError {
         /// Human-readable description of the parse failure.
         message: String,
     },
+    /// A `--best-of` run measured a different set of cases or metrics across its
+    /// repetitions, so the per-metric minimum is not well defined.
+    Inconsistent {
+        /// The engine whose repeated harvests disagreed.
+        engine: String,
+        /// Human-readable description of the cross-run mismatch.
+        message: String,
+    },
     /// A result is already stored for this run's identity (same partition and
     /// commit) and the run did not request an overwrite.
     Duplicate {
@@ -132,6 +140,10 @@ impl fmt::Display for RunError {
                 write!(f, "engine {engine:?} has an invalid command: {message}")
             }
             Self::Parse { message } => write!(f, "failed to parse benchmark output: {message}"),
+            Self::Inconsistent { engine, message } => write!(
+                f,
+                "engine {engine:?} produced inconsistent results across --best-of runs: {message}"
+            ),
             Self::Duplicate { key } => write!(
                 f,
                 "a result is already stored for this run at {key}; pass --overwrite to replace it"
@@ -153,6 +165,7 @@ impl Error for RunError {
             Self::Engine { .. }
             | Self::Command { .. }
             | Self::Parse { .. }
+            | Self::Inconsistent { .. }
             | Self::Duplicate { .. }
             | Self::Analyze { .. }
             | Self::Backfill { .. }
@@ -251,6 +264,18 @@ mod tests {
         assert!(command.source().is_none());
         assert!(parse.to_string().contains("bad"));
         assert!(command.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn inconsistent_error_is_displayed_and_has_no_source() {
+        let error = RunError::Inconsistent {
+            engine: "criterion".to_owned(),
+            message: "benchmark case 'a/b' is missing from run 2".to_owned(),
+        };
+        assert!(error.to_string().contains("--best-of runs"), "{error}");
+        assert!(error.to_string().contains("criterion"), "{error}");
+        assert!(error.to_string().contains("missing from run 2"), "{error}");
+        assert!(error.source().is_none());
     }
 
     #[test]

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -373,7 +373,8 @@ struct CollectCommand {
 
     /// Run the whole suite this many times and keep, per metric, the best
     /// (minimum) observed value — a noise-reduction pass for jittery runners.
-    /// Every run must produce the same set of benchmark cases or collection fails.
+    /// Every run must produce the same benchmark cases and the same metrics
+    /// per case or collection fails.
     #[arg(long = "best-of", value_name = "N", default_value_t = NonZeroUsize::MIN, help_heading = HEADING_ENV)]
     best_of: NonZeroUsize,
 
@@ -826,7 +827,8 @@ struct BackfillCommand {
 
     /// Run the whole suite this many times per commit and keep, per metric, the
     /// best (minimum) observed value — a noise-reduction pass for jittery runners.
-    /// Every run must produce the same set of benchmark cases or collection fails.
+    /// Every run must produce the same benchmark cases and the same metrics
+    /// per case or collection fails.
     #[arg(long = "best-of", value_name = "N", default_value_t = NonZeroUsize::MIN, help_heading = HEADING_ENV)]
     best_of: NonZeroUsize,
 

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -7,6 +7,7 @@
 //! groups are factored into [`clap::Args`] structs and `#[command(flatten)]`ed
 //! into each subcommand so the same option means the same thing everywhere.
 
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use cbh_command::{
@@ -370,6 +371,12 @@ struct CollectCommand {
     #[arg(long, help_heading = HEADING_ENV, conflicts_with = "overwrite")]
     skip_existing: bool,
 
+    /// Run the whole suite this many times and keep, per metric, the best
+    /// (minimum) observed value — a noise-reduction pass for jittery runners.
+    /// Every run must produce the same set of benchmark cases or collection fails.
+    #[arg(long = "best-of", value_name = "N", default_value_t = NonZeroUsize::MIN, help_heading = HEADING_ENV)]
+    best_of: NonZeroUsize,
+
     /// Arguments after `--` forwarded verbatim to `cargo bench` after the scope
     /// flags.
     #[arg(last = true, value_name = "ARGS")]
@@ -394,6 +401,7 @@ impl CollectCommand {
             skip_existing: self.skip_existing,
             passthrough: self.passthrough,
             verbose: self.env.verbose,
+            best_of: self.best_of,
         }
     }
 }
@@ -816,6 +824,12 @@ struct BackfillCommand {
     #[arg(long, help_heading = HEADING_ENV)]
     ignore_errors: bool,
 
+    /// Run the whole suite this many times per commit and keep, per metric, the
+    /// best (minimum) observed value — a noise-reduction pass for jittery runners.
+    /// Every run must produce the same set of benchmark cases or collection fails.
+    #[arg(long = "best-of", value_name = "N", default_value_t = NonZeroUsize::MIN, help_heading = HEADING_ENV)]
+    best_of: NonZeroUsize,
+
     /// Arguments after `--` forwarded verbatim to `cargo bench` after the scope
     /// flags.
     #[arg(last = true, value_name = "ARGS")]
@@ -841,6 +855,7 @@ impl BackfillCommand {
             ignore_errors: self.ignore_errors,
             passthrough: self.passthrough,
             verbose: self.env.verbose,
+            best_of: self.best_of,
         }
     }
 }
@@ -1052,6 +1067,30 @@ mod tests {
         };
         assert!(options.all_features);
         assert!(options.features.is_empty());
+    }
+
+    #[test]
+    fn collect_best_of_defaults_to_one_and_parses_a_value() {
+        let Command::Collect(options) = parse(&["collect"]) else {
+            panic!("expected collect command");
+        };
+        assert_eq!(
+            options.best_of.get(),
+            1,
+            "--best-of defaults to a single run"
+        );
+
+        let Command::Collect(options) = parse(&["collect", "--best-of", "5", "--no-store"]) else {
+            panic!("expected collect command");
+        };
+        assert_eq!(options.best_of.get(), 5);
+        assert!(options.no_store, "--best-of coexists with --no-store");
+    }
+
+    #[test]
+    fn collect_best_of_rejects_zero() {
+        let parsed = Cli::from_args(&["cargo-bench-history"], &["collect", "--best-of", "0"]);
+        assert!(parsed.is_err(), "--best-of 0 must be rejected");
     }
 
     #[test]
@@ -1836,6 +1875,33 @@ mod tests {
             panic!("expected backfill command");
         };
         assert!(!options.verbose);
+    }
+
+    #[test]
+    fn backfill_best_of_defaults_to_one_and_parses_a_value() {
+        let Command::Backfill(options) = parse(&["backfill", "abc123", "def456"]) else {
+            panic!("expected backfill command");
+        };
+        assert_eq!(
+            options.best_of.get(),
+            1,
+            "--best-of defaults to a single run"
+        );
+
+        let Command::Backfill(options) = parse(&["backfill", "abc123", "def456", "--best-of", "3"])
+        else {
+            panic!("expected backfill command");
+        };
+        assert_eq!(options.best_of.get(), 3);
+    }
+
+    #[test]
+    fn backfill_best_of_rejects_zero() {
+        let parsed = Cli::from_args(
+            &["cargo-bench-history"],
+            &["backfill", "abc123", "def456", "--best-of", "0"],
+        );
+        assert!(parsed.is_err(), "--best-of 0 must be rejected");
     }
 
     #[test]

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -1,6 +1,7 @@
 //! The parsed command model the binary and tests operate on: the [`Command`]
 //! enum and its per-subcommand option structs.
 
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use cbh_model::BenchmarkIdPrefix;
@@ -70,7 +71,7 @@ pub enum Command {
 
 /// Options for the `collect` command.
 #[doc(hidden)]
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CollectOptions {
     /// Path to the configuration file, if overridden.
     pub config_path: Option<PathBuf>,
@@ -112,9 +113,33 @@ pub struct CollectOptions {
     pub passthrough: Vec<String>,
     /// Emit detailed diagnostic notes to standard error describing each step.
     pub verbose: bool,
+    /// Run the whole suite this many times and store, per metric, the best
+    /// (minimum) observed value (`--best-of`). One reproduces a plain single run.
+    pub best_of: NonZeroUsize,
 }
 
-/// Options for the `install` command.
+impl Default for CollectOptions {
+    fn default() -> Self {
+        Self {
+            config_path: None,
+            repo: None,
+            local: None,
+            packages: Vec::new(),
+            excludes: Vec::new(),
+            benches: Vec::new(),
+            features: Vec::new(),
+            all_features: false,
+            no_default_features: false,
+            machine_key: None,
+            no_store: false,
+            overwrite: false,
+            skip_existing: false,
+            passthrough: Vec::new(),
+            verbose: false,
+            best_of: NonZeroUsize::MIN,
+        }
+    }
+}
 #[doc(hidden)]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct InstallOptions {
@@ -401,7 +426,7 @@ pub struct PruneOptions {
 
 /// Options for the `backfill` command.
 #[doc(hidden)]
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BackfillOptions {
     /// Path to the configuration file, if overridden.
     pub config_path: Option<PathBuf>,
@@ -441,6 +466,34 @@ pub struct BackfillOptions {
     pub passthrough: Vec<String>,
     /// Emit detailed diagnostic notes to standard error describing each step.
     pub verbose: bool,
+    /// Run the whole suite this many times per commit and store, per metric, the
+    /// best (minimum) observed value (`--best-of`). One reproduces a plain single
+    /// run.
+    pub best_of: NonZeroUsize,
+}
+
+impl Default for BackfillOptions {
+    fn default() -> Self {
+        Self {
+            config_path: None,
+            repo: None,
+            local: None,
+            from: String::new(),
+            to: String::new(),
+            packages: Vec::new(),
+            excludes: Vec::new(),
+            benches: Vec::new(),
+            features: Vec::new(),
+            all_features: false,
+            no_default_features: false,
+            machine_key: None,
+            overwrite: false,
+            ignore_errors: false,
+            passthrough: Vec::new(),
+            verbose: false,
+            best_of: NonZeroUsize::MIN,
+        }
+    }
 }
 
 /// Options for the `bless` command.

--- a/packages/cbh_model/src/aggregate.rs
+++ b/packages/cbh_model/src/aggregate.rs
@@ -1,0 +1,498 @@
+//! Combining several runs of the same suite into one best-of-N result set.
+//!
+//! The `--best-of N` collection mode runs the whole benchmark suite `N` times and
+//! reduces the runs to a single stored result set by keeping, per metric, the
+//! **minimum** observed value. Benchmark interference is one-sided — a contended
+//! CI runner only ever makes a benchmark *slower* — so the minimum is the sample
+//! least perturbed by transient noise. The winning [`Metric`] is carried over
+//! wholesale (its own dispersion travels with it), so a stored result may blend
+//! metrics selected from different physical runs.
+//!
+//! The reduction is a pure function over the stored [`BenchmarkResult`] shape, so
+//! it lives here with the data model where it is cheap to mutation-test in
+//! isolation.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+use crate::{BenchmarkId, BenchmarkResult, MetricKind, MetricList};
+
+/// The best-of-N reduction: combined results plus per-metric provenance.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Combined {
+    /// One result per benchmark case, each metric the minimum across the runs.
+    pub results: Vec<BenchmarkResult>,
+    /// Which run each stored metric was selected from, for verbose diagnostics.
+    ///
+    /// One entry per stored metric, in the same order the metrics appear in
+    /// [`results`](Self::results).
+    pub selections: Vec<Selection>,
+}
+
+/// Provenance of one selected metric: the samples seen and which run won.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Selection {
+    /// The benchmark case the metric belongs to.
+    pub id: BenchmarkId,
+    /// The metric kind that was reduced.
+    pub kind: MetricKind,
+    /// The value observed for this metric in each run, in run order.
+    pub samples: Vec<f64>,
+    /// Zero-based index of the run whose value was kept (the minimum; ties resolve
+    /// to the earliest run).
+    pub chosen_run: usize,
+}
+
+/// A cross-run inconsistency that makes a best-of-N reduction ill-defined.
+///
+/// Every run must measure the same set of cases and the same metrics per case, so
+/// that each metric has exactly one sample per run to minimize over. A missing or
+/// extra case or metric in any run is a hard error rather than something to paper
+/// over, because it means the runs did not exercise the same work.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AggregateError {
+    /// A benchmark case is present in some runs but absent from `run_index`.
+    MissingCase {
+        /// The case that is not measured uniformly across the runs.
+        id: BenchmarkId,
+        /// Zero-based index of the run the case is missing from.
+        run_index: usize,
+    },
+    /// A metric of `kind` for `id` is present in some runs but absent from
+    /// `run_index`.
+    MissingMetric {
+        /// The case whose metrics differ across the runs.
+        id: BenchmarkId,
+        /// The metric kind that is not reported uniformly across the runs.
+        kind: MetricKind,
+        /// Zero-based index of the run the metric is missing from.
+        run_index: usize,
+    },
+}
+
+impl fmt::Display for AggregateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCase { id, run_index } => write!(
+                f,
+                "benchmark case '{id}' is missing from run {}; every best-of run must \
+                 measure the same set of cases",
+                run_index.saturating_add(1)
+            ),
+            Self::MissingMetric {
+                id,
+                kind,
+                run_index,
+            } => write!(
+                f,
+                "metric '{}' for benchmark case '{id}' is missing from run {}; every \
+                 best-of run must report the same metrics per case",
+                kind.as_str(),
+                run_index.saturating_add(1)
+            ),
+        }
+    }
+}
+
+impl Error for AggregateError {}
+
+/// Reduces `runs` to a single result set, keeping the minimum value per metric.
+///
+/// Each element of `runs` is one run's harvested results; the slice therefore has
+/// one entry per benchmark repetition. Every run must measure the same cases and
+/// the same metrics per case (see [`AggregateError`]); given that, each metric is
+/// reduced to its minimum across the runs, with ties resolved to the earliest run.
+/// The winning [`Metric`](crate::Metric) is kept wholesale, so its dispersion
+/// travels with its value. Case order and per-case metric order follow the first
+/// run, so `N == 1` reproduces that run's results unchanged.
+///
+/// An empty slice yields an empty result set: with no runs there is nothing to
+/// reduce and no reference to check consistency against.
+///
+/// # Errors
+///
+/// Returns [`AggregateError`] if any run measures a different set of cases, or a
+/// different set of metrics for a shared case, than the first run.
+pub fn min_per_metric(runs: &[Vec<BenchmarkResult>]) -> Result<Combined, AggregateError> {
+    let Some((reference, rest)) = runs.split_first() else {
+        return Ok(Combined {
+            results: Vec::new(),
+            selections: Vec::new(),
+        });
+    };
+
+    // Index every run by case identity so cross-run lookups are direct. The
+    // reference run also fixes the output order of cases and, per case, of metrics.
+    let indexed: Vec<HashMap<&BenchmarkId, &BenchmarkResult>> = runs
+        .iter()
+        .map(|results| results.iter().map(|result| (&result.id, result)).collect())
+        .collect();
+
+    check_case_consistency(reference, rest, &indexed)?;
+    check_metric_consistency(reference, &indexed)?;
+
+    let mut results = Vec::with_capacity(reference.len());
+    let mut selections = Vec::new();
+    for reference_result in reference {
+        let id = &reference_result.id;
+        let mut metrics = MetricList::new();
+        for reference_metric in &reference_result.metrics {
+            let kind = reference_metric.kind;
+
+            // Consistency is already verified, so every run has this metric. Track
+            // the smallest sample and the run it came from in one pass, updating
+            // only on a strictly smaller value so ties resolve to the earliest run.
+            let mut samples = Vec::with_capacity(indexed.len());
+            let mut winner: Option<&crate::Metric> = None;
+            let mut chosen_run = 0_usize;
+            for (run_index, run) in indexed.iter().enumerate() {
+                let metric = run
+                    .get(id)
+                    .and_then(|result| find_metric(result, kind))
+                    .expect("consistency check guarantees this metric is in every run");
+                let is_better = match winner {
+                    Some(best) => metric.value < best.value,
+                    None => true,
+                };
+                if is_better {
+                    winner = Some(metric);
+                    chosen_run = run_index;
+                }
+                samples.push(metric.value);
+            }
+            let winner = winner
+                .expect("a reduced metric is measured in at least one run")
+                .clone();
+            metrics.push(winner);
+            selections.push(Selection {
+                id: id.clone(),
+                kind,
+                samples,
+                chosen_run,
+            });
+        }
+        results.push(BenchmarkResult {
+            id: id.clone(),
+            metrics,
+        });
+    }
+
+    Ok(Combined {
+        results,
+        selections,
+    })
+}
+
+/// Verifies every run measures exactly the reference run's set of cases.
+fn check_case_consistency(
+    reference: &[BenchmarkResult],
+    rest: &[Vec<BenchmarkResult>],
+    indexed: &[HashMap<&BenchmarkId, &BenchmarkResult>],
+) -> Result<(), AggregateError> {
+    // The reference run's own lookup fixes what every later run must contain; the
+    // remaining lookups line up one-to-one with `rest` (run 1 onward).
+    let Some((reference_lookup, rest_lookups)) = indexed.split_first() else {
+        return Ok(());
+    };
+    for (offset, (run, lookup)) in rest.iter().zip(rest_lookups).enumerate() {
+        // `rest` starts at run 1, so its zero-based index is the offset plus one.
+        let run_index = offset.saturating_add(1);
+        for reference_result in reference {
+            if !lookup.contains_key(&reference_result.id) {
+                return Err(AggregateError::MissingCase {
+                    id: reference_result.id.clone(),
+                    run_index,
+                });
+            }
+        }
+        // A case in this run but not the reference is equally inconsistent: report
+        // it as missing from the reference run (index zero).
+        for result in run {
+            if !reference_lookup.contains_key(&result.id) {
+                return Err(AggregateError::MissingCase {
+                    id: result.id.clone(),
+                    run_index: 0,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Verifies every run reports the reference run's metrics for each shared case.
+///
+/// Case consistency is assumed already checked, so every run holds each reference
+/// case.
+fn check_metric_consistency(
+    reference: &[BenchmarkResult],
+    indexed: &[HashMap<&BenchmarkId, &BenchmarkResult>],
+) -> Result<(), AggregateError> {
+    for (run_index, lookup) in indexed.iter().enumerate() {
+        for reference_result in reference {
+            let id = &reference_result.id;
+            let result = lookup
+                .get(id)
+                .expect("case consistency guarantees every run holds this case");
+            for reference_metric in &reference_result.metrics {
+                if find_metric(result, reference_metric.kind).is_none() {
+                    return Err(AggregateError::MissingMetric {
+                        id: id.clone(),
+                        kind: reference_metric.kind,
+                        run_index,
+                    });
+                }
+            }
+            // A metric in this run but not the reference is equally inconsistent:
+            // report it as missing from the reference run (index zero).
+            for metric in &result.metrics {
+                if find_metric(reference_result, metric.kind).is_none() {
+                    return Err(AggregateError::MissingMetric {
+                        id: id.clone(),
+                        kind: metric.kind,
+                        run_index: 0,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Finds the metric of `kind` in `result`, or `None` when it carries no such kind.
+fn find_metric(result: &BenchmarkResult, kind: MetricKind) -> Option<&crate::Metric> {
+    result.metrics.iter().find(|metric| metric.kind == kind)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
+    #![allow(
+        clippy::float_cmp,
+        reason = "aggregated values are exact copies of the inputs, not computed"
+    )]
+
+    use nonempty::nonempty;
+
+    use super::*;
+    use crate::Metric;
+
+    fn id(name: &str) -> BenchmarkId {
+        BenchmarkId::new(nonempty![name.to_owned()])
+    }
+
+    fn result(name: &str, metrics: Vec<Metric>) -> BenchmarkResult {
+        BenchmarkResult::new(id(name), metrics)
+    }
+
+    fn wall(value: f64) -> Metric {
+        Metric::new(MetricKind::WallTime, value)
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        let combined = min_per_metric(&[]).unwrap();
+        assert!(combined.results.is_empty());
+        assert!(combined.selections.is_empty());
+    }
+
+    #[test]
+    fn single_run_is_returned_unchanged() {
+        // N == 1 must reproduce the run byte-for-byte, dispersion included.
+        let metric = wall(7.4).with_dispersion(Some(0.5), Some(7.0), Some(7.9));
+        let runs = vec![vec![result("case", vec![metric.clone()])]];
+
+        let combined = min_per_metric(&runs).unwrap();
+
+        assert_eq!(combined.results, runs[0]);
+        assert_eq!(combined.results[0].metrics[0], metric);
+        assert_eq!(combined.selections.len(), 1);
+        assert_eq!(combined.selections[0].chosen_run, 0);
+        assert_eq!(combined.selections[0].samples, vec![7.4]);
+    }
+
+    #[test]
+    fn minimum_value_is_selected_with_its_own_dispersion() {
+        // The smallest value wins and drags along its own dispersion, not the
+        // reference run's.
+        let low = wall(5.0).with_dispersion(Some(0.1), Some(4.9), Some(5.1));
+        let runs = vec![
+            vec![result("case", vec![wall(9.0)])],
+            vec![result("case", vec![low.clone()])],
+            vec![result("case", vec![wall(7.0)])],
+        ];
+
+        let combined = min_per_metric(&runs).unwrap();
+
+        assert_eq!(combined.results.len(), 1);
+        assert_eq!(combined.results[0].metrics[0], low);
+        let selection = &combined.selections[0];
+        assert_eq!(selection.samples, vec![9.0, 5.0, 7.0]);
+        assert_eq!(selection.chosen_run, 1);
+    }
+
+    #[test]
+    fn each_metric_is_minimized_independently() {
+        // A result's two metrics can take their minima from different runs.
+        let runs = vec![
+            vec![result(
+                "case",
+                vec![wall(5.0), Metric::new(MetricKind::ProcessorTime, 20.0)],
+            )],
+            vec![result(
+                "case",
+                vec![wall(8.0), Metric::new(MetricKind::ProcessorTime, 11.0)],
+            )],
+        ];
+
+        let combined = min_per_metric(&runs).unwrap();
+
+        let metrics = &combined.results[0].metrics;
+        assert_eq!(metrics[0].value, 5.0);
+        assert_eq!(metrics[1].value, 11.0);
+        assert_eq!(combined.selections[0].chosen_run, 0);
+        assert_eq!(combined.selections[1].chosen_run, 1);
+    }
+
+    #[test]
+    fn ties_resolve_to_the_earliest_run() {
+        let runs = vec![
+            vec![result("case", vec![wall(5.0)])],
+            vec![result("case", vec![wall(5.0)])],
+        ];
+
+        let combined = min_per_metric(&runs).unwrap();
+
+        assert_eq!(combined.selections[0].chosen_run, 0);
+    }
+
+    #[test]
+    fn case_and_metric_order_follow_the_first_run() {
+        let runs = vec![
+            vec![
+                result("beta", vec![wall(2.0)]),
+                result("alpha", vec![wall(1.0)]),
+            ],
+            vec![
+                result("alpha", vec![wall(1.0)]),
+                result("beta", vec![wall(2.0)]),
+            ],
+        ];
+
+        let combined = min_per_metric(&runs).unwrap();
+
+        let names: Vec<String> = combined
+            .results
+            .iter()
+            .map(|result| result.id.qualified())
+            .collect();
+        assert_eq!(names, vec!["beta".to_owned(), "alpha".to_owned()]);
+    }
+
+    #[test]
+    fn a_case_missing_from_a_later_run_is_an_error() {
+        let runs = vec![
+            vec![result("a", vec![wall(1.0)]), result("b", vec![wall(1.0)])],
+            vec![result("a", vec![wall(1.0)])],
+        ];
+
+        let error = min_per_metric(&runs).unwrap_err();
+
+        match error {
+            AggregateError::MissingCase { id, run_index } => {
+                assert_eq!(id.qualified(), "b");
+                assert_eq!(run_index, 1);
+            }
+            other => panic!("expected a missing-case error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_case_only_in_a_later_run_is_an_error() {
+        // An extra case in a later run is reported as missing from the first run.
+        let runs = vec![
+            vec![result("a", vec![wall(1.0)])],
+            vec![result("a", vec![wall(1.0)]), result("b", vec![wall(1.0)])],
+        ];
+
+        let error = min_per_metric(&runs).unwrap_err();
+
+        match error {
+            AggregateError::MissingCase { id, run_index } => {
+                assert_eq!(id.qualified(), "b");
+                assert_eq!(run_index, 0);
+            }
+            other => panic!("expected a missing-case error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_metric_missing_from_a_later_run_is_an_error() {
+        let runs = vec![
+            vec![result(
+                "case",
+                vec![wall(1.0), Metric::new(MetricKind::ProcessorTime, 2.0)],
+            )],
+            vec![result("case", vec![wall(1.0)])],
+        ];
+
+        let error = min_per_metric(&runs).unwrap_err();
+
+        match error {
+            AggregateError::MissingMetric {
+                id,
+                kind,
+                run_index,
+            } => {
+                assert_eq!(id.qualified(), "case");
+                assert_eq!(kind, MetricKind::ProcessorTime);
+                assert_eq!(run_index, 1);
+            }
+            other => panic!("expected a missing-metric error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_extra_metric_in_a_later_run_is_an_error() {
+        let runs = vec![
+            vec![result("case", vec![wall(1.0)])],
+            vec![result(
+                "case",
+                vec![wall(1.0), Metric::new(MetricKind::ProcessorTime, 2.0)],
+            )],
+        ];
+
+        let error = min_per_metric(&runs).unwrap_err();
+
+        match error {
+            AggregateError::MissingMetric {
+                kind, run_index, ..
+            } => {
+                assert_eq!(kind, MetricKind::ProcessorTime);
+                assert_eq!(run_index, 0);
+            }
+            other => panic!("expected a missing-metric error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_messages_name_the_case_and_run() {
+        let missing_case = AggregateError::MissingCase {
+            id: id("some/case"),
+            run_index: 2,
+        };
+        let text = missing_case.to_string();
+        assert!(text.contains("some/case"), "{text}");
+        assert!(text.contains("run 3"), "{text}");
+
+        let missing_metric = AggregateError::MissingMetric {
+            id: id("some/case"),
+            kind: MetricKind::WallTime,
+            run_index: 0,
+        };
+        let text = missing_metric.to_string();
+        assert!(text.contains("wall_time"), "{text}");
+        assert!(text.contains("run 1"), "{text}");
+    }
+}

--- a/packages/cbh_model/src/lib.rs
+++ b/packages/cbh_model/src/lib.rs
@@ -23,6 +23,7 @@
 //!
 //! [`cargo-bench-history`]: https://github.com/folo-rs/folo
 
+mod aggregate;
 mod benchmark_id;
 mod bless;
 mod comparability;
@@ -31,6 +32,7 @@ mod context;
 mod metric;
 mod run;
 
+pub use aggregate::{AggregateError, Combined, Selection, min_per_metric};
 pub use benchmark_id::{BenchmarkId, BenchmarkIdPrefix, EmptyBenchmarkIdPrefix};
 pub use bless::{BLESS_SCHEMA_VERSION, BlessingRecord};
 pub use comparability::{DiscriminantSet, Engine, StorageKey, parse_key, sanitize_segment};


### PR DESCRIPTION
## Problem

Benchmark collection on CI runners shows high, uneven noise (+50% or more on some benchmarks, not evenly distributed across the suite — so it is environmental interference, not a machine-SKU difference). Because interference only ever makes a benchmark *slower*, the noise is effectively **one-sided**.

## Approach

Add a `--best-of <N>` option to the `collect` and `backfill` commands. When `N > 1`, run the whole benchmark suite `N` times and store, **per metric**, the sample with the **minimum** `value` (keeping that winning sample's own `std_dev` / interval wholesale). The runs are spaced apart in wall-clock time, so a transient interference spike is unlikely to hit the same benchmark in every run; the min discards the interference. `N = 1` reproduces today's behaviour byte-for-byte.

```
cargo-bench-history collect --best-of 3
```

## Design decisions

- **Flag**: `--best-of <N>`, default `1`, typed `NonZeroUsize` (clap rejects `0`). Allowed together with `--no-store`.
- **Aggregator**: `min` per `(BenchmarkId, MetricKind)`. Ties → earliest run wins.
- **Dispersion**: the winning `Metric` is stored wholesale, so a stored result may blend metrics selected from different physical runs — accepted.
- **Missing case = hard error**: the set of benchmark cases and, within each case, the set of metric kinds, must be identical across all N runs. Any asymmetry fails the whole collection.
- **Fail-fast**: any non-zero `cargo bench` exit fails the whole collection (unchanged).
- **Scope**: both `collect` and `backfill`.
- **Observation time**: the first run's start time (git/rustc/hardware context is probed once, after the loop).

### Acknowledged limitations

- Job-long systematic bias (a runner slow for the *entire* job) is not removed by min-of-N.
- Callgrind is deterministic, so min-of-N over Callgrind metrics is a costly no-op; the `cargo bench` interface does not let us select engines per run.

## Changes

- **cbh_model**: new pure `aggregate::min_per_metric` reduction + `Combined` / `Selection` / `AggregateError`, carrying per-metric provenance for verbose diagnostics.
- **cbh_command**: `best_of: NonZeroUsize` on `CollectOptions` / `BackfillOptions`.
- **cbh_cli**: `--best-of <N>` arg on both subcommands.
- **cargo-bench-history**: `run_engines` refactored into an N-run loop; new `RunError::Inconsistent` variant; explanatory verbose reporting of the sampled values and kept minimum.
- **Docs**: DESIGN.md, README.md, lib.rs crate docs, AGENTS.md.

## Validation

`just package="cargo-bench-history cbh_model cbh_cli cbh_command" validate-local` passes end-to-end: 379 tests pass, mutants 172 caught / 43 unviable / 0 missed / 0 timeout, zero warnings.