### PR TITLE
Seed a benchmarking-in-progress placeholder comment at PR benchmark start

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -190,22 +190,28 @@ because a PR failure is a transient condition, not the persistent one the issue 
 tracks.
 
 Because a full benchmark run takes hours and a new push *cancels* the in-flight one (see
-Concurrency), the comment on display can lag the PR tip by a long way, and a reader has no way to
-tell current numbers from hours-old ones. Two mechanisms keep that honest. First, every comment
-records **which commit it measured** — a human-visible line printing the full SHA bare (GitHub
-autolinks it to the commit and abbreviates it for display, so we neither truncate it ourselves nor
-lose the click-through) plus a hidden full-SHA marker.
-Second, a lightweight **`mark-stale` job** runs at the *start* of each new run (right after the
-short delta preflight, in parallel with the multi-hour collect) and, if a comment already exists,
-prepends a warning banner stating how far behind `HEAD` those numbers now are — *"N commits behind
-HEAD"*, or a numberless *"out of date"* when the two share no history (e.g. a force-push) or the
-marker is absent. The distance comes from the GitHub compare API (`ahead_by`), which needs no
-clone and still resolves a commit orphaned by a force-push; any inability to compute it degrades
-to the numberless wording rather than failing the run. The banner is bounded by a sentinel pair so
-a re-run *replaces* rather than stacks it, and the next completed analyze — which rewrites the body
-from scratch with a fresh analyzed-commit marker — drops it automatically once real new results
-land. `mark-stale` is gated on the same non-empty delta as collect, so it never races the cleanup
-path that *deletes* the comment when the PR no longer touches anything benchmarkable.
+Concurrency), on a PR's first push there is nothing on display yet, and on later pushes the comment
+on display can lag the PR tip by a long way with no way for a reader to tell current numbers from
+hours-old ones. A lightweight **`mark-stale` job** runs at the *start* of each new run (right after
+the short delta preflight, in parallel with the multi-hour collect) and keeps the comment honest
+about the run just begun. When the PR has **no comment yet**, it seeds a *"benchmarking in
+progress"* placeholder — carrying the same hidden dedup marker and disclosing the collection scope,
+so the author knows results are coming rather than seeing nothing for hours; it refreshes that
+placeholder's scope on later pushes and steps aside once a completed analyze overwrites it with real
+findings. When a comment **already carries results**, two further mechanisms flag their age: every
+such comment records **which commit it measured** — a human-visible line printing the full SHA bare
+(GitHub autolinks it to the commit and abbreviates it for display, so we neither truncate it
+ourselves nor lose the click-through) plus a hidden full-SHA marker — and `mark-stale` prepends a
+warning banner stating how far behind `HEAD` those numbers now are: *"N commits behind HEAD"*, or a
+numberless *"out of date"* when the two share no history (e.g. a force-push) or the marker is
+absent. The distance comes from the GitHub compare API (`ahead_by`), which needs no clone and still
+resolves a commit orphaned by a force-push; any inability to compute it degrades to the numberless
+wording rather than failing the run. The banner is bounded by a sentinel pair so a re-run *replaces*
+rather than stacks it, and the next completed analyze — which rewrites the body from scratch with a
+fresh analyzed-commit marker — drops it automatically once real new results land. The staleness pass
+skips a still-empty placeholder (it has no results to age), leaving the placeholder's own upkeep to
+the seeding pass. `mark-stale` is gated on the same non-empty delta as collect, so it never races the
+cleanup path that *deletes* the comment when the PR no longer touches anything benchmarkable.
 
 Collection is **delta-scoped**: a preflight job diffs the PR against `main` and benchmarks only
 the touched packages, since re-measuring the whole workspace on every PR push would be

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -23,10 +23,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# The hidden HTML marker that identifies this workflow's rolling PR comment, defined once and shared
-# by the `analyze` job (which posts/updates it) and the `cleanup` job (which deletes it when the PR
-# no longer touches any benchmarkable package). The comment module dedups solely on this marker, so
-# a single definition keeps the post and delete paths from drifting apart.
+# The hidden HTML marker that identifies this workflow's rolling PR comment, defined once and shared by
+# the `analyze` job (which posts/updates it with results), the `mark-stale` job (which seeds/refreshes an
+# in-progress placeholder carrying it), and the `cleanup` job (which deletes it when the PR no longer
+# touches any benchmarkable package). The comment module dedups solely on this marker, so a single
+# definition keeps the post, placeholder and delete paths from drifting apart.
 #
 # PR_COMMIT_MARKER_PREFIX is the prefix of a SECOND hidden marker the `analyze` job embeds to record
 # which commit its numbers describe (`<prefix><full-sha> -->`). The `mark-stale` job parses that SHA
@@ -102,18 +103,22 @@ jobs:
             "skip_all=$($output.SkipAll)"
           ) | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
 
-  # As soon as a new run is known to be collecting (the delta is non-empty), flag any existing rolling
-  # comment as STALE so a reader is not misled by hours-old numbers while the multi-hour collect+analyze
-  # runs. Deliberately lightweight - default (shallow) checkout + preinstalled gh + a direct module
-  # call, no build-env setup, no Azure, no full history - so the warning appears within minutes of the
-  # push (right after this short delta job), long before analyze rewrites the comment. It reads the
-  # analyzed-commit marker from the current comment and asks the GitHub compare API how far HEAD is
-  # ahead, which needs no clone and still resolves a commit orphaned by a force-push. Gated on
+  # At the START of every collecting run (delta non-empty), keep the rolling PR comment honest about the
+  # fresh run in two complementary ways. If a comment with real results already exists, flag it STALE so
+  # a reader is not misled by hours-old numbers while the multi-hour collect+analyze runs. If the PR has
+  # no comment yet - the common case on a PR's first push - seed a "benchmarking in progress" placeholder
+  # instead, so the author knows results are on the way rather than seeing nothing for hours; the same
+  # step refreshes that placeholder's disclosed scope on later pushes and steps aside once analyze writes
+  # real findings. Deliberately lightweight - default (shallow) checkout + preinstalled gh + a direct
+  # module call, no build-env setup, no Azure, no full history - so the signal appears within minutes of
+  # the push (right after this short delta job), long before analyze rewrites the comment. The staleness
+  # side reads the analyzed-commit marker from the current comment and asks the GitHub compare API how
+  # far HEAD is ahead, which needs no clone and still resolves a commit orphaned by a force-push. Gated on
   # skip_all != 'true' for the same reason collect is: when the PR now touches nothing benchmarkable the
-  # `cleanup` job DELETES the comment instead, and marking a comment about to be deleted would only race
-  # that delete. Runs in parallel with collect (both `needs: delta`), and mirrors collect's gating
-  # exactly - no `always()`, so a FAILED or skipped delta skips this job too rather than flagging a
-  # comment stale for a run that will never collect; the same-repo gate rides along from delta, which is
+  # `cleanup` job DELETES the comment instead, and posting or marking a comment about to be deleted would
+  # only race that delete. Runs in parallel with collect (both `needs: delta`), and mirrors collect's
+  # gating exactly - no `always()`, so a FAILED or skipped delta skips this job too rather than acting on
+  # a comment for a run that will never collect; the same-repo gate rides along from delta, which is
   # skipped on forks (skipping this dependent with it).
   mark-stale:
     needs: delta
@@ -121,9 +126,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # pull-requests to PATCH the rolling comment; contents so the compare API can read commit topology
-    # and the checkout can put the shared BenchHistoryComment module on disk (the marking logic lives
-    # there so it is unit-tested against a mocked gh, mirroring how analyze posts via the same module).
+    # pull-requests to POST/PATCH the rolling comment; contents so the compare API can read commit
+    # topology and the checkout can put the shared BenchHistoryComment module on disk (the marking and
+    # placeholder logic lives there so it is unit-tested against a mocked gh, mirroring how analyze posts
+    # via the same module).
     permissions:
       contents: read
       pull-requests: write
@@ -134,7 +140,7 @@ jobs:
         # compare API, so no local history is walked here - only the module needs to be on disk.
         uses: actions/checkout@v6
 
-      - name: Flag rolling PR comment as stale
+      - name: Signal the new run on the rolling PR comment
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -143,17 +149,21 @@ jobs:
           MARKER: ${{ env.PR_COMMENT_MARKER }}
           COMMIT_MARKER_PREFIX: ${{ env.PR_COMMIT_MARKER_PREFIX }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_PACKAGES: ${{ needs.delta.outputs.packages }}
         # Import and call the shared module directly (like cleanup) rather than via `just`: this job
         # deliberately skips setup-environment to stay lightweight, so it must not assume `just` is
-        # preinstalled on the runner image. The real logic (SHA/repo validation, compare-distance
-        # lookup, banner insertion) lives in the Pester-tested module; this step is just glue.
+        # preinstalled on the runner image. The real logic (SHA/repo validation, compare-distance lookup,
+        # banner insertion, placeholder rendering) lives in the Pester-tested module; this step is just
+        # glue. The two calls are ordered stale-then-placeholder so they compose: Set-RollingCommentStaleness
+        # marks an existing results comment (and no-ops on a placeholder or when there is no comment), then
+        # Publish-InProgressComment seeds/refreshes the placeholder only when there are no results yet.
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
           Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
 
-          Write-Host "Flagging the rolling benchmark comment on $env:REPO PR #$env:PR_NUMBER as stale relative to head $env:HEAD_SHA."
+          Write-Host "Flagging any prior benchmark results on $env:REPO PR #$env:PR_NUMBER as stale relative to head $env:HEAD_SHA."
           $marked = Set-RollingCommentStaleness `
             -Repo $env:REPO `
             -PrNumber $env:PR_NUMBER `
@@ -164,7 +174,20 @@ jobs:
           if ($marked) {
             Write-Host "Added a staleness warning to the rolling PR comment."
           } else {
-            Write-Host "No staleness warning needed (no rolling comment yet, or it already reflects head)."
+            Write-Host "No staleness warning needed (no results comment yet, an in-progress placeholder, or it already reflects head)."
+          }
+
+          Write-Host "Ensuring an in-progress placeholder is present so the author knows benchmark results are coming."
+          $posted = Publish-InProgressComment `
+            -Repo $env:REPO `
+            -PrNumber $env:PR_NUMBER `
+            -Marker $env:MARKER `
+            -Packages $env:PR_PACKAGES `
+            -Verbose
+          if ($posted) {
+            Write-Host "Posted or refreshed the in-progress benchmark placeholder comment."
+          } else {
+            Write-Host "No placeholder change needed (the PR already has a rolling comment with results, or the placeholder is current)."
           }
 
   # Benchmark ONLY the touched packages across the full platform matrix, keyed by the PR head

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -547,6 +547,27 @@ Describe 'Set-RollingCommentStaleness (mocked gh api)' {
         }
     }
 
+    Context 'when the comment is an in-progress placeholder (no results yet)' {
+        BeforeEach {
+            # A placeholder carries the dedup marker plus the in-progress marker but NO analyzed-commit
+            # marker: there are no results to age, so the staleness pass must step aside entirely -
+            # neither hitting the compare API nor PATCHing a misleading "out of date" banner over a
+            # comment that already reads "benchmarking in progress".
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-in-progress -->\n\n### Benchmark history (vs `main`)\n\nbenchmarking in progress","html_url":"u"}]'
+            }
+        }
+
+        It 'is a no-op returning false, touching neither the compare api nor a PATCH' {
+            $result = Set-RollingCommentStaleness -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -CommitMarkerPrefix $script:CommitPrefix -HeadSha $script:HeadSha2
+            $result | Should -BeFalse
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' } -Times 0 -Exactly
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { [bool]($args | Where-Object { $_ -like 'repos/*/compare/*' }) } -Times 0 -Exactly
+        }
+    }
+
     Context 'when the comment already carries a stale banner (re-run)' {
         BeforeEach {
             Remove-Item -LiteralPath $script:StaleCapture -ErrorAction SilentlyContinue
@@ -650,6 +671,187 @@ Describe 'Add-StalenessBanner (unexported string transform)' {
                 # The banner must land after the real marker line, i.e. past the whole code block.
                 $bannerLine | Should -BeGreaterThan $realMarkerLine
             }
+        }
+    }
+}
+
+Describe 'Publish-InProgressComment (mocked gh api)' {
+    BeforeAll {
+        # An unsorted, duplicate-free-after-sort package list so the assertions also prove the rendering
+        # sorts it; kept in sync with the InModuleScope literal used by the idempotency context below.
+        $script:Packages = 'pool events'
+        # Fixed capture path (recomputed identically in the mock and the assertions) for the posted body:
+        # the temp body file is deleted once `gh` returns, so a post-hoc ParameterFilter could not read it.
+        $script:InProgressCapture = Join-Path ([System.IO.Path]::GetTempPath()) 'bh-inprogress-captured-body.md'
+        # The JSON list `gh` "returns" for the already-matches case is written to a file the mock reads
+        # back inline, because a mock scriptblock cannot see test-scope variables.
+        $script:InProgressListFile = Join-Path ([System.IO.Path]::GetTempPath()) 'bh-inprogress-existing-list.json'
+    }
+
+    AfterAll {
+        Remove-Item -LiteralPath $script:InProgressCapture -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $script:InProgressListFile -ErrorAction SilentlyContinue
+    }
+
+    Context 'when the PR has no rolling comment yet' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:InProgressCapture -ErrorAction SilentlyContinue
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-inprogress-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'POST') { $global:LASTEXITCODE = 0; return '{"id":99,"html_url":"https://github.com/o/r/pull/5#issuecomment-99"}' }
+                $global:LASTEXITCODE = 0
+                return '[]'
+            }
+        }
+
+        It 'posts a placeholder carrying both markers and the disclosed scope' {
+            $result = Publish-InProgressComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages
+            $result | Should -BeTrue
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'POST') -and ($args -contains 'repos/o/r/issues/5/comments')
+            }
+            $sent = Get-Content -LiteralPath $script:InProgressCapture -Raw
+            $sent | Should -BeLike '*<!-- folo-bench-history-pr -->*'
+            $sent | Should -BeLike '*<!-- folo-bench-history-in-progress -->*'
+            $sent | Should -BeLike '*Benchmarking in progress*'
+            $sent | Should -BeLike '*Collection scope*'
+            $sent | Should -BeLike '*events*'
+            $sent | Should -BeLike '*pool*'
+        }
+
+        It 'never carries an analyzed-commit marker, so a later mark-stale treats it as in-progress' {
+            Publish-InProgressComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages | Out-Null
+            $sent = Get-Content -LiteralPath $script:InProgressCapture -Raw
+            $sent | Should -Not -BeLike '*folo-bench-history-commit:*'
+        }
+    }
+
+    Context 'when a completed analyze already posted real results' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:InProgressCapture -ErrorAction SilentlyContinue
+            # A results comment carries the dedup + analyzed-commit markers but NOT the in-progress marker;
+            # the placeholder path must never overwrite those findings (no POST, no PATCH).
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-inprogress-captured-body.md') -Force
+                    }
+                }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\nreal findings","html_url":"u"}]'
+            }
+        }
+
+        It 'leaves the results comment untouched, returning false' {
+            $result = Publish-InProgressComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages
+            $result | Should -BeFalse
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'POST' } -Times 0 -Exactly
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when an in-progress placeholder already exists with a stale scope' {
+        BeforeEach {
+            Remove-Item -LiteralPath $script:InProgressCapture -ErrorAction SilentlyContinue
+            # The placeholder carries the in-progress marker but its body differs from the freshly-rendered
+            # one, so it must be refreshed (PATCHed) in place rather than left as-is.
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) {
+                    if ($a -like 'body=@*') {
+                        Copy-Item -LiteralPath $a.Substring('body=@'.Length) `
+                            -Destination (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-inprogress-captured-body.md') -Force
+                    }
+                }
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                $global:LASTEXITCODE = 0
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-in-progress -->\n\nan out-of-date placeholder scope","html_url":"u"}]'
+            }
+        }
+
+        It 'refreshes the placeholder in place with the current scope' {
+            $result = Publish-InProgressComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages
+            $result | Should -BeTrue
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter {
+                ($args -contains 'PATCH') -and ($args -contains 'repos/o/r/issues/comments/42')
+            }
+            $sent = Get-Content -LiteralPath $script:InProgressCapture -Raw
+            $sent | Should -BeLike '*<!-- folo-bench-history-in-progress -->*'
+            $sent | Should -BeLike '*events*'
+        }
+    }
+
+    Context 'when the existing placeholder already matches the current scope' {
+        BeforeEach {
+            # Render the exact body Publish-InProgressComment will produce for these packages and hand it
+            # back as the existing comment, so the idempotency check sees no change. The literal packages
+            # here must match $script:Packages passed by the It.
+            $canonical = InModuleScope BenchHistoryComment {
+                Format-InProgressBody -Marker '<!-- folo-bench-history-pr -->' -Packages 'pool events'
+            }
+            $list = '[' + (@{ id = 42; body = $canonical; html_url = 'u' } | ConvertTo-Json -Compress) + ']'
+            Set-Content -LiteralPath $script:InProgressListFile -Value $list -Encoding utf8 -NoNewline
+            Mock gh -ModuleName BenchHistoryComment {
+                if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
+                $global:LASTEXITCODE = 0
+                return (Get-Content -LiteralPath (Join-Path ([System.IO.Path]::GetTempPath()) 'bh-inprogress-existing-list.json') -Raw)
+            }
+        }
+
+        It 'is a no-op returning false, without patching' {
+            $result = Publish-InProgressComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages
+            $result | Should -BeFalse
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'PATCH' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when -WhatIf is passed and no comment exists' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 0; '[]' }
+        }
+
+        It 'reports the post without performing it' {
+            Publish-InProgressComment -Repo 'o/r' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages -WhatIf | Out-Null
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { $args -contains 'POST' } -Times 0 -Exactly
+        }
+    }
+
+    Context 'input validation' {
+        It 'rejects a malformed repository' {
+            { Publish-InProgressComment -Repo 'bad repo' -PrNumber '5' -Marker $script:Marker -Packages $script:Packages } |
+                Should -Throw '*owner/name*'
+        }
+    }
+}
+
+Describe 'Format-InProgressBody (unexported string transform)' {
+    It 'renders a single changed package with singular wording' {
+        InModuleScope BenchHistoryComment {
+            $body = Format-InProgressBody -Marker '<!-- folo-bench-history-pr -->' -Packages 'solo'
+            $body.Contains('benchmarking the 1 package this PR changed (`solo`).') | Should -BeTrue
+        }
+    }
+
+    It 'sorts and de-duplicates multiple changed packages with plural wording' {
+        InModuleScope BenchHistoryComment {
+            $body = Format-InProgressBody -Marker '<!-- folo-bench-history-pr -->' -Packages 'beta alpha beta'
+            $body.Contains('benchmarking the 2 packages this PR changed (`alpha`, `beta`).') | Should -BeTrue
+        }
+    }
+
+    It 'leads with the dedup and in-progress markers, then the shared header and status' {
+        InModuleScope BenchHistoryComment {
+            $body = Format-InProgressBody -Marker '<!-- folo-bench-history-pr -->' -Packages 'solo'
+            $lines = $body -split "`n"
+            $lines[0] | Should -Be '<!-- folo-bench-history-pr -->'
+            $lines[1] | Should -Be $script:InProgressMarker
+            $body.Contains('### Benchmark history (vs `main`)') | Should -BeTrue
+            $body | Should -BeLike '*Benchmarking in progress*'
         }
     }
 }

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -13,13 +13,17 @@
 # imports this module directly and calls Remove-RollingComment to sweep away a comment left by an
 # earlier iteration of the same PR (e.g. a benchmarked change that was later reverted).
 #
-# A benchmark run takes many hours, and a new push cancels the in-flight one, so the comment a reader
-# sees can lag the PR tip by a long way. Two seams keep that honest: the analyze job embeds a hidden
-# "analyzed commit" marker in the body (which commit the numbers describe), and the mark-stale job -
-# which fires at the START of a new run - calls Set-RollingCommentStaleness to prepend a warning
-# banner stating how far behind HEAD those numbers now are (via Get-CommitsBehind), so nobody mistakes
-# hours-old results for the current state. The banner clears itself when the next analyze rewrites the
-# body with fresh results.
+# A benchmark run takes many hours, and a new push cancels the in-flight one, so on the FIRST run of a
+# PR there is nothing on display yet and on later runs the comment a reader sees can lag the PR tip by
+# a long way. Three seams keep that honest, all driven by the lightweight mark-stale job that fires at
+# the START of a new run. First, before any comment exists, Publish-InProgressComment seeds a
+# "benchmarking in progress" placeholder (carrying the in-progress marker above) so the author knows
+# results are coming; it refreshes that placeholder's disclosed scope on re-runs and steps aside once
+# real findings land. Second, the analyze job embeds a hidden "analyzed commit" marker in the body
+# (which commit the numbers describe). Third, once results exist, Set-RollingCommentStaleness prepends
+# a warning banner stating how far behind HEAD those numbers now are (via Get-CommitsBehind), so nobody
+# mistakes hours-old results for the current state; it skips the still-empty placeholder, which has no
+# results to stale. The banner clears itself when the next analyze rewrites the body with fresh results.
 #
 # Every GitHub-touching call goes through `gh api` behind the single Invoke-GhCapture seam the
 # Pester suite (BenchHistoryComment.Tests.ps1) mocks, so the find/update/create/delete logic is
@@ -35,6 +39,16 @@ Set-StrictMode -Version Latest
 # unlike the caller-supplied dedup and analyzed-commit markers it needs no workflow-level definition.
 $script:StaleBannerOpen = '<!-- folo-bench-history-stale -->'
 $script:StaleBannerClose = '<!-- /folo-bench-history-stale -->'
+
+# Hidden marker identifying an "in-progress" placeholder comment - the one Publish-InProgressComment
+# seeds at the START of a run (via the mark-stale job) when the PR has no rolling comment yet, so the
+# author knows benchmark results are coming rather than seeing nothing for the multi-hour collect.
+# Purely internal to this module, like the stale-banner sentinels: Publish-InProgressComment writes it
+# and both it and Set-RollingCommentStaleness read it to tell a still-empty placeholder apart from a
+# comment carrying real results. A results comment never has it - the analyze compose step rebuilds the
+# body from scratch without it - so its presence unambiguously means "no results yet". Because the
+# writer and both readers live here, it needs no workflow-level definition.
+$script:InProgressMarker = '<!-- folo-bench-history-in-progress -->'
 
 function Invoke-GhCapture {
     # Runs `gh` with the given arguments, capturing stdout and stderr SEPARATELY. stderr is
@@ -442,6 +456,17 @@ function Set-RollingCommentStaleness {
 
     $body = $existing.body
 
+    # An in-progress placeholder (seeded by Publish-InProgressComment when the run started and the PR had
+    # no comment yet) carries no results, so there is nothing to flag as stale - marking it would only
+    # stamp a misleading "out of date" banner onto a comment that already says "in progress". Recognise
+    # it by its hidden marker and step aside; Publish-InProgressComment, called right after this in the
+    # same job, keeps the placeholder's disclosed scope current instead.
+    if ($body.Contains($script:InProgressMarker)) {
+        Write-Verbose ("Rolling comment on PR #$PrNumber is an in-progress placeholder with no results " +
+            "yet; nothing to flag as stale.")
+        return $false
+    }
+
     # Pull the analyzed commit SHA out of the hidden marker the analyze job embeds
     # ("$CommitMarkerPrefix<40-hex> -->"). A pre-change comment - or any body missing the marker -
     # yields no SHA, in which case a distance cannot be expressed and we fall back to the numberless
@@ -507,4 +532,125 @@ function Set-RollingCommentStaleness {
     return $true
 }
 
-Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment, Get-CommitsBehind, Set-RollingCommentStaleness
+function Format-InProgressBody {
+    # Pure string transform: renders the "benchmarking in progress" placeholder body, prefixed with the
+    # dedup $Marker (so the next run - and the eventual analyze - find and update THIS comment instead of
+    # posting a duplicate) and the hidden in-progress marker (so Set-RollingCommentStaleness and
+    # Publish-InProgressComment can tell a still-empty placeholder from a comment carrying real results).
+    # Mirrors the analyze comment's header and "Collection scope" line - listing exactly the packages
+    # this PR changed, sorted and de-duped the same way - so the placeholder reads as an early form of the
+    # very comment analyze will later overwrite. Factored out (and kept unexported) so the rendering is
+    # one testable place, mirroring Add-StalenessBanner.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string] $Marker,
+        [Parameter(Mandatory)][string] $Packages
+    )
+
+    # Split the space-separated package list the delta job produced, dropping blanks and de-duping, then
+    # render each as inline code - the same shaping the analyze compose step applies, so the two scope
+    # lines stay worded alike. A distinct local name (not $Packages) avoids coercing the array back into
+    # the string-typed parameter.
+    $names = @(($Packages -split '\s+') | Where-Object { $_ } | Sort-Object -Unique)
+    $renderedPackages = ($names | ForEach-Object { '`' + $_ + '`' }) -join ', '
+    $packageNoun = if ($names.Count -eq 1) { 'package' } else { 'packages' }
+    $scope = "**Collection scope:** benchmarking the $($names.Count) $packageNoun this PR changed ($renderedPackages)."
+
+    $lines = @(
+        $Marker
+        $script:InProgressMarker
+        ''
+        "### Benchmark history (vs ``main``)"
+        ''
+        $scope
+        ''
+        ('⏳ **Benchmarking in progress.** Results will appear here when the run completes - this can ' +
+            'take a few hours. This comment refreshes automatically on every push.')
+    )
+    return ($lines -join "`n")
+}
+
+function Publish-InProgressComment {
+    # Called at the START of a new PR benchmark run (the mark-stale job), right after
+    # Set-RollingCommentStaleness, to make sure the PR shows a "benchmarking in progress" placeholder so
+    # the author knows results are coming during the multi-hour collect instead of seeing nothing. Three
+    # outcomes, keyed off the hidden in-progress marker:
+    #   * no rolling comment yet          -> POST the placeholder;
+    #   * the placeholder already exists  -> PATCH it so the disclosed collection scope tracks the current
+    #                                        delta (a no-op when it already matches);
+    #   * a comment carrying real results -> leave it untouched - analyzed findings must never be
+    #                                        clobbered by a placeholder; Set-RollingCommentStaleness owns
+    #                                        that comment's staleness.
+    # Returns $true when a comment was posted or updated. SupportsShouldProcess because posting/editing a
+    # comment is state-changing (matches the module's other mutating helpers): the POST/PATCH is gated on
+    # ShouldProcess so `-WhatIf` reports without performing it.
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber,
+        [Parameter(Mandatory)][string] $Marker,
+        [Parameter(Mandatory)][string] $Packages
+    )
+
+    Assert-RepoAndPr -Repo $Repo -PrNumber $PrNumber
+
+    $existing = Find-RollingComment -Repo $Repo -PrNumber $PrNumber -Marker $Marker
+
+    # A comment WITHOUT the in-progress marker carries real analyzed results (or is a legacy pre-change
+    # comment); either way it is not ours to overwrite - the marker exists precisely to keep this path
+    # from clobbering findings. Leave it to Set-RollingCommentStaleness, which flagged it stale just before
+    # this call. Literal substring match (.Contains, ordinal) for the same reason the other markers use it.
+    if ($existing -and -not $existing.body.Contains($script:InProgressMarker)) {
+        Write-Verbose ("Rolling comment on PR #$PrNumber already carries analyzed results; leaving it " +
+            "untouched rather than overwriting it with an in-progress placeholder.")
+        return $false
+    }
+
+    $body = Format-InProgressBody -Marker $Marker -Packages $Packages
+
+    # Refresh an existing placeholder in place, or post a fresh one; a placeholder that already matches the
+    # current scope needs no write. Both writes send the body through a FILE (`-F body=@<path>`) for the
+    # same reasons the module's other writers do: it sidesteps the command-line length limit and any
+    # Markdown shell-escaping, and keeps the body out of process listings.
+    if ($existing) {
+        if ($existing.body -eq $body) {
+            Write-Verbose ("In-progress placeholder on PR #$PrNumber already reflects the current scope; " +
+                "nothing to update.")
+            return $false
+        }
+        $action = 'Refresh in-progress placeholder'
+        $target = "comment #$($existing.id) on PR #$PrNumber"
+        $method = 'PATCH'
+        $apiPath = "repos/$Repo/issues/comments/$($existing.id)"
+        $logMessage = ("Refreshing the in-progress placeholder #$($existing.id) on PR #$PrNumber so its " +
+            "disclosed scope tracks the current delta.")
+    } else {
+        $action = 'Post in-progress placeholder'
+        $target = "PR #$PrNumber"
+        $method = 'POST'
+        $apiPath = "repos/$Repo/issues/$PrNumber/comments"
+        $logMessage = ("No rolling comment on PR #$PrNumber yet; posting an in-progress placeholder so the " +
+            "author knows benchmark results are on the way.")
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($target, $action)) {
+        return $false
+    }
+
+    $tempBodyFile = New-TemporaryFile
+    try {
+        Set-Content -LiteralPath $tempBodyFile.FullName -Value $body -Encoding utf8 -NoNewline
+        Write-Verbose $logMessage
+        Invoke-GhCapture -Arguments @(
+            'api', '--method', $method, $apiPath, '-F', "body=@$($tempBodyFile.FullName)"
+        ) | Out-Null
+    }
+    finally {
+        Remove-Item -LiteralPath $tempBodyFile.FullName -Force -ErrorAction SilentlyContinue
+    }
+    return $true
+}
+
+Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment, Get-CommitsBehind, Set-RollingCommentStaleness, Publish-InProgressComment


### PR DESCRIPTION
[Copilot speaking]

## Problem

The PR benchmark workflow (`.github/workflows/pr-bench-history.yml`) takes hours to produce results. Its lightweight `mark-stale` leader job runs at the *start* of every run but previously only prepended a staleness banner to an **already existing** rolling comment. On a PR's **first** push there is no comment yet, so the job did nothing and the author saw nothing — with no signal that benchmark results were coming later.

## What changed

The `mark-stale` job now keeps the rolling comment honest in two complementary ways, via two small, independently Pester-tested module functions called in sequence:

- **`Set-RollingCommentStaleness`** (existing) — flags a comment that carries **real results** as stale. Taught to **no-op on an in-progress placeholder** (nothing to age).
- **`Publish-InProgressComment`** (new) — **posts** a "⏳ Benchmarking in progress" placeholder when the PR has no rolling comment yet, **refreshes** its disclosed collection scope in place on later pushes, and **leaves a results comment untouched**.

A new module-internal hidden marker `<!-- folo-bench-history-in-progress -->` distinguishes a placeholder from a results comment. The placeholder mirrors the final comment's header and **Collection scope** line (listing the packages this PR changed), so it reads as an early form of the very comment `analyze` later overwrites.

### Composition (mark-stale step, in order)

| Current comment state | Set-RollingCommentStaleness | Publish-InProgressComment |
| --- | --- | --- |
| none | no-op (no comment) | POST placeholder |
| results (analyzed-commit marker) | prepend stale banner | no-op (results present) |
| in-progress placeholder (re-run) | no-op (in-progress marker) | refresh scope if changed |
| legacy (no markers) | out-of-date banner | no-op (no in-progress marker) |

## Files

- `scripts/bench-history/BenchHistoryComment.psm1` — in-progress marker, `Format-InProgressBody` (private renderer), `Publish-InProgressComment` (exported), staleness no-op on placeholders.
- `.github/workflows/pr-bench-history.yml` — `mark-stale` job wires the two calls in stale-then-placeholder order and passes `PR_PACKAGES` for the scope line.
- `.github/workflows/design.md` — documents the placeholder-seeding role.
- `scripts/bench-history/BenchHistoryComment.Tests.ps1` — Pester coverage for the new function, the renderer, and the staleness no-op.

## Validation

- `just test-scripts` — 261 passed / 0 failed
- `just validate-scripts` — PSScriptAnalyzer: no issues
- `just validate-workflows` — actionlint: clean

No merge-gating behavior changes; the comment stays advisory.