### PR TITLE
Announce effective selection for prune, bless, and unbless

### DIFF
--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -496,7 +496,10 @@ Regardless of `--verbose`, every query run (`analyze`, `list`, `prune`, `examine
 one-line **effective-selection** summary to stderr — the engine, target-triple, and
 machine-key facets (each marked when auto-detected), the resolved base branch, and the
 `--since` cutoff — so the user always sees what was actually searched, not just
-what they typed. Two empty outcomes also explain themselves in the stdout report without
+what they typed. The `bless` / `unbless` mutation commands print the same line, naming the
+facets and the context commit they act at (defaulted to `HEAD` unless `--context` is given;
+`bless` also names its base branch), so a manual acceptance states exactly which partition
+and commit it touched. Two empty outcomes also explain themselves in the stdout report without
 verbose diagnostics: when facet-matching runs were stored but none entered the analysis the
 hint breaks down why, and when the effective (possibly auto-detected) partition holds no
 runs at all the hint names that partition and suggests widening it. A zero-run outcome is

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -218,5 +218,8 @@ The line is most valuable when a query comes back empty. When the effective — 
 auto-detected — partition holds no stored runs at all, the stdout report's hint names that
 partition and suggests widening it (for instance `--target-triple all`), so an
 auto-detected facet that quietly missed is distinguished from a genuinely empty project. The
-enumerating commands (`list`, `prune`, `examine`) resolve their dataset through the same path
-and so emit the same line.
+other selection-driven commands emit the same line through one shared announcement builder:
+`list`, `prune`, and `examine` name the same facets, base branch, and `--since` cutoff, while
+the `bless` / `unbless` mutation commands name the facets and the context commit they act at
+(`bless` also names its base branch), so the wording is identical wherever auto-detection can
+surprise you.

--- a/packages/cbh_analyze/src/announce.rs
+++ b/packages/cbh_analyze/src/announce.rs
@@ -1,0 +1,223 @@
+//! The always-on effective-selection announcement shared by every command that
+//! auto-detects or defaults a selection parameter.
+//!
+//! Each query or mutation command resolves the same kinds of hidden input — the
+//! discriminant partition (target-triple / machine-key auto-detected), the base
+//! branch, the context commit, the `--since` window — and echoes them through one
+//! builder here, so the wording is identical everywhere and there is a single
+//! formatter to maintain. The line is emitted to stderr regardless of `--verbose`
+//! (see [`ReporterExt::announce`](cbh_diag::ReporterExt::announce)), so a plain run
+//! never hides a value it defaulted.
+
+use cbh_detect::DiscriminantSetQuery;
+use jiff::Timestamp;
+
+use super::facets::describe_effective_facets;
+
+/// The resolved base branch a run split history against, for the announcement.
+pub(crate) struct AnnouncedBase<'a> {
+    /// The base ref's display name.
+    pub(crate) name: &'a str,
+    /// Whether the base was auto-detected (no explicit `--base`).
+    pub(crate) auto: bool,
+}
+
+/// The resolved context commit a command acts at, for the announcement.
+pub(crate) struct AnnouncedContext<'a> {
+    /// The short commit ID the context resolved to.
+    pub(crate) short: &'a str,
+    /// Whether the context defaulted to `HEAD` (no explicit `--context`).
+    pub(crate) defaulted_head: bool,
+}
+
+/// The resolved `--since` cutoff and the reason it holds that value.
+pub(crate) struct AnnouncedSince<'a> {
+    /// The resolved lower-bound instant, or `None` for no cutoff.
+    pub(crate) cutoff: Option<Timestamp>,
+    /// Why the cutoff is what it is (e.g. explicit, or a mode default).
+    pub(crate) reason: &'a str,
+}
+
+/// Builds the always-on, one-line effective-selection announcement.
+///
+/// Leads with the discriminant partition (always, naming auto-detected facets) and
+/// appends whichever of the base branch, context commit, and `--since` window the
+/// command resolved — each marked when auto-detected or defaulted — so the caller
+/// passes only the segments that apply to it.
+pub(crate) fn selection_announcement(
+    facets: &DiscriminantSetQuery,
+    base: Option<AnnouncedBase<'_>>,
+    context: Option<AnnouncedContext<'_>>,
+    since: Option<AnnouncedSince<'_>>,
+) -> String {
+    let mut segments = vec![format!("selection: {}", describe_effective_facets(facets))];
+    if let Some(base) = base {
+        segments.push(if base.auto {
+            format!("base={} (auto-detected)", base.name)
+        } else {
+            format!("base={}", base.name)
+        });
+    }
+    if let Some(context) = context {
+        segments.push(if context.defaulted_head {
+            format!("context={} (defaulted to HEAD)", context.short)
+        } else {
+            format!("context={}", context.short)
+        });
+    }
+    if let Some(since) = since {
+        segments.push(format!(
+            "since={} ({})",
+            since
+                .cutoff
+                .map_or_else(|| "none".to_owned(), |cutoff| cutoff.to_string()),
+            since.reason
+        ));
+    }
+    segments.join("; ")
+}
+
+#[cfg(test)]
+mod tests {
+    use cbh_detect::FacetFilter;
+    use nonempty::nonempty;
+
+    use super::*;
+
+    fn auto_facets() -> DiscriminantSetQuery {
+        DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
+            machine_key: FacetFilter::Auto("abcd".to_owned()),
+        }
+    }
+
+    #[test]
+    fn facets_only_line_names_just_the_partition() {
+        let line = selection_announcement(&auto_facets(), None, None, None);
+        assert_eq!(
+            line,
+            "selection: engine=all, target-triple=x86_64-pc-windows-msvc (auto-detected), \
+             machine-key=abcd (auto-detected)"
+        );
+    }
+
+    #[test]
+    fn base_segment_marks_auto_and_explicit() {
+        let auto = selection_announcement(
+            &auto_facets(),
+            Some(AnnouncedBase {
+                name: "main",
+                auto: true,
+            }),
+            None,
+            None,
+        );
+        assert!(auto.contains("; base=main (auto-detected)"), "{auto}");
+
+        let explicit = selection_announcement(
+            &auto_facets(),
+            Some(AnnouncedBase {
+                name: "release",
+                auto: false,
+            }),
+            None,
+            None,
+        );
+        assert!(explicit.contains("; base=release"), "{explicit}");
+        assert!(!explicit.contains("base=release (auto"), "{explicit}");
+    }
+
+    #[test]
+    fn context_segment_marks_defaulted_head_and_explicit() {
+        let defaulted = selection_announcement(
+            &auto_facets(),
+            None,
+            Some(AnnouncedContext {
+                short: "a1b2c3d4",
+                defaulted_head: true,
+            }),
+            None,
+        );
+        assert!(
+            defaulted.contains("; context=a1b2c3d4 (defaulted to HEAD)"),
+            "{defaulted}"
+        );
+
+        let explicit = selection_announcement(
+            &auto_facets(),
+            None,
+            Some(AnnouncedContext {
+                short: "a1b2c3d4",
+                defaulted_head: false,
+            }),
+            None,
+        );
+        assert!(explicit.contains("; context=a1b2c3d4"), "{explicit}");
+        assert!(!explicit.contains("defaulted to HEAD"), "{explicit}");
+    }
+
+    #[test]
+    fn since_segment_renders_cutoff_and_none_with_reason() {
+        let cutoff = Timestamp::from_second(1_700_000_000).unwrap();
+        let with_cutoff = selection_announcement(
+            &auto_facets(),
+            None,
+            None,
+            Some(AnnouncedSince {
+                cutoff: Some(cutoff),
+                reason: "from the --since option",
+            }),
+        );
+        assert!(
+            with_cutoff.contains(&format!("; since={cutoff} (from the --since option)")),
+            "{with_cutoff}"
+        );
+
+        let no_cutoff = selection_announcement(
+            &auto_facets(),
+            None,
+            None,
+            Some(AnnouncedSince {
+                cutoff: None,
+                reason: "no default look-back",
+            }),
+        );
+        assert!(
+            no_cutoff.contains("; since=none (no default look-back)"),
+            "{no_cutoff}"
+        );
+    }
+
+    #[test]
+    fn segments_appear_in_facets_base_context_since_order() {
+        let cutoff = Timestamp::from_second(1_700_000_000).unwrap();
+        let facets = DiscriminantSetQuery {
+            engine: FacetFilter::Explicit(nonempty!["criterion".to_owned()]),
+            target_triple: FacetFilter::All,
+            machine_key: FacetFilter::All,
+        };
+        let line = selection_announcement(
+            &facets,
+            Some(AnnouncedBase {
+                name: "main",
+                auto: false,
+            }),
+            Some(AnnouncedContext {
+                short: "deadbeef",
+                defaulted_head: true,
+            }),
+            Some(AnnouncedSince {
+                cutoff: Some(cutoff),
+                reason: "from the --since option",
+            }),
+        );
+        assert_eq!(
+            line,
+            format!(
+                "selection: engine=criterion, target-triple=all, machine-key=all; base=main; \
+                 context=deadbeef (defaulted to HEAD); since={cutoff} (from the --since option)"
+            )
+        );
+    }
+}

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -31,9 +31,11 @@ use cbh_storage::{Storage, build_storage, finish_with_flush};
 use jiff::Timestamp;
 use tick::Clock;
 
+use super::announce::{AnnouncedBase, AnnouncedContext, selection_announcement};
+use super::history::resolve_base;
 use super::{
-    AutoFacets, Selection, detect_auto_facets, facet_filtered_candidates, resolve_base_ref,
-    resolve_facets, resolve_now,
+    AutoFacets, Selection, detect_auto_facets, facet_filtered_candidates, resolve_facets,
+    resolve_now,
 };
 use crate::AnalyzeError;
 
@@ -176,13 +178,35 @@ where
     // Blessing is base-branch-only: a feature-branch blessing would silently
     // vanish (or duplicate) once the branch is squash-merged, so it is refused
     // outright with no `--force` escape hatch.
-    let base = resolve_base_ref(git, config, options.base.as_deref())
+    let base = resolve_base(git, config, options.base.as_deref())
         .await?
         .ok_or_else(|| AnalyzeError::Bless {
             message: "could not determine the base branch; specify it with --base".to_owned(),
         })?;
+
+    let selection = Selection::from_bless(options);
+    let facets = resolve_facets(&selection, Some(auto))?;
+
+    // The always-on effective-selection announcement: one line, printed regardless
+    // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
+    // branch, and context commit, so a plain run never hides a value it defaulted.
+    // Emitted before the base-branch guard so even that refusal states what was
+    // selected.
+    reporter.announce(&selection_announcement(
+        &facets,
+        Some(AnnouncedBase {
+            name: &base.name,
+            auto: options.base.is_none(),
+        }),
+        Some(AnnouncedContext {
+            short,
+            defaulted_head: options.context.is_none(),
+        }),
+        None,
+    ));
+
     let on_base = git
-        .merge_base(&head, &base)
+        .merge_base(&head, &base.commit)
         .await
         .map_err(AnalyzeError::Io)?
         .as_deref()
@@ -193,7 +217,7 @@ where
                 "the context commit {short} is not on the base branch {}; blessings are only \
                  allowed on the base branch, since a feature-branch blessing would not survive \
                  a squash merge",
-                short_commit_id(&base)
+                short_commit_id(&base.commit)
             ),
         });
     }
@@ -206,8 +230,6 @@ where
     let working_tree_dirty =
         options.context.is_none() && git.is_dirty().await.map_err(AnalyzeError::Io)?;
 
-    let selection = Selection::from_bless(options);
-    let facets = resolve_facets(&selection, Some(auto))?;
     let candidates = facet_filtered_candidates(storage, project_id, &facets, reporter).await?;
     let clean_at_head: Vec<StorageKey> = candidates
         .into_iter()
@@ -281,6 +303,21 @@ where
 
     let selection = Selection::from_unbless(options);
     let facets = resolve_facets(&selection, Some(auto))?;
+
+    // The always-on effective-selection announcement: one line, printed regardless
+    // of `--verbose`, naming the resolved (possibly auto-detected) partition and the
+    // context commit whose blessings are being removed. `unbless` acts purely at a
+    // commit and never resolves a base branch, so no base segment appears.
+    reporter.announce(&selection_announcement(
+        &facets,
+        None,
+        Some(AnnouncedContext {
+            short,
+            defaulted_head: options.context.is_none(),
+        }),
+        None,
+    ));
+
     let candidates = facet_filtered_candidates(storage, project_id, &facets, reporter).await?;
     let blessings_at_head: Vec<String> = candidates
         .into_iter()
@@ -697,5 +734,81 @@ mod tests {
             }
             other => panic!("expected a bless error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn bless_announces_the_effective_selection() {
+        let storage = MemoryStorage::new();
+        block_on(storage.put(&clean_key("c2"), clean_run_json("c2", 1000).as_bytes())).unwrap();
+        let reporter = RecordingReporter::new();
+        block_on(bless_with(
+            &master_git(),
+            &storage,
+            "folo",
+            &config(),
+            &bless_options(&["all_the_time/read_cell"]),
+            &auto(),
+            ts(1_700_000_000),
+            "0.0.1",
+            &reporter,
+        ))
+        .unwrap();
+        // The auto-detected partition, auto-detected base branch, and the context
+        // commit (defaulted to HEAD) are all named on the always-on line.
+        assert!(
+            reporter.announced("target-triple=x86_64-unknown-linux-gnu (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("machine-key=synthetic (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("base=master (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("context=c2 (defaulted to HEAD)"),
+            "{:?}",
+            reporter.announcements()
+        );
+    }
+
+    #[test]
+    fn unbless_announces_the_effective_selection_without_a_base() {
+        let storage = MemoryStorage::new();
+        block_on(storage.put(&clean_key("c2"), clean_run_json("c2", 1000).as_bytes())).unwrap();
+        let git = master_git();
+        drive_bless(&storage, &git, &bless_options(&["all_the_time/read_cell"])).unwrap();
+        let reporter = RecordingReporter::new();
+        block_on(unbless_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &UnblessOptions::default(),
+            &auto(),
+            &reporter,
+        ))
+        .unwrap();
+        assert!(
+            reporter.announced("machine-key=synthetic (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("context=c2 (defaulted to HEAD)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        // `unbless` resolves no base branch, so the line carries no base segment.
+        assert!(
+            !reporter.announced("base="),
+            "{:?}",
+            reporter.announcements()
+        );
     }
 }

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -14,6 +14,7 @@ use cbh_model::{BenchmarkIdPrefix, BlessingRecord, DiscriminantSet, StorageKey};
 use cbh_storage::Storage;
 use jiff::Timestamp;
 
+use super::announce::{AnnouncedBase, AnnouncedSince, selection_announcement};
 use super::facets::{
     AutoFacets, describe_effective_facets, facets_are_unconstrained, resolve_facets,
 };
@@ -436,22 +437,18 @@ fn effective_selection_summary(
     since_explicit: bool,
     mode: AnalysisMode,
 ) -> String {
-    let base = if base_auto {
-        format!("base={base_name} (auto-detected)")
-    } else {
-        format!("base={base_name}")
-    };
-    let since = format!(
-        "since={} ({})",
-        since.map_or_else(|| "none".to_owned(), |since| since.to_string()),
-        since_cutoff_reason(since_explicit, mode)
-    );
-    [
-        format!("selection: {}", describe_effective_facets(facets)),
-        base,
-        since,
-    ]
-    .join("; ")
+    selection_announcement(
+        facets,
+        Some(AnnouncedBase {
+            name: base_name,
+            auto: base_auto,
+        }),
+        None,
+        Some(AnnouncedSince {
+            cutoff: since,
+            reason: since_cutoff_reason(since_explicit, mode),
+        }),
+    )
 }
 
 /// How many facet-matching candidates were excluded, by reason.

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -325,15 +325,3 @@ pub(crate) async fn resolve_base<G: GitHistory>(
     }
     Ok(None)
 }
-
-/// Resolves just the base ref's commit ID (discarding its display name), for
-/// callers such as `bless` that compare against the commit but never name it.
-pub(crate) async fn resolve_base_ref<G: GitHistory>(
-    git: &G,
-    config: &Config,
-    base: Option<&str>,
-) -> Result<Option<String>, AnalyzeError> {
-    Ok(resolve_base(git, config, base)
-        .await?
-        .map(|resolved| resolved.commit))
-}

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -33,6 +33,7 @@
 //!
 //! [`cargo-bench-history`]: https://github.com/folo-rs/folo
 
+mod announce;
 mod bless;
 mod dataset;
 mod error;
@@ -55,8 +56,7 @@ pub use error::AnalyzeError;
 pub use examine::execute as examine;
 pub(crate) use facets::{AutoFacets, resolve_facets};
 pub(crate) use history::{
-    DirtyTipPolicy, ResolvedHistory, dirty_base_exception_warning, resolve_base_ref,
-    resolve_history,
+    DirtyTipPolicy, ResolvedHistory, dirty_base_exception_warning, resolve_history,
 };
 pub use list::execute as list;
 pub(crate) use load::{RunIndex, facet_filtered_candidates};

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -34,6 +34,7 @@ use jiff::Timestamp;
 use serde::Serialize;
 use tick::Clock;
 
+use super::announce::{AnnouncedBase, AnnouncedSince, selection_announcement};
 use super::{
     AutoFacets, DirtyTipPolicy, ReportFormat, ResolvedHistory, Selection, before_since_cutoff,
     detect_auto_facets, facet_filtered_candidates, parse_since, resolve_facets, resolve_history,
@@ -77,6 +78,18 @@ impl Scope {
     /// Whether this scope deletes dirty runs.
     fn touches_dirty(self) -> bool {
         matches!(self, Self::All | Self::Dirty)
+    }
+}
+
+/// Explains `prune`'s `--since` cutoff for the effective-selection announcement.
+///
+/// `prune` has no history-mode default look-back — it considers the whole selected
+/// history — so the cutoff is either the explicit `--since` value or absent.
+fn prune_since_reason(explicit: bool) -> &'static str {
+    if explicit {
+        "from the --since option"
+    } else {
+        "no default look-back"
     }
 }
 
@@ -184,6 +197,24 @@ where
         tip_is_merge_base,
         ..
     } = resolve_history(git, config, &selection, DirtyTipPolicy::Always, reporter).await?;
+
+    // The always-on effective-selection announcement: one line, printed regardless
+    // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
+    // branch, and `--since` cutoff a plain run would otherwise resolve silently.
+    // Emitted before the `--prune-base` guard so even that refusal states what was
+    // selected.
+    reporter.announce(&selection_announcement(
+        &facets,
+        Some(AnnouncedBase {
+            name: &base_name,
+            auto: options.base.is_none(),
+        }),
+        None,
+        Some(AnnouncedSince {
+            cutoff: since,
+            reason: prune_since_reason(options.since.is_some()),
+        }),
+    ));
 
     // The `--prune-base` guard: when the context resolves onto the base branch
     // itself (`context == base`), the whole selection is base-branch history.
@@ -909,6 +940,73 @@ mod tests {
         rendered
             .markdown
             .expect("the Markdown report was rendered for the requested path")
+    }
+
+    #[test]
+    fn prune_announces_the_effective_selection() {
+        let storage = MemoryStorage::new();
+        store(&storage, &dirty_key("f2", 300), &set("f2"));
+        let reporter = RecordingReporter::new();
+        block_on(prune_with(
+            &feature_git(),
+            &storage,
+            "folo",
+            &config(),
+            &dirty_options(),
+            &auto(),
+            now(),
+            &reporter,
+        ))
+        .unwrap();
+        // The auto-detected partition, auto-detected base branch, and the (absent,
+        // no-default-look-back) `--since` cutoff are all named on the always-on line.
+        assert!(
+            reporter.announced("target-triple=x86_64-unknown-linux-gnu (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("machine-key=synthetic (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("base=master (auto-detected)"),
+            "{:?}",
+            reporter.announcements()
+        );
+        assert!(
+            reporter.announced("since=none (no default look-back)"),
+            "{:?}",
+            reporter.announcements()
+        );
+    }
+
+    #[test]
+    fn prune_announces_an_explicit_since_reason() {
+        let storage = MemoryStorage::new();
+        store(&storage, &dirty_key("f2", 300), &set("f2"));
+        let options = PruneOptions {
+            since: Some("2024-01-01".to_owned()),
+            ..dirty_options()
+        };
+        let reporter = RecordingReporter::new();
+        block_on(prune_with(
+            &feature_git(),
+            &storage,
+            "folo",
+            &config(),
+            &options,
+            &auto(),
+            now(),
+            &reporter,
+        ))
+        .unwrap();
+        assert!(
+            reporter.announced("since=2024-01-01T00:00:00Z (from the --since option)"),
+            "{:?}",
+            reporter.announcements()
+        );
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## Problem

The always-on `[bench-history] selection: …` line — added in #371 to echo the invisible auto-detected/defaulted selection parameters (chiefly `--target-triple` and `--machine-key`, plus the resolved base branch and `--since`) — was only emitted from `select_dataset` in `cbh_analyze`, which serves `analyze` / `list` / `examine`.

`prune`, `bless`, and `unbless` resolve their selection through the lower-level primitives (`resolve_facets` + `facet_filtered_candidates`, and — for prune — `resolve_history`) and never called `announce`, so they silently ran against auto-detected values. `DESIGN.md` even claimed `prune` was covered; it was not, and no test asserted it.

Repro (nothing printed but the plan header):

```
cargo run -p cargo-bench-history --release -- prune --context <ctx> --all --dry-run --base <base>
Prune plan for project folo (target <ctx>)
No run matches the selection.
```

## Change

- New `cbh_analyze::announce` module with a single shared `selection_announcement` builder that assembles `selection: <facets>[; base=…][; context=…][; since=…]` from optional segments, so the wording lives in one formatter.
- `effective_selection_summary` (analyze/list/examine) now delegates to it — **output is byte-identical**, verified by the existing pinned tests.
- `prune`, `bless`, and `unbless` now announce their resolved selection **before** their guards (prune's `--prune-base` check, bless's on-base check), so even a refusal states what was selected.
  - Query family (analyze/list/examine/**prune**): facets + base + `--since`.
  - Mutation family (**bless**/**unbless**): facets + resolved context commit (defaulted to `HEAD`); **bless** also names its base. **unbless** resolves no base, so it carries no base segment.
- Retired `resolve_base_ref` (bless was its only caller) in favour of `resolve_base`, which also yields the base's display name for the announcement.

## Docs

- `DESIGN.md` and `docs/analyze.md` updated to describe the shared builder and the mutation-command announcements (and to stop implying prune was already covered by the `select_dataset` path).

## Tests / validation

- 5 unit tests for the builder's per-segment shapes and ordering.
- Per-command announcement assertions for prune (2), bless (1), unbless (1, including the no-base guarantee).
- `just package=cbh_analyze validate-local` passes, including mutation testing (**0 missed**: 244 caught, 42 unviable). `cargo-bench-history` integration suite green.