### PR TITLE
Fix New-Item -LiteralPath breaking bench-history CI recipes

### DIFF
--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -116,9 +116,12 @@ gh-write-bench-history-machine-key file:
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
+    Import-Module ./scripts/bench-history/BenchHistoryPath.psm1 -Force
+
     $file = "{{file}}"
-    $parent = Split-Path -Parent $file
-    if ($parent) { New-Item -ItemType Directory -LiteralPath $parent -Force | Out-Null }
+    # Ensure the key file's parent directory exists (a no-op when the path is a bare filename). The
+    # creation lives in the Pester-tested module so this glue actually runs somewhere other than CI.
+    New-BenchHistoryDirectory -Path (Split-Path -Parent $file)
 
     Write-Verbose "Resolving this runner's real hardware machine key; the fingerprint components are logged to stderr under --verbose for debugging a key change." -Verbose
     # The key is the tool's sole stdout line; --verbose components go to stderr, so the pipeline
@@ -178,9 +181,10 @@ gh-analyze-bench-history dir keydir:
     $PSNativeCommandUseErrorActionPreference = $true
 
     Import-Module ./scripts/bench-history/BenchHistoryMachineKey.psm1 -Force
+    Import-Module ./scripts/bench-history/BenchHistoryPath.psm1 -Force
 
     $dir = "{{dir}}"
-    New-Item -ItemType Directory -LiteralPath $dir -Force | Out-Null
+    New-BenchHistoryDirectory -Path $dir
     $reportPath = Join-Path $dir "report.md"
     $jsonPath = Join-Path $dir "report.json"
     $summaryPath = Join-Path $dir "summary.md"
@@ -250,9 +254,10 @@ gh-analyze-pr-bench-history dir base keydir:
     $PSNativeCommandUseErrorActionPreference = $true
 
     Import-Module ./scripts/bench-history/BenchHistoryMachineKey.psm1 -Force
+    Import-Module ./scripts/bench-history/BenchHistoryPath.psm1 -Force
 
     $dir = "{{dir}}"
-    New-Item -ItemType Directory -LiteralPath $dir -Force | Out-Null
+    New-BenchHistoryDirectory -Path $dir
     $reportPath = Join-Path $dir "report.md"
     $jsonPath = Join-Path $dir "report.json"
     $summaryPath = Join-Path $dir "summary.md"

--- a/scripts/bench-history/BenchHistoryPath.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryPath.Tests.ps1
@@ -1,0 +1,68 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for BenchHistoryPath.psm1. Proves the directory preparation the benchmark-history
+# automation recipes depend on - creating a scratch/report directory (and the machine-key file's
+# parent) before writing into it - actually runs, without a workflow run. Because a justfile [script]
+# block is invisible to both PSScriptAnalyzer and Pester, an invalid cmdlet invocation in this glue
+# (New-Item -LiteralPath, which New-Item does not support) once reached CI unvalidated; exercising the
+# extracted seam here executes the exact line that broke, so the same class of mistake fails loudly in
+# `just test-scripts` instead of in a live run. Directories are real temp paths so creation, the
+# idempotent already-exists case, nested-parent creation and the empty-path no-op are asserted, not
+# faked.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'BenchHistoryPath.psm1') -Force
+
+    function Get-ScratchPath {
+        Join-Path ([System.IO.Path]::GetTempPath()) ("bh-path-$([guid]::NewGuid().ToString('n'))")
+    }
+}
+
+Describe 'New-BenchHistoryDirectory' {
+    Context 'creating a directory' {
+        It 'creates a missing directory' {
+            $dir = Get-ScratchPath
+            try {
+                New-BenchHistoryDirectory -Path $dir
+                Test-Path -LiteralPath $dir -PathType Container | Should -BeTrue
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'creates any missing intermediate parents' {
+            $root = Get-ScratchPath
+            $nested = Join-Path $root (Join-Path 'cache' 'objects')
+            try {
+                New-BenchHistoryDirectory -Path $nested
+                Test-Path -LiteralPath $nested -PathType Container | Should -BeTrue
+            } finally {
+                Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'is a no-op when the directory already exists' {
+            $dir = Get-ScratchPath
+            try {
+                New-BenchHistoryDirectory -Path $dir
+                # A pre-existing file inside proves the second call did not recreate/clear the directory.
+                $marker = Join-Path $dir 'marker.txt'
+                Set-Content -LiteralPath $marker -Value 'kept' -Encoding utf8
+                { New-BenchHistoryDirectory -Path $dir } | Should -Not -Throw
+                Test-Path -LiteralPath $marker -PathType Leaf | Should -BeTrue
+            } finally {
+                Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'no directory component' {
+        It 'does nothing for an empty path (a bare filename has no parent)' {
+            { New-BenchHistoryDirectory -Path '' } | Should -Not -Throw
+        }
+
+        It 'does nothing for a null path' {
+            { New-BenchHistoryDirectory -Path $null } | Should -Not -Throw
+        }
+    }
+}

--- a/scripts/bench-history/BenchHistoryPath.psm1
+++ b/scripts/bench-history/BenchHistoryPath.psm1
@@ -1,0 +1,47 @@
+#requires -Version 7
+
+# Output-directory preparation shared by the benchmark-history automation recipes in
+# justfiles/just_automation.just. Both analyze recipes (gh-analyze-bench-history,
+# gh-analyze-pr-bench-history) must ensure their scratch report directory exists before writing the
+# four report artefacts into it, and gh-write-bench-history-machine-key must ensure the parent
+# directory of the key file exists before writing the key.
+#
+# Ensuring a directory exists looks trivial, but the exact cmdlet invocation is a footgun: New-Item's
+# directory-creation parameter is -Path, NOT -LiteralPath (unlike Get-/Set-/Remove-Item, New-Item has
+# no -LiteralPath), and getting it wrong fails the whole step with "A parameter cannot be found that
+# matches parameter name 'LiteralPath'". A justfile [script] block is invisible to both
+# PSScriptAnalyzer and Pester, so exactly that mistake once shipped straight to CI in all three
+# recipes. Keeping the one line here behind a seam the Pester suite (BenchHistoryPath.Tests.ps1)
+# actually executes is what stops it recurring, and the recipes become a thin import + call.
+
+Set-StrictMode -Version Latest
+
+function New-BenchHistoryDirectory {
+    # Ensures $Path exists as a directory, creating any missing parents, and is a no-op when it
+    # already exists - so a recipe can call it unconditionally on a path that may or may not have been
+    # created yet. An empty or null $Path is treated as "nothing to create" rather than an error: that
+    # is what `Split-Path -Parent` yields for a bare filename with no directory component, and
+    # gh-write-bench-history-machine-key relies on it to skip creation in that case.
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string] $Path
+    )
+
+    if ([string]::IsNullOrEmpty($Path)) {
+        Write-Verbose 'No directory to create (the path has no directory component); nothing to do.'
+        return
+    }
+
+    # -Path (New-Item has no -LiteralPath); -Force makes an already-existing directory a no-op instead
+    # of an error and creates any missing intermediate parents.
+    if ($PSCmdlet.ShouldProcess($Path, 'create directory')) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+        Write-Verbose "Ensured directory exists: $Path."
+    }
+}
+
+Export-ModuleMember -Function New-BenchHistoryDirectory


### PR DESCRIPTION
[Copilot speaking]

## What broke

The [Benchmark history](https://github.com/folo-rs/folo/actions/runs/29188125773) workflow failed on every push to `main`. All four `collect` legs failed at **Record runner machine key** and the `analyze` job failed at **Analyze benchmark history**, both with:

```
New-Item: A parameter cannot be found that matches parameter name 'LiteralPath'.
error: recipe `gh-write-bench-history-machine-key` failed with exit code 1
```

## Root cause

Three `[script]` recipes in `justfiles/just_automation.just` (`gh-write-bench-history-machine-key`, `gh-analyze-bench-history`, `gh-analyze-pr-bench-history`) ensured a directory existed with `New-Item -ItemType Directory -LiteralPath ...`. **`New-Item` has no `-LiteralPath` parameter** (only `-Path`) — unlike `Get-`/`Set-`/`Remove-Item`. So the invocation failed on every platform. Introduced in #379; the rest of the repo already uses `-Path`.

## Testing gap

The directory-creation glue lived **inline in justfile `[script]` blocks**, which are invisible to both PSScriptAnalyzer (it only lints `.ps1`/`.psm1`) and Pester. Nothing ever executed those lines until CI did, so the invalid parameter shipped unnoticed. These `gh-*` recipes are CI-only entry points that talk to the real Azure store, so they aren't run locally either.

## Fix + gap filled

- Extracted the directory-ensure step into a new tested module `scripts/bench-history/BenchHistoryPath.psm1` (`New-BenchHistoryDirectory`, using the correct `-Path`), following the same module + `SupportsShouldProcess` pattern the other bench-history automation uses.
- Added `scripts/bench-history/BenchHistoryPath.Tests.ps1`, a Pester suite that **actually creates directories through the function** (missing dir, nested parents, idempotent re-create, empty/null no-op). This executes the exact line that broke, so the same class of mistake now fails loudly in `just test-scripts` / `just validate-scripts` instead of in a live run.
- The three recipes are now thin import + call wrappers.

## Verification

- `just test-scripts` → 281 passed (incl. 5 new).
- `just validate-scripts` → PSScriptAnalyzer clean.
- Confirmed `New-Item -LiteralPath` throws while `-Path` succeeds.