### PR TITLE
Exclude ghost benchmarks from `analyze` by default

### DIFF
--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -273,6 +273,7 @@ fn build_options(
         markdown_summary: None,
         include_improvements: true,
         include_inactive: false,
+        include_ghosts: true,
         verbose: false,
         timing,
     }

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -53,9 +53,12 @@ New per-series logic must be side-effect-free. Flow and rationale: [`docs/analyz
 (`list.rs`, `prune.rs`, `examine.rs`, each `pub(crate) mod`; `bless`/`unbless` in `bless.rs`
 reuse the same facet selection). **A selection parameter added to one must be added to all
 four** unless genuinely inapplicable. The analysis-only flags
-(`--include-improvements`, `--include-inactive`) and the analyze-only condensed
-`--markdown-summary` output are **not** part of the lockstep — only `analyze` detects;
-`list`/`prune`/`examine` reuse the selection but never analyze. Each is
+(`--include-improvements`, `--include-inactive`, `--include-ghosts`) and the
+analyze-only condensed `--markdown-summary` output are **not** part of the lockstep —
+only `analyze` detects; `list`/`prune`/`examine` reuse the selection but never analyze.
+`--include-ghosts` in particular changes only *which reconstructed series are detected
+on* (it drops benchmarks absent at the context commit), not which runs are *selected*,
+so `list runs` may report more series than `analyze` now analyzes. Each is
 generic over the `GitHistory` + `Storage` ports so tests drive it with fakes + `block_on`.
 Semantics and per-command behaviour: DESIGN §7–§8.
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -443,6 +443,20 @@ widen as history accumulates. Positional prefix subjects scope the analysis to b
 whose id starts with a prefix; there is no metric filter, since metrics are an internal
 detail users are not expected to know.
 
+By default `analyze` also drops **ghost benchmarks** — benchmark identities that appear in
+the selected data set but have no run at the **context commit** (the resolved `--context`,
+`HEAD` by default). In a long-lived project benchmarks are renamed, removed, or replaced, and
+re-flagging a change on a benchmark that no longer exists is noise; presence is judged
+per discriminant set (a set behind on collection at the context commit legitimately differs
+from another) and a present benchmark keeps all its metric-kind series. The filter runs
+before detection, so ghosts never contribute p-values to the false-discovery-rate correction.
+`--include-ghosts` opts back in and analyzes every benchmark in the data set. If a set has no
+runs at the context commit at all (`HEAD` was never collected, a collect failed, or `--until`
+excluded the tip), every benchmark is a ghost and the set analyzes empty with a dedicated
+hint pointing at `--include-ghosts` — an empty outcome the tool explains rather than guesses
+around. Because it changes only which reconstructed series are detected on (not which runs
+are selected), `--include-ghosts` is analyze-only and outside the selection lockstep (§8.5).
+
 Output toggles select which renderings one analysis pass emits — text to stdout by default,
 with file toggles that compose so a single pass can emit text, Markdown, and JSON at once;
 requesting no output at all is an error. Beyond those three canonical renderings, `analyze`
@@ -749,7 +763,12 @@ or two branch points, which is why the techniques differ by mode:
 
 Modes apply to `analyze` only; `list`, `prune`, and `examine` reuse the same data-set
 *selection* but never analyze, so the mode selection and improvement/inactive flags are
-analyze-only and not part of the selection lockstep.
+analyze-only and not part of the selection lockstep. The **ghost filter** (§7.3) is likewise
+analyze-only and outside the lockstep: it applies in both modes, dropping — before detection
+— any benchmark absent at the context commit (the analyzed tip) unless `--include-ghosts` is
+passed. In branch mode a benchmark removed on the branch is a ghost and a benchmark newly
+added on the branch is present and kept; dirty snapshots at the branch tip count as present
+via the base-tip dirty exception.
 
 ### 8.6 Re-baselining: blessings and resolved spikes
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -27,14 +27,20 @@ reactor-free and unchanged under Miri while still scaling on real hardware.
 flowchart TD
   EXEC["analyze"] --> SD["select data set (the load)"]
   SD --> DS[("series + run tallies + blessings")]
-  DS --> AB["apply blessings (history re-baseline)"]
+  DS --> GF["drop ghost benchmarks\n(absent at context commit; unless --include-ghosts)"]
+  GF --> AB["apply blessings (history re-baseline)"]
   AB --> FC["detect changes (per series)"]
   FC --> SUM["per-set summaries"]
   SUM --> RENDER["render reports"]
 ```
 
 The cost is overwhelmingly in the **load** and secondarily in the **detect**; everything
-else is bookkeeping. Each analysis mode (`history`, `branch`) is a separate
+else is bookkeeping. The **ghost filter** between the load and detect is a cheap
+per-series pass: it drops every reconstructed series whose benchmark has no run at the
+context commit (the analyzed tip), so a benchmark that no longer exists is not re-flagged.
+It runs before blessings and detection so ghosts never enter the false-discovery
+correction; `--include-ghosts` skips it. Each analysis mode (`history`, `branch`) is a
+separate
 invocation with its own load — there is no dataset cache across modes — and the mode is
 auto-detected once per run from git topology.
 

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -741,9 +741,13 @@ async fn analyze_alloc_tracker_ignores_gaps_in_a_sparse_history() {
         day += 1;
     }
 
-    let report = workspace.drive_json(&["analyze"]).await;
     // Only `allocate_vec`'s allocated-bytes step is a finding. A gap read as a drop
     // to zero would manufacture wild swings; instead the series is contiguous.
+    //
+    // The sparse history ends on a `free_box` commit, so `allocate_vec` is absent at
+    // the tip and the default ghost filter would drop it. This test is about gap
+    // reconstruction, not tip presence, so it analyzes every benchmark.
+    let report = workspace.drive_json(&["analyze", "--include-ghosts"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["regressions"], 1,
@@ -1537,6 +1541,10 @@ async fn analyze_criterion_machine_keys_stay_isolated() {
             "x86_64-pc-windows-msvc",
             "--machine-key",
             "all",
+            // The flat machine stops collecting at d4 while the rising history runs to
+            // d8, so `mk-flat` is a ghost at the tip. This test is about machine-key
+            // isolation, not tip presence, so it analyzes every benchmark.
+            "--include-ghosts",
         ])
         .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1711,5 +1719,50 @@ async fn analyze_criterion_feature_branch_admits_dirty_snapshots() {
     assert_eq!(
         regressions, 0,
         "with --no-dirty only the flat clean Criterion series remains: {report}"
+    );
+}
+
+/// By default `analyze` ignores "ghost" benchmarks — ones no longer present at the
+/// context commit — so a regression on a since-removed benchmark is not re-flagged.
+/// `--include-ghosts` opts back in and the removed benchmark's regression surfaces.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_excludes_ghost_benchmarks_by_default() {
+    let workspace = Workspace::repo(&storage_only_config());
+    // `bench_000` runs flat through the tip; `bench_001` climbs into a regression but
+    // is dropped from the suite at the tip commit, so it is a ghost there.
+    for (date, label, values) in [
+        ("2024-01-01", "c1", vec![100.0, 100.0]),
+        ("2024-01-02", "c2", vec![100.0, 100.0]),
+        ("2024-01-03", "c3", vec![100.0, 100.0]),
+        ("2024-01-04", "c4", vec![100.0, 130.0]),
+        ("2024-01-05", "c5", vec![100.0, 130.0]),
+        ("2024-01-06", "c6", vec![100.0, 130.0]),
+    ] {
+        workspace.commit_dated(date, label);
+        workspace.seed_many_callgrind(label, &values);
+    }
+    // The tip carries only the surviving benchmark; `bench_001` is absent here.
+    workspace.commit_dated("2024-01-07", "c7");
+    workspace.seed_many_callgrind("c7", &[100.0]);
+
+    // Default: the ghost's regression is filtered out, and the JSON reports the count.
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(parsed["regressions"], 0, "{report}");
+    assert_eq!(parsed["ghosts_excluded"], 1, "{report}");
+    assert!(
+        !report.contains("many::bench_001"),
+        "the ghost benchmark must not appear: {report}"
+    );
+
+    // --include-ghosts analyzes the removed benchmark and surfaces its regression.
+    let report = workspace.drive_json(&["analyze", "--include-ghosts"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(parsed["regressions"], 1, "{report}");
+    assert_eq!(parsed["ghosts_excluded"], 0, "{report}");
+    assert!(
+        report.contains("many::bench_001"),
+        "the removed benchmark's regression must surface: {report}"
     );
 }

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1116,7 +1116,7 @@ impl Workspace {
     /// Seeds one Callgrind result set carrying one `Ir` benchmark per entry in
     /// `values` for the previously created commit `label`, all in the shared
     /// `x86_64`/`synthetic` partition.
-    fn seed_many_callgrind(&self, label: &str, values: &[f64]) {
+    pub(crate) fn seed_many_callgrind(&self, label: &str, values: &[f64]) {
         let commit_id = self.commit_id(label);
         let observed = self.committer_time(&commit_id);
         let key = format!(

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -17,8 +17,9 @@ use cbh_config::{
 };
 use cbh_detect::{
     AnalysisConfig, AnalysisContext, Series, SeriesFilter, apply_blessings, find_changes_spawned,
+    retain_present_at_context, short_commit,
 };
-use cbh_diag::{Reporter, ReporterExt, StderrReporter};
+use cbh_diag::{Reporter, ReporterExt, StderrReporter, count_noun};
 use cbh_git::{GitHistory, SystemGitHistory};
 use cbh_model::DiscriminantSet;
 use cbh_probe::{EnvironmentProbe, SystemProbe, resolve_machine_key};
@@ -195,6 +196,43 @@ where
     );
 
     let mut series = dataset.series;
+
+    // Ghost filtering (default): analyze only benchmarks that still exist at the
+    // context commit. A benchmark that appears only for past commits — renamed,
+    // removed, or replaced — is a "ghost"; re-flagging it is noise. Dropping
+    // ghosts *before* detection also keeps them out of the false-discovery-rate
+    // correction, so a removed benchmark cannot dilute the correction for real
+    // ones. `--include-ghosts` opts out and analyzes every benchmark in the data
+    // set. Presence is read from the raw points, independent of re-baselining.
+    let ghosts_excluded = if options.include_ghosts {
+        0
+    } else {
+        let ghost_started = Instant::now();
+        let ghosts = retain_present_at_context(&mut series, &dataset.tip_commit);
+        for (set, id) in &ghosts {
+            reporter.note_with(|| {
+                format!(
+                    "excluding benchmark {} from {set}: not present at the context commit {}",
+                    id.qualified(),
+                    short_commit(&dataset.tip_commit),
+                )
+            });
+        }
+        reporter.note_with(|| {
+            format!(
+                "ghost filter: excluded {} not present at the context commit {}; {} remain",
+                count_noun(ghosts.len(), "ghost benchmark"),
+                short_commit(&dataset.tip_commit),
+                count_noun(series.len(), "series"),
+            )
+        });
+        reporter.timing(
+            "ghost filter (retain_present_at_context)",
+            ghost_started.elapsed(),
+        );
+        ghosts.len()
+    };
+
     // Re-baseline blessed series before detection (history mode only; branch
     // mode carries an empty blessing map).
     let rebaseline_started = Instant::now();
@@ -245,13 +283,21 @@ where
     // When stored runs existed but none entered the analysis, the empty outcome is
     // otherwise indistinguishable from "no data". Explain the dominant reasons so
     // the user can act without resorting to `--verbose`.
-    let hint = empty_history_hint(
-        dataset.run_index.is_empty(),
-        dataset.candidate_count,
-        &dataset.target_ref,
-        dataset.tally,
-        &dataset.facets,
-    );
+    //
+    // The ghost filter is a distinct empty case: runs *did* load and analyze, but
+    // every benchmark was dropped as a ghost. `empty_history_hint` keys off an
+    // empty load and stays silent here, so name the ghost case on its own.
+    let hint = if ghosts_excluded > 0 && series.is_empty() {
+        Some(all_ghosts_hint(&dataset.tip_commit))
+    } else {
+        empty_history_hint(
+            dataset.run_index.is_empty(),
+            dataset.candidate_count,
+            &dataset.target_ref,
+            dataset.tally,
+            &dataset.facets,
+        )
+    };
 
     // Admitting a dirty snapshot on the base branch's tip is a courtesy for the
     // "evaluating the tool" / "accidentally working on the base branch" cases; warn
@@ -274,6 +320,7 @@ where
         sets: &summaries,
         hint: hint.as_deref(),
         warning: warning.as_deref(),
+        ghosts_excluded,
     };
     let render_started = Instant::now();
     let rendered = request.render_analyze(
@@ -283,6 +330,20 @@ where
     reporter.timing("report render", render_started.elapsed());
 
     Ok((rendered, regressions))
+}
+
+/// The empty-outcome hint for the all-ghosts case: runs loaded and analyzed, but
+/// the ghost filter dropped every benchmark because none is present at the context
+/// commit. Distinct from [`empty_history_hint`], which speaks only to an empty load.
+fn all_ghosts_hint(tip_commit: &str) -> String {
+    format!(
+        "Runs were analyzed, but every benchmark was filtered as a ghost — none is \
+         present at the context commit {}. This usually means the context commit has \
+         no stored runs (collect at the context commit) or its benchmark set differs \
+         from history. Pass --include-ghosts to analyze every benchmark, including \
+         removed ones.",
+        short_commit(tip_commit)
+    )
 }
 
 #[cfg(test)]
@@ -514,6 +575,18 @@ mod tests {
 
     fn options() -> AnalyzeOptions {
         AnalyzeOptions::default()
+    }
+
+    /// Options that also analyze ghost benchmarks — ones absent at the context
+    /// commit. Several counting/faceting fixtures seed history that stops short of
+    /// the `linear_git` tip (`c3` carries no runs), so the default ghost filter
+    /// would empty the analysis; these tests exercise loading and tallying over the
+    /// full data set, not tip-presence, so they opt the filter off.
+    fn ghost_options() -> AnalyzeOptions {
+        AnalyzeOptions {
+            include_ghosts: true,
+            ..AnalyzeOptions::default()
+        }
     }
 
     /// A fixed clock anchor for the history-mode default `--since` window in unit
@@ -934,7 +1007,7 @@ mod tests {
         }
 
         let git = linear_git();
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &ghost_options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let sets = parsed["sets"].as_array().unwrap();
@@ -952,6 +1025,106 @@ mod tests {
             .unwrap();
         assert_eq!(set_b["runs"], 2, "{report}");
         assert_eq!(set_b["series"], 1, "{report}");
+    }
+
+    /// A stored result set naming several benchmarks, each carrying one `Ir` metric,
+    /// so one commit's object can present or omit specific benchmarks — the shape a
+    /// ghost (a benchmark that disappears before the tip) needs.
+    fn multi_bench(effective: i64, commit: &str, benches: &[(&str, f64)]) -> Run {
+        let time = ts(effective);
+        let context = RunContext::new(
+            time,
+            GitInfo {
+                commit: Some(commit.to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let records = benches
+            .iter()
+            .map(|(name, value)| {
+                BenchmarkResult::new(
+                    BenchmarkId::new(nonempty![(*name).to_owned()]),
+                    vec![Metric::new(MetricKind::InstructionCount, *value)],
+                )
+            })
+            .collect::<Vec<_>>();
+        Run::new(context, records)
+    }
+
+    #[test]
+    fn a_ghost_benchmark_is_excluded_by_default_and_kept_with_the_flag() {
+        // `kept` is measured through the tip (c0..c3); `ghost` disappears after c2.
+        // The tip is c3, so `ghost` is no longer part of the current suite there.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &multi_bench(0, "c0", &[("kept", 100.0), ("ghost", 100.0)]),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &multi_bench(1, "c1", &[("kept", 100.0), ("ghost", 100.0)]),
+        );
+        store(
+            &storage,
+            &clean_key("c2"),
+            &multi_bench(2, "c2", &[("kept", 100.0), ("ghost", 100.0)]),
+        );
+        store(
+            &storage,
+            &clean_key("c3"),
+            &multi_bench(3, "c3", &[("kept", 100.0)]),
+        );
+        let git = linear_git();
+
+        // Default: the ghost is filtered out before detection, and the verbose trail
+        // names it and the context commit it is absent from.
+        let (report, _, reporter) = analyze_json(&git, &storage, "folo", &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["ghosts_excluded"], 1, "{report}");
+        assert_eq!(parsed["series"], 1, "only `kept` survives, {report}");
+        assert!(
+            reporter.contains("excluding benchmark ghost"),
+            "{:?}",
+            reporter.notes()
+        );
+        assert!(
+            reporter.contains("not present at the context commit c3"),
+            "{:?}",
+            reporter.notes()
+        );
+
+        // --include-ghosts analyzes both benchmarks and drops nothing.
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &ghost_options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["ghosts_excluded"], 0, "{report}");
+        assert_eq!(parsed["series"], 2, "both benchmarks analyzed, {report}");
+    }
+
+    #[test]
+    fn an_all_ghosts_analysis_emits_the_dedicated_hint() {
+        // Every benchmark disappears before the tip (data stops at c2, tip is c3), so
+        // the default filter empties the analysis. The empty outcome must read as an
+        // all-ghosts case, distinct from a bare "no data".
+        let storage = MemoryStorage::new();
+        store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
+        store(&storage, &clean_key("c1"), &ir_set(1, "c1", 100.0));
+        store(&storage, &clean_key("c2"), &ir_set(2, "c2", 100.0));
+        let git = linear_git();
+
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["ghosts_excluded"], 1, "{report}");
+        assert_eq!(parsed["series"], 0, "{report}");
+        assert_eq!(parsed["runs"], 3, "the runs still loaded, {report}");
+        let hint = parsed["hint"].as_str().unwrap_or_default();
+        assert!(hint.contains("filtered as a ghost"), "{report}");
+        assert!(hint.contains("--include-ghosts"), "{report}");
     }
 
     #[test]
@@ -1376,7 +1549,7 @@ mod tests {
 
         let opts = AnalyzeOptions {
             target_triple: vec!["x86_64-pc-windows-msvc".to_owned()],
-            ..options()
+            ..ghost_options()
         };
         let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1402,7 +1575,7 @@ mod tests {
 
         let opts = AnalyzeOptions {
             target_triple: vec!["x86_64-unknown-linux-gnu".to_owned()],
-            ..options()
+            ..ghost_options()
         };
         let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1425,7 +1598,7 @@ mod tests {
         );
         let git = linear_git();
 
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &ghost_options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["sets"].as_array().unwrap().len(), 2, "{report}");
     }

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -339,9 +339,9 @@ fn all_ghosts_hint(tip_commit: &str) -> String {
     format!(
         "Runs were analyzed, but every benchmark was filtered as a ghost — none is \
          present at the context commit {}. This usually means the context commit has \
-         no stored runs (collect at the context commit) or its benchmark set differs \
-         from history. Pass --include-ghosts to analyze every benchmark, including \
-         removed ones.",
+         no stored runs (collect at the context commit), a --until cutoff excluded the \
+         runs at the context commit, or its benchmark set differs from history. Pass \
+         --include-ghosts to analyze every benchmark, including removed ones.",
         short_commit(tip_commit)
     )
 }

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -470,6 +470,13 @@ struct AnalyzeCommand {
     #[arg(long, help_heading = HEADING_ANALYSIS)]
     include_inactive: bool,
 
+    /// Analyze every benchmark in the data set, including "ghosts" no longer
+    /// present at the context commit. By default only benchmarks measured at the
+    /// context commit (the current suite) are analyzed, so a renamed or removed
+    /// benchmark is not re-flagged.
+    #[arg(long, help_heading = HEADING_ANALYSIS)]
+    include_ghosts: bool,
+
     /// Also write a condensed Markdown summary — only the most significant findings
     /// — to this path (a relative path resolves against the working directory). The
     /// full `--markdown` report carries every finding; this summary is capped so a
@@ -500,6 +507,7 @@ impl AnalyzeCommand {
             markdown_summary: self.markdown_summary,
             include_improvements: self.include_improvements,
             include_inactive: self.include_inactive,
+            include_ghosts: self.include_ghosts,
             verbose: self.env.verbose,
             timing: false,
         }
@@ -1510,6 +1518,22 @@ mod tests {
             panic!("expected analyze command");
         };
         assert!(!options.include_inactive);
+    }
+
+    #[test]
+    fn analyze_parses_include_ghosts_switch() {
+        let Command::Analyze(options) = parse(&["analyze", "--include-ghosts"]) else {
+            panic!("expected analyze command");
+        };
+        assert!(options.include_ghosts);
+
+        let Command::Analyze(options) = parse(&["analyze"]) else {
+            panic!("expected analyze command");
+        };
+        assert!(
+            !options.include_ghosts,
+            "ghost filtering is on by default (the flag opts out of it)"
+        );
     }
 
     #[test]

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -208,6 +208,11 @@ pub struct AnalyzeOptions {
     /// state no longer reflects (a regression that later recovered). Hidden by
     /// default since they need no action.
     pub include_inactive: bool,
+    /// Analyze every benchmark found in the data set, including "ghosts" — ones
+    /// no longer present at the context commit. By default only benchmarks
+    /// measured at the context commit (the current suite) are analyzed, so a
+    /// renamed or removed benchmark is not re-flagged.
+    pub include_ghosts: bool,
     /// Emit detailed diagnostic notes to standard error describing each step.
     pub verbose: bool,
     /// Emit per-stage wall-clock timings to standard error, independent of

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -27,5 +27,5 @@ pub use run_points::{MetricPoint, ResultPoints, RunPoints};
 pub use selection::{SelectedCommit, select_commits};
 pub use series::{
     Blessing, BlessingPlacement, LoadedObject, Series, SeriesBuilder, SeriesFilter, SeriesPoint,
-    apply_blessings, build_series,
+    apply_blessings, build_series, retain_present_at_context,
 };

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -13,8 +13,8 @@
 //! a large history, so the storage key is reduced to a 4-byte ordinal and the
 //! per-point commit string is interned to a shared `Arc<str>` rather than cloned.
 
-use std::collections::HashMap;
 use std::collections::hash_map::Entry as MapEntry;
+use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
 use std::sync::Arc;
 
@@ -510,6 +510,61 @@ pub fn apply_blessings<S: BuildHasher>(
     }
 }
 
+/// Drops every series whose benchmark is not present at `context_commit`, keeping
+/// only the benchmarks the context commit actually measured.
+///
+/// Presence is evaluated per `(discriminant set, benchmark id)`: a benchmark is
+/// kept when at least one of its points was measured against `context_commit` — a
+/// clean run or a dirty snapshot on that commit — after which *all* of its
+/// metric-kind series are retained. A benchmark with points only on earlier commits
+/// is a "ghost" that no longer exists in the current suite; all of its series are
+/// removed so the detectors never re-flag a benchmark that is gone.
+///
+/// The check reads each series' raw points, so it is independent of any blessing
+/// re-baselining; call it *before* [`apply_blessings`]. When `context_commit` was
+/// itself never measured, every benchmark is a ghost and the whole list is emptied
+/// — the caller distinguishes that empty outcome for the user.
+///
+/// Returns the removed ghost benchmark identities, deduplicated across metric kinds
+/// and ordered by `(set, id)`, so a caller can report exactly what it excluded.
+#[must_use]
+pub fn retain_present_at_context(
+    series: &mut Vec<Series>,
+    context_commit: &str,
+) -> Vec<(DiscriminantSet, BenchmarkId)> {
+    // The benchmarks the context commit measured: a single series carrying a point
+    // on that commit marks its whole benchmark present, across every metric kind.
+    // Keyed by `(set, id)` so a benchmark present in one discriminant set does not
+    // rescue a same-named ghost in another — sets are analyzed independently.
+    let mut present: HashSet<(DiscriminantSet, BenchmarkId)> = HashSet::new();
+    for one in series.iter() {
+        let measured_here = one
+            .points
+            .iter()
+            .any(|point| point.commit.as_deref() == Some(context_commit));
+        if measured_here {
+            present.insert((one.set.clone(), one.id.clone()));
+        }
+    }
+
+    // Retain the present benchmarks and record each dropped ghost once (a benchmark
+    // spans several metric-kind series, so dedupe by identity).
+    let mut removed: HashSet<(DiscriminantSet, BenchmarkId)> = HashSet::new();
+    series.retain(|one| {
+        if present.contains(&(one.set.clone(), one.id.clone())) {
+            true
+        } else {
+            removed.insert((one.set.clone(), one.id.clone()));
+            false
+        }
+    });
+
+    // A stable, deterministic order for the diagnostics the caller emits.
+    let mut removed: Vec<(DiscriminantSet, BenchmarkId)> = removed.into_iter().collect();
+    removed.sort_unstable();
+    removed
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -942,6 +997,257 @@ mod tests {
             "an unrelated set leaves the series active from the start"
         );
         assert!(series[0].blessing.is_none(), "no blessing recorded");
+    }
+
+    /// A clean/dirty object at `commit` under `triple` whose run carries one
+    /// `InstructionCount` result per `(package, value)`, so several benchmarks share
+    /// one stored run exactly as a real `clean.json` holds a whole suite.
+    fn multi_object(
+        triple: &str,
+        commit: &str,
+        filename: &str,
+        observation: i64,
+        benches: &[(&str, f64)],
+    ) -> LoadedObject {
+        let object_key =
+            format!("v1/proj/objects/callgrind/{triple}/synthetic/{commit}/{filename}");
+        let context = RunContext::new(
+            ts(observation),
+            GitInfo {
+                commit: Some(format!("{commit}full")),
+                branch: Some("main".to_owned()),
+                dirty: filename != "clean.json",
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let records = benches
+            .iter()
+            .map(|(package, value)| {
+                BenchmarkResult::new(
+                    BenchmarkId::new(
+                        NonEmpty::from_vec(vec![
+                            (*package).to_owned(),
+                            "group".to_owned(),
+                            "case".to_owned(),
+                        ])
+                        .unwrap(),
+                    ),
+                    vec![Metric::new(MetricKind::InstructionCount, *value)],
+                )
+            })
+            .collect();
+        LoadedObject {
+            key: parse_key(&object_key).unwrap(),
+            object_key,
+            result: Run::new(context, records),
+        }
+    }
+
+    /// A clean object under the default triple.
+    fn clean_multi(commit: &str, observation: i64, benches: &[(&str, f64)]) -> LoadedObject {
+        multi_object(
+            "x86_64-unknown-linux-gnu",
+            commit,
+            "clean.json",
+            observation,
+            benches,
+        )
+    }
+
+    #[test]
+    fn retain_present_at_context_drops_a_benchmark_absent_at_the_context() {
+        // `pkgb` was measured at c0 but not at the context commit c1, so it is a
+        // ghost: every one of its series is removed, and `pkga` (present at c1)
+        // stays. The dropped identity is reported for diagnostics.
+        let objects = vec![
+            clean_multi("c0", 100, &[("pkga", 10.0), ("pkgb", 20.0)]),
+            clean_multi("c1", 200, &[("pkga", 11.0)]),
+        ];
+        let mut series = build_series(&objects, &order(&["c0", "c1"]), &SeriesFilter::default());
+        assert_eq!(
+            series.len(),
+            2,
+            "both benchmarks build a series before filtering"
+        );
+
+        let removed = retain_present_at_context(&mut series, "c1");
+
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].id.qualified(), "pkga/group/case");
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].1.qualified(), "pkgb/group/case");
+    }
+
+    #[test]
+    fn retain_present_at_context_keeps_every_metric_kind_of_a_present_benchmark() {
+        // The benchmark carried two metric kinds historically but only
+        // InstructionCount at the context commit. Presence is benchmark-level, so
+        // the ConditionalBranches series — which has no point at c1 — is retained
+        // because its benchmark is present, and nothing is reported as a ghost.
+        let objects = vec![
+            clean_metrics(
+                "c0",
+                100,
+                "pkga",
+                &[
+                    (MetricKind::InstructionCount, 10.0),
+                    (MetricKind::ConditionalBranches, 100.0),
+                ],
+            ),
+            clean_metrics("c1", 200, "pkga", &[(MetricKind::InstructionCount, 11.0)]),
+        ];
+        let mut series = build_series(&objects, &order(&["c0", "c1"]), &SeriesFilter::default());
+        assert_eq!(series.len(), 2, "one series per metric kind");
+
+        let removed = retain_present_at_context(&mut series, "c1");
+
+        assert_eq!(series.len(), 2, "both metric-kind series survive");
+        assert!(
+            removed.is_empty(),
+            "the benchmark is present, so nothing is a ghost"
+        );
+    }
+
+    /// A clean object whose single `package` result carries several metric kinds.
+    fn clean_metrics(
+        commit: &str,
+        observation: i64,
+        package: &str,
+        metrics: &[(MetricKind, f64)],
+    ) -> LoadedObject {
+        let object_key = format!(
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
+        );
+        let context = RunContext::new(
+            ts(observation),
+            GitInfo {
+                commit: Some(format!("{commit}full")),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let record = BenchmarkResult::new(
+            BenchmarkId::new(
+                NonEmpty::from_vec(vec![
+                    package.to_owned(),
+                    "group".to_owned(),
+                    "case".to_owned(),
+                ])
+                .unwrap(),
+            ),
+            metrics
+                .iter()
+                .map(|(kind, value)| Metric::new(*kind, *value))
+                .collect::<Vec<_>>(),
+        );
+        LoadedObject {
+            key: parse_key(&object_key).unwrap(),
+            object_key,
+            result: Run::new(context, vec![record]),
+        }
+    }
+
+    #[test]
+    fn retain_present_at_context_empties_when_the_context_has_no_runs() {
+        // c2 is an analyzed commit that carries no runs. Every benchmark is a ghost,
+        // so the list empties — the caller turns this into the "collect at the
+        // context commit / --include-ghosts" hint.
+        let objects = vec![
+            clean_multi("c0", 100, &[("pkga", 10.0)]),
+            clean_multi("c1", 200, &[("pkga", 11.0)]),
+        ];
+        let mut series = build_series(
+            &objects,
+            &order(&["c0", "c1", "c2"]),
+            &SeriesFilter::default(),
+        );
+
+        let removed = retain_present_at_context(&mut series, "c2");
+
+        assert!(series.is_empty(), "no benchmark is present at c2");
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].1.qualified(), "pkga/group/case");
+    }
+
+    #[test]
+    fn retain_present_at_context_is_evaluated_per_discriminant_set() {
+        // The same benchmark id exists under two triples. It is present at the
+        // context c1 in the linux set but only at c0 in the arm set, so it is kept
+        // in one set and dropped in the other — presence never leaks across sets.
+        let objects = vec![
+            multi_object(
+                "x86_64-unknown-linux-gnu",
+                "c0",
+                "clean.json",
+                100,
+                &[("pkga", 10.0)],
+            ),
+            multi_object(
+                "x86_64-unknown-linux-gnu",
+                "c1",
+                "clean.json",
+                200,
+                &[("pkga", 11.0)],
+            ),
+            multi_object(
+                "aarch64-unknown-linux-gnu",
+                "c0",
+                "clean.json",
+                100,
+                &[("pkga", 20.0)],
+            ),
+        ];
+        let mut series = build_series(&objects, &order(&["c0", "c1"]), &SeriesFilter::default());
+        assert_eq!(series.len(), 2, "one series per set");
+
+        let removed = retain_present_at_context(&mut series, "c1");
+
+        assert_eq!(
+            series.len(),
+            1,
+            "the arm-set ghost is dropped, the linux one kept"
+        );
+        assert_eq!(
+            series[0].points.len(),
+            2,
+            "the surviving series is the linux one (c0 + c1)"
+        );
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].1.qualified(), "pkga/group/case");
+        assert_ne!(
+            removed[0].0, series[0].set,
+            "the dropped ghost is in the other discriminant set"
+        );
+    }
+
+    #[test]
+    fn retain_present_at_context_admits_a_dirty_snapshot_at_the_context() {
+        // `pkga` exists at the context commit only as a dirty snapshot (the
+        // uncommitted-work case), which still counts as present; `pkgb`, seen only
+        // at c0, is the ghost.
+        let objects = vec![
+            clean_multi("c0", 100, &[("pkga", 10.0), ("pkgb", 20.0)]),
+            multi_object(
+                "x86_64-unknown-linux-gnu",
+                "c1",
+                "dirty-200.json",
+                200,
+                &[("pkga", 11.0)],
+            ),
+        ];
+        let mut series = build_series(&objects, &order(&["c0", "c1"]), &SeriesFilter::default());
+
+        let removed = retain_present_at_context(&mut series, "c1");
+
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].id.qualified(), "pkga/group/case");
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].1.qualified(), "pkgb/group/case");
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -551,10 +551,13 @@ pub fn retain_present_at_context(
     // spans several metric-kind series, so dedupe by identity).
     let mut removed: HashSet<(DiscriminantSet, BenchmarkId)> = HashSet::new();
     series.retain(|one| {
-        if present.contains(&(one.set.clone(), one.id.clone())) {
+        // Clone the identity key once per series and reuse it for both the presence
+        // test and the removed-set insert, avoiding a second clone per ghost.
+        let key = (one.set.clone(), one.id.clone());
+        if present.contains(&key) {
             true
         } else {
-            removed.insert((one.set.clone(), one.id.clone()));
+            removed.insert(key);
             false
         }
     });

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -109,6 +109,12 @@ pub struct ReportInput<'a> {
     /// A warning shown when the analysis admitted dirty runs on the base branch's
     /// tip (the working-tree-dirty exception). Absent in the normal case.
     pub warning: Option<&'a str>,
+    /// How many benchmarks were dropped as "ghosts" — present only for past commits,
+    /// not at the context commit — before detection. Zero when `--include-ghosts`
+    /// disabled the filter or nothing was dropped. Carried for the JSON report so a
+    /// machine consumer sees that scoping happened; the text and Markdown reports
+    /// surface it only through the verbose trail and the empty-outcome hint.
+    pub ghosts_excluded: usize,
 }
 
 /// The JSON shape of a per-set slice.
@@ -227,6 +233,9 @@ struct JsonReport<'a> {
     regressions: usize,
     /// Number of flagged improvements.
     improvements: usize,
+    /// Benchmarks dropped as ghosts (present only for past commits, not at the
+    /// context commit) before detection. Zero when `--include-ghosts` was passed.
+    ghosts_excluded: usize,
     /// A diagnostic hint when stored runs existed but none were analyzed.
     #[serde(skip_serializing_if = "Option::is_none")]
     hint: Option<&'a str>,
@@ -807,6 +816,7 @@ fn render_json(input: &ReportInput<'_>) -> String {
         series: input.series,
         regressions: count_top(input.findings, Direction::Regression),
         improvements: count_top(input.findings, Direction::Improvement),
+        ghosts_excluded: input.ghosts_excluded,
         hint: input.hint,
         warning: input.warning,
         findings: input
@@ -975,6 +985,7 @@ mod tests {
             sets: summaries,
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         }
     }
 
@@ -996,6 +1007,7 @@ mod tests {
             sets: &[],
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         }
     }
 
@@ -1226,6 +1238,7 @@ mod tests {
             sets: &[],
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Text, false);
         assert!(report.contains("Analyzed project folo"), "{report}");
@@ -1249,6 +1262,7 @@ mod tests {
             sets: &[],
             hint: Some("Found 2 stored runs ... dirty snapshots"),
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Text, false);
         assert!(report.contains("No notable changes detected."), "{report}");
@@ -1319,6 +1333,7 @@ mod tests {
             sets: &summaries,
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Text, false);
         // The per-set counts line carries the set's own tallies, distinct from the
@@ -1527,6 +1542,7 @@ mod tests {
             sets: &[],
             hint: Some("Found 2 stored runs ... commit your working tree"),
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Markdown, false);
         assert!(report.contains("No notable changes detected."), "{report}");
@@ -1549,6 +1565,7 @@ mod tests {
             sets: &[],
             hint: Some("dirty snapshots on base-branch commits"),
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Json, false);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1596,6 +1613,7 @@ mod tests {
             sets: &[],
             hint: None,
             warning: Some("Warning: dirty runs were included."),
+            ghosts_excluded: 0,
         };
         let text = render(&input, ReportFormat::Text, false);
         assert!(text.contains("No notable changes detected."), "{text}");
@@ -1621,6 +1639,7 @@ mod tests {
             sets: &[],
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Json, false);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1696,6 +1715,7 @@ mod tests {
             sets: &[],
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         };
 
         let text = render(&input, ReportFormat::Text, false);
@@ -1961,6 +1981,7 @@ mod tests {
             sets: &summaries,
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Text, false);
         assert!(report.contains("drift"), "{report}");
@@ -2004,6 +2025,7 @@ mod tests {
             sets: &summaries,
             hint: None,
             warning: None,
+            ghosts_excluded: 0,
         };
         let report = render(&input, ReportFormat::Markdown, false);
         assert!(report.contains("drift"), "{report}");


### PR DESCRIPTION
[Copilot speaking]

## Problem

`cargo-bench-history analyze` reconstructs a per-`(discriminant set, benchmark, metric)` series from git topology and detects notable changes. It previously analyzed **every** benchmark found anywhere in the selected data set — including benchmarks that no longer exist in the current suite. In a long-lived project benchmarks are renamed, removed, or replaced, so re-flagging a change on a benchmark that is gone is noise.

## Change

By default, `analyze` now analyzes only benchmarks **present at the context commit** (the resolved `--context`, `HEAD` by default). Benchmarks that appear only for past commits ("ghosts") are dropped **before** detection — so they also never enter the Benjamini–Hochberg false-discovery correction and cannot dilute it for real benchmarks. Presence is judged per `(discriminant set, benchmark id)`; a present benchmark keeps all its metric-kind series.

A new `--include-ghosts` flag opts back into analyzing every benchmark in the data set. It is analyze-only and outside the analyze/list/prune/examine selection lockstep — it changes *which reconstructed series are detected on*, not *which runs are selected*.

### Empty context commit

If a set has no runs at the context commit at all (e.g. `HEAD` was never collected, a collect failed, or `--until` excluded the tip), every benchmark is a ghost and the set analyzes empty — with a dedicated hint pointing at `--include-ghosts`, distinct from the existing empty-load hint. This matches the tool's "explain empty outcomes, never guess" philosophy.

## Implementation

- **cbh_detect**: pure, Miri-safe `retain_present_at_context` filter (+ unit tests).
- **cbh_command / cbh_cli**: `AnalyzeOptions.include_ghosts` and the `--include-ghosts` flag.
- **cbh_analyze**: apply the filter (gated on the flag) after the load and before blessings/detection, with a per-ghost verbose trail and the all-ghosts empty-outcome hint.
- **cbh_render**: a top-level `ghosts_excluded` JSON count so a machine consumer sees that scoping happened.
- **Docs**: DESIGN §7.3/§8.5, `docs/analyze.md` flow, and the AGENTS "Selection lockstep" note.
- **Tests**: unit (cbh_detect), orchestration (cbh_analyze pipeline), CLI parse, and an integration test. Two existing integration tests whose synthetic histories end on a commit lacking the analyzed benchmark were opted into `--include-ghosts` (with comments) to preserve their original intent.

## Validation

Full package-scoped `just validate-local` on **both Windows and Linux (WSL)**: format, clippy, tests, docs, Miri, machete, release build, and mutation testing — all green, **0 missed mutants** (1099 tested, 961 caught, 138 unviable) on each platform.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 67414ff9-09bf-481b-9d4d-9a4f4622ca02