### PR TITLE
Remove finding confidence from cargo-bench-history outputs

### DIFF
--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -746,6 +746,13 @@ report with false positives. Because no engine is exempt from noise, **every** c
 p-value enters a single **Benjamini–Hochberg** false-discovery-rate procedure — there is no
 bypass — and only survivors are reported.
 
+Because a surfaced finding has, by construction, already cleared these gates, the detector
+**confidence** (`1 - p_value`) is *not* a report field: rendering it would restate a binary
+that the report already conveys by the finding's mere presence, and its exact value is a
+statistical intermediate meaningless to a reader. It is surfaced only through the
+`--verbose` diagnostic channel — one note per emitted finding — so the value behind each
+emit decision stays reconstructible from the logs without cluttering the report.
+
 All of this math lives in a pure, Miri-safe statistics crate (`cbh_stats`), unit-tested
 with named, value-asserting cases on hand-computable inputs rather than threshold-mutation
 guards, so the whole detector is verifiable without real-time delays.
@@ -832,7 +839,7 @@ of history the findings describe — annotated `+ uncommitted changes` when the 
 was dirty, so a reader (or the auto-filed regression issue) can tie the report to an exact
 commit. Text goes to stdout as one paragraph per finding — the benchmark id on its own
 line as a chapter title, then a direction-coloured headline pairing the relative-change
-percent with the metric and its confidence, a dimmed detail line, and (in history mode
+percent with the metric, a dimmed detail line, and (in history mode
 only) a small line chart of the series — with colour enabled only
 when stdout is a terminal and not disabled by environment. The text and Markdown reports
 group findings under a per-set header, which also states the **facet-filter flags** that

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -168,6 +168,8 @@ async fn analyze_markdown_output_renders_blocks() {
     // the set `##`), then a bold percentage headline naming the metric.
     assert!(report.contains("\n### `"), "{report}");
     assert!(report.contains("**+"), "{report}");
+    // The headline names the metric in backticks, not just the direction arrow.
+    assert!(report.contains("`instruction_count`"), "{report}");
     assert!(report.contains("via change point"), "{report}");
 }
 
@@ -229,6 +231,8 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
     // heading level up.
     assert!(summary.contains("\n## `"), "{summary}");
     assert!(summary.contains("**+"), "{summary}");
+    // The headline names the metric in backticks, not just the direction arrow.
+    assert!(summary.contains("`instruction_count`"), "{summary}");
     // A single seeded regression is well within the top-20 cap, so no truncation note
     // is added.
     assert!(

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -165,9 +165,9 @@ async fn analyze_markdown_output_renders_blocks() {
     // Findings render as heading + bold-headline blocks; there is no table.
     assert!(!report.contains("| Change | Direction |"), "{report}");
     // Each finding leads with its benchmark id as a `###` chapter title (nested under
-    // the set `##`), then a bold percentage headline carrying the confidence.
+    // the set `##`), then a bold percentage headline naming the metric.
     assert!(report.contains("\n### `"), "{report}");
-    assert!(report.contains("% confidence)"), "{report}");
+    assert!(report.contains("**+"), "{report}");
     assert!(report.contains("via change point"), "{report}");
 }
 
@@ -225,10 +225,10 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
         "{summary}"
     );
     // Each finding leads with its benchmark id as a `##` chapter title, then a bold
-    // percentage headline carrying the confidence — the same block the full report
-    // uses, one heading level up.
+    // percentage headline naming the metric — the same block the full report uses, one
+    // heading level up.
     assert!(summary.contains("\n## `"), "{summary}");
-    assert!(summary.contains("% confidence)"), "{summary}");
+    assert!(summary.contains("**+"), "{summary}");
     // A single seeded regression is well within the top-20 cap, so no truncation note
     // is added.
     assert!(
@@ -291,15 +291,16 @@ async fn analyze_markdown_summary_caps_findings_and_names_the_total() {
         summary.contains("Showing the top 20 of 25 findings by magnitude."),
         "{summary}"
     );
-    // Exactly the cap of finding headlines survives in the summary. Each finding
-    // headline carries the confidence, which appears nowhere else, so it counts blocks.
-    let summary_blocks = summary.matches("% confidence)").count();
+    // Exactly the cap of finding headlines survives in the summary. Each finding leads
+    // with its own `##` id heading, so counting the headings counts the blocks.
+    let summary_blocks = summary.matches("\n## `").count();
     assert_eq!(
         summary_blocks, 20,
         "summary should keep only the cap: {summary}"
     );
-    // The full report from the same run still lists every finding.
-    let full_blocks = full.matches("% confidence)").count();
+    // The full report from the same run still lists every finding, each under its own
+    // `###` id heading (nested one level below the per-set `##` heading).
+    let full_blocks = full.matches("\n### `").count();
     assert_eq!(
         full_blocks, 25,
         "full report should keep every finding: {full}"

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -257,6 +257,32 @@ where
         "change detection (find_changes: per-series detectors + FDR filter)",
         detect_started.elapsed(),
     );
+    // The detector confidence (`1 - p_value`) is a statistical intermediate, not a
+    // report field: a reported finding has already cleared the significance gate and
+    // the false-discovery filter, so the raw percentage is meaningless to a reader.
+    // Surface it here, in verbose mode only, so the value behind each emit decision
+    // stays reconstructible from the logs without cluttering the report.
+    reporter.if_enabled(|notes| {
+        for finding in &findings {
+            let direction = if finding.is_regression() {
+                "regression"
+            } else {
+                "improvement"
+            };
+            notes.note(&format!(
+                "reporting {direction} in {metric} on {id} \
+                 [{engine}/{triple}/{machine}]: detector confidence {confidence:.0}% \
+                 (1 - p_value of the significance test) cleared the significance gate \
+                 and the Benjamini–Hochberg false-discovery filter, so the change is emitted",
+                metric = finding.kind.as_str(),
+                id = finding.id.qualified(),
+                engine = finding.set.engine,
+                triple = finding.set.target_triple,
+                machine = finding.set.machine_key,
+                confidence = finding.confidence * 100.0,
+            ));
+        }
+    });
     let regressions = findings
         .iter()
         .filter(|finding| finding.is_regression())
@@ -1832,6 +1858,37 @@ mod tests {
         ))
         .expect("a flagged regression must not fail the analysis");
         assert_eq!(regressions, 1, "the seeded step is a flagged regression");
+    }
+
+    #[test]
+    fn verbose_notes_report_the_confidence_behind_each_emitted_finding() {
+        // The confidence percentage is no longer a report field, but it must remain
+        // reconstructible in verbose mode: for every emitted finding a note states the
+        // value and that it cleared the gates that decide emission.
+        let storage = MemoryStorage::new();
+        seed_linear_step(&storage);
+        let git = linear6_git();
+
+        let (report, regressions, reporter) = analyze_json(&git, &storage, "folo", &options());
+        assert_eq!(regressions, 1, "the seeded step is a flagged regression");
+
+        assert!(
+            reporter.contains("detector confidence")
+                && reporter.contains("cleared the significance gate"),
+            "a verbose note should surface the finding's confidence: {:?}",
+            reporter.notes()
+        );
+        assert!(
+            reporter.contains("nm/nm::observe/pull"),
+            "the confidence note should name the benchmark it belongs to: {:?}",
+            reporter.notes()
+        );
+        // The rendered report itself never carries the confidence — it lives in the
+        // verbose channel alone.
+        assert!(
+            !report.contains("confidence"),
+            "the JSON report must not carry the confidence: {report}"
+        );
     }
 
     #[test]

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -279,7 +279,7 @@ where
                 engine = finding.set.engine,
                 triple = finding.set.target_triple,
                 machine = finding.set.machine_key,
-                confidence = finding.confidence * 100.0,
+                confidence = (finding.confidence * 100.0).clamp(0.0, 100.0),
             ));
         }
     });
@@ -1886,7 +1886,7 @@ mod tests {
         // The rendered report itself never carries the confidence — it lives in the
         // verbose channel alone.
         assert!(
-            !report.contains("confidence"),
+            !report.contains("\"confidence\":"),
             "the JSON report must not carry the confidence: {report}"
         );
     }

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -255,6 +255,12 @@ pub struct Finding {
     pub relative_delta: f64,
     /// How confident the detector is (`1 - p_value` of the significance test that
     /// confirmed the move).
+    ///
+    /// A statistical intermediate carried out of detection for verbose diagnostics
+    /// only — the significance gate and false-discovery filter already decide
+    /// whether a finding surfaces, so the raw value is *not* rendered in any report
+    /// (text, Markdown, or JSON); it is surfaced only through the verbose note the
+    /// analyze pipeline emits for each reported finding.
     pub confidence: f64,
     /// Commit the change is attributed to, if known.
     pub commit: Option<String>,

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -417,10 +417,7 @@ fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled:
     } else {
         format!(" {}", "(recovered)".dimmed())
     };
-    lines.push(format!(
-        "  {headline} {}{status}",
-        finding.kind.as_str(),
-    ));
+    lines.push(format!("  {headline} {}{status}", finding.kind.as_str()));
 
     lines.push(format!("    {}", detail_text(finding)).dimmed().to_string());
 
@@ -1367,10 +1364,7 @@ mod tests {
         // The benchmark id leads on its own chapter-title line; the change headline
         // that follows carries the metric, no longer the id.
         assert!(report.contains("nm/nm::observe/pull"), "{report}");
-        assert!(
-            report.contains("+30.00% instruction_count"),
-            "{report}"
-        );
+        assert!(report.contains("+30.00% instruction_count"), "{report}");
         // The detail line carries the move; the meaningless confidence percentage is
         // no longer rendered anywhere.
         assert!(
@@ -2303,10 +2297,7 @@ mod tests {
         );
 
         let text = render(&input, ReportFormat::Text, false);
-        assert!(
-            text.contains("+30.00% instruction_count"),
-            "{text}"
-        );
+        assert!(text.contains("+30.00% instruction_count"), "{text}");
         assert!(!text.contains("`instruction_count`"), "{text}");
     }
 }

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -1365,13 +1365,13 @@ mod tests {
         // that follows carries the metric, no longer the id.
         assert!(report.contains("nm/nm::observe/pull"), "{report}");
         assert!(report.contains("+30.00% instruction_count"), "{report}");
-        // The detail line carries the move; the meaningless confidence percentage is
-        // no longer rendered anywhere.
+        // The detail line carries the move; the legacy `(NN% confidence)` suffix is
+        // no longer rendered on the headline.
         assert!(
             report.contains("regression via change point · 100 → 130"),
             "{report}"
         );
-        assert!(!report.contains("confidence"), "{report}");
+        assert!(!report.contains(" confidence)"), "{report}");
     }
 
     #[test]
@@ -1537,13 +1537,13 @@ mod tests {
         assert!(!report.contains("—"), "{report}");
         // An active finding carries no recovered suffix.
         assert!(!report.contains("_(recovered)_"), "{report}");
-        // The detail line carries the move; the meaningless confidence percentage is
-        // no longer rendered anywhere.
+        // The detail line carries the move; the legacy `(NN% confidence)` suffix is
+        // no longer rendered on the headline.
         assert!(
             report.contains("regression via change point · 100 → 130"),
             "{report}"
         );
-        assert!(!report.contains("confidence"), "{report}");
+        assert!(!report.contains(" confidence)"), "{report}");
     }
 
     #[test]

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -169,9 +169,6 @@ struct JsonFinding<'a> {
     latest: f64,
     /// The change relative to the baseline (`(latest - baseline) / baseline`).
     relative_delta: f64,
-    /// The detector's confidence (`1 - p_value`), approaching `1.0` as the change
-    /// becomes statistically unambiguous.
-    confidence: f64,
     /// Commit the change is attributed to, if known.
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<&'a str>,
@@ -201,7 +198,6 @@ impl<'a> JsonFinding<'a> {
             baseline: finding.baseline,
             latest: finding.latest,
             relative_delta: finding.relative_delta,
-            confidence: finding.confidence,
             commit: finding.commit.as_deref(),
             active: finding.active,
             flipped_at: finding.flipped_at.as_deref(),
@@ -401,9 +397,9 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
 }
 
 /// Appends one finding as a paragraph: the benchmark id on its own line as a
-/// chapter title, then a direction-colored `percentage metric (confidence)`
-/// headline, a dimmed detail line, an optional blessing/recovery note, and (in
-/// history mode) a chart of the metric over commits.
+/// chapter title, then a direction-colored `percentage metric` headline, a dimmed
+/// detail line, an optional blessing/recovery note, and (in history mode) a chart
+/// of the metric over commits.
 fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled: bool) {
     lines.push(String::new());
 
@@ -422,9 +418,8 @@ fn push_finding_block(lines: &mut Vec<String>, finding: &Finding, chart_enabled:
         format!(" {}", "(recovered)".dimmed())
     };
     lines.push(format!(
-        "  {headline} {} ({} confidence){status}",
+        "  {headline} {}{status}",
         finding.kind.as_str(),
-        format_confidence(finding.confidence),
     ));
 
     lines.push(format!("    {}", detail_text(finding)).dimmed().to_string());
@@ -478,8 +473,8 @@ fn runs_with_span(runs: usize, span: Option<(&str, &str)>) -> String {
 
 /// The plain-text detail body shared by the text and Markdown reports: the
 /// direction, detector, the `baseline → latest` move, the attributed commit, and
-/// (when located) the flip/recovery commit. Confidence rides on the headline line
-/// instead. Carries no styling and no leading indent; each format applies its own.
+/// (when located) the flip/recovery commit. Carries no styling and no leading
+/// indent; each format applies its own.
 fn detail_text(finding: &Finding) -> String {
     let mut detail = format!(
         "{} via {} · {} → {} · @ {}",
@@ -823,9 +818,9 @@ fn push_set_filter_footer(lines: &mut Vec<String>, set: &DiscriminantSet) {
 }
 
 /// Appends one finding as a Markdown block mirroring the text report: the benchmark
-/// id as a `heading` (a chapter title), then a bold `percentage metric (confidence)`
-/// line, the shared detail line, an optional blessing note, and (in history mode) the
-/// metric chart in a fenced `text` block so it survives Markdown rendering. `heading`
+/// id as a `heading` (a chapter title), then a bold `percentage metric` line, the
+/// shared detail line, an optional blessing note, and (in history mode) the metric
+/// chart in a fenced `text` block so it survives Markdown rendering. `heading`
 /// carries the ATX prefix (`##`/`###`) so the block nests correctly — top-level in the
 /// summary, one level under the set heading in the full report.
 fn push_finding_markdown(
@@ -846,10 +841,9 @@ fn push_finding_markdown(
         " _(recovered)_".to_owned()
     };
     lines.push(format!(
-        "**{}** `{}` ({} confidence){status}",
+        "**{}** `{}`{status}",
         format_percent(finding.relative_delta),
         finding.kind.as_str(),
-        format_confidence(finding.confidence),
     ));
 
     lines.push(String::new());
@@ -929,11 +923,6 @@ fn method_label(method: FindingMethod) -> &'static str {
         FindingMethod::ChangePoint => "change point",
         FindingMethod::Drift => "drift",
     }
-}
-
-/// Formats a detector's confidence as a whole-number percentage.
-fn format_confidence(confidence: f64) -> String {
-    format!("{:.0}%", (confidence * 100.0).clamp(0.0, 100.0))
 }
 
 /// Renders a benchmark identity as `package/group/case/value`, omitting absent
@@ -1376,18 +1365,19 @@ mod tests {
         assert!(report.contains("+30.00%"), "{report}");
         assert!(!report.contains("[major]"), "{report}");
         // The benchmark id leads on its own chapter-title line; the change headline
-        // that follows carries the metric and confidence, no longer the id.
+        // that follows carries the metric, no longer the id.
         assert!(report.contains("nm/nm::observe/pull"), "{report}");
         assert!(
-            report.contains("+30.00% instruction_count (100% confidence)"),
+            report.contains("+30.00% instruction_count"),
             "{report}"
         );
-        // Confidence rides on the headline now, so the detail line drops it.
+        // The detail line carries the move; the meaningless confidence percentage is
+        // no longer rendered anywhere.
         assert!(
             report.contains("regression via change point · 100 → 130"),
             "{report}"
         );
-        assert!(!report.contains("100% confidence · 100"), "{report}");
+        assert!(!report.contains("confidence"), "{report}");
     }
 
     #[test]
@@ -1546,19 +1536,20 @@ mod tests {
         // (`##`), so it reads as a chapter title; the change headline follows.
         assert!(report.contains("### `nm/nm::observe/pull`"), "{report}");
         assert!(
-            report.contains("**+30.00%** `instruction_count` (100% confidence)"),
+            report.contains("**+30.00%** `instruction_count`"),
             "{report}"
         );
         // The old inline em-dash headline is gone.
         assert!(!report.contains("—"), "{report}");
         // An active finding carries no recovered suffix.
         assert!(!report.contains("_(recovered)_"), "{report}");
-        // Confidence rides on the headline now, so the detail line drops it.
+        // The detail line carries the move; the meaningless confidence percentage is
+        // no longer rendered anywhere.
         assert!(
             report.contains("regression via change point · 100 → 130"),
             "{report}"
         );
-        assert!(!report.contains("100% confidence · 100"), "{report}");
+        assert!(!report.contains("confidence"), "{report}");
     }
 
     #[test]
@@ -1574,7 +1565,7 @@ mod tests {
         // The headline suffix flags a recovered finding; the shared detail line names
         // the recovery commit.
         assert!(
-            report.contains("`instruction_count` (100% confidence) _(recovered)_"),
+            report.contains("`instruction_count` _(recovered)_"),
             "{report}"
         );
         assert!(report.contains("recovers at c4"), "{report}");
@@ -1753,6 +1744,9 @@ mod tests {
         // The bulky per-commit series is no longer carried: JSON mirrors the text
         // data, not the chart it draws from.
         assert!(finding.get("series").is_none(), "{report}");
+        // The detector confidence is an internal statistical intermediate, not part
+        // of the machine-readable report.
+        assert!(finding.get("confidence").is_none(), "{report}");
         // The per-set breakdown carries the partition triple and tallies only — no
         // duplicated findings array.
         let set_json = &parsed["sets"][0];
@@ -2304,13 +2298,13 @@ mod tests {
         // code (backticks) rather than bare prose. The text report carries no such markup.
         let markdown = render(&input, ReportFormat::Markdown, false);
         assert!(
-            markdown.contains("`instruction_count` (100% confidence)"),
+            markdown.contains("**+30.00%** `instruction_count`"),
             "{markdown}"
         );
 
         let text = render(&input, ReportFormat::Text, false);
         assert!(
-            text.contains("instruction_count (100% confidence)"),
+            text.contains("+30.00% instruction_count"),
             "{text}"
         );
         assert!(!text.contains("`instruction_count`"), "{text}");


### PR DESCRIPTION
[Copilot speaking]

## Why

The detector's finding-level confidence (`1 - p_value`) was rendered in every cargo-bench-history report as e.g. `(100% confidence)`. This is visual noise: if we are not confident we do not emit a finding at all, so a finding's mere presence already conveys confidence. The exact numeric value is just one of several mathematical intermediates behind the emit decision, and it is meaningless to nearly all users.

## What changed

- **Removed confidence from all three output formats** (`cbh_render/src/report.rs`):
  - Text headline: `+30.00% instruction_count (100% confidence)` -> `+30.00% instruction_count`
  - Markdown headline: `**+30.00%** \`instruction_count\` (100% confidence)` -> `**+30.00%** \`instruction_count\``
  - JSON: dropped the `confidence` field from `JsonFinding`
  - Deleted the now-unused `format_confidence` helper and updated doc comments.
- **Kept it internally** (`cbh_detect/src/detect/findings.rs`): `Finding.confidence` is still computed and carried out of pure detection; its doc now states it is a verbose-only diagnostic, not a report field.
- **Verbose logging** (`cbh_analyze/src/pipeline.rs`): for each emitted finding, a `--verbose` note now records its confidence and that it cleared the significance gate and the Benjamini-Hochberg FDR filter, so the value behind each emit decision stays reconstructible from the logs.
- **Docs**: updated `DESIGN.md` sections 8.3 and 8.7 to describe confidence as a verbose-only intermediate rather than a rendered field.

## Note for reviewers

The verbose note covers the *emit* side of "when it plays a role in deciding to emit (or not to emit) a finding". The dropped-candidate ("not to emit") side happens inside the pure, spawner-parallel, Miri-safe detection layer, where the package `AGENTS.md` forbids side effects / a threaded reporter, so confidence is surfaced at the pipeline boundary instead. If we also want dropped-candidate confidences logged, that requires reworking that architectural constraint and can be a follow-up.

Build and clippy are clean on the three crates; render/detect/analyze unit tests (including a new pipeline test) and all 47 `analyze` integration tests pass.