### PR TITLE
Reduce mutants job to 8 shards

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -575,13 +575,13 @@ jobs:
   mutants:
     needs: [delta, test-x64]
     if: needs.delta.outputs.skip_all != 'true'
-    # Sharded mutation-testing work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
-    timeout-minutes: 180
+    # Sharded mutation-testing work budget (~180 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 270
     strategy:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        shard: [1/16, 2/16, 3/16, 4/16, 5/16, 6/16, 7/16, 8/16, 9/16, 10/16, 11/16, 12/16, 13/16, 14/16, 15/16, 16/16]
+        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
The `mutants` job fanned out to 16 shards per platform (32 concurrent runners across Ubuntu + Windows), which consumed too many GitHub runners and starved other jobs.

This halves the matrix to 8 shards per platform, roughly halving the concurrent runner footprint.

Because cargo-mutants shards distribute mutants by count, each shard now handles ~2× the work, so the per-shard work budget and job timeout are grown to stay coherent with the timeout-sizing convention in `.github/workflows/design.md` (work budget + ~90 min cold-setup allowance):

- Work budget comment: ~90 min → ~180 min
- `timeout-minutes`: 180 → 270

Validated with `just validate-workflows` (actionlint).