### PR TITLE
Remove --until flag from cargo-bench-history

### DIFF
--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -262,7 +262,6 @@ fn build_options(
         base: Some(base.to_owned()),
         no_dirty: false,
         since,
-        until: None,
         engine: vec!["all".to_owned()],
         target_triple: vec!["all".to_owned()],
         machine_key: vec!["all".to_owned()],

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -86,8 +86,8 @@ flowchart LR
 * **Observation timestamp** — every run carries a single wall-clock timestamp: when the
   benches ran and were stored. It is **provenance only** and never orders anything. It
   names dirty snapshot files so concurrent snapshots of one commit coexist. The
-  benchmarked commit's position on the timeline — and the basis for the `--since` /
-  `--until` window — is its committer date, read from the git graph at analyze time and
+  benchmarked commit's position on the timeline — and the basis for the `--since`
+  cutoff — is its committer date, read from the git graph at analyze time and
   never copied onto the run, so a rebase or amended date can never leave a stale
   timestamp behind. There is deliberately no "effective timestamp" concept and no
   timestamp override.
@@ -436,10 +436,14 @@ and the report ends with a warning that the data is ephemeral and suggests switc
 branch to persist history. The exception is limited to the tip and a flag overrides it.
 
 Series are ordered by git topology; runs on one commit sub-order clean-before-dirty, then
-by storage key. The `--since` / `--until` window drops whole runs by each commit's
+by storage key. The `--since` cutoff drops whole runs older than it by each commit's
 committer date (decided from topology before any out-of-window body is fetched); `--since`
 defaults to a six-month look-back uniformly, so a scheduled trend watch does not silently
-widen as history accumulates. Positional prefix subjects scope the analysis to benchmarks
+widen as history accumulates. The cutoff is deliberately one-sided: `--context` already
+anchors the newest edge of the timeline (its first-parent tip, the merge-base split, and the
+ghost-detection reference), so a symmetric `--until` would only re-trim that same edge by
+timestamp — a topology-first tool moves the tip with `--context` instead — and is therefore
+omitted. Positional prefix subjects scope the analysis to benchmarks
 whose id starts with a prefix; there is no metric filter, since metrics are an internal
 detail users are not expected to know.
 
@@ -451,8 +455,8 @@ per discriminant set (a set behind on collection at the context commit legitimat
 from another) and a present benchmark keeps all its metric-kind series. The filter runs
 before detection, so ghosts never contribute p-values to the false-discovery-rate correction.
 `--include-ghosts` opts back in and analyzes every benchmark in the data set. If a set has no
-runs at the context commit at all (`HEAD` was never collected, a collect failed, or `--until`
-excluded the tip), every benchmark is a ghost and the set analyzes empty with a dedicated
+runs at the context commit at all (`HEAD` was never collected or a collect failed),
+every benchmark is a ghost and the set analyzes empty with a dedicated
 hint pointing at `--include-ghosts` — an empty outcome the tool explains rather than guesses
 around. Because it changes only which reconstructed series are detected on (not which runs
 are selected), `--include-ghosts` is analyze-only and outside the selection lockstep (§8.5).
@@ -473,7 +477,7 @@ regression watch, a PR comment bot) reads that rather than the exit status.
 Regardless of `--verbose`, every query run (`analyze`, `list`, `prune`, `examine`) prints a
 one-line **effective-selection** summary to stderr — the engine, target-triple, and
 machine-key facets (each marked when auto-detected), the resolved base branch, and the
-`--since` / `--until` window — so the user always sees what was actually searched, not just
+`--since` cutoff — so the user always sees what was actually searched, not just
 what they typed. Two empty outcomes also explain themselves in the stdout report without
 verbose diagnostics: when facet-matching runs were stored but none entered the analysis the
 hint breaks down why, and when the effective (possibly auto-detected) partition holds no

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -56,7 +56,7 @@ in [`DESIGN.md`](DESIGN.md).
 flowchart TD
   subgraph P1["Phase 1 — key-only filtering (no payload fetched)"]
     L["list keys (one round-trip)"] --> KF["parse key + facet match"]
-    KF --> WF["history / dirty / since-until filters\n(commit time + topology)"]
+    KF --> WF["history / dirty / since filter\n(commit time + topology)"]
     WF --> SK["sort survivors by storage key\n→ assign each a global ordinal"]
   end
   SK --> P23
@@ -71,7 +71,7 @@ flowchart TD
 Design properties that make this both fast and deterministic:
 
 * **Phase 1 never fetches a payload.** History membership, base-side dirty admission, and
-  the `--since`/`--until` window are all decided from the *key* and git topology, so an
+  the `--since` cutoff are all decided from the *key* and git topology, so an
   excluded object costs zero round-trips.
 * **Ordering is fixed before parallelism.** Survivors are sorted by storage key and each is
   assigned a global ordinal *before* chunking, so the result never depends on which worker
@@ -208,7 +208,7 @@ keeping its own measurement clean.
 A third reporter channel runs **regardless of `--verbose`**: a single **effective-selection**
 line to standard error naming the facets actually queried — engine, target triple, and
 machine key, each tagged when it was auto-detected rather than typed — plus the resolved base
-branch and the `--since` / `--until` window. Auto-detection is convenient but invisible, and
+branch and the `--since` cutoff. Auto-detection is convenient but invisible, and
 this line makes it legible so a surprising result can be traced to *what* was searched before
 suspecting the data. It is one line by construction, so it neither buries the verbose notes
 nor perturbs the timing channel, and like both of them it stays on stderr to keep stdout a

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -142,7 +142,7 @@
 //! removed. When the context resolves onto the base branch itself, the whole
 //! selection *is* base-branch history, so the deletion is refused unless
 //! `--prune-base` confirms it. Narrow the selection with a facet, a `<commit>`
-//! argument, `--since`, or `--until`. `--dry-run` previews without deleting.
+//! argument, or `--since`. `--dry-run` previews without deleting.
 //!
 //! ## `examine`
 //!
@@ -186,12 +186,14 @@
 //!   (`--engine` defaults to every engine; `list discriminants` is a catalog and
 //!   defaults to every partition). The literal `all` removes the filter
 //!   for that dimension, e.g. `--machine-key all` spans every machine.
-//! * **Commit selection** (`--context`, `--base`, `--since`, `--until`) —
-//!   `--context` is the ref whose history is analyzed (default `HEAD`); `--base` is
-//!   the ref it branched from (default: the configured or detected default branch),
-//!   which determines the merge-base split. `--since`/`--until` bound the window by
-//!   each commit's **committer date** (read from git history) and accept an RFC 3339
-//!   timestamp, a `YYYY-MM-DD` date, or a relative duration such as `6 months ago`.
+//! * **Commit selection** (`--context`, `--base`, `--since`) — `--context` is the
+//!   ref whose history is analyzed (default `HEAD`); `--base` is the ref it branched
+//!   from (default: the configured or detected default branch), which determines the
+//!   merge-base split. Because `--context` already anchors the newest edge of the
+//!   timeline, `--since` is a one-sided cutoff: it bounds only the oldest commit to
+//!   include by that commit's **committer date** (read from git history) and accepts
+//!   an RFC 3339 timestamp, a `YYYY-MM-DD` date, or a relative duration such as
+//!   `6 months ago`.
 //! * **Data filtering** (`--no-dirty`) — exclude dirty snapshots.
 //!
 //! # Analyze modes

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -648,10 +648,10 @@ impl Workspace {
     /// at UTC midnight), on the current branch and returns its full commit ID, reusing the
     /// commit ID (without redating) if the label already exists.
     ///
-    /// Pinning the author and committer date lets the window tests exercise
-    /// `--since`/`--until`: `analyze`/`list` read each commit's committer timestamp
-    /// from git topology to decide the window before any object is fetched, so the
-    /// date stamped here governs how a seeded object behaves under the window.
+    /// Pinning the author and committer date lets the cutoff tests exercise
+    /// `--since`: `analyze`/`list` read each commit's committer timestamp
+    /// from git topology to decide the cutoff before any object is fetched, so the
+    /// date stamped here governs how a seeded object behaves under the cutoff.
     pub(crate) fn commit_dated(&self, date: &str, label: &str) -> String {
         if let Some(commit_id) = self.commits.borrow().get(label) {
             return commit_id.clone();

--- a/packages/cargo-bench-history/tests/cbh_integration/prune.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/prune.rs
@@ -297,38 +297,6 @@ async fn prune_dirty_since_only_removes_runs_on_or_after_the_cutoff() {
     );
 }
 
-/// `--until` removes only the runs on or before the cutoff: the mirror of `--since`,
-/// also reading object bodies to recover each run's commit time.
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn prune_dirty_until_only_removes_runs_on_or_before_the_cutoff() {
-    let workspace = Workspace::repo(&storage_only_config());
-    workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind("c1", 100.0);
-    workspace.checkout_new_branch("feature");
-    workspace.commit_dated("2024-01-02", "f1");
-    workspace.seed_dirty_callgrind("2024-01-02", "f1", 100.0);
-    workspace.commit_dated("2024-01-05", "f2");
-    workspace.seed_dirty_callgrind("2024-01-05", "f2", 200.0);
-
-    // Only the 2024-01-02 run is on or before the cutoff.
-    let message = workspace
-        .drive_json(&["prune", "--dirty", "--until", "2024-01-03"])
-        .await;
-    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
-    assert_eq!(parsed["totals"]["runs"], 1, "{message}");
-
-    // The later run survives the cutoff; only the on-or-before run was removed.
-    let message = workspace
-        .drive_json(&["prune", "--dirty", "--dry-run"])
-        .await;
-    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
-    assert_eq!(
-        parsed["totals"]["runs"], 1,
-        "the later run survived the cutoff: {message}"
-    );
-}
-
 /// The `--all` scope deletes clean *and* dirty runs (and their blessing sidecars)
 /// for the narrowed selection. A `<commit>` argument selecting one feature commit removes its
 /// clean and dirty runs while leaving the base-branch run intact.

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -22,9 +22,7 @@ use super::load::{
     RunIndex, WorkerFold, facet_filtered_candidates, fold_runs_chunked, load_objects_concurrently,
 };
 use super::selection::Selection;
-use super::window::{
-    WindowEdge, auto_mode, parse_until, resolve_since, since_cutoff_reason, window_excludes,
-};
+use super::window::{auto_mode, before_since_cutoff, resolve_since, since_cutoff_reason};
 use crate::AnalyzeError;
 
 /// The data an analysis (or listing) draws on, plus the bookkeeping needed to
@@ -192,13 +190,6 @@ where
             since_cutoff_reason(selection.since.is_some(), mode)
         )
     });
-    let until = parse_until(selection.until, now)?;
-    reporter.note_with(|| {
-        format!(
-            "until cutoff: {}",
-            until.map_or_else(|| "none".to_owned(), |until| until.to_string())
-        )
-    });
 
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
@@ -210,7 +201,6 @@ where
         since,
         selection.since.is_some(),
         mode,
-        until,
     ));
 
     // Tally why candidates do not enter the analysis, so a `0 runs` outcome can
@@ -220,13 +210,12 @@ where
     let mut excluded_outside_history = 0_usize;
     let mut excluded_dirty_base = 0_usize;
     let mut excluded_since = 0_usize;
-    let mut excluded_until = 0_usize;
 
     // Phase 1 — key-only filtering, in candidate order. Every exclusion that does
     // not need the object's payload runs here, before anything is fetched, so an
     // excluded candidate never costs a round-trip: history membership, base-side
-    // dirty admission, and the `--since`/`--until` window (decided from each
-    // commit's committer time, which git reports with the topology).
+    // dirty admission, and the `--since` cutoff (decided from each commit's
+    // committer time, which git reports with the topology).
     let phase1_started = Instant::now();
     let mut to_fetch: Vec<(String, StorageKey)> = Vec::new();
     for (key, parsed) in candidates {
@@ -256,28 +245,15 @@ where
             });
             continue;
         }
-        match window_excludes(commit_times.get(&parsed.commit).copied(), since, until) {
-            Some(WindowEdge::Since) => {
-                excluded_since = excluded_since.saturating_add(1);
-                reporter.note_with(|| {
-                    format!(
-                        "excluding {key}: commit {} is before the --since cutoff",
-                        parsed.commit
-                    )
-                });
-                continue;
-            }
-            Some(WindowEdge::Until) => {
-                excluded_until = excluded_until.saturating_add(1);
-                reporter.note_with(|| {
-                    format!(
-                        "excluding {key}: commit {} is after the --until cutoff",
-                        parsed.commit
-                    )
-                });
-                continue;
-            }
-            None => {}
+        if before_since_cutoff(commit_times.get(&parsed.commit).copied(), since) {
+            excluded_since = excluded_since.saturating_add(1);
+            reporter.note_with(|| {
+                format!(
+                    "excluding {key}: commit {} is before the --since cutoff",
+                    parsed.commit
+                )
+            });
+            continue;
         }
         to_fetch.push((key, parsed));
     }
@@ -356,8 +332,7 @@ where
     reporter.note_with(|| {
         format!(
             "{} entered the analysis ({excluded_outside_history} outside history, \
-         {excluded_dirty_base} dirty-on-base, {excluded_since} before --since, \
-         {excluded_until} after --until)",
+         {excluded_dirty_base} dirty-on-base, {excluded_since} before --since)",
             count_noun(run_index.total(), "object")
         )
     });
@@ -432,7 +407,6 @@ where
             outside_history: excluded_outside_history,
             dirty_base: excluded_dirty_base,
             since: excluded_since,
-            until: excluded_until,
         },
         included_dirty_base_exception,
         target_ref,
@@ -448,7 +422,7 @@ where
 
 /// Builds the always-on, one-line summary of a run's effective selection: the
 /// discriminant partition it searched (naming auto-detected facets), the base
-/// branch it split history against, and the resolved look-back window.
+/// branch it split history against, and the resolved look-back cutoff.
 ///
 /// Emitted to standard error regardless of `--verbose` so a plain run never hides
 /// a value it auto-detected or defaulted. `base_auto` marks the base as
@@ -461,7 +435,6 @@ fn effective_selection_summary(
     since: Option<Timestamp>,
     since_explicit: bool,
     mode: AnalysisMode,
-    until: Option<Timestamp>,
 ) -> String {
     let base = if base_auto {
         format!("base={base_name} (auto-detected)")
@@ -473,15 +446,12 @@ fn effective_selection_summary(
         since.map_or_else(|| "none".to_owned(), |since| since.to_string()),
         since_cutoff_reason(since_explicit, mode)
     );
-    let mut parts = vec![
+    [
         format!("selection: {}", describe_effective_facets(facets)),
         base,
         since,
-    ];
-    if let Some(until) = until {
-        parts.push(format!("until={until}"));
-    }
-    parts.join("; ")
+    ]
+    .join("; ")
 }
 
 /// How many facet-matching candidates were excluded, by reason.
@@ -493,8 +463,6 @@ pub(crate) struct ExclusionTally {
     dirty_base: usize,
     /// Effective time is before the `--since` cutoff.
     since: usize,
-    /// Effective time is after the `--until` cutoff.
-    until: usize,
 }
 
 /// Builds a diagnostic hint explaining an empty outcome, so a bare `0 runs` never
@@ -504,8 +472,8 @@ pub(crate) struct ExclusionTally {
 /// hint names the effective (possibly auto-detected) partition it searched — so an
 /// auto-detected target-triple / machine-key that simply does not match the stored
 /// data explains itself — and distinguishes a genuinely empty project from a
-/// missed partition. When runs matched the facets but topology or the window
-/// excluded them all, the hint breaks down the dominant exclusion reasons.
+/// missed partition. When runs matched the facets but topology or the `--since`
+/// cutoff excluded them all, the hint breaks down the dominant exclusion reasons.
 ///
 /// Returns `None` when at least one run was loaded.
 pub(crate) fn empty_history_hint(
@@ -565,12 +533,6 @@ pub(crate) fn empty_history_hint(
             count_noun(tally.since, "run")
         ));
     }
-    if tally.until > 0 {
-        lines.push(format!(
-            "  - {} newer than the --until cutoff.",
-            count_noun(tally.until, "run")
-        ));
-    }
     lines.push("Re-run with --verbose for a per-object explanation.".to_owned());
     Some(lines.join("\n"))
 }
@@ -599,7 +561,6 @@ mod tests {
             outside_history: 0,
             dirty_base: 0,
             since: 0,
-            until: 0,
         };
         let facets = unconstrained_facets();
         // Runs were actually loaded → no hint regardless of candidate count.
@@ -612,7 +573,6 @@ mod tests {
             outside_history: 2,
             dirty_base: 1,
             since: 4,
-            until: 0,
         };
         let hint = empty_history_hint(true, 7, "master", tally, &facets).unwrap();
         assert!(hint.contains("7 stored runs"), "{hint}");
@@ -633,40 +593,36 @@ mod tests {
             outside_history: 0,
             dirty_base: 3,
             since: 0,
-            until: 0,
         };
         let hint = empty_history_hint(true, 3, "master", dirty_only, &facets).unwrap();
         assert!(hint.contains("dirty (uncommitted-tree)"), "{hint}");
         assert!(!hint.contains("outside"), "{hint}");
         assert!(!hint.contains("--since cutoff"), "{hint}");
-        assert!(!hint.contains("--until cutoff"), "{hint}");
 
         // Only the outside-history reason is present here (dirty omitted).
         let outside_only = ExclusionTally {
             outside_history: 2,
             dirty_base: 0,
             since: 0,
-            until: 0,
         };
         let hint = empty_history_hint(true, 2, "master", outside_only, &facets).unwrap();
         assert!(hint.contains("outside master"), "{hint}");
         assert!(!hint.contains("dirty (uncommitted-tree)"), "{hint}");
         assert!(!hint.contains("--since cutoff"), "{hint}");
 
-        // Only the until reason is present here.
-        let until_only = ExclusionTally {
+        // Only the since reason is present here.
+        let since_only = ExclusionTally {
             outside_history: 0,
             dirty_base: 0,
-            since: 0,
-            until: 5,
+            since: 5,
         };
-        let hint = empty_history_hint(true, 5, "master", until_only, &facets).unwrap();
+        let hint = empty_history_hint(true, 5, "master", since_only, &facets).unwrap();
         assert!(
-            hint.contains("5 runs newer than the --until cutoff"),
+            hint.contains("5 runs older than the --since cutoff"),
             "{hint}"
         );
         assert!(!hint.contains("dirty (uncommitted-tree)"), "{hint}");
-        assert!(!hint.contains("--since cutoff"), "{hint}");
+        assert!(!hint.contains("outside"), "{hint}");
     }
 
     #[test]
@@ -675,7 +631,6 @@ mod tests {
             outside_history: 0,
             dirty_base: 0,
             since: 0,
-            until: 0,
         };
 
         // Unconstrained facets that matched nothing → a genuinely empty project.
@@ -720,7 +675,6 @@ mod tests {
             Some(since),
             false,
             AnalysisMode::History,
-            None,
         );
         assert!(
             summary.contains("target-triple=x86_64-pc-windows-msvc (auto-detected)"),
@@ -744,9 +698,8 @@ mod tests {
             target_triple: FacetFilter::All,
             machine_key: FacetFilter::All,
         };
-        let until = Timestamp::from_second(1_700_100_000).unwrap();
-        // Branch mode, explicit base, no default window: nothing is marked
-        // auto-detected and the until edge is shown when set.
+        // Branch mode, explicit base, no default cutoff: nothing is marked
+        // auto-detected.
         let summary = effective_selection_summary(
             &facets,
             "release",
@@ -754,7 +707,6 @@ mod tests {
             None,
             false,
             AnalysisMode::Branch,
-            Some(until),
         );
         assert!(summary.contains("engine=criterion"), "{summary}");
         assert!(summary.contains("target-triple=all"), "{summary}");
@@ -764,6 +716,5 @@ mod tests {
             summary.contains("no default look-back window outside history mode"),
             "{summary}"
         );
-        assert!(summary.contains(&format!("until={until}")), "{summary}");
     }
 }

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -52,7 +52,7 @@ pub(crate) struct ResolvedHistory {
     /// object whose commit is absent is outside the analyzed history.
     pub(crate) order: HashMap<String, usize>,
     /// Committer timestamp of each first-parent commit, for deciding the
-    /// `--since`/`--until` window from topology before any object is fetched. A
+    /// `--since` cutoff from topology before any object is fetched. A
     /// commit absent here has an unknown time and is treated as in-window.
     pub(crate) commit_times: HashMap<String, Timestamp>,
     /// Subject line of each first-parent commit that has one, for labeling

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -66,4 +66,4 @@ pub use prune::execute as prune;
 pub use report::RenderedReports;
 pub(crate) use report::ReportRequest;
 pub(crate) use selection::Selection;
-pub(crate) use window::{WindowEdge, parse_since, parse_until, window_excludes};
+pub(crate) use window::{before_since_cutoff, parse_since};

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -41,7 +41,7 @@ use crate::{AnalyzeError, RenderedReports, ReportRequest};
 /// `None` reads the runtime wall clock (`Clock::new_tokio`), while tests pass a
 /// frozen clock (`Clock::new_frozen_at`) so the anchor is deterministic. That
 /// single anchor drives both the history-mode default `--since` look-back and the
-/// resolution of any relative `--since`/`--until` duration, so the whole window is
+/// resolution of any relative `--since` duration, so the cutoff is
 /// deterministic under a frozen clock.
 ///
 /// Returns the rendered reports for the requested formats plus the regression
@@ -339,9 +339,9 @@ fn all_ghosts_hint(tip_commit: &str) -> String {
     format!(
         "Runs were analyzed, but every benchmark was filtered as a ghost — none is \
          present at the context commit {}. This usually means the context commit has \
-         no stored runs (collect at the context commit), a --until cutoff excluded the \
-         runs at the context commit, or its benchmark set differs from history. Pass \
-         --include-ghosts to analyze every benchmark, including removed ones.",
+        no stored runs (collect at the context commit), or its benchmark set differs \
+        from history. Pass --include-ghosts to analyze every benchmark, including \
+        removed ones.",
         short_commit(tip_commit)
     )
 }
@@ -455,8 +455,8 @@ mod tests {
 
     /// A linear master history `c0 - c1 - c2 - c3`, HEAD at the tip. Each commit
     /// carries committer time `ts(N)` for `cN`, matching the `effective`-second
-    /// convention the seeders use, so the topology-decided `--since`/`--until`
-    /// window can be exercised.
+    /// convention the seeders use, so the topology-decided `--since`
+    /// cutoff can be exercised.
     fn linear_git() -> FakeGitHistory {
         let mut git = FakeGitHistory::new();
         git.commit_at("c0", None, ts(0))
@@ -1647,30 +1647,6 @@ mod tests {
         let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 2, "only c2 and c3 are within the window");
-    }
-
-    #[test]
-    fn until_window_excludes_later_runs() {
-        let storage = MemoryStorage::new();
-        // c0..c3 at epoch seconds 0..3. `--until` epoch 1 keeps only c0 and c1.
-        for (index, value) in [100.0, 100.0, 130.0, 130.0].into_iter().enumerate() {
-            let commit = format!("c{index}");
-            let second = i64::try_from(index).unwrap();
-            store(
-                &storage,
-                &clean_key(&commit),
-                &ir_set(second, &commit, value),
-            );
-        }
-        let git = linear_git();
-
-        let opts = AnalyzeOptions {
-            until: Some("1970-01-01T00:00:01Z".to_owned()),
-            ..options()
-        };
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
-        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-        assert_eq!(parsed["runs"], 2, "only c0 and c1 are within the window");
     }
 
     #[test]

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -35,9 +35,9 @@ use serde::Serialize;
 use tick::Clock;
 
 use super::{
-    AutoFacets, DirtyTipPolicy, ReportFormat, ResolvedHistory, Selection, WindowEdge,
-    detect_auto_facets, facet_filtered_candidates, parse_since, parse_until, resolve_facets,
-    resolve_history, resolve_now, window_excludes,
+    AutoFacets, DirtyTipPolicy, ReportFormat, ResolvedHistory, Selection, before_since_cutoff,
+    detect_auto_facets, facet_filtered_candidates, parse_since, resolve_facets, resolve_history,
+    resolve_now,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 
@@ -84,7 +84,7 @@ impl Scope {
 /// history, and orchestrate.
 ///
 /// `clock_override` injects the [`tick::Clock`] that anchors a relative
-/// `--since`/`--until` bound (see [`resolve_now`](super::resolve_now)); production
+/// `--since` bound (see [`resolve_now`](super::resolve_now)); production
 /// passes `None` for the runtime wall clock.
 // Thin real-adapter wiring: loads config from disk, builds the configured storage,
 // and shells out via `SystemGitHistory`/`detect_auto_facets` before delegating every
@@ -168,7 +168,6 @@ where
         options.json.as_deref(),
     )?;
     let since = parse_since(options.since.as_deref(), now)?;
-    let until = parse_until(options.until.as_deref(), now)?;
     let scope = Scope::from_options(options)?;
     let selection = Selection::from_prune(options);
 
@@ -284,25 +283,13 @@ where
             RunKind::Bless => unreachable!("blessings were partitioned out"),
         }
 
-        // The time window is a per-commit property — git's committer date — which
-        // topology already resolved with the rest of the history, so deciding it
-        // needs no object fetch.
-        if since.is_some() || until.is_some() {
-            match window_excludes(commit_times.get(&parsed.commit).copied(), since, until) {
-                Some(WindowEdge::Since) => {
-                    reporter.note_with(|| {
-                        format!("skipping {key}: its commit predates the --since cutoff")
-                    });
-                    continue;
-                }
-                Some(WindowEdge::Until) => {
-                    reporter.note_with(|| {
-                        format!("skipping {key}: its commit is after the --until cutoff")
-                    });
-                    continue;
-                }
-                None => {}
-            }
+        // The `--since` cutoff is a per-commit property — git's committer date —
+        // which topology already resolved with the rest of the history, so deciding
+        // it needs no object fetch.
+        if before_since_cutoff(commit_times.get(&parsed.commit).copied(), since) {
+            reporter
+                .note_with(|| format!("skipping {key}: its commit predates the --since cutoff"));
+            continue;
         }
 
         if kind == RunKind::Clean {
@@ -822,7 +809,7 @@ mod tests {
     }
 
     /// A feature history whose own commits carry committer dates, for the
-    /// `--since`/`--until` window tests. Branched off the base at `c1`:
+    /// `--since` cutoff tests. Branched off the base at `c1`:
     ///
     /// ```text
     /// master:  c0 - c1 - c2 - c3
@@ -848,7 +835,7 @@ mod tests {
     }
 
     /// A fixed analysis anchor for prune tests. These exercise absolute or
-    /// unset `--since`/`--until` windows, so the exact instant is immaterial; it
+    /// unset `--since` cutoffs, so the exact instant is immaterial; it
     /// only stands in for the clock reading `prune::execute` supplies in production.
     fn now() -> Timestamp {
         "2024-06-01T00:00:00Z"
@@ -1387,35 +1374,6 @@ mod tests {
         assert!(
             !remaining.contains(&dirty_key("f3", 30)),
             "f3 (committed at 300s) is after --since and removed"
-        );
-    }
-
-    #[test]
-    fn until_only_removes_commits_on_or_before_the_cutoff() {
-        let storage = MemoryStorage::new();
-        store(&storage, &dirty_key("f1", 10), &set("f1"));
-        store(&storage, &dirty_key("f2", 20), &set("f2"));
-        store(&storage, &dirty_key("f3", 30), &set("f3"));
-        let git = dated_feature_git();
-
-        let opts = PruneOptions {
-            until: Some("1970-01-01T00:03:00Z".to_owned()), // 180s
-            ..dirty_options()
-        };
-        prune(&storage, &git, &opts);
-
-        let remaining = keys(&storage);
-        assert!(
-            !remaining.contains(&dirty_key("f1", 10)),
-            "f1 (committed at 100s) is before --until and removed"
-        );
-        assert!(
-            !remaining.contains(&dirty_key("f2", 20)),
-            "f2 (committed exactly at the 180s cutoff) is removed (inclusive)"
-        );
-        assert!(
-            remaining.contains(&dirty_key("f3", 30)),
-            "f3 (committed at 300s) is after --until and kept"
         );
     }
 

--- a/packages/cbh_analyze/src/selection.rs
+++ b/packages/cbh_analyze/src/selection.rs
@@ -6,8 +6,8 @@ use cbh_command::{
 };
 
 /// The data-set selection parameters shared by the query commands: which stored
-/// objects to consider (facets + `--since` / `--until`) and how to resolve the git
-/// timeline (`--repo` is resolved by the caller into the [`GitHistory`] adapter;
+/// objects to consider (facets + `--since`) and how to resolve the git timeline
+/// (`--repo` is resolved by the caller into the [`GitHistory`] adapter;
 /// `--context` / `--base` / `--no-dirty` steer the topology query). Analyze's
 /// benchmark-prefix scope is deliberately *not* here: it filters which series are
 /// built, not which runs load.
@@ -21,7 +21,6 @@ pub(crate) struct Selection<'a> {
     pub(crate) base: Option<&'a str>,
     pub(crate) no_dirty: bool,
     pub(crate) since: Option<&'a str>,
-    pub(crate) until: Option<&'a str>,
     pub(crate) engine: &'a [String],
     pub(crate) target_triple: &'a [String],
     pub(crate) machine_key: &'a [String],
@@ -34,7 +33,6 @@ impl<'a> Selection<'a> {
             base: options.base.as_deref(),
             no_dirty: options.no_dirty,
             since: options.since.as_deref(),
-            until: options.until.as_deref(),
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
@@ -47,7 +45,6 @@ impl<'a> Selection<'a> {
             base: options.base.as_deref(),
             no_dirty: options.no_dirty,
             since: options.since.as_deref(),
-            until: options.until.as_deref(),
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
@@ -60,7 +57,6 @@ impl<'a> Selection<'a> {
             base: options.base.as_deref(),
             no_dirty: options.no_dirty,
             since: options.since.as_deref(),
-            until: options.until.as_deref(),
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
@@ -77,7 +73,6 @@ impl<'a> Selection<'a> {
             // `--clean`) decides which runs are actually removed.
             no_dirty: false,
             since: options.since.as_deref(),
-            until: options.until.as_deref(),
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
@@ -93,7 +88,6 @@ impl<'a> Selection<'a> {
             base: options.base.as_deref(),
             no_dirty: false,
             since: None,
-            until: None,
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,
@@ -107,7 +101,6 @@ impl<'a> Selection<'a> {
             base: options.base.as_deref(),
             no_dirty: false,
             since: None,
-            until: None,
             engine: &options.engine,
             target_triple: &options.target_triple,
             machine_key: &options.machine_key,

--- a/packages/cbh_analyze/src/window.rs
+++ b/packages/cbh_analyze/src/window.rs
@@ -1,6 +1,6 @@
-//! `--since` / `--until` window resolution: parsing the edges, deciding the
+//! `--since` cutoff resolution: parsing the lower-bound edge, deciding the
 //! history-mode default look-back, and testing each committer time against the
-//! resolved window.
+//! resolved cutoff.
 
 use cbh_detect::AnalysisMode;
 use jiff::civil::Date;
@@ -83,48 +83,22 @@ pub(crate) fn parse_since(
     parse_instant(value, "--since", now)
 }
 
-/// Parses the `--until` option into an absolute upper-bound instant, if set.
+/// Decides whether a commit's `committer_time` places it before the `--since`
+/// lower bound (an inclusive-on-or-after cutoff), matching the object-timestamp
+/// comparison the analysis used before topology carried the time.
 ///
-/// See [`parse_instant`] for the accepted input forms. `now` anchors a relative
-/// duration.
-pub(crate) fn parse_until(
-    value: Option<&str>,
-    now: Timestamp,
-) -> Result<Option<Timestamp>, AnalyzeError> {
-    parse_instant(value, "--until", now)
-}
-
-/// Which edge of the `--since`/`--until` window a commit falls outside of.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum WindowEdge {
-    /// The commit predates the `--since` lower bound.
-    Since,
-    /// The commit postdates the `--until` upper bound.
-    Until,
-}
-
-/// Decides whether a commit's `committer_time` places it outside the
-/// `--since`/`--until` window, reporting which edge it fell off.
-///
-/// `--since` is an inclusive-on-or-after lower bound and `--until` an
-/// inclusive-on-or-before upper bound, matching the object-timestamp comparison
-/// the analysis used before topology carried the time. A commit with an unknown
-/// time (`None`) is never excluded — git always reports a committer date for a
-/// real commit, so this only guards a degenerate input conservatively (by
-/// keeping the object and letting the rest of the pipeline judge it).
-pub(crate) fn window_excludes(
+/// A commit with an unknown time (`None`) is never excluded — git always reports a
+/// committer date for a real commit, so this only guards a degenerate input
+/// conservatively (by keeping the object and letting the rest of the pipeline
+/// judge it).
+pub(crate) fn before_since_cutoff(
     committer_time: Option<Timestamp>,
     since: Option<Timestamp>,
-    until: Option<Timestamp>,
-) -> Option<WindowEdge> {
-    let time = committer_time?;
-    if since.is_some_and(|since| time < since) {
-        return Some(WindowEdge::Since);
-    }
-    if until.is_some_and(|until| time > until) {
-        return Some(WindowEdge::Until);
-    }
-    None
+) -> bool {
+    let Some(time) = committer_time else {
+        return false;
+    };
+    since.is_some_and(|since| time < since)
 }
 
 /// Parses a time-cutoff option into an absolute instant, if set.
@@ -271,27 +245,17 @@ mod tests {
     }
 
     #[test]
-    fn window_excludes_decides_each_edge_from_committer_time() {
+    fn before_since_cutoff_decides_from_committer_time() {
         let since = Some(ts(10));
-        let until = Some(ts(20));
-        // Before the lower bound, after the upper bound, and inside the window.
-        assert_eq!(
-            window_excludes(Some(ts(5)), since, until),
-            Some(WindowEdge::Since)
-        );
-        assert_eq!(
-            window_excludes(Some(ts(25)), since, until),
-            Some(WindowEdge::Until)
-        );
-        assert_eq!(window_excludes(Some(ts(15)), since, until), None);
-        // Both bounds are inclusive: a commit exactly on an edge stays in-window.
-        assert_eq!(window_excludes(Some(ts(10)), since, until), None);
-        assert_eq!(window_excludes(Some(ts(20)), since, until), None);
-        // An open bound never excludes on that side.
-        assert_eq!(window_excludes(Some(ts(0)), None, until), None);
-        assert_eq!(window_excludes(Some(ts(99)), since, None), None);
-        // An unknown committer time is never excluded, even with both bounds set.
-        assert_eq!(window_excludes(None, since, until), None);
+        // Before the lower bound is excluded; on or after it stays in.
+        assert!(before_since_cutoff(Some(ts(5)), since));
+        assert!(!before_since_cutoff(Some(ts(15)), since));
+        // The bound is inclusive: a commit exactly on the edge stays in.
+        assert!(!before_since_cutoff(Some(ts(10)), since));
+        // An open bound never excludes.
+        assert!(!before_since_cutoff(Some(ts(0)), None));
+        // An unknown committer time is never excluded, even with a bound set.
+        assert!(!before_since_cutoff(None, since));
     }
 
     #[test]

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -281,11 +281,6 @@ struct TimelineArgs {
     /// a `YYYY-MM-DD` date, or a relative duration such as `6 months ago`.
     #[arg(long, value_name = "WHEN")]
     since: Option<String>,
-
-    /// Only consider commits made on or before this cutoff (same formats as
-    /// `--since`).
-    #[arg(long, value_name = "WHEN")]
-    until: Option<String>,
 }
 
 /// Per-format report output shared by `analyze`/`list`/`prune`.
@@ -496,7 +491,6 @@ impl AnalyzeCommand {
             base: self.timeline.base,
             no_dirty: self.no_dirty,
             since: self.timeline.since,
-            until: self.timeline.until,
             engine: self.facets.engine,
             target_triple: self.facets.target_triple,
             machine_key: self.facets.machine_key,
@@ -583,7 +577,6 @@ impl ListCommand {
             base: self.timeline.base,
             no_dirty: self.no_dirty,
             since: self.timeline.since,
-            until: self.timeline.until,
             engine: self.facets.engine,
             target_triple: self.facets.target_triple,
             machine_key: self.facets.machine_key,
@@ -646,7 +639,6 @@ impl ExamineCommand {
             base: self.timeline.base,
             no_dirty: self.no_dirty,
             since: self.timeline.since,
-            until: self.timeline.until,
             engine: self.facets.engine,
             target_triple: self.facets.target_triple,
             machine_key: self.facets.machine_key,
@@ -734,11 +726,6 @@ struct PruneCommitArgs {
     /// `YYYY-MM-DD` date, or a relative duration such as `6 months ago`.
     #[arg(long, value_name = "WHEN")]
     since: Option<String>,
-
-    /// Only prune commits made on or before this cutoff (same formats as
-    /// `--since`).
-    #[arg(long, value_name = "WHEN")]
-    until: Option<String>,
 }
 
 impl PruneCommand {
@@ -755,7 +742,6 @@ impl PruneCommand {
             base: self.commit_selection.base,
             commit: self.commit,
             since: self.commit_selection.since,
-            until: self.commit_selection.until,
             engine: self.facets.engine,
             target_triple: self.facets.target_triple,
             machine_key: self.facets.machine_key,
@@ -1441,7 +1427,7 @@ mod tests {
             "feature",
             "--base",
             "master",
-            "--until",
+            "--since",
             "2024-06-01T00:00:00Z",
             "--no-dirty",
             "--engine",
@@ -1459,7 +1445,7 @@ mod tests {
         assert_eq!(options.repo, Some(PathBuf::from("/work/folo")));
         assert_eq!(options.context.as_deref(), Some("feature"));
         assert_eq!(options.base.as_deref(), Some("master"));
-        assert_eq!(options.until.as_deref(), Some("2024-06-01T00:00:00Z"));
+        assert_eq!(options.since.as_deref(), Some("2024-06-01T00:00:00Z"));
         assert!(options.no_dirty);
         assert_eq!(
             options.engine,
@@ -1477,7 +1463,30 @@ mod tests {
         assert!(options.engine.is_empty());
         assert!(options.target_triple.is_empty());
         assert!(options.machine_key.is_empty());
-        assert!(options.until.is_none());
+        assert!(options.since.is_none());
+    }
+
+    #[test]
+    fn until_flag_is_rejected_after_removal() {
+        // `--until` was removed in favour of `--context` as the timeline's end, so
+        // every command that previously accepted it now rejects it as unknown.
+        for args in [
+            vec!["analyze", "--until", "2024-06-01"],
+            vec!["list", "runs", "--until", "2024-06-01"],
+            vec![
+                "examine",
+                "--benchmark",
+                "b",
+                "--metric",
+                "m",
+                "--until",
+                "2024-06-01",
+            ],
+            vec!["prune", "--dirty", "--until", "2024-06-01"],
+        ] {
+            let error = Cli::from_args(&["cargo-bench-history"], &args).unwrap_err();
+            assert!(error.status.is_err(), "{args:?} should reject --until");
+        }
     }
 
     #[test]
@@ -1640,8 +1649,6 @@ mod tests {
             "ci-pool",
             "--since",
             "2024-01-01",
-            "--until",
-            "2024-02-01",
             "--no-text",
             "--markdown",
             "examine.md",
@@ -1665,7 +1672,6 @@ mod tests {
         );
         assert_eq!(options.machine_key, vec!["ci-pool".to_owned()]);
         assert_eq!(options.since.as_deref(), Some("2024-01-01"));
-        assert_eq!(options.until.as_deref(), Some("2024-02-01"));
         assert!(options.no_text);
         assert_eq!(options.markdown, Some(PathBuf::from("examine.md")));
         assert_eq!(options.json, Some(PathBuf::from("examine.json")));
@@ -1791,8 +1797,6 @@ mod tests {
             "master",
             "--since",
             "2024-01-01T00:00:00Z",
-            "--until",
-            "2024-06-01T00:00:00Z",
             "--engine",
             "callgrind",
             "--target-triple",
@@ -1817,7 +1821,6 @@ mod tests {
             vec!["abc123".to_owned(), "def456".to_owned()]
         );
         assert_eq!(options.since.as_deref(), Some("2024-01-01T00:00:00Z"));
-        assert_eq!(options.until.as_deref(), Some("2024-06-01T00:00:00Z"));
         assert_eq!(options.engine, vec!["callgrind".to_owned()]);
         assert_eq!(
             options.target_triple,

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -1486,6 +1486,16 @@ mod tests {
         ] {
             let error = Cli::from_args(&["cargo-bench-history"], &args).unwrap_err();
             assert!(error.status.is_err(), "{args:?} should reject --until");
+            assert!(
+                error.output.contains("--until"),
+                "{args:?} error should name the rejected flag: {}",
+                error.output
+            );
+            assert!(
+                error.output.contains("unexpected argument"),
+                "{args:?} error should reject --until as an unexpected argument: {}",
+                error.output
+            );
         }
     }
 

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -173,8 +173,6 @@ pub struct AnalyzeOptions {
     pub no_dirty: bool,
     /// Only consider commits made on or after this cutoff, if set.
     pub since: Option<String>,
-    /// Only consider commits made on or before this cutoff, if set.
-    pub until: Option<String>,
     /// Restrict analysis to these engines (repeatable). Empty auto-detects every
     /// engine; the `all` keyword is an explicit synonym for no filter.
     pub engine: Vec<String>,
@@ -278,8 +276,6 @@ pub struct ListOptions {
     pub no_dirty: bool,
     /// Only consider commits made on or after this cutoff, if set.
     pub since: Option<String>,
-    /// Only consider commits made on or before this cutoff, if set.
-    pub until: Option<String>,
     /// Restrict the listing to these engines (repeatable). Empty auto-detects
     /// every engine; the `all` keyword is an explicit synonym for no filter.
     pub engine: Vec<String>,
@@ -334,8 +330,6 @@ pub struct ExamineOptions {
     pub no_dirty: bool,
     /// Only consider commits made on or after this cutoff, if set.
     pub since: Option<String>,
-    /// Only consider commits made on or before this cutoff, if set.
-    pub until: Option<String>,
     /// Restrict the examination to these engines (repeatable). Empty auto-detects
     /// every engine; the `all` keyword is an explicit synonym for no filter.
     pub engine: Vec<String>,
@@ -396,8 +390,6 @@ pub struct PruneOptions {
     pub commit: Vec<String>,
     /// Only prune commits made on or after this cutoff, if set.
     pub since: Option<String>,
-    /// Only prune commits made on or before this cutoff, if set.
-    pub until: Option<String>,
     /// Restrict removal to these engines (repeatable). Empty auto-detects every
     /// engine; the `all` keyword is an explicit synonym for no filter.
     pub engine: Vec<String>,

--- a/packages/cbh_git/src/git_history.rs
+++ b/packages/cbh_git/src/git_history.rs
@@ -20,11 +20,11 @@ use crate::process::capture;
 /// its subject line.
 ///
 /// `analyze` orders a series by first-parent topology and filters it by the
-/// `--since`/`--until` window. The window is a per-commit property — a commit's
+/// `--since` cutoff. The cutoff is a per-commit property — a commit's
 /// committer date — that topology alone decides, letting out-of-window objects be
 /// skipped before any stored object is fetched. `committer_time` is `None` only
 /// when `git` emitted an unparseable date, which a real commit never does; such a
-/// commit is treated as in-window (never excluded by the window).
+/// commit is treated as in-window (never excluded by the cutoff).
 ///
 /// `subject` is the commit's title (`git`'s `%s`), harvested on the same walk so
 /// `examine` can label each data point with what its commit changed. It is empty
@@ -67,7 +67,7 @@ pub trait GitHistory {
     ///
     /// This is the linear mainline of the ref — the timeline `analyze` orders a
     /// series by. Each commit carries its committer timestamp, which `analyze`
-    /// uses to apply the `--since`/`--until` window before fetching any object,
+    /// uses to apply the `--since` cutoff before fetching any object,
     /// and its subject line, which `examine` uses to label each data point.
     /// An unresolvable ref yields an empty list.
     fn first_parent(


### PR DESCRIPTION
[Copilot speaking]

## Why

`--until` and `--context` were largely duplicative. `--context` already defines the **end of the timeline**: it sets the tip of the first-parent walk, the merge-base split, *and* the ghost-detection reference commit. `--until` only trimmed the newest edge of the `[--since, --until]` window by committer timestamp *without* moving the context commit — a mostly-degenerate case the design already flagged ("if `--until` excludes the tip, every benchmark is a ghost and the set analyzes empty"). It added surface area and confusion for no capability `--context` doesn't already provide.

## What changed

Removed `--until` from all four query commands (`analyze`, `list`, `examine`, `prune`) to preserve the selection lockstep. `--since` stays everywhere it exists today.

The asymmetry is justified: `--since` bounds the *older* edge, which nothing else anchors (`--base` is topological, not time-based) and it carries the meaningful six-month default look-back in history mode. `--until` bounded the *newer* edge, which `--context` already anchors.

The only capability lost is timestamp-based (vs topological) trimming of the newest edge, which differs only in histories with non-monotonic committer dates — philosophically consistent with this topology-first tool.

Mechanically this collapses the two-edged window plumbing to a one-sided cutoff:
- `WindowEdge` enum + `window_excludes(...) -> Option<WindowEdge>` → `before_since_cutoff(...) -> bool`
- dropped `parse_until`, the `until` fields on the four options structs, `Selection.until`, and the `ExclusionTally.until` counter/hint branch

Docs updated: `cargo-bench-history` module docs, `docs/DESIGN.md` (§2, §7.3, effective-selection line — with the design rationale recorded), and `docs/analyze.md`. Tests updated: CLI parse tests now assert `--until` is rejected; the `--until`-specific unit/integration tests were removed (the mirror `--since` tests remain).

## Validation

- `just validate-local` (scoped to the affected packages) is green: format-check, clippy (zero warnings), build, unit + integration tests, docs, and mutation testing (634 caught, 0 missed).
- Confirmed `analyze --help` / `prune --help` no longer list `--until`, and that passing `--until` errors with "unexpected argument".

Note: `cbh_*` are internal, `#[doc(hidden)]` impl crates released in lockstep with the `cargo-bench-history` shell, so removing these fields is not an external API break.