### PR TITLE
Retitle PR benchmark comment to "Performance impact"

### DIFF
--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -424,7 +424,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
-          $header = "### Benchmark history (vs ``main``)"
+          $header = "### Performance impact (vs ``main``)"
 
           # Record which commit these numbers describe: a human-visible line and, embedded once in the
           # body via the shared prefix, a hidden full-SHA marker the mark-stale job parses on the next

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -398,7 +398,7 @@ Describe 'Set-RollingCommentStaleness (mocked gh api)' {
                 if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42,"html_url":"https://github.com/o/r/pull/5#issuecomment-42"}' }
                 foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":3}' } }
                 $global:LASTEXITCODE = 0
-                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\n### Benchmark history\nold findings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->\n\n### Performance impact\nold findings","html_url":"https://github.com/o/r/pull/5#issuecomment-42"}]'
             }
         }
 
@@ -556,7 +556,7 @@ Describe 'Set-RollingCommentStaleness (mocked gh api)' {
             Mock gh -ModuleName BenchHistoryComment {
                 if ($args -contains 'PATCH') { $global:LASTEXITCODE = 0; return '{"id":42}' }
                 $global:LASTEXITCODE = 0
-                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-in-progress -->\n\n### Benchmark history (vs `main`)\n\nbenchmarking in progress","html_url":"u"}]'
+                return '[{"id":42,"body":"<!-- folo-bench-history-pr -->\n<!-- folo-bench-history-in-progress -->\n\n### Performance impact (vs `main`)\n\nbenchmarking in progress","html_url":"u"}]'
             }
         }
 
@@ -632,13 +632,13 @@ Describe 'Add-StalenessBanner (unexported string transform)' {
                     '> [!WARNING]'
                     '> a banner that was never closed'
                     ''
-                    '### Benchmark history'
+                    '### Performance impact'
                     'precious findings that must not vanish'
                 ) -join "`n"
 
                 $result = Add-StalenessBanner -Body $body -Warning 'fresh warning' -Marker $marker
 
-                $result | Should -BeLike '*### Benchmark history*'
+                $result | Should -BeLike '*### Performance impact*'
                 $result | Should -BeLike '*precious findings that must not vanish*'
                 # The fresh banner is still inserted after the marker.
                 $result | Should -BeLike '*fresh warning*'
@@ -850,7 +850,7 @@ Describe 'Format-InProgressBody (unexported string transform)' {
             $lines = $body -split "`n"
             $lines[0] | Should -Be '<!-- folo-bench-history-pr -->'
             $lines[1] | Should -Be $script:InProgressMarker
-            $body.Contains('### Benchmark history (vs `main`)') | Should -BeTrue
+            $body.Contains('### Performance impact (vs `main`)') | Should -BeTrue
             $body | Should -BeLike '*Benchmarking in progress*'
         }
     }

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -561,7 +561,7 @@ function Format-InProgressBody {
         $Marker
         $script:InProgressMarker
         ''
-        "### Benchmark history (vs ``main``)"
+        "### Performance impact (vs ``main``)"
         ''
         $scope
         ''


### PR DESCRIPTION
[Copilot speaking]

The rolling PR benchmark comment posted by the "PR Benchmark history" workflow was titled "Benchmark history", but that comment does not present a history: it reports the analysis of this branch's benchmark levels *against* history. "Performance impact" describes what a reader actually sees, so this renames the comment header to `### Performance impact (vs \`main\`)`.

### Approach

- Updated the header string in two places that must stay in lockstep: the analyze compose step in `pr-bench-history.yml` and the in-progress placeholder in `BenchHistoryComment.psm1` (`Format-InProgressBody`), which deliberately mirrors the analyze header.
- Updated the Pester tests that assert on or fixture the header text.

### Scope notes

This is intentionally limited to the PR comment title. The feature/workflow names, the design-doc section heading, and the full-report artifact title (`# Benchmark history analysis:`) are left as-is, since those legitimately refer to the benchmark-history feature and the "analysis" wording there is already accurate.

All 53 `BenchHistoryComment.Tests.ps1` cases pass.