### PR TITLE
Chart each examine timeseries before its points

### DIFF
--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -613,7 +613,7 @@ Markdown tables, not of the data. The text and Markdown renderings **lead each s
 same small line chart `analyze` draws**, reusing its renderer, so a maintainer sees the shape
 of the series before reading the points it pivots; because `examine` makes no
 regression/improvement judgment the line is **neutral (uncolored)** rather than
-direction-coloured, and it is drawn only when a set has at least two points. The JSON form
+direction-colored, and it is drawn only when a set has at least two points. The JSON form
 carries no chart (a charting concern the human reports draw from internally, not data a
 consumer reconstructs).
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -605,7 +605,13 @@ three output renderings compose from one pass as everywhere else: the per-commit
 stdout by default, the same table in Markdown, and a machine-readable JSON form that carries,
 per discriminant set, the ordered points with full-precision values and each commit's full
 title — the 50-character title truncation is a readability convenience of the text and
-Markdown tables, not of the data.
+Markdown tables, not of the data. The text and Markdown renderings **lead each set with the
+same small line chart `analyze` draws**, reusing its renderer, so a maintainer sees the shape
+of the series before reading the points it pivots; because `examine` makes no
+regression/improvement judgment the line is **neutral (uncolored)** rather than
+direction-coloured, and it is drawn only when a set has at least two points. The JSON form
+carries no chart (a charting concern the human reports draw from internally, not data a
+consumer reconstructs).
 
 ## 8. Analysis
 

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -101,11 +101,14 @@ async fn examine_renders_a_text_pivot_with_titles() {
         message.contains("c6"),
         "the tip's title is shown: {message}"
     );
-    // The series is charted before its data points (the rasciigraph axis marker).
-    assert!(
-        message.contains('┤') || message.contains('┼'),
-        "a chart leads the points: {message}"
-    );
+    // The series is charted before its data points: the rasciigraph axis marker
+    // appears ahead of the first point row (c1's title).
+    let axis = message
+        .find('┤')
+        .or_else(|| message.find('┼'))
+        .expect("a chart leads the points");
+    let first_point = message.find("c1").expect("the first point row is present");
+    assert!(axis < first_point, "a chart leads the points: {message}");
 }
 
 /// `examine` renders a per-set Markdown table with a row per observation.

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -102,12 +102,16 @@ async fn examine_renders_a_text_pivot_with_titles() {
         "the tip's title is shown: {message}"
     );
     // The series is charted before its data points: the rasciigraph axis marker
-    // appears ahead of the first point row (c1's title).
+    // appears ahead of the first point row. Match c1's title with its leading
+    // column gap and trailing newline so the short commit hash (which can contain
+    // "c1") cannot be mistaken for the point row.
     let axis = message
         .find('┤')
         .or_else(|| message.find('┼'))
         .expect("a chart leads the points");
-    let first_point = message.find("c1").expect("the first point row is present");
+    let first_point = message
+        .find("  c1\n")
+        .expect("the first point row is present");
     assert!(axis < first_point, "a chart leads the points: {message}");
 }
 
@@ -134,21 +138,18 @@ async fn examine_renders_a_markdown_table() {
         markdown.contains("# Data points for nm/nm::observe/pull"),
         "{markdown}"
     );
-    assert!(
-        markdown.contains("| Commit | Value | Kind | Title |"),
-        "the table header is present: {markdown}"
-    );
+    let table = markdown
+        .find("| Commit | Value | Kind | Title |")
+        .expect("the table header is present");
     assert!(markdown.contains("| clean | c1 |"), "{markdown}");
     assert!(markdown.contains("130"), "{markdown}");
     // The two-point series is charted, fenced as a `text` block before the table.
     assert!(
-        markdown.contains("```text"),
-        "the chart is fenced: {markdown}"
-    );
-    assert!(
         markdown.contains('┤') || markdown.contains('┼'),
         "a chart is drawn: {markdown}"
     );
+    let fence = markdown.find("```text").expect("the chart is fenced");
+    assert!(fence < table, "the chart precedes the table: {markdown}");
 }
 
 /// `examine` names one metric, isolating it from the other metrics recorded on the

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -101,6 +101,11 @@ async fn examine_renders_a_text_pivot_with_titles() {
         message.contains("c6"),
         "the tip's title is shown: {message}"
     );
+    // The series is charted before its data points (the rasciigraph axis marker).
+    assert!(
+        message.contains('┤') || message.contains('┼'),
+        "a chart leads the points: {message}"
+    );
 }
 
 /// `examine` renders a per-set Markdown table with a row per observation.
@@ -132,6 +137,15 @@ async fn examine_renders_a_markdown_table() {
     );
     assert!(markdown.contains("| clean | c1 |"), "{markdown}");
     assert!(markdown.contains("130"), "{markdown}");
+    // The two-point series is charted, fenced as a `text` block before the table.
+    assert!(
+        markdown.contains("```text"),
+        "the chart is fenced: {markdown}"
+    );
+    assert!(
+        markdown.contains('┤') || markdown.contains('┼'),
+        "a chart is drawn: {markdown}"
+    );
 }
 
 /// `examine` names one metric, isolating it from the other metrics recorded on the

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -922,10 +922,14 @@ mod tests {
 
         let report = examine(&storage, &git, &options());
         // The rasciigraph axis marker proves the neutral chart was drawn.
-        let axis = report.find('┤').or_else(|| report.find('┼'));
-        assert!(axis.is_some(), "a chart is drawn: {report}");
+        let axis = report
+            .find('┤')
+            .or_else(|| report.find('┼'))
+            .expect("a chart is drawn");
         // It leads the set: the chart precedes the first point row (the c0 title).
-        let first_point = report.find("Add the pull benchmark");
+        let first_point = report
+            .find("Add the pull benchmark")
+            .expect("the first point row is present");
         assert!(
             axis < first_point,
             "the chart precedes the points: {report}"

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -13,10 +13,12 @@
 //!
 //! It runs no detection, re-baselining, or blessing: it shows every selected point
 //! exactly as the chart would plot it (a commit's clean run and its dirty snapshots
-//! each contribute a flagged row, clean before dirty). Like `analyze` it needs a
-//! resolvable repository — first-parent topology to order the points and each
-//! commit's title to label them — and repeats the pivot once per matching
-//! discriminant set.
+//! each contribute a flagged row, clean before dirty). The text and Markdown
+//! renderings lead each set with the same small line chart `analyze` draws (reusing
+//! its renderer), neutral/uncolored since `examine` makes no regression/improvement
+//! judgment. Like `analyze` it needs a resolvable repository — first-parent topology
+//! to order the points and each commit's title to label them — and repeats the pivot
+//! once per matching discriminant set.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -36,8 +38,9 @@ use serde::Serialize;
 use tick::Clock;
 
 use super::{
-    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, detect_auto_facets,
-    dirty_base_exception_warning, empty_history_hint, format_value, resolve_now, select_dataset,
+    AutoFacets, ChartColor, ReportFormat, Selection, Series, SeriesFilter, chart,
+    detect_auto_facets, dirty_base_exception_warning, empty_history_hint, format_value,
+    resolve_now, select_dataset,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 
@@ -319,6 +322,14 @@ fn short_commit_id(commit_id: &str) -> &str {
     commit_id.get(..12).unwrap_or(commit_id)
 }
 
+/// The neutral line chart of a set's ordered values, drawn before its data points
+/// (the same chart `analyze` renders for a finding, but uncolored because `examine`
+/// makes no judgment). `None` when there are too few points to plot.
+fn chart_of_points(points: &[DataPoint]) -> Option<String> {
+    let values: Vec<f64> = points.iter().map(|point| point.value).collect();
+    chart(&values, ChartColor::Neutral, 0)
+}
+
 /// Renders the pivot in the requested format, appending the diagnostic hint and
 /// ephemeral-data warning (if any).
 fn render_pivot(
@@ -346,6 +357,14 @@ fn render_pivot_text(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
         for set in &pivot.sets {
             lines.push(String::new());
             lines.push(set.set.to_string());
+            // Lead the set with the same small line chart `analyze` draws, so a
+            // maintainer sees the shape of the series before reading the points it
+            // pivots. Neutral (uncolored) because `examine` makes no regression /
+            // improvement judgment.
+            if let Some(chart) = chart_of_points(&set.points) {
+                lines.push(chart);
+                lines.push(String::new());
+            }
             // Align the commit and value columns so a maintainer can read the values
             // straight down and spot where one jumps.
             let commit_width = set
@@ -387,6 +406,14 @@ fn render_pivot_markdown(pivot: &Pivot, hint: Option<&str>, warning: Option<&str
         for set in &pivot.sets {
             lines.push(String::new());
             lines.push(format!("## {}", set.set));
+            // The same neutral series chart the text pivot draws, fenced as a `text`
+            // block so it survives Markdown rendering (mirrors `analyze`).
+            if let Some(chart) = chart_of_points(&set.points) {
+                lines.push(String::new());
+                lines.push("```text".to_owned());
+                lines.push(chart);
+                lines.push("```".to_owned());
+            }
             lines.push(String::new());
             lines.push("| Commit | Value | Kind | Title |".to_owned());
             lines.push("| --- | --- | --- | --- |".to_owned());
@@ -871,6 +898,86 @@ mod tests {
             "{report}"
         );
         assert!(report.contains("| c0 | 100 | clean |"), "{report}");
+    }
+
+    #[test]
+    fn text_draws_a_neutral_chart_before_the_points() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        store(
+            &storage,
+            &clean_key("c2"),
+            &single_metric_run(2, "c2", 128.0),
+        );
+        let git = linear_git();
+
+        let report = examine(&storage, &git, &options());
+        // The rasciigraph axis marker proves the neutral chart was drawn.
+        let axis = report.find('┤').or_else(|| report.find('┼'));
+        assert!(axis.is_some(), "a chart is drawn: {report}");
+        // It leads the set: the chart precedes the first point row (the c0 title).
+        let first_point = report.find("Add the pull benchmark");
+        assert!(
+            axis < first_point,
+            "the chart precedes the points: {report}"
+        );
+        // A neutral chart carries no color (no ANSI escapes).
+        assert!(!report.contains('\u{1b}'), "no ANSI escape: {report:?}");
+    }
+
+    #[test]
+    fn markdown_fences_the_chart_before_the_table() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        let git = linear_git();
+
+        let report = examine_markdown(&storage, &git, &options());
+        let fence = report.find("```text").expect("the chart is fenced");
+        assert!(
+            report.contains('┤') || report.contains('┼'),
+            "a chart is drawn: {report}"
+        );
+        // The fenced chart precedes the per-set table.
+        let table = report
+            .find("| Commit | Value | Kind | Title |")
+            .expect("the table header is present");
+        assert!(fence < table, "the chart precedes the table: {report}");
+    }
+
+    #[test]
+    fn a_single_point_set_draws_no_chart() {
+        // A lone observation has too few points to plot, so no chart is drawn.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = linear_git();
+
+        let report = examine(&storage, &git, &options());
+        assert!(
+            !report.contains('┤') && !report.contains('┼'),
+            "no chart for a single point: {report}"
+        );
     }
 
     #[test]

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -49,7 +49,7 @@ mod window;
 
 pub use bless::{bless, unbless};
 pub(crate) use cbh_detect::{Series, SeriesFilter, apply_blessings};
-pub(crate) use cbh_render::{ReportFormat, format_value};
+pub(crate) use cbh_render::{ChartColor, ReportFormat, chart, format_value};
 pub(crate) use dataset::{empty_history_hint, select_dataset};
 pub use error::AnalyzeError;
 pub use examine::execute as examine;

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -593,10 +593,10 @@ impl From<Direction> for ChartColor {
 /// Renders a compact line chart of a finding's series values over commits, colored
 /// by direction. Returns `None` when there are too few points to plot.
 ///
-/// When `active_from` is past the start, the pre-blessing prefix is drawn greyed
-/// (the level that was re-baselined away) and the active window in the direction
-/// color, so the chart shows the full history while making clear which part the
-/// detector judged.
+/// When `active_from` falls in the series interior, the pre-blessing prefix is drawn
+/// greyed (the level that was re-baselined away) and the active window in the
+/// direction color, so the chart shows the full history while making clear which part
+/// the detector judged.
 fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) -> Option<String> {
     let values: Vec<f64> = series.iter().map(|point| point.value).collect();
     chart(&values, direction.into(), active_from)
@@ -634,12 +634,14 @@ fn chart_plan(color: ChartColor, len: usize, active_from: usize) -> ChartPlan {
 /// dimensions, colored per `color`. Returns `None` when there are fewer than two
 /// points (nothing to plot).
 ///
-/// When `color` names a direction and `active_from` is past the start, the
-/// pre-blessing prefix is drawn greyed and the active window in the line color, so
-/// the chart shows the full history while making clear which part the detector
-/// judged. A [`ChartColor::Neutral`] chart makes no judgment, so it always draws the
-/// whole series as a single uncolored line regardless of `active_from`; callers with
-/// no blessing pass `0`.
+/// When `color` names a direction and `active_from` falls in the series interior
+/// (`0 < active_from < values.len()`), the pre-blessing prefix is drawn greyed and
+/// the active window in the line color, so the chart shows the full history while
+/// making clear which part the detector judged. An `active_from` of `0` (everything
+/// active) or at/past the end (nothing active) draws the whole series as a single
+/// colored line. A [`ChartColor::Neutral`] chart makes no judgment, so it always draws
+/// the whole series as a single uncolored line regardless of `active_from`; callers
+/// with no blessing pass `0`.
 #[must_use]
 pub fn chart(values: &[f64], color: ChartColor, active_from: usize) -> Option<String> {
     if values.len() < 2 {

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -608,7 +608,7 @@ fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) ->
 /// Separating the decision from the drawing keeps it observable without going through
 /// `colored`'s process-global override (which the plotting functions consult), so the
 /// color/overlay choice can be asserted deterministically.
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 enum ChartPlan {
     /// A single uncolored line — a neutral chart that makes no judgment.
     Plain,

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -14,7 +14,7 @@ use std::num::NonZero;
 use cbh_detect::{Direction, Finding, FindingMethod, SeriesValue, short_commit};
 use cbh_model::{BenchmarkId, DiscriminantSet};
 use colored::{Color, Colorize};
-use rasciigraph::{Config, plot_colored, plot_many_colored};
+use rasciigraph::{Config, plot, plot_colored, plot_many_colored};
 use serde::Serialize;
 
 /// Height, in rows, of a history-mode finding chart.
@@ -554,6 +554,42 @@ fn active_window(values: &[f64], active_from: usize) -> Vec<f64> {
         .collect()
 }
 
+/// The line color of a rendered metric chart.
+///
+/// `analyze` colors a finding's chart by the direction of the detected change;
+/// `examine` makes no such judgment and draws a neutral line, so the color
+/// vocabulary lives here in the rendering crate rather than being borrowed from the
+/// detector's [`Direction`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChartColor {
+    /// A regression — the line is drawn in red.
+    Regression,
+    /// An improvement — the line is drawn in green.
+    Improvement,
+    /// No judgment — the line is drawn uncolored, in the terminal's default color.
+    Neutral,
+}
+
+impl ChartColor {
+    /// The `rasciigraph` line color, or `None` for a neutral (uncolored) line.
+    fn line_color(self) -> Option<Color> {
+        match self {
+            Self::Regression => Some(Color::Red),
+            Self::Improvement => Some(Color::Green),
+            Self::Neutral => None,
+        }
+    }
+}
+
+impl From<Direction> for ChartColor {
+    fn from(direction: Direction) -> Self {
+        match direction {
+            Direction::Regression => Self::Regression,
+            Direction::Improvement => Self::Improvement,
+        }
+    }
+}
+
 /// Renders a compact line chart of a finding's series values over commits, colored
 /// by direction. Returns `None` when there are too few points to plot.
 ///
@@ -563,28 +599,74 @@ fn active_window(values: &[f64], active_from: usize) -> Vec<f64> {
 /// detector judged.
 fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) -> Option<String> {
     let values: Vec<f64> = series.iter().map(|point| point.value).collect();
+    chart(&values, direction.into(), active_from)
+}
+
+/// The plotting strategy [`chart`] selects for a series, deciding how the line is
+/// colored before any characters are drawn.
+///
+/// Separating the decision from the drawing keeps it observable without going through
+/// `colored`'s process-global override (which the plotting functions consult), so the
+/// color/overlay choice can be asserted deterministically.
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+enum ChartPlan {
+    /// A single uncolored line — a neutral chart that makes no judgment.
+    Plain,
+    /// A single line drawn in one color: the whole series is active, so there is no
+    /// pre-blessing prefix to distinguish.
+    Solid(Color),
+    /// A greyed pre-blessing prefix overlaid with the color-drawn active window, so an
+    /// interior blessing boundary shows which part of the history the detector judged.
+    Split(Color),
+}
+
+/// Chooses how a `len`-point series colored per `color` with active window `active_from`
+/// is plotted. Only meaningful once the series has enough points to plot (see [`chart`]).
+fn chart_plan(color: ChartColor, len: usize, active_from: usize) -> ChartPlan {
+    match color.line_color() {
+        Some(line_color) if !covers_whole_series(active_from, len) => ChartPlan::Split(line_color),
+        Some(line_color) => ChartPlan::Solid(line_color),
+        None => ChartPlan::Plain,
+    }
+}
+
+/// Renders a compact line chart of `values` over commits at the report's fixed chart
+/// dimensions, colored per `color`. Returns `None` when there are fewer than two
+/// points (nothing to plot).
+///
+/// When `color` names a direction and `active_from` is past the start, the
+/// pre-blessing prefix is drawn greyed and the active window in the line color, so
+/// the chart shows the full history while making clear which part the detector
+/// judged. A [`ChartColor::Neutral`] chart makes no judgment, so it always draws the
+/// whole series as a single uncolored line regardless of `active_from`; callers with
+/// no blessing pass `0`.
+#[must_use]
+pub fn chart(values: &[f64], color: ChartColor, active_from: usize) -> Option<String> {
     if values.len() < 2 {
         return None;
     }
-    let line_color = match direction {
-        Direction::Regression => Color::Red,
-        Direction::Improvement => Color::Green,
-    };
     let config = Config::default()
         .with_height(CHART_HEIGHT)
         .with_width(CHART_WIDTH);
-    let chart = if covers_whole_series(active_from, values.len()) {
-        plot_colored(values, config.with_series_colors(vec![line_color])).to_string()
-    } else {
-        // Two overlaid series: the greyed pre-blessing prefix and the
-        // direction-colored active window. They share the boundary point so the
-        // line reads as continuous; `NaN` renders as a gap elsewhere.
-        let grey = grey_prefix(&values, active_from);
-        let active = active_window(&values, active_from);
-        let config = config.with_series_colors(vec![Color::BrightBlack, line_color]);
-        plot_many_colored(vec![grey, active], config).to_string()
+    let rendered = match chart_plan(color, values.len(), active_from) {
+        // A judged chart with an interior active window overlays two series: the
+        // greyed pre-blessing prefix and the direction-colored active window. They
+        // share the boundary point so the line reads as continuous; `NaN` renders as
+        // a gap elsewhere.
+        ChartPlan::Split(line_color) => {
+            let grey = grey_prefix(values, active_from);
+            let active = active_window(values, active_from);
+            let config = config.with_series_colors(vec![Color::BrightBlack, line_color]);
+            plot_many_colored(vec![grey, active], config).to_string()
+        }
+        ChartPlan::Solid(line_color) => {
+            plot_colored(values.to_vec(), config.with_series_colors(vec![line_color])).to_string()
+        }
+        // A neutral chart carries no color, so it plots uncolored and never depends
+        // on `colored`'s process-global override.
+        ChartPlan::Plain => plot(values.to_vec(), config),
     };
-    Some(chart.trim_end_matches('\n').to_owned())
+    Some(rendered.trim_end_matches('\n').to_owned())
 }
 
 fn render_markdown(input: &ReportInput<'_>) -> String {
@@ -1850,6 +1932,90 @@ mod tests {
         // A partial active window (active_from in the interior) overlays the greyed
         // pre-blessing prefix and the active tail as two series.
         assert!(chart_of(&series, Direction::Improvement, 1).is_some());
+    }
+
+    #[test]
+    fn chart_neutral_plots_uncolored_without_ansi() {
+        // A neutral chart carries no color, so it must not depend on `colored`'s
+        // override at all. Force it on to prove the neutral path never emits ANSI.
+        let _color = ColorOverride::force(true);
+        let chart = chart(&[1.0, 2.0, 3.0], ChartColor::Neutral, 0).expect("two-plus points plot");
+        // The rasciigraph axis marker proves a chart was drawn, and no escape byte
+        // proves the neutral line stayed uncolored.
+        assert!(chart.contains('┤') || chart.contains('┼'), "{chart}");
+        assert!(!chart.contains('\u{1b}'), "no ANSI escape: {chart:?}");
+    }
+
+    #[test]
+    fn chart_needs_at_least_two_points() {
+        let _color = ColorOverride::force(false);
+        // A single point cannot be plotted, in any color.
+        assert!(chart(&[1.0], ChartColor::Neutral, 0).is_none());
+        assert!(chart(&[1.0], ChartColor::Regression, 0).is_none());
+        // Two points is the minimum that plots.
+        assert!(chart(&[1.0, 2.0], ChartColor::Neutral, 0).is_some());
+    }
+
+    #[test]
+    fn chart_neutral_ignores_the_active_window() {
+        // A neutral chart makes no judgment, so an interior `active_from` still draws
+        // the whole series as one uncolored line rather than the greyed overlay.
+        let _color = ColorOverride::force(false);
+        let whole = chart(&[1.0, 2.0, 3.0], ChartColor::Neutral, 0).expect("plots");
+        let with_window = chart(&[1.0, 2.0, 3.0], ChartColor::Neutral, 1).expect("plots");
+        assert_eq!(
+            whole, with_window,
+            "neutral ignores active_from: {with_window:?}"
+        );
+    }
+
+    #[test]
+    fn chart_plan_draws_one_solid_line_when_the_whole_series_is_active() {
+        // Both boundaries `covers_whole_series` recognizes collapse to a single
+        // color-drawn line: nothing to grey at the start (`active_from == 0`) and
+        // nothing active at the end (`active_from >= len`). `Solid` (not `Split`)
+        // proves no greyed pre-blessing overlay is drawn.
+        assert_eq!(
+            chart_plan(ChartColor::Regression, 4, 0),
+            ChartPlan::Solid(Color::Red)
+        );
+        assert_eq!(
+            chart_plan(ChartColor::Regression, 4, 4),
+            ChartPlan::Solid(Color::Red)
+        );
+    }
+
+    #[test]
+    fn chart_plan_splits_an_interior_active_window() {
+        // An interior blessing boundary overlays the greyed pre-blessing prefix on the
+        // color-drawn active window, mapping each direction to its own line color.
+        assert_eq!(
+            chart_plan(ChartColor::Regression, 4, 2),
+            ChartPlan::Split(Color::Red)
+        );
+        assert_eq!(
+            chart_plan(ChartColor::Improvement, 4, 2),
+            ChartPlan::Split(Color::Green)
+        );
+    }
+
+    #[test]
+    fn chart_plan_is_plain_and_windowless_for_a_neutral_chart() {
+        // A neutral chart is always a single uncolored line, whatever the active window.
+        assert_eq!(chart_plan(ChartColor::Neutral, 4, 0), ChartPlan::Plain);
+        assert_eq!(chart_plan(ChartColor::Neutral, 4, 2), ChartPlan::Plain);
+    }
+
+    #[test]
+    fn chart_color_maps_each_direction() {
+        assert_eq!(
+            ChartColor::from(Direction::Regression),
+            ChartColor::Regression
+        );
+        assert_eq!(
+            ChartColor::from(Direction::Improvement),
+            ChartColor::Improvement
+        );
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## What

`cargo-bench-history examine` now renders a small line chart before the data points for each timeseries it emits (one per matching discriminant set), reusing `analyze`'s chart renderer to the maximum practical extent.

- **Text** and **Markdown** output lead each set with the chart (Markdown fences it as a ```` ```text ```` block, mirroring `analyze`).
- The chart is drawn only when a set has **≥ 2 points** (consistent with `analyze`).
- Because `examine` makes no regression/improvement judgment, the line is **neutral (uncolored)** — confirmed with the requester.
- **JSON** output is unchanged (charting is a presentation concern, not data).

## How

- `cbh_render` gains a public `chart(values, ChartColor, active_from)` entry point plus a `ChartColor` enum (`Regression` / `Improvement` / `Neutral`, with `From<Direction>`). The color/rendering deps stay confined to `cbh_render`.
- The finding-oriented `chart_of(...)` is reduced to a thin adapter over `chart`, so `analyze`'s colored output stays byte-identical.
- The plotting-strategy decision is split into a small `chart_plan(...)` returning a `ChartPlan` (`Plain` / `Solid` / `Split`). This separates the color/overlay choice from the drawing so it can be unit-tested deterministically, without depending on `colored`'s process-global override (which the plot functions consult and which races across the parallel test suite).
- `examine` builds each set's values and calls `chart(&values, ChartColor::Neutral, 0)`.

## Tests

- `cbh_render`: `chart_plan` unit tests pin each color/overlay decision at both `covers_whole_series` boundaries and an interior window; neutral-path tests prove the chart draws, carries no ANSI, and ignores `active_from`.
- `cbh_analyze` (`examine`): text/Markdown draw a neutral chart before the points and a single-point set draws none.
- `cargo-bench-history` integration tests assert the chart axis marker (and the Markdown fence) appear before the points.

## Validation

Format, clippy (dev + release), tests (nextest), doctests, docs, Miri, and scoped mutation testing (`cbh_render` + `cbh_analyze`, 0 missed) all pass. DESIGN.md §7.8 updated to describe the new behavior.