### PR TITLE
Use real machine keys in bench-history CI

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -29,23 +29,6 @@ on:
         required: false
         type: string
         default: ""
-      # Optional switch to RE-SURVEY the existing history WITHOUT collecting anything new. Leave
-      # false for a normal dispatch (collects the current tip, exactly like a push). Set it true to
-      # SKIP the whole benchmark matrix and run ONLY the analyze job against the current stored
-      # history, refreshing the rolling regression issue in minutes instead of the ~hour a full
-      # collect costs. Use it after the data set changed OUT OF BAND and you want the issue to
-      # reflect it now - for example a blessing/unblessing, a `prune`, or an administrative
-      # overwrite done from a developer machine. It is general-purpose (re-analysis of the current
-      # store), NOT a blessing-specific switch, and is correct for any such change because the
-      # analyze job always re-lists the store and deletes/overwrites bump the cache-invalidation
-      # marker (see the analyze job and DESIGN.md 6.2). Mutually exclusive with
-      # recollect_commit_id: setting both is rejected by the reject-conflicting-inputs job, since a
-      # recollect is itself a collection. Ignored on push (only a dispatch can set it).
-      reanalyze:
-        description: "Re-run analysis only, skipping collection (leave false for a normal run)"
-        required: false
-        type: boolean
-        default: false
 
 # Group by the commit SHA, not the ref. Distinct commits must collect in parallel - each is
 # its own history data point, and cancelling one to favour a newer commit would drop that
@@ -58,14 +41,9 @@ on:
 # racing a push of the same tip) would share a group and wrongly cancel each other. The `-<id>`
 # suffix is appended only when a recollect id is supplied (via the `&&`/`||` idiom); pushes and
 # plain dispatches carry an empty id, so the suffix is omitted entirely and their grouping is
-# unchanged (no trailing dash). For the same reason a `-reanalyze` suffix is appended when the
-# reanalyze switch is set: a reanalyze dispatch shares the tip's github.sha, so without the suffix
-# it would wrongly cancel (or be cancelled by) a concurrent push or recollect of the same tip -
-# whereas two reanalyze dispatches of the same tip still share the suffixed group and dedup as
-# intended. The two suffixes are mutually exclusive on a valid run (a both-set dispatch is rejected
-# by the reject-conflicting-inputs job), so at most one is ever appended.
+# unchanged (no trailing dash).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}${{ inputs.recollect_commit_id && format('-{0}', inputs.recollect_commit_id) || '' }}${{ inputs.reanalyze && '-reanalyze' || '' }}
+  group: ${{ github.workflow }}-${{ github.sha }}${{ inputs.recollect_commit_id && format('-{0}', inputs.recollect_commit_id) || '' }}
   cancel-in-progress: true
 
 # Title of the rolling failure-alert issue, defined once and shared by the two jobs that
@@ -77,49 +55,13 @@ env:
   FAILURE_ISSUE_TITLE: Benchmark-history workflow failed
 
 jobs:
-  # Reject a self-contradictory manual dispatch BEFORE any expensive work starts. `reanalyze`
-  # (analysis only, no collection) and `recollect_commit_id` (re-measure and overwrite one commit)
-  # are mutually exclusive: a recollect IS a collection, so asking to both skip collection and
-  # recollect a commit is a contradiction. Rather than a script that validates the combination,
-  # this job's own `if:` IS the validation - it runs ONLY when both inputs are set, and when it runs
-  # it does nothing but fail. In every valid mode (push, plain dispatch, recollect-only,
-  # reanalyze-only) the condition is false and the job is SKIPPED, so it costs nothing and, crucially,
-  # every downstream job keys off its `skipped` result to mean "inputs are consistent" (a `failure`
-  # means the contradiction was dispatched). It carries the same repo/main gate as the others purely
-  # for consistency; nothing runs off-main anyway. No checkout, permissions or setup-environment - it
-  # only needs to print and exit non-zero.
-  reject-conflicting-inputs:
-    if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main' && inputs.reanalyze && inputs.recollect_commit_id != ''
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Reject conflicting reanalyze + recollect inputs
-        shell: pwsh
-        env:
-          RECOLLECT_COMMIT_ID: ${{ inputs.recollect_commit_id }}
-        run: |
-          Set-StrictMode -Version Latest
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-
-          # The value is echoed for the log only; it is never spliced into a command. The failure is
-          # the whole point of this step - pick exactly one mode and re-dispatch.
-          throw ("Conflicting dispatch inputs: 'reanalyze' is set AND 'recollect_commit_id' is " +
-            "'$env:RECOLLECT_COMMIT_ID'. A recollect re-measures and OVERWRITES a commit (a " +
-            "collection), which contradicts reanalyze (analysis only, no collection). Choose one: " +
-            "leave recollect_commit_id empty to reanalyze, or clear reanalyze to recollect.")
-
   collect:
-    # Never collect in reanalyze mode: that mode re-surveys the existing store only, so the whole
-    # benchmark matrix is skipped and just the analyze job runs. `!inputs.reanalyze` is also what
-    # keeps collection off for a rejected both-inputs-set dispatch (reanalyze is set there too), so
-    # this job needs no dependency on the guard. Otherwise, skip everywhere the OIDC sign-in cannot
-    # work: forks (only this repository's
-    # identity can federate into Azure) and any ref other than main (the federated
-    # credential is scoped to refs/heads/main, so a workflow_dispatch from a feature
-    # branch would mint a non-matching subject and fail at azure/login). Gating here
-    # makes such manual runs skip cleanly instead of failing red.
-    if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main' && !inputs.reanalyze
+    # Skip everywhere the OIDC sign-in cannot work: forks (only this repository's identity can
+    # federate into Azure) and any ref other than main (the federated credential is scoped to
+    # refs/heads/main, so a workflow_dispatch from a feature branch would mint a non-matching
+    # subject and fail at azure/login). Gating here makes such manual runs skip cleanly instead
+    # of failing red.
+    if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
 
     strategy:
       # One platform's benchmarks failing must not abandon the others' history for this
@@ -185,30 +127,48 @@ jobs:
           Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
           Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
-      # The deterministic engines (Callgrind, allocation/time counters) are
-      # hardware-independent; the wall-clock engines are pinned to the fixed `github` machine
-      # key (see the gh-collect-bench-history recipe) so a heterogeneous runner pool does not
-      # fork the series. RECOLLECT_COMMIT_ID (empty on a push/plain dispatch) switches the recipe
-      # from appending the pushed commit to re-measuring and OVERWRITING one historical commit;
-      # it is passed through the environment so an untrusted dispatch input is never spliced into
-      # a shell command line here.
+      # The deterministic engines (Callgrind, allocation/time counters) are hardware-independent; the
+      # wall-clock engines are partitioned by each runner's OWN real hardware fingerprint (see the
+      # gh-collect-bench-history recipe) so a heterogeneous runner pool splits into one clean series
+      # per SKU rather than one jittery mixed series. RECOLLECT_COMMIT_ID (empty on a push/plain
+      # dispatch) switches the recipe from appending the pushed commit to re-measuring and OVERWRITING
+      # one historical commit; it is passed through the environment so an untrusted dispatch input is
+      # never spliced into a shell command line here.
       - name: Collect benchmark history
         env:
           RECOLLECT_COMMIT_ID: ${{ inputs.recollect_commit_id }}
         run: just gh-collect-bench-history
 
+      # Record THIS runner's real hardware fingerprint so the single analyze job can thread the exact
+      # keys collected this run into its `--machine-key` filter (collect is a matrix, analyze is not,
+      # so analyze cannot re-derive them). Runs only after a SUCCESSFUL collect - a failed leg
+      # collected nothing, so its key must not be threaded - which is the default step behavior (a
+      # prior step's failure skips this one). The write recipe logs the fingerprint components under
+      # --verbose for debugging a key change.
+      - name: Record runner machine key
+        shell: pwsh
+        env:
+          KEY_FILE: ${{ runner.temp }}/machine-key.txt
+        run: just gh-write-bench-history-machine-key "$env:KEY_FILE"
+
+      # Upload this leg's key under a per-platform artifact name so the analyze job can download every
+      # leg's key together (one file per platform). if-no-files-found: error catches a broken
+      # key-write step loudly rather than silently dropping a key from the analysis.
+      - name: Upload runner machine key
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-history-machine-key-${{ matrix.platform }}
+          path: ${{ runner.temp }}/machine-key.txt
+          if-no-files-found: error
+
   analyze:
-    # Survey the (possibly re-collected, or in reanalyze mode simply the existing) history for
-    # regressions and post a rolling issue when any finding survives. Runs after every platform
-    # finishes (even partially: fail-fast is off) so this commit's analysis reflects whatever did
-    # land, and only on main (where OIDC sign-in works), matching collect's gate. `always()` is what
-    # lets it run despite a partially-failed - or entirely skipped (reanalyze) - collect; the guard's
-    # `skipped` result then gates it to consistent-input runs only, so a rejected both-inputs-set
-    # dispatch (guard `failure`) does NOT analyze. This is also the reanalyze entry point: with
-    # collect skipped, this is the only job that runs, re-listing the store (picking up out-of-band
-    # additions) while deletes/overwrites are handled by the cache-invalidation marker (DESIGN 6.2).
-    needs: [reject-conflicting-inputs, collect]
-    if: always() && needs.reject-conflicting-inputs.result == 'skipped' && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    # Survey the (possibly re-collected) history for regressions and post a rolling issue when any
+    # finding survives. Runs after every platform finishes (even partially: fail-fast is off) so this
+    # commit's analysis reflects whatever did land, and only on main (where OIDC sign-in works),
+    # matching collect's gate. `always()` is what lets it run despite a partially-failed collect;
+    # the repo/ref gate then keeps it off forks and non-main refs (where collect itself skips).
+    needs: [collect]
+    if: always() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Analysis loads the whole store and reduces it; far faster than benchmarking, but the cap
     # must still clear a cold-cache setup-environment (up to ~90 min) on top of the analysis.
@@ -285,14 +245,28 @@ jobs:
           restore-keys: |
             bench-history-cache-
 
+      # Download every collect leg's machine-key file (one per-platform artifact) into a single
+      # directory so the analysis can thread the EXACT fingerprints collected this run into its
+      # `--machine-key` filter. The default (no merge-multiple) keeps one subdirectory per artifact;
+      # the recipe scans recursively. A leg whose collection failed uploaded nothing, so its key is
+      # simply absent and not analyzed. If EVERY leg failed there are no matching artifacts: a pattern
+      # download tolerates zero matches (it does not fail), and the recipe treats the empty directory
+      # as "nothing to analyze".
+      - name: Download collected machine keys
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bench-history-machine-key-*
+          path: ${{ steps.scratch.outputs.dir }}/machine-keys
+
       # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
       # top-findings Markdown) and notable.txt into the scratch directory. Findings never fail
-      # the recipe (the tool always exits 0); the issue is advisory, not a gate.
+      # the recipe (the tool always exits 0); the issue is advisory, not a gate. The second argument
+      # is the downloaded machine-key directory whose fingerprints scope the analysis.
       - name: Analyze benchmark history
         shell: pwsh
         env:
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
-        run: just gh-analyze-bench-history "$env:SCRATCH_DIR"
+        run: just gh-analyze-bench-history "$env:SCRATCH_DIR" "$env:SCRATCH_DIR/machine-keys"
 
       - name: Read notable flag
         id: notable
@@ -397,12 +371,8 @@ jobs:
   alert:
     # Open a deduplicated issue whenever collection or analysis fails, so a broken
     # run is noticed instead of silently rotting. Same main-only gate as the others.
-    # A REJECTED both-inputs-set dispatch is deliberately excluded (`guard.result != 'failure'`):
-    # that is an operator input mistake, not a pipeline-health failure, and the red run is already
-    # self-evident to whoever dispatched it - filing the rolling "workflow failed" issue for a typo
-    # would be misleading noise. Genuine collect/analyze failures (guard skipped) still alert.
-    needs: [reject-conflicting-inputs, collect, analyze]
-    if: failure() && needs.reject-conflicting-inputs.result != 'failure' && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    needs: [collect, analyze]
+    if: failure() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -462,16 +432,12 @@ jobs:
     # success() function, so a future unrelated job cannot affect this decision); if either the
     # collect or analyze it cares about failed, alert (failure()) handles it and this stays off.
     # Same main-only gate as the others. A no-op on runs when no failure issue is open.
-    # `always()` is REQUIRED, not cosmetic: a green reanalyze run legitimately SKIPS collect, and a
-    # skipped `needs` job would otherwise force this plain-conditional job to skip too (the guard,
-    # also normally skipped, is in `needs` for the same reason). With `always()` the explicit result
-    # checks below do all the deciding - a `skipped` collect is accepted alongside `success` so an
-    # analysis-only run still clears a stale alert, while a rejected both-inputs-set dispatch leaves
-    # analyze skipped (not success), keeping this off.
-    needs: [reject-conflicting-inputs, collect, analyze]
+    # `always()` lets the explicit result checks below do all the deciding, independent of the
+    # default all-needs-succeeded gate.
+    needs: [collect, analyze]
     if: >-
       always()
-      && (needs.collect.result == 'success' || needs.collect.result == 'skipped')
+      && needs.collect.result == 'success'
       && needs.analyze.result == 'success'
       && github.repository == 'folo-rs/folo'
       && github.ref == 'refs/heads/main'

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -149,16 +149,13 @@ invalidates a level that was previously accepted. Analysis is unaffected by the 
 surveys the current `main` tip.
 
 The stored history can also change *out of band* — a blessing or unblessing, a `prune`, or an
-administrative overwrite performed from a developer machine — and by default those only surface in
-the rolling issue on the next push, which pays for a full collection to re-survey data that already
-exists. A `workflow_dispatch` with `reanalyze` set is the cheap escape hatch: it *skips collection
-entirely* and runs only the analysis job, refreshing the rolling issue in minutes. It is
-general-purpose — re-analysis of the current store, not tied to any one kind of edit — and correct
-for every kind because the analysis always re-lists the store (so out-of-band additions are seen)
-while deletions and overwrites bump the cache-invalidation marker (so those are seen too); the
-reanalysis itself writes nothing. `reanalyze` and `recollect_commit_id` are mutually exclusive — a
-recollect *is* a collection, so requesting both is contradictory — and a dispatch that sets both is
-rejected before any work starts rather than silently picking one.
+administrative overwrite performed from a developer machine. Those surface in the rolling issue on
+the next push, which re-lists the store (so out-of-band additions are seen) while deletions and
+overwrites bump the cache-invalidation marker (so those are seen too). There is deliberately no
+"analysis only" dispatch mode: analysis threads the *exact machine keys collected this run* from the
+collect matrix into the single analyze job (see below), so a mode that skipped collection would have
+no keys to analyze. To force a refresh out of band, push a commit or dispatch a `recollect_commit_id`
+run (which still collects, hence still produces keys).
 A downstream analysis job reads the accumulated
 history and files a single rolling, advisory issue when it detects a notable regression;
 regressions never fail the run. Because a GitHub issue body is size-capped and a large

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -155,13 +155,34 @@ jobs:
           Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
       # Collect only the delta-affected packages (space-separated from the delta job), keyed by the
-      # PR head commit with the fixed `github` machine key so the wall-clock series stays comparable
-      # to main's baseline. `--skip-existing` makes a re-run of the same head SHA a no-op append.
+      # PR head commit and stamped with THIS runner's real hardware fingerprint (no fixed key) so the
+      # wall-clock series lives on the same per-SKU partitions as main's baseline. `--skip-existing`
+      # makes a re-run of the same head SHA a no-op append.
       - name: Collect PR benchmark history
         shell: pwsh
         env:
           PR_PACKAGES: ${{ needs.delta.outputs.packages }}
         run: just gh-collect-pr-bench-history "$env:PR_PACKAGES"
+
+      # Record THIS runner's real hardware fingerprint so the single analyze job can thread the exact
+      # keys collected this run into its `--machine-key` filter (collect is a matrix, analyze is not).
+      # Runs only after a SUCCESSFUL collect - the default step behavior - so a failed leg's key is
+      # not threaded. The write recipe logs the fingerprint components under --verbose.
+      - name: Record runner machine key
+        shell: pwsh
+        env:
+          KEY_FILE: ${{ runner.temp }}/machine-key.txt
+        run: just gh-write-bench-history-machine-key "$env:KEY_FILE"
+
+      # Upload this leg's key under a per-platform artifact name so the analyze job can download every
+      # leg's key together (one file per platform). if-no-files-found: error catches a broken
+      # key-write step loudly rather than silently dropping a key from the analysis.
+      - name: Upload runner machine key
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-bench-history-machine-key-${{ matrix.platform }}
+          path: ${{ runner.temp }}/machine-key.txt
+          if-no-files-found: error
 
   # Compare the PR head against `main` in branch mode and post/update the rolling PR comment. Runs
   # after every platform finishes (even partially: fail-fast is off) so the comparison reflects
@@ -242,13 +263,27 @@ jobs:
       # vs origin/main), including improvements as well as regressions. Findings never fail the
       # recipe (the tool always exits 0); the PR comment is advisory, not a gate. Analysis is
       # deliberately run UNSCOPED: `analyze`'s default ghost-exclusion (only benchmarks present at
+      # Download every collect leg's machine-key file (one per-platform artifact) into a single
+      # directory so the analysis can thread the EXACT fingerprints collected this run into its
+      # `--machine-key` filter. The default (no merge-multiple) keeps one subdirectory per artifact;
+      # the recipe scans recursively. A leg whose collection failed uploaded nothing, so its key is
+      # simply absent; if EVERY leg failed the pattern download matches nothing (it does not fail) and
+      # the recipe treats the empty directory as "nothing to analyze".
+      - name: Download collected machine keys
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pr-bench-history-machine-key-*
+          path: ${{ steps.scratch.outputs.dir }}/machine-keys
+
       # the PR head are analyzed) restricts it to exactly the collected packages, so no per-package
       # filter is needed - the recipe must not pass `--include-ghosts`. See the recipe / design.md.
+      # The third argument is the downloaded machine-key directory whose fingerprints scope the
+      # analysis.
       - name: Analyze PR benchmark history
         shell: pwsh
         env:
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
-        run: just gh-analyze-pr-bench-history "$env:SCRATCH_DIR" origin/main
+        run: just gh-analyze-pr-bench-history "$env:SCRATCH_DIR" origin/main "$env:SCRATCH_DIR/machine-keys"
 
       - name: Read notable flag
         id: notable

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -118,7 +118,7 @@ gh-write-bench-history-machine-key file:
 
     $file = "{{file}}"
     $parent = Split-Path -Parent $file
-    if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+    if ($parent) { New-Item -ItemType Directory -LiteralPath $parent -Force | Out-Null }
 
     Write-Verbose "Resolving this runner's real hardware machine key; the fingerprint components are logged to stderr under --verbose for debugging a key change." -Verbose
     # The key is the tool's sole stdout line; --verbose components go to stderr, so the pipeline
@@ -132,7 +132,7 @@ gh-write-bench-history-machine-key file:
     # Normalize to lowercase right after validation so the persisted file and the verbose log below
     # always agree, even if the tool ever emits uppercase or mixed-case hex.
     $key = $key.ToLowerInvariant()
-    Set-Content -Path $file -Value $key -Encoding utf8 -NoNewline
+    Set-Content -LiteralPath $file -Value $key -Encoding utf8 -NoNewline
     Write-Verbose "Wrote machine key '$key' to $file." -Verbose
 
 # Analyzes the collected history for regressions across ALL engines and target triples, restricted
@@ -180,7 +180,7 @@ gh-analyze-bench-history dir keydir:
     Import-Module ./scripts/bench-history/BenchHistoryMachineKey.psm1 -Force
 
     $dir = "{{dir}}"
-    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    New-Item -ItemType Directory -LiteralPath $dir -Force | Out-Null
     $reportPath = Join-Path $dir "report.md"
     $jsonPath = Join-Path $dir "report.json"
     $summaryPath = Join-Path $dir "summary.md"
@@ -194,10 +194,10 @@ gh-analyze-bench-history dir keydir:
         # keep the recipe's four-artefact contract) and skip the tool. The collect-failure alert
         # already notifies, so this deliberately does not itself fail.
         Write-Warning "No machine keys were collected this run (every collect leg failed); skipping analysis and emitting a non-notable placeholder report."
-        Set-Content -Path $reportPath -Value "# Benchmark history`n`nNo machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
-        Set-Content -Path $summaryPath -Value "No machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
-        Set-Content -Path $jsonPath -Value '{"notable":false}' -Encoding utf8
-        Set-Content -Path $notablePath -Value 'false' -Encoding utf8
+        Set-Content -LiteralPath $reportPath -Value "# Benchmark history`n`nNo machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -LiteralPath $summaryPath -Value "No machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -LiteralPath $jsonPath -Value '{"notable":false}' -Encoding utf8
+        Set-Content -LiteralPath $notablePath -Value 'false' -Encoding utf8
         return
     }
 
@@ -206,9 +206,9 @@ gh-analyze-bench-history dir keydir:
     Write-Verbose "Analyzing benchmark history in a single pass; writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, mirroring fetched cloud objects under $cacheDir so the history is downloaded at most once across runs." -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
-    $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
     $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }
-    Set-Content -Path $notablePath -Value $notable -Encoding utf8
+    Set-Content -LiteralPath $notablePath -Value $notable -Encoding utf8
     Write-Verbose "Analysis complete: notable=$notable (full report at $reportPath, condensed summary at $summaryPath)." -Verbose
 
 # The PR counterpart of `gh-analyze-bench-history`: analyzes the collected history in BRANCH mode -
@@ -252,7 +252,7 @@ gh-analyze-pr-bench-history dir base keydir:
     Import-Module ./scripts/bench-history/BenchHistoryMachineKey.psm1 -Force
 
     $dir = "{{dir}}"
-    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    New-Item -ItemType Directory -LiteralPath $dir -Force | Out-Null
     $reportPath = Join-Path $dir "report.md"
     $jsonPath = Join-Path $dir "report.json"
     $summaryPath = Join-Path $dir "summary.md"
@@ -265,10 +265,10 @@ gh-analyze-pr-bench-history dir base keydir:
         # non-notable placeholder set (keeping the recipe's four-artefact contract) and skip the tool;
         # the workflow's collect-failure handling notifies separately.
         Write-Warning "No machine keys were collected this run (every collect leg failed); skipping PR analysis and emitting a non-notable placeholder report."
-        Set-Content -Path $reportPath -Value "# PR benchmark history`n`nNo machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
-        Set-Content -Path $summaryPath -Value "No machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
-        Set-Content -Path $jsonPath -Value '{"notable":false}' -Encoding utf8
-        Set-Content -Path $notablePath -Value 'false' -Encoding utf8
+        Set-Content -LiteralPath $reportPath -Value "# PR benchmark history`n`nNo machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -LiteralPath $summaryPath -Value "No machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -LiteralPath $jsonPath -Value '{"notable":false}' -Encoding utf8
+        Set-Content -LiteralPath $notablePath -Value 'false' -Encoding utf8
         return
     }
 
@@ -277,9 +277,9 @@ gh-analyze-pr-bench-history dir base keydir:
     Write-Verbose "Analyzing PR benchmark history in branch mode (context HEAD vs base {{base}}); writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, including improvements as well as regressions, and mirroring fetched cloud objects under $cacheDir." -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --context HEAD --base '{{base}}' --include-improvements --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
-    $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
     $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }
-    Set-Content -Path $notablePath -Value $notable -Encoding utf8
+    Set-Content -LiteralPath $notablePath -Value $notable -Encoding utf8
     Write-Verbose "PR analysis complete: notable=$notable (full report at $reportPath, condensed summary at $summaryPath)." -Verbose
 
 # Files (or updates in place) a single rolling issue identified by its exact title, from a

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -7,18 +7,20 @@
 
 # Collects the whole workspace's benchmark history (excluding the slow, special-purpose
 # `benchmarks` package) into the prod Azure store, keyed by the current commit. The machine
-# partition for noisy wall-clock engines is pinned to the fixed key `github` rather than
-# auto-detected: the GitHub-hosted runner pool may contain differently-specced machines, and a
-# per-machine fingerprint would fork the series (and split the history) whenever a run lands on
-# a different SKU. Pinning keeps every push on one series (accepting the jitter a heterogeneous
-# pool causes); a genuine hardware migration is absorbed by blessing the resulting step change.
-# Deterministic engines (Callgrind, allocation/time counters) are hardware-independent and
-# ignore the key. `--best-of 3` counteracts the same runner noise from the other direction: the
+# partition for noisy wall-clock engines is the runner's OWN auto-detected hardware fingerprint,
+# NOT a fixed key: the GitHub-hosted runner pool is heterogeneous, and pinning every SKU onto one
+# synthetic series just mixes incomparable machines and jitters daily. Letting each runner stamp
+# its real fingerprint splits the data into one clean series per hardware type; the analyze job is
+# fed the exact fingerprints collected this run (see gh-analyze-bench-history) so it surveys only
+# those series. Deterministic engines (Callgrind, allocation/time counters) are hardware-independent
+# and ignore the key. `--best-of 3` counteracts the same runner noise from the other direction: the
 # suite runs three times and each metric keeps its minimum sample, since benchmark interference
 # on a shared runner is one-sided (it only ever makes a case slower) and the runs are spaced far
 # enough apart in time that a transient slowdown is unlikely to hit every one. This roughly
 # triples the wall-clock benchmark portion of the collect job (see bench-history.yml's
-# `timeout-minutes`). `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
+# `timeout-minutes`). `--verbose` makes the collect log spell out the resolved machine key and the
+# fingerprint components behind it, so a key change (a runner-pool SKU shift) is debuggable from the
+# log alone. `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
 # already-stored object is skipped, not overwritten), so a re-triggered run of an
 # already-collected commit never bumps the cache-invalidation marker the `analyze` job's
 # read-through cache depends on - a re-run of the same commit is not "better" data, so there is
@@ -67,10 +69,11 @@ gh-collect-bench-history:
 # and it is safe because branch-mode `analyze` only ever flags a series that has a data point at the
 # branch-unique head commit, i.e. exactly the packages collected here (see
 # gh-analyze-pr-bench-history and .github/workflows/design.md). Everything else is identical to the
-# push-to-main collect: the fixed `github` machine key keeps PR wall-clock series comparable to
-# main's baseline, `--best-of 3` sheds one-sided runner jitter, and `--skip-existing` makes a re-run
-# of the same head SHA a no-op append. There is no recollect mode on PRs (that repairs main's
-# permanent history); the scope decision lives in
+# push-to-main collect: each runner stamps its OWN real hardware fingerprint (no fixed key), so PR
+# wall-clock series live on the same per-SKU partitions as main's baseline, `--best-of 3` sheds
+# one-sided runner jitter, `--verbose` logs the resolved key and its components, and
+# `--skip-existing` makes a re-run of the same head SHA a no-op append. There is no recollect mode on
+# PRs (that repairs main's permanent history); the scope decision lives in
 # scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this is
 # a thin import + call. `packages` must be non-empty - the workflow only invokes this recipe when
 # the delta produced at least one benchmarkable package, and an empty scope would wrongly fall back
@@ -95,19 +98,63 @@ gh-collect-pr-bench-history packages:
     $toolArgs = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package $packageList -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
 
-# Analyzes the collected history for regressions across ALL engines and target triples, but
-# only the `github` machine key - the fixed key `gh-collect-bench-history` stamps on the
-# GitHub runner pool's data. Restricting it here (rather than `--machine-key all`) keeps this
-# job surveying only GitHub-pool history and never mixes in a stray key some other machine may
-# have inserted into the shared store. It writes four artefacts INTO the given {{dir}}:
-# report.md (the full Markdown report), report.json (the full JSON report), summary.md (the
-# Markdown report condensed to the top findings by magnitude, so the rolling regression issue's
-# body stays under GitHub's 65,536-character limit) and notable.txt (`true`/`false`, the JSON
-# `notable` flag). Findings never fail the recipe (the tool always exits 0); the workflow files
-# a rolling issue when notable, posting the summary as the body and attaching the two full
-# reports as run artifacts. `auto` mode on a clean `main` checkout resolves to long-range
-# history-trend detection. A single analyze pass emits every report via the per-format output
-# toggles (`--no-text --markdown --json --markdown-summary`).
+# Writes THIS runner's real hardware machine key (the fingerprint the collect step just stamped its
+# wall-clock results with) to {{file}}, so the single analyze job can thread the EXACT keys collected
+# this run into its `--machine-key` filter. Collection is a matrix across a heterogeneous runner pool
+# but analysis is one job that cannot re-derive those keys from its own hardware, so each collect leg
+# records its key here and uploads it as a per-platform artifact; the analyze job downloads them all
+# and gh-analyze-bench-history turns the directory into repeated `--machine-key` args (see
+# scripts/bench-history/BenchHistoryMachineKey.psm1). The `machine-key` command prints ONLY the key
+# to stdout (captured here) while `--verbose` sends the fingerprint components to stderr, so the same
+# components appear in the workflow log for debugging a key change without polluting the file. Shared
+# by both bench-history.yml and pr-bench-history.yml; run after a SUCCESSFUL collect (a failed leg
+# collected nothing, so its key must not be threaded).
+[group('automation')]
+[script]
+gh-write-bench-history-machine-key file:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $file = "{{file}}"
+    $parent = Split-Path -Parent $file
+    if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+
+    Write-Verbose "Resolving this runner's real hardware machine key; the fingerprint components are logged to stderr under --verbose for debugging a key change." -Verbose
+    # The key is the tool's sole stdout line; --verbose components go to stderr, so the pipeline
+    # captures only the key. Select the last stdout line defensively in case cargo emits anything to
+    # stdout, then validate it is the expected 16-hex-character fingerprint before persisting.
+    $key = (cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- machine-key --verbose | Select-Object -Last 1)
+    $key = if ($null -eq $key) { '' } else { $key.Trim() }
+    if ($key -notmatch '^[0-9a-fA-F]{16}$') {
+        throw "machine-key produced '$key', which is not a 16-hex-character fingerprint; refusing to persist it."
+    }
+    Set-Content -Path $file -Value $key.ToLowerInvariant() -Encoding utf8 -NoNewline
+    Write-Verbose "Wrote machine key '$key' to $file." -Verbose
+
+# Analyzes the collected history for regressions across ALL engines and target triples, restricted
+# to the EXACT machine keys collected this run. Collection now stamps each runner's real hardware
+# fingerprint (no fixed `github` key), and every collect leg uploaded its fingerprint as an artifact;
+# the analyze job downloads them all into {{keydir}} and this recipe turns that directory into the
+# repeated `--machine-key <fingerprint>` args via the Pester-tested Get-MachineKeyArgument (see
+# scripts/bench-history/BenchHistoryMachineKey.psm1). Threading the exact keys (rather than
+# `--machine-key all`) keeps the survey scoped to the machines that actually measured this commit and
+# never mixes in a stray key some other machine inserted into the shared store. Only hardware-
+# DEPENDENT engines partition by machine key; deterministic engines (Callgrind, alloc/time counters)
+# are exempt from the machine-key filter inside the tool, so they are analyzed regardless.
+#
+# {{keydir}} may be EMPTY when every collect leg failed (a total collect failure uploads nothing):
+# there is then no new data at this commit to survey, so the recipe writes a non-notable placeholder
+# report set and returns without invoking the tool (the workflow's separate collect-failure alert
+# does the notifying). It writes four artefacts INTO the given {{dir}}: report.md (the full Markdown
+# report), report.json (the full JSON report), summary.md (the Markdown report condensed to the top
+# findings by magnitude, so the rolling regression issue's body stays under GitHub's 65,536-character
+# limit) and notable.txt (`true`/`false`, the JSON `notable` flag). Findings never fail the recipe
+# (the tool always exits 0); the workflow files a rolling issue when notable, posting the summary as
+# the body and attaching the two full reports as run artifacts. `auto` mode on a clean `main`
+# checkout resolves to long-range history-trend detection. A single analyze pass emits every report
+# via the per-format output toggles (`--no-text --markdown --json --markdown-summary`); `--verbose`
+# makes the analysis log spell out the effective machine-key selection for debugging.
 #
 # {{dir}} is a scratch directory OUTSIDE the repo checkout (the bench-history.yml `analyze`
 # job passes the runner temp dir). Keeping every artefact out of the working tree is what
@@ -122,10 +169,12 @@ gh-collect-pr-bench-history packages:
 # a stale mirror is wiped via the cloud-side marker only after a deliberate `--overwrite`/`prune`.
 [group('automation')]
 [script]
-gh-analyze-bench-history dir:
+gh-analyze-bench-history dir keydir:
     Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module ./scripts/bench-history/BenchHistoryMachineKey.psm1 -Force
 
     $dir = "{{dir}}"
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
@@ -134,10 +183,25 @@ gh-analyze-bench-history dir:
     $summaryPath = Join-Path $dir "summary.md"
     $notablePath = Join-Path $dir "notable.txt"
     $cacheDir = Join-Path $dir "cache"
-    $common = @('--engine', 'all', '--target-triple', 'all', '--machine-key', 'github')
+
+    $keyArgs = @(Get-MachineKeyArgument -KeyDirectory "{{keydir}}" -Verbose)
+    if ($keyArgs.Count -eq 0) {
+        # Total collect failure: no keys were uploaded, so there is nothing new to analyze. Emit a
+        # non-notable placeholder set (the workflow's Read-notable step needs notable.txt; the rest
+        # keep the recipe's four-artefact contract) and skip the tool. The collect-failure alert
+        # already notifies, so this deliberately does not itself fail.
+        Write-Warning "No machine keys were collected this run (every collect leg failed); skipping analysis and emitting a non-notable placeholder report."
+        Set-Content -Path $reportPath -Value "# Benchmark history`n`nNo machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -Path $summaryPath -Value "No machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -Path $jsonPath -Value '{"notable":false}' -Encoding utf8
+        Set-Content -Path $notablePath -Value 'false' -Encoding utf8
+        return
+    }
+
+    $common = @('--engine', 'all', '--target-triple', 'all') + $keyArgs
 
     Write-Verbose "Analyzing benchmark history in a single pass; writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, mirroring fetched cloud objects under $cacheDir so the history is downloaded at most once across runs." -Verbose
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
     $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }
@@ -154,9 +218,12 @@ gh-analyze-bench-history dir:
 # head is checked out detached, so there is no local `main` branch to auto-resolve, whereas
 # `fetch-depth: 0` populates the `origin/main` remote-tracking ref the merge-base needs.
 # `--include-improvements` is added so the rolling PR comment can also surface detected speedups, not
-# only regressions. Everything else matches the main analyze: only the `github` machine key (the
-# fixed key collection stamps on the runner pool), all engines and triples, findings never fail the
-# recipe (the tool always exits 0), and `--cache` mirrors fetched cloud objects under {{dir}}/cache.
+# only regressions. Everything else matches the main analyze: the EXACT machine keys collected this
+# run (threaded from {{keydir}} via Get-MachineKeyArgument, not the removed fixed `github` key), all
+# engines and triples, findings never fail the recipe (the tool always exits 0), `--verbose` logs the
+# effective machine-key selection, and `--cache` mirrors fetched cloud objects under {{dir}}/cache. A
+# total collect failure leaves {{keydir}} empty; as in the main analyze, the recipe then writes a
+# non-notable placeholder set and skips the tool.
 #
 # This is intentionally NOT package-scoped even though collection is: `analyze` has no per-package
 # filter (only positional id-prefix subjects), and benchmark ids are engine-dependent (Callgrind
@@ -174,10 +241,12 @@ gh-analyze-bench-history dir:
 # dir), so `analyze`'s own `git status --porcelain` dirty-check never sees these artefacts.
 [group('automation')]
 [script]
-gh-analyze-pr-bench-history dir base:
+gh-analyze-pr-bench-history dir base keydir:
     Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module ./scripts/bench-history/BenchHistoryMachineKey.psm1 -Force
 
     $dir = "{{dir}}"
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
@@ -186,10 +255,24 @@ gh-analyze-pr-bench-history dir base:
     $summaryPath = Join-Path $dir "summary.md"
     $notablePath = Join-Path $dir "notable.txt"
     $cacheDir = Join-Path $dir "cache"
-    $common = @('--engine', 'all', '--target-triple', 'all', '--machine-key', 'github')
+
+    $keyArgs = @(Get-MachineKeyArgument -KeyDirectory "{{keydir}}" -Verbose)
+    if ($keyArgs.Count -eq 0) {
+        # Total collect failure: no keys were uploaded, so there is nothing new to analyze. Emit a
+        # non-notable placeholder set (keeping the recipe's four-artefact contract) and skip the tool;
+        # the workflow's collect-failure handling notifies separately.
+        Write-Warning "No machine keys were collected this run (every collect leg failed); skipping PR analysis and emitting a non-notable placeholder report."
+        Set-Content -Path $reportPath -Value "# PR benchmark history`n`nNo machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -Path $summaryPath -Value "No machine keys were collected this run, so there was nothing to analyze." -Encoding utf8
+        Set-Content -Path $jsonPath -Value '{"notable":false}' -Encoding utf8
+        Set-Content -Path $notablePath -Value 'false' -Encoding utf8
+        return
+    }
+
+    $common = @('--engine', 'all', '--target-triple', 'all') + $keyArgs
 
     Write-Verbose "Analyzing PR benchmark history in branch mode (context HEAD vs base {{base}}); writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, including improvements as well as regressions, and mirroring fetched cloud objects under $cacheDir." -Verbose
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --context HEAD --base '{{base}}' --include-improvements --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --context HEAD --base '{{base}}' --include-improvements --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
     $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -129,7 +129,10 @@ gh-write-bench-history-machine-key file:
     if ($key -notmatch '^[0-9a-fA-F]{16}$') {
         throw "machine-key produced '$key', which is not a 16-hex-character fingerprint; refusing to persist it."
     }
-    Set-Content -Path $file -Value $key.ToLowerInvariant() -Encoding utf8 -NoNewline
+    # Normalize to lowercase right after validation so the persisted file and the verbose log below
+    # always agree, even if the tool ever emits uppercase or mixed-case hex.
+    $key = $key.ToLowerInvariant()
+    Set-Content -Path $file -Value $key -Encoding utf8 -NoNewline
     Write-Verbose "Wrote machine key '$key' to $file." -Verbose
 
 # Analyzes the collected history for regressions across ALL engines and target triples, restricted

--- a/packages/cargo-bench-history/README.md
+++ b/packages/cargo-bench-history/README.md
@@ -47,6 +47,11 @@ cargo bench-history analyze --local=./bench-history
 # with the commit that caused it (both --benchmark and --metric are required).
 cargo bench-history examine --local=./bench-history \
     --benchmark my_pkg/my_group/my_case --metric instruction_count
+
+# Print this machine's hardware fingerprint (the key hardware-dependent history is
+# partitioned by). --verbose additionally reports the factors behind the key on
+# standard error, for tracing a key change to the hardware detail that moved.
+cargo bench-history machine-key
 ```
 
 ## See also

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -206,6 +206,15 @@ so an accidental change to the canonical form is caught. A command-line override
 the computed fingerprint (it is CLI-only — a committed config would carry a machine key
 wrong for some checkouts). The key is computed only for hardware-dependent engines.
 
+The individual factors behind the fingerprint (the version tag, processor and memory-region
+counts, and CPU brand) are surfaced for debugging: `collect` and the query commands emit
+them to standard error under `--verbose`, and the standalone `machine-key` command prints
+the key to standard output (with `--verbose` adding the factors to standard error). The
+latter exists so CI can capture the real per-runner key and thread it into a later `analyze`
+selection, now that runs are keyed by the auto-detected fingerprint rather than a fixed pin.
+The same factors and resulting fingerprint are also recorded on every stored run as
+write-only provenance (see §5).
+
 ## 5. Run context
 
 Captured once per stored run: the observation timestamp (above); the git commit, branch,
@@ -216,6 +225,15 @@ environment (with `Local` a first-class provider alongside the automated ones); 
 and cargo versions and the resolved execution triple; and provenance (tool version, schema
 version, machine key). Git and environment access go through a small abstraction so the
 logic is unit-testable without a real repo or CI.
+
+The context also carries optional **host-hardware provenance** (`context.machine`): the
+fingerprint factors (processor and memory-region counts, CPU brand) and the auto-detected
+key they hash to. It is **write-only** — nothing reads it back — and exists purely so that a
+later change in a machine key can be traced to the specific factor that moved (for example, a
+runner pool swapping CPU models). It records the auto-detected fingerprint regardless of any
+`--machine-key` override, and is an additive, backward-compatible field (absent on runs
+written before it existed and on the non-`collect` construction sites that do not probe
+hardware), so its introduction only bumps the schema version for legibility.
 
 ## 6. Storage
 

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -19,14 +19,17 @@ use cbh_engines::{
     parse_criterion_case,
 };
 use cbh_git::{BenchRunner, TokioBenchRunner};
-use cbh_probe::{EnvironmentProbe, HardwareProfile, RustcInfo, SystemProbe, resolve_machine_key};
+use cbh_probe::{
+    EnvironmentProbe, HardwareProfile, RustcInfo, SystemProbe, describe_fingerprint_components,
+    resolve_machine_key,
+};
 use cbh_storage::{Storage, StorageError, StorageFacade, build_storage};
 use jiff::Timestamp;
 use tick::Clock;
 
 use crate::model::{
-    BenchmarkResult, DiscriminantSet, Engine, EnvironmentInfo, GitInfo, Run, RunContext,
-    ToolchainInfo, detect_environment, min_per_metric,
+    BenchmarkResult, DiscriminantSet, Engine, EnvironmentInfo, GitInfo, MachineInfo, Run,
+    RunContext, ToolchainInfo, detect_environment, min_per_metric,
 };
 use crate::{CollectOptions, LocalStorageSelection, RunError, RunOutcome, finish_with_flush};
 
@@ -397,6 +400,16 @@ where
         &effective_machine_key,
         options.machine_key.is_some(),
     ));
+    // Under --verbose, spell out the individual hardware factors behind the
+    // auto-detected fingerprint so that if the machine key changes between runs
+    // the responsible factor can be identified from the log (even when an
+    // explicit --machine-key override is currently masking the fingerprint).
+    deps.reporter.note_with(|| {
+        format!(
+            "hardware fingerprint components: {}",
+            describe_fingerprint_components(&shared.hardware)
+        )
+    });
 
     let mut stored = 0_usize;
     let mut harvested = 0_usize;
@@ -454,6 +467,21 @@ fn collect_selection_summary(
         "collecting: target-triple={triple} (toolchain host); \
          machine-key={machine_key} ({machine_source}), used by hardware-dependent engines"
     )
+}
+
+/// Builds the write-only host-hardware provenance recorded on every stored run:
+/// the fingerprint factors and the key they hash to.
+///
+/// It always records the auto-detected fingerprint (independent of any
+/// `--machine-key` override used to partition storage), so that a later change in
+/// a partition key can be traced back to the specific hardware factor that moved.
+fn machine_info(hardware: &HardwareProfile) -> MachineInfo {
+    MachineInfo {
+        processors: hardware.processors,
+        memory_regions: hardware.memory_regions,
+        cpu_brand: hardware.cpu_brand.clone(),
+        fingerprint: resolve_machine_key(None, hardware),
+    }
 }
 
 /// Emits the per-metric best-of provenance: the samples seen and which run won.
@@ -644,6 +672,11 @@ where
         },
         deps.tool_version.to_owned(),
     );
+    // Record the host hardware provenance on every stored run (write-only): the
+    // fingerprint factors and the key they hash to, so a later change in a
+    // machine key can be traced to the specific factor that moved.
+    let mut context = context;
+    context.machine = Some(machine_info(&shared.hardware));
     let run = Run::new(context, records);
 
     // Hardware-dependent engines (such as Criterion) partition their history by a

--- a/packages/cargo-bench-history/src/commands/machine_key.rs
+++ b/packages/cargo-bench-history/src/commands/machine_key.rs
@@ -1,0 +1,90 @@
+//! The `machine-key` command: print this machine's hardware fingerprint.
+//!
+//! The key is what hardware-dependent engines partition their history by, so it
+//! is printed to standard output (clean, one line) for CI to capture and thread
+//! into an `analyze` selection. Under `--verbose`, the individual factors that
+//! make up the fingerprint are emitted to standard error so a change in the key
+//! can be traced to the specific factor that changed.
+
+use cbh_diag::{Reporter, ReporterExt, StderrReporter};
+use cbh_probe::{
+    EnvironmentProbe, HardwareProfile, SystemProbe, describe_fingerprint_components,
+    resolve_machine_key,
+};
+
+use crate::{MachineKeyOptions, RunError, RunOutcome};
+
+/// Executes the `machine-key` command against the real host.
+///
+/// # Errors
+///
+/// Never fails: hardware probing is best-effort and always yields a profile.
+/// Returns a `Result` to match the shape every command handler shares.
+pub(crate) async fn execute(options: &MachineKeyOptions) -> Result<RunOutcome, RunError> {
+    let profile = SystemProbe::default().hardware().await;
+    let reporter = StderrReporter::new(options.verbose);
+    Ok(machine_key_outcome(&profile, &reporter))
+}
+
+/// Derives the machine key from `profile` and emits the outcome (pure over its
+/// inputs, so it is unit-tested without probing the host).
+///
+/// The key becomes the outcome message (printed to standard output). The
+/// fingerprint components are emitted as a diagnostic note, which the reporter
+/// only surfaces (to standard error) under `--verbose`.
+fn machine_key_outcome(profile: &HardwareProfile, reporter: &dyn Reporter) -> RunOutcome {
+    reporter.note_with(|| {
+        format!(
+            "machine-key components: {}",
+            describe_fingerprint_components(profile)
+        )
+    });
+    RunOutcome::Completed {
+        message: resolve_machine_key(None, profile),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use cbh_diag::RecordingReporter;
+
+    use super::*;
+
+    fn profile(processors: usize, memory_regions: usize, brand: Option<&str>) -> HardwareProfile {
+        HardwareProfile {
+            processors,
+            memory_regions,
+            cpu_brand: brand.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn outcome_message_is_the_fingerprint() {
+        let hardware = profile(8, 1, Some("Test CPU 3000"));
+        let reporter = RecordingReporter::new();
+
+        let outcome = machine_key_outcome(&hardware, &reporter);
+
+        let RunOutcome::Completed { message } = outcome else {
+            panic!("machine-key should complete: {outcome:?}");
+        };
+        assert_eq!(message, resolve_machine_key(None, &hardware));
+    }
+
+    #[test]
+    fn verbose_note_lists_the_components() {
+        let hardware = profile(8, 1, Some("Test CPU 3000"));
+        let reporter = RecordingReporter::new();
+
+        let _ = machine_key_outcome(&hardware, &reporter);
+
+        assert!(
+            reporter.contains("machine-key components:")
+                && reporter.contains("processors=8")
+                && reporter.contains("cpu_brand=\"Test CPU 3000\""),
+            "{:?}",
+            reporter.notes()
+        );
+    }
+}

--- a/packages/cargo-bench-history/src/commands/mod.rs
+++ b/packages/cargo-bench-history/src/commands/mod.rs
@@ -4,9 +4,11 @@
 mod backfill;
 mod collect;
 mod install;
+mod machine_key;
 mod reporting;
 
 pub(crate) use backfill::execute as backfill;
 pub(crate) use collect::execute as collect;
 pub(crate) use install::execute as install;
+pub(crate) use machine_key::execute as machine_key;
 pub(crate) use reporting::{analyze, bless, examine, list, prune, unbless};

--- a/packages/cargo-bench-history/src/dispatch.rs
+++ b/packages/cargo-bench-history/src/dispatch.rs
@@ -114,5 +114,6 @@ pub async fn run_with_overrides(
         }
         Command::Bless(options) => commands::bless(options, workspace_dir, clock).await,
         Command::Unbless(options) => commands::unbless(options, workspace_dir).await,
+        Command::MachineKey(options) => commands::machine_key(options).await,
     }
 }

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -175,6 +175,19 @@
 //! at *later* commits remain in force, so the timeline may stay blessed past the
 //! unblessed commit.
 //!
+//! ## `machine-key`
+//!
+//! Prints this machine's hardware fingerprint — the machine key that
+//! hardware-dependent engines partition their history by — to standard output as a
+//! single clean line, and exits. It probes only the host's hardware: no repository,
+//! git, config, or storage is touched. This is the key `collect` stamps its
+//! hardware-dependent results with, so CI captures it to thread the exact keys a
+//! collection produced into the matching `analyze` selection (see the per-push and
+//! per-PR workflows). Under `--verbose` the individual factors behind the
+//! fingerprint (processor count, memory regions, CPU brand, and the factor-set
+//! version tag) are written to standard error, so a change in the key can be traced
+//! to the specific factor that moved.
+//!
 //! # Selecting data: options shared by the query commands
 //!
 //! `analyze`, `list`, `prune`, and `examine` share one selection model, organized
@@ -302,8 +315,8 @@ mod output;
 pub use cbh_cli::{Cli, EarlyExit};
 pub use cbh_command::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,
-    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions,
-    UnblessOptions,
+    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection,
+    MachineKeyOptions, PruneOptions, UnblessOptions,
 };
 pub use cbh_config::{ConfigError, default_template};
 pub(crate) use cbh_model as model;

--- a/packages/cargo-bench-history/tests/cbh_integration/collect.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/collect.rs
@@ -29,6 +29,25 @@ async fn collect_callgrind_end_to_end_stores_results() {
     assert_eq!(set.schema_version, SCHEMA_VERSION);
     assert_eq!(set.context.tool_version, TOOL_VERSION);
 
+    // The host-hardware provenance is recorded on every stored run (write-only),
+    // even for a hardware-independent engine: its fingerprint is the auto-detected
+    // machine key, a 16-char lowercase hex digest of the probed factors.
+    let machine = set
+        .context
+        .machine
+        .as_ref()
+        .expect("collect records host-hardware provenance");
+    assert!(machine.processors >= 1, "{machine:?}");
+    assert!(machine.memory_regions >= 1, "{machine:?}");
+    assert_eq!(machine.fingerprint.len(), 16, "{machine:?}");
+    assert!(
+        machine
+            .fingerprint
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "{machine:?}"
+    );
+
     assert_eq!(set.results.len(), 1);
     let record = &set.results[0];
     // The unparametrized summary carries no parameter segment, so its identity

--- a/packages/cargo-bench-history/tests/cbh_integration/machine_key.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/machine_key.rs
@@ -1,0 +1,28 @@
+use crate::harness::*;
+
+/// Driving `machine-key` through the production `run` entry probes the real host
+/// and returns its hardware fingerprint as the completed message. This exercises
+/// the dispatch arm and the thin real-host `execute` wrapper end to end; the
+/// fingerprint-derivation logic itself is unit-tested pure over a synthetic
+/// profile, so here we only assert the shape CI captures and threads into
+/// `--machine-key` (a single lowercase 16-hex-character line).
+#[tokio::test]
+#[cfg_attr(miri, ignore)] // Probes the real host, which Miri cannot do.
+async fn machine_key_reports_this_host_fingerprint() {
+    let outcome = run(&command_from(&["machine-key"])).await.unwrap();
+
+    let RunOutcome::Completed { message } = outcome else {
+        panic!("machine-key should complete: {outcome:?}");
+    };
+    assert_eq!(
+        message.len(),
+        16,
+        "the fingerprint should be 16 hex characters: {message:?}"
+    );
+    assert!(
+        message
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+        "the fingerprint should be lowercase hex: {message:?}"
+    );
+}

--- a/packages/cargo-bench-history/tests/cbh_integration/main.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/main.rs
@@ -20,5 +20,6 @@ mod examine;
 mod harness;
 mod install;
 mod list;
+mod machine_key;
 mod prune;
 mod storage;

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 
 use cbh_command::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,
-    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions,
-    UnblessOptions,
+    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection,
+    MachineKeyOptions, PruneOptions, UnblessOptions,
 };
 use cbh_model::BenchmarkIdPrefix;
 use clap::{ArgGroup, Args, Parser, Subcommand as ClapSubcommand, ValueEnum};
@@ -95,6 +95,7 @@ impl Cli {
             Subcommand::Examine(command) => Command::Examine(command.into_options()),
             Subcommand::Install(command) => Command::Install(command.into_options()),
             Subcommand::List(command) => Command::List(command.into_options()),
+            Subcommand::MachineKey(command) => Command::MachineKey(command.into_options()),
             Subcommand::Prune(command) => Command::Prune(command.into_options()),
             Subcommand::Unbless(command) => Command::Unbless(command.into_options()),
         }
@@ -129,6 +130,8 @@ enum Subcommand {
     Install(InstallCommand),
     /// List the data set a matching `analyze` would include, without analyzing it.
     List(ListCommand),
+    /// Print this machine's hardware fingerprint (the machine key).
+    MachineKey(MachineKeyCommand),
     /// Show the raw per-commit data points of one `(benchmark, metric)` series.
     Examine(ExamineCommand),
     /// Delete stored runs (and their blessing sidecars) from the resolved data set.
@@ -419,6 +422,25 @@ impl InstallCommand {
     fn into_options(self) -> InstallOptions {
         InstallOptions {
             config_path: self.config,
+            verbose: self.verbose,
+        }
+    }
+}
+
+/// Print this machine's hardware fingerprint (the machine key).
+#[derive(Args, Debug)]
+struct MachineKeyCommand {
+    /// Also emit the individual hardware components that make up the fingerprint
+    /// to standard error (processor count, memory-region count, CPU brand, and
+    /// the fingerprint version), so a change in the key can be traced to which
+    /// factor changed. The key itself always goes to standard output.
+    #[arg(long, help_heading = HEADING_ENV)]
+    verbose: bool,
+}
+
+impl MachineKeyCommand {
+    fn into_options(self) -> MachineKeyOptions {
+        MachineKeyOptions {
             verbose: self.verbose,
         }
     }
@@ -1391,6 +1413,25 @@ mod tests {
 
         let Command::Install(options) = parse(&["install"]) else {
             panic!("expected install command");
+        };
+        assert!(!options.verbose);
+    }
+
+    #[test]
+    fn machine_key_maps_to_machine_key_command() {
+        let command = parse(&["machine-key"]);
+        assert_eq!(command, Command::MachineKey(MachineKeyOptions::default()));
+    }
+
+    #[test]
+    fn machine_key_parses_verbose_switch() {
+        let Command::MachineKey(options) = parse(&["machine-key", "--verbose"]) else {
+            panic!("expected machine-key command");
+        };
+        assert!(options.verbose);
+
+        let Command::MachineKey(options) = parse(&["machine-key"]) else {
+            panic!("expected machine-key command");
         };
         assert!(!options.verbose);
     }

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -67,6 +67,9 @@ pub enum Command {
     Bless(BlessOptions),
     /// Remove blessings recorded at the current commit.
     Unbless(UnblessOptions),
+    /// Print this machine's hardware fingerprint (the machine key
+    /// hardware-dependent engines partition by).
+    MachineKey(MachineKeyOptions),
 }
 
 /// Options for the `collect` command.
@@ -146,6 +149,20 @@ pub struct InstallOptions {
     /// Path to the configuration file to generate, if overridden.
     pub config_path: Option<PathBuf>,
     /// Emit detailed diagnostic notes to standard error describing each step.
+    pub verbose: bool,
+}
+
+/// Options for the `machine-key` command.
+///
+/// The command derives no configuration, git, or storage state: it only probes
+/// the host hardware and prints the resulting fingerprint, so its sole option is
+/// the shared verbosity flag.
+#[doc(hidden)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct MachineKeyOptions {
+    /// Emit the individual hardware components that make up the fingerprint to
+    /// standard error, so a change in the key can be traced to which factor
+    /// changed. The key itself always goes to standard output.
     pub verbose: bool,
 }
 

--- a/packages/cbh_command/src/lib.rs
+++ b/packages/cbh_command/src/lib.rs
@@ -28,6 +28,6 @@ mod command;
 
 pub use command::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,
-    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection, PruneOptions,
-    UnblessOptions,
+    ExamineOptions, InstallOptions, ListOptions, ListSubject, LocalStorageSelection,
+    MachineKeyOptions, PruneOptions, UnblessOptions,
 };

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -80,8 +80,9 @@ pub struct MachineInfo {
     pub memory_regions: usize,
     /// Best-effort CPU brand string (`None` when it could not be determined).
     pub cpu_brand: Option<String>,
-    /// The machine fingerprint these factors hash to — the auto-detected machine
-    /// key hardware-dependent engines partition by.
+    /// The hardware fingerprint these factors hash to: the host's auto-detected
+    /// identity, recorded regardless of the machine key the run was partitioned
+    /// under (see the type-level note).
     pub fingerprint: String,
 }
 

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -30,10 +30,21 @@ pub struct RunContext {
     pub toolchain: ToolchainInfo,
     /// Version of the cargo-bench-history tool that produced this run.
     pub tool_version: String,
+    /// Host hardware provenance: the machine fingerprint and the factors it
+    /// derives from. Write-only — nothing reads it back today; it is recorded so
+    /// that a later change in a machine key can be traced to the specific factor
+    /// that changed. `None` on runs written before this field existed (and on the
+    /// many non-collect construction sites that do not probe hardware).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub machine: Option<MachineInfo>,
 }
 
 impl RunContext {
     /// Creates a run context from its components.
+    ///
+    /// The host [`machine`](Self::machine) provenance is left absent; `collect`
+    /// sets it after construction (it is the only site that probes hardware), so
+    /// the many other callers need not thread a value they cannot supply.
     #[must_use]
     pub fn new(
         observation: Timestamp,
@@ -48,8 +59,30 @@ impl RunContext {
             env,
             toolchain,
             tool_version,
+            machine: None,
         }
     }
+}
+
+/// Host hardware provenance recorded with a run: the machine fingerprint and the
+/// factors it hashes.
+///
+/// Write-only metadata. Nothing reads it back today; it exists so that a later
+/// change in a machine key can be traced to the specific hardware factor that
+/// changed (for example, a runner pool swapping CPU models). It records the host's
+/// auto-detected fingerprint and is independent of any `--machine-key` override
+/// used to partition storage.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MachineInfo {
+    /// Number of logical processors the host reported.
+    pub processors: usize,
+    /// Number of NUMA memory regions the host reported.
+    pub memory_regions: usize,
+    /// Best-effort CPU brand string (`None` when it could not be determined).
+    pub cpu_brand: Option<String>,
+    /// The machine fingerprint these factors hash to — the auto-detected machine
+    /// key hardware-dependent engines partition by.
+    pub fingerprint: String,
 }
 
 /// Identification of the git commit a run was measured against.
@@ -164,6 +197,57 @@ mod tests {
     fn detect_environment_defaults_to_local() {
         let detected = detect_environment(env_from(&[]));
         assert_eq!(detected.provider, EnvironmentProvider::Local);
+    }
+
+    #[test]
+    fn machine_info_is_omitted_when_absent_and_restored_when_present() {
+        let epoch = "2024-01-01T00:00:00Z".parse().unwrap();
+        let context = RunContext::new(
+            epoch,
+            GitInfo::default(),
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+
+        // Absent host provenance must not appear on the wire, so old readers and
+        // records stay byte-compatible.
+        let json = serde_json::to_string(&context).unwrap();
+        assert!(!json.contains("machine"), "{json}");
+        assert_eq!(serde_json::from_str::<RunContext>(&json).unwrap(), context);
+
+        // A populated value round-trips intact.
+        let mut with_machine = context;
+        with_machine.machine = Some(MachineInfo {
+            processors: 8,
+            memory_regions: 1,
+            cpu_brand: Some("Test CPU 3000".to_owned()),
+            fingerprint: "d3ddd69dcf3b84ea".to_owned(),
+        });
+        let json = serde_json::to_string(&with_machine).unwrap();
+        assert!(
+            json.contains("\"fingerprint\":\"d3ddd69dcf3b84ea\""),
+            "{json}"
+        );
+        assert_eq!(
+            serde_json::from_str::<RunContext>(&json).unwrap(),
+            with_machine
+        );
+    }
+
+    #[test]
+    fn run_context_without_machine_field_deserializes_to_none() {
+        // A record written before the host-provenance field existed omits it
+        // entirely; it must still parse, leaving `machine` absent.
+        let json = r#"{
+            "observation": "2024-01-01T00:00:00Z",
+            "git": {"commit": null, "branch": null, "dirty": false},
+            "env": {"provider": "local", "run_id": null, "pull_request": null},
+            "toolchain": {"target_triple": "", "rustc_version": null},
+            "tool_version": "0.0.1"
+        }"#;
+        let context: RunContext = serde_json::from_str(json).unwrap();
+        assert_eq!(context.machine, None);
     }
 
     #[test]

--- a/packages/cbh_model/src/lib.rs
+++ b/packages/cbh_model/src/lib.rs
@@ -38,7 +38,8 @@ pub use bless::{BLESS_SCHEMA_VERSION, BlessingRecord};
 pub use comparability::{DiscriminantSet, Engine, StorageKey, parse_key, sanitize_segment};
 pub use constants::{OBJECTS_SEGMENT, STORAGE_VERSION};
 pub use context::{
-    EnvironmentInfo, EnvironmentProvider, GitInfo, RunContext, ToolchainInfo, detect_environment,
+    EnvironmentInfo, EnvironmentProvider, GitInfo, MachineInfo, RunContext, ToolchainInfo,
+    detect_environment,
 };
 pub use metric::{Metric, MetricKind};
 pub use run::{BenchmarkResult, MetricList, Run, SCHEMA_VERSION};

--- a/packages/cbh_model/src/run.rs
+++ b/packages/cbh_model/src/run.rs
@@ -9,11 +9,14 @@ use crate::{BenchmarkId, Metric, MetricKind, RunContext};
 ///
 /// Records which on-disk format a file was written with. Reads are not gated on
 /// it: version 2 dropped the redundant per-object `commit` timestamp (a run's
-/// timeline position is resolved from git topology, keyed by its commit ID), and
+/// timeline position is resolved from git topology, keyed by its commit ID),
 /// version 3 dropped the redundant `short_commit` (an abbreviation of the full
-/// commit ID the analysis already has from the storage key). Older records still
-/// deserialize because the removed fields are simply ignored.
-pub const SCHEMA_VERSION: u32 = 3;
+/// commit ID the analysis already has from the storage key), and version 4 added
+/// the optional host-hardware provenance (`context.machine`). Every one of these
+/// changes is wire-compatible: older records still deserialize because a removed
+/// field is ignored and an added field defaults to absent. The version is bumped
+/// so a file's provenance stays legible, not because a read path branches on it.
+pub const SCHEMA_VERSION: u32 = 4;
 
 /// A complete benchmark run: the unit of storage (one immutable file per run).
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -155,17 +158,24 @@ mod tests {
     use nonempty::nonempty;
 
     use super::*;
-    use crate::{EnvironmentInfo, GitInfo, MetricKind, ToolchainInfo};
+    use crate::{EnvironmentInfo, GitInfo, MachineInfo, MetricKind, ToolchainInfo};
 
     fn sample_context() -> RunContext {
         let epoch = "2024-01-01T00:00:00Z".parse().unwrap();
-        RunContext::new(
+        let mut context = RunContext::new(
             epoch,
             GitInfo::default(),
             EnvironmentInfo::default(),
             ToolchainInfo::default(),
             "0.0.1".to_owned(),
-        )
+        );
+        context.machine = Some(MachineInfo {
+            processors: 8,
+            memory_regions: 1,
+            cpu_brand: Some("Test CPU 3000".to_owned()),
+            fingerprint: "d3ddd69dcf3b84ea".to_owned(),
+        });
+        context
     }
 
     #[test]

--- a/packages/cbh_probe/src/lib.rs
+++ b/packages/cbh_probe/src/lib.rs
@@ -28,5 +28,5 @@ mod machine;
 mod probe;
 
 pub use host::RustcInfo;
-pub use machine::{HardwareProfile, resolve_machine_key};
+pub use machine::{HardwareProfile, describe_fingerprint_components, resolve_machine_key};
 pub use probe::{EnvironmentProbe, SystemProbe};

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -9,6 +9,12 @@
 //! share a key; genuinely different hardware produces a different key. The host
 //! *name* is deliberately not a factor, since pool machines have distinct names
 //! but equivalent hardware.
+//!
+//! The key is surfaced two ways for operators. [`resolve_machine_key`] yields the
+//! key itself (what `collect` stamps hardware-dependent results with and the
+//! `machine-key` command prints), while [`describe_fingerprint_components`] renders
+//! the individual factors that fed the hash, so a change in the key can be traced —
+//! in verbose logs — to the specific hardware detail that moved.
 
 use cbh_model::sanitize_segment;
 use sha2::{Digest, Sha256};
@@ -88,6 +94,26 @@ pub fn resolve_machine_key(override_key: Option<&str>, profile: &HardwareProfile
         Some(key) => sanitize_segment(key),
         None => fingerprint(profile),
     }
+}
+
+/// Renders the individual factors behind a machine [`fingerprint`] as a
+/// diagnostic, single-line summary (pure).
+///
+/// It reports the fingerprint version tag and each hardware factor using the same
+/// normalized values that enter the hash, so that when a machine key changes the
+/// specific factor responsible can be identified from a `--verbose` log. An absent
+/// CPU brand is shown as `<none>` (matching the empty value it contributes to the
+/// canonical string) rather than omitted, so its absence is itself visible.
+#[must_use]
+pub fn describe_fingerprint_components(profile: &HardwareProfile) -> String {
+    let brand = profile.cpu_brand.as_deref().map_or_else(
+        || "<none>".to_owned(),
+        |brand| format!("\"{}\"", normalize_brand(brand)),
+    );
+    format!(
+        "version={FINGERPRINT_VERSION}, processors={}, memory_regions={}, cpu_brand={brand}",
+        profile.processors, profile.memory_regions,
+    )
 }
 
 /// Profiles the host hardware (best effort).
@@ -258,6 +284,24 @@ mod tests {
         assert_eq!(
             resolve_machine_key(Some("ci/pool one"), &hardware),
             "ci_pool_one"
+        );
+    }
+
+    #[test]
+    fn describe_components_lists_version_and_normalized_factors() {
+        let described = describe_fingerprint_components(&profile(8, 1, Some("Intel  Xeon  E5")));
+        assert_eq!(
+            described,
+            "version=mk1, processors=8, memory_regions=1, cpu_brand=\"Intel Xeon E5\""
+        );
+    }
+
+    #[test]
+    fn describe_components_marks_an_absent_brand() {
+        let described = describe_fingerprint_components(&profile(4, 2, None));
+        assert_eq!(
+            described,
+            "version=mk1, processors=4, memory_regions=2, cpu_brand=<none>"
         );
     }
 

--- a/scripts/bench-history/BenchHistoryCollect.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryCollect.Tests.ps1
@@ -12,7 +12,6 @@ BeforeAll {
     $script:Scope = @(
         '--workspace',
         '--exclude', 'benchmarks',
-        '--machine-key', 'github',
         '--best-of', '3',
         '--verbose'
     )
@@ -96,7 +95,6 @@ Describe 'Get-BenchHistoryCollectCommand' {
                 'collect',
                 '--package', 'nm',
                 '--package', 'many_cpus',
-                '--machine-key', 'github',
                 '--best-of', '3',
                 '--verbose',
                 '--skip-existing'
@@ -114,7 +112,6 @@ Describe 'Get-BenchHistoryCollectCommand' {
             $result | Should -Be @(
                 'collect',
                 '--package', 'nm',
-                '--machine-key', 'github',
                 '--best-of', '3',
                 '--verbose',
                 '--skip-existing'

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -79,9 +79,13 @@ function Get-BenchHistoryCollectCommand {
     )
 
     # Scope + noise-reduction flags shared by both modes: `collect` and `backfill` flatten the same
-    # clap arg groups, so this array applies verbatim to either subcommand. The fixed `github`
-    # machine key keeps the whole GitHub runner pool on one wall-clock series; `--best-of 3` keeps
-    # each metric's minimum across three runs to shed one-sided runner jitter.
+    # clap arg groups, so this array applies verbatim to either subcommand. No `--machine-key`
+    # override: each runner stamps its results with its OWN real hardware fingerprint, so a
+    # heterogeneous GitHub runner pool splits into one clean wall-clock series per hardware type
+    # instead of one jittery series mixing incomparable machines. `--best-of 3` keeps each metric's
+    # minimum across three runs to shed one-sided runner jitter; `--verbose` makes the collect log
+    # spell out the resolved machine key and the fingerprint components behind it, so a key change is
+    # debuggable from the log alone.
     $packages = @($Package | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     if ($packages.Count -gt 0) {
         # Explicit package scoping (PR workflow): one `--package <name>` per touched crate.
@@ -96,7 +100,6 @@ function Get-BenchHistoryCollectCommand {
     }
 
     $scope = $selection + @(
-        '--machine-key', 'github',
         '--best-of', '3',
         '--verbose'
     )

--- a/scripts/bench-history/BenchHistoryMachineKey.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryMachineKey.Tests.ps1
@@ -101,6 +101,33 @@ Describe 'Get-MachineKeyArgument' {
         }
     }
 
+    Context 'verbose diagnostics' {
+        It 'uses the singular noun for exactly one key' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'abcdef0123456789'
+                $verbose = Get-MachineKeyArgument -KeyDirectory $dir -Verbose 4>&1 |
+                    Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+                ($verbose -join "`n") | Should -Match 'Threading 1 machine key into analysis'
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'uses the plural noun for more than one key' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'ffff0000ffff0000'
+                Write-KeyFile -Directory $dir -Name 'windows-latest' -Content '00001111aaaa2222'
+                $verbose = Get-MachineKeyArgument -KeyDirectory $dir -Verbose 4>&1 |
+                    Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+                ($verbose -join "`n") | Should -Match 'Threading 2 machine keys into analysis'
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
     Context 'zero collected keys (total collect failure)' {
         It 'returns an empty vector for a non-existent directory' {
             $missing = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('n'))

--- a/scripts/bench-history/BenchHistoryMachineKey.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryMachineKey.Tests.ps1
@@ -1,0 +1,149 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for BenchHistoryMachineKey.psm1. Proves the machine-key threading the bench-history
+# `analyze` step depends on - reading the collect matrix's uploaded fingerprint files into the
+# repeated `--machine-key` argument vector, with dedupe, ordering, validation and the empty-directory
+# edge case a total collect failure produces - without a workflow run. Key files are real temp files
+# so the on-disk read and the missing/empty guards are asserted, not faked.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'BenchHistoryMachineKey.psm1') -Force
+
+    # A fresh, isolated key directory per test; helpers create the per-artifact files inside it the
+    # same way `actions/download-artifact` would (one file per collect leg).
+    function Get-KeyDirectory {
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("bh-mk-$([guid]::NewGuid().ToString('n'))")
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        return $dir
+    }
+
+    function Write-KeyFile {
+        param(
+            [Parameter(Mandatory)] [string] $Directory,
+            [Parameter(Mandatory)] [string] $Name,
+            [Parameter(Mandatory)] [AllowEmptyString()] [string] $Content
+        )
+        # Each collect leg's artifact typically arrives in its own subdirectory (download without
+        # merge), so nest the file to prove the recursive scan finds it.
+        $sub = Join-Path $Directory $Name
+        New-Item -ItemType Directory -Path $sub -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $sub 'machine-key.txt') -Value $Content -Encoding utf8
+    }
+}
+
+Describe 'Get-MachineKeyArgument' {
+    Context 'a normal multi-runner collection' {
+        It 'builds one --machine-key per distinct fingerprint, sorted' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'ffff0000ffff0000'
+                Write-KeyFile -Directory $dir -Name 'windows-latest' -Content '00001111aaaa2222'
+                $result = Get-MachineKeyArgument -KeyDirectory $dir
+                $result | Should -Be @(
+                    '--machine-key', '00001111aaaa2222',
+                    '--machine-key', 'ffff0000ffff0000'
+                )
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'collapses duplicate fingerprints from identically-specced runners' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'abcdef0123456789'
+                Write-KeyFile -Directory $dir -Name 'ubuntu-24.04-arm' -Content 'abcdef0123456789'
+                $result = Get-MachineKeyArgument -KeyDirectory $dir
+                $result | Should -Be @('--machine-key', 'abcdef0123456789')
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'trims surrounding whitespace and lowercases before use' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'windows-11-arm' -Content "  ABCDEF0123456789`n"
+                $result = Get-MachineKeyArgument -KeyDirectory $dir
+                $result | Should -Be @('--machine-key', 'abcdef0123456789')
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'returns a string array even for a single key' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'abcdef0123456789'
+                $result = Get-MachineKeyArgument -KeyDirectory $dir
+                , $result | Should -BeOfType [string[]]
+                $result.Count | Should -Be 2
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'zero collected keys (total collect failure)' {
+        It 'returns an empty vector for a non-existent directory' {
+            $missing = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('n'))
+            @(Get-MachineKeyArgument -KeyDirectory $missing).Count | Should -Be 0
+        }
+
+        It 'returns an empty vector for an empty directory' {
+            $dir = Get-KeyDirectory
+            try {
+                @(Get-MachineKeyArgument -KeyDirectory $dir).Count | Should -Be 0
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'returns an empty vector for a null or blank directory argument' {
+            @(Get-MachineKeyArgument -KeyDirectory $null).Count | Should -Be 0
+            @(Get-MachineKeyArgument -KeyDirectory '   ').Count | Should -Be 0
+        }
+    }
+
+    Context 'corrupt uploads' {
+        It 'throws on an empty key file' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content ''
+                { Get-MachineKeyArgument -KeyDirectory $dir } | Should -Throw '*is empty*'
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'throws on a non-hex fingerprint' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'not-a-fingerprint'
+                { Get-MachineKeyArgument -KeyDirectory $dir } | Should -Throw '*16-hex-character*'
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'throws on a fingerprint of the wrong length' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'abcdef01'
+                { Get-MachineKeyArgument -KeyDirectory $dir } | Should -Throw '*16-hex-character*'
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'throws on a file carrying shell metacharacters' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'abc; rm -rf /'
+                { Get-MachineKeyArgument -KeyDirectory $dir } | Should -Throw '*16-hex-character*'
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/scripts/bench-history/BenchHistoryMachineKey.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryMachineKey.Tests.ps1
@@ -82,6 +82,23 @@ Describe 'Get-MachineKeyArgument' {
                 Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
+
+        It 'ignores stray non-key files the artifact download may leave alongside the keys' {
+            $dir = Get-KeyDirectory
+            try {
+                Write-KeyFile -Directory $dir -Name 'ubuntu-latest' -Content 'abcdef0123456789'
+                # Files the download can drop next to the real keys - metadata, a macOS `.DS_Store`,
+                # an accidental readme. None is a machine-key.txt, so the scan must skip them all
+                # rather than fail fingerprint validation and abort the whole analysis.
+                Set-Content -LiteralPath (Join-Path $dir 'metadata.json') -Value '{ "not": "a key" }' -Encoding utf8
+                Set-Content -LiteralPath (Join-Path $dir 'README.md') -Value 'not a fingerprint' -Encoding utf8
+                Set-Content -LiteralPath (Join-Path $dir 'ubuntu-latest/.DS_Store') -Value 'junk' -Encoding utf8
+                $result = Get-MachineKeyArgument -KeyDirectory $dir
+                $result | Should -Be @('--machine-key', 'abcdef0123456789')
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
     }
 
     Context 'zero collected keys (total collect failure)' {
@@ -93,6 +110,18 @@ Describe 'Get-MachineKeyArgument' {
         It 'returns an empty vector for an empty directory' {
             $dir = Get-KeyDirectory
             try {
+                @(Get-MachineKeyArgument -KeyDirectory $dir).Count | Should -Be 0
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'returns an empty vector for a directory holding only stray non-key files' {
+            $dir = Get-KeyDirectory
+            try {
+                # A total collect failure uploads no machine-key.txt; anything else in the tree is not
+                # a key, so the recipe treats it as zero collected keys and the caller skips analysis.
+                Set-Content -LiteralPath (Join-Path $dir 'metadata.json') -Value '{}' -Encoding utf8
                 @(Get-MachineKeyArgument -KeyDirectory $dir).Count | Should -Be 0
             } finally {
                 Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/bench-history/BenchHistoryMachineKey.psm1
+++ b/scripts/bench-history/BenchHistoryMachineKey.psm1
@@ -69,7 +69,10 @@ function Get-MachineKeyArgument {
 
     $keys = [System.Collections.Generic.List[string]]::new()
     foreach ($file in $files) {
-        $raw = Get-Content -LiteralPath $file.FullName -Raw
+        # Read with a terminating error: a genuinely empty file returns $null (handled as the
+        # "is empty" corrupt-upload case below), but an unreadable file (permissions/IO) must surface
+        # its real failure here rather than fall through to the misleading "is empty" guard.
+        $raw = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction Stop
         $key = if ($null -eq $raw) { '' } else { $raw.Trim() }
         if ($key -eq '') {
             throw ("Machine-key file '$($file.FullName)' is empty. Each collect leg writes exactly " +
@@ -90,7 +93,8 @@ function Get-MachineKeyArgument {
     }
 
     $unique = @($keys | Sort-Object -Unique)
-    Write-Verbose ("Threading $($unique.Count) machine key(s) into analysis: " +
+    $noun = if ($unique.Count -eq 1) { 'machine key' } else { 'machine keys' }
+    Write-Verbose ("Threading $($unique.Count) $noun into analysis: " +
         ($unique -join ', ') + '.')
 
     $arguments = [System.Collections.Generic.List[string]]::new()

--- a/scripts/bench-history/BenchHistoryMachineKey.psm1
+++ b/scripts/bench-history/BenchHistoryMachineKey.psm1
@@ -1,0 +1,100 @@
+#requires -Version 7
+
+# Machine-key threading for the benchmark-history `analyze` step, shared by the push-to-main workflow
+# (.github/workflows/bench-history.yml, via the gh-analyze-bench-history recipe) and the per-PR
+# workflow (.github/workflows/pr-bench-history.yml, via gh-analyze-pr-bench-history).
+#
+# Collection runs as a matrix across a heterogeneous GitHub runner pool, so each leg stamps its
+# results with its OWN real hardware fingerprint (there is no longer a fixed `github` key). Analysis,
+# by contrast, runs as a single job that cannot re-derive those keys from its own hardware, so each
+# collect leg writes its fingerprint to a file and uploads it as an artifact; the analyze job
+# downloads them all into one directory and this module turns that directory into the repeated
+# `--machine-key <fingerprint>` argument vector the tool is invoked with. Threading the EXACT keys
+# collected this run (rather than `--machine-key all`) keeps the analysis scoped to the machines that
+# actually measured this commit, without assuming anything about other data in the shared store.
+#
+# Building the vector is real logic - directory scan, per-file validation, dedupe and ordering, plus
+# the empty-directory edge case a total collect failure produces - so it lives here behind a seam the
+# Pester suite (BenchHistoryMachineKey.Tests.ps1) exercises, and the recipe is a thin import + call.
+
+Set-StrictMode -Version Latest
+
+function Get-MachineKeyArgument {
+    # Reads every machine-key file the collect matrix uploaded into $KeyDirectory and returns the
+    # `--machine-key <fingerprint>` argument vector (a string[]) to splat into the analyze tool call.
+    # Each collect leg's artifact contributes one file holding a single 16-hex-character fingerprint
+    # (as emitted by `cargo-bench-history machine-key`); files are read recursively so it does not
+    # matter whether the download flattened them or kept one subdirectory per artifact.
+    #
+    # Keys are trimmed, lowercased, de-duplicated and sorted so two runners with identical hardware
+    # collapse to one `--machine-key` (the tool would otherwise see a redundant repeat) and the
+    # argument order is deterministic for stable logs. A file that is missing, empty, or does not hold
+    # a valid fingerprint is a corrupted upload rather than a benign state, so it throws rather than
+    # silently narrowing the analysis.
+    #
+    # An absent or empty directory returns an empty vector, NOT an error: a total collect failure
+    # (every matrix leg failed, so nothing was uploaded) legitimately yields zero keys, and the caller
+    # detects that and skips the analysis (there is no new data to survey) while the workflow's
+    # separate collect-failure alert does the notifying. Only hardware-DEPENDENT engines partition by
+    # machine key; deterministic engines (Callgrind, alloc_tracker) are exempt from the machine-key
+    # filter inside the tool, so a non-empty vector still analyzes them too.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string] $KeyDirectory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($KeyDirectory) -or -not (Test-Path -LiteralPath $KeyDirectory)) {
+        Write-Verbose ("No machine-key directory at '$KeyDirectory': treating as zero collected " +
+            'keys (a total collect failure uploads nothing). The caller skips analysis.')
+        return @()
+    }
+
+    $files = @(Get-ChildItem -LiteralPath $KeyDirectory -Recurse -File)
+    if ($files.Count -eq 0) {
+        Write-Verbose ("Machine-key directory '$KeyDirectory' is empty: zero collected keys. The " +
+            'caller skips analysis.')
+        return @()
+    }
+
+    $keys = [System.Collections.Generic.List[string]]::new()
+    foreach ($file in $files) {
+        $raw = Get-Content -LiteralPath $file.FullName -Raw
+        $key = if ($null -eq $raw) { '' } else { $raw.Trim() }
+        if ($key -eq '') {
+            throw ("Machine-key file '$($file.FullName)' is empty. Each collect leg writes exactly " +
+                'one fingerprint; an empty file means the key-writing step produced no output and ' +
+                'the upload is corrupt.')
+        }
+
+        # A fingerprint is the lowercase hex of a truncated SHA-256 (cbh_probe FINGERPRINT_HEX_LEN),
+        # so it is exactly 16 hex characters. Rejecting anything else fails loudly on a corrupt upload
+        # instead of threading garbage into `--machine-key` (which would silently match no series).
+        if ($key -notmatch '^[0-9a-fA-F]{16}$') {
+            throw ("Machine-key file '$($file.FullName)' does not contain a 16-hex-character " +
+                "fingerprint; got '$key'. Collection writes the key with `cargo-bench-history " +
+                'machine-key`, so a malformed value indicates a corrupt upload.')
+        }
+
+        $keys.Add($key.ToLowerInvariant())
+    }
+
+    $unique = @($keys | Sort-Object -Unique)
+    Write-Verbose ("Threading $($unique.Count) machine key(s) into analysis: " +
+        ($unique -join ', ') + '.')
+
+    $arguments = [System.Collections.Generic.List[string]]::new()
+    foreach ($key in $unique) {
+        $arguments.Add('--machine-key')
+        $arguments.Add($key)
+    }
+
+    # Comma-wrap the typed array so a single-key result is still returned as a [string[]] rather than
+    # unrolled to a bare string by PowerShell's pipeline, keeping the contract the caller splats.
+    return , $arguments.ToArray()
+}
+
+Export-ModuleMember -Function Get-MachineKeyArgument

--- a/scripts/bench-history/BenchHistoryMachineKey.psm1
+++ b/scripts/bench-history/BenchHistoryMachineKey.psm1
@@ -22,9 +22,12 @@ Set-StrictMode -Version Latest
 function Get-MachineKeyArgument {
     # Reads every machine-key file the collect matrix uploaded into $KeyDirectory and returns the
     # `--machine-key <fingerprint>` argument vector (a string[]) to splat into the analyze tool call.
-    # Each collect leg's artifact contributes one file holding a single 16-hex-character fingerprint
-    # (as emitted by `cargo-bench-history machine-key`); files are read recursively so it does not
-    # matter whether the download flattened them or kept one subdirectory per artifact.
+    # Each collect leg's artifact contributes one `machine-key.txt` holding a single 16-hex-character
+    # fingerprint (as emitted by `cargo-bench-history machine-key`); the scan is restricted to that
+    # exact filename and recursive, so it does not matter whether the download flattened the files or
+    # kept one subdirectory per artifact, while stray files the download may drop alongside them (e.g.
+    # `actions/download-artifact` metadata, a `.DS_Store`, an accidental readme) are ignored rather
+    # than mistaken for a corrupt key and failing the whole analysis.
     #
     # Keys are trimmed, lowercased, de-duplicated and sorted so two runners with identical hardware
     # collapse to one `--machine-key` (the tool would otherwise see a redundant repeat) and the
@@ -53,10 +56,14 @@ function Get-MachineKeyArgument {
         return @()
     }
 
-    $files = @(Get-ChildItem -LiteralPath $KeyDirectory -Recurse -File)
+    # Scan recursively but ONLY for the `machine-key.txt` each collect leg writes: restricting the
+    # filename means an unrelated file the artifact download may leave in the tree (metadata, a
+    # `.DS_Store`, a stray readme) is skipped instead of failing fingerprint validation, and
+    # -ErrorAction Stop turns any enumeration error into a hard failure rather than a partial key set.
+    $files = @(Get-ChildItem -LiteralPath $KeyDirectory -Recurse -File -Filter 'machine-key.txt' -ErrorAction Stop)
     if ($files.Count -eq 0) {
-        Write-Verbose ("Machine-key directory '$KeyDirectory' is empty: zero collected keys. The " +
-            'caller skips analysis.')
+        Write-Verbose ("Machine-key directory '$KeyDirectory' holds no machine-key.txt files: zero " +
+            'collected keys. The caller skips analysis.')
         return @()
     }
 


### PR DESCRIPTION
[Copilot speaking]

## Problem

The bench-history CI collects wall-clock benchmarks across a 4-platform matrix and stamped every hardware-dependent result with the fixed synthetic machine key **`github`**. GitHub hands out a heterogeneous pool of SKUs, so one series mixed incomparable machines and jittered every day (not a clean step when the pool is upgraded, since it never happens all at once).

## What changed

- **Drop the `github` pin.** Each collect leg now stamps its results with its **own real hardware fingerprint**, so each hardware type forms its own clean series.
- **New `cargo-bench-history machine-key` command.** Prints this machine's fingerprint to stdout (one clean line); under `--verbose` it writes the fingerprint *components* (processor/memory-region counts, CPU brand, version tag) to stderr. It touches no repo/git/config/storage.
- **Thread the exact collected keys into analyze.** Collect is a matrix (N runners → N keys) but analyze is a single job that can't re-derive them, so each collect leg records + uploads its key as a per-platform artifact, and analyze downloads them all and threads the exact keys into its `--machine-key` filter. The directory→args conversion lives in a Pester-tested module (`Get-MachineKeyArgument`), including the total-collect-failure (zero keys) edge case.
- **Better key visibility for debugging.** `--verbose` now reports the fingerprint components from collect, the query commands, and the new command; the CI recipes run bench-history with `--verbose`.
- **Write-only provenance.** Every stored run JSON now records the fingerprint factors + resolved key (new optional `RunContext.machine`, schema version 3 → 4). Nothing reads it back today; it exists purely so a future key change can be traced to the specific hardware detail that moved.
- **Drop the `reanalyze` workflow feature.** It ran analyze with collect skipped, so there would be no collected keys to thread — a genuine plot hole. `recollect_commit_id` stays (it still runs the collect matrix).

Deterministic engines (Callgrind, alloc/time counters) store under the literal `synthetic` key and are exempt from the machine-key filter, so threading real fingerprints still analyzes them.

## Notes / accepted trade-offs

- **History discontinuity.** Existing hardware-dependent history is under `github`; new data lands under real fingerprints, so wall-clock regression detection effectively rebuilds history. Deterministic engines are unaffected. Orphaned `github` data is left in place.
- **Series fragmentation.** Real keys only help if the SKU set is small and recurring; a wide rotation fragments history into sparse series. Observable later via `list discriminants`.

## Validation

`just clippy` (zero warnings), `just docs` + `just docs-default-features`, affected package tests (417 passed), Miri for `cbh_model`/`cbh_probe` (90 passed), `just format-check`, `just validate-scripts` (PSScriptAnalyzer clean), `just test-scripts` (242 Pester passed), `just validate-workflows` (actionlint clean).