### PR TITLE
Mark PR benchmark comment stale when a new run starts

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -192,7 +192,9 @@ tracks.
 Because a full benchmark run takes hours and a new push *cancels* the in-flight one (see
 Concurrency), the comment on display can lag the PR tip by a long way, and a reader has no way to
 tell current numbers from hours-old ones. Two mechanisms keep that honest. First, every comment
-records **which commit it measured** — a human-visible short SHA plus a hidden full-SHA marker.
+records **which commit it measured** — a human-visible line printing the full SHA bare (GitHub
+autolinks it to the commit and abbreviates it for display, so we neither truncate it ourselves nor
+lose the click-through) plus a hidden full-SHA marker.
 Second, a lightweight **`mark-stale` job** runs at the *start* of each new run (right after the
 short delta preflight, in parallel with the multi-hour collect) and, if a comment already exists,
 prepends a warning banner stating how far behind `HEAD` those numbers now are — *"N commits behind

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -189,6 +189,22 @@ measured. A run *failure* surfaces only as the red check, with no issue and no f
 because a PR failure is a transient condition, not the persistent one the issue lifecycle
 tracks.
 
+Because a full benchmark run takes hours and a new push *cancels* the in-flight one (see
+Concurrency), the comment on display can lag the PR tip by a long way, and a reader has no way to
+tell current numbers from hours-old ones. Two mechanisms keep that honest. First, every comment
+records **which commit it measured** — a human-visible short SHA plus a hidden full-SHA marker.
+Second, a lightweight **`mark-stale` job** runs at the *start* of each new run (right after the
+short delta preflight, in parallel with the multi-hour collect) and, if a comment already exists,
+prepends a warning banner stating how far behind `HEAD` those numbers now are — *"N commits behind
+HEAD"*, or a numberless *"out of date"* when the two share no history (e.g. a force-push) or the
+marker is absent. The distance comes from the GitHub compare API (`ahead_by`), which needs no
+clone and still resolves a commit orphaned by a force-push; any inability to compute it degrades
+to the numberless wording rather than failing the run. The banner is bounded by a sentinel pair so
+a re-run *replaces* rather than stacks it, and the next completed analyze — which rewrites the body
+from scratch with a fresh analyzed-commit marker — drops it automatically once real new results
+land. `mark-stale` is gated on the same non-empty delta as collect, so it never races the cleanup
+path that *deletes* the comment when the PR no longer touches anything benchmarkable.
+
 Collection is **delta-scoped**: a preflight job diffs the PR against `main` and benchmarks only
 the touched packages, since re-measuring the whole workspace on every PR push would be
 wasteful. Analysis, by contrast, is deliberately **not** package-scoped — yet it stays correctly

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -27,8 +27,14 @@ concurrency:
 # by the `analyze` job (which posts/updates it) and the `cleanup` job (which deletes it when the PR
 # no longer touches any benchmarkable package). The comment module dedups solely on this marker, so
 # a single definition keeps the post and delete paths from drifting apart.
+#
+# PR_COMMIT_MARKER_PREFIX is the prefix of a SECOND hidden marker the `analyze` job embeds to record
+# which commit its numbers describe (`<prefix><full-sha> -->`). The `mark-stale` job parses that SHA
+# back out to measure how far the displayed results now lag HEAD. Defined here once so the writer
+# (analyze compose step) and the reader (mark-stale) cannot drift, mirroring PR_COMMENT_MARKER.
 env:
   PR_COMMENT_MARKER: "<!-- folo-bench-history-pr -->"
+  PR_COMMIT_MARKER_PREFIX: "<!-- folo-bench-history-commit:"
 
 jobs:
   # Compute which packages the PR touched (cargo-delta vs origin/main), filtered to the
@@ -95,6 +101,50 @@ jobs:
             "packages_json=$($output.PackagesJson)"
             "skip_all=$($output.SkipAll)"
           ) | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
+  # As soon as a new run is known to be collecting (the delta is non-empty), flag any existing rolling
+  # comment as STALE so a reader is not misled by hours-old numbers while the multi-hour collect+analyze
+  # runs. Deliberately lightweight - default (shallow) checkout + preinstalled gh + a direct module
+  # call, no build-env setup, no Azure, no full history - so the warning appears within minutes of the
+  # push (right after this short delta job), long before analyze rewrites the comment. It reads the
+  # analyzed-commit marker from the current comment and asks the GitHub compare API how far HEAD is
+  # ahead, which needs no clone and still resolves a commit orphaned by a force-push. Gated on
+  # skip_all != 'true' for the same reason collect is: when the PR now touches nothing benchmarkable the
+  # `cleanup` job DELETES the comment instead, and marking a comment about to be deleted would only race
+  # that delete. Runs in parallel with collect (both `needs: delta`).
+  mark-stale:
+    needs: delta
+    if: >-
+      always()
+      && github.repository == 'folo-rs/folo'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && needs.delta.outputs.skip_all != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # pull-requests to PATCH the rolling comment; contents so the compare API can read commit topology
+    # and the checkout can put the shared BenchHistoryComment module on disk (the marking logic lives
+    # there so it is unit-tested against a mocked gh, mirroring how analyze posts via the same module).
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        # Default shallow checkout is enough: the commits-behind count is computed server-side by the
+        # compare API, so no local history is walked here - only the module needs to be on disk.
+        uses: actions/checkout@v6
+
+      - name: Flag rolling PR comment as stale
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: ${{ env.PR_COMMENT_MARKER }}
+          COMMIT_MARKER_PREFIX: ${{ env.PR_COMMIT_MARKER_PREFIX }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: just gh-mark-pr-bench-history-stale "$env:REPO" "$env:PR_NUMBER" "$env:MARKER" "$env:COMMIT_MARKER_PREFIX" "$env:HEAD_SHA"
 
   # Benchmark ONLY the touched packages across the full platform matrix, keyed by the PR head
   # commit, appending the results into the prod store. Skipped when the PR touches nothing
@@ -284,6 +334,8 @@ jobs:
         shell: pwsh
         env:
           MARKER: ${{ env.PR_COMMENT_MARKER }}
+          COMMIT_MARKER_PREFIX: ${{ env.PR_COMMIT_MARKER_PREFIX }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           NOTABLE: ${{ steps.notable.outputs.value }}
           REPORT_ARTIFACT_URL: ${{ steps.full_reports.outputs.artifact-url }}
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
@@ -294,6 +346,14 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
 
           $header = "### Benchmark history (vs ``main``)"
+
+          # Record which commit these numbers describe: a human-visible short-SHA line (so a reader can
+          # see at a glance what was measured) and, embedded once in the body via the shared prefix, a
+          # hidden full-SHA marker the mark-stale job parses on the next push to measure how far behind
+          # HEAD the results have fallen. Both derive from the same head SHA in this one step, so they
+          # cannot drift.
+          $shortSha = $env:HEAD_SHA.Substring(0, 7)
+          $analyzedLine = "**Analyzed commit:** ``$shortSha``"
 
           # Disclose the collection scope so a reader never mistakes a clean result for the whole
           # suite: PR runs benchmark ONLY the packages this PR changed (cargo-delta scoped), and the
@@ -322,6 +382,8 @@ jobs:
               ''
               $scope
               ''
+              $analyzedLine
+              ''
               $summary
               ''
               '---'
@@ -338,15 +400,19 @@ jobs:
               ''
               $scope
               ''
+              $analyzedLine
+              ''
               '✅ No benchmark regressions detected against `main`.'
               ''
               'This check is advisory and never blocks the merge. It refreshes on every push.'
             )
           }
 
-          # Prepend the hidden dedup marker so the comment module finds and updates this same comment
-          # on the next push instead of posting a duplicate.
-          $body = @($env:MARKER, '') + $parts
+          # Prepend the hidden dedup marker (so the comment module finds and updates this same comment
+          # on the next push instead of posting a duplicate) and the hidden analyzed-commit marker (so
+          # mark-stale can recover the measured SHA); both are HTML comments, invisible when rendered.
+          $commitMarker = "$env:COMMIT_MARKER_PREFIX$env:HEAD_SHA -->"
+          $body = @($env:MARKER, $commitMarker, '') + $parts
           Set-Content -Path (Join-Path $env:SCRATCH_DIR 'comment-body.md') -Value ($body -join "`n") -Encoding utf8
 
       # One rolling comment per PR, updated in place (deduped by the hidden marker) so repeated pushes

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -111,14 +111,13 @@ jobs:
   # ahead, which needs no clone and still resolves a commit orphaned by a force-push. Gated on
   # skip_all != 'true' for the same reason collect is: when the PR now touches nothing benchmarkable the
   # `cleanup` job DELETES the comment instead, and marking a comment about to be deleted would only race
-  # that delete. Runs in parallel with collect (both `needs: delta`).
+  # that delete. Runs in parallel with collect (both `needs: delta`), and mirrors collect's gating
+  # exactly - no `always()`, so a FAILED or skipped delta skips this job too rather than flagging a
+  # comment stale for a run that will never collect; the same-repo gate rides along from delta, which is
+  # skipped on forks (skipping this dependent with it).
   mark-stale:
     needs: delta
-    if: >-
-      always()
-      && github.repository == 'folo-rs/folo'
-      && github.event.pull_request.head.repo.full_name == github.repository
-      && needs.delta.outputs.skip_all != 'true'
+    if: needs.delta.outputs.skip_all != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -144,7 +143,29 @@ jobs:
           MARKER: ${{ env.PR_COMMENT_MARKER }}
           COMMIT_MARKER_PREFIX: ${{ env.PR_COMMIT_MARKER_PREFIX }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: just gh-mark-pr-bench-history-stale "$env:REPO" "$env:PR_NUMBER" "$env:MARKER" "$env:COMMIT_MARKER_PREFIX" "$env:HEAD_SHA"
+        # Import and call the shared module directly (like cleanup) rather than via `just`: this job
+        # deliberately skips setup-environment to stay lightweight, so it must not assume `just` is
+        # preinstalled on the runner image. The real logic (SHA/repo validation, compare-distance
+        # lookup, banner insertion) lives in the Pester-tested module; this step is just glue.
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
+
+          Write-Host "Flagging the rolling benchmark comment on $env:REPO PR #$env:PR_NUMBER as stale relative to head $env:HEAD_SHA."
+          $marked = Set-RollingCommentStaleness `
+            -Repo $env:REPO `
+            -PrNumber $env:PR_NUMBER `
+            -Marker $env:MARKER `
+            -CommitMarkerPrefix $env:COMMIT_MARKER_PREFIX `
+            -HeadSha $env:HEAD_SHA `
+            -Verbose
+          if ($marked) {
+            Write-Host "Added a staleness warning to the rolling PR comment."
+          } else {
+            Write-Host "No staleness warning needed (no rolling comment yet, or it already reflects head)."
+          }
 
   # Benchmark ONLY the touched packages across the full platform matrix, keyed by the PR head
   # commit, appending the results into the prod store. Skipped when the PR touches nothing

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -368,13 +368,14 @@ jobs:
 
           $header = "### Benchmark history (vs ``main``)"
 
-          # Record which commit these numbers describe: a human-visible short-SHA line (so a reader can
-          # see at a glance what was measured) and, embedded once in the body via the shared prefix, a
-          # hidden full-SHA marker the mark-stale job parses on the next push to measure how far behind
-          # HEAD the results have fallen. Both derive from the same head SHA in this one step, so they
-          # cannot drift.
-          $shortSha = $env:HEAD_SHA.Substring(0, 7)
-          $analyzedLine = "**Analyzed commit:** ``$shortSha``"
+          # Record which commit these numbers describe: a human-visible line and, embedded once in the
+          # body via the shared prefix, a hidden full-SHA marker the mark-stale job parses on the next
+          # push to measure how far behind HEAD the results have fallen. Both derive from the same head
+          # SHA in this one step, so they cannot drift. The visible line prints the FULL 40-char SHA
+          # bare (no backticks): GitHub autolinks a bare commit SHA to the commit and renders it
+          # abbreviated, so we get a click-through link and short display for free - manually truncating
+          # into a code span would only throw both away.
+          $analyzedLine = "**Analyzed commit:** $env:HEAD_SHA"
 
           # Disclose the collection scope so a reader never mistakes a clean result for the whole
           # suite: PR runs benchmark ONLY the packages this PR changed (cargo-delta scoped), and the

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -248,6 +248,38 @@ gh-file-pr-comment repo pr marker body_file:
         -Verbose
     Write-Verbose "Rolling PR comment is available at $url." -Verbose
 
+# Flags the rolling benchmark comment on a pull request as STALE at the start of a new run: a benchmark
+# takes hours and a new push cancels the in-flight run, so the numbers on display can lag the PR tip by
+# a long way. Thin wrapper over Set-RollingCommentStaleness in
+# scripts/bench-history/BenchHistoryComment.psm1 (Pester-tested via `just test-scripts`). It reads the
+# analyzed-commit SHA the analyze job embedded in the comment (via `commit_marker_prefix`), counts how
+# far `head_sha` is ahead of it, and prepends a warning banner ("N commits behind HEAD", or a
+# numberless "out of date" when the two share no history). A no-op when the PR has no rolling comment
+# yet or already reflects `head_sha`. `repo` is `owner/name` and `pr` the PR number; both, and the
+# SHA, are validated in the module before being spliced into the REST path. Needs GH_TOKEN in the
+# environment (the workflow supplies it).
+[group('automation')]
+[script]
+gh-mark-pr-bench-history-stale repo pr marker commit_marker_prefix head_sha:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
+
+    Write-Verbose "Flagging the rolling benchmark comment on {{repo}} PR #{{pr}} as stale relative to head {{head_sha}}." -Verbose
+    $marked = Set-RollingCommentStaleness `
+        -Repo '{{repo}}' `
+        -PrNumber '{{pr}}' `
+        -Marker '{{marker}}' `
+        -CommitMarkerPrefix '{{commit_marker_prefix}}' `
+        -HeadSha '{{head_sha}}' `
+        -Verbose
+    if ($marked) {
+        Write-Verbose "Added a staleness warning to the rolling PR comment." -Verbose
+    } else {
+        Write-Verbose "No staleness warning needed (no rolling comment yet, or it already reflects head)." -Verbose
+    }
+
 # The release-automation logic lives in scripts/release/ReleaseAutomation.psm1, with a Pester
 # suite (scripts/release/ReleaseAutomation.Tests.ps1) that exercises it against fixtures via
 # `just test-scripts`. The recipes below are thin wrappers that import the module and call its

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -248,38 +248,6 @@ gh-file-pr-comment repo pr marker body_file:
         -Verbose
     Write-Verbose "Rolling PR comment is available at $url." -Verbose
 
-# Flags the rolling benchmark comment on a pull request as STALE at the start of a new run: a benchmark
-# takes hours and a new push cancels the in-flight run, so the numbers on display can lag the PR tip by
-# a long way. Thin wrapper over Set-RollingCommentStaleness in
-# scripts/bench-history/BenchHistoryComment.psm1 (Pester-tested via `just test-scripts`). It reads the
-# analyzed-commit SHA the analyze job embedded in the comment (via `commit_marker_prefix`), counts how
-# far `head_sha` is ahead of it, and prepends a warning banner ("N commits behind HEAD", or a
-# numberless "out of date" when the two share no history). A no-op when the PR has no rolling comment
-# yet or already reflects `head_sha`. `repo` is `owner/name` and `pr` the PR number; both, and the
-# SHA, are validated in the module before being spliced into the REST path. Needs GH_TOKEN in the
-# environment (the workflow supplies it).
-[group('automation')]
-[script]
-gh-mark-pr-bench-history-stale repo pr marker commit_marker_prefix head_sha:
-    Set-StrictMode -Version Latest
-    $ErrorActionPreference = "Stop"
-    $PSNativeCommandUseErrorActionPreference = $true
-    Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
-
-    Write-Verbose "Flagging the rolling benchmark comment on {{repo}} PR #{{pr}} as stale relative to head {{head_sha}}." -Verbose
-    $marked = Set-RollingCommentStaleness `
-        -Repo '{{repo}}' `
-        -PrNumber '{{pr}}' `
-        -Marker '{{marker}}' `
-        -CommitMarkerPrefix '{{commit_marker_prefix}}' `
-        -HeadSha '{{head_sha}}' `
-        -Verbose
-    if ($marked) {
-        Write-Verbose "Added a staleness warning to the rolling PR comment." -Verbose
-    } else {
-        Write-Verbose "No staleness warning needed (no rolling comment yet, or it already reflects head)." -Verbose
-    }
-
 # The release-automation logic lives in scripts/release/ReleaseAutomation.psm1, with a Pester
 # suite (scripts/release/ReleaseAutomation.Tests.ps1) that exercises it against fixtures via
 # `just test-scripts`. The recipes below are thin wrappers that import the module and call its

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -293,3 +293,277 @@ Describe 'Remove-RollingComment (mocked gh api)' {
         }
     }
 }
+
+Describe 'Get-CommitsBehind (mocked gh compare api)' {
+    BeforeAll {
+        # Full 40-hex SHAs: Get-CommitsBehind validates the shape before splicing them into the
+        # compare path, so short placeholders would be rejected.
+        $script:BaseSha = '1111111111111111111111111111111111111111'
+        $script:HeadSha = '2222222222222222222222222222222222222222'
+    }
+
+    Context 'when the two commits share history' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                $global:LASTEXITCODE = 0
+                '{"status":"ahead","ahead_by":3,"behind_by":0,"total_commits":3}'
+            }
+        }
+
+        It 'returns the ahead-by count as the distance' {
+            $result = Get-CommitsBehind -Repo 'o/r' -BaseSha $script:BaseSha -HeadSha $script:HeadSha
+            $result.Related | Should -BeTrue
+            $result.Behind | Should -Be 3
+        }
+
+        It 'queries the compare endpoint for base...head' {
+            Get-CommitsBehind -Repo 'o/r' -BaseSha $script:BaseSha -HeadSha $script:HeadSha | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'api') -and ($args -contains "repos/o/r/compare/$($script:BaseSha)...$($script:HeadSha)")
+            }
+        }
+    }
+
+    Context 'when the head is identical to the base' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 0; '{"status":"identical","ahead_by":0,"behind_by":0}' }
+        }
+
+        It 'reports a related zero distance' {
+            $result = Get-CommitsBehind -Repo 'o/r' -BaseSha $script:BaseSha -HeadSha $script:HeadSha
+            $result.Related | Should -BeTrue
+            $result.Behind | Should -Be 0
+        }
+    }
+
+    Context 'when the commits share no history' {
+        BeforeEach {
+            # The compare endpoint 404s with this message for unrelated histories (e.g. a force-push).
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 1; 'gh: No common ancestor for the two commits (HTTP 404)' }
+        }
+
+        It 'reports unrelated with no distance' {
+            $result = Get-CommitsBehind -Repo 'o/r' -BaseSha $script:BaseSha -HeadSha $script:HeadSha
+            $result.Related | Should -BeFalse
+            $result.Behind | Should -Be 0
+        }
+    }
+
+    Context 'when the compare fails for another reason' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 1; 'HTTP 500: Internal Server Error' }
+        }
+
+        It 'rethrows rather than reporting a bogus "out of date"' {
+            { Get-CommitsBehind -Repo 'o/r' -BaseSha $script:BaseSha -HeadSha $script:HeadSha } | Should -Throw '*HTTP 500*'
+        }
+    }
+
+    Context 'input validation' {
+        It 'rejects a non-hex base SHA' {
+            { Get-CommitsBehind -Repo 'o/r' -BaseSha 'not-a-sha' -HeadSha $script:HeadSha } | Should -Throw '*40-character hex*'
+        }
+
+        It 'rejects a malformed repository' {
+            { Get-CommitsBehind -Repo 'bad' -BaseSha $script:BaseSha -HeadSha $script:HeadSha } | Should -Throw '*owner/name*'
+        }
+    }
+}
+
+Describe 'Set-RollingCommentStaleness (mocked gh api)' {
+    BeforeAll {
+        $script:CommitPrefix = '<!-- folo-bench-history-commit:'
+        $script:AnalyzedSha = '1111111111111111111111111111111111111111'
+        $script:HeadSha2 = '2222222222222222222222222222222222222222'
+        # Fixed capture path (recomputed identically in the mock and the assertions) for the PATCHed
+        # body, mirroring the Publish-RollingComment tests: the temp body file is deleted once `gh`
+        # returns, so a post-hoc ParameterFilter could not read it.
+        $script:StaleCapture = Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md'
+    }
+
+    AfterAll {
+        Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+    }
+
+    Context 'when the analyzed commit is behind head' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42,"html_url":"https://github.com/o/r/pull/5#issuecomment-42"}' }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":3}' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\n### Benchmark history\nold findings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+            }
+        }
+
+        It 'patches the comment with an N-commits-behind warning and preserves the analyzed marker' {
+            $result = Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2
+            $result | Should -BeTrue
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'PATCH') -and ($args -contains 'repos/o/r/issues/comments/42')
+            }
+            $sent = Get-Content -LiteralPath $script:StaleCapture -Raw
+            $sent | Should -BeLike '*3 commits behind HEAD*'
+            $sent | Should -BeLike '*[!WARNING]*'
+            # The analyzed-commit marker must survive so the next run can still parse it.
+            $sent | Should -BeLike "*$($script:CommitPrefix)$($script:AnalyzedSha)*"
+        }
+    }
+
+    Context 'when the analyzed commit is exactly one commit behind' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":1}' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'uses the singular "commit"' {
+            Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2 | Out-Null
+            $sent = Get-Content -LiteralPath $script:StaleCapture -Raw
+            $sent | Should -BeLike '*1 commit behind HEAD*'
+            $sent | Should -Not -BeLike '*1 commits behind*'
+        }
+    }
+
+    Context 'when the analyzed commit shares no history with head' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 1; return 'gh: No common ancestor for the two commits (HTTP 404)' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'patches a numberless "out of date" warning' {
+            Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2 | Out-Null
+            $sent = Get-Content -LiteralPath $script:StaleCapture -Raw
+            $sent | Should -BeLike '*out of date*'
+            $sent | Should -Not -BeLike '*behind HEAD*'
+        }
+    }
+
+    Context 'when the comment lacks an analyzed-commit marker (pre-change comment)' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'falls back to "out of date" without calling the compare api' {
+            Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2 | Out-Null
+            $sent = Get-Content -LiteralPath $script:StaleCapture -Raw
+            $sent | Should -BeLike '*out of date*'
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { [bool]($args | Where-Object { $_ -like 'repos/*/compare/*' }) } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when the analyzed commit already equals head' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"identical","ahead_by":0}' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'adds no warning and does not patch' {
+            $result = Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2
+            $result | Should -BeFalse
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when the PR has no rolling comment yet' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 0; '[]' }
+        }
+
+        It 'is a no-op returning false' {
+            $result = Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2
+            $result | Should -BeFalse
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when the comment already carries a stale banner (re-run)' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":3}' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n\n<!-- folo-bench-history-stale -->\n> [!WARNING]\n> Benchmark results are 2 commits behind HEAD. This comment will be updated when newer results are available.\n<!-- /folo-bench-history-stale -->\n\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'replaces the old banner instead of stacking a second one' {
+            Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2 | Out-Null
+            $sent = Get-Content -LiteralPath $script:StaleCapture -Raw
+            $sent | Should -BeLike '*3 commits behind HEAD*'
+            $sent | Should -Not -BeLike '*2 commits behind HEAD*'
+            ([regex]::Matches($sent, '\[!WARNING\]')).Count | Should -Be 1
+        }
+    }
+
+    Context 'when -WhatIf is passed' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":3}' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'reports the edit without performing the PATCH' {
+            Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2 -WhatIf | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'input validation' {
+        It 'rejects a non-hex head SHA' {
+            { Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha 'nope' } |
+                Should -Throw '*40-character hex*'
+        }
+    }
+}

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -466,6 +466,34 @@ Describe 'Set-RollingCommentStaleness (mocked gh api)' {
         }
     }
 
+    Context 'when the compare lookup fails for a transient reason' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-stale-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                # A non-404 compare failure (e.g. a transient 500) is a genuine error Get-CommitsBehind
+                # rethrows; staleness marking is best-effort and must degrade rather than fail the run.
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 1; return 'HTTP 500: Internal Server Error' } }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nfindings","html_url":"u"}]'
+            }
+        }
+
+        It 'degrades to the numberless "out of date" warning instead of throwing' {
+            $result = Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2
+            $result | Should -BeTrue
+            $sent = Get-Content -LiteralPath $script:StaleCapture -Raw
+            $sent | Should -BeLike '*out of date*'
+            $sent | Should -Not -BeLike '*behind HEAD*'
+        }
+    }
+
     Context 'when the comment lacks an analyzed-commit marker (pre-change comment)' {
         BeforeEach {
             Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
@@ -567,3 +595,62 @@ Describe 'Set-RollingCommentStaleness (mocked gh api)' {
         }
     }
 }
+
+Describe 'Add-StalenessBanner (unexported string transform)' {
+    Context 'when an opening sentinel has no matching close (manually edited/truncated comment)' {
+        It 'preserves the trailing body instead of dropping it' {
+            InModuleScope BenchHistoryComment {
+                $marker = '<!-- folo-bench-history-pr -->'
+                # An open sentinel with NO closing sentinel is not a block we produced. Stripping from it
+                # to end-of-body would silently delete the benchmark findings that follow, so they must
+                # survive verbatim.
+                $body = @(
+                    $marker
+                    ''
+                    $script:StaleBannerOpen
+                    '> [!WARNING]'
+                    '> a banner that was never closed'
+                    ''
+                    '### Benchmark history'
+                    'precious findings that must not vanish'
+                ) -join "`n"
+
+                $result = Add-StalenessBanner -Body $body -Warning 'fresh warning' -Marker $marker
+
+                $result | Should -BeLike '*### Benchmark history*'
+                $result | Should -BeLike '*precious findings that must not vanish*'
+                # The fresh banner is still inserted after the marker.
+                $result | Should -BeLike '*fresh warning*'
+            }
+        }
+    }
+
+    Context 'when the marker text also appears quoted elsewhere (e.g. inside a code block)' {
+        It 'inserts after the whole-line marker, not the quoted occurrence' {
+            InModuleScope BenchHistoryComment {
+                $marker = '<!-- folo-bench-history-pr -->'
+                # The marker text appears first inside a fenced code block (indented, with trailing text)
+                # and only later on its own line as the real marker. A substring match would latch onto
+                # the quoted line; a whole-line (trimmed-equality) match lands on the real marker.
+                $body = @(
+                    '### Example usage'
+                    '```'
+                    "    $marker  <- quoted in docs, NOT the real marker"
+                    '```'
+                    $marker
+                    'findings'
+                ) -join "`n"
+
+                $result = Add-StalenessBanner -Body $body -Warning 'fresh warning' -Marker $marker
+                $lines = $result -split "`n"
+
+                ([regex]::Matches($result, '\[!WARNING\]')).Count | Should -Be 1
+                $bannerLine = [array]::IndexOf($lines, '> [!WARNING]')
+                $realMarkerLine = [array]::IndexOf($lines, $marker)
+                # The banner must land after the real marker line, i.e. past the whole code block.
+                $bannerLine | Should -BeGreaterThan $realMarkerLine
+            }
+        }
+    }
+}
+

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -13,12 +13,28 @@
 # imports this module directly and calls Remove-RollingComment to sweep away a comment left by an
 # earlier iteration of the same PR (e.g. a benchmarked change that was later reverted).
 #
+# A benchmark run takes many hours, and a new push cancels the in-flight one, so the comment a reader
+# sees can lag the PR tip by a long way. Two seams keep that honest: the analyze job embeds a hidden
+# "analyzed commit" marker in the body (which commit the numbers describe), and the mark-stale job -
+# which fires at the START of a new run - calls Set-RollingCommentStaleness to prepend a warning
+# banner stating how far behind HEAD those numbers now are (via Get-CommitsBehind), so nobody mistakes
+# hours-old results for the current state. The banner clears itself when the next analyze rewrites the
+# body with fresh results.
+#
 # Every GitHub-touching call goes through `gh api` behind the single Invoke-GhCapture seam the
 # Pester suite (BenchHistoryComment.Tests.ps1) mocks, so the find/update/create/delete logic is
 # exercised without touching a real pull request. Unlike an agent-authored GitHub post, this is
 # CI/bot output and therefore carries NO `[Copilot speaking]` prefix.
 
 Set-StrictMode -Version Latest
+
+# Sentinel pair bounding the staleness warning banner Set-RollingCommentStaleness prepends. Keeping the
+# banner between two hidden markers makes a re-run REPLACE it (strip the old block, insert the new)
+# rather than stack a second copy, and lets the block be located without depending on its wording.
+# Purely internal to this module - only Set-RollingCommentStaleness produces and consumes it - so
+# unlike the caller-supplied dedup and analyzed-commit markers it needs no workflow-level definition.
+$script:StaleBannerOpen = '<!-- folo-bench-history-stale -->'
+$script:StaleBannerClose = '<!-- /folo-bench-history-stale -->'
 
 function Invoke-GhCapture {
     # Runs `gh` with the given arguments, capturing stdout and stderr SEPARATELY. stderr is
@@ -33,7 +49,13 @@ function Invoke-GhCapture {
     param([Parameter(Mandatory)][object[]] $Arguments)
 
     $PSNativeCommandUseErrorActionPreference = $false
-    $stderrFile = New-TemporaryFile
+    # `-WhatIf:$false` on the temp-file bookkeeping: New-TemporaryFile and Remove-Item both support
+    # ShouldProcess, so an ambient $WhatIfPreference from a SupportsShouldProcess CALLER (e.g.
+    # Set-RollingCommentStaleness -WhatIf, which still needs the read GETs that back its preview) would
+    # otherwise make New-TemporaryFile a no-op and null out $stderrFile. This stderr redirect is a
+    # read-side implementation detail, never the state change -WhatIf is meant to gate, so it must run
+    # regardless; the caller gates the actual mutating `gh` call itself.
+    $stderrFile = New-TemporaryFile -WhatIf:$false
     try {
         $stderrPath = $stderrFile.FullName
         $stdout = (gh @Arguments 2>$stderrPath | Out-String)
@@ -48,7 +70,38 @@ function Invoke-GhCapture {
         return $stdout
     }
     finally {
-        Remove-Item -LiteralPath $stderrFile.FullName -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $stderrFile.FullName -Force -ErrorAction SilentlyContinue -WhatIf:$false
+    }
+}
+
+function Assert-Repo {
+    # Guards the `owner/name` value spliced into every `gh api` REST path (`repos/<repo>/...`). It
+    # arrives from workflow context (`github.repository`), but validating its shape here keeps the path
+    # well-formed and forecloses any path-traversal/injection surprise if a caller ever passes it from a
+    # less trustworthy source. Throws on a malformed value. Shared by Assert-RepoAndPr and the
+    # compare-API caller (which has no PR number).
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string] $Repo)
+
+    if ($Repo -notmatch '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$') {
+        throw "Repository must be in 'owner/name' form, got '$Repo'."
+    }
+}
+
+function Assert-CommitSha {
+    # Guards a commit SHA spliced into a `gh api` compare path (`repos/<repo>/compare/<base>...<head>`).
+    # Both the PR head SHA (from `github.event.pull_request.head.sha`) and the analyzed SHA parsed from
+    # the hidden marker are full 40-char hex, so requiring that shape both rejects a malformed/injected
+    # value and keeps the REST path well-formed. $Label names which SHA in the error. Throws on a
+    # malformed value.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $Sha,
+        [Parameter(Mandatory)][string] $Label
+    )
+
+    if ($Sha -notmatch '^[0-9a-fA-F]{40}$') {
+        throw "$Label commit SHA must be a 40-character hex string, got '$Sha'."
     }
 }
 
@@ -63,9 +116,7 @@ function Assert-RepoAndPr {
         [Parameter(Mandatory)][string] $PrNumber
     )
 
-    if ($Repo -notmatch '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$') {
-        throw "Repository must be in 'owner/name' form, got '$Repo'."
-    }
+    Assert-Repo -Repo $Repo
     # `^[1-9][0-9]*$` (not `^[0-9]+$`): a PR number is a positive integer, so reject `0` and any
     # leading-zero form to match the error message and keep a well-formed REST path.
     if ($PrNumber -notmatch '^[1-9][0-9]*$') {
@@ -219,4 +270,212 @@ function Remove-RollingComment {
     return $true
 }
 
-Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment
+function Get-CommitsBehind {
+    # Counts how many commits $HeadSha carries beyond $BaseSha using the GitHub compare API, so the
+    # rolling comment can state how far its analyzed commit lags the current PR tip WITHOUT a
+    # full-history clone: the topology is computed server-side and still resolves a commit orphaned by a
+    # force-push (which a fresh shallow checkout would not contain). Returns a hashtable:
+    #   @{ Related = $true;  Behind = <int> }  when the two commits share history (Behind = `ahead_by`,
+    #                                           the commits HEAD has that BASE lacks - exactly the
+    #                                           "results are N commits behind the tip" figure);
+    #   @{ Related = $false; Behind = 0 }       when they have NO common ancestor (compare 404s) or the
+    #                                           base SHA no longer resolves - the caller then renders the
+    #                                           numberless "out of date" wording.
+    # Only a 404 is treated as "not comparable"; every other `gh` failure is a genuine error and is
+    # rethrown, so a transient outage is never silently reported as "out of date". Isolates the real
+    # `gh api` compare call behind Invoke-GhCapture so the tests can mock it.
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $BaseSha,
+        [Parameter(Mandatory)][string] $HeadSha
+    )
+
+    Assert-Repo -Repo $Repo
+    Assert-CommitSha -Sha $BaseSha -Label 'Base'
+    Assert-CommitSha -Sha $HeadSha -Label 'Head'
+
+    try {
+        # `<base>...<head>` (three dots) is the compare endpoint's basehead syntax; both SHAs are
+        # validated 40-hex above, so the path is safe to splice.
+        $output = Invoke-GhCapture -Arguments @(
+            'api', "repos/$Repo/compare/$BaseSha...$HeadSha"
+        )
+    }
+    catch {
+        # The compare endpoint 404s with "No common ancestor for the two commits" for unrelated
+        # histories (e.g. a force-push that replaced the branch) and with a not-found message when the
+        # base SHA no longer resolves. Both mean "cannot express a distance" -> Related=$false so the
+        # caller falls back to the numberless wording. Match the HTTP status (gh appends "(HTTP 404)")
+        # or the specific messages; anything else is a real failure and propagates.
+        $message = $_.Exception.Message
+        if ($message -match 'HTTP 404' -or $message -match '(?i)no common ancestor' -or
+            $message -match '(?i)no commit found') {
+            return @{ Related = $false; Behind = 0 }
+        }
+        throw
+    }
+
+    $comparison = $output | ConvertFrom-Json
+    # `ahead_by` is always present on a successful compare; guard defensively so a schema surprise
+    # degrades to the "out of date" wording rather than throwing.
+    if ($comparison -and ($comparison.PSObject.Properties.Name -contains 'ahead_by')) {
+        return @{ Related = $true; Behind = [int] $comparison.ahead_by }
+    }
+    return @{ Related = $false; Behind = 0 }
+}
+
+function Add-StalenessBanner {
+    # Pure string transform: returns $Body with a fresh staleness banner carrying $Warning inserted
+    # just after the dedup $Marker line, replacing any banner a previous run left behind. Factored out
+    # of Set-RollingCommentStaleness (and kept unexported) so the strip/insert bookkeeping is one
+    # testable place. Idempotent by construction: it first removes every line of any existing
+    # sentinel-bounded block, then rebuilds "marker, blank, banner, blank, rest" with the rest's leading
+    # blank lines trimmed, so re-running on its own output yields byte-identical text (no stacking, no
+    # accumulating blank lines).
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string] $Body,
+        [Parameter(Mandatory)][string] $Warning,
+        [Parameter(Mandatory)][string] $Marker
+    )
+
+    # 1. Drop any previously-inserted banner block (open..close inclusive).
+    $kept = [System.Collections.Generic.List[string]]::new()
+    $inBanner = $false
+    foreach ($line in @($Body -split "`n")) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq $script:StaleBannerOpen) { $inBanner = $true; continue }
+        if ($inBanner) {
+            if ($trimmed -eq $script:StaleBannerClose) { $inBanner = $false }
+            continue
+        }
+        $kept.Add($line)
+    }
+
+    # 2. Build the fresh banner: a GitHub "warning" alert bounded by the sentinel pair so the next
+    #    strip finds it.
+    $banner = @(
+        $script:StaleBannerOpen
+        '> [!WARNING]'
+        "> $Warning"
+        $script:StaleBannerClose
+    )
+
+    # 3. Insert it right after the dedup marker line, with exactly one blank line on each side. If the
+    #    marker is somehow absent, prepend the banner at the very top instead.
+    $markerIndex = -1
+    for ($i = 0; $i -lt $kept.Count; $i++) {
+        if ($kept[$i].Contains($Marker)) { $markerIndex = $i; break }
+    }
+    if ($markerIndex -lt 0) {
+        return (($banner + @('') + @($kept)) -join "`n")
+    }
+
+    $after = [System.Collections.Generic.List[string]]::new()
+    for ($i = $markerIndex + 1; $i -lt $kept.Count; $i++) { $after.Add($kept[$i]) }
+    while ($after.Count -gt 0 -and $after[0].Trim() -eq '') { $after.RemoveAt(0) }
+
+    $assembled = [System.Collections.Generic.List[string]]::new()
+    for ($i = 0; $i -le $markerIndex; $i++) { $assembled.Add($kept[$i]) }
+    $assembled.Add('')
+    foreach ($b in $banner) { $assembled.Add($b) }
+    $assembled.Add('')
+    foreach ($a in $after) { $assembled.Add($a) }
+    return ($assembled -join "`n")
+}
+
+function Set-RollingCommentStaleness {
+    # Called at the START of a new PR benchmark run (the mark-stale job) to flag that the rolling
+    # comment's currently-displayed findings now lag the PR tip and a fresh run is underway, so a reader
+    # never mistakes hours-old numbers for the current state. Finds the rolling comment by $Marker
+    # (no-op when the PR has none yet); reads the analyzed commit SHA from the hidden
+    # "$CommitMarkerPrefix<40-hex> -->" marker the analyze job embeds; asks Get-CommitsBehind how far
+    # that commit lags $HeadSha; and PATCHes a warning banner onto the TOP of the comment body. Three
+    # outcomes:
+    #   * a concrete distance                       -> "... N commit(s) behind HEAD ..."
+    #   * unrelated histories / no analyzed marker  -> generic "... out of date ..." (no number)
+    #   * already at $HeadSha (distance 0)          -> no banner is warranted, so nothing is patched.
+    # The banner is bounded by a sentinel pair (see Add-StalenessBanner) so a re-run replaces rather
+    # than stacks it, and the next completed analyze - which rewrites the whole body from scratch -
+    # drops it automatically once real new results land. Returns $true when the comment was patched.
+    # SupportsShouldProcess because editing a comment is state-changing (matches the module's other
+    # mutating helpers): the PATCH is gated on ShouldProcess so `-WhatIf` reports without performing it.
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber,
+        [Parameter(Mandatory)][string] $Marker,
+        [Parameter(Mandatory)][string] $CommitMarkerPrefix,
+        [Parameter(Mandatory)][string] $HeadSha
+    )
+
+    Assert-RepoAndPr -Repo $Repo -PrNumber $PrNumber
+    Assert-CommitSha -Sha $HeadSha -Label 'Head'
+
+    $existing = Find-RollingComment -Repo $Repo -PrNumber $PrNumber -Marker $Marker
+    if (-not $existing) {
+        Write-Verbose ("No rolling comment on PR #$PrNumber to flag as stale; nothing to do (the first " +
+            "completed run will post one carrying the analyzed-commit marker).")
+        return $false
+    }
+
+    $body = $existing.body
+
+    # Pull the analyzed commit SHA out of the hidden marker the analyze job embeds
+    # ("$CommitMarkerPrefix<40-hex> -->"). A pre-change comment - or any body missing the marker -
+    # yields no SHA, in which case a distance cannot be expressed and we fall back to the numberless
+    # wording. Escape the prefix: it is HTML and contains regex metacharacters (`!`, `-`).
+    $analyzedSha = $null
+    $match = [regex]::Match($body, "$([regex]::Escape($CommitMarkerPrefix))([0-9a-fA-F]{40})")
+    if ($match.Success) { $analyzedSha = $match.Groups[1].Value }
+
+    $warning = $null
+    if ($analyzedSha) {
+        $distance = Get-CommitsBehind -Repo $Repo -BaseSha $analyzedSha -HeadSha $HeadSha
+        if ($distance.Related -and $distance.Behind -eq 0) {
+            Write-Verbose ("Rolling comment on PR #$PrNumber already reflects HEAD ($HeadSha); leaving it " +
+                "unmarked.")
+            return $false
+        }
+        if ($distance.Related) {
+            $noun = if ($distance.Behind -eq 1) { 'commit' } else { 'commits' }
+            $warning = "Benchmark results are $($distance.Behind) $noun behind HEAD. This comment will be updated when newer results are available."
+        }
+    }
+    if (-not $warning) {
+        $warning = 'Benchmark results are out of date. This comment will be updated when newer results are available.'
+    }
+
+    $newBody = Add-StalenessBanner -Body $body -Warning $warning -Marker $Marker
+    if ($newBody -eq $body) {
+        Write-Verbose ("Rolling comment on PR #$PrNumber already carries this staleness banner; no update " +
+            "needed.")
+        return $false
+    }
+
+    if (-not $PSCmdlet.ShouldProcess("comment #$($existing.id) on PR #$PrNumber", 'Flag benchmark comment as stale')) {
+        return $false
+    }
+
+    # Send the edited body through a FILE (`-F body=@<path>`) for the same reasons Publish-RollingComment
+    # does: a rendered report can run to tens of kilobytes (over the command-line length limit), it
+    # avoids shell-escaping arbitrary Markdown, and it keeps the body out of process listings.
+    $tempBodyFile = New-TemporaryFile
+    try {
+        Set-Content -LiteralPath $tempBodyFile.FullName -Value $newBody -Encoding utf8 -NoNewline
+        Write-Verbose ("Flagging rolling comment #$($existing.id) on PR #$PrNumber as stale: $warning")
+        Invoke-GhCapture -Arguments @(
+            'api', '--method', 'PATCH', "repos/$Repo/issues/comments/$($existing.id)", '-F', "body=@$($tempBodyFile.FullName)"
+        ) | Out-Null
+    }
+    finally {
+        Remove-Item -LiteralPath $tempBodyFile.FullName -Force -ErrorAction SilentlyContinue
+    }
+    return $true
+}
+
+Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment, Get-CommitsBehind, Set-RollingCommentStaleness

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -342,18 +342,32 @@ function Add-StalenessBanner {
         [Parameter(Mandatory)][string] $Marker
     )
 
-    # 1. Drop any previously-inserted banner block (open..close inclusive).
+    # 1. Drop any previously-inserted banner block, but ONLY when it is COMPLETE (both the opening and
+    #    the closing sentinel present). An opening sentinel with no matching close - a manually edited or
+    #    truncated comment - is NOT a block we produced, so stripping from it to end-of-body would
+    #    silently delete the benchmark findings that follow. Buffer the lines after an open sentinel and
+    #    discard them only once the matching close is seen; if the body ends first, flush the buffer back
+    #    verbatim so the body is preserved intact.
     $kept = [System.Collections.Generic.List[string]]::new()
+    $pending = [System.Collections.Generic.List[string]]::new()
     $inBanner = $false
     foreach ($line in @($Body -split "`n")) {
         $trimmed = $line.Trim()
-        if ($trimmed -eq $script:StaleBannerOpen) { $inBanner = $true; continue }
+        if (-not $inBanner -and $trimmed -eq $script:StaleBannerOpen) {
+            $inBanner = $true
+            $pending.Clear()
+            $pending.Add($line)
+            continue
+        }
         if ($inBanner) {
-            if ($trimmed -eq $script:StaleBannerClose) { $inBanner = $false }
+            $pending.Add($line)
+            if ($trimmed -eq $script:StaleBannerClose) { $inBanner = $false; $pending.Clear() }
             continue
         }
         $kept.Add($line)
     }
+    # Unterminated open sentinel: keep the buffered lines rather than dropping the remainder of the body.
+    if ($inBanner) { foreach ($p in $pending) { $kept.Add($p) } }
 
     # 2. Build the fresh banner: a GitHub "warning" alert bounded by the sentinel pair so the next
     #    strip finds it.
@@ -364,11 +378,14 @@ function Add-StalenessBanner {
         $script:StaleBannerClose
     )
 
-    # 3. Insert it right after the dedup marker line, with exactly one blank line on each side. If the
-    #    marker is somehow absent, prepend the banner at the very top instead.
+    # 3. Insert it right after the dedup marker line, with exactly one blank line on each side. Match the
+    #    marker as a whole line (trimmed equality) rather than a substring: the marker occupies its own
+    #    line by construction (Publish-RollingComment prepends "$Marker`n`n..."), so an equality test
+    #    keeps insertion deterministic and cannot latch onto the marker text quoted elsewhere in the body
+    #    (e.g. inside a code block). If the marker is somehow absent, prepend the banner at the very top.
     $markerIndex = -1
     for ($i = 0; $i -lt $kept.Count; $i++) {
-        if ($kept[$i].Contains($Marker)) { $markerIndex = $i; break }
+        if ($kept[$i].Trim() -eq $Marker) { $markerIndex = $i; break }
     }
     if ($markerIndex -lt 0) {
         return (($banner + @('') + @($kept)) -join "`n")
@@ -435,13 +452,25 @@ function Set-RollingCommentStaleness {
 
     $warning = $null
     if ($analyzedSha) {
-        $distance = Get-CommitsBehind -Repo $Repo -BaseSha $analyzedSha -HeadSha $HeadSha
-        if ($distance.Related -and $distance.Behind -eq 0) {
+        # Staleness marking is best-effort (see the workflow design doc): a transient compare API / `gh`
+        # failure must NOT fail the whole run. Only a genuine distance lets us word the banner with a
+        # number; any error leaves $distance null so the numberless "out of date" fallback below applies,
+        # and the cause is recorded in -Verbose so the run log still explains the missing figure.
+        $distance = $null
+        try {
+            $distance = Get-CommitsBehind -Repo $Repo -BaseSha $analyzedSha -HeadSha $HeadSha
+        }
+        catch {
+            Write-Verbose ("Compare lookup failed for analyzed commit $analyzedSha " +
+                "(head $HeadSha) on PR #$PrNumber; using generic out-of-date wording. " +
+                "Error: $($_.Exception.Message)")
+        }
+        if ($distance -and $distance.Related -and $distance.Behind -eq 0) {
             Write-Verbose ("Rolling comment on PR #$PrNumber already reflects HEAD ($HeadSha); leaving it " +
                 "unmarked.")
             return $false
         }
-        if ($distance.Related) {
+        if ($distance -and $distance.Related) {
             $noun = if ($distance.Behind -eq 1) { 'commit' } else { 'commits' }
             $warning = "Benchmark results are $($distance.Behind) $noun behind HEAD. This comment will be updated when newer results are available."
         }


### PR DESCRIPTION
[Copilot speaking]

## Problem

`pr-bench-history.yml` posts one rolling PR comment with benchmark findings. Because a full benchmark run takes **many hours** — and a new push *cancels* the in-flight run via `cancel-in-progress` — a reader has no way to tell whether the comment reflects the current PR tip or a much older commit. Nothing in the comment identifies which commit it analyzed, and nothing flags that a newer run is already underway.

## What this does

1. **Records the analyzed commit.** The `analyze` compose step now stamps every comment with a human-visible `**Analyzed commit:** <short-sha>` line and a hidden full-SHA marker (`<!-- folo-bench-history-commit:<sha> -->`), both derived from the same PR head SHA so they can't drift.
2. **Flags staleness at the start of each run.** A new lightweight `mark-stale` job runs right after the short `delta` preflight — in parallel with the multi-hour `collect` — finds any existing rolling comment, and prepends a warning banner:
   - **"Benchmark results are N commits behind HEAD. This comment will be updated when newer results are available."**
   - or a numberless **"Benchmark results are out of date."** when the analyzed commit shares no history with HEAD (e.g. a force-push) or the marker is absent (pre-change comments self-heal on the next completed run).

## How

- **Distance without a clone.** `N` comes from the GitHub compare API (`ahead_by`), computed server-side, so it needs no full-history checkout and still resolves a commit orphaned by a force-push. A `404 no-common-ancestor` cleanly signals the "out of date" fallback; any other API failure also degrades to the numberless wording rather than failing the run.
- **Idempotent banner.** The banner is bounded by a sentinel pair, so a re-run *replaces* rather than stacks it. `N == 0` (already at HEAD) adds no banner. When the next `analyze` rewrites the body from scratch with a fresh analyzed-commit marker, the banner disappears automatically.
- **Gating.** `mark-stale` is gated on the same non-empty delta as `collect` (`skip_all != 'true'`), so it never races the `cleanup` job that *deletes* the comment when the PR no longer touches anything benchmarkable.
- **Thin workflow, tested logic.** All logic lives in `BenchHistoryComment.psm1` (`Get-CommitsBehind`, `Set-RollingCommentStaleness`, private `Add-StalenessBanner`) behind the mocked `gh` seam; the workflow calls it through a thin `gh-mark-pr-bench-history-stale` recipe.

## Validation

- `just test-scripts` — 247 Pester tests pass (16 new for the two functions).
- `just validate-scripts` — PSScriptAnalyzer clean.
- `just validate-workflows` — actionlint clean.

Design rationale documented in `.github/workflows/design.md`.