### PR TITLE
Add per-PR benchmark-history workflow

### DIFF
--- a/.github/workflows/cancel-pr-bench-history.yml
+++ b/.github/workflows/cancel-pr-bench-history.yml
@@ -1,0 +1,37 @@
+name: Cancel PR Benchmark history
+
+# When a pull request closes (merged or abandoned), any PR Benchmark history run still in flight for
+# its branch is wasted work - a multi-hour benchmark matrix whose result no open PR will ever read.
+# The concurrency in pr-bench-history.yml only supersedes a run when a *new* commit lands on the same
+# branch; a close pushes no such commit, so nothing cancels the run and it burns runner minutes to
+# completion. This workflow fires on the close event and joins the *same* concurrency group as that
+# run, so cancel-in-progress tears the stale run down. See design.md (Concurrency).
+on:
+  pull_request:
+    types: [closed]
+
+# This group string must stay byte-for-byte identical to pr-bench-history.yml's. That workflow builds
+# it from ${{ github.workflow }}-${{ github.head_ref || github.ref }}, where github.workflow resolves
+# to its name ("PR Benchmark history"); we hardcode that literal here so this run lands in the closing
+# PR branch's group and supersedes the run already there.
+concurrency:
+  group: PR Benchmark history-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      # Entering the shared concurrency group above is what cancels the stale PR Benchmark history
+      # run; this step only records that it happened. It is intentionally the whole job - there is no
+      # benchmark work to do on a PR close.
+      - name: Report supersession
+        shell: pwsh
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          Write-Host "Joined concurrency group PR Benchmark history-$env:HEAD_REF; any in-progress PR Benchmark history run for this branch is now cancelled."

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -183,7 +183,9 @@ hidden marker, updated in place on every push) rather than the rolling issue the
 workflow files; the comment lives and dies with the pull request. The comment is strictly
 advisory — findings never affect the check's exit code, so a regression note never blocks a
 merge — and it reports detected improvements alongside regressions, or a plain "no regressions"
-state. A run *failure* surfaces only as the red check, with no issue and no failure comment,
+state. It also states its **collection scope** — which packages were benchmarked — so a clean
+result is never mistaken for the whole suite being clean when only the changed subset was
+measured. A run *failure* surfaces only as the red check, with no issue and no failure comment,
 because a PR failure is a transient condition, not the persistent one the issue lifecycle
 tracks.
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -40,11 +40,12 @@ Commit-driven and PR-driven workflows cancel superseded runs, keyed on the ref, 
 a new commit abandons the outdated run. That supersession only fires when a *new commit*
 arrives on the branch, so closing or merging a PR — which pushes nothing to the PR branch —
 would otherwise leave its in-flight Validation run to burn to completion. A dedicated
-companion workflow closes that gap: it triggers on the PR-close event and joins Validation's
-concurrency group so cancel-in-progress reclaims the stale run. The exception is history
-collection, which is keyed on the commit **SHA**: each commit is a distinct measurement, so
-distinct commits must run in parallel and only a redundant re-trigger of the *same* commit is
-deduplicated. Schedule-driven workflows carry no concurrency block at all.
+companion workflow closes that gap: it triggers on the PR-close event and joins the target
+workflow's concurrency group so cancel-in-progress reclaims the stale run. Both the Validation
+workflow and the PR benchmark-history workflow pair with such a close companion. The exception
+is history collection on `main`, which is keyed on the commit **SHA**: each commit is a distinct
+measurement, so distinct commits must run in parallel and only a redundant re-trigger of the
+*same* commit is deduplicated. Schedule-driven workflows carry no concurrency block at all.
 
 ## Thin steps
 
@@ -77,6 +78,42 @@ green without one; the Azure jobs flip that skip into a hard failure so a miscon
 can never silently pass by testing nothing. All Azure authentication uses GitHub OIDC
 workload-identity federation — no long-lived secret is stored — and is gated to same-repo
 runs, since a fork cannot federate into the tenant.
+
+## Federated identity
+
+Every Azure sign-in in these workflows uses GitHub OIDC workload-identity federation, so no
+long-lived storage secret is ever committed or held as a repository secret. A job requests a
+short-lived GitHub OIDC token (`permissions: id-token: write`), and Azure exchanges it for
+managed-identity credentials only when the token's *subject* matches a federated credential
+registered on that identity. The subject encodes the triggering event: a push to a branch
+presents `repo:folo-rs/folo:ref:refs/heads/<branch>` (e.g. `…:ref:refs/heads/main`), while a
+pull-request run presents `repo:folo-rs/folo:pull_request`. The audience is always
+`api://AzureADTokenExchange`. The two non-secret identifiers a job needs — the managed
+identity's client id and the tenant id — live in `constants.env` and are remapped to the
+standard `AZURE_*` names the tool and `azure/login` read (`AZURE_PROD_CLIENT_ID` →
+`AZURE_CLIENT_ID`) by a single shared federation step, so the mapping is defined once rather
+than copy-pasted per job.
+
+Federation only works for **same-repo** runs: a fork's run cannot mint a token whose subject
+names this repository, so fork PRs skip the Azure-touching jobs rather than fail.
+
+Two managed identities exist, each registered with exactly the subjects its events present:
+
+| Event | OIDC subject | Identity | Consumer |
+| --- | --- | --- | --- |
+| push to `main` | `…:ref:refs/heads/main` | prod | `bench-history.yml` |
+| pull request | `…:pull_request` | prod | `pr-bench-history.yml` |
+| push to `main` | `…:ref:refs/heads/main` | test | `test-azure` backend tests |
+| pull request | `…:pull_request` | test | `test-azure` backend tests |
+
+The **prod** identity backs history collection and the PR benchmark workflow; the **test**
+identity backs the Azure-backend test jobs against a throwaway account. Both trust `main` and
+`pull_request` so each identity's on-main and on-PR consumers can sign in. Granting the prod
+identity a `pull_request` credential is a deliberate tradeoff: it widens prod's write surface
+from "only pushes to `main`" to "any same-repo PR run", accepting a larger blast radius in
+exchange for letting a PR's benchmarks be compared against the very store that holds `main`'s
+baseline. The narrower alternative — a separate PR store — was rejected because branch-mode
+analysis must read the base's accumulated history and the tool reads a single backend.
 
 ## Benchmark history
 
@@ -116,6 +153,47 @@ regressions never fail the run. Because a GitHub issue body is size-capped and a
 analysis can exceed it, the issue carries a **condensed summary** (the top findings) and
 links to the **full Markdown and JSON reports**, which the job uploads as a run artifact — so
 the issue always fits while the complete data stays one click away.
+
+### PR benchmark history
+
+The same measure-and-report loop runs on pull requests, retuned to answer "does this PR move
+any benchmark relative to `main`?" instead of "is `main` trending?". It reuses the analysis
+tool's **branch mode**: with the PR head as context and `main` as the base, the tool splits the
+head's first-parent ancestry at the merge-base and compares the branch tip's level against the
+base ancestry's clean baseline, so a finding means *this branch changed the level* rather than
+that the long-range trend moved. To keep that topology intact the collect and analyze jobs
+check out the PR head's real commit — not the synthetic `pull_request` merge ref, whose first
+parent is `main` and would corrupt the comparison — with full history, since both the
+merge-base and the first-parent walk need it.
+
+Because a PR is transient, the findings land in a single **rolling PR comment** (deduped by a
+hidden marker, updated in place on every push) rather than the rolling issue the `main`
+workflow files; the comment lives and dies with the pull request. The comment is strictly
+advisory — findings never affect the check's exit code, so a regression note never blocks a
+merge — and it reports detected improvements alongside regressions, or a plain "no regressions"
+state. A run *failure* surfaces only as the red check, with no issue and no failure comment,
+because a PR failure is a transient condition, not the persistent one the issue lifecycle
+tracks.
+
+Collection is **delta-scoped**: a preflight job diffs the PR against `main` and benchmarks only
+the touched packages, since re-measuring the whole workspace on every PR push would be
+wasteful. Analysis, by contrast, is deliberately **not** package-scoped, and that is a
+structural guarantee rather than a happy coincidence. Branch mode only yields a finding for a
+series that has a data point at the branch tip, and only the collected (touched) packages have
+a point at the PR's branch-unique head commit — for *every* measurement engine. An untouched
+package's latest point sits on the base ancestry, so its tip level equals its base level and it
+can never be flagged. Filtering analysis by package name would in fact be wrong: benchmark
+identities are engine-dependent (some engines identify a series by bare operation name with no
+package prefix), so a name filter would silently drop those series and turn a real regression
+into a false negative. The scoping therefore lives entirely in *what gets collected*; analysis
+surveys everything and stays correct by construction.
+
+When a PR touches no benchmarkable package — including a PR that touched one earlier and then
+reverted it — a lightweight cleanup path removes any rolling comment a prior push left behind
+and posts nothing, so a stale, misleading comment never lingers; it is a no-op when there was
+no comment. PR runs read the shared history cache **restore-only** (never saving), keeping the
+baseline warm without accumulating per-PR cache entries, which the append-only store makes
+safe even when slightly stale.
 
 ## Failure alerting
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -189,16 +189,20 @@ tracks.
 
 Collection is **delta-scoped**: a preflight job diffs the PR against `main` and benchmarks only
 the touched packages, since re-measuring the whole workspace on every PR push would be
-wasteful. Analysis, by contrast, is deliberately **not** package-scoped, and that is a
-structural guarantee rather than a happy coincidence. Branch mode only yields a finding for a
-series that has a data point at the branch tip, and only the collected (touched) packages have
-a point at the PR's branch-unique head commit — for *every* measurement engine. An untouched
-package's latest point sits on the base ancestry, so its tip level equals its base level and it
-can never be flagged. Filtering analysis by package name would in fact be wrong: benchmark
-identities are engine-dependent (some engines identify a series by bare operation name with no
-package prefix), so a name filter would silently drop those series and turn a real regression
-into a false negative. The scoping therefore lives entirely in *what gets collected*; analysis
-surveys everything and stays correct by construction.
+wasteful. Analysis, by contrast, is deliberately **not** package-scoped — yet it stays correctly
+scoped anyway, by construction rather than by a name filter. `analyze` by default considers only
+benchmarks **present at the context commit** (the PR head), dropping any "ghost" benchmark with
+no run there *before* detection. Because only the touched packages are collected at the PR's
+branch-unique head commit, only they are present there, so every untouched package is excluded
+as a ghost automatically — for *every* measurement engine — leaving exactly the collected set to
+analyze. Package scoping thus falls out of *what gets collected*, with no need to filter analysis
+by name, which would in fact be wrong: benchmark identities are engine-dependent (some engines
+identify a series by bare operation name with no package prefix), so a name filter would silently
+drop those series and turn a real regression into a false negative. The PR analysis therefore
+relies on that default ghost exclusion and must never pass `--include-ghosts`, which would
+re-admit every historical benchmark and defeat the scoping. As a side benefit the same filter
+also drops a benchmark the PR itself *removed*, so a deletion is never mis-reported as a
+regression.
 
 When a PR touches no benchmarkable package — including a PR that touched one earlier and then
 reverted it — a lightweight cleanup path removes any rolling comment a prior push left behind

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -240,7 +240,10 @@ jobs:
       # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
       # top-findings Markdown) and notable.txt into the scratch directory, in BRANCH mode (PR head
       # vs origin/main), including improvements as well as regressions. Findings never fail the
-      # recipe (the tool always exits 0); the PR comment is advisory, not a gate.
+      # recipe (the tool always exits 0); the PR comment is advisory, not a gate. Analysis is
+      # deliberately run UNSCOPED: `analyze`'s default ghost-exclusion (only benchmarks present at
+      # the PR head are analyzed) restricts it to exactly the collected packages, so no per-package
+      # filter is needed - the recipe must not pass `--include-ghosts`. See the recipe / design.md.
       - name: Analyze PR benchmark history
         shell: pwsh
         env:

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -301,7 +301,7 @@ jobs:
           $packages = @(($env:PACKAGES -split '\s+') | Where-Object { $_ } | Sort-Object -Unique)
           $renderedPackages = ($packages | ForEach-Object { '`' + $_ + '`' }) -join ', '
           $packageNoun = if ($packages.Count -eq 1) { 'package' } else { 'packages' }
-          $scope = "**Collection scope:** benchmarked the $($packages.Count) $packageNoun this PR changed ($renderedPackages). Packages this PR did not change were not benchmarked, so these results cover only the changed subset."
+          $scope = "**Collection scope:** benchmarked the $($packages.Count) $packageNoun this PR changed ($renderedPackages)."
           if ($env:NOTABLE -eq 'true') {
             $summary = (Get-Content (Join-Path $env:SCRATCH_DIR 'summary.md') -Raw).TrimEnd()
             $fullReport = "**Full report:** the complete Markdown and JSON reports are attached to this workflow run. [Download the full report bundle]($env:REPORT_ARTIFACT_URL)."

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -1,0 +1,390 @@
+name: PR Benchmark history
+
+# Per-push benchmark feedback on pull requests: the PR counterpart of bench-history.yml. Where that
+# workflow collects on every push to `main` and files a rolling ISSUE about long-range trends, this
+# one runs on every push to a PR branch, benchmarks only the packages the PR touched (cargo-delta
+# scoped), compares the PR head's benchmark level against `main` in BRANCH mode, and posts/updates a
+# rolling PR COMMENT with the findings. PR-head points are written into the SAME prod Azure store as
+# the `main` baseline (branch-mode comparison reads a single backend); PR commits are
+# topologically branch-unique, so they never enter `main`'s history analysis. Findings are advisory:
+# they never gate the merge, only inform. See .github/workflows/design.md (Benchmark history).
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+# Key by the PR head ref and cancel in progress: a newer push supersedes the running benchmark,
+# because a PR's benchmark is only ever interesting for its current tip (unlike bench-history.yml,
+# which keys per-SHA with NO cancel because each `main` commit is a permanent data point). The
+# companion cancel-pr-bench-history.yml joins this SAME group on `pull_request: closed` to tear down
+# an in-flight run when the PR merges or closes; its hardcoded group string must stay byte-identical
+# to the one built here from ${{ github.workflow }} (the name "PR Benchmark history").
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# The hidden HTML marker that identifies this workflow's rolling PR comment, defined once and shared
+# by the `analyze` job (which posts/updates it) and the `cleanup` job (which deletes it when the PR
+# no longer touches any benchmarkable package). The comment module dedups solely on this marker, so
+# a single definition keeps the post and delete paths from drifting apart.
+env:
+  PR_COMMENT_MARKER: "<!-- folo-bench-history-pr -->"
+
+jobs:
+  # Compute which packages the PR touched (cargo-delta vs origin/main), filtered to the
+  # benchmarkable set (everything except the slow, special-purpose `benchmarks` crate). The result
+  # gates the whole workflow: a non-empty set drives collect+analyze, an empty set routes to
+  # cleanup. Runs only for same-repo PRs - fork runs cannot federate into Azure (no secrets), so
+  # like bench-history.yml's fork gate they are skipped silently; because every downstream job
+  # `needs` this one, a skipped delta cascades to skip them too.
+  delta:
+    if: github.repository == 'folo-rs/folo' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.compute.outputs.packages }}
+      packages_json: ${{ steps.compute.outputs.packages_json }}
+      skip_all: ${{ steps.compute.outputs.skip_all }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        # Full history so cargo-delta can diff against origin/main in a throwaway worktree (the
+        # merge ref the pull_request event checks out is fine for the diff; only collect/analyze
+        # need the real head SHA for branch-mode topology).
+        with:
+          fetch-depth: 0
+
+      - name: Setup environment
+        # Same composite the package-scoped jobs use, so cargo-delta is installed once (via
+        # `just install-tools`) and the shared prerequisites cache is primed for the collect job.
+        uses: ./.github/actions/setup-environment
+
+      - name: Compute delta
+        id: compute
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          # The cargo-delta pipeline lives in the Pester-tested Delta module (shared with the local
+          # `just delta` recipe and validation.yml so they cannot drift); Select-BenchmarkablePackage
+          # lives in the collection module so the same "drop benchmarks" rule the collect step uses
+          # also decides here whether anything is left to bench. See scripts/build/Delta.psm1 and
+          # scripts/bench-history/BenchHistoryCollect.psm1.
+          Import-Module ./scripts/build/Delta.psm1 -Force
+          Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
+
+          # Full history is already present (fetch-depth: 0), so -SkipFetch avoids a redundant fetch;
+          # the module analyzes origin/main in a throwaway worktree and cleans up after itself.
+          $affected = @(Invoke-CargoDelta -SkipFetch)
+          # Drop the excluded `benchmarks` crate BEFORE shaping the outputs, so `skip_all` reflects
+          # the benchmarkable set: a PR that touches only `benchmarks` (or nothing) collects nothing
+          # and instead has its stale comment (if any) cleaned up.
+          $benchmarkable = @(Select-BenchmarkablePackage -Package $affected)
+          $output = Get-DeltaOutput -Affected $benchmarkable
+
+          if ($benchmarkable.Count -eq 0) {
+            Write-Host 'No benchmarkable packages touched by this PR; collection will be skipped and any stale rolling comment removed.'
+          } else {
+            Write-Host "Benchmarkable packages touched by this PR: $($output.Packages)"
+          }
+
+          @(
+            "packages=$($output.Packages)"
+            "packages_json=$($output.PackagesJson)"
+            "skip_all=$($output.SkipAll)"
+          ) | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
+  # Benchmark ONLY the touched packages across the full platform matrix, keyed by the PR head
+  # commit, appending the results into the prod store. Skipped when the PR touches nothing
+  # benchmarkable (delta.skip_all). Mirrors bench-history.yml's collect job, differing only in the
+  # checkout (real head SHA, full history) and the package-scoped recipe.
+  collect:
+    needs: delta
+    if: needs.delta.outputs.skip_all != 'true'
+
+    strategy:
+      # One platform's benchmarks failing must not abandon the others for this PR head; each
+      # platform stores into its own partition independently.
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
+
+    runs-on: ${{ matrix.platform }}
+    # Same ceiling as the main collect: `--best-of 3` roughly triples the ~60-75 min suite, and the
+    # 360-minute cap (GitHub's hosted maximum) bounds only a genuinely stuck run since the matrix
+    # runs in parallel.
+    timeout-minutes: 360
+
+    # id-token to self-federate with Entra (the prod identity's `pull_request` federated credential,
+    # added by infra/azure-bench-history-prod/, matches a same-repo PR run's OIDC subject), contents
+    # for the checkout. Same on-demand OIDC minting as the main collect keeps a multi-hour run
+    # authenticated past the ~1h access-token lifetime.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        # Check out the REAL PR head commit with FULL history, NOT the default pull_request merge ref
+        # (refs/pull/N/merge): that merge commit's first parent is `main`, which would corrupt
+        # branch-mode topology. A full clone is required (not shallow) because cargo-bench-history
+        # walks the head's first-parent ancestry and computes the merge-base with the base; fetch-depth
+        # 0 also populates refs/remotes/origin/main for the analyze job's base ref.
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      # Reused unchanged from bench-history.yml: export the prod identity's client id and tenant
+      # under the standard names cargo-bench-history reads, then let the tool mint OIDC assertions on
+      # demand (no azure/login). The same prod identity backs main and PR runs. See
+      # scripts/bench-history/AzureFederation.psm1.
+      - name: Configure Azure federation identity from constants.env
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
+          Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
+
+      # Collect only the delta-affected packages (space-separated from the delta job), keyed by the
+      # PR head commit with the fixed `github` machine key so the wall-clock series stays comparable
+      # to main's baseline. `--skip-existing` makes a re-run of the same head SHA a no-op append.
+      - name: Collect PR benchmark history
+        shell: pwsh
+        env:
+          PR_PACKAGES: ${{ needs.delta.outputs.packages }}
+        run: just gh-collect-pr-bench-history "$env:PR_PACKAGES"
+
+  # Compare the PR head against `main` in branch mode and post/update the rolling PR comment. Runs
+  # after every platform finishes (even partially: fail-fast is off) so the comparison reflects
+  # whatever landed. Uses always() so a partially-failed collect still analyzes, but the explicit
+  # same-repo + skip_all gates keep it from running on forks or empty deltas.
+  analyze:
+    needs: [delta, collect]
+    if: >-
+      always()
+      && github.repository == 'folo-rs/folo'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && needs.delta.outputs.skip_all != 'true'
+    runs-on: ubuntu-latest
+    # Analysis loads the store and reduces it; far faster than benchmarking, but the cap must clear a
+    # cold-cache setup-environment on top of the analysis.
+    timeout-minutes: 150
+
+    # id-token to self-federate with Entra (reads the history), contents for checkout, and
+    # pull-requests to post/update the rolling comment.
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        # Same real-head-SHA + full-history checkout as collect: branch mode walks the head's
+        # first-parent ancestry and needs origin/main (from fetch-depth 0) for the merge-base.
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Configure Azure federation identity from constants.env
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
+          Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
+
+      # All bench-history scratch - the read-through cache and every rendered report/summary/notable/
+      # comment-body file - lives under the runner temp directory, OUTSIDE the repo checkout, so
+      # analyze's own `git status --porcelain` dirty-check never sees these files. The individual
+      # filenames (cache/, report.md, report.json, summary.md, notable.txt) are the contract the
+      # gh-analyze-pr-bench-history recipe writes; comment-body.md is composed here.
+      - name: Resolve scratch directory
+        id: scratch
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $dir = Join-Path $env:RUNNER_TEMP 'bench-history'
+          New-Item -ItemType Directory -Path $dir -Force | Out-Null
+          "dir=$dir" | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
+      # RESTORE-ONLY the read-through cache produced on `main` (the default-branch caches are visible
+      # to PR branches), so the baseline history is warm without every PR saving its own cache entry
+      # (which would clutter the cache with per-PR mirrors). PR runs never SAVE; the append-only
+      # store keeps a slightly-stale mirror harmless. The path MUST match the `--cache` directory the
+      # gh-analyze-pr-bench-history recipe passes (`<scratch>/cache`).
+      - name: Restore benchmark-history read-through cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.scratch.outputs.dir }}/cache
+          key: bench-history-cache-pr-${{ github.run_id }}
+          restore-keys: |
+            bench-history-cache-
+
+      # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
+      # top-findings Markdown) and notable.txt into the scratch directory, in BRANCH mode (PR head
+      # vs origin/main), including improvements as well as regressions. Findings never fail the
+      # recipe (the tool always exits 0); the PR comment is advisory, not a gate.
+      - name: Analyze PR benchmark history
+        shell: pwsh
+        env:
+          SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
+        run: just gh-analyze-pr-bench-history "$env:SCRATCH_DIR" origin/main
+
+      - name: Read notable flag
+        id: notable
+        shell: pwsh
+        env:
+          SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $value = (Get-Content (Join-Path $env:SCRATCH_DIR 'notable.txt') -Raw).Trim()
+          "value=$value" | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
+      # Attach the full Markdown and JSON reports to the run as a single artifact when there are
+      # findings, so the rolling comment can carry only the condensed summary (staying under GitHub's
+      # 65,536-character comment limit) while a reader can still download the complete reports.
+      - name: Upload full benchmark reports
+        id: full_reports
+        if: steps.notable.outputs.value == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-bench-history-full-report
+          path: |
+            ${{ steps.scratch.outputs.dir }}/report.md
+            ${{ steps.scratch.outputs.dir }}/report.json
+          if-no-files-found: error
+
+      # Compose the rolling comment body (always, into comment-body.md): when notable, the condensed
+      # summary + a link to the full-report artifact + a "how to read" footer; otherwise a compact
+      # "no regressions" state. The hidden marker is embedded so the module finds this same comment
+      # on the next push. The comment is advisory - it explicitly is NOT a merge gate.
+      - name: Compose PR benchmark comment
+        shell: pwsh
+        env:
+          MARKER: ${{ env.PR_COMMENT_MARKER }}
+          NOTABLE: ${{ steps.notable.outputs.value }}
+          REPORT_ARTIFACT_URL: ${{ steps.full_reports.outputs.artifact-url }}
+          SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $header = "### Benchmark history (vs ``main``)"
+          if ($env:NOTABLE -eq 'true') {
+            $summary = (Get-Content (Join-Path $env:SCRATCH_DIR 'summary.md') -Raw).TrimEnd()
+            $fullReport = "**Full report:** the complete Markdown and JSON reports are attached to this workflow run. [Download the full report bundle]($env:REPORT_ARTIFACT_URL)."
+            # Literal Markdown: the single-quoted here-string keeps the inline-code backticks verbatim.
+            $footer = @'
+          **How to read this**
+
+          This compares this PR's benchmark level against `main` (branch mode). It is **advisory** - it never blocks the merge; the workflow's check status reflects run success, not whether there are findings. Shared runners are noisy, so treat small movements with suspicion (`--best-of 3` and the false-discovery filter already suppress most noise).
+
+          To investigate a finding, copy its benchmark id and metric and run:
+
+          `cargo bench-history examine --benchmark <id> --metric <name>`
+
+          If a regression is an intentional tradeoff, bless it on the base commit; if it is a defect, fix it. Improvements are shown for information only.
+          '@
+            $parts = @(
+              $header
+              ''
+              $summary
+              ''
+              '---'
+              ''
+              $fullReport
+              ''
+              '---'
+              ''
+              $footer
+            )
+          } else {
+            $parts = @(
+              $header
+              ''
+              '✅ No benchmark regressions detected against `main` for the packages this PR touched.'
+              ''
+              'This check is advisory and never blocks the merge. It refreshes on every push; if the PR later stops touching any benchmarked package, this comment is removed.'
+            )
+          }
+
+          # Prepend the hidden dedup marker so the comment module finds and updates this same comment
+          # on the next push instead of posting a duplicate.
+          $body = @($env:MARKER, '') + $parts
+          Set-Content -Path (Join-Path $env:SCRATCH_DIR 'comment-body.md') -Value ($body -join "`n") -Encoding utf8
+
+      # One rolling comment per PR, updated in place (deduped by the hidden marker) so repeated pushes
+      # never spam the thread. Posted via `gh` through the shared gh-file-pr-comment recipe (the
+      # workflow's one comment path) so the body file can live in the runner temp dir, outside the
+      # repo checkout.
+      - name: Post rolling PR comment
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: ${{ env.PR_COMMENT_MARKER }}
+          SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
+        run: just gh-file-pr-comment "$env:REPO" "$env:PR_NUMBER" "$env:MARKER" (Join-Path $env:SCRATCH_DIR 'comment-body.md')
+
+  # When the PR no longer touches any benchmarkable package (delta.skip_all), remove any rolling
+  # comment left by an EARLIER iteration of the same PR - e.g. a benchmarked change that was later
+  # reverted - so a stale, misleading comment does not linger. A no-op when there is no such comment.
+  # Deliberately lightweight (checkout + preinstalled gh + direct module import, no build-env setup,
+  # no Azure, no history), mirroring bench-history.yml's alert/resolve jobs.
+  cleanup:
+    needs: delta
+    if: needs.delta.outputs.skip_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # pull-requests to delete the rolling comment, contents for the checkout that puts the shared
+    # BenchHistoryComment module on disk (the removal logic lives there so it is unit-tested against
+    # a mocked gh, mirroring how the analyze job posts via the same module).
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Remove stale rolling comment if present
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: ${{ env.PR_COMMENT_MARKER }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
+
+          $removed = Remove-RollingComment -Repo $env:REPO -PrNumber $env:PR_NUMBER -Marker $env:MARKER -Verbose
+          if ($removed) {
+            Write-Host "Removed a stale rolling benchmark comment from PR #$env:PR_NUMBER (the PR no longer touches any benchmarkable package)."
+          } else {
+            Write-Host "No rolling benchmark comment to remove on PR #$env:PR_NUMBER."
+          }

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -340,7 +340,7 @@ jobs:
               ''
               '✅ No benchmark regressions detected against `main`.'
               ''
-              'This check is advisory and never blocks the merge. It refreshes on every push; if the PR later stops touching any benchmarked package, this comment is removed.'
+              'This check is advisory and never blocks the merge. It refreshes on every push.'
             )
           }
 

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -287,12 +287,21 @@ jobs:
           NOTABLE: ${{ steps.notable.outputs.value }}
           REPORT_ARTIFACT_URL: ${{ steps.full_reports.outputs.artifact-url }}
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
+          PACKAGES: ${{ needs.delta.outputs.packages }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
           $header = "### Benchmark history (vs ``main``)"
+
+          # Disclose the collection scope so a reader never mistakes a clean result for the whole
+          # suite: PR runs benchmark ONLY the packages this PR changed (cargo-delta scoped), and the
+          # analyze ghost filter narrows the report to exactly that set. List them explicitly.
+          $packages = @(($env:PACKAGES -split '\s+') | Where-Object { $_ } | Sort-Object -Unique)
+          $renderedPackages = ($packages | ForEach-Object { '`' + $_ + '`' }) -join ', '
+          $packageNoun = if ($packages.Count -eq 1) { 'package' } else { 'packages' }
+          $scope = "**Collection scope:** benchmarked the $($packages.Count) $packageNoun this PR changed ($renderedPackages). Packages this PR did not change were not benchmarked, so these results cover only the changed subset."
           if ($env:NOTABLE -eq 'true') {
             $summary = (Get-Content (Join-Path $env:SCRATCH_DIR 'summary.md') -Raw).TrimEnd()
             $fullReport = "**Full report:** the complete Markdown and JSON reports are attached to this workflow run. [Download the full report bundle]($env:REPORT_ARTIFACT_URL)."
@@ -311,6 +320,8 @@ jobs:
             $parts = @(
               $header
               ''
+              $scope
+              ''
               $summary
               ''
               '---'
@@ -325,7 +336,9 @@ jobs:
             $parts = @(
               $header
               ''
-              '✅ No benchmark regressions detected against `main` for the packages this PR touched.'
+              $scope
+              ''
+              '✅ No benchmark regressions detected against `main`.'
               ''
               'This check is advisory and never blocks the merge. It refreshes on every push; if the PR later stops touching any benchmarked package, this comment is removed.'
             )

--- a/delta.toml
+++ b/delta.toml
@@ -9,7 +9,7 @@ file_exclude_patterns = ["target", "mutants.out", "mutants.out.old", "**/.*"]
 #
 # Keep this list small. A file earns a trip wire only when it genuinely changes what "passing"
 # means for *every* crate AND, when changed on its own, touches no package - so without the trip
-# wire delta would select nothing and validate nothing. Only three files clear that bar:
+# wire delta would select nothing and validate nothing. Only four files clear that bar:
 #
 #   - rust-toolchain.toml - the pinned stable toolchain; a bump changes codegen, lints and MSRV
 #     behavior for every crate.

--- a/delta.toml
+++ b/delta.toml
@@ -4,28 +4,38 @@
 # Exclude build artifacts, mutation outputs, and dotfiles/directories.
 file_exclude_patterns = ["target", "mutants.out", "mutants.out.old", "**/.*"]
 
-# Trip wire patterns - if any changed file matches these patterns,
-# all crates in the workspace are considered impacted. This is used
-# for files that affect the entire workspace, such as configuration
-# files, workflow definitions and the build system itself.
+# Trip wire patterns - if any changed file matches these, every crate in the workspace is
+# validated regardless of what the dependency analysis would otherwise select.
 #
-# The workspace-root Cargo.toml and Cargo.lock are deliberately omitted: ordinary
-# dependency-management edits touch them constantly yet rarely affect every crate, so
-# treating them as trip wires would force a full-workspace run on almost every PR and
-# defeat delta scoping. Genuinely cross-cutting manifest changes (e.g. a shared
-# [workspace.dependencies] bump) are still caught by the push-to-main backstop, which
-# always validates the full workspace regardless of delta.
+# Keep this list small. A file earns a trip wire only when it genuinely changes what "passing"
+# means for *every* crate AND, when changed on its own, touches no package - so without the trip
+# wire delta would select nothing and validate nothing. Only three files clear that bar:
+#
+#   - rust-toolchain.toml - the pinned stable toolchain; a bump changes codegen, lints and MSRV
+#     behavior for every crate.
+#   - constants.env - holds the MSRV floor and the pinned nightly (a change there must be checked
+#     against the whole workspace).
+#   - clippy.toml - lint configuration; under `-D warnings` a change flips clippy pass/fail for
+#     every crate.
+#
+# Everything else is deliberately NOT a trip wire. Workflow definitions (`.github/**`), the build
+# system (`justfile`, `justfiles/**`), release configuration (`release-plz.toml`), formatting
+# config (`unstable-rustfmt.toml`) and delta's own config (`delta.toml`) do not change any crate's
+# build/test correctness. A change that breaks the *mechanism* fails the PR's own jobs (which run
+# those very workflows and recipes), so it never passes silently; the format check runs
+# whole-workspace anyway; and the rare correctness impact that dependency analysis cannot see is
+# caught by the push-to-main backstop, which always validates the full workspace. Making these
+# trip wires only forced a full-workspace run on the many PRs that touch them for unrelated
+# reasons - pure jitter with little safety in return.
+#
+# The workspace-root Cargo.toml and Cargo.lock are omitted for the same reason: routine
+# dependency edits touch them constantly yet rarely affect every crate. If the backstop ever
+# catches something a delta build missed, add the *specific* file here rather than broadening
+# back to whole directory trees.
 trip_wire_patterns = [
     "rust-toolchain.toml",
     "clippy.toml",
-    "unstable-rustfmt.toml",
     "constants.env",
-    "release-plz.toml",
-    "cargo-delta.toml",
-    "delta.toml",
-    "justfile",
-    "justfiles/**",
-    ".github/**",
 ]
 
 [parser]

--- a/delta.toml
+++ b/delta.toml
@@ -17,16 +17,17 @@ file_exclude_patterns = ["target", "mutants.out", "mutants.out.old", "**/.*"]
 #     against the whole workspace).
 #   - clippy.toml - lint configuration; under `-D warnings` a change flips clippy pass/fail for
 #     every crate.
+#   - unstable-rustfmt.toml - formatting configuration; the format check is a hard gate run across
+#     the whole workspace, so a change flips `cargo fmt --check` pass/fail for every crate.
 #
 # Everything else is deliberately NOT a trip wire. Workflow definitions (`.github/**`), the build
-# system (`justfile`, `justfiles/**`), release configuration (`release-plz.toml`), formatting
-# config (`unstable-rustfmt.toml`) and delta's own config (`delta.toml`) do not change any crate's
-# build/test correctness. A change that breaks the *mechanism* fails the PR's own jobs (which run
-# those very workflows and recipes), so it never passes silently; the format check runs
-# whole-workspace anyway; and the rare correctness impact that dependency analysis cannot see is
-# caught by the push-to-main backstop, which always validates the full workspace. Making these
-# trip wires only forced a full-workspace run on the many PRs that touch them for unrelated
-# reasons - pure jitter with little safety in return.
+# system (`justfile`, `justfiles/**`), release configuration (`release-plz.toml`) and delta's own
+# config (`delta.toml`) do not change any crate's build/test correctness. A change that breaks the
+# *mechanism* fails the PR's own jobs (which run those very workflows and recipes), so it never
+# passes silently; and the rare correctness impact that dependency analysis cannot see is caught by
+# the push-to-main backstop, which always validates the full workspace. Making these trip wires
+# only forced a full-workspace run on the many PRs that touch them for unrelated reasons - pure
+# jitter with little safety in return.
 #
 # The workspace-root Cargo.toml and Cargo.lock are omitted for the same reason: routine
 # dependency edits touch them constantly yet rarely affect every crate. If the backstop ever
@@ -35,6 +36,7 @@ file_exclude_patterns = ["target", "mutants.out", "mutants.out.old", "**/.*"]
 trip_wire_patterns = [
     "rust-toolchain.toml",
     "clippy.toml",
+    "unstable-rustfmt.toml",
     "constants.env",
 ]
 

--- a/docs/cargo-delta.md
+++ b/docs/cargo-delta.md
@@ -12,9 +12,16 @@ which packages are directly modified and which are indirectly affected (via depe
 Only those packages are validated.
 
 Certain files are designated as "trip wires" (see `delta.toml`). If any trip wire file is
-changed, all packages are validated regardless. Trip wires include workspace-wide configuration
-files (`rust-toolchain.toml`, `clippy.toml`, etc.), workflow definitions and the build system
-itself.
+changed, all packages are validated regardless. The list is deliberately small - only files that
+change what "passing" means for *every* crate and that, changed alone, touch no package (so delta
+would otherwise validate nothing): the pinned toolchain (`rust-toolchain.toml`), the MSRV/nightly
+pins (`constants.env`) and the lint configuration (`clippy.toml`).
+
+Workflow definitions (`.github/**`), the build system (`justfile`, `justfiles/**`) and similar
+tooling/config files are intentionally *not* trip wires: they do not change any crate's build/test
+correctness, a change that breaks the mechanism fails the PR's own jobs, and the rare miss is
+caught by the push-to-main backstop. Treating them as trip wires only forced a full-workspace run
+on the many PRs that touch them for unrelated reasons.
 
 The workspace-root `Cargo.toml` and `Cargo.lock` are intentionally *not* trip wires: routine
 dependency edits touch them constantly but rarely affect every package, so tripping the whole

--- a/docs/cargo-delta.md
+++ b/docs/cargo-delta.md
@@ -15,7 +15,8 @@ Certain files are designated as "trip wires" (see `delta.toml`). If any trip wir
 changed, all packages are validated regardless. The list is deliberately small - only files that
 change what "passing" means for *every* crate and that, changed alone, touch no package (so delta
 would otherwise validate nothing): the pinned toolchain (`rust-toolchain.toml`), the MSRV/nightly
-pins (`constants.env`) and the lint configuration (`clippy.toml`).
+pins (`constants.env`), the lint configuration (`clippy.toml`) and the formatting configuration
+(`unstable-rustfmt.toml`, whose format check is a hard whole-workspace gate).
 
 Workflow definitions (`.github/**`), the build system (`justfile`, `justfiles/**`) and similar
 tooling/config files are intentionally *not* trip wires: they do not change any crate's build/test

--- a/infra/azure-bench-history-prod/README.md
+++ b/infra/azure-bench-history-prod/README.md
@@ -16,12 +16,16 @@ the environment can be deleted and re-created with one command.
 - A **Storage account** — `StorageV2`, HTTPS-only, TLS 1.2, **shared-key access
   disabled** (Entra ID only, so there is no account key to leak). Container and blob
   soft-delete are disabled, matching the test account.
-- A **dedicated user-assigned managed identity** (`id-folo-bench-history-prod`) with a
-  **GitHub OIDC federated credential** for `main`. The bench-history workflow federates into
+- A **dedicated user-assigned managed identity** (`id-folo-bench-history-prod`) with
+  **GitHub OIDC federated credentials** for `main` and for same-repo **pull requests**. Both
+  the bench-history workflow (on `main`) and the PR benchmark-history workflow federate into
   it with no stored secret: `cargo-bench-history` mints a fresh GitHub OIDC token on
   demand and exchanges it with Entra for each access token (so a multi-hour run stays
-  authenticated). Only `main` is trusted — there is no pull-request credential —
-  because collection only ever runs on `main` (push + gated dispatch).
+  authenticated). The pull-request credential (subject `…:pull_request`) is what lets the PR
+  workflow collect PR-head points and analyze them against `main`'s baseline in the same
+  store; only **same-repo** PRs can federate (forks carry no secrets), and the credential can
+  be removed by setting the `trustPullRequests` parameter in `main.bicep` to `false` and
+  redeploying, reverting prod to main-only.
 - **`Storage Blob Data Contributor`** role assignments on the account for that managed
   identity and (optionally) a local developer principal. That single role covers
   container create/delete and blob read/write/delete via the data plane, which is all

--- a/infra/azure-bench-history-prod/main.bicep
+++ b/infra/azure-bench-history-prod/main.bicep
@@ -6,9 +6,10 @@
 //
 //   * a Storage account (Entra-only: shared-key access disabled, HTTPS only) that
 //     holds the real, long-lived benchmark history;
-//   * a dedicated user-assigned managed identity (the prod CI principal) with a
-//     GitHub OIDC federated credential for `main`, so the nightly workflow can
-//     sign in without a stored secret;
+//   * a dedicated user-assigned managed identity (the prod CI principal) with
+//     GitHub OIDC federated credentials for `main` and for same-repo pull requests,
+//     so both the nightly workflow and the PR benchmark-history workflow can sign in
+//     without a stored secret;
 //   * `Storage Blob Data Contributor` role assignments on the account for that
 //     managed identity and (optionally) a local developer principal.
 //
@@ -39,6 +40,9 @@ param githubBranches array = [
   'main'
 ]
 
+@description('Whether to trust pull-request workflow runs from the same repository.')
+param trustPullRequests bool = true
+
 @description('Object id of a local developer principal (user or group) to grant data access. Empty skips the grant.')
 param localPrincipalId string = ''
 
@@ -60,14 +64,31 @@ var blobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 var githubIssuer = 'https://token.actions.githubusercontent.com'
 var federationAudience = 'api://AzureADTokenExchange'
 
-// The nightly collection only ever runs on `main` (schedule and gated dispatch),
-// so unlike the test identity there is no pull-request credential here.
-var federatedCredentials = [
+// The nightly collection runs on `main` (schedule and gated dispatch), and the PR
+// benchmark-history workflow (.github/workflows/pr-bench-history.yml) collects and
+// analyzes on same-repo pull requests, writing PR-head points into this same prod
+// store so branch-mode analyze can compare them against main's baseline. That PR
+// workflow needs its own OIDC subject, so — mirroring the test identity — this
+// grants one federated credential per trusted branch PLUS a pull-request credential
+// (subject `…:pull_request`). Adding the PR credential deliberately widens prod's
+// write surface to same-repo PR runs; forks cannot federate (no secrets on fork
+// runs), so only same-repo PRs are trusted. Set `trustPullRequests` to false to
+// revert prod to main-only.
+var branchCredentials = [
   for branch in githubBranches: {
     name: 'github-branch-${replace(branch, '/', '-')}'
     subject: 'repo:${githubOrg}/${githubRepo}:ref:refs/heads/${branch}'
   }
 ]
+var pullRequestCredential = trustPullRequests
+  ? [
+      {
+        name: 'github-pull-request'
+        subject: 'repo:${githubOrg}/${githubRepo}:pull_request'
+      }
+    ]
+  : []
+var federatedCredentials = concat(branchCredentials, pullRequestCredential)
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: storageAccountName

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -59,6 +59,42 @@ gh-collect-bench-history:
     $toolArgs = Get-BenchHistoryCollectCommand -RecollectCommitId $env:RECOLLECT_COMMIT_ID -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
 
+# The PR counterpart of `gh-collect-bench-history`: collects benchmark history for ONLY the
+# packages a pull request touched (the pr-bench-history.yml `delta` job computes them from
+# cargo-delta and passes them here space-separated, already filtered to the benchmarkable set), into
+# the SAME prod Azure store, keyed by the PR head commit. Scoping to the touched packages is a pure
+# cost optimisation - a PR rarely changes every crate, and the full 4-platform matrix is expensive -
+# and it is safe because branch-mode `analyze` only ever flags a series that has a data point at the
+# branch-unique head commit, i.e. exactly the packages collected here (see
+# gh-analyze-pr-bench-history and .github/workflows/design.md). Everything else is identical to the
+# push-to-main collect: the fixed `github` machine key keeps PR wall-clock series comparable to
+# main's baseline, `--best-of 3` sheds one-sided runner jitter, and `--skip-existing` makes a re-run
+# of the same head SHA a no-op append. There is no recollect mode on PRs (that repairs main's
+# permanent history); the scope decision lives in
+# scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this is
+# a thin import + call. `packages` must be non-empty - the workflow only invokes this recipe when
+# the delta produced at least one benchmarkable package, and an empty scope would wrongly fall back
+# to a whole-workspace run, so guard against it here.
+[group('automation')]
+[script]
+gh-collect-pr-bench-history packages:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
+
+    # The delta job passes the touched packages space-separated (the same shape validation.yml's
+    # `just package="..."` gating uses); split them into the array the module scopes on.
+    $packageList = @('{{packages}}'.Split([char[]]@(' ', "`t", "`n"), [StringSplitOptions]::RemoveEmptyEntries))
+    if ($packageList.Count -eq 0) {
+        throw "gh-collect-pr-bench-history requires at least one package to collect; got an empty list. The pr-bench-history workflow must gate this recipe on a non-empty benchmarkable delta."
+    }
+
+    Write-Verbose "Collecting PR benchmark history scoped to the touched packages: $($packageList -join ', ')." -Verbose
+    $toolArgs = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package $packageList -Verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
+
 # Analyzes the collected history for regressions across ALL engines and target triples, but
 # only the `github` machine key - the fixed key `gh-collect-bench-history` stamps on the
 # GitHub runner pool's data. Restricting it here (rather than `--machine-key all`) keeps this
@@ -108,6 +144,55 @@ gh-analyze-bench-history dir:
     Set-Content -Path $notablePath -Value $notable -Encoding utf8
     Write-Verbose "Analysis complete: notable=$notable (full report at $reportPath, condensed summary at $summaryPath)." -Verbose
 
+# The PR counterpart of `gh-analyze-bench-history`: analyzes the collected history in BRANCH mode -
+# comparing the PR head's benchmark level against its base branch - and writes the same four
+# artefacts (report.md, report.json, summary.md, notable.txt) INTO {{dir}}. Branch mode is what the
+# tool auto-selects when the context (the PR head, defaulting to HEAD) differs from {{base}}: it
+# splits the head's first-parent ancestry at the merge-base with the base, treats the base
+# ancestry's clean points as the baseline, and reports how the branch tip's level moved. `{{base}}`
+# is passed EXPLICITLY (the pr-bench-history.yml `analyze` job passes `origin/main`) because the PR
+# head is checked out detached, so there is no local `main` branch to auto-resolve, whereas
+# `fetch-depth: 0` populates the `origin/main` remote-tracking ref the merge-base needs.
+# `--include-improvements` is added so the rolling PR comment can also surface detected speedups, not
+# only regressions. Everything else matches the main analyze: only the `github` machine key (the
+# fixed key collection stamps on the runner pool), all engines and triples, findings never fail the
+# recipe (the tool always exits 0), and `--cache` mirrors fetched cloud objects under {{dir}}/cache.
+#
+# This is intentionally NOT package-scoped even though collection is: `analyze` has no per-package
+# filter (only positional id-prefix subjects), and benchmark ids are engine-dependent (Callgrind
+# carries the package, Criterion group ids are crate-prefixed, but alloc_tracker/all_the_time use a
+# bare operation name), so an id-prefix filter would silently drop the measurement-engine series for
+# a touched package. The scoping is instead a structural property of branch mode: only the collected
+# (touched) packages have a point at the branch-unique head commit, so only they can produce a
+# finding - an untouched package's latest point sits on the base ancestry, giving tip == base and no
+# finding, for EVERY engine. See .github/workflows/design.md for the full invariant.
+#
+# {{dir}} is a scratch directory OUTSIDE the repo checkout (the `analyze` job passes the runner temp
+# dir), so `analyze`'s own `git status --porcelain` dirty-check never sees these artefacts.
+[group('automation')]
+[script]
+gh-analyze-pr-bench-history dir base:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $dir = "{{dir}}"
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    $reportPath = Join-Path $dir "report.md"
+    $jsonPath = Join-Path $dir "report.json"
+    $summaryPath = Join-Path $dir "summary.md"
+    $notablePath = Join-Path $dir "notable.txt"
+    $cacheDir = Join-Path $dir "cache"
+    $common = @('--engine', 'all', '--target-triple', 'all', '--machine-key', 'github')
+
+    Write-Verbose "Analyzing PR benchmark history in branch mode (context HEAD vs base {{base}}); writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, including improvements as well as regressions, and mirroring fetched cloud objects under $cacheDir." -Verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --context HEAD --base '{{base}}' --include-improvements --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
+    Write-Verbose "Computing the notable flag from the JSON report." -Verbose
+    $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
+    $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }
+    Set-Content -Path $notablePath -Value $notable -Encoding utf8
+    Write-Verbose "PR analysis complete: notable=$notable (full report at $reportPath, condensed summary at $summaryPath)." -Verbose
+
 # Files (or updates in place) a single rolling issue identified by its exact title, from a
 # pre-rendered body file. Thin wrapper over Publish-RollingIssue in
 # scripts/bench-history/BenchHistoryIssue.psm1 (Pester-tested via `just test-scripts`), the one
@@ -133,6 +218,32 @@ gh-file-rolling-issue title label body_file:
         -BodyFile '{{body_file}}' `
         -Verbose
     Write-Verbose "Rolling issue is available at $url." -Verbose
+
+# Posts (or updates in place) the single rolling benchmark comment on a pull request, from a
+# pre-rendered body file. Thin wrapper over Publish-RollingComment in
+# scripts/bench-history/BenchHistoryComment.psm1 (Pester-tested via `just test-scripts`), the PR
+# counterpart of gh-file-rolling-issue: where main keeps a rolling ISSUE keyed by title, a PR keeps
+# a rolling COMMENT keyed by a hidden HTML `marker` embedded in the body, so every push updates one
+# comment instead of spamming the thread. `gh` reads the body from any path (--body-file semantics),
+# so it can live in the runner temp dir, outside the repo checkout. `repo` is `owner/name`
+# ('{{repo}}') and `pr` the PR number; both are validated in the module before being spliced into
+# the REST path. Needs GH_TOKEN in the environment (the workflow supplies it).
+[group('automation')]
+[script]
+gh-file-pr-comment repo pr marker body_file:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
+
+    Write-Verbose "Posting or updating the rolling benchmark comment on {{repo}} PR #{{pr}} from body file {{body_file}}." -Verbose
+    $url = Publish-RollingComment `
+        -Repo '{{repo}}' `
+        -PrNumber '{{pr}}' `
+        -Marker '{{marker}}' `
+        -BodyFile '{{body_file}}' `
+        -Verbose
+    Write-Verbose "Rolling PR comment is available at $url." -Verbose
 
 # The release-automation logic lives in scripts/release/ReleaseAutomation.psm1, with a Pester
 # suite (scripts/release/ReleaseAutomation.Tests.ps1) that exercises it against fixtures via

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -162,10 +162,13 @@ gh-analyze-bench-history dir:
 # filter (only positional id-prefix subjects), and benchmark ids are engine-dependent (Callgrind
 # carries the package, Criterion group ids are crate-prefixed, but alloc_tracker/all_the_time use a
 # bare operation name), so an id-prefix filter would silently drop the measurement-engine series for
-# a touched package. The scoping is instead a structural property of branch mode: only the collected
-# (touched) packages have a point at the branch-unique head commit, so only they can produce a
-# finding - an untouched package's latest point sits on the base ancestry, giving tip == base and no
-# finding, for EVERY engine. See .github/workflows/design.md for the full invariant.
+# a touched package. The scoping is instead enforced by `analyze`'s DEFAULT ghost exclusion: it
+# analyzes only benchmarks present at the context commit (HEAD, the PR head), and only the collected
+# (touched) packages have a run there, so every untouched package is dropped as a "ghost" before
+# detection - for EVERY engine. This recipe therefore MUST NOT pass `--include-ghosts`: that flag
+# re-admits every historical benchmark in the store and would defeat the scoping. As a bonus the
+# same default also drops a benchmark this PR removed, so a deletion is never mis-flagged as a
+# regression. See .github/workflows/design.md for the full invariant.
 #
 # {{dir}} is a scratch directory OUTSIDE the repo checkout (the `analyze` job passes the runner temp
 # dir), so `analyze`'s own `git status --porcelain` dirty-check never sees these artefacts.

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -114,7 +114,9 @@ validate-scripts:
             $relative = $finding.ScriptName.Substring($root.Length).TrimStart('\', '/')
             Write-Host ("{0}:{1} [{2}] {3}: {4}" -f $relative, $finding.Line, $finding.Severity, $finding.RuleName, $finding.Message)
         }
-        throw "PSScriptAnalyzer reported $($results.Count) issue(s). Fix them (or add a justified SuppressMessageAttribute) so the tree stays clean."
+        $issueNoun = if ($results.Count -eq 1) { 'issue' } else { 'issues' }
+        $issuePronoun = if ($results.Count -eq 1) { 'it' } else { 'them' }
+        throw "PSScriptAnalyzer reported $($results.Count) $issueNoun. Fix $issuePronoun (or add a justified SuppressMessageAttribute) so the tree stays clean."
     }
 
     Write-Host "PSScriptAnalyzer: no issues in scripts/."

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -260,18 +260,24 @@
 //!    managed identity below.
 //! 3. **For CI, authenticate with GitHub OIDC workload identity federation** instead
 //!    of a stored secret: create a user-assigned managed identity, add a federated
-//!    credential whose subject matches the workflow's OIDC token (for a run
-//!    on the default branch that is `repo:<owner>/<repo>:ref:refs/heads/main`) and
-//!    whose audience is `api://AzureADTokenExchange`, then grant it the role from
-//!    step 2. Run the tool from a job that has `permissions: { id-token: write }`,
-//!    with the managed identity's client ID and your Entra tenant ID exported as the
-//!    `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` environment variables. The tool then
-//!    mints a fresh OIDC assertion straight from GitHub's per-job token endpoint for
-//!    each Entra token exchange, so it stays authenticated even across the hourly
-//!    access-token refresh of a multi-hour benchmark run — no `azure/login` step and
-//!    no stored secret are involved. (When those variables are absent — locally, or in
-//!    a short job that runs `azure/login` — the tool instead picks up the ambient
-//!    Azure CLI session.)
+//!    credential whose subject matches the workflow's OIDC token, and whose audience
+//!    is `api://AzureADTokenExchange`, then grant it the role from step 2. The subject
+//!    must match **each event that runs the tool**, so register one credential per
+//!    event: a run on the default branch presents
+//!    `repo:<owner>/<repo>:ref:refs/heads/main`, while a pull-request-triggered run
+//!    (for example a workflow that benchmarks a PR) presents
+//!    `repo:<owner>/<repo>:pull_request` and needs its own credential with that
+//!    subject. Only **same-repo** pull requests can federate — a fork's run cannot
+//!    mint a token whose subject names your repository, so fork PRs cannot reach the
+//!    store and such workflows must skip them. Run the tool from a job that has
+//!    `permissions: { id-token: write }`, with the managed identity's client ID and
+//!    your Entra tenant ID exported as the `AZURE_CLIENT_ID` and `AZURE_TENANT_ID`
+//!    environment variables. The tool then mints a fresh OIDC assertion straight from
+//!    GitHub's per-job token endpoint for each Entra token exchange, so it stays
+//!    authenticated even across the hourly access-token refresh of a multi-hour
+//!    benchmark run — no `azure/login` step and no stored secret are involved. (When
+//!    those variables are absent — locally, or in a short job that runs `azure/login`
+//!    — the tool instead picks up the ambient Azure CLI session.)
 //!
 //! Worked, runnable examples of all of the above live in the folo repository as Bicep
 //! templates with PowerShell deploy wrappers: the long-lived store with its own
@@ -279,8 +285,11 @@
 //! <https://github.com/folo-rs/folo/tree/main/infra/azure-bench-history-prod> and a
 //! separate test account/identity at
 //! <https://github.com/folo-rs/folo/tree/main/infra/azure-bench-history-test>, with the
-//! account name baked into the committed `.cargo/bench_history.toml` and the per-push
-//! consumer at <https://github.com/folo-rs/folo/blob/main/.github/workflows/bench-history.yml>.
+//! account name baked into the committed `.cargo/bench_history.toml`, the per-push
+//! consumer at <https://github.com/folo-rs/folo/blob/main/.github/workflows/bench-history.yml>,
+//! and the per-pull-request consumer (which collects and compares a PR against `main`,
+//! and relies on the identity's `pull_request` federated credential) at
+//! <https://github.com/folo-rs/folo/blob/main/.github/workflows/pr-bench-history.yml>.
 
 mod commands;
 mod config_writer;

--- a/packages/cbh_config/src/config.rs
+++ b/packages/cbh_config/src/config.rs
@@ -28,7 +28,10 @@ const DEFAULT_TEMPLATE: &str = "\
 # Authentication is always Microsoft Entra ID (OAuth): the endpoint must be
 # HTTPS and the identity running the tool is granted data-plane access to the
 # container. In CI, GitHub Actions federates into Azure without a stored secret;
-# for setup, see
+# the federated credential's subject must match the triggering event — e.g.
+# `repo:<owner>/<repo>:ref:refs/heads/main` for a default-branch run, or
+# `repo:<owner>/<repo>:pull_request` for a pull-request run (same-repo only).
+# For setup, see
 # https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-azure
 #
 # [storage.azure]

--- a/scripts/bench-history/BenchHistoryCollect.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryCollect.Tests.ps1
@@ -88,6 +88,69 @@ Describe 'Get-BenchHistoryCollectCommand' {
             { Get-BenchHistoryCollectCommand -RecollectCommitId "abc1234; rm -rf /" } | Should -Throw '*hex commit SHA*'
         }
     }
+
+    Context 'package scoping (PR workflow)' {
+        It 'scopes to the given packages with repeated --package instead of --workspace' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package @('nm', 'many_cpus')
+            $result | Should -Be @(
+                'collect',
+                '--package', 'nm',
+                '--package', 'many_cpus',
+                '--machine-key', 'github',
+                '--best-of', '3',
+                '--verbose',
+                '--skip-existing'
+            )
+        }
+
+        It 'does not fall back to a whole-workspace scope when packages are given' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package @('nm')
+            $result | Should -Not -Contain '--workspace'
+            $result | Should -Not -Contain '--exclude'
+        }
+
+        It 'ignores blank entries in the package list' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package @('nm', '', '  ')
+            $result | Should -Be @(
+                'collect',
+                '--package', 'nm',
+                '--machine-key', 'github',
+                '--best-of', '3',
+                '--verbose',
+                '--skip-existing'
+            )
+        }
+
+        It 'treats an all-blank package list as no scope (whole workspace)' {
+            $result = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package @('', '  ')
+            $result | Should -Be (@('collect') + $script:Scope + @('--skip-existing'))
+        }
+    }
+}
+
+Describe 'Select-BenchmarkablePackage' {
+    It 'drops the excluded benchmarks package' {
+        Select-BenchmarkablePackage -Package @('nm', 'benchmarks', 'many_cpus') |
+            Should -Be @('nm', 'many_cpus')
+    }
+
+    It 'returns an empty array when only benchmarks changed' {
+        @(Select-BenchmarkablePackage -Package @('benchmarks')).Count | Should -Be 0
+    }
+
+    It 'returns an empty array for an empty input' {
+        @(Select-BenchmarkablePackage -Package @()).Count | Should -Be 0
+    }
+
+    It 'preserves order and leaves other packages untouched' {
+        Select-BenchmarkablePackage -Package @('many_cpus', 'nm', 'events') |
+            Should -Be @('many_cpus', 'nm', 'events')
+    }
+
+    It 'matches the excluded name case-sensitively' {
+        Select-BenchmarkablePackage -Package @('Benchmarks', 'nm') |
+            Should -Be @('Benchmarks', 'nm')
+    }
 }
 
 

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -1,7 +1,8 @@
 #requires -Version 7
 
-# Argument selection for the benchmark-history `collect` step (.github/workflows/bench-history.yml,
-# via the gh-collect-bench-history recipe).
+# Argument selection for the benchmark-history `collect` step, shared by the push-to-main workflow
+# (.github/workflows/bench-history.yml, via the gh-collect-bench-history recipe) and the per-PR
+# workflow (.github/workflows/pr-bench-history.yml, via gh-collect-pr-bench-history).
 #
 # The step has two modes and the choice between them is real logic - a branch, input validation and
 # error handling - so it lives here behind a seam the Pester suite (BenchHistoryCollect.Tests.ps1)
@@ -15,30 +16,86 @@
 # `backfill <id> <id> --overwrite`, which benchmarks the code AT that commit in a throwaway worktree
 # while running THIS (HEAD) build of the tool - repairing a point corrupted by a bad benchmark day
 # without adopting the tool version that shipped at that commit.
+#
+# Collection scope is orthogonal to the mode: with no explicit package list the whole workspace is
+# benched except the special-purpose `benchmarks` crate (the push-to-main default); the PR workflow
+# instead passes the delta-affected packages so it benches only what the PR touched.
+# Select-BenchmarkablePackage is the shared helper that drops `benchmarks` from a delta-affected set
+# before both the scope decision and the "is there anything to bench at all" gate.
 
 Set-StrictMode -Version Latest
+
+# The one workspace package the benchmark-history collection never benches: it is the slow,
+# special-purpose `benchmarks` crate. The push-to-main workflow excludes it with
+# `--workspace --exclude benchmarks`; the PR workflow scopes to the delta-affected packages, so it
+# must drop this name from that set before collecting (and before deciding whether anything is left
+# to bench at all). Defined once so the exclusion cannot drift between the two paths.
+$script:ExcludedPackage = 'benchmarks'
+
+function Select-BenchmarkablePackage {
+    # Filters a delta-affected package list down to the ones the benchmark-history workflow actually
+    # collects, i.e. everything except the excluded `benchmarks` crate. The PR workflow's `delta`
+    # job feeds the result into Get-DeltaOutput, so an empty result is what makes the workflow treat
+    # "only non-benchmarkable packages changed" as "nothing to bench" (skip collection, clean up any
+    # stale comment). Order-preserving; a case-sensitive match, matching how `cargo`/the tool treat
+    # package names. Pure, so the filtering is unit-tested independently of the delta orchestration.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]] $Package
+    )
+
+    return @($Package | Where-Object { $_ -cne $script:ExcludedPackage })
+}
 
 function Get-BenchHistoryCollectCommand {
     # Builds the argument vector passed to the tool after `--` (a `collect ...` or `backfill ...`
     # invocation), choosing the mode from $RecollectCommitId. Returns a string[]; throws when a
     # non-empty id is not a plausible commit SHA. Emits an explanatory verbose note describing which
     # mode was chosen and why, for the workflow log.
+    #
+    # $Package selects the collection scope. When empty (the push-to-main default), the whole
+    # workspace is benched except the excluded `benchmarks` crate (`--workspace --exclude
+    # benchmarks`). When non-empty (the PR workflow, which passes the delta-affected packages), the
+    # run is scoped to exactly those packages (`--package <name>` each); the caller is expected to
+    # have already dropped `benchmarks` via Select-BenchmarkablePackage. An empty scope is not an
+    # error here: the PR workflow structurally never reaches collection with an empty benchmarkable
+    # set (its `delta` job gates that case out to the cleanup path), so the only caller that passes
+    # no packages is the push-to-main path, which wants exactly the whole-workspace default.
     [CmdletBinding()]
     [OutputType([string[]])]
     param(
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [string] $RecollectCommitId
+        [string] $RecollectCommitId,
+
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]] $Package
     )
 
     # Scope + noise-reduction flags shared by both modes: `collect` and `backfill` flatten the same
     # clap arg groups, so this array applies verbatim to either subcommand. The fixed `github`
     # machine key keeps the whole GitHub runner pool on one wall-clock series; `--best-of 3` keeps
     # each metric's minimum across three runs to shed one-sided runner jitter.
-    $scope = @(
-        '--workspace',
-        '--exclude', 'benchmarks',
+    $packages = @($Package | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($packages.Count -gt 0) {
+        # Explicit package scoping (PR workflow): one `--package <name>` per touched crate.
+        $selection = @()
+        foreach ($name in $packages) { $selection += @('--package', $name) }
+        Write-Verbose ("Scoping collection to the delta-affected packages: " +
+            ($packages -join ', ') + '.')
+    } else {
+        $selection = @('--workspace', '--exclude', $script:ExcludedPackage)
+        Write-Verbose ("No explicit package scope: benching the whole workspace except the " +
+            "'$script:ExcludedPackage' crate.")
+    }
+
+    $scope = $selection + @(
         '--machine-key', 'github',
         '--best-of', '3',
         '--verbose'
@@ -70,4 +127,4 @@ function Get-BenchHistoryCollectCommand {
     return @('backfill', $recollect, $recollect) + $scope + @('--overwrite')
 }
 
-Export-ModuleMember -Function Get-BenchHistoryCollectCommand
+Export-ModuleMember -Function Get-BenchHistoryCollectCommand, Select-BenchmarkablePackage

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -25,6 +25,7 @@ BeforeAll {
 AfterAll {
     Remove-Item -LiteralPath $script:BodyFile -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $script:UnmarkedBodyFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-comment-captured-body.md') -ErrorAction SilentlyContinue
 }
 
 Describe 'Find-RollingComment (mocked gh api)' {
@@ -142,11 +143,11 @@ Describe 'Publish-RollingComment (mocked gh api)' {
             Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'POST' } -Times 0 -Exactly
         }
 
-        It 'patches the matched comment id and passes the rendered body' {
+        It 'patches the matched comment id and sends the rendered body via a file' {
             Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile | Out-Null
             Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
                 ($args -contains 'PATCH') -and ($args -contains 'repos/o/r/issues/comments/42') -and
-                (($args -join "`n") -like '*body=*rendered body*')
+                ($args -contains "body=@$($script:BodyFile)")
             }
         }
 
@@ -159,6 +160,17 @@ Describe 'Publish-RollingComment (mocked gh api)' {
     Context 'when no rolling comment exists yet' {
         BeforeEach {
             Mock gh -ModuleName BenchHistoryComment {
+                # Capture the body file's content while it still exists: Publish-RollingComment sends
+                # the body via `-F body=@<path>` and deletes any temp file it created once `gh`
+                # returns, so a post-hoc ParameterFilter could no longer read it. The fixed capture
+                # path is recomputed identically in the assertion, so no cross-scope variable is
+                # needed between this module-scoped mock and the test.
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-comment-captured-body.md') -Force
+                    }
+                }
                 if ($args -contains 'POST') {
                     $global:LASTEXITCODE = 0
                     return '{"id":99,"html_url":"https://github.com/o/r/pull/5#issuecomment-99"}'
@@ -180,11 +192,11 @@ Describe 'Publish-RollingComment (mocked gh api)' {
                 Should -Be 'https://github.com/o/r/pull/5#issuecomment-99'
         }
 
-        It 'prepends the marker when the rendered body lacks it' {
+        It 'prepends the marker when the rendered body lacks it, sending it via a file' {
             Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:UnmarkedBodyFile | Out-Null
-            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
-                ($args -contains 'POST') -and (($args -join "`n") -like "*$($script:Marker)*")
-            }
+            $sent = Get-Content -LiteralPath (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-comment-captured-body.md') -Raw
+            $sent | Should -BeLike "*$($script:Marker)*"
+            $sent | Should -BeLike '*rendered body without marker*'
         }
     }
 

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -1,0 +1,278 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for BenchHistoryComment.psm1. The one tool that would touch GitHub for real -- `gh` --
+# is isolated behind the module's Invoke-GhCapture seam and mocked here in the module's scope, so the
+# rolling-comment logic (find-by-marker, update-in-place vs. create, delete-if-present, error
+# propagation, and the path-splice validation) is exercised without posting to a real pull request.
+# Body files are real temp files so the on-disk read and the missing/empty guards are asserted, not
+# faked.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'BenchHistoryComment.psm1') -Force
+
+    $script:Marker = '<!-- folo-bench-history-pr -->'
+
+    # A real body file (already carrying the marker) so Publish-RollingComment's Test-Path guard
+    # passes; `gh` is mocked, so its contents only matter where a test inspects the posted body.
+    $script:BodyFile = Join-Path ([System.IO.Path]::GetTempPath()) ("bh-comment-$([guid]::NewGuid().ToString('n')).md")
+    Set-Content -LiteralPath $script:BodyFile -Value "$script:Marker`n`nrendered body" -Encoding utf8
+
+    # A body file WITHOUT the marker, to prove the module prepends it before posting.
+    $script:UnmarkedBodyFile = Join-Path ([System.IO.Path]::GetTempPath()) ("bh-comment-unmarked-$([guid]::NewGuid().ToString('n')).md")
+    Set-Content -LiteralPath $script:UnmarkedBodyFile -Value 'rendered body without marker' -Encoding utf8
+}
+
+AfterAll {
+    Remove-Item -LiteralPath $script:BodyFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $script:UnmarkedBodyFile -ErrorAction SilentlyContinue
+}
+
+Describe 'Find-RollingComment (mocked gh api)' {
+    Context 'when a comment carrying the marker exists' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                $global:LASTEXITCODE = 0
+                '[{"id":7,"body":"just a chat comment","html_url":"https://github.com/o/r/pull/5#issuecomment-7"},{"id":42,"body":"<!-- folo-bench-history-pr -->\nfindings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+        }
+
+        It 'returns that comment' {
+            $comment = Find-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker
+            $comment.id | Should -Be 42
+            $comment.html_url | Should -Be 'https://github.com/o/r/pull/5#issuecomment-42'
+        }
+
+        It 'lists the PR issue comments with pagination' {
+            Find-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'api') -and ($args -contains '--paginate') -and
+                ($args -contains 'repos/o/r/issues/5/comments')
+            }
+        }
+    }
+
+    Context 'when no comment carries the marker' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                $global:LASTEXITCODE = 0
+                '[{"id":7,"body":"just a chat comment","html_url":"https://github.com/o/r/pull/5#issuecomment-7"}]'
+            }
+        }
+
+        It 'returns null' {
+            Find-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'when the comment list is empty' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 0; '[]' }
+        }
+
+        It 'returns null' {
+            Find-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'when gh fails' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 1; 'HTTP 503: Service Unavailable' }
+        }
+
+        It 'throws, surfacing the gh output' {
+            { Find-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker } | Should -Throw '*503*'
+        }
+    }
+
+    Context 'when gh prints a warning to stderr but still exits 0' {
+        BeforeEach {
+            # The real gotcha: gh emits a note on stderr while returning valid JSON on stdout and
+            # exiting 0. A naive 2>&1 merge would corrupt the JSON; the module must parse stdout only.
+            Mock gh -ModuleName BenchHistoryComment {
+                Write-Error 'gh: a new release of gh is available' -ErrorAction Continue
+                $global:LASTEXITCODE = 0
+                '[{"id":42,"body":"<!-- folo-bench-history-pr -->\nfindings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+        }
+
+        It 'ignores the stderr note and still parses the comment from stdout' {
+            (Find-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker).id | Should -Be 42
+        }
+    }
+
+    Context 'input validation' {
+        It 'rejects a malformed repository' {
+            { Find-RollingComment -Repo 'not-a-repo' -PrNumber '5' -Marker $script:Marker } |
+                Should -Throw "*owner/name*"
+        }
+
+        It 'rejects a non-numeric PR number' {
+            { Find-RollingComment -Repo 'o/r' -PrNumber '5; rm -rf /' -Marker $script:Marker } |
+                Should -Throw '*positive integer*'
+        }
+    }
+}
+
+Describe 'Publish-RollingComment (mocked gh api)' {
+    Context 'when a rolling comment already exists' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'PATCH') {
+                    $global:LASTEXITCODE = 0
+                    return '{"id":42,"html_url":"https://github.com/o/r/pull/5#issuecomment-42"}'
+                }
+                if ($args -contains 'POST') {
+                    $global:LASTEXITCODE = 0
+                    return '{"id":99,"html_url":"https://github.com/o/r/pull/5#issuecomment-99"}'
+                }
+                # list
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\nold findings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+        }
+
+        It 'updates the existing comment instead of posting a duplicate' {
+            Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' }
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'POST' } -Times 0 -Exactly
+        }
+
+        It 'patches the matched comment id and passes the rendered body' {
+            Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'PATCH') -and ($args -contains 'repos/o/r/issues/comments/42') -and
+                (($args -join "`n") -like '*body=*rendered body*')
+            }
+        }
+
+        It 'returns the existing comment url' {
+            Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile |
+                Should -Be 'https://github.com/o/r/pull/5#issuecomment-42'
+        }
+    }
+
+    Context 'when no rolling comment exists yet' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'POST') {
+                    $global:LASTEXITCODE = 0
+                    return '{"id":99,"html_url":"https://github.com/o/r/pull/5#issuecomment-99"}'
+                }
+                $global:LASTEXITCODE = 0
+                return '[]'
+            }
+        }
+
+        It 'creates a new comment on the PR' {
+            Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'POST') -and ($args -contains 'repos/o/r/issues/5/comments')
+            }
+        }
+
+        It 'returns the created comment url' {
+            Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile |
+                Should -Be 'https://github.com/o/r/pull/5#issuecomment-99'
+        }
+
+        It 'prepends the marker when the rendered body lacks it' {
+            Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:UnmarkedBodyFile | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'POST') -and (($args -join "`n") -like "*$($script:Marker)*")
+            }
+        }
+    }
+
+    Context 'error handling' {
+        It 'throws when the body file does not exist' {
+            $missing = Join-Path ([System.IO.Path]::GetTempPath()) "bh-missing-$([guid]::NewGuid().ToString('n')).md"
+            { Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $missing } |
+                Should -Throw '*does not exist*'
+        }
+
+        It 'throws when the body file is empty' {
+            $empty = Join-Path ([System.IO.Path]::GetTempPath()) "bh-empty-$([guid]::NewGuid().ToString('n')).md"
+            Set-Content -LiteralPath $empty -Value '' -Encoding utf8
+            try {
+                { Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $empty } |
+                    Should -Throw '*is empty*'
+            }
+            finally {
+                Remove-Item -LiteralPath $empty -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'throws when gh create fails, surfacing its output' {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'POST') { $global:LASTEXITCODE = 1; return 'could not create comment' }
+                $global:LASTEXITCODE = 0; return '[]'
+            }
+            { Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile } |
+                Should -Throw '*could not create comment*'
+        }
+
+        It 'throws when gh edit fails, surfacing its output' {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 1; return 'could not edit comment' }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\nold","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+            { Publish-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -BodyFile $script:BodyFile } |
+                Should -Throw '*could not edit comment*'
+        }
+    }
+}
+
+Describe 'Remove-RollingComment (mocked gh api)' {
+    Context 'when a rolling comment exists' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'DELETE') { $global:LASTEXITCODE = 0; return '' }
+                $global:LASTEXITCODE = 0
+                return '[{"id":7,"body":"chatter","html_url":"https://github.com/o/r/pull/5#issuecomment-7"},{"id":42,"body":"<!-- folo-bench-history-pr -->\nstale findings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+        }
+
+        It 'deletes the matching comment and returns true' {
+            $removed = Remove-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker
+            $removed | Should -BeTrue
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'DELETE') -and ($args -contains 'repos/o/r/issues/comments/42')
+            }
+        }
+
+        It 'never deletes a non-matching comment' {
+            Remove-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'DELETE') -and ($args -contains 'repos/o/r/issues/comments/7')
+            } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when no rolling comment exists' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 0; '[]' }
+        }
+
+        It 'deletes nothing and returns false' {
+            $removed = Remove-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker
+            $removed | Should -BeFalse
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'DELETE' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when gh delete fails' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'DELETE') { $global:LASTEXITCODE = 1; return 'could not delete comment' }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\nstale","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+        }
+
+        It 'throws, surfacing the gh output' {
+            { Remove-RollingComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker } |
+                Should -Throw '*could not delete comment*'
+        }
+    }
+}

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -110,6 +110,11 @@ Describe 'Find-RollingComment (mocked gh api)' {
             { Find-RollingComment -Repo 'o/r' -PrNumber '5; rm -rf /' -Marker $script:Marker } |
                 Should -Throw '*positive integer*'
         }
+
+        It 'rejects a zero PR number' {
+            { Find-RollingComment -Repo 'o/r' -PrNumber '0' -Marker $script:Marker } |
+                Should -Throw '*positive integer*'
+        }
     }
 }
 

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -66,7 +66,9 @@ function Assert-RepoAndPr {
     if ($Repo -notmatch '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$') {
         throw "Repository must be in 'owner/name' form, got '$Repo'."
     }
-    if ($PrNumber -notmatch '^[0-9]+$') {
+    # `^[1-9][0-9]*$` (not `^[0-9]+$`): a PR number is a positive integer, so reject `0` and any
+    # leading-zero form to match the error message and keep a well-formed REST path.
+    if ($PrNumber -notmatch '^[1-9][0-9]*$') {
         throw "Pull request number must be a positive integer, got '$PrNumber'."
     }
 }
@@ -96,8 +98,11 @@ function Find-RollingComment {
     # A no-comments list is the literal `[]`, which ConvertFrom-Json yields as an empty array; the
     # @() wrapper keeps a single-object result enumerable under strict mode.
     $comments = $output | ConvertFrom-Json
+    # A literal substring match (.Contains, ordinal) rather than -like: the marker is a fixed HTML
+    # string, so treating it as a wildcard pattern would misbehave if it ever gained wildcard
+    # metacharacters ([, ], *, ?).
     foreach ($comment in @($comments)) {
-        if ($comment.body -and ($comment.body -like "*$Marker*")) { return $comment }
+        if ($comment.body -and $comment.body.Contains($Marker)) { return $comment }
     }
     return $null
 }
@@ -131,7 +136,9 @@ function Publish-RollingComment {
     # The marker is this module's responsibility, not the caller's: prepend it as a hidden HTML
     # comment when the rendered body lacks it, so the dedup contract holds even if a future body
     # template forgets to embed it.
-    if ($body -notlike "*$Marker*") {
+    # Literal substring check (.Contains, ordinal) rather than -notlike: the marker is a fixed hidden
+    # string, so a wildcard match would misfire if it ever contained wildcard metacharacters.
+    if (-not $body.Contains($Marker)) {
         $body = "$Marker`n`n$body"
     }
 

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -133,29 +133,44 @@ function Publish-RollingComment {
         throw "Comment body file '$BodyFile' is empty."
     }
 
-    # The marker is this module's responsibility, not the caller's: prepend it as a hidden HTML
-    # comment when the rendered body lacks it, so the dedup contract holds even if a future body
-    # template forgets to embed it.
+    # Hand the body to `gh` through a FILE (`-F body=@<path>`) rather than inline on the command
+    # line: a rendered report can run to tens of kilobytes, which would risk the OS command-line
+    # length limit (~32 KB on Windows), force fragile shell-escaping of arbitrary Markdown, and
+    # expose the body in process listings. The common case sends $BodyFile untouched. Only when the
+    # rendered body lacks the dedup $Marker - this module's responsibility, not the caller's, so the
+    # contract holds even if a future body template forgets to embed it - do we materialise a
+    # marker-prefixed temp file and send that instead, deleting it once `gh` has run.
     # Literal substring check (.Contains, ordinal) rather than -notlike: the marker is a fixed hidden
     # string, so a wildcard match would misfire if it ever contained wildcard metacharacters.
+    $bodyFileToSend = $BodyFile
+    $tempBodyFile = $null
     if (-not $body.Contains($Marker)) {
-        $body = "$Marker`n`n$body"
+        $tempBodyFile = New-TemporaryFile
+        Set-Content -LiteralPath $tempBodyFile.FullName -Value "$Marker`n`n$body" -Encoding utf8 -NoNewline
+        $bodyFileToSend = $tempBodyFile.FullName
     }
 
-    $existing = Find-RollingComment -Repo $Repo -PrNumber $PrNumber -Marker $Marker
+    try {
+        $existing = Find-RollingComment -Repo $Repo -PrNumber $PrNumber -Marker $Marker
 
-    if ($existing) {
-        Write-Verbose ("Updating existing rolling comment #$($existing.id) on PR #$PrNumber in place " +
-            "rather than posting a duplicate.")
-        $output = Invoke-GhCapture -Arguments @(
-            'api', '--method', 'PATCH', "repos/$Repo/issues/comments/$($existing.id)", '-f', "body=$body"
-        )
-    } else {
-        Write-Verbose ("No rolling comment found on PR #$PrNumber; posting a new one carrying the " +
-            "dedup marker so later pushes update it.")
-        $output = Invoke-GhCapture -Arguments @(
-            'api', '--method', 'POST', "repos/$Repo/issues/$PrNumber/comments", '-f', "body=$body"
-        )
+        if ($existing) {
+            Write-Verbose ("Updating existing rolling comment #$($existing.id) on PR #$PrNumber in place " +
+                "rather than posting a duplicate.")
+            $output = Invoke-GhCapture -Arguments @(
+                'api', '--method', 'PATCH', "repos/$Repo/issues/comments/$($existing.id)", '-F', "body=@$bodyFileToSend"
+            )
+        } else {
+            Write-Verbose ("No rolling comment found on PR #$PrNumber; posting a new one carrying the " +
+                "dedup marker so later pushes update it.")
+            $output = Invoke-GhCapture -Arguments @(
+                'api', '--method', 'POST', "repos/$Repo/issues/$PrNumber/comments", '-F', "body=@$bodyFileToSend"
+            )
+        }
+    }
+    finally {
+        if ($tempBodyFile) {
+            Remove-Item -LiteralPath $tempBodyFile.FullName -Force -ErrorAction SilentlyContinue
+        }
     }
 
     # Both the PATCH and POST comment endpoints return the comment object; surface its html_url,

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -1,0 +1,200 @@
+#requires -Version 7
+
+# Rolling PR-comment plumbing for the per-PR benchmark-history workflow
+# (.github/workflows/pr-bench-history.yml).
+#
+# The PR counterpart of BenchHistoryIssue.psm1: where the push-to-main workflow keeps one rolling
+# ISSUE, the PR workflow keeps one rolling COMMENT on the pull request, updated in place on every
+# push so a PR never accumulates a trail of stale benchmark comments. A hidden HTML marker embedded
+# in the body is what makes the comment findable again on the next run (mirroring how the issue
+# module dedups by exact title). The two callers reach this seam differently: the `analyze` job
+# posts findings via the thin gh-file-pr-comment `just` recipe (its job already has `just`), while
+# the lightweight `cleanup` job - which runs when a PR no longer touches any benchmarkable package -
+# imports this module directly and calls Remove-RollingComment to sweep away a comment left by an
+# earlier iteration of the same PR (e.g. a benchmarked change that was later reverted).
+#
+# Every GitHub-touching call goes through `gh api` behind the single Invoke-GhCapture seam the
+# Pester suite (BenchHistoryComment.Tests.ps1) mocks, so the find/update/create/delete logic is
+# exercised without touching a real pull request. Unlike an agent-authored GitHub post, this is
+# CI/bot output and therefore carries NO `[Copilot speaking]` prefix.
+
+Set-StrictMode -Version Latest
+
+function Invoke-GhCapture {
+    # Runs `gh` with the given arguments, capturing stdout and stderr SEPARATELY. stderr is
+    # redirected to a temp file so it never contaminates stdout: `gh` can print warnings - e.g.
+    # deprecation or rate-limit notes - to stderr while still exiting 0, and folding those into
+    # stdout (a bare `2>&1`) would break the JSON parsing the callers do. Returns the captured
+    # stdout as a single string on success; on a non-zero exit, throws with whatever `gh` wrote
+    # (stderr first, then any stdout) so the failure is never swallowed. Inspecting the exit code
+    # ourselves - rather than letting a non-zero `gh` abort - is why the native-error toggle is off.
+    # This is the single seam the Pester suite mocks (via `Mock gh`).
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][object[]] $Arguments)
+
+    $PSNativeCommandUseErrorActionPreference = $false
+    $stderrFile = New-TemporaryFile
+    try {
+        $stderrPath = $stderrFile.FullName
+        $stdout = (gh @Arguments 2>$stderrPath | Out-String)
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $stderr = Get-Content -LiteralPath $stderrPath -Raw
+            $parts = @()
+            if ($stderr -and $stderr.Trim()) { $parts += $stderr.Trim() }
+            if ($stdout -and $stdout.Trim()) { $parts += $stdout.Trim() }
+            throw "gh $($Arguments -join ' ') failed (exit $exitCode): $($parts -join ' ')"
+        }
+        return $stdout
+    }
+    finally {
+        Remove-Item -LiteralPath $stderrFile.FullName -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-RepoAndPr {
+    # Guards the two values that get spliced into a `gh api` REST path (`repos/<repo>/issues/...`).
+    # Both arrive from workflow context (`github.repository`, the PR number), but validating their
+    # shape here keeps the path well-formed and forecloses any path-traversal/injection surprise if
+    # a caller ever passes them from a less trustworthy source. Throws on a malformed value.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber
+    )
+
+    if ($Repo -notmatch '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$') {
+        throw "Repository must be in 'owner/name' form, got '$Repo'."
+    }
+    if ($PrNumber -notmatch '^[0-9]+$') {
+        throw "Pull request number must be a positive integer, got '$PrNumber'."
+    }
+}
+
+function Find-RollingComment {
+    # Returns the first issue comment on the pull request whose body contains $Marker, or $null when
+    # none does. Issue comments (which is what PR conversation comments are) come back from a single
+    # paginated `gh api` call - `--paginate` merges every page into one JSON array, so a PR with more
+    # than one page of comments is handled without special-casing. Matching on the hidden marker
+    # rather than the author lets the same rolling comment be found regardless of which bot identity
+    # posted it. Isolates the real `gh api` list call so the tests can mock it.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber,
+        [Parameter(Mandatory)][string] $Marker
+    )
+
+    Assert-RepoAndPr -Repo $Repo -PrNumber $PrNumber
+
+    # Invoke-GhCapture keeps stderr off stdout so ConvertFrom-Json always sees clean JSON even if
+    # `gh` emitted a warning; `--paginate` follows the next-page links and merges the array pages.
+    $output = Invoke-GhCapture -Arguments @(
+        'api', '--paginate', "repos/$Repo/issues/$PrNumber/comments"
+    )
+
+    # A no-comments list is the literal `[]`, which ConvertFrom-Json yields as an empty array; the
+    # @() wrapper keeps a single-object result enumerable under strict mode.
+    $comments = $output | ConvertFrom-Json
+    foreach ($comment in @($comments)) {
+        if ($comment.body -and ($comment.body -like "*$Marker*")) { return $comment }
+    }
+    return $null
+}
+
+function Publish-RollingComment {
+    # Maintains exactly ONE rolling comment on the pull request: when a comment carrying $Marker
+    # already exists its body is PATCHed in place (so repeated pushes update one comment instead of
+    # spamming the thread), otherwise a new comment is POSTed. The rendered body is read from
+    # $BodyFile (any path - typically the runner temp dir, so no scratch file lands in the checkout
+    # where `analyze`'s dirty-check would see it). The hidden $Marker is guaranteed to be present in
+    # whatever gets posted - prepended when the rendered body does not already contain it - so the
+    # NEXT run can find this same comment. Returns the comment's html_url.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber,
+        [Parameter(Mandatory)][string] $Marker,
+        [Parameter(Mandatory)][string] $BodyFile
+    )
+
+    Assert-RepoAndPr -Repo $Repo -PrNumber $PrNumber
+
+    if (-not (Test-Path -LiteralPath $BodyFile)) {
+        throw "Comment body file '$BodyFile' does not exist."
+    }
+    $body = Get-Content -LiteralPath $BodyFile -Raw
+    if ([string]::IsNullOrWhiteSpace($body)) {
+        throw "Comment body file '$BodyFile' is empty."
+    }
+
+    # The marker is this module's responsibility, not the caller's: prepend it as a hidden HTML
+    # comment when the rendered body lacks it, so the dedup contract holds even if a future body
+    # template forgets to embed it.
+    if ($body -notlike "*$Marker*") {
+        $body = "$Marker`n`n$body"
+    }
+
+    $existing = Find-RollingComment -Repo $Repo -PrNumber $PrNumber -Marker $Marker
+
+    if ($existing) {
+        Write-Verbose ("Updating existing rolling comment #$($existing.id) on PR #$PrNumber in place " +
+            "rather than posting a duplicate.")
+        $output = Invoke-GhCapture -Arguments @(
+            'api', '--method', 'PATCH', "repos/$Repo/issues/comments/$($existing.id)", '-f', "body=$body"
+        )
+    } else {
+        Write-Verbose ("No rolling comment found on PR #$PrNumber; posting a new one carrying the " +
+            "dedup marker so later pushes update it.")
+        $output = Invoke-GhCapture -Arguments @(
+            'api', '--method', 'POST', "repos/$Repo/issues/$PrNumber/comments", '-f', "body=$body"
+        )
+    }
+
+    # Both the PATCH and POST comment endpoints return the comment object; surface its html_url,
+    # falling back to the existing url (edit path) or empty string if the field is somehow absent.
+    $result = $output | ConvertFrom-Json
+    if ($result -and $result.html_url) { return $result.html_url }
+    if ($existing -and $existing.html_url) { return $existing.html_url }
+    return ''
+}
+
+function Remove-RollingComment {
+    # Deletes the rolling comment (the one carrying $Marker) from the pull request, if present; a
+    # no-op that returns $false when none is found. The mirror image of Publish-RollingComment,
+    # called by the `cleanup` job when the PR no longer touches any benchmarkable package: a comment
+    # left by an earlier iteration (which did touch one) must not linger and mislead. Returns $true
+    # when a comment was deleted. The real `gh api` calls go through Invoke-GhCapture so the Pester
+    # suite can mock them. SupportsShouldProcess because deleting a GitHub comment is a state-changing
+    # action (matches the repo convention for Set-/New-/Stop- helpers): the DELETE is gated on
+    # ShouldProcess so `-WhatIf` reports the delete without performing it.
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber,
+        [Parameter(Mandatory)][string] $Marker
+    )
+
+    Assert-RepoAndPr -Repo $Repo -PrNumber $PrNumber
+
+    $existing = Find-RollingComment -Repo $Repo -PrNumber $PrNumber -Marker $Marker
+    if (-not $existing) {
+        Write-Verbose ("No rolling comment on PR #$PrNumber to remove; nothing to do (the PR either " +
+            "never had one or it was already deleted).")
+        return $false
+    }
+
+    if (-not $PSCmdlet.ShouldProcess("comment #$($existing.id) on PR #$PrNumber", 'Delete rolling comment')) {
+        return $false
+    }
+
+    Write-Verbose ("Deleting stale rolling comment #$($existing.id) from PR #$PrNumber because the PR " +
+        "no longer touches any benchmarkable package.")
+    Invoke-GhCapture -Arguments @(
+        'api', '--method', 'DELETE', "repos/$Repo/issues/comments/$($existing.id)"
+    ) | Out-Null
+    return $true
+}
+
+Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment


### PR DESCRIPTION
[Copilot speaking]

## What & why

The existing `bench-history.yml` collects benchmark results on every push to `main` and files a rolling **issue** about long-range trends. This adds the equivalent feedback loop for **pull requests**: on every push to a PR branch it benchmarks the touched packages, compares the PR tip against `main`, and posts/updates a rolling **PR comment** with the findings.

Findings are strictly **advisory** — they never affect the check's exit code and never gate a merge.

## How it works

- **`pr-bench-history.yml`** (`pull_request: opened/synchronize/reopened`, same-repo only):
  - **`delta`** — cargo-delta-scopes to the packages the PR touches (vs `origin/main`), filtered to the benchmarkable set. Empty set routes to `cleanup`.
  - **`collect`** (matrix ×4) — checks out the **real PR head SHA** with full history (not the synthetic merge ref, whose first parent is `main` and would corrupt branch-mode topology), federates into the **prod** Azure store, and benchmarks only the touched packages with the fixed `github` machine key.
  - **`analyze`** — runs the tool in **branch mode** (`--context HEAD --base origin/main --include-improvements`), restore-only warm cache from `main`, and posts/updates one rolling comment (deduped by a hidden marker).
  - **`cleanup`** — when the PR no longer touches any benchmarkable package (including a change that was reverted), removes any stale rolling comment and posts nothing.
- **`cancel-pr-bench-history.yml`** — joins the same concurrency group on PR close to cancel an in-flight run.

## Scoping invariant

Collection is delta-scoped as a cost optimization. Analysis is deliberately **not** package-scoped: branch mode only flags a series that has a data point at the branch tip, and only the collected (touched) packages have a point at the PR's branch-unique head commit — for every engine. Filtering analysis by package name would be actively wrong because benchmark ids are engine-dependent (some omit the package prefix), so it would silently drop those series. Documented as an invariant in `design.md`.

## Federation gap fixed

The prod Azure identity previously trusted only `main`. This adds a `pull_request` federated credential (subject `repo:folo-rs/folo:pull_request`) to `infra/azure-bench-history-prod/` — **already deployed** — so same-repo PR runs can authenticate. `design.md` now documents the complete federated-trust model (per-event subject → identity → consumer), and the user-facing crate docs (`cargo-bench-history` `//!` and the install config template) now cover the `pull_request` subject variant and the same-repo-only constraint.

## Validation

- `just validate-workflows` (actionlint) — clean
- `just validate-scripts` (PSScriptAnalyzer) — clean
- `just test-scripts` (Pester) — 230 passed
- `just package="cargo-bench-history" docs` (rustdoc) — clean
- `just package="cbh_config" test` — 33 passed

Note: this PR's own runs are the first to exercise the new `pull_request` credential.