### PR TITLE
Add recollect mode to bench-history collect job

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -38,10 +38,12 @@ on:
 # an already-pushed commit), which `--skip-existing` would make a no-op append anyway. The
 # recollect commit id is folded into the key because a workflow_dispatch's github.sha is the
 # `main` tip, not the target: without it, two recollects of different commits (or a recollect
-# racing a push of the same tip) would share a group and wrongly cancel each other. It is empty
-# for pushes and plain dispatches, leaving their grouping unchanged.
+# racing a push of the same tip) would share a group and wrongly cancel each other. The `-<id>`
+# suffix is appended only when a recollect id is supplied (via the `&&`/`||` idiom); pushes and
+# plain dispatches carry an empty id, so the suffix is omitted entirely and their grouping is
+# unchanged (no trailing dash).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}-${{ inputs.recollect_commit_id }}
+  group: ${{ github.workflow }}-${{ github.sha }}${{ inputs.recollect_commit_id && format('-{0}', inputs.recollect_commit_id) || '' }}
   cancel-in-progress: true
 
 # Title of the rolling failure-alert issue, defined once and shared by the two jobs that

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -14,15 +14,34 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      # Optional escape hatch to REPAIR a corrupted history point. Leave empty for a normal
+      # dispatch (collects the current tip in append mode, exactly like a push). Set it to the
+      # full or short commit SHA of an already-collected `main` commit whose stored data point is
+      # bad (transient spikes, a degraded benchmark runner that day): the collect job then
+      # re-measures ONLY that commit and OVERWRITES its stored point, running the benchmark code
+      # AT that commit in a throwaway worktree while using THIS (HEAD) build of the tool. The
+      # analyze job ignores this input and always surveys the current `main` tip. See the
+      # gh-collect-bench-history recipe (RECOLLECT MODE) for the mechanics and caveats (e.g. it
+      # drops any blessings recorded at that commit).
+      recollect_commit_id:
+        description: "Commit SHA to re-collect and overwrite (leave empty for a normal run)"
+        required: false
+        type: string
+        default: ""
 
 # Group by the commit SHA, not the ref. Distinct commits must collect in parallel - each is
 # its own history data point, and cancelling one to favour a newer commit would drop that
 # commit's measurements, defeating the per-commit goal (so the usual ref-keyed
 # cancel-in-progress from validation.yml would be wrong here). cancel-in-progress therefore
 # only dedups a redundant re-trigger of the SAME commit (a re-run, or a workflow_dispatch on
-# an already-pushed commit), which `--skip-existing` would make a no-op append anyway.
+# an already-pushed commit), which `--skip-existing` would make a no-op append anyway. The
+# recollect commit id is folded into the key because a workflow_dispatch's github.sha is the
+# `main` tip, not the target: without it, two recollects of different commits (or a recollect
+# racing a push of the same tip) would share a group and wrongly cancel each other. It is empty
+# for pushes and plain dispatches, leaving their grouping unchanged.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.sha }}-${{ inputs.recollect_commit_id }}
   cancel-in-progress: true
 
 # Title of the rolling failure-alert issue, defined once and shared by the two jobs that
@@ -74,6 +93,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        # A normal push/dispatch only benchmarks the tip, so a shallow clone is enough. A
+        # recollect (recollect_commit_id set) must instead re-measure a historical commit, whose
+        # objects and first-parent ancestry the `backfill` worktree needs present locally - so
+        # fetch the full history in that case only. The `&&`/`||` idiom yields '0' when the input
+        # is a non-empty string and '1' (the shallow default) when it is empty or absent.
+        with:
+          fetch-depth: ${{ inputs.recollect_commit_id && '0' || '1' }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -102,8 +128,13 @@ jobs:
       # The deterministic engines (Callgrind, allocation/time counters) are
       # hardware-independent; the wall-clock engines are pinned to the fixed `github` machine
       # key (see the gh-collect-bench-history recipe) so a heterogeneous runner pool does not
-      # fork the series.
+      # fork the series. RECOLLECT_COMMIT_ID (empty on a push/plain dispatch) switches the recipe
+      # from appending the pushed commit to re-measuring and OVERWRITING one historical commit;
+      # it is passed through the environment so an untrusted dispatch input is never spliced into
+      # a shell command line here.
       - name: Collect benchmark history
+        env:
+          RECOLLECT_COMMIT_ID: ${{ inputs.recollect_commit_id }}
         run: just gh-collect-bench-history
 
   analyze:

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -93,6 +93,19 @@ times per commit and keeps, per metric, the minimum sample: runner interference 
 (a contended host only ever makes a benchmark slower) and the repeats are spaced apart in
 time, so the minimum is the reading least perturbed by transient noise. This trades a
 proportionally longer collection job for a more stable series.
+
+Even with those defences, a single day of a badly degraded runner can still leave one commit's
+data point corrupted. Collection is therefore also manually re-runnable against a specific
+historical commit: a `workflow_dispatch` with a `recollect_commit_id` re-measures just that
+commit and *overwrites* its stored point instead of appending the pushed tip. The subtlety this
+resolves is that the collection tool lives in the same repository as the benchmarks, so a naive
+"check out that commit and re-run" would also run the tool as it shipped at that commit. Instead
+the re-collection benchmarks the code *at* the target commit in a throwaway worktree while
+running the current tool, so only the measured code — never the collection logic — comes from
+the past. The overwrite bumps the cache-invalidation marker so downstream analysis refreshes,
+and it deliberately discards any blessings recorded at that commit, since a fresh measurement
+invalidates a level that was previously accepted. Analysis is unaffected by the input and always
+surveys the current `main` tip.
 A downstream analysis job reads the accumulated
 history and files a single rolling, advisory issue when it detects a notable regression;
 regressions never fail the run. Because a GitHub issue body is size-capped and a large

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -23,9 +23,37 @@
 # already-collected commit never bumps the cache-invalidation marker the `analyze` job's
 # read-through cache depends on - a re-run of the same commit is not "better" data, so there is
 # nothing to replace.
+#
+# RECOLLECT MODE. When the environment variable `RECOLLECT_COMMIT_ID` is set (the bench-history.yml
+# `collect` job wires it from the optional `recollect_commit_id` workflow_dispatch input), this
+# recipe instead re-measures that ONE historical commit and OVERWRITES its stored point, rather
+# than appending the pushed commit. It does so with `backfill <id> <id> --overwrite`, which
+# benchmarks the code AT that commit inside a throwaway git worktree (never the primary checkout)
+# while running THIS (HEAD) build of the tool - so a data point corrupted by a bad benchmark day
+# (transient spikes, a degraded runner) is replaced by a clean re-run under the CURRENT collection
+# logic, never the tool version that happened to ship at that commit. `--overwrite` bumps the
+# cloud cache-invalidation marker so the `analyze` job's read-through cache refreshes; note it also
+# drops any blessings recorded at that commit, which must be re-applied if the re-measured level is
+# still an intentional step change. The value must be a real commit on `main`'s first-parent
+# history. The mode selection and the untrusted-input validation live in
+# scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this
+# recipe is a thin import + call; the value is read from the environment, never spliced into the
+# script body.
 [group('automation')]
+[script]
 gh-collect-bench-history:
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- collect --workspace --exclude benchmarks --machine-key github --best-of 3 --skip-existing --verbose
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
+
+    # RECOLLECT_COMMIT_ID is empty on a push / plain dispatch (normal append) and a commit SHA when
+    # repairing one historical point (overwrite). The mode-selection logic - and the untrusted-input
+    # validation - lives in the module so it is Pester-tested (BenchHistoryCollect.Tests.ps1); this
+    # step is a thin wrapper that runs whatever subcommand + flags it returns.
+    $toolArgs = Get-BenchHistoryCollectCommand -RecollectCommitId $env:RECOLLECT_COMMIT_ID -Verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
 
 # Analyzes the collected history for regressions across ALL engines and target triples, but
 # only the `github` machine key - the fixed key `gh-collect-bench-history` stamps on the

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -34,8 +34,12 @@
 # logic, never the tool version that happened to ship at that commit. `--overwrite` bumps the
 # cloud cache-invalidation marker so the `analyze` job's read-through cache refreshes; note it also
 # drops any blessings recorded at that commit, which must be re-applied if the re-measured level is
-# still an intentional step change. The value must be a real commit on `main`'s first-parent
-# history. The mode selection and the untrusted-input validation live in
+# still an intentional step change. The value should be a real commit on `main`'s first-parent
+# history: the module validates only the SHA *format*, and `backfill` then requires the id to
+# *resolve* to a commit in the clone (failing loudly otherwise) - but neither checks main
+# ancestry, so a resolvable off-main commit is not rejected; it would just overwrite/store a
+# point the `analyze` job (which surveys only `main`) never surfaces. The mode selection and the
+# untrusted-input validation live in
 # scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this
 # recipe is a thin import + call; the value is read from the environment, never spliced into the
 # script body.

--- a/scripts/bench-history/BenchHistoryCollect.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryCollect.Tests.ps1
@@ -1,0 +1,93 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for BenchHistoryCollect.psm1. Proves the mode selection the bench-history `collect`
+# step depends on - append vs. overwrite, and the untrusted-input validation - without a workflow
+# run: each case asserts the exact argument vector the step would hand the tool.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'BenchHistoryCollect.psm1') -Force
+
+    # Flags shared by both modes; asserted as a slice so a case only spells out what makes it
+    # distinct (the subcommand, its positionals, and the append/overwrite tail).
+    $script:Scope = @(
+        '--workspace',
+        '--exclude', 'benchmarks',
+        '--machine-key', 'github',
+        '--best-of', '3',
+        '--verbose'
+    )
+}
+
+Describe 'Get-BenchHistoryCollectCommand' {
+    Context 'append mode (no recollect commit id)' {
+        It 'collects the pushed commit in append mode for an empty id' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId ''
+            $result | Should -Be (@('collect') + $script:Scope + @('--skip-existing'))
+        }
+
+        It 'treats a null id as append mode' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId $null
+            $result | Should -Be (@('collect') + $script:Scope + @('--skip-existing'))
+        }
+
+        It 'treats a whitespace-only id as append mode' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId "  `t "
+            $result | Should -Be (@('collect') + $script:Scope + @('--skip-existing'))
+        }
+
+        It 'never overwrites in append mode' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId ''
+            $result | Should -Not -Contain '--overwrite'
+            $result | Should -Not -Contain 'backfill'
+        }
+    }
+
+    Context 'recollect mode (a commit id set)' {
+        It 'overwrites a single historical commit via backfill for a full SHA' {
+            $sha = '0123456789abcdef0123456789abcdef01234567'
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId $sha
+            $result | Should -Be (@('backfill', $sha, $sha) + $script:Scope + @('--overwrite'))
+        }
+
+        It 'accepts a short SHA and passes it as both range endpoints' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId 'abc1234'
+            $result | Should -Be (@('backfill', 'abc1234', 'abc1234') + $script:Scope + @('--overwrite'))
+        }
+
+        It 'trims surrounding whitespace before use' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId '  abc1234  '
+            $result | Should -Be (@('backfill', 'abc1234', 'abc1234') + $script:Scope + @('--overwrite'))
+        }
+
+        It 'never appends in recollect mode' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId 'abc1234'
+            $result | Should -Not -Contain '--skip-existing'
+            $result | Should -Not -Contain 'collect'
+        }
+    }
+
+    Context 'invalid commit ids' {
+        It 'rejects a value shorter than 7 characters' {
+            { Get-BenchHistoryCollectCommand -RecollectCommitId 'abc123' } | Should -Throw '*hex commit SHA*'
+        }
+
+        It 'rejects a value longer than 40 characters' {
+            $tooLong = '0' * 41
+            { Get-BenchHistoryCollectCommand -RecollectCommitId $tooLong } | Should -Throw '*hex commit SHA*'
+        }
+
+        It 'rejects non-hex characters' {
+            { Get-BenchHistoryCollectCommand -RecollectCommitId 'abcdefg' } | Should -Throw '*hex commit SHA*'
+        }
+
+        It 'rejects a ref expression such as HEAD~1' {
+            { Get-BenchHistoryCollectCommand -RecollectCommitId 'HEAD~1' } | Should -Throw '*hex commit SHA*'
+        }
+
+        It 'rejects an id carrying shell metacharacters' {
+            { Get-BenchHistoryCollectCommand -RecollectCommitId "abc1234; rm -rf /" } | Should -Throw '*hex commit SHA*'
+        }
+    }
+}
+
+

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -1,0 +1,70 @@
+#requires -Version 7
+
+# Argument selection for the benchmark-history `collect` step (.github/workflows/bench-history.yml,
+# via the gh-collect-bench-history recipe).
+#
+# The step has two modes and the choice between them is real logic - a branch, input validation and
+# error handling - so it lives here behind a seam the Pester suite (BenchHistoryCollect.Tests.ps1)
+# exercises, and the recipe is a thin import + call. The recollect commit id arrives from an
+# untrusted workflow_dispatch input, so validating it here (rather than splicing it into a shell
+# command line) is also what keeps it injection-safe.
+#
+# Normal mode (no recollect id): append the pushed commit with `collect --skip-existing`, so a
+# re-triggered run of an already-collected commit is a no-op rather than a rewrite. Recollect mode
+# (a commit id set): re-measure just that one historical commit and OVERWRITE its stored point with
+# `backfill <id> <id> --overwrite`, which benchmarks the code AT that commit in a throwaway worktree
+# while running THIS (HEAD) build of the tool - repairing a point corrupted by a bad benchmark day
+# without adopting the tool version that shipped at that commit.
+
+Set-StrictMode -Version Latest
+
+function Get-BenchHistoryCollectCommand {
+    # Builds the argument vector passed to the tool after `--` (a `collect ...` or `backfill ...`
+    # invocation), choosing the mode from $RecollectCommitId. Returns a string[]; throws when a
+    # non-empty id is not a plausible commit SHA. Emits an explanatory verbose note describing which
+    # mode was chosen and why, for the workflow log.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $RecollectCommitId
+    )
+
+    # Scope + noise-reduction flags shared by both modes: `collect` and `backfill` flatten the same
+    # clap arg groups, so this array applies verbatim to either subcommand. The fixed `github`
+    # machine key keeps the whole GitHub runner pool on one wall-clock series; `--best-of 3` keeps
+    # each metric's minimum across three runs to shed one-sided runner jitter.
+    $scope = @(
+        '--workspace',
+        '--exclude', 'benchmarks',
+        '--machine-key', 'github',
+        '--best-of', '3',
+        '--verbose'
+    )
+
+    $recollect = if ($null -eq $RecollectCommitId) { '' } else { $RecollectCommitId.Trim() }
+
+    if ($recollect -eq '') {
+        Write-Verbose ('No recollect commit id: appending the pushed commit with `collect ' +
+            '--skip-existing`, so an already-stored object is left untouched rather than rewritten.')
+        return @('collect') + $scope + @('--skip-existing')
+    }
+
+    # A commit SHA only - hex, 7-40 chars. Rejecting anything else fails a typo'd dispatch loudly
+    # (before an expensive benchmark run) and, because the value is an untrusted dispatch input,
+    # also guarantees it can carry no shell metacharacters.
+    if ($recollect -notmatch '^[0-9a-fA-F]{7,40}$') {
+        throw ("Recollect commit id must be a 7-40 character hex commit SHA on main's history, " +
+            "got '$recollect'.")
+    }
+
+    Write-Verbose ("Recollect commit ${recollect}: re-measuring that single commit in a throwaway " +
+        'worktree and overwriting its stored point with `backfill --overwrite`, using this HEAD ' +
+        'build of the tool so only the benchmark code - not the collection logic - comes from that ' +
+        'commit.')
+    return @('backfill', $recollect, $recollect) + $scope + @('--overwrite')
+}
+
+Export-ModuleMember -Function Get-BenchHistoryCollectCommand

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -56,8 +56,8 @@ function Get-BenchHistoryCollectCommand {
     # (before an expensive benchmark run) and, because the value is an untrusted dispatch input,
     # also guarantees it can carry no shell metacharacters.
     if ($recollect -notmatch '^[0-9a-fA-F]{7,40}$') {
-        throw ("Recollect commit id must be a 7-40 character hex commit SHA on main's history, " +
-            "got '$recollect'.")
+        throw ("Recollect commit id must be a 7-40 character hex commit SHA, got '$recollect'. " +
+            "That it names a commit actually on main's history is verified later by the backfill step.")
     }
 
     Write-Verbose ("Recollect commit ${recollect}: re-measuring that single commit in a throwaway " +

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -57,7 +57,10 @@ function Get-BenchHistoryCollectCommand {
     # also guarantees it can carry no shell metacharacters.
     if ($recollect -notmatch '^[0-9a-fA-F]{7,40}$') {
         throw ("Recollect commit id must be a 7-40 character hex commit SHA, got '$recollect'. " +
-            "That it names a commit actually on main's history is verified later by the backfill step.")
+            "This validates the format only; that the id resolves to a real commit is enforced " +
+            "later by the backfill step (which fails if the ref cannot be resolved), while whether " +
+            "that commit is actually on main's history is the operator's responsibility - a " +
+            'resolvable off-main commit is not rejected.')
     }
 
     Write-Verbose ("Recollect commit ${recollect}: re-measuring that single commit in a throwaway " +


### PR DESCRIPTION
## What

Adds the ability to manually re-run the on-push benchmark-history workflow to **repair a single corrupted historical data point** — e.g. one full of transient spikes because the benchmark PC was degraded that day.

The **Benchmark history** workflow now accepts an optional `recollect_commit_id` `workflow_dispatch` input:

- **Empty (normal push / plain dispatch):** unchanged — appends the pushed commit with `collect --skip-existing`.
- **Set to a commit SHA:** re-measures *only that commit* and overwrites its stored point with `backfill <id> <id> --overwrite`.

The analyze stage is deliberately unchanged and always analyzes the tip of `main`.

## Why `backfill` instead of a checkout

`cargo-bench-history` lives in the same repo as the benchmarks, so a naive checkout of the old commit would run the *old* tool. `backfill` already solves this: it benchmarks the code **at the target commit in a throwaway worktree** while running **this (HEAD) build of the tool**. So only the benchmark code — not the collection logic — comes from the target commit. **No Rust changes were needed.**

## Wiring details

- **Full-history checkout only when recollecting** (`fetch-depth` conditional) — backfill's worktree + first-parent topology walk need the commit's objects/ancestry present; normal pushes stay shallow.
- **Untrusted input is passed via the environment** (`RECOLLECT_COMMIT_ID`) and validated as a 7–40 char hex SHA rather than spliced into a shell command line.
- **Concurrency group folds in the recollect id** so two distinct recollects (or a recollect racing a push of the same `main` tip) don't cancel each other.
- **Mode-selection logic lives in a Pester-tested PowerShell module** (`scripts/bench-history/BenchHistoryCollect.psm1`) per the scripts convention; the `gh-collect-bench-history` recipe is a thin wrapper.

## Caveat

A clean `--overwrite` drops any **blessings** recorded at that commit across the re-run platforms. If the level there is still an intentional step change, re-bless afterward. (Documented in `design.md`.)

## Validation

- `just validate-workflows` (actionlint) — clean
- `just validate-scripts` (PSScriptAnalyzer) — zero findings
- `just test-scripts` (Pester) — 199 passed, 0 failed

## Usage

Run the **Benchmark history** workflow via *Run workflow* from `main`, entering the commit SHA in `recollect_commit_id`.