### PR TITLE
Cancel in-flight Validation run when its PR closes

### DIFF
--- a/.github/workflows/cancel-validation.yml
+++ b/.github/workflows/cancel-validation.yml
@@ -1,0 +1,37 @@
+name: Cancel Validation
+
+# When a pull request closes (merged or abandoned), any Validation run still in flight for its
+# branch is wasted work. The concurrency in validation.yml only supersedes a run when a *new*
+# commit lands on the same branch; a close pushes no such commit, so nothing cancels the run and it
+# burns runner minutes to completion. This workflow fires on the close event and joins the *same*
+# concurrency group as that Validation run, so cancel-in-progress tears the stale run down. See
+# design.md (Concurrency).
+on:
+  pull_request:
+    types: [closed]
+
+# This group string must stay byte-for-byte identical to validation.yml's. That workflow builds it
+# from ${{ github.workflow }}-${{ github.head_ref || github.ref }}, where github.workflow resolves
+# to its name ("Validation"); we hardcode that literal here so this run lands in the closing PR
+# branch's group and supersedes the run already there.
+concurrency:
+  group: Validation-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      # Entering the shared concurrency group above is what cancels the stale Validation run; this
+      # step only records that it happened. It is intentionally the whole job - there is no package
+      # work to do on a PR close.
+      - name: Report supersession
+        shell: pwsh
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          Write-Host "Joined concurrency group Validation-$env:HEAD_REF; any in-progress Validation run for this branch is now cancelled."

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -37,10 +37,14 @@ vary by platform.
 ## Concurrency
 
 Commit-driven and PR-driven workflows cancel superseded runs, keyed on the ref, so pushing
-a new commit abandons the outdated run. The exception is history collection, which is keyed
-on the commit **SHA**: each commit is a distinct measurement, so distinct commits must run
-in parallel and only a redundant re-trigger of the *same* commit is deduplicated.
-Schedule-driven workflows carry no concurrency block at all.
+a new commit abandons the outdated run. That supersession only fires when a *new commit*
+arrives on the branch, so closing or merging a PR — which pushes nothing to the PR branch —
+would otherwise leave its in-flight Validation run to burn to completion. A dedicated
+companion workflow closes that gap: it triggers on the PR-close event and joins Validation's
+concurrency group so cancel-in-progress reclaims the stale run. The exception is history
+collection, which is keyed on the commit **SHA**: each commit is a distinct measurement, so
+distinct commits must run in parallel and only a redundant re-trigger of the *same* commit is
+deduplicated. Schedule-driven workflows carry no concurrency block at all.
 
 ## Thin steps
 


### PR DESCRIPTION
[Copilot speaking]

## Problem

The `Validation` workflow keeps running even after its PR is merged, wasting GitHub runner minutes. `validation.yml`'s concurrency (`cancel-in-progress`) only supersedes a run when a **new commit** lands on the same branch. Merging or closing a PR pushes nothing to the PR branch, so the in-flight Validation run is never cancelled and burns to completion.

## Fix

A small companion workflow, `.github/workflows/cancel-validation.yml`, that:

- Triggers on `pull_request: [closed]` — covers both merged and abandoned PRs.
- Joins the **exact same concurrency group** as the Validation run for that branch (`Validation-${{ github.head_ref || github.ref }}`) with `cancel-in-progress: true`.

Concurrency groups are shared repo-wide, so GitHub cancels the stale in-progress Validation run the moment this run is created. The job body is just an informational log line — entering the group is what does the work.

### Notes

- The group string is intentionally hardcoded to match `validation.yml` byte-for-byte (where `${{ github.workflow }}` resolves to `Validation`). This coupling is called out in a comment in both places.
- No `permissions` block is needed — the cancellation is a scheduling-level operation requiring no token scope, matching the repo convention of omitting `permissions` on jobs that need nothing.
- Because this is a `pull_request` trigger, it only takes effect once merged to `main` (GitHub uses the base-branch version of `pull_request` workflows).
- Updated `design.md`'s Concurrency section per the workflows `AGENTS.md` rule.

## Validation

- `just validate-workflows` (actionlint) — clean, exit 0.