### PR TITLE
Prune rarely-informative checks from PR validation

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -61,14 +61,28 @@ keyed on the same event. Both reduce to "the full set on push, the pruned set on
 
 ## Concurrency
 
-Commit-driven and PR-driven workflows cancel superseded runs, keyed on the ref, so pushing
-a new commit abandons the outdated run. That supersession only fires when a *new commit*
-arrives on the branch, so closing or merging a PR — which pushes nothing to the PR branch —
-would otherwise leave its in-flight Validation run to burn to completion. A dedicated
-companion workflow closes that gap: it triggers on the PR-close event and joins the target
-workflow's concurrency group so cancel-in-progress reclaims the stale run. Both the Validation
-workflow and the PR benchmark-history workflow pair with such a close companion. The exception
-is history collection on `main`, which is keyed on the commit **SHA**: each commit is a distinct
+PR-driven Validation runs cancel superseded runs, keyed on the branch, so pushing a new
+commit to a pull request abandons the outdated in-progress run. That supersession only fires
+when a *new commit* arrives on the branch, so closing or merging a PR — which pushes nothing
+to the PR branch — would otherwise leave its in-flight Validation run to burn to completion.
+A dedicated companion workflow closes that gap: it triggers on the PR-close event and joins
+the target workflow's concurrency group so cancel-in-progress reclaims the stale run. Both the
+Validation workflow and the PR benchmark-history workflow pair with such a close companion.
+
+Pushes to `main` are the deliberate exception: they share the ref-keyed group but do **not**
+cancel in progress, so a commit landing while an earlier one is still validating *queues*
+behind it rather than killing it. `main` is validated **sequentially**, one commit at a time,
+each to completion. This is what makes `main` the trustworthy backstop for the checks pruned
+from PR validation and lets the per-run failure alert (see Failure alerting) attribute a
+breakage to the commit that caused it — a superseded, cancelled run would neither finish those
+checks nor fire the alert. The one limitation is inherent to GitHub concurrency: only a single
+run may sit queued, so a rapid burst of pushes collapses to "the one already running, then the
+newest", skipping the intermediate commits; the newest still validates the cumulative tree, so
+`main`'s current state is never left unvalidated. The split is expressed by making
+cancel-in-progress an expression — `${{ github.event_name != 'push' }}` — true for the
+`pull_request` event and false for a push to `main`.
+
+History collection on `main` is keyed instead on the commit **SHA**: each commit is a distinct
 measurement, so distinct commits must run in parallel and only a redundant re-trigger of the
 *same* commit is deduplicated. Schedule-driven workflows carry no concurrency block at all.
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -42,17 +42,20 @@ leaning on push-to-`main` as the backstop for what it drops. PRs run the test an
 suites only on the x86_64 Windows and Linux runners: the whole ARM pass (which carries the
 MSRV *test* run) and the macOS legs of the test and docs jobs wait for `main`, because
 architecture- and OS-gated behaviour rarely diverges on a PR and re-running the
-platform-independent test and doc suites on macOS almost never is informative. Miri runs on
-Windows only for a PR — being an architecture-agnostic interpreter, its Linux and ARM
-re-runs are a `main`-only sanity net over cfg-gated paths — and the release-profile Clippy
-pass and the `careful` run are skipped entirely on PRs. The compile-oriented passes (dev
-Clippy, release build, frozen-minimum check, feature `hack`) deliberately keep their macOS
-leg on PRs, because a cheap macOS cross-compile still catches macOS-specific build breaks
-that the pruned runtime passes would not. MSRV *compilation* therefore stays covered on
-every PR by `check-frozen`, which compiles all targets on the MSRV toolchain against the
-frozen minimum-version lockfile even though the ARM MSRV test pass is `main`-only. Because a
-push to `main` is the first place the pruned checks can fail, that event — unlike a PR —
-files a tracking issue (see Failure alerting).
+platform-independent test and doc suites on macOS almost never is informative. The base Miri
+pass runs on Windows only for a PR — being an architecture-agnostic interpreter, its Linux
+and ARM re-runs are a `main`-only sanity net over cfg-gated paths — and the release-profile
+Clippy pass and the `careful` run are skipped entirely on PRs. The many-seeds Miri passes are
+the exception to that pruning: gated by *package* rather than by event, they run on Linux —
+on a PR as much as on `main` — whenever their specific package is touched, because their
+worth is catching seed-dependent UB in that code, not covering a platform. The
+compile-oriented passes (dev Clippy, release build, frozen-minimum check, feature `hack`)
+deliberately keep their macOS leg on PRs, because a cheap macOS cross-compile still catches
+macOS-specific build breaks that the pruned runtime passes would not. MSRV *compilation*
+therefore stays covered on every PR by `check-frozen`, which compiles all targets on the
+MSRV toolchain against the frozen minimum-version lockfile even though the ARM MSRV test
+pass is `main`-only. Because a push to `main` is the first place the pruned checks can fail,
+that event — unlike a PR — files a tracking issue (see Failure alerting).
 
 The event split is expressed two ways: a job whose every leg is pruned on a PR (the ARM test
 and Miri passes, `clippy-release`, `careful`) carries a whole-job `github.event_name ==

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -10,9 +10,11 @@ Validation runs each `just` command as its own parallel job rather than one comb
 `validate-local` step. Parallelism gives faster feedback and pinpoints failures by check
 name instead of burying them in a monolithic log. Expensive jobs gate behind cheaper
 equivalents so a fast failure short-circuits slow work — for example, Miri and mutation
-testing only start once the plain dev `cargo check` and the base test pass have already
-succeeded, since there is nothing to interpret or mutate in code that does not compile or
-whose tests already fail.
+testing only start once the dev Clippy pass and the base test pass have already succeeded,
+since there is nothing to interpret or mutate in code that does not compile or whose tests
+already fail. Clippy stands in for a bare `cargo check` here: Clippy compiles the code as a
+prerequisite to linting it, so a standalone `check` job would only re-prove what a green
+Clippy already guarantees.
 
 ## Selective validation
 
@@ -33,6 +35,29 @@ shape: it is an architecture-agnostic interpreter, so a second ARM run earns its
 by subjecting ARM-gated paths to Miri's UB detection. Platform-agnostic checks (formatting,
 workflow validation, script tests) run on a single Linux runner because their result cannot
 vary by platform.
+
+Not every check earns its place on every pull request. The full matrix runs on each push to
+`main`, but pull-request validation prunes the rarely-informative legs to cut runner cost,
+leaning on push-to-`main` as the backstop for what it drops. PRs build and test only the
+x86_64 Windows and Linux runners: the whole ARM pass (which carries the MSRV *test* run) and
+the macOS legs of the test and docs jobs wait for `main`, because architecture- and
+OS-gated behaviour rarely diverges on a PR and re-running the platform-independent test and
+doc suites on macOS almost never is informative. Miri runs on Windows only for a PR — being
+an architecture-agnostic interpreter, its Linux and ARM re-runs are a `main`-only sanity net
+over cfg-gated paths — and the release-profile Clippy pass and the `careful` run are skipped
+entirely on PRs. The compile-oriented passes (dev Clippy, release build, frozen-minimum
+check, feature `hack`) deliberately keep their macOS leg on PRs, because a cheap macOS
+cross-compile still catches macOS-specific build breaks that the pruned runtime passes would
+not. MSRV *compilation* therefore stays covered on every PR by `check-frozen`, which compiles
+all targets on the MSRV toolchain against the frozen minimum-version lockfile even though the
+ARM MSRV test pass is `main`-only. Because a push to `main` is the first place the pruned
+checks can fail, that event — unlike a PR — files a tracking issue (see Failure alerting).
+
+The event split is expressed two ways: a job whose every leg is pruned on a PR (the ARM test
+and Miri passes, `clippy-release`, `careful`) carries a whole-job `github.event_name ==
+'push'` guard, while a job that keeps some legs on a PR (macOS-dropping test/docs, the
+Ubuntu-dropping `miri-x64`) selects its platform list with a `fromJSON` conditional matrix
+keyed on the same event. Both reduce to "the full set on push, the pruned set on a PR".
 
 ## Concurrency
 
@@ -215,7 +240,7 @@ safe even when slightly stale.
 
 ## Failure alerting
 
-The history and release workflows both open a GitHub issue on failure, but with
+The history, release, and validation workflows all open a GitHub issue on failure, but with
 deliberately different lifecycles matched to what failed. A benchmark-history failure is
 a recurring condition on a rolling target, so it opens a *deduplicated* tracking issue
 (keyed on a fixed title) that a companion job closes automatically once the workflow is
@@ -223,7 +248,13 @@ green again — exactly one open issue per persistent failure, cleared without m
 intervention. A release failure is a discrete event tied to one publish attempt, so it
 opens a *per-run* issue (identified by the failing run) that stays open until a human
 investigates; each failed release is tracked individually rather than folded into a
-rolling issue.
+rolling issue. A push-to-`main` Validation failure follows the same per-run shape as the
+release alert — a fresh `ci-failure` issue per failing run, no dedup and no auto-close —
+because it now backstops the checks pruned from PR validation, so each such failure warrants
+individual triage. It fires *only* on push to `main`: a PR failure is already self-evident as
+the red check and needs no issue, so the alert is gated on the `main` ref (which a
+`pull_request` run never presents) and on `failure()`, leaving a green or skipped-only run to
+file nothing.
 
 ## Release automation
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -61,28 +61,14 @@ keyed on the same event. Both reduce to "the full set on push, the pruned set on
 
 ## Concurrency
 
-PR-driven Validation runs cancel superseded runs, keyed on the branch, so pushing a new
-commit to a pull request abandons the outdated in-progress run. That supersession only fires
-when a *new commit* arrives on the branch, so closing or merging a PR — which pushes nothing
-to the PR branch — would otherwise leave its in-flight Validation run to burn to completion.
-A dedicated companion workflow closes that gap: it triggers on the PR-close event and joins
-the target workflow's concurrency group so cancel-in-progress reclaims the stale run. Both the
-Validation workflow and the PR benchmark-history workflow pair with such a close companion.
-
-Pushes to `main` are the deliberate exception: they share the ref-keyed group but do **not**
-cancel in progress, so a commit landing while an earlier one is still validating *queues*
-behind it rather than killing it. `main` is validated **sequentially**, one commit at a time,
-each to completion. This is what makes `main` the trustworthy backstop for the checks pruned
-from PR validation and lets the per-run failure alert (see Failure alerting) attribute a
-breakage to the commit that caused it — a superseded, cancelled run would neither finish those
-checks nor fire the alert. The one limitation is inherent to GitHub concurrency: only a single
-run may sit queued, so a rapid burst of pushes collapses to "the one already running, then the
-newest", skipping the intermediate commits; the newest still validates the cumulative tree, so
-`main`'s current state is never left unvalidated. The split is expressed by making
-cancel-in-progress an expression — `${{ github.event_name != 'push' }}` — true for the
-`pull_request` event and false for a push to `main`.
-
-History collection on `main` is keyed instead on the commit **SHA**: each commit is a distinct
+Commit-driven and PR-driven workflows cancel superseded runs, keyed on the ref, so pushing
+a new commit abandons the outdated run. That supersession only fires when a *new commit*
+arrives on the branch, so closing or merging a PR — which pushes nothing to the PR branch —
+would otherwise leave its in-flight Validation run to burn to completion. A dedicated
+companion workflow closes that gap: it triggers on the PR-close event and joins the target
+workflow's concurrency group so cancel-in-progress reclaims the stale run. Both the Validation
+workflow and the PR benchmark-history workflow pair with such a close companion. The exception
+is history collection on `main`, which is keyed on the commit **SHA**: each commit is a distinct
 measurement, so distinct commits must run in parallel and only a redundant re-trigger of the
 *same* commit is deduplicated. Schedule-driven workflows carry no concurrency block at all.
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -38,20 +38,21 @@ vary by platform.
 
 Not every check earns its place on every pull request. The full matrix runs on each push to
 `main`, but pull-request validation prunes the rarely-informative legs to cut runner cost,
-leaning on push-to-`main` as the backstop for what it drops. PRs build and test only the
-x86_64 Windows and Linux runners: the whole ARM pass (which carries the MSRV *test* run) and
-the macOS legs of the test and docs jobs wait for `main`, because architecture- and
-OS-gated behaviour rarely diverges on a PR and re-running the platform-independent test and
-doc suites on macOS almost never is informative. Miri runs on Windows only for a PR — being
-an architecture-agnostic interpreter, its Linux and ARM re-runs are a `main`-only sanity net
-over cfg-gated paths — and the release-profile Clippy pass and the `careful` run are skipped
-entirely on PRs. The compile-oriented passes (dev Clippy, release build, frozen-minimum
-check, feature `hack`) deliberately keep their macOS leg on PRs, because a cheap macOS
-cross-compile still catches macOS-specific build breaks that the pruned runtime passes would
-not. MSRV *compilation* therefore stays covered on every PR by `check-frozen`, which compiles
-all targets on the MSRV toolchain against the frozen minimum-version lockfile even though the
-ARM MSRV test pass is `main`-only. Because a push to `main` is the first place the pruned
-checks can fail, that event — unlike a PR — files a tracking issue (see Failure alerting).
+leaning on push-to-`main` as the backstop for what it drops. PRs run the test and docs
+suites only on the x86_64 Windows and Linux runners: the whole ARM pass (which carries the
+MSRV *test* run) and the macOS legs of the test and docs jobs wait for `main`, because
+architecture- and OS-gated behaviour rarely diverges on a PR and re-running the
+platform-independent test and doc suites on macOS almost never is informative. Miri runs on
+Windows only for a PR — being an architecture-agnostic interpreter, its Linux and ARM
+re-runs are a `main`-only sanity net over cfg-gated paths — and the release-profile Clippy
+pass and the `careful` run are skipped entirely on PRs. The compile-oriented passes (dev
+Clippy, release build, frozen-minimum check, feature `hack`) deliberately keep their macOS
+leg on PRs, because a cheap macOS cross-compile still catches macOS-specific build breaks
+that the pruned runtime passes would not. MSRV *compilation* therefore stays covered on
+every PR by `check-frozen`, which compiles all targets on the MSRV toolchain against the
+frozen minimum-version lockfile even though the ARM MSRV test pass is `main`-only. Because a
+push to `main` is the first place the pruned checks can fail, that event — unlike a PR —
+files a tracking issue (see Failure alerting).
 
 The event split is expressed two ways: a job whose every leg is pruned on a PR (the ARM test
 and Miri passes, `clippy-release`, `careful`) carries a whole-job `github.event_name ==

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,14 +7,8 @@ on:
     branches: [main]
 
 concurrency:
-  # PR runs supersede: a new commit cancels the outdated in-progress run, keyed on the PR
-  # branch (cancel-in-progress is true for the `pull_request` event). Pushes to `main`, by
-  # contrast, must NOT cancel each other - `main` is the backstop branch and files a per-run
-  # failure issue, so every landed commit is validated to completion. For the `push` event
-  # cancel-in-progress is false, so a new `main` push queues behind the in-progress run
-  # instead of killing it: `main` validation is sequential. See design.md (Concurrency).
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: true
 
 jobs:
   # Determines which packages are impacted by changes in a PR branch compared

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,8 +7,14 @@ on:
     branches: [main]
 
 concurrency:
+  # PR runs supersede: a new commit cancels the outdated in-progress run, keyed on the PR
+  # branch (cancel-in-progress is true for the `pull_request` event). Pushes to `main`, by
+  # contrast, must NOT cancel each other - `main` is the backstop branch and files a per-run
+  # failure issue, so every landed commit is validated to completion. For the `push` event
+  # cancel-in-progress is false, so a new `main` push queues behind the in-progress run
+  # instead of killing it: `main` validation is sequential. See design.md (Concurrency).
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   # Determines which packages are impacted by changes in a PR branch compared

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -149,26 +149,6 @@ jobs:
       - name: Run default-features-check
         run: just default-features-check
 
-  check-dev:
-    needs: [delta]
-    if: needs.delta.outputs.skip_all != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-
-      - name: Run check dev on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" check dev
-
   clippy-dev:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
@@ -201,7 +181,8 @@ jobs:
   #
   # Coverage requires the nightly toolchain (llvm-tools-preview is installed only there via
   # `just install-tools`), so this is the nightly test pass. The MSRV test pass runs on the
-  # ARM runners (`test-arm`), and MSRV compilation of every target is covered by `check-dev`.
+  # ARM runners (`test-arm`, push-to-`main` only), and MSRV compilation of every target is
+  # covered by `check-frozen` (which compiles all targets on MSRV against the frozen minimums).
   # Paired with `test-arm`; both carry an explicit `-x64`/`-arm` suffix for symmetry.
   test-x64:
     needs: [delta]
@@ -244,13 +225,15 @@ jobs:
       - name: Run benchmark targets on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" test-benches
 
+  # macOS is dropped on PRs (a doctest pass on macOS is rarely informative); the full
+  # three-platform matrix runs on push to `main`.
   test-docs:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest", "macos-latest", "windows-latest"]' || '["ubuntu-latest", "windows-latest"]') }}
 
     runs-on: ${{ matrix.platform }}
 
@@ -264,13 +247,15 @@ jobs:
       - name: Run test-docs on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" test-docs
 
+  # macOS is dropped on PRs (rustdoc output does not vary by platform, so a macOS docs build
+  # is rarely informative); the full three-platform matrix runs on push to `main`.
   docs:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest", "macos-latest", "windows-latest"]' || '["ubuntu-latest", "windows-latest"]') }}
 
     runs-on: ${{ matrix.platform }}
 
@@ -287,13 +272,15 @@ jobs:
       - name: Run docs-default-features on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" docs-default-features
 
+  # Ubuntu is dropped on PRs: Miri is an architecture-agnostic interpreter, so the Linux run
+  # is a push-to-`main`-only sanity net over the Windows pass. Both platforms run on push.
   miri-x64:
-    needs: [delta, check-dev, test-x64]
+    needs: [delta, clippy-dev, test-x64]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest", "windows-latest"]' || '["windows-latest"]') }}
 
     runs-on: ${{ matrix.platform }}
 
@@ -316,7 +303,8 @@ jobs:
   # `test-x64`; both carry an explicit `-x64`/`-arm` suffix.
   test-arm:
     needs: [delta]
-    if: needs.delta.outputs.skip_all != 'true'
+    # Push-to-`main` only: every leg here is ARM or macOS, all pruned from PR validation.
+    if: github.event_name == 'push' && needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -350,8 +338,10 @@ jobs:
   # architecture-agnostic for platform-neutral code; we run it on ARM purely to exercise
   # cfg(target_arch = "aarch64") (and similar) code paths under Miri's UB detection.
   miri-arm:
-    needs: [delta, check-dev, test-arm]
-    if: needs.delta.outputs.skip_all != 'true'
+    needs: [delta, clippy-dev, test-arm]
+    # Push-to-`main` only: an architecture-agnostic interpreter re-run on ARM is a sanity net
+    # over cfg-gated paths, not PR-worthy signal.
+    if: github.event_name == 'push' && needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -369,12 +359,13 @@ jobs:
       - name: Run miri on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" miri
 
-  # Miri with many seeds is very slow, so we only run it for select packages on Windows.
+  # Miri with many seeds is very slow, so we only run it for select packages on Linux (these
+  # exercise platform-independent code, so Linux's lower overhead is preferred over Windows).
   # These jobs only run when their specific package is affected by changes.
-  # Gated behind the base `miri-x64` and `miri-arm` jobs so a quick Miri failure short-circuits
-  # the much more expensive many-seeds run.
+  # Gated behind the base `miri-x64` job so a quick Miri failure short-circuits the much more
+  # expensive many-seeds run.
   miri-harder-events-once:
-    needs: [delta, miri-x64, miri-arm]
+    needs: [delta, miri-x64]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'events_once'))
@@ -384,7 +375,7 @@ jobs:
         shard: [1/4, 2/4, 3/4, 4/4]
     # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
     timeout-minutes: 180
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -393,11 +384,11 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run miri-harder for events_once on windows-latest (shard ${{ matrix.shard }})
+      - name: Run miri-harder for events_once on ubuntu-latest (shard ${{ matrix.shard }})
         run: just package=events_once miri-harder ${{ matrix.shard }}
 
   miri-harder-infinity-pool:
-    needs: [delta, miri-x64, miri-arm]
+    needs: [delta, miri-x64]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'infinity_pool'))
@@ -407,7 +398,7 @@ jobs:
         shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
     # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
     timeout-minutes: 180
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -416,11 +407,11 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run miri-harder for infinity_pool on windows-latest (shard ${{ matrix.shard }})
+      - name: Run miri-harder for infinity_pool on ubuntu-latest (shard ${{ matrix.shard }})
         run: just package=infinity_pool miri-harder ${{ matrix.shard }}
 
   miri-harder-events:
-    needs: [delta, miri-x64, miri-arm]
+    needs: [delta, miri-x64]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'events'))
@@ -430,7 +421,7 @@ jobs:
         shard: [1/2, 2/2]
     # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
     timeout-minutes: 180
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -439,11 +430,11 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run miri-harder for events on windows-latest (shard ${{ matrix.shard }})
+      - name: Run miri-harder for events on ubuntu-latest (shard ${{ matrix.shard }})
         run: just package=events miri-harder ${{ matrix.shard }}
 
   miri-harder-awaiter-set:
-    needs: [delta, miri-x64, miri-arm]
+    needs: [delta, miri-x64]
     if: >-
       needs.delta.outputs.skip_all != 'true'
       && (needs.delta.outputs.packages == '' || contains(fromJson(needs.delta.outputs.packages_json), 'awaiter_set'))
@@ -453,7 +444,7 @@ jobs:
         shard: [1/2, 2/2]
     # Many-seeds Miri work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
     timeout-minutes: 180
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -462,7 +453,7 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run miri-harder for awaiter_set on windows-latest (shard ${{ matrix.shard }})
+      - name: Run miri-harder for awaiter_set on ubuntu-latest (shard ${{ matrix.shard }})
         run: just package=awaiter_set miri-harder ${{ matrix.shard }}
 
   machete:
@@ -486,29 +477,10 @@ jobs:
       - name: Run machete on ${{ matrix.platform }}
         run: just machete
 
-  check-release:
-    needs: [delta, check-dev]
-    if: needs.delta.outputs.skip_all != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-
-      - name: Run check release on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" check release
-
   clippy-release:
     needs: [delta, clippy-dev]
-    if: needs.delta.outputs.skip_all != 'true'
+    # Push-to-`main` only: release-profile Clippy rarely diverges from the dev pass on a PR.
+    if: github.event_name == 'push' && needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -527,7 +499,7 @@ jobs:
         run: just package="${{ needs.delta.outputs.packages }}" clippy release
 
   build-release:
-    needs: [delta, check-dev]
+    needs: [delta, clippy-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -549,11 +521,11 @@ jobs:
   # Verifies the workspace still compiles at the minimum dependency versions declared in
   # Cargo.toml (our published minimum-version promises), rather than the higher versions
   # pinned in Cargo.lock. The `check-frozen` recipe freezes every workspace dependency to
-  # its declared minimum, regenerates the lockfile, and runs `check`. Gated behind check-dev
+  # its declared minimum, regenerates the lockfile, and runs `check`. Gated behind clippy-dev
   # because checking the frozen minimums is pointless if the code does not even build with
   # the normal lockfile versions.
   check-frozen:
-    needs: [delta, check-dev]
+    needs: [delta, clippy-dev]
     if: needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
@@ -641,7 +613,8 @@ jobs:
 
   careful:
     needs: [delta, test-x64]
-    if: needs.delta.outputs.skip_all != 'true'
+    # Push-to-`main` only: `cargo careful` rarely surfaces PR-specific signal.
+    if: github.event_name == 'push' && needs.delta.outputs.skip_all != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -917,3 +890,81 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           run_command: send-notifications
           fail_ci_if_error: true
+
+  # File a GitHub issue whenever any job above fails on a push to `main`, so a push-to-main
+  # failure is tracked rather than lost. PR runs surface a failure as the red check and need
+  # no issue - and this workflow now leans more heavily on push-to-main as the backstop for
+  # the checks pruned from PR validation (ARM, macOS test/docs, the Linux Miri run,
+  # clippy-release, careful), so a green PR no longer implies those passed.
+  #
+  # A fresh issue is filed per failing run - no dedup, no auto-close - mirroring the release
+  # workflow's per-run alert: each failure is investigated and closed individually, and a
+  # later green run does not touch prior issues. `failure()` fires only on a real failure, so
+  # a fully-green (or skipped-only) run files nothing. `needs` lists every job so a failure in
+  # any of them reaches this gate.
+  alert:
+    needs:
+      - delta
+      - test-scripts
+      - validate-workflows
+      - format-check
+      - default-features-check
+      - clippy-dev
+      - test-x64
+      - test-docs
+      - docs
+      - miri-x64
+      - test-arm
+      - miri-arm
+      - miri-harder-events-once
+      - miri-harder-infinity-pool
+      - miri-harder-events
+      - miri-harder-awaiter-set
+      - machete
+      - clippy-release
+      - build-release
+      - check-frozen
+      - mutants
+      - run-examples
+      - hack
+      - careful
+      - test-azurite
+      - test-azure
+      - test-azure-gh
+      - coverage-notify
+    if: failure() && github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Open failure issue for this run
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          # Ensure the shared label exists (idempotent) so `gh issue create` cannot fail on a
+          # missing label.
+          $PSNativeCommandUseErrorActionPreference = $false
+          gh label create ci-failure --color B60205 --description "CI workflow failure" --force *> $null
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $body = @"
+          The Validation workflow failed on a push to ``main``.
+
+          Push-to-``main`` validation is the backstop for the checks pruned from PR validation
+          (ARM and macOS test/docs runs, the Linux Miri sanity run, ``clippy-release`` and
+          ``careful``), so this failure may be in a check a PR never ran.
+
+          Failed run: $env:RUN_URL
+          "@
+          gh issue create --label ci-failure --title "Validation workflow failed (run $env:RUN_ID)" --body $body


### PR DESCRIPTION
[Copilot speaking]

## What & why

Reduce GitHub runner usage by moving rarely-informative Validation checks to **push-to-`main` only**, keeping them out of PR validation. Because this leans more heavily on push-to-`main` as the backstop, a push-to-`main` failure now files a tracking issue.

## Changes (`.github/workflows/validation.yml`)

**Moved to push-to-`main` only** (skipped on PRs):
- **ARM everywhere** — `test-arm` and `miri-arm` become whole-job push-only.
- **macOS in test jobs** — `test-arm` (push-only) and `test-docs` (macOS dropped on PR via conditional matrix).
- **macOS in `docs`** — dropped on PR via conditional matrix.
- **`miri-x64`** — PR runs Windows only; push runs Ubuntu + Windows.
- **`clippy-release`** and **`careful`** — whole-job push-only.

Compile-oriented jobs (`clippy-dev`, `build-release`, `check-frozen`, `hack`) **keep** their macOS leg on PRs — a cheap cross-compile still catches macOS-specific build breaks.

**Removed redundant `check` jobs** — Clippy compiles as a prerequisite to linting, so `check-dev`/`check-release` only re-proved what a green Clippy already guarantees. Dependents (`miri-x64`, `miri-arm`, `build-release`, `check-frozen`) now depend on `clippy-dev`.

**`miri-harder-*` moved to Linux** — they exercise platform-independent code, so Linux's lower overhead is preferred over Windows; they now gate on `miri-x64` alone.

**New `alert` job** — on a push-to-`main` failure it files a fresh per-run `ci-failure` issue (no dedup, no auto-close), mirroring the release workflow's alert. PR failures file nothing (the red check is self-evident).

Docs updated in `.github/workflows/design.md` (job gating, platform strategy, failure alerting).

## Notes

- **MSRV compilation** stays covered on every PR by `check-frozen` (compiles all targets on the MSRV toolchain against the frozen-minimum lockfile), even though the ARM MSRV *test* pass is now `main`-only. Release-profile MSRV compilation (`check-release`) is dropped with no replacement — release-only MSRV breaks are very rare.
- ⚠️ **Branch protection:** if "required status checks" list any removed/renamed/now-push-only legs (`check-dev`, `check-release`, `clippy-release (…)`, `careful (…)`, `test-arm (…)`, `miri-arm (…)`, `miri-x64 (ubuntu-latest)`), those settings need updating in repo settings or PRs will hang waiting on checks that never run. Not editable via repo files.

## Validation

`just validate-workflows` (actionlint) passes; the `needs` list in the new `alert` job also validates every referenced job name.