### PR TITLE
Echo effective defaulted CLI values in cargo-bench-history

### DIFF
--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -76,11 +76,15 @@ cargo tools share these grouped conventions. Full group/flag map: DESIGN §7.
 through the guarded `ReporterExt` surface — `note_with(|| format!(…))` for one lazy line,
 `if_enabled(|notes| …)` for a block; the unconditional `Sink` is sealed, so there is no
 `enabled()`/`note()` guard to forget. Stage timings are a separate channel
-(`ReporterExt::timing`). Production `StderrReporter` writes `[bench-history] …` to **stderr
-only when verbose** (never stdout, so machine-readable output stays clean). The reporter is
+(`ReporterExt::timing`). A third channel, `ReporterExt::announce`, is **always on** (not
+verbose-gated): use it only for the one-line effective-selection / effective-partition
+summaries that must appear on every run, never for per-object chatter. Production
+`StderrReporter` writes `[bench-history] …` to **stderr** (notes/timings only when verbose;
+announcements always) — never stdout, so machine-readable output stays clean. The reporter is
 `&dyn` (not `+ Sync`) so run futures stay `!Send` / Miri-driven. Notes must be **explanatory,
 not conclusion-only** (see `docs/standalone-binaries.md`). Tests use the `#[cfg(test)]`
-`RecordingReporter`.
+`RecordingReporter` (`notes()`/`contains()` for notes, `announcements()`/`announced()` for the
+always-on channel).
 
 ## Storage & engines (essentials)
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -384,6 +384,13 @@ write the same clean key and the second collides — so coverage gaps are expect
 from *different commits* covering different subsets, not from multiple partial runs at one
 commit.
 
+Regardless of `--verbose`, `collect` prints a one-line **effective-partition** summary to
+stderr naming the storage partition its results land in: the target triple (always the
+toolchain host) and the machine key hardware-dependent engines use — marked as
+auto-detected or as coming from `--machine-key`. This makes the otherwise-invisible
+auto-detected partition self-describing on every run. `backfill` reuses the same `collect`
+path and so emits the line per commit, each reflecting that commit's own probed toolchain.
+
 ### 7.2 `install`
 
 Generates a fully commented example config if absent and points the user at it, never
@@ -447,10 +454,18 @@ ranked list is meaningless for the enumerating commands, and it never displaces 
 reports, which the workflow attaches alongside it. **Findings never affect the exit code**:
 the process exits non-zero only when the analysis fails to *run*. A finding is advisory, and
 the machine-readable signal lives in the JSON report. Downstream automation (a scheduled
-regression watch, a PR comment bot) reads that rather than the exit status. When
-facet-matching runs were stored but none entered the analysis, the report carries a plain
-hint explaining the empty result even without verbose diagnostics, so a zero-run outcome is
-never mistaken for "no data".
+regression watch, a PR comment bot) reads that rather than the exit status.
+
+Regardless of `--verbose`, every query run (`analyze`, `list`, `prune`, `examine`) prints a
+one-line **effective-selection** summary to stderr — the engine, target-triple, and
+machine-key facets (each marked when auto-detected), the resolved base branch, and the
+`--since` / `--until` window — so the user always sees what was actually searched, not just
+what they typed. Two empty outcomes also explain themselves in the stdout report without
+verbose diagnostics: when facet-matching runs were stored but none entered the analysis the
+hint breaks down why, and when the effective (possibly auto-detected) partition holds no
+runs at all the hint names that partition and suggests widening it. A zero-run outcome is
+thus never mistaken for "no data", and an auto-detected partition that quietly missed is
+never mistaken for an empty project.
 
 ### 7.4 `backfill`
 
@@ -814,8 +829,12 @@ logic stays synchronous — parse, map, comparability, series, findings, format 
 Miri-safe bulk of the code and tests. Async is pushed only to the I/O edges, each a small
 port trait (`impl Future` return, no async-trait macro) with a real Tokio adapter and an
 in-`#[cfg(test)]` in-memory fake: the process runner, the environment and git-history
-probes, the benchmark-output harvester, the config writer for `install`, the verbose
-reporter, and storage. Time comes from an injected clock (the workspace `tick` crate), so
+probes, the benchmark-output harvester, the config writer for `install`, the diagnostics
+reporter, and storage. The reporter carries three independent channels — verbose-gated
+per-object **notes**, independent stage **timings**, and **always-on one-line summaries**
+(the effective-selection and effective-partition lines above) — all written to stderr so
+stdout stays a clean machine-readable stream of reports and JSON. Time comes from an
+injected clock (the workspace `tick` crate), so
 tests drive it deterministically and orchestration never reads the wall clock directly.
 Orchestration takes the injected ports, and the public async entry wires the real adapters.
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -196,3 +196,21 @@ thousands of them would both bury the timings and distort the very wall clock be
 measured. A programmatic caller can therefore request the stage timings alone, without the
 note flood — which is exactly how the stress harness surfaces the load breakdown while
 keeping its own measurement clean.
+
+## Seeing what was searched, always
+
+A third reporter channel runs **regardless of `--verbose`**: a single **effective-selection**
+line to standard error naming the facets actually queried — engine, target triple, and
+machine key, each tagged when it was auto-detected rather than typed — plus the resolved base
+branch and the `--since` / `--until` window. Auto-detection is convenient but invisible, and
+this line makes it legible so a surprising result can be traced to *what* was searched before
+suspecting the data. It is one line by construction, so it neither buries the verbose notes
+nor perturbs the timing channel, and like both of them it stays on stderr to keep stdout a
+clean stream of reports.
+
+The line is most valuable when a query comes back empty. When the effective — possibly
+auto-detected — partition holds no stored runs at all, the stdout report's hint names that
+partition and suggests widening it (for instance `--target-triple all`), so an
+auto-detected facet that quietly missed is distinguished from a genuinely empty project. The
+enumerating commands (`list`, `prune`, `examine`) resolve their dataset through the same path
+and so emit the same line.

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -384,6 +384,20 @@ where
         hardware: deps.probe.hardware().await,
     };
 
+    // The always-on effective-partition announcement: one line, printed regardless
+    // of `--verbose`, naming the storage partition this run's results land in (the
+    // target triple, always the toolchain host, and the machine key hardware-
+    // dependent engines use — an explicit `--machine-key` or the auto-detected
+    // fingerprint). It mirrors the query commands' effective-selection summary so
+    // the partition a `collect` writes and an `analyze` reads is stated the same way.
+    let effective_machine_key =
+        resolve_machine_key(options.machine_key.as_deref(), &shared.hardware);
+    deps.reporter.announce(&collect_selection_summary(
+        &shared.target_triple,
+        &effective_machine_key,
+        options.machine_key.is_some(),
+    ));
+
     let mut stored = 0_usize;
     let mut harvested = 0_usize;
     let mut labels = Vec::new();
@@ -411,6 +425,35 @@ where
         harvested,
         labels,
     })
+}
+
+/// Builds the always-on, one-line summary of a collect run's effective storage
+/// partition: the target triple its results are keyed under (always the toolchain
+/// host, since the tool benchmarks the OS it runs on) and the machine key
+/// hardware-dependent engines use — an explicit `--machine-key` override or the
+/// auto-detected hardware fingerprint.
+///
+/// A pure formatter so the wording is unit-tested without a probe; the effective
+/// values are resolved by the caller.
+fn collect_selection_summary(
+    target_triple: &str,
+    machine_key: &str,
+    machine_key_explicit: bool,
+) -> String {
+    let triple = if target_triple.is_empty() {
+        "unknown"
+    } else {
+        target_triple
+    };
+    let machine_source = if machine_key_explicit {
+        "from --machine-key"
+    } else {
+        "auto-detected"
+    };
+    format!(
+        "collecting: target-triple={triple} (toolchain host); \
+         machine-key={machine_key} ({machine_source}), used by hardware-dependent engines"
+    )
 }
 
 /// Emits the per-metric best-of provenance: the samples seen and which run won.
@@ -1107,6 +1150,33 @@ mod tests {
     }
 
     #[test]
+    fn collect_selection_summary_names_the_effective_partition() {
+        // Auto-detected fingerprint: the machine key is marked auto-detected and the
+        // triple is named as the toolchain host.
+        let auto = collect_selection_summary("x86_64-pc-windows-msvc", "abcd1234", false);
+        assert!(
+            auto.contains("target-triple=x86_64-pc-windows-msvc (toolchain host)"),
+            "{auto}"
+        );
+        assert!(
+            auto.contains("machine-key=abcd1234 (auto-detected)"),
+            "{auto}"
+        );
+
+        // An explicit `--machine-key` is attributed to the option, not auto-detection.
+        let explicit = collect_selection_summary("aarch64-apple-darwin", "ci-pool", true);
+        assert!(
+            explicit.contains("machine-key=ci-pool (from --machine-key)"),
+            "{explicit}"
+        );
+        assert!(!explicit.contains("auto-detected"), "{explicit}");
+
+        // A missing host triple degrades to a readable placeholder rather than blank.
+        let unknown = collect_selection_summary("", "abcd1234", false);
+        assert!(unknown.contains("target-triple=unknown"), "{unknown}");
+    }
+
+    #[test]
     fn build_message_brackets_labels_only_when_present() {
         let labels = vec!["callgrind: 1 stored".to_owned()];
         let with_labels = build_message(false, 1, 1, &labels);
@@ -1474,6 +1544,70 @@ mod tests {
             reporter.contains("stored v1/folo/objects/callgrind/"),
             "expected a stored-key note, got {:?}",
             reporter.notes()
+        );
+    }
+
+    #[test]
+    fn collect_announces_the_effective_storage_partition() {
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = FakeOutput::with_two_callgrind_summaries();
+        let storage = MemoryStorage::new();
+        let reporter = RecordingReporter::new();
+
+        drive_at_with(
+            FROZEN_UNIX,
+            &CollectOptions::default(),
+            &runner,
+            &probe,
+            &output,
+            &storage,
+            &reporter,
+        )
+        .unwrap();
+
+        // The always-on announcement names the probed host triple and the
+        // auto-detected machine key, so a collect run reports where its results
+        // land even without `--verbose`.
+        assert!(
+            reporter.announced("target-triple=x86_64-pc-windows-msvc (toolchain host)"),
+            "expected the effective-partition announcement, got {:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("(auto-detected)"),
+            "machine key should read as auto-detected, got {:?}",
+            reporter.announcements()
+        );
+    }
+
+    #[test]
+    fn collect_announcement_attributes_an_explicit_machine_key() {
+        let runner = FakeRunner::succeeding();
+        let probe = FakeProbe::new();
+        let output = FakeOutput::with_two_callgrind_summaries();
+        let storage = MemoryStorage::new();
+        let reporter = RecordingReporter::new();
+        let options = CollectOptions {
+            machine_key: Some("ci-pool-a".to_owned()),
+            ..CollectOptions::default()
+        };
+
+        drive_at_with(
+            FROZEN_UNIX,
+            &options,
+            &runner,
+            &probe,
+            &output,
+            &storage,
+            &reporter,
+        )
+        .unwrap();
+
+        assert!(
+            reporter.announced("machine-key=ci-pool-a (from --machine-key)"),
+            "explicit key should be attributed to the option, got {:?}",
+            reporter.announcements()
         );
     }
 

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -7,14 +7,16 @@ use std::time::Instant;
 
 use anyspawn::Spawner;
 use cbh_config::Config;
-use cbh_detect::{AnalysisMode, BlessingPlacement, Series, SeriesFilter};
+use cbh_detect::{AnalysisMode, BlessingPlacement, DiscriminantSetQuery, Series, SeriesFilter};
 use cbh_diag::{Reporter, ReporterExt, count_noun};
 use cbh_git::GitHistory;
 use cbh_model::{BenchmarkIdPrefix, BlessingRecord, DiscriminantSet, StorageKey};
 use cbh_storage::Storage;
 use jiff::Timestamp;
 
-use super::facets::{AutoFacets, resolve_facets};
+use super::facets::{
+    AutoFacets, describe_effective_facets, facets_are_unconstrained, resolve_facets,
+};
 use super::history::{DirtyTipPolicy, ResolvedHistory, resolve_history};
 use super::load::{
     RunIndex, WorkerFold, facet_filtered_candidates, fold_runs_chunked, load_objects_concurrently,
@@ -44,6 +46,10 @@ pub(crate) struct SelectedDataSet {
     pub(crate) included_dirty_base_exception: bool,
     /// The target ref the timeline was resolved against (for diagnostics).
     pub(crate) target_ref: String,
+    /// The resolved discriminant-set query (the effective, possibly auto-detected
+    /// engine / target-triple / machine-key facets), so an empty outcome can name
+    /// the exact partition it searched.
+    pub(crate) facets: DiscriminantSetQuery,
     /// Subject line of each in-history commit that has one, so `examine` can label
     /// each data point with what its commit changed. A commit absent here has an
     /// empty subject; only `examine` reads this.
@@ -116,6 +122,7 @@ where
     let topology_started = Instant::now();
     let ResolvedHistory {
         target_ref,
+        base_name,
         tip_commit,
         tip_dirty,
         order,
@@ -192,6 +199,19 @@ where
             until.map_or_else(|| "none".to_owned(), |until| until.to_string())
         )
     });
+
+    // The always-on effective-selection announcement: one line, printed regardless
+    // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
+    // branch, and look-back window a plain run would otherwise resolve silently.
+    reporter.announce(&effective_selection_summary(
+        &facets,
+        base_name.as_deref(),
+        selection.base.is_none(),
+        since,
+        selection.since.is_some(),
+        mode,
+        until,
+    ));
 
     // Tally why candidates do not enter the analysis, so a `0 runs` outcome can
     // explain itself (via `--verbose` per object, and via a summary hint when
@@ -416,6 +436,7 @@ where
         },
         included_dirty_base_exception,
         target_ref,
+        facets,
         commit_subjects,
         tip_commit,
         tip_dirty,
@@ -423,6 +444,44 @@ where
         merge_base_index,
         blessings,
     })
+}
+
+/// Builds the always-on, one-line summary of a run's effective selection: the
+/// discriminant partition it searched (naming auto-detected facets), the base
+/// branch it split history against, and the resolved look-back window.
+///
+/// Emitted to standard error regardless of `--verbose` so a plain run never hides
+/// a value it auto-detected or defaulted. `base_auto` marks the base as
+/// auto-detected (no explicit `--base`); `since_explicit` selects the wording for
+/// why the `--since` cutoff is what it is.
+fn effective_selection_summary(
+    facets: &DiscriminantSetQuery,
+    base_name: Option<&str>,
+    base_auto: bool,
+    since: Option<Timestamp>,
+    since_explicit: bool,
+    mode: AnalysisMode,
+    until: Option<Timestamp>,
+) -> String {
+    let base = match base_name {
+        Some(name) if base_auto => format!("base={name} (auto-detected)"),
+        Some(name) => format!("base={name}"),
+        None => "base=none".to_owned(),
+    };
+    let since = format!(
+        "since={} ({})",
+        since.map_or_else(|| "none".to_owned(), |since| since.to_string()),
+        since_cutoff_reason(since_explicit, mode)
+    );
+    let mut parts = vec![
+        format!("selection: {}", describe_effective_facets(facets)),
+        base,
+        since,
+    ];
+    if let Some(until) = until {
+        parts.push(format!("until={until}"));
+    }
+    parts.join("; ")
 }
 
 /// How many facet-matching candidates were excluded, by reason.
@@ -438,19 +497,47 @@ pub(crate) struct ExclusionTally {
     until: usize,
 }
 
-/// Builds a diagnostic hint for the case where stored runs matched the facet
-/// filters but none entered the analysis, so the empty outcome explains itself.
+/// Builds a diagnostic hint explaining an empty outcome, so a bare `0 runs` never
+/// leaves a user guessing.
 ///
-/// Returns `None` when at least one run was loaded, or when there were no
-/// candidates at all (a genuinely empty history needs no special explanation).
+/// Two empty cases are named. When *no* stored run matched the facet filters, the
+/// hint names the effective (possibly auto-detected) partition it searched — so an
+/// auto-detected target-triple / machine-key that simply does not match the stored
+/// data explains itself — and distinguishes a genuinely empty project from a
+/// missed partition. When runs matched the facets but topology or the window
+/// excluded them all, the hint breaks down the dominant exclusion reasons.
+///
+/// Returns `None` when at least one run was loaded.
 pub(crate) fn empty_history_hint(
     loaded_is_empty: bool,
     candidate_count: usize,
     target_ref: &str,
     tally: ExclusionTally,
+    facets: &DiscriminantSetQuery,
 ) -> Option<String> {
-    if !loaded_is_empty || candidate_count == 0 {
+    if !loaded_is_empty {
         return None;
+    }
+
+    if candidate_count == 0 {
+        // No stored run matched the facets at all. Either the project holds no runs
+        // yet, or an auto-detected facet points at a partition nothing was recorded
+        // under. Name the partition so the second case is not mistaken for the first.
+        if facets_are_unconstrained(facets) {
+            return Some(
+                "No benchmark runs are stored for this project yet. Record some with a \
+                 `collect` (or `backfill`) run, then try again."
+                    .to_owned(),
+            );
+        }
+        return Some(format!(
+            "No stored runs matched the current selection ({}). Nothing has been \
+             collected for this discriminant partition yet, or an auto-detected facet \
+             does not match the stored data. Pass --target-triple all / --machine-key all \
+             to widen the search, or run `list discriminants` to see which partitions \
+             hold data.",
+            describe_effective_facets(facets)
+        ));
     }
 
     let mut lines = vec![format!(
@@ -491,7 +578,20 @@ pub(crate) fn empty_history_hint(
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use cbh_detect::FacetFilter;
+    use nonempty::nonempty;
+
     use super::*;
+
+    /// A facet query with no auto-detected or explicit constraints, for the
+    /// exclusion-reason cases whose hint text does not depend on the facets.
+    fn unconstrained_facets() -> DiscriminantSetQuery {
+        DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::All,
+            machine_key: FacetFilter::All,
+        }
+    }
 
     #[test]
     fn empty_history_hint_explains_only_when_runs_were_excluded() {
@@ -501,10 +601,12 @@ mod tests {
             since: 0,
             until: 0,
         };
-        // No candidates at all → a genuinely empty history needs no hint.
-        assert_eq!(empty_history_hint(true, 0, "master", no_exclusions), None);
-        // Runs were actually loaded → no hint.
-        assert_eq!(empty_history_hint(false, 3, "master", no_exclusions), None);
+        let facets = unconstrained_facets();
+        // Runs were actually loaded → no hint regardless of candidate count.
+        assert_eq!(
+            empty_history_hint(false, 3, "master", no_exclusions, &facets),
+            None
+        );
 
         let tally = ExclusionTally {
             outside_history: 2,
@@ -512,7 +614,7 @@ mod tests {
             since: 4,
             until: 0,
         };
-        let hint = empty_history_hint(true, 7, "master", tally).unwrap();
+        let hint = empty_history_hint(true, 7, "master", tally, &facets).unwrap();
         assert!(hint.contains("7 stored runs"), "{hint}");
         assert!(
             hint.contains("1 dirty (uncommitted-tree) snapshot"),
@@ -533,7 +635,7 @@ mod tests {
             since: 0,
             until: 0,
         };
-        let hint = empty_history_hint(true, 3, "master", dirty_only).unwrap();
+        let hint = empty_history_hint(true, 3, "master", dirty_only, &facets).unwrap();
         assert!(hint.contains("dirty (uncommitted-tree)"), "{hint}");
         assert!(!hint.contains("outside"), "{hint}");
         assert!(!hint.contains("--since cutoff"), "{hint}");
@@ -546,7 +648,7 @@ mod tests {
             since: 0,
             until: 0,
         };
-        let hint = empty_history_hint(true, 2, "master", outside_only).unwrap();
+        let hint = empty_history_hint(true, 2, "master", outside_only, &facets).unwrap();
         assert!(hint.contains("outside master"), "{hint}");
         assert!(!hint.contains("dirty (uncommitted-tree)"), "{hint}");
         assert!(!hint.contains("--since cutoff"), "{hint}");
@@ -558,12 +660,110 @@ mod tests {
             since: 0,
             until: 5,
         };
-        let hint = empty_history_hint(true, 5, "master", until_only).unwrap();
+        let hint = empty_history_hint(true, 5, "master", until_only, &facets).unwrap();
         assert!(
             hint.contains("5 runs newer than the --until cutoff"),
             "{hint}"
         );
         assert!(!hint.contains("dirty (uncommitted-tree)"), "{hint}");
         assert!(!hint.contains("--since cutoff"), "{hint}");
+    }
+
+    #[test]
+    fn empty_history_hint_names_the_empty_partition_when_nothing_matched() {
+        let no_exclusions = ExclusionTally {
+            outside_history: 0,
+            dirty_base: 0,
+            since: 0,
+            until: 0,
+        };
+
+        // Unconstrained facets that matched nothing → a genuinely empty project.
+        let hint =
+            empty_history_hint(true, 0, "master", no_exclusions, &unconstrained_facets()).unwrap();
+        assert!(hint.contains("No benchmark runs are stored"), "{hint}");
+        assert!(hint.contains("collect"), "{hint}");
+        // It must not misdescribe an empty project as a missed partition.
+        assert!(!hint.contains("auto-detected facet"), "{hint}");
+
+        // Auto-detected facets that matched nothing → name the searched partition so
+        // the user learns which auto-detected values missed.
+        let auto = DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
+            machine_key: FacetFilter::Auto("abcd".to_owned()),
+        };
+        let hint = empty_history_hint(true, 0, "master", no_exclusions, &auto).unwrap();
+        assert!(
+            hint.contains("target-triple=x86_64-pc-windows-msvc (auto-detected)"),
+            "{hint}"
+        );
+        assert!(hint.contains("machine-key=abcd (auto-detected)"), "{hint}");
+        assert!(hint.contains("--target-triple all"), "{hint}");
+        assert!(hint.contains("list discriminants"), "{hint}");
+    }
+
+    #[test]
+    fn effective_selection_summary_names_auto_detected_inputs() {
+        let facets = DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
+            machine_key: FacetFilter::Auto("abcd".to_owned()),
+        };
+        let since = Timestamp::from_second(1_700_000_000).unwrap();
+        // History mode, auto-detected base, default look-back: every defaulted value
+        // is named and marked.
+        let summary = effective_selection_summary(
+            &facets,
+            Some("main"),
+            true,
+            Some(since),
+            false,
+            AnalysisMode::History,
+            None,
+        );
+        assert!(
+            summary.contains("target-triple=x86_64-pc-windows-msvc (auto-detected)"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("machine-key=abcd (auto-detected)"),
+            "{summary}"
+        );
+        assert!(summary.contains("base=main (auto-detected)"), "{summary}");
+        assert!(
+            summary.contains("history-mode default six-month look-back"),
+            "{summary}"
+        );
+    }
+
+    #[test]
+    fn effective_selection_summary_marks_explicit_inputs_without_auto() {
+        let facets = DiscriminantSetQuery {
+            engine: FacetFilter::Explicit(nonempty!["criterion".to_owned()]),
+            target_triple: FacetFilter::All,
+            machine_key: FacetFilter::All,
+        };
+        let until = Timestamp::from_second(1_700_100_000).unwrap();
+        // Branch mode, explicit base, no default window: nothing is marked
+        // auto-detected and the until edge is shown when set.
+        let summary = effective_selection_summary(
+            &facets,
+            Some("release"),
+            false,
+            None,
+            false,
+            AnalysisMode::Branch,
+            Some(until),
+        );
+        assert!(summary.contains("engine=criterion"), "{summary}");
+        assert!(summary.contains("target-triple=all"), "{summary}");
+        assert!(summary.contains("base=release"), "{summary}");
+        assert!(!summary.contains("auto-detected"), "{summary}");
+        assert!(
+            summary.contains("no default look-back window outside history mode"),
+            "{summary}"
+        );
+        assert!(summary.contains(&format!("until={until}")), "{summary}");
     }
 }

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -205,7 +205,7 @@ where
     // branch, and look-back window a plain run would otherwise resolve silently.
     reporter.announce(&effective_selection_summary(
         &facets,
-        base_name.as_deref(),
+        &base_name,
         selection.base.is_none(),
         since,
         selection.since.is_some(),
@@ -456,17 +456,17 @@ where
 /// why the `--since` cutoff is what it is.
 fn effective_selection_summary(
     facets: &DiscriminantSetQuery,
-    base_name: Option<&str>,
+    base_name: &str,
     base_auto: bool,
     since: Option<Timestamp>,
     since_explicit: bool,
     mode: AnalysisMode,
     until: Option<Timestamp>,
 ) -> String {
-    let base = match base_name {
-        Some(name) if base_auto => format!("base={name} (auto-detected)"),
-        Some(name) => format!("base={name}"),
-        None => "base=none".to_owned(),
+    let base = if base_auto {
+        format!("base={base_name} (auto-detected)")
+    } else {
+        format!("base={base_name}")
     };
     let since = format!(
         "since={} ({})",
@@ -715,7 +715,7 @@ mod tests {
         // is named and marked.
         let summary = effective_selection_summary(
             &facets,
-            Some("main"),
+            "main",
             true,
             Some(since),
             false,
@@ -749,7 +749,7 @@ mod tests {
         // auto-detected and the until edge is shown when set.
         let summary = effective_selection_summary(
             &facets,
-            Some("release"),
+            "release",
             false,
             None,
             false,

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -175,6 +175,7 @@ where
             dataset.candidate_count,
             &dataset.target_ref,
             dataset.tally,
+            &dataset.facets,
         )
     } else {
         Some(unmatched_series_hint(

--- a/packages/cbh_analyze/src/facets.rs
+++ b/packages/cbh_analyze/src/facets.rs
@@ -92,6 +92,44 @@ fn describe_filter(filter: &FacetFilter) -> Option<String> {
     }
 }
 
+/// Renders every facet's effective value — always naming all three, including an
+/// unconstrained `all` — for the always-on effective-selection summary and the
+/// empty-partition hint.
+///
+/// Unlike [`describe_facets`] (a verbose-note helper that omits unconstrained
+/// facets), this names each facet so a plain run shows exactly which discriminant
+/// partition it searched and which values were auto-detected.
+pub(crate) fn describe_effective_facets(facets: &DiscriminantSetQuery) -> String {
+    [
+        ("engine", &facets.engine),
+        ("target-triple", &facets.target_triple),
+        ("machine-key", &facets.machine_key),
+    ]
+    .into_iter()
+    .map(|(label, filter)| format!("{label}={}", describe_effective_filter(filter)))
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
+/// Renders one facet filter for the effective summary, naming an unconstrained
+/// filter `all` rather than omitting it.
+fn describe_effective_filter(filter: &FacetFilter) -> String {
+    match filter {
+        FacetFilter::All => "all".to_owned(),
+        FacetFilter::Auto(value) => format!("{value} (auto-detected)"),
+        FacetFilter::Explicit(values) => values.iter().cloned().collect::<Vec<_>>().join("|"),
+    }
+}
+
+/// Whether every facet is unconstrained (`all`): the query spans every stored
+/// discriminant partition rather than a specific machine's. Distinguishes a
+/// genuinely empty project from an auto-detected partition that matched nothing.
+pub(crate) fn facets_are_unconstrained(facets: &DiscriminantSetQuery) -> bool {
+    matches!(facets.engine, FacetFilter::All)
+        && matches!(facets.target_triple, FacetFilter::All)
+        && matches!(facets.machine_key, FacetFilter::All)
+}
+
 /// Parses an `--engine` facet value into an [`Engine`], if set.
 fn parse_engine(name: Option<&str>) -> Result<Option<Engine>, AnalyzeError> {
     match name {
@@ -142,5 +180,44 @@ mod tests {
         assert!(parse_engine(Some("callgrind")).unwrap().is_some());
         let error = parse_engine(Some("nonsuch")).unwrap_err();
         assert!(error.to_string().contains("unknown"), "{error}");
+    }
+
+    #[test]
+    fn describe_effective_facets_names_every_facet_including_all() {
+        let query = DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
+            machine_key: FacetFilter::Explicit(nonempty!["abcd".to_owned()]),
+        };
+        // Unlike `describe_facets`, an unconstrained facet is named `all` rather
+        // than dropped, so the summary always shows the full partition searched.
+        assert_eq!(
+            describe_effective_facets(&query),
+            "engine=all, target-triple=x86_64-pc-windows-msvc (auto-detected), machine-key=abcd"
+        );
+    }
+
+    #[test]
+    fn facets_are_unconstrained_only_when_every_facet_is_all() {
+        let all = DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::All,
+            machine_key: FacetFilter::All,
+        };
+        assert!(facets_are_unconstrained(&all));
+
+        let one_auto = DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::Auto("x86_64".to_owned()),
+            machine_key: FacetFilter::All,
+        };
+        assert!(!facets_are_unconstrained(&one_auto));
+
+        let one_explicit = DiscriminantSetQuery {
+            engine: FacetFilter::Explicit(nonempty!["criterion".to_owned()]),
+            target_triple: FacetFilter::All,
+            machine_key: FacetFilter::All,
+        };
+        assert!(!facets_are_unconstrained(&one_explicit));
     }
 }

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -37,10 +37,9 @@ pub(crate) struct ResolvedHistory {
     pub(crate) target_ref: String,
     /// The display name of the base ref the target's history was split against
     /// (an explicit `--base`, the configured default branch, or the detected one),
-    /// for the effective-selection summary. `None` only when no base could be
-    /// resolved — which the merge-base check below turns into an error, so a
-    /// successfully resolved history always names its base.
-    pub(crate) base_name: Option<String>,
+    /// for the effective-selection summary. Always present: `resolve_history`
+    /// refuses to build a `ResolvedHistory` when no base can be resolved.
+    pub(crate) base_name: String,
     /// The full commit ID the target ref resolved to — the analyzed tip commit, carried
     /// into the report so it names the exact commit the findings describe.
     pub(crate) tip_commit: String,
@@ -105,10 +104,25 @@ where
         });
     };
 
-    let base = resolve_base(git, config, selection.base).await?;
-    let (base_name, base_commit_id) = match base {
-        Some(ResolvedBase { name, commit }) => (Some(name), Some(commit)),
-        None => (None, None),
+    // A base branch is required: the analysis splits the target's first-parent line
+    // at its merge-base with the base, so a run with no resolvable base has no
+    // topology to split on. Refuse before walking the ancestry rather than carrying
+    // an unresolved base through. The usual cause is a shallow clone or a checkout
+    // that never fetched the base branch.
+    let Some(ResolvedBase {
+        name: base_name,
+        commit: base_commit_id,
+    }) = resolve_base(git, config, selection.base).await?
+    else {
+        return Err(AnalyzeError::Analyze {
+            message: format!(
+                "could not determine the base branch to compare {target_ref} against: no \
+                 --base was given and no default branch could be resolved. Pass an explicit \
+                 --base, set project.default_branch, or make the default branch available \
+                 (a shallow clone or a checkout that never fetched the base branch is the \
+                 usual cause)."
+            ),
+        });
     };
     let first_parent_started = Instant::now();
     let first_parent = git
@@ -134,13 +148,10 @@ where
         }
         ancestry.push(commit.commit_id);
     }
-    let merge_base = match &base_commit_id {
-        Some(base) => git
-            .merge_base(&target_commit_id, base)
-            .await
-            .map_err(AnalyzeError::Io)?,
-        None => None,
-    };
+    let merge_base = git
+        .merge_base(&target_commit_id, &base_commit_id)
+        .await
+        .map_err(AnalyzeError::Io)?;
 
     reporter.if_enabled(|notes| {
         notes.note(&format!(
@@ -148,9 +159,7 @@ where
             count_noun(commit_count, "commit")
         ));
         notes.note(&format!(
-            "base ref {} resolves to {}; merge-base with target is {}",
-            base_name.as_deref().unwrap_or("<none>"),
-            base_commit_id.as_deref().unwrap_or("<none>"),
+            "base ref {base_name} resolves to {base_commit_id}; merge-base with target is {}",
             merge_base.as_deref().unwrap_or("<none>")
         ));
     });
@@ -159,45 +168,36 @@ where
     // first-parent line at the merge-base. A merge-base we cannot determine leaves
     // no topology to split on, and guessing a mode from the incomplete history would
     // silently mislead — so refuse and say how to supply the missing history. The
-    // usual cause is a shallow clone whose depth stops short of the branch point, or
-    // a checkout that never fetched the base branch.
+    // base resolved (checked above), so the only remaining cause is a shallow clone
+    // whose depth stops short of the branch point, or a checkout that never fetched
+    // the base branch.
     let Some(merge_base) = merge_base else {
-        let message = match base_commit_id.as_deref() {
-            // The base resolved, but shares no common ancestor with the target. By
-            // far the usual cause is a shallow clone whose depth stops short of the
-            // branch point, so the primary remedy is to deepen the clone — not to
-            // pick a different base. Only once the history is known-complete is a
-            // genuinely disjoint base worth calling out, and even then the deliberate
-            // `--base` a user passed is theirs to reconsider, not ours to second-guess.
-            Some(base) => {
-                let remedy = match selection.base {
-                    Some(explicit) => format!(
-                        " If the history is already complete, {explicit} is genuinely unrelated \
-                         to the target and cannot serve as its base."
-                    ),
-                    None => " If the history is already complete, the base branch is unrelated to \
-                             the target; name the intended base with --base or \
-                             project.default_branch."
-                        .to_owned(),
-                };
-                format!(
-                    "could not determine the merge-base of the target {target_ref} \
-                     ({target_commit_id}) and the base commit {base}: they share no common \
-                     ancestor in the available history. This is almost always a shallow clone \
-                     whose depth stops short of the branch point — fetch the full history (`git \
-                     fetch --unshallow`, or set fetch-depth: 0 on actions/checkout) so the branch \
-                     point is present.{remedy}"
-                )
-            }
-            None => format!(
-                "could not determine the base branch to compare {target_ref} against: no \
-                 --base was given and no default branch could be resolved. Pass an explicit \
-                 --base, set project.default_branch, or make the default branch available \
-                 (a shallow clone or a checkout that never fetched the base branch is the \
-                 usual cause)."
+        // The base resolved, but shares no common ancestor with the target. By far
+        // the usual cause is a shallow clone whose depth stops short of the branch
+        // point, so the primary remedy is to deepen the clone — not to pick a
+        // different base. Only once the history is known-complete is a genuinely
+        // disjoint base worth calling out, and even then the deliberate `--base` a
+        // user passed is theirs to reconsider, not ours to second-guess.
+        let remedy = match selection.base {
+            Some(explicit) => format!(
+                " If the history is already complete, {explicit} is genuinely unrelated \
+                 to the target and cannot serve as its base."
             ),
+            None => " If the history is already complete, the base branch is unrelated to \
+                     the target; name the intended base with --base or \
+                     project.default_branch."
+                .to_owned(),
         };
-        return Err(AnalyzeError::Analyze { message });
+        return Err(AnalyzeError::Analyze {
+            message: format!(
+                "could not determine the merge-base of the target {target_ref} \
+                 ({target_commit_id}) and the base commit {base_commit_id}: they share no \
+                 common ancestor in the available history. This is almost always a shallow \
+                 clone whose depth stops short of the branch point — fetch the full history \
+                 (`git fetch --unshallow`, or set fetch-depth: 0 on actions/checkout) so the \
+                 branch point is present.{remedy}"
+            ),
+        });
     };
 
     // The base-branch dirty-tip exception: `analyze`/`list` admit a base-side tip's

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -300,19 +300,15 @@ pub(crate) async fn resolve_base<G: GitHistory>(
     base: Option<&str>,
 ) -> Result<Option<ResolvedBase>, AnalyzeError> {
     if let Some(base) = base {
-        return git
-            .resolve(base)
-            .await
-            .map_err(AnalyzeError::Io)?
-            .map(|commit| {
-                Some(ResolvedBase {
-                    name: base.to_owned(),
-                    commit,
-                })
-            })
-            .ok_or_else(|| AnalyzeError::Analyze {
+        let Some(commit) = git.resolve(base).await.map_err(AnalyzeError::Io)? else {
+            return Err(AnalyzeError::Analyze {
                 message: format!("could not resolve --base {base:?}"),
             });
+        };
+        return Ok(Some(ResolvedBase {
+            name: base.to_owned(),
+            commit,
+        }));
     }
     if let Some(default) = config.project.default_branch.as_deref()
         && let Some(commit) = git.resolve(default).await.map_err(AnalyzeError::Io)?

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -35,6 +35,12 @@ pub(crate) enum DirtyTipPolicy {
 pub(crate) struct ResolvedHistory {
     /// The target ref the timeline was resolved against (for diagnostics).
     pub(crate) target_ref: String,
+    /// The display name of the base ref the target's history was split against
+    /// (an explicit `--base`, the configured default branch, or the detected one),
+    /// for the effective-selection summary. `None` only when no base could be
+    /// resolved — which the merge-base check below turns into an error, so a
+    /// successfully resolved history always names its base.
+    pub(crate) base_name: Option<String>,
     /// The full commit ID the target ref resolved to — the analyzed tip commit, carried
     /// into the report so it names the exact commit the findings describe.
     pub(crate) tip_commit: String,
@@ -99,7 +105,11 @@ where
         });
     };
 
-    let base_commit_id = resolve_base_ref(git, config, selection.base).await?;
+    let base = resolve_base(git, config, selection.base).await?;
+    let (base_name, base_commit_id) = match base {
+        Some(ResolvedBase { name, commit }) => (Some(name), Some(commit)),
+        None => (None, None),
+    };
     let first_parent_started = Instant::now();
     let first_parent = git
         .first_parent(&target_commit_id)
@@ -138,7 +148,8 @@ where
             count_noun(commit_count, "commit")
         ));
         notes.note(&format!(
-            "base ref resolves to {}; merge-base with target is {}",
+            "base ref {} resolves to {}; merge-base with target is {}",
+            base_name.as_deref().unwrap_or("<none>"),
             base_commit_id.as_deref().unwrap_or("<none>"),
             merge_base.as_deref().unwrap_or("<none>")
         ));
@@ -243,6 +254,7 @@ where
 
     Ok(ResolvedHistory {
         target_ref: target_ref.to_owned(),
+        base_name,
         tip_commit: target_commit_id,
         tip_dirty: working_tree_dirty,
         order,
@@ -263,62 +275,69 @@ pub(crate) fn dirty_base_exception_warning() -> String {
         .to_owned()
 }
 
-/// Resolves the base ref the target's history is split against, returning its
-/// commit ID or `None` when no base can be determined.
+/// The base ref a target's history is split against, resolved to both its display
+/// name and its commit ID in a single pass so a diagnostic can name the branch
+/// while the analysis compares against the commit.
+pub(crate) struct ResolvedBase {
+    /// The base ref's display name (an explicit `--base`, the configured
+    /// `project.default_branch`, or the repository's detected default branch).
+    pub(crate) name: String,
+    /// The commit ID the base ref resolved to.
+    pub(crate) commit: String,
+}
+
+/// Resolves the base ref the target's history is split against, returning both its
+/// display name and commit ID, or `None` when no base can be determined.
 ///
 /// Precedence: an explicit `--base` (an error if it does not resolve), then the
 /// configured `project.default_branch`, then the repository's detected default
-/// branch (`origin/HEAD`, else `main`/`master`).
-pub(crate) async fn resolve_base_ref<G: GitHistory>(
+/// branch (`origin/HEAD`, else `main`/`master`). A candidate that names a branch
+/// which does not resolve to a commit falls through to the next source, so the
+/// returned name always pairs with a real commit.
+pub(crate) async fn resolve_base<G: GitHistory>(
     git: &G,
     config: &Config,
     base: Option<&str>,
-) -> Result<Option<String>, AnalyzeError> {
+) -> Result<Option<ResolvedBase>, AnalyzeError> {
     if let Some(base) = base {
         return git
             .resolve(base)
             .await
             .map_err(AnalyzeError::Io)?
-            .map(Some)
+            .map(|commit| {
+                Some(ResolvedBase {
+                    name: base.to_owned(),
+                    commit,
+                })
+            })
             .ok_or_else(|| AnalyzeError::Analyze {
                 message: format!("could not resolve --base {base:?}"),
             });
     }
     if let Some(default) = config.project.default_branch.as_deref()
-        && let Some(resolved) = git.resolve(default).await.map_err(AnalyzeError::Io)?
+        && let Some(commit) = git.resolve(default).await.map_err(AnalyzeError::Io)?
     {
-        return Ok(Some(resolved));
+        return Ok(Some(ResolvedBase {
+            name: default.to_owned(),
+            commit,
+        }));
     }
     if let Some(name) = git.default_branch().await.map_err(AnalyzeError::Io)?
-        && let Some(resolved) = git.resolve(&name).await.map_err(AnalyzeError::Io)?
+        && let Some(commit) = git.resolve(&name).await.map_err(AnalyzeError::Io)?
     {
-        return Ok(Some(resolved));
+        return Ok(Some(ResolvedBase { name, commit }));
     }
     Ok(None)
 }
 
-/// Resolves the *display name* of the base ref (without resolving it to a commit ID),
-/// for diagnostics such as the `prune --prune-base` guard.
-///
-/// Mirrors [`resolve_base_ref`]'s precedence: an explicit `--base`, then the
-/// configured `project.default_branch` (only when it resolves), then the
-/// repository's detected default branch. Returns `None` when no base can be named.
-pub(crate) async fn resolve_base_name<G: GitHistory>(
+/// Resolves just the base ref's commit ID (discarding its display name), for
+/// callers such as `bless` that compare against the commit but never name it.
+pub(crate) async fn resolve_base_ref<G: GitHistory>(
     git: &G,
     config: &Config,
     base: Option<&str>,
 ) -> Result<Option<String>, AnalyzeError> {
-    if let Some(base) = base {
-        return Ok(Some(base.to_owned()));
-    }
-    if let Some(default) = config.project.default_branch.as_deref()
-        && git
-            .resolve(default)
-            .await
-            .map_err(AnalyzeError::Io)?
-            .is_some()
-    {
-        return Ok(Some(default.to_owned()));
-    }
-    git.default_branch().await.map_err(AnalyzeError::Io)
+    Ok(resolve_base(git, config, base)
+        .await?
+        .map(|resolved| resolved.commit))
 }

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -55,8 +55,8 @@ pub use error::AnalyzeError;
 pub use examine::execute as examine;
 pub(crate) use facets::{AutoFacets, resolve_facets};
 pub(crate) use history::{
-    DirtyTipPolicy, ResolvedHistory, dirty_base_exception_warning, resolve_base_name,
-    resolve_base_ref, resolve_history,
+    DirtyTipPolicy, ResolvedHistory, dirty_base_exception_warning, resolve_base_ref,
+    resolve_history,
 };
 pub use list::execute as list;
 pub(crate) use load::{RunIndex, facet_filtered_candidates};

--- a/packages/cbh_analyze/src/list.rs
+++ b/packages/cbh_analyze/src/list.rs
@@ -177,6 +177,7 @@ where
                 dataset.candidate_count,
                 &dataset.target_ref,
                 dataset.tally,
+                &dataset.facets,
             );
             let warning = dataset
                 .included_dirty_base_exception

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -250,6 +250,7 @@ where
         dataset.candidate_count,
         &dataset.target_ref,
         dataset.tally,
+        &dataset.facets,
     );
 
     // Admitting a dirty snapshot on the base branch's tip is a courtesy for the

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -36,8 +36,8 @@ use tick::Clock;
 
 use super::{
     AutoFacets, DirtyTipPolicy, ReportFormat, ResolvedHistory, Selection, WindowEdge,
-    detect_auto_facets, facet_filtered_candidates, parse_since, parse_until, resolve_base_name,
-    resolve_facets, resolve_history, resolve_now, window_excludes,
+    detect_auto_facets, facet_filtered_candidates, parse_since, parse_until, resolve_facets,
+    resolve_history, resolve_now, window_excludes,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 
@@ -177,6 +177,7 @@ where
 
     let ResolvedHistory {
         target_ref,
+        base_name,
         order,
         commit_times,
         admit_dirty,
@@ -187,11 +188,11 @@ where
 
     // The `--prune-base` guard: when the context resolves onto the base branch
     // itself (`context == base`), the whole selection is base-branch history.
-    // Refuse to delete it without explicit confirmation.
+    // Refuse to delete it without explicit confirmation. The tip being its own
+    // merge-base means the base resolved, so `base_name` is always `Some` here; the
+    // fallback to the target ref is a defensive belt-and-braces only.
     if tip_is_merge_base && !options.prune_base {
-        let base = resolve_base_name(git, config, selection.base)
-            .await?
-            .unwrap_or_else(|| target_ref.clone());
+        let base = base_name.unwrap_or_else(|| target_ref.clone());
         return Err(AnalyzeError::Analyze {
             message: format!(
                 "this will delete benchmark history of the {base} branch, which is the base \

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -188,15 +188,12 @@ where
 
     // The `--prune-base` guard: when the context resolves onto the base branch
     // itself (`context == base`), the whole selection is base-branch history.
-    // Refuse to delete it without explicit confirmation. The tip being its own
-    // merge-base means the base resolved, so `base_name` is always `Some` here; the
-    // fallback to the target ref is a defensive belt-and-braces only.
+    // Refuse to delete it without explicit confirmation.
     if tip_is_merge_base && !options.prune_base {
-        let base = base_name.unwrap_or_else(|| target_ref.clone());
         return Err(AnalyzeError::Analyze {
             message: format!(
-                "this will delete benchmark history of the {base} branch, which is the base \
-                 branch. Confirm with --prune-base if this is correct."
+                "this will delete benchmark history of the {base_name} branch, which is the \
+                 base branch. Confirm with --prune-base if this is correct."
             ),
         });
     }

--- a/packages/cbh_diag/README.md
+++ b/packages/cbh_diag/README.md
@@ -1,6 +1,6 @@
 # cbh_diag
 
 Implementation crate for [`cargo-bench-history`](https://github.com/folo-rs/folo). Do
-not depend on this directly — it carries the verbose-diagnostics reporter and a few
-shared text helpers, and has no stable public API. Use the `cargo-bench-history` tool
-instead.
+not depend on this directly — it carries the diagnostics reporter (verbose notes, stage
+timings, and always-on one-line summaries) and a few shared text helpers, and has no stable
+public API. Use the `cargo-bench-history` tool instead.

--- a/packages/cbh_diag/src/report.rs
+++ b/packages/cbh_diag/src/report.rs
@@ -17,10 +17,12 @@
 //!
 //! Announcements are a *third*, always-on channel ([`ReporterExt::announce`]):
 //! a single line stating the effective, possibly auto-detected inputs a run
-//! resolved (the target triple, machine key, base branch, and look-back window it
-//! actually used). Unlike notes, they are emitted *regardless* of `--verbose`, so
-//! a plain run never hides which values it defaulted. Like notes they go to
-//! standard error, so machine-readable stdout stays clean.
+//! resolved. Which inputs appear varies by command — a `collect` run announces
+//! the target triple and machine key it partitioned under, while a query run
+//! also names the base branch and look-back window it analyzed. Unlike notes,
+//! they are emitted *regardless* of `--verbose`, so a plain run never hides which
+//! values it defaulted. Like notes they go to standard error, so
+//! machine-readable stdout stays clean.
 //!
 //! The unconditional emit primitives live on a sealed [`Sink`] trait that cannot
 //! be named outside this module, so the only note-emitting surface a caller sees

--- a/packages/cbh_diag/src/report.rs
+++ b/packages/cbh_diag/src/report.rs
@@ -15,6 +15,13 @@
 //! tens of thousands of objects, would otherwise drown in (and be slowed by) one
 //! note per object.
 //!
+//! Announcements are a *third*, always-on channel ([`ReporterExt::announce`]):
+//! a single line stating the effective, possibly auto-detected inputs a run
+//! resolved (the target triple, machine key, base branch, and look-back window it
+//! actually used). Unlike notes, they are emitted *regardless* of `--verbose`, so
+//! a plain run never hides which values it defaulted. Like notes they go to
+//! standard error, so machine-readable stdout stays clean.
+//!
 //! The unconditional emit primitives live on a sealed [`Sink`] trait that cannot
 //! be named outside this module, so the only note-emitting surface a caller sees
 //! is the guarded [`note_with`](ReporterExt::note_with) /
@@ -44,6 +51,10 @@ mod sealed {
         /// Records the wall-clock duration of a named pipeline `stage`
         /// unconditionally.
         fn emit_timing(&self, stage: &str, elapsed: Duration);
+
+        /// Emits an always-on announcement unconditionally (not gated on
+        /// `--verbose`).
+        fn emit_announcement(&self, message: &str);
     }
 }
 
@@ -101,6 +112,15 @@ pub trait ReporterExt {
     /// fold"`. This is a separate channel from [`note`](Notes::note) so the
     /// per-stage cost can be surfaced without the per-object note flood.
     fn timing(&self, stage: &str, elapsed: Duration);
+
+    /// Emits an always-on, one-line announcement of a run's effective inputs.
+    ///
+    /// Unlike [`note_with`](Self::note_with), this channel is *not* gated on
+    /// `--verbose`: it is the one diagnostic a plain run always prints, so a value
+    /// that was auto-detected or defaulted (the target triple, machine key, base
+    /// branch, or look-back window) is never resolved silently. Emitted to
+    /// standard error so machine-readable stdout stays clean.
+    fn announce(&self, message: &str);
 }
 
 impl<R: Reporter + ?Sized> ReporterExt for R {
@@ -118,6 +138,10 @@ impl<R: Reporter + ?Sized> ReporterExt for R {
 
     fn timing(&self, stage: &str, elapsed: Duration) {
         self.emit_timing(stage, elapsed);
+    }
+
+    fn announce(&self, message: &str) {
+        self.emit_announcement(message);
     }
 }
 
@@ -207,6 +231,16 @@ impl Sink for StderrReporter {
             );
         }
     }
+
+    /// Writes the announcement to standard error unconditionally.
+    ///
+    /// A pure standard-error side effect with no return value or observable state,
+    /// untestable for the same reason as [`emit_note`](Self::emit_note). Unlike a
+    /// note it is not gated on `verbose`: the announcement is always shown.
+    #[cfg_attr(test, mutants::skip)]
+    fn emit_announcement(&self, message: &str) {
+        eprintln!("[bench-history] {message}");
+    }
 }
 
 /// Formats a stage duration for a timing note: seconds (with millisecond
@@ -239,6 +273,7 @@ mod test_support {
     pub struct RecordingReporter {
         notes: RefCell<Vec<String>>,
         timings: RefCell<Vec<String>>,
+        announcements: RefCell<Vec<String>>,
     }
 
     impl RecordingReporter {
@@ -265,6 +300,19 @@ mod test_support {
                 .iter()
                 .any(|stage| stage.contains(needle))
         }
+
+        /// Returns a snapshot of the announcements recorded so far.
+        pub fn announcements(&self) -> Vec<String> {
+            self.announcements.borrow().clone()
+        }
+
+        /// Whether any recorded announcement contains `needle`.
+        pub fn announced(&self, needle: &str) -> bool {
+            self.announcements
+                .borrow()
+                .iter()
+                .any(|line| line.contains(needle))
+        }
     }
 
     impl Sink for RecordingReporter {
@@ -280,6 +328,10 @@ mod test_support {
             // Record only the stage label; the elapsed time is non-deterministic, so
             // tests assert that a stage *was* timed, not how long it took.
             self.timings.borrow_mut().push(stage.to_owned());
+        }
+
+        fn emit_announcement(&self, message: &str) {
+            self.announcements.borrow_mut().push(message.to_owned());
         }
     }
 }
@@ -323,6 +375,32 @@ mod tests {
         assert_eq!(reporter.notes(), vec!["a per-object note".to_owned()]);
         assert!(reporter.timed("select_dataset"));
         assert!(!reporter.timed("find_changes"));
+    }
+
+    #[test]
+    fn recording_reporter_captures_announcements_separately_from_notes() {
+        let reporter = RecordingReporter::new();
+        reporter.emit_note("a per-object note");
+        reporter.emit_announcement("selection: target-triple=x86_64 (auto-detected)");
+
+        // Announcements live in their own channel, so they neither disturb nor are
+        // disturbed by the per-object note stream.
+        assert_eq!(reporter.notes(), vec!["a per-object note".to_owned()]);
+        assert_eq!(
+            reporter.announcements(),
+            vec!["selection: target-triple=x86_64 (auto-detected)".to_owned()]
+        );
+        assert!(reporter.announced("auto-detected"));
+        assert!(!reporter.announced("machine-key"));
+    }
+
+    #[test]
+    fn reporter_ext_announce_forwards_to_the_sink() {
+        // `ReporterExt::announce` is the always-on, crate-facing entry point; it
+        // must forward to the sink's `emit_announcement` rather than drop the line.
+        let reporter = RecordingReporter::new();
+        reporter.announce("selection: base=main (auto-detected)");
+        assert!(reporter.announced("base=main"));
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## Summary

`cargo-bench-history` has several CLI arguments whose defaults are **auto-detected** and therefore invisible — most notably `--target-triple` (current platform for some commands, `all` for others) and `--machine-key` (a hardware fingerprint). Previously these effective values were only surfaced under `--verbose`, and an auto-detected partition that matched **zero** stored runs reported a bare `0 runs` with no explanation of what was searched.

This PR makes the effective, defaulted values self-describing on every run (two user-approved deliverables):

### 1. Always-on effective-selection / effective-partition summary
- Adds a third channel, `announce`, to `cbh_diag`'s `Reporter` — alongside the verbose `note` channel and the independent `timing` channel. It writes a single `[bench-history] …` line to **stderr regardless of `--verbose`**, keeping stdout a clean machine-readable stream.
- Query commands (`analyze` / `list` / `prune` / `examine`) emit a one-line **effective-selection** summary: the engine / target-triple / machine-key facets (each marked when auto-detected), the resolved base branch, and the `--since` / `--until` window.
- `collect` / `backfill` emit a matching **effective-partition** line naming the target triple (always the toolchain host) and the machine key results are keyed under (auto-detected or from `--machine-key`), so the partition a run *writes* and a query *reads* is stated the same way.

### 2. Empty-result hint names the effective partition
- When the effective (possibly auto-detected) partition holds **no** stored runs at all, the stdout hint now names that partition and suggests widening it (`--target-triple all` / `--machine-key all`) or running `list discriminants` — so a missed auto-detected facet is no longer mistaken for an empty project. The existing "runs matched but none entered the analysis" breakdown is unchanged.

### Supporting change
- Surfaces the resolved base-branch **name** out of `resolve_history` (unifying base resolution into a single `resolve_base`, retiring `resolve_base_name`) so the summary can name it. `ResolvedHistory.base_name` is a plain `String` — the "no base resolvable" case returns early via a `let-else` error, so the type reflects the invariant instead of an unjustified `Option`.

Docs updated in lockstep: `DESIGN.md`, `analyze.md`, `AGENTS.md`, and the `cbh_diag` README.

## Testing
- New unit tests pin the summary/hint string outputs (`effective_selection_summary`, `empty_history_hint` zero-candidate branch, `collect_selection_summary`) and assert the always-on announcement end-to-end via `RecordingReporter::announced()`.
- Scoped `validate-local` for `cbh_diag cbh_analyze cargo-bench-history` passes clean on **Windows and WSL/Linux** — including mutation testing (423 mutants, 0 missed on each).