### PR TITLE
Add RelativeSpeed and processor model to many_cpus; fold into cargo-bench-history machine key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,6 @@ dependencies = [
  "many_cpus",
  "mutants",
  "sha2",
- "tokio",
 ]
 
 [[package]]

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -195,12 +195,12 @@ The goal is a fingerprint equal for pool-equivalent machines and different for g
 different hardware; it is **never** keyed on hostname or serial, since cloud pool nodes
 differ in name but are equivalent. It hashes the stable, pool-equivalent attributes
 available without elevated privileges across platforms — all from the in-workspace
-`many_cpus`: the processor and memory-region counts, a best-effort CPU brand string, and a
-histogram of the per-processor relative speeds (as `(speed, count)` pairs). The speed
-histogram distinguishes machines that agree on their counts and brand but differ in their
-mix of processor speeds (for example a hybrid performance/efficiency core layout versus a
-uniform one). Finer signals such as RAM size were left out for little discriminating value
-in homogeneous CI pools.
+`many_cpus`: the processor and memory-region counts, the distinct processor models present
+(a sorted, deduplicated list), and a histogram of the per-processor relative speeds (as
+`(speed, count)` pairs). The speed histogram distinguishes machines that agree on their
+counts and models but differ in their mix of processor speeds (for example a hybrid
+performance/efficiency core layout versus a uniform one). Finer signals such as RAM size were
+left out for little discriminating value in homogeneous CI pools.
 
 Because the key is persisted and compared across machines and tool versions, it uses a
 **fixed** hash (not a seeded/default hasher) over a version-tagged canonical string,
@@ -210,7 +210,7 @@ the computed fingerprint (it is CLI-only — a committed config would carry a ma
 wrong for some checkouts). The key is computed only for hardware-dependent engines.
 
 The individual factors behind the fingerprint (the version tag, processor and memory-region
-counts, CPU brand, and the per-processor speed histogram) are surfaced for debugging:
+counts, processor models, and the per-processor speed histogram) are surfaced for debugging:
 `collect` and the query commands emit them to standard error under `--verbose`, and the
 standalone `machine-key` command prints the key to standard output (with `--verbose` adding
 the factors to standard error). The
@@ -231,7 +231,7 @@ version, machine key). Git and environment access go through a small abstraction
 logic is unit-testable without a real repo or CI.
 
 The context also carries optional **host-hardware provenance** (`context.machine`): the
-fingerprint factors (processor and memory-region counts, CPU brand, per-processor speed
+fingerprint factors (processor and memory-region counts, processor models, per-processor speed
 histogram) and the auto-detected key they hash to. It is **write-only** — nothing reads it
 back — and exists purely so that a
 later change in a machine key can be traced to the specific factor that moved (for example, a

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -194,9 +194,12 @@ full repeatable, `all`-aware, auto-detecting facet model.
 The goal is a fingerprint equal for pool-equivalent machines and different for genuinely
 different hardware; it is **never** keyed on hostname or serial, since cloud pool nodes
 differ in name but are equivalent. It hashes the stable, pool-equivalent attributes
-available without elevated privileges across platforms — the processor and memory-region
-counts (from the in-workspace `many_cpus`) and a best-effort CPU brand string. Finer
-signals such as RAM size or base frequency were left out for little discriminating value
+available without elevated privileges across platforms — all from the in-workspace
+`many_cpus`: the processor and memory-region counts, a best-effort CPU brand string, and a
+histogram of the per-processor relative speeds (as `(speed, count)` pairs). The speed
+histogram distinguishes machines that agree on their counts and brand but differ in their
+mix of processor speeds (for example a hybrid performance/efficiency core layout versus a
+uniform one). Finer signals such as RAM size were left out for little discriminating value
 in homogeneous CI pools.
 
 Because the key is persisted and compared across machines and tool versions, it uses a
@@ -207,9 +210,10 @@ the computed fingerprint (it is CLI-only — a committed config would carry a ma
 wrong for some checkouts). The key is computed only for hardware-dependent engines.
 
 The individual factors behind the fingerprint (the version tag, processor and memory-region
-counts, and CPU brand) are surfaced for debugging: `collect` and the query commands emit
-them to standard error under `--verbose`, and the standalone `machine-key` command prints
-the key to standard output (with `--verbose` adding the factors to standard error). The
+counts, CPU brand, and the per-processor speed histogram) are surfaced for debugging:
+`collect` and the query commands emit them to standard error under `--verbose`, and the
+standalone `machine-key` command prints the key to standard output (with `--verbose` adding
+the factors to standard error). The
 latter exists so CI can capture the real per-runner key and thread it into a later `analyze`
 selection, now that runs are keyed by the auto-detected fingerprint rather than a fixed pin.
 The same factors and resulting fingerprint are also recorded on every stored run as
@@ -227,8 +231,9 @@ version, machine key). Git and environment access go through a small abstraction
 logic is unit-testable without a real repo or CI.
 
 The context also carries optional **host-hardware provenance** (`context.machine`): the
-fingerprint factors (processor and memory-region counts, CPU brand) and the auto-detected
-key they hash to. It is **write-only** — nothing reads it back — and exists purely so that a
+fingerprint factors (processor and memory-region counts, CPU brand, per-processor speed
+histogram) and the auto-detected key they hash to. It is **write-only** — nothing reads it
+back — and exists purely so that a
 later change in a machine key can be traced to the specific factor that moved (for example, a
 runner pool swapping CPU models). It records the auto-detected fingerprint regardless of any
 `--machine-key` override, and is an additive, backward-compatible field (absent on runs

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -480,6 +480,7 @@ fn machine_info(hardware: &HardwareProfile) -> MachineInfo {
         processors: hardware.processors,
         memory_regions: hardware.memory_regions,
         cpu_brand: hardware.cpu_brand.clone(),
+        processor_speeds: hardware.processor_speeds.clone(),
         fingerprint: resolve_machine_key(None, hardware),
     }
 }
@@ -1328,6 +1329,7 @@ mod tests {
                     processors: 8,
                     memory_regions: 1,
                     cpu_brand: Some("Test CPU 3000".to_owned()),
+                    processor_speeds: vec![(3141, 8)],
                 },
             }
         }

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -479,7 +479,7 @@ fn machine_info(hardware: &HardwareProfile) -> MachineInfo {
     MachineInfo {
         processors: hardware.processors,
         memory_regions: hardware.memory_regions,
-        cpu_brand: hardware.cpu_brand.clone(),
+        processor_models: hardware.processor_models.clone(),
         processor_speeds: hardware.processor_speeds.clone(),
         fingerprint: resolve_machine_key(None, hardware),
     }
@@ -1328,7 +1328,7 @@ mod tests {
                 hardware: HardwareProfile {
                     processors: 8,
                     memory_regions: 1,
-                    cpu_brand: Some("Test CPU 3000".to_owned()),
+                    processor_models: vec!["Test CPU 3000".to_owned()],
                     processor_speeds: vec![(3141, 8)],
                 },
             }

--- a/packages/cargo-bench-history/src/commands/machine_key.rs
+++ b/packages/cargo-bench-history/src/commands/machine_key.rs
@@ -56,6 +56,7 @@ mod tests {
             processors,
             memory_regions,
             cpu_brand: brand.map(ToOwned::to_owned),
+            processor_speeds: Vec::new(),
         }
     }
 

--- a/packages/cargo-bench-history/src/commands/machine_key.rs
+++ b/packages/cargo-bench-history/src/commands/machine_key.rs
@@ -51,18 +51,18 @@ mod tests {
 
     use super::*;
 
-    fn profile(processors: usize, memory_regions: usize, brand: Option<&str>) -> HardwareProfile {
+    fn profile(processors: usize, memory_regions: usize, models: &[&str]) -> HardwareProfile {
         HardwareProfile {
             processors,
             memory_regions,
-            cpu_brand: brand.map(ToOwned::to_owned),
+            processor_models: models.iter().map(|model| (*model).to_owned()).collect(),
             processor_speeds: Vec::new(),
         }
     }
 
     #[test]
     fn outcome_message_is_the_fingerprint() {
-        let hardware = profile(8, 1, Some("Test CPU 3000"));
+        let hardware = profile(8, 1, &["Test CPU 3000"]);
         let reporter = RecordingReporter::new();
 
         let outcome = machine_key_outcome(&hardware, &reporter);
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn verbose_note_lists_the_components() {
-        let hardware = profile(8, 1, Some("Test CPU 3000"));
+        let hardware = profile(8, 1, &["Test CPU 3000"]);
         let reporter = RecordingReporter::new();
 
         let _ = machine_key_outcome(&hardware, &reporter);
@@ -83,7 +83,7 @@ mod tests {
         assert!(
             reporter.contains("machine-key components:")
                 && reporter.contains("processors=8")
-                && reporter.contains("cpu_brand=\"Test CPU 3000\""),
+                && reporter.contains("processor_models=Test CPU 3000"),
             "{:?}",
             reporter.notes()
         );

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -184,9 +184,9 @@
 //! hardware-dependent results with, so CI captures it to thread the exact keys a
 //! collection produced into the matching `analyze` selection (see the per-push and
 //! per-PR workflows). Under `--verbose` the individual factors behind the
-//! fingerprint (processor count, memory regions, CPU brand, and the factor-set
-//! version tag) are written to standard error, so a change in the key can be traced
-//! to the specific factor that moved.
+//! fingerprint (processor count, memory regions, processor models, the per-processor
+//! speed histogram, and the factor-set version tag) are written to standard error, so
+//! a change in the key can be traced to the specific factor that moved.
 //!
 //! # Selecting data: options shared by the query commands
 //!

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -431,9 +431,10 @@ impl InstallCommand {
 #[derive(Args, Debug)]
 struct MachineKeyCommand {
     /// Also emit the individual hardware components that make up the fingerprint
-    /// to standard error (processor count, memory-region count, CPU brand, and
-    /// the fingerprint version), so a change in the key can be traced to which
-    /// factor changed. The key itself always goes to standard output.
+    /// to standard error (processor count, memory-region count, processor models,
+    /// per-processor speed histogram, and the fingerprint version), so a change in
+    /// the key can be traced to which factor changed. The key itself always goes to
+    /// standard output.
     #[arg(long, help_heading = HEADING_ENV)]
     verbose: bool,
 }

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -268,7 +268,7 @@ fn cases() -> Vec<SignalCase> {
             branch: [run_of(200.0, 49), run_of(100.0, 1)].concat(),
             expected_history: Outcome::Rise,
             expected_branch: Outcome::Quiet,
-        }
+        },
     ]
 }
 

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -78,15 +78,13 @@ pub struct MachineInfo {
     pub processors: usize,
     /// Number of NUMA memory regions the host reported.
     pub memory_regions: usize,
-    /// Distinct processor model strings the host reported, sorted ascending. Empty when
-    /// none could be determined, and defaults to empty when reading older records that
-    /// predate this factor.
+    /// Distinct processor model strings the host reported, sorted ascending.
+    /// Defaults to empty when reading older records that predate this factor.
     #[serde(default)]
     pub processor_models: Vec<String>,
     /// Histogram of the per-processor relative speeds the host reported, as
-    /// `(speed, count)` pairs sorted ascending by speed. Empty when no speeds
-    /// were reported. Defaults to empty when reading older records that predate
-    /// this factor.
+    /// `(speed, count)` pairs sorted ascending by speed. Defaults to empty when
+    /// reading older records that predate this factor.
     #[serde(default)]
     pub processor_speeds: Vec<(u64, usize)>,
     /// The hardware fingerprint these factors hash to: the host's auto-detected

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -230,11 +230,11 @@ mod tests {
             memory_regions: 1,
             cpu_brand: Some("Test CPU 3000".to_owned()),
             processor_speeds: vec![(3141, 8)],
-            fingerprint: "d3ddd69dcf3b84ea".to_owned(),
+            fingerprint: "test-fingerprint".to_owned(),
         });
         let json = serde_json::to_string(&with_machine).unwrap();
         assert!(
-            json.contains("\"fingerprint\":\"d3ddd69dcf3b84ea\""),
+            json.contains("\"fingerprint\":\"test-fingerprint\""),
             "{json}"
         );
         assert_eq!(

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -80,6 +80,12 @@ pub struct MachineInfo {
     pub memory_regions: usize,
     /// Best-effort CPU brand string (`None` when it could not be determined).
     pub cpu_brand: Option<String>,
+    /// Histogram of the per-processor relative speeds the host reported, as
+    /// `(speed, count)` pairs sorted ascending by speed. Empty when no speeds
+    /// were reported. Defaults to empty when reading older records that predate
+    /// this factor.
+    #[serde(default)]
+    pub processor_speeds: Vec<(u64, usize)>,
     /// The hardware fingerprint these factors hash to: the host's auto-detected
     /// identity, recorded regardless of the machine key the run was partitioned
     /// under (see the type-level note).
@@ -223,6 +229,7 @@ mod tests {
             processors: 8,
             memory_regions: 1,
             cpu_brand: Some("Test CPU 3000".to_owned()),
+            processor_speeds: vec![(3141, 8)],
             fingerprint: "d3ddd69dcf3b84ea".to_owned(),
         });
         let json = serde_json::to_string(&with_machine).unwrap();

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -78,8 +78,11 @@ pub struct MachineInfo {
     pub processors: usize,
     /// Number of NUMA memory regions the host reported.
     pub memory_regions: usize,
-    /// Best-effort CPU brand string (`None` when it could not be determined).
-    pub cpu_brand: Option<String>,
+    /// Distinct processor model strings the host reported, sorted ascending. Empty when
+    /// none could be determined, and defaults to empty when reading older records that
+    /// predate this factor.
+    #[serde(default)]
+    pub processor_models: Vec<String>,
     /// Histogram of the per-processor relative speeds the host reported, as
     /// `(speed, count)` pairs sorted ascending by speed. Empty when no speeds
     /// were reported. Defaults to empty when reading older records that predate
@@ -228,7 +231,7 @@ mod tests {
         with_machine.machine = Some(MachineInfo {
             processors: 8,
             memory_regions: 1,
-            cpu_brand: Some("Test CPU 3000".to_owned()),
+            processor_models: vec!["Test CPU 3000".to_owned()],
             processor_speeds: vec![(3141, 8)],
             fingerprint: "test-fingerprint".to_owned(),
         });

--- a/packages/cbh_model/src/run.rs
+++ b/packages/cbh_model/src/run.rs
@@ -174,7 +174,7 @@ mod tests {
             memory_regions: 1,
             cpu_brand: Some("Test CPU 3000".to_owned()),
             processor_speeds: vec![(3141, 8)],
-            fingerprint: "d3ddd69dcf3b84ea".to_owned(),
+            fingerprint: "test-fingerprint".to_owned(),
         });
         context
     }

--- a/packages/cbh_model/src/run.rs
+++ b/packages/cbh_model/src/run.rs
@@ -172,7 +172,7 @@ mod tests {
         context.machine = Some(MachineInfo {
             processors: 8,
             memory_regions: 1,
-            cpu_brand: Some("Test CPU 3000".to_owned()),
+            processor_models: vec!["Test CPU 3000".to_owned()],
             processor_speeds: vec![(3141, 8)],
             fingerprint: "test-fingerprint".to_owned(),
         });

--- a/packages/cbh_model/src/run.rs
+++ b/packages/cbh_model/src/run.rs
@@ -173,6 +173,7 @@ mod tests {
             processors: 8,
             memory_regions: 1,
             cpu_brand: Some("Test CPU 3000".to_owned()),
+            processor_speeds: vec![(3141, 8)],
             fingerprint: "d3ddd69dcf3b84ea".to_owned(),
         });
         context

--- a/packages/cbh_probe/Cargo.toml
+++ b/packages/cbh_probe/Cargo.toml
@@ -21,11 +21,9 @@ cbh_git = { workspace = true }
 cbh_model = { workspace = true }
 many_cpus = { workspace = true }
 sha2 = { workspace = true }
-tokio = { workspace = true, features = ["fs", "process"] }
 
 [dev-dependencies]
 mutants = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -45,8 +45,7 @@ pub struct HardwareProfile {
     ///
     /// Populated from every processor's model, then whitespace-normalized,
     /// deduplicated and sorted, so machines that agree on their set of models hash
-    /// alike regardless of how many processors of each model they have. Empty when no
-    /// model could be determined.
+    /// alike regardless of how many processors of each model they have.
     pub processor_models: Vec<String>,
     /// Histogram of the per-processor relative speeds the system reports, as
     /// `(speed, count)` pairs sorted ascending by speed.

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -81,14 +81,24 @@ fn normalize_brand(brand: &str) -> String {
 }
 
 /// Renders a speed histogram to a canonical `speedxcount` list joined by commas,
-/// for example `3141x4,6283x2` (pure). Entries are sorted ascending before
-/// rendering so equivalent histograms hash identically regardless of the order in
-/// which their `(speed, count)` pairs are supplied. An empty histogram renders as
-/// an empty string.
+/// for example `3141x4,6283x2` (pure). Because `HardwareProfile::processor_speeds`
+/// is public, a caller may supply the pairs in any order, split one speed across
+/// several entries, or include zero-count entries. Counts are therefore merged per
+/// speed, zero-count speeds dropped, and the result rendered ascending by speed, so
+/// that any two representations of the same histogram render — and hash —
+/// identically. An empty histogram renders as an empty string.
 fn render_speed_histogram(speeds: &[(u64, usize)]) -> String {
-    let mut sorted = speeds.to_vec();
-    sorted.sort_unstable();
-    sorted
+    let mut merged: BTreeMap<u64, usize> = BTreeMap::new();
+    for &(speed, count) in speeds {
+        if count == 0 {
+            continue;
+        }
+        let total = merged.entry(speed).or_insert(0);
+        *total = total
+            .checked_add(count)
+            .expect("processor count cannot exceed the usize range");
+    }
+    merged
         .iter()
         .map(|(speed, count)| format!("{speed}x{count}"))
         .collect::<Vec<_>>()
@@ -291,6 +301,19 @@ mod tests {
     }
 
     #[test]
+    fn equivalent_speed_histogram_representations_produce_the_same_fingerprint() {
+        // `HardwareProfile::processor_speeds` is public, so a caller can express the
+        // same histogram as split or zero-padded entries. Rendering merges counts
+        // per speed and drops zero counts, so those representations hash alike.
+        let canonical = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4)]);
+        let split = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 1), (3141, 3)]);
+        let zero_padded =
+            profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 0)]);
+        assert_eq!(fingerprint(&canonical), fingerprint(&split));
+        assert_eq!(fingerprint(&canonical), fingerprint(&zero_padded));
+    }
+
+    #[test]
     fn brand_whitespace_differences_do_not_change_the_fingerprint() {
         assert_eq!(
             fingerprint(&profile(8, 1, Some("Intel Xeon  E5"))),
@@ -393,6 +416,15 @@ mod tests {
             render_speed_histogram(&[(6283, 2), (3141, 4)]),
             "3141x4,6283x2"
         );
+    }
+
+    #[test]
+    fn render_speed_histogram_merges_duplicate_speeds_and_drops_zero_counts() {
+        // Duplicate speeds are summed into a single entry...
+        assert_eq!(render_speed_histogram(&[(3141, 2), (3141, 2)]), "3141x4");
+        // ...and zero-count speeds contribute nothing to the canonical string.
+        assert_eq!(render_speed_histogram(&[(3141, 4), (6283, 0)]), "3141x4");
+        assert_eq!(render_speed_histogram(&[(3141, 0)]), "");
     }
 
     #[test]

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -198,7 +198,7 @@ pub(crate) fn system_profile() -> HardwareProfile {
         cpu_brand: representative_brand(
             all_processors
                 .iter()
-                .map(|processor| processor.cpu_brand().map(ToOwned::to_owned)),
+                .map(|processor| processor.brand().map(ToOwned::to_owned)),
         ),
         processor_speeds: speed_histogram(
             all_processors

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -81,10 +81,14 @@ fn normalize_brand(brand: &str) -> String {
 }
 
 /// Renders a speed histogram to a canonical `speedxcount` list joined by commas,
-/// for example `3141x4,6283x2` (pure). An empty histogram renders as an empty
-/// string.
+/// for example `3141x4,6283x2` (pure). Entries are sorted ascending before
+/// rendering so equivalent histograms hash identically regardless of the order in
+/// which their `(speed, count)` pairs are supplied. An empty histogram renders as
+/// an empty string.
 fn render_speed_histogram(speeds: &[(u64, usize)]) -> String {
-    speeds
+    let mut sorted = speeds.to_vec();
+    sorted.sort_unstable();
+    sorted
         .iter()
         .map(|(speed, count)| format!("{speed}x{count}"))
         .collect::<Vec<_>>()
@@ -277,6 +281,16 @@ mod tests {
     }
 
     #[test]
+    fn speed_histogram_order_does_not_change_the_fingerprint() {
+        // `HardwareProfile::processor_speeds` is public, so a caller can supply the
+        // same histogram with its pairs in a different order. Rendering sorts them,
+        // so equivalent hardware still hashes to the same fingerprint.
+        let ascending = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 4)]);
+        let descending = profile_with_speeds(8, 1, Some("Brand A"), vec![(6283, 4), (3141, 4)]);
+        assert_eq!(fingerprint(&ascending), fingerprint(&descending));
+    }
+
+    #[test]
     fn brand_whitespace_differences_do_not_change_the_fingerprint() {
         assert_eq!(
             fingerprint(&profile(8, 1, Some("Intel Xeon  E5"))),
@@ -371,6 +385,14 @@ mod tests {
             "3141x4,6283x2"
         );
         assert_eq!(render_speed_histogram(&[]), "");
+    }
+
+    #[test]
+    fn render_speed_histogram_sorts_pairs_ascending() {
+        assert_eq!(
+            render_speed_histogram(&[(6283, 2), (3141, 4)]),
+            "3141x4,6283x2"
+        );
     }
 
     #[test]

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -307,8 +307,7 @@ mod tests {
         // per speed and drops zero counts, so those representations hash alike.
         let canonical = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4)]);
         let split = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 1), (3141, 3)]);
-        let zero_padded =
-            profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 0)]);
+        let zero_padded = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 0)]);
         assert_eq!(fingerprint(&canonical), fingerprint(&split));
         assert_eq!(fingerprint(&canonical), fingerprint(&zero_padded));
     }

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -16,7 +16,7 @@
 //! the individual factors that fed the hash, so a change in the key can be traced —
 //! in verbose logs — to the specific hardware detail that moved.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use cbh_model::sanitize_segment;
 use sha2::{Digest, Sha256};
@@ -41,8 +41,13 @@ pub struct HardwareProfile {
     pub processors: usize,
     /// Maximum number of NUMA memory regions the system reports.
     pub memory_regions: usize,
-    /// Best-effort CPU brand string (`None` when it cannot be determined).
-    pub cpu_brand: Option<String>,
+    /// Distinct processor model strings the system reports, sorted ascending.
+    ///
+    /// Populated from every processor's model, then whitespace-normalized,
+    /// deduplicated and sorted, so machines that agree on their set of models hash
+    /// alike regardless of how many processors of each model they have. Empty when no
+    /// model could be determined.
+    pub processor_models: Vec<String>,
     /// Histogram of the per-processor relative speeds the system reports, as
     /// `(speed, count)` pairs sorted ascending by speed.
     ///
@@ -54,30 +59,26 @@ pub struct HardwareProfile {
 
 /// Renders a profile to its canonical, hashable string (pure).
 ///
-/// The factors are emitted in a fixed order as `key=value` lines, prefixed with
-/// the fingerprint version. The brand is normalized so incidental whitespace
-/// differences do not change the key; an absent brand contributes an empty value
-/// so that machines differing only in whether a brand could be read still hash
-/// consistently with their factor set. The speed histogram is rendered in its
-/// fixed ascending order.
+/// The factors are emitted in a fixed order as `key=value` lines, prefixed with the
+/// fingerprint version. Models are rendered as a sorted, deduplicated, comma-joined
+/// list, and the speed histogram in its fixed ascending order, so machines that differ
+/// only cosmetically - in model order, duplicate models, or incidental whitespace - hash
+/// consistently. An absent model set and an empty histogram both contribute an empty
+/// value.
 fn canonical(profile: &HardwareProfile) -> String {
-    let brand = profile
-        .cpu_brand
-        .as_deref()
-        .map(normalize_brand)
-        .unwrap_or_default();
     format!(
-        "{FINGERPRINT_VERSION}\nprocessors={}\nmemory_regions={}\ncpu_brand={brand}\nprocessor_speeds={}",
+        "{FINGERPRINT_VERSION}\nprocessors={}\nmemory_regions={}\nprocessor_models={}\nprocessor_speeds={}",
         profile.processors,
         profile.memory_regions,
+        render_models(&profile.processor_models),
         render_speed_histogram(&profile.processor_speeds),
     )
 }
 
-/// Collapses runs of whitespace to single spaces and trims the ends, so two
-/// identical CPUs whose brand strings differ only cosmetically hash alike (pure).
-fn normalize_brand(brand: &str) -> String {
-    brand.split_whitespace().collect::<Vec<_>>().join(" ")
+/// Collapses runs of whitespace to single spaces and trims the ends, so two identical
+/// processors whose model strings differ only cosmetically hash alike (pure).
+fn normalize_model(model: &str) -> String {
+    model.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Renders a speed histogram to a canonical `speedxcount` list joined by commas,
@@ -118,15 +119,35 @@ fn speed_histogram(speeds: impl IntoIterator<Item = u64>) -> Vec<(u64, usize)> {
     counts.into_iter().collect()
 }
 
-/// Picks a representative CPU brand from a sequence of per-processor brands: the
-/// first non-empty, whitespace-normalized brand, or `None` when none is reported
-/// (pure).
-fn representative_brand(brands: impl IntoIterator<Item = Option<String>>) -> Option<String> {
-    brands
-        .into_iter()
-        .flatten()
-        .map(|brand| normalize_brand(&brand))
-        .find(|brand| !brand.is_empty())
+/// Renders a list of processor models to a canonical, comma-joined string, for example
+/// `AMD EPYC,Intel Xeon` (pure). Because `HardwareProfile::processor_models` is public, a
+/// caller may supply the models in any order, with duplicates, or with cosmetic whitespace
+/// differences. Each model is whitespace-normalized, empties are dropped, and the distinct
+/// models are sorted, so any two representations of the same model set render - and hash -
+/// identically. An empty list renders as an empty string.
+fn render_models(models: &[String]) -> String {
+    let mut distinct: BTreeSet<String> = BTreeSet::new();
+    for model in models {
+        let normalized = normalize_model(model);
+        if !normalized.is_empty() {
+            distinct.insert(normalized);
+        }
+    }
+    distinct.into_iter().collect::<Vec<_>>().join(",")
+}
+
+/// Reduces a sequence of per-processor models to the distinct, whitespace-normalized
+/// models present, sorted ascending (pure). Empty and whitespace-only models are dropped,
+/// so a machine whose processors all report the same model yields a single-entry list.
+fn distinct_models(models: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut distinct: BTreeSet<String> = BTreeSet::new();
+    for model in models {
+        let normalized = normalize_model(&model);
+        if !normalized.is_empty() {
+            distinct.insert(normalized);
+        }
+    }
+    distinct.into_iter().collect()
 }
 
 /// The stable machine fingerprint of `profile`: the lowercase hex of the first
@@ -162,15 +183,17 @@ pub fn resolve_machine_key(override_key: Option<&str>, profile: &HardwareProfile
 ///
 /// It reports the fingerprint version tag and each hardware factor using the same
 /// normalized values that enter the hash, so that when a machine key changes the
-/// specific factor responsible can be identified from a `--verbose` log. An absent
-/// CPU brand is shown as `<none>` (matching the empty value it contributes to the
-/// canonical string) rather than omitted, so its absence is itself visible.
+/// specific factor responsible can be identified from a `--verbose` log. An absent model
+/// set is shown as `<none>` (matching the empty value it contributes to the canonical
+/// string) rather than omitted, so its absence is itself visible.
 #[must_use]
 pub fn describe_fingerprint_components(profile: &HardwareProfile) -> String {
-    let brand = profile.cpu_brand.as_deref().map_or_else(
-        || "<none>".to_owned(),
-        |brand| format!("\"{}\"", normalize_brand(brand)),
-    );
+    let models = render_models(&profile.processor_models);
+    let models = if models.is_empty() {
+        "<none>".to_owned()
+    } else {
+        models
+    };
     let speeds = render_speed_histogram(&profile.processor_speeds);
     let speeds = if speeds.is_empty() {
         "<none>".to_owned()
@@ -178,16 +201,16 @@ pub fn describe_fingerprint_components(profile: &HardwareProfile) -> String {
         speeds
     };
     format!(
-        "version={FINGERPRINT_VERSION}, processors={}, memory_regions={}, cpu_brand={brand}, processor_speeds={speeds}",
+        "version={FINGERPRINT_VERSION}, processors={}, memory_regions={}, processor_models={models}, processor_speeds={speeds}",
         profile.processors, profile.memory_regions,
     )
 }
 
 /// Profiles the host hardware (best effort).
 ///
-/// The processor and memory-region counts, the per-processor speed histogram and
-/// the representative CPU brand all come from `many_cpus`, so the fingerprint is
-/// built from a single, consistent hardware source.
+/// The processor and memory-region counts, the per-processor speed histogram and the
+/// distinct processor models all come from `many_cpus`, so the fingerprint is built from
+/// a single, consistent hardware source.
 #[cfg_attr(test, mutants::skip)] // Queries the host; the pure logic it feeds is tested.
 pub(crate) fn system_profile() -> HardwareProfile {
     let hardware = many_cpus::SystemHardware::current();
@@ -195,10 +218,10 @@ pub(crate) fn system_profile() -> HardwareProfile {
     HardwareProfile {
         processors: hardware.max_processor_count(),
         memory_regions: hardware.max_memory_region_count(),
-        cpu_brand: representative_brand(
+        processor_models: distinct_models(
             all_processors
                 .iter()
-                .map(|processor| processor.brand().map(ToOwned::to_owned)),
+                .map(|processor| processor.model().to_owned()),
         ),
         processor_speeds: speed_histogram(
             all_processors
@@ -213,11 +236,11 @@ pub(crate) fn system_profile() -> HardwareProfile {
 mod tests {
     use super::*;
 
-    fn profile(processors: usize, memory_regions: usize, brand: Option<&str>) -> HardwareProfile {
+    fn profile(processors: usize, memory_regions: usize, models: &[&str]) -> HardwareProfile {
         HardwareProfile {
             processors,
             memory_regions,
-            cpu_brand: brand.map(ToOwned::to_owned),
+            processor_models: models.iter().map(|model| (*model).to_owned()).collect(),
             processor_speeds: Vec::new(),
         }
     }
@@ -225,13 +248,13 @@ mod tests {
     fn profile_with_speeds(
         processors: usize,
         memory_regions: usize,
-        brand: Option<&str>,
+        models: &[&str],
         processor_speeds: Vec<(u64, usize)>,
     ) -> HardwareProfile {
         HardwareProfile {
             processors,
             memory_regions,
-            cpu_brand: brand.map(ToOwned::to_owned),
+            processor_models: models.iter().map(|model| (*model).to_owned()).collect(),
             processor_speeds,
         }
     }
@@ -242,8 +265,8 @@ mod tests {
         // canonical factor string, not a seeded or platform-varying one. If the
         // factor set, ordering, version tag, or hash changes, this must be
         // updated deliberately (and existing history is understood to fork).
-        let key = fingerprint(&profile(8, 1, Some("Test CPU 3000")));
-        assert_eq!(key, "bfa6cd4cc92868db");
+        let key = fingerprint(&profile(8, 1, &["Test CPU 3000"]));
+        assert_eq!(key, "1e3277ddba18263f");
     }
 
     #[test]
@@ -253,15 +276,15 @@ mod tests {
         let key = fingerprint(&profile_with_speeds(
             4,
             1,
-            Some("Test CPU 3000"),
+            &["Test CPU 3000"],
             vec![(3141, 2), (6283, 2)],
         ));
-        assert_eq!(key, "3d4b6c38a6756893");
+        assert_eq!(key, "55e2e3746d2a53be");
     }
 
     #[test]
     fn fingerprint_is_sixteen_lowercase_hex_chars() {
-        let key = fingerprint(&profile(4, 2, None));
+        let key = fingerprint(&profile(4, 2, &[]));
         assert_eq!(key.len(), FINGERPRINT_HEX_LEN);
         assert!(
             key.chars()
@@ -272,21 +295,22 @@ mod tests {
 
     #[test]
     fn distinct_factors_produce_distinct_fingerprints() {
-        let base = fingerprint(&profile(8, 1, Some("Brand A")));
-        assert_ne!(base, fingerprint(&profile(16, 1, Some("Brand A"))));
-        assert_ne!(base, fingerprint(&profile(8, 2, Some("Brand A"))));
-        assert_ne!(base, fingerprint(&profile(8, 1, Some("Brand B"))));
-        assert_ne!(base, fingerprint(&profile(8, 1, None)));
+        let base = fingerprint(&profile(8, 1, &["Model A"]));
+        assert_ne!(base, fingerprint(&profile(16, 1, &["Model A"])));
+        assert_ne!(base, fingerprint(&profile(8, 2, &["Model A"])));
+        assert_ne!(base, fingerprint(&profile(8, 1, &["Model B"])));
+        assert_ne!(base, fingerprint(&profile(8, 1, &["Model A", "Model B"])));
+        assert_ne!(base, fingerprint(&profile(8, 1, &[])));
         assert_ne!(
             base,
-            fingerprint(&profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 8)])),
+            fingerprint(&profile_with_speeds(8, 1, &["Model A"], vec![(3141, 8)])),
         );
     }
 
     #[test]
     fn distinct_speed_histograms_produce_distinct_fingerprints() {
-        let uniform = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 8)]);
-        let hybrid = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 4)]);
+        let uniform = profile_with_speeds(8, 1, &["Model A"], vec![(3141, 8)]);
+        let hybrid = profile_with_speeds(8, 1, &["Model A"], vec![(3141, 4), (6283, 4)]);
         assert_ne!(fingerprint(&uniform), fingerprint(&hybrid));
     }
 
@@ -295,8 +319,8 @@ mod tests {
         // `HardwareProfile::processor_speeds` is public, so a caller can supply the
         // same histogram with its pairs in a different order. Rendering sorts them,
         // so equivalent hardware still hashes to the same fingerprint.
-        let ascending = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 4)]);
-        let descending = profile_with_speeds(8, 1, Some("Brand A"), vec![(6283, 4), (3141, 4)]);
+        let ascending = profile_with_speeds(8, 1, &["Model A"], vec![(3141, 4), (6283, 4)]);
+        let descending = profile_with_speeds(8, 1, &["Model A"], vec![(6283, 4), (3141, 4)]);
         assert_eq!(fingerprint(&ascending), fingerprint(&descending));
     }
 
@@ -305,27 +329,37 @@ mod tests {
         // `HardwareProfile::processor_speeds` is public, so a caller can express the
         // same histogram as split or zero-padded entries. Rendering merges counts
         // per speed and drops zero counts, so those representations hash alike.
-        let canonical = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4)]);
-        let split = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 1), (3141, 3)]);
-        let zero_padded = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 0)]);
+        let canonical = profile_with_speeds(8, 1, &["Model A"], vec![(3141, 4)]);
+        let split = profile_with_speeds(8, 1, &["Model A"], vec![(3141, 1), (3141, 3)]);
+        let zero_padded = profile_with_speeds(8, 1, &["Model A"], vec![(3141, 4), (6283, 0)]);
         assert_eq!(fingerprint(&canonical), fingerprint(&split));
         assert_eq!(fingerprint(&canonical), fingerprint(&zero_padded));
     }
 
     #[test]
-    fn brand_whitespace_differences_do_not_change_the_fingerprint() {
+    fn model_order_and_duplicates_do_not_change_the_fingerprint() {
+        // `HardwareProfile::processor_models` is public, so a caller can supply the same
+        // models in a different order or with duplicates. Rendering sorts and dedups them,
+        // so equivalent hardware still hashes to the same fingerprint.
+        let ascending = profile(8, 1, &["Model A", "Model B"]);
+        let shuffled = profile(8, 1, &["Model B", "Model A", "Model A"]);
+        assert_eq!(fingerprint(&ascending), fingerprint(&shuffled));
+    }
+
+    #[test]
+    fn model_whitespace_differences_do_not_change_the_fingerprint() {
         assert_eq!(
-            fingerprint(&profile(8, 1, Some("Intel Xeon  E5"))),
-            fingerprint(&profile(8, 1, Some("  Intel   Xeon E5 "))),
+            fingerprint(&profile(8, 1, &["Intel Xeon  E5"])),
+            fingerprint(&profile(8, 1, &["  Intel   Xeon E5 "])),
         );
     }
 
     #[test]
     fn canonical_is_versioned_and_ordered() {
-        let rendered = canonical(&profile(8, 1, Some("CPU X")));
+        let rendered = canonical(&profile(8, 1, &["CPU X"]));
         assert_eq!(
             rendered,
-            "mk2\nprocessors=8\nmemory_regions=1\ncpu_brand=CPU X\nprocessor_speeds="
+            "mk2\nprocessors=8\nmemory_regions=1\nprocessor_models=CPU X\nprocessor_speeds="
         );
     }
 
@@ -334,36 +368,36 @@ mod tests {
         let rendered = canonical(&profile_with_speeds(
             4,
             1,
-            Some("CPU X"),
+            &["CPU X"],
             vec![(3141, 2), (6283, 2)],
         ));
         assert_eq!(
             rendered,
-            "mk2\nprocessors=4\nmemory_regions=1\ncpu_brand=CPU X\nprocessor_speeds=3141x2,6283x2"
+            "mk2\nprocessors=4\nmemory_regions=1\nprocessor_models=CPU X\nprocessor_speeds=3141x2,6283x2"
         );
     }
 
     #[test]
-    fn canonical_renders_absent_brand_as_empty() {
-        let rendered = canonical(&profile(2, 1, None));
-        assert!(rendered.contains("\ncpu_brand=\n"), "{rendered}");
+    fn canonical_renders_absent_models_as_empty() {
+        let rendered = canonical(&profile(2, 1, &[]));
+        assert!(rendered.contains("\nprocessor_models=\n"), "{rendered}");
     }
 
     #[test]
-    fn normalize_brand_collapses_and_trims_whitespace() {
-        assert_eq!(normalize_brand("  a   b\tc \n"), "a b c");
-        assert_eq!(normalize_brand("   "), "");
+    fn normalize_model_collapses_and_trims_whitespace() {
+        assert_eq!(normalize_model("  a   b\tc \n"), "a b c");
+        assert_eq!(normalize_model("   "), "");
     }
 
     #[test]
     fn resolve_machine_key_uses_fingerprint_without_override() {
-        let hardware = profile(8, 1, Some("CPU X"));
+        let hardware = profile(8, 1, &["CPU X"]);
         assert_eq!(resolve_machine_key(None, &hardware), fingerprint(&hardware));
     }
 
     #[test]
     fn resolve_machine_key_prefers_sanitized_override() {
-        let hardware = profile(8, 1, Some("CPU X"));
+        let hardware = profile(8, 1, &["CPU X"]);
         assert_eq!(
             resolve_machine_key(Some("ci/pool one"), &hardware),
             "ci_pool_one"
@@ -375,21 +409,21 @@ mod tests {
         let described = describe_fingerprint_components(&profile_with_speeds(
             8,
             1,
-            Some("Intel  Xeon  E5"),
+            &["Intel  Xeon  E5", "AMD EPYC"],
             vec![(3141, 6), (6283, 2)],
         ));
         assert_eq!(
             described,
-            "version=mk2, processors=8, memory_regions=1, cpu_brand=\"Intel Xeon E5\", processor_speeds=3141x6,6283x2"
+            "version=mk2, processors=8, memory_regions=1, processor_models=AMD EPYC,Intel Xeon E5, processor_speeds=3141x6,6283x2"
         );
     }
 
     #[test]
     fn describe_components_marks_absent_factors() {
-        let described = describe_fingerprint_components(&profile(4, 2, None));
+        let described = describe_fingerprint_components(&profile(4, 2, &[]));
         assert_eq!(
             described,
-            "version=mk2, processors=4, memory_regions=2, cpu_brand=<none>, processor_speeds=<none>"
+            "version=mk2, processors=4, memory_regions=2, processor_models=<none>, processor_speeds=<none>"
         );
     }
 
@@ -427,20 +461,35 @@ mod tests {
     }
 
     #[test]
-    fn representative_brand_picks_the_first_non_empty_normalized_brand() {
+    fn distinct_models_normalizes_sorts_and_dedups() {
+        // Raw per-processor models arrive in arbitrary order, with duplicates, cosmetic
+        // whitespace and empty entries; the distinct set is normalized and sorted.
+        let models = distinct_models([
+            "  Intel  Xeon  ".to_owned(),
+            "AMD EPYC".to_owned(),
+            "Intel Xeon".to_owned(),
+            String::new(),
+            "   ".to_owned(),
+        ]);
+        assert_eq!(models, vec!["AMD EPYC".to_owned(), "Intel Xeon".to_owned()]);
         assert_eq!(
-            representative_brand([
-                None,
-                Some("   ".to_owned()),
-                Some("  Intel  Xeon  ".to_owned())
-            ]),
-            Some("Intel Xeon".to_owned())
+            distinct_models(std::iter::empty::<String>()),
+            Vec::<String>::new()
         );
-        assert_eq!(representative_brand([None, Some("  ".to_owned())]), None);
+    }
+
+    #[test]
+    fn render_models_joins_sorted_distinct_with_commas() {
         assert_eq!(
-            representative_brand(std::iter::empty::<Option<String>>()),
-            None
+            render_models(&["Intel Xeon".to_owned(), "AMD EPYC".to_owned()]),
+            "AMD EPYC,Intel Xeon"
         );
+        // Duplicates and cosmetic whitespace collapse to a single entry.
+        assert_eq!(
+            render_models(&["AMD EPYC".to_owned(), "  AMD   EPYC ".to_owned()]),
+            "AMD EPYC"
+        );
+        assert_eq!(render_models(&[]), "");
     }
 
     #[test]

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -16,6 +16,8 @@
 //! the individual factors that fed the hash, so a change in the key can be traced —
 //! in verbose logs — to the specific hardware detail that moved.
 
+use std::collections::BTreeMap;
+
 use cbh_model::sanitize_segment;
 use sha2::{Digest, Sha256};
 
@@ -24,7 +26,7 @@ use sha2::{Digest, Sha256};
 /// Bumping it deliberately forks the machine key (and thus the stored series) so
 /// that a change to which factors are hashed is an explicit, visible event rather
 /// than a silent break in history.
-const FINGERPRINT_VERSION: &str = "mk1";
+const FINGERPRINT_VERSION: &str = "mk2";
 
 /// Number of hex characters kept from the SHA-256 digest. Eight bytes (64 bits)
 /// is short enough for a readable path segment yet wide enough that accidental
@@ -41,6 +43,13 @@ pub struct HardwareProfile {
     pub memory_regions: usize,
     /// Best-effort CPU brand string (`None` when it cannot be determined).
     pub cpu_brand: Option<String>,
+    /// Histogram of the per-processor relative speeds the system reports, as
+    /// `(speed, count)` pairs sorted ascending by speed.
+    ///
+    /// This distinguishes machines that agree on processor and memory-region
+    /// counts but differ in their mix of processor speeds (for example a hybrid
+    /// performance/efficiency core layout versus a uniform one).
+    pub processor_speeds: Vec<(u64, usize)>,
 }
 
 /// Renders a profile to its canonical, hashable string (pure).
@@ -49,7 +58,8 @@ pub struct HardwareProfile {
 /// the fingerprint version. The brand is normalized so incidental whitespace
 /// differences do not change the key; an absent brand contributes an empty value
 /// so that machines differing only in whether a brand could be read still hash
-/// consistently with their factor set.
+/// consistently with their factor set. The speed histogram is rendered in its
+/// fixed ascending order.
 fn canonical(profile: &HardwareProfile) -> String {
     let brand = profile
         .cpu_brand
@@ -57,8 +67,10 @@ fn canonical(profile: &HardwareProfile) -> String {
         .map(normalize_brand)
         .unwrap_or_default();
     format!(
-        "{FINGERPRINT_VERSION}\nprocessors={}\nmemory_regions={}\ncpu_brand={brand}",
-        profile.processors, profile.memory_regions,
+        "{FINGERPRINT_VERSION}\nprocessors={}\nmemory_regions={}\ncpu_brand={brand}\nprocessor_speeds={}",
+        profile.processors,
+        profile.memory_regions,
+        render_speed_histogram(&profile.processor_speeds),
     )
 }
 
@@ -66,6 +78,41 @@ fn canonical(profile: &HardwareProfile) -> String {
 /// identical CPUs whose brand strings differ only cosmetically hash alike (pure).
 fn normalize_brand(brand: &str) -> String {
     brand.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Renders a speed histogram to a canonical `speedxcount` list joined by commas,
+/// for example `3141x4,6283x2` (pure). An empty histogram renders as an empty
+/// string.
+fn render_speed_histogram(speeds: &[(u64, usize)]) -> String {
+    speeds
+        .iter()
+        .map(|(speed, count)| format!("{speed}x{count}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Builds a speed histogram from a sequence of per-processor speeds: `(speed,
+/// count)` pairs sorted ascending by speed (pure).
+fn speed_histogram(speeds: impl IntoIterator<Item = u64>) -> Vec<(u64, usize)> {
+    let mut counts: BTreeMap<u64, usize> = BTreeMap::new();
+    for speed in speeds {
+        let count = counts.entry(speed).or_insert(0);
+        *count = count
+            .checked_add(1)
+            .expect("processor count cannot exceed the usize range");
+    }
+    counts.into_iter().collect()
+}
+
+/// Picks a representative CPU brand from a sequence of per-processor brands: the
+/// first non-empty, whitespace-normalized brand, or `None` when none is reported
+/// (pure).
+fn representative_brand(brands: impl IntoIterator<Item = Option<String>>) -> Option<String> {
+    brands
+        .into_iter()
+        .flatten()
+        .map(|brand| normalize_brand(&brand))
+        .find(|brand| !brand.is_empty())
 }
 
 /// The stable machine fingerprint of `profile`: the lowercase hex of the first
@@ -110,94 +157,41 @@ pub fn describe_fingerprint_components(profile: &HardwareProfile) -> String {
         || "<none>".to_owned(),
         |brand| format!("\"{}\"", normalize_brand(brand)),
     );
+    let speeds = render_speed_histogram(&profile.processor_speeds);
+    let speeds = if speeds.is_empty() {
+        "<none>".to_owned()
+    } else {
+        speeds
+    };
     format!(
-        "version={FINGERPRINT_VERSION}, processors={}, memory_regions={}, cpu_brand={brand}",
+        "version={FINGERPRINT_VERSION}, processors={}, memory_regions={}, cpu_brand={brand}, processor_speeds={speeds}",
         profile.processors, profile.memory_regions,
     )
 }
 
 /// Profiles the host hardware (best effort).
 ///
-/// The processor and memory-region counts come from `many_cpus`; the CPU brand is
-/// read per platform and left `None` when it cannot be determined.
+/// The processor and memory-region counts, the per-processor speed histogram and
+/// the representative CPU brand all come from `many_cpus`, so the fingerprint is
+/// built from a single, consistent hardware source.
 #[cfg_attr(test, mutants::skip)] // Queries the host; the pure logic it feeds is tested.
-pub(crate) async fn system_profile() -> HardwareProfile {
+pub(crate) fn system_profile() -> HardwareProfile {
     let hardware = many_cpus::SystemHardware::current();
+    let all_processors = hardware.all_processors();
     HardwareProfile {
         processors: hardware.max_processor_count(),
         memory_regions: hardware.max_memory_region_count(),
-        cpu_brand: detect_cpu_brand().await,
+        cpu_brand: representative_brand(
+            all_processors
+                .iter()
+                .map(|processor| processor.cpu_brand().map(ToOwned::to_owned)),
+        ),
+        processor_speeds: speed_histogram(
+            all_processors
+                .iter()
+                .map(|processor| processor.relative_speed().as_u64()),
+        ),
     }
-}
-
-#[cfg(target_os = "linux")]
-#[cfg_attr(test, mutants::skip)] // Reads `/proc`; the parser it delegates to is tested.
-async fn detect_cpu_brand() -> Option<String> {
-    let text = tokio::fs::read_to_string("/proc/cpuinfo").await.ok()?;
-    parse_cpuinfo_brand(&text)
-}
-
-#[cfg(target_os = "windows")]
-#[cfg_attr(test, mutants::skip)] // Reads an environment variable; nothing further to assert.
-#[expect(
-    clippy::unused_async,
-    reason = "uniform async signature across the per-platform detect_cpu_brand variants"
-)]
-async fn detect_cpu_brand() -> Option<String> {
-    std::env::var("PROCESSOR_IDENTIFIER")
-        .ok()
-        .map(|value| normalize_brand(&value))
-        .filter(|value| !value.is_empty())
-}
-
-#[cfg(target_os = "macos")]
-#[cfg_attr(test, mutants::skip)] // Spawns `sysctl`; the parser it delegates to is tested.
-async fn detect_cpu_brand() -> Option<String> {
-    let output = tokio::process::Command::new("sysctl")
-        .args(["-n", "machdep.cpu.brand_string"])
-        .output()
-        .await
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    parse_sysctl_brand(&String::from_utf8_lossy(&output.stdout))
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
-#[cfg_attr(test, mutants::skip)] // No CPU-brand source is known on this platform.
-#[expect(
-    clippy::unused_async,
-    reason = "uniform async signature across the per-platform detect_cpu_brand variants"
-)]
-async fn detect_cpu_brand() -> Option<String> {
-    None
-}
-
-/// Extracts the CPU brand from `/proc/cpuinfo` text: the value of the first
-/// `model name` line, whitespace-normalized (pure).
-#[cfg(any(test, target_os = "linux"))]
-fn parse_cpuinfo_brand(text: &str) -> Option<String> {
-    for line in text.lines() {
-        let Some((key, value)) = line.split_once(':') else {
-            continue;
-        };
-        if key.trim() == "model name" {
-            let brand = normalize_brand(value);
-            if !brand.is_empty() {
-                return Some(brand);
-            }
-        }
-    }
-    None
-}
-
-/// Extracts the CPU brand from `sysctl -n machdep.cpu.brand_string` output: the
-/// whitespace-normalized text, or `None` when it is empty (pure).
-#[cfg(any(test, target_os = "macos"))]
-fn parse_sysctl_brand(text: &str) -> Option<String> {
-    let brand = normalize_brand(text);
-    if brand.is_empty() { None } else { Some(brand) }
 }
 
 #[cfg(test)]
@@ -210,6 +204,21 @@ mod tests {
             processors,
             memory_regions,
             cpu_brand: brand.map(ToOwned::to_owned),
+            processor_speeds: Vec::new(),
+        }
+    }
+
+    fn profile_with_speeds(
+        processors: usize,
+        memory_regions: usize,
+        brand: Option<&str>,
+        processor_speeds: Vec<(u64, usize)>,
+    ) -> HardwareProfile {
+        HardwareProfile {
+            processors,
+            memory_regions,
+            cpu_brand: brand.map(ToOwned::to_owned),
+            processor_speeds,
         }
     }
 
@@ -220,7 +229,20 @@ mod tests {
         // factor set, ordering, version tag, or hash changes, this must be
         // updated deliberately (and existing history is understood to fork).
         let key = fingerprint(&profile(8, 1, Some("Test CPU 3000")));
-        assert_eq!(key, "d3ddd69dcf3b84ea");
+        assert_eq!(key, "bfa6cd4cc92868db");
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_a_fixed_profile_with_speeds() {
+        // Companion golden that pins the rendering of the speed histogram into the
+        // hash, so a change to how speeds enter the key is a deliberate event.
+        let key = fingerprint(&profile_with_speeds(
+            4,
+            1,
+            Some("Test CPU 3000"),
+            vec![(3141, 2), (6283, 2)],
+        ));
+        assert_eq!(key, "3d4b6c38a6756893");
     }
 
     #[test]
@@ -241,6 +263,17 @@ mod tests {
         assert_ne!(base, fingerprint(&profile(8, 2, Some("Brand A"))));
         assert_ne!(base, fingerprint(&profile(8, 1, Some("Brand B"))));
         assert_ne!(base, fingerprint(&profile(8, 1, None)));
+        assert_ne!(
+            base,
+            fingerprint(&profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 8)])),
+        );
+    }
+
+    #[test]
+    fn distinct_speed_histograms_produce_distinct_fingerprints() {
+        let uniform = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 8)]);
+        let hybrid = profile_with_speeds(8, 1, Some("Brand A"), vec![(3141, 4), (6283, 4)]);
+        assert_ne!(fingerprint(&uniform), fingerprint(&hybrid));
     }
 
     #[test]
@@ -256,14 +289,28 @@ mod tests {
         let rendered = canonical(&profile(8, 1, Some("CPU X")));
         assert_eq!(
             rendered,
-            "mk1\nprocessors=8\nmemory_regions=1\ncpu_brand=CPU X"
+            "mk2\nprocessors=8\nmemory_regions=1\ncpu_brand=CPU X\nprocessor_speeds="
+        );
+    }
+
+    #[test]
+    fn canonical_renders_the_speed_histogram_in_order() {
+        let rendered = canonical(&profile_with_speeds(
+            4,
+            1,
+            Some("CPU X"),
+            vec![(3141, 2), (6283, 2)],
+        ));
+        assert_eq!(
+            rendered,
+            "mk2\nprocessors=4\nmemory_regions=1\ncpu_brand=CPU X\nprocessor_speeds=3141x2,6283x2"
         );
     }
 
     #[test]
     fn canonical_renders_absent_brand_as_empty() {
         let rendered = canonical(&profile(2, 1, None));
-        assert!(rendered.ends_with("cpu_brand="), "{rendered}");
+        assert!(rendered.contains("\ncpu_brand=\n"), "{rendered}");
     }
 
     #[test]
@@ -289,61 +336,64 @@ mod tests {
 
     #[test]
     fn describe_components_lists_version_and_normalized_factors() {
-        let described = describe_fingerprint_components(&profile(8, 1, Some("Intel  Xeon  E5")));
+        let described = describe_fingerprint_components(&profile_with_speeds(
+            8,
+            1,
+            Some("Intel  Xeon  E5"),
+            vec![(3141, 6), (6283, 2)],
+        ));
         assert_eq!(
             described,
-            "version=mk1, processors=8, memory_regions=1, cpu_brand=\"Intel Xeon E5\""
+            "version=mk2, processors=8, memory_regions=1, cpu_brand=\"Intel Xeon E5\", processor_speeds=3141x6,6283x2"
         );
     }
 
     #[test]
-    fn describe_components_marks_an_absent_brand() {
+    fn describe_components_marks_absent_factors() {
         let described = describe_fingerprint_components(&profile(4, 2, None));
         assert_eq!(
             described,
-            "version=mk1, processors=4, memory_regions=2, cpu_brand=<none>"
+            "version=mk2, processors=4, memory_regions=2, cpu_brand=<none>, processor_speeds=<none>"
         );
     }
 
     #[test]
-    fn parse_cpuinfo_brand_reads_the_first_model_name() {
-        let text = "\
-processor\t: 0
-vendor_id\t: GenuineIntel
-model name\t: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
-processor\t: 1
-model name\t: Some Other Core
-";
+    fn speed_histogram_counts_and_orders_speeds() {
+        let histogram = speed_histogram([6283, 3141, 6283, 3141, 3141]);
+        assert_eq!(histogram, vec![(3141, 3), (6283, 2)]);
+        assert_eq!(speed_histogram(std::iter::empty()), Vec::new());
+    }
+
+    #[test]
+    fn render_speed_histogram_joins_pairs_with_commas() {
         assert_eq!(
-            parse_cpuinfo_brand(text),
-            Some("Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz".to_owned())
+            render_speed_histogram(&[(3141, 4), (6283, 2)]),
+            "3141x4,6283x2"
         );
+        assert_eq!(render_speed_histogram(&[]), "");
     }
 
     #[test]
-    fn parse_cpuinfo_brand_absent_yields_none() {
-        assert_eq!(parse_cpuinfo_brand("processor\t: 0\nflags\t: fpu\n"), None);
-        assert_eq!(parse_cpuinfo_brand(""), None);
-    }
-
-    #[test]
-    fn parse_cpuinfo_brand_blank_value_yields_none() {
-        assert_eq!(parse_cpuinfo_brand("model name\t:   \n"), None);
-    }
-
-    #[test]
-    fn parse_sysctl_brand_normalizes_and_handles_empty() {
+    fn representative_brand_picks_the_first_non_empty_normalized_brand() {
         assert_eq!(
-            parse_sysctl_brand("Apple M2 Pro\n"),
-            Some("Apple M2 Pro".to_owned())
+            representative_brand([
+                None,
+                Some("   ".to_owned()),
+                Some("  Intel  Xeon  ".to_owned())
+            ]),
+            Some("Intel Xeon".to_owned())
         );
-        assert_eq!(parse_sysctl_brand("  \n"), None);
+        assert_eq!(representative_brand([None, Some("  ".to_owned())]), None);
+        assert_eq!(
+            representative_brand(std::iter::empty::<Option<String>>()),
+            None
+        );
     }
 
-    #[tokio::test]
+    #[test]
     #[cfg_attr(miri, ignore)] // Queries real hardware, which Miri cannot model.
-    async fn system_profile_reports_at_least_one_processor() {
-        let hardware = system_profile().await;
+    fn system_profile_reports_at_least_one_processor() {
+        let hardware = system_profile();
         assert!(hardware.processors >= 1, "{hardware:?}");
         assert!(hardware.memory_regions >= 1, "{hardware:?}");
         // The fingerprint of whatever this machine is must be well-formed.

--- a/packages/cbh_probe/src/probe.rs
+++ b/packages/cbh_probe/src/probe.rs
@@ -99,7 +99,7 @@ impl EnvironmentProbe for SystemProbe {
 
     #[cfg_attr(test, mutants::skip)] // Queries the host hardware; the fingerprint logic is tested.
     async fn hardware(&self) -> HardwareProfile {
-        system_profile().await
+        system_profile()
     }
 }
 

--- a/packages/many_cpus/src/lib.rs
+++ b/packages/many_cpus/src/lib.rs
@@ -339,5 +339,5 @@
 pub use many_cpus_impl::fake;
 pub use many_cpus_impl::{
     EfficiencyClass, MemoryRegionId, Processor, ProcessorId, ProcessorSet, ProcessorSetBuilder,
-    ResourceQuota, SystemHardware,
+    RelativeSpeed, ResourceQuota, SystemHardware,
 };

--- a/packages/many_cpus/tests/many_cpus_reexports.rs
+++ b/packages/many_cpus/tests/many_cpus_reexports.rs
@@ -47,7 +47,7 @@ fn processor_set_basics_via_re_exports() {
     require_memory_region_id(any_processor.memory_region_id());
     require_efficiency_class(any_processor.efficiency_class());
     require_relative_speed(any_processor.relative_speed());
-    _ = any_processor.brand();
+    _ = any_processor.model();
 }
 
 #[test]

--- a/packages/many_cpus/tests/many_cpus_reexports.rs
+++ b/packages/many_cpus/tests/many_cpus_reexports.rs
@@ -9,7 +9,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use many_cpus::{
     EfficiencyClass, MemoryRegionId, Processor, ProcessorId, ProcessorSet, ProcessorSetBuilder,
-    ResourceQuota, SystemHardware,
+    RelativeSpeed, ResourceQuota, SystemHardware,
 };
 use static_assertions::assert_impl_all;
 
@@ -18,10 +18,12 @@ assert_impl_all!(ProcessorSet: Send, Sync, UnwindSafe, RefUnwindSafe);
 assert_impl_all!(ProcessorSetBuilder: Send, Sync);
 assert_impl_all!(Processor: Send, Sync, UnwindSafe, RefUnwindSafe);
 assert_impl_all!(ResourceQuota: Send, Sync, UnwindSafe, RefUnwindSafe);
+assert_impl_all!(RelativeSpeed: Send, Sync, UnwindSafe, RefUnwindSafe);
 
 fn require_processor_id(_: ProcessorId) {}
 fn require_memory_region_id(_: MemoryRegionId) {}
 fn require_efficiency_class(_: EfficiencyClass) {}
+fn require_relative_speed(_: RelativeSpeed) {}
 
 #[test]
 fn system_hardware_inspection_via_re_exports() {
@@ -44,6 +46,7 @@ fn processor_set_basics_via_re_exports() {
     require_processor_id(any_processor.id());
     require_memory_region_id(any_processor.memory_region_id());
     require_efficiency_class(any_processor.efficiency_class());
+    require_relative_speed(any_processor.relative_speed());
 }
 
 #[test]
@@ -73,7 +76,7 @@ mod with_test_util {
     #[test]
     fn fake_processor_builder_constructor_via_re_exports() {
         let builder = HardwareBuilder::new()
-            .processor(ProcessorBuilder::new().id(0))
+            .processor(ProcessorBuilder::new().id(0).relative_speed(nz!(3600)))
             .processor(ProcessorBuilder::new().id(1).memory_region(1));
         let hardware = SystemHardware::fake(builder);
         assert!(hardware.max_processor_count() >= 2);

--- a/packages/many_cpus/tests/many_cpus_reexports.rs
+++ b/packages/many_cpus/tests/many_cpus_reexports.rs
@@ -47,6 +47,7 @@ fn processor_set_basics_via_re_exports() {
     require_memory_region_id(any_processor.memory_region_id());
     require_efficiency_class(any_processor.efficiency_class());
     require_relative_speed(any_processor.relative_speed());
+    _ = any_processor.cpu_brand();
 }
 
 #[test]

--- a/packages/many_cpus/tests/many_cpus_reexports.rs
+++ b/packages/many_cpus/tests/many_cpus_reexports.rs
@@ -47,7 +47,7 @@ fn processor_set_basics_via_re_exports() {
     require_memory_region_id(any_processor.memory_region_id());
     require_efficiency_class(any_processor.efficiency_class());
     require_relative_speed(any_processor.relative_speed());
-    _ = any_processor.cpu_brand();
+    _ = any_processor.brand();
 }
 
 #[test]

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -44,7 +44,7 @@ smallvec = { workspace = true }
 windows = { workspace = true, features = [
     "Win32_System_JobObjects",
     "Win32_System_Kernel",
-    "Win32_System_Power",
+    "Win32_System_Registry",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
 ] }

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -44,6 +44,7 @@ smallvec = { workspace = true }
 windows = { workspace = true, features = [
     "Win32_System_JobObjects",
     "Win32_System_Kernel",
+    "Win32_System_Power",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
 ] }

--- a/packages/many_cpus_impl/src/fake/builder.rs
+++ b/packages/many_cpus_impl/src/fake/builder.rs
@@ -14,7 +14,7 @@ pub(crate) struct ResolvedProcessor {
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
-    pub(crate) cpu_brand: Option<Arc<str>>,
+    pub(crate) brand: Option<Arc<str>>,
 }
 
 /// Builder for configuring fake hardware.
@@ -248,7 +248,7 @@ impl HardwareBuilder {
                 memory_region_id: p.memory_region_id,
                 efficiency_class: p.efficiency_class,
                 relative_speed: p.relative_speed,
-                cpu_brand: p.cpu_brand.clone(),
+                brand: p.brand.clone(),
             });
         }
 

--- a/packages/many_cpus_impl/src/fake/builder.rs
+++ b/packages/many_cpus_impl/src/fake/builder.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 use std::num::NonZero;
+use std::sync::Arc;
 
 use crate::fake::ProcessorBuilder;
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
@@ -13,6 +14,7 @@ pub(crate) struct ResolvedProcessor {
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
+    pub(crate) cpu_brand: Option<Arc<str>>,
 }
 
 /// Builder for configuring fake hardware.
@@ -246,6 +248,7 @@ impl HardwareBuilder {
                 memory_region_id: p.memory_region_id,
                 efficiency_class: p.efficiency_class,
                 relative_speed: p.relative_speed,
+                cpu_brand: p.cpu_brand.clone(),
             });
         }
 

--- a/packages/many_cpus_impl/src/fake/builder.rs
+++ b/packages/many_cpus_impl/src/fake/builder.rs
@@ -14,7 +14,7 @@ pub(crate) struct ResolvedProcessor {
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
-    pub(crate) brand: Option<Arc<str>>,
+    pub(crate) model: Option<Arc<str>>,
 }
 
 /// Builder for configuring fake hardware.
@@ -248,7 +248,7 @@ impl HardwareBuilder {
                 memory_region_id: p.memory_region_id,
                 efficiency_class: p.efficiency_class,
                 relative_speed: p.relative_speed,
-                brand: p.brand.clone(),
+                model: p.model.clone(),
             });
         }
 

--- a/packages/many_cpus_impl/src/fake/builder.rs
+++ b/packages/many_cpus_impl/src/fake/builder.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::num::NonZero;
 
 use crate::fake::ProcessorBuilder;
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A processor with a resolved ID, ready to be used by the backend.
 #[derive(Clone, Debug)]
@@ -12,6 +12,7 @@ pub(crate) struct ResolvedProcessor {
     pub(crate) id: ProcessorId,
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
+    pub(crate) relative_speed: RelativeSpeed,
 }
 
 /// Builder for configuring fake hardware.
@@ -244,6 +245,7 @@ impl HardwareBuilder {
                 id,
                 memory_region_id: p.memory_region_id,
                 efficiency_class: p.efficiency_class,
+                relative_speed: p.relative_speed,
             });
         }
 

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -23,7 +23,7 @@ pub(crate) struct FakeProcessor {
     memory_region_id: MemoryRegionId,
     efficiency_class: EfficiencyClass,
     relative_speed: RelativeSpeed,
-    cpu_brand: Option<Arc<str>>,
+    brand: Option<Arc<str>>,
 }
 
 impl Display for FakeProcessor {
@@ -31,11 +31,7 @@ impl Display for FakeProcessor {
         write!(
             f,
             "FakeProcessor({} in region {}, {:?}, speed {}, brand {:?})",
-            self.id,
-            self.memory_region_id,
-            self.efficiency_class,
-            self.relative_speed,
-            self.cpu_brand
+            self.id, self.memory_region_id, self.efficiency_class, self.relative_speed, self.brand
         )
     }
 }
@@ -47,14 +43,14 @@ impl FakeProcessor {
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
         relative_speed: RelativeSpeed,
-        cpu_brand: Option<Arc<str>>,
+        brand: Option<Arc<str>>,
     ) -> Self {
         Self {
             id,
             memory_region_id,
             efficiency_class,
             relative_speed,
-            cpu_brand,
+            brand,
         }
     }
 }
@@ -76,8 +72,8 @@ impl AbstractProcessor for FakeProcessor {
         self.relative_speed
     }
 
-    fn cpu_brand(&self) -> Option<&str> {
-        self.cpu_brand.as_deref()
+    fn brand(&self) -> Option<&str> {
+        self.brand.as_deref()
     }
 }
 
@@ -125,7 +121,7 @@ impl FakePlatform {
                     p.memory_region_id,
                     p.efficiency_class,
                     p.relative_speed,
-                    p.cpu_brand.clone(),
+                    p.brand.clone(),
                 )
             })
             .collect();
@@ -525,7 +521,7 @@ mod tests {
     }
 
     #[test]
-    fn fake_processor_cpu_brand_returns_configured_value() {
+    fn fake_processor_brand_returns_configured_value() {
         let with_brand = FakeProcessor::new(
             0,
             0,
@@ -541,8 +537,8 @@ mod tests {
             None,
         );
 
-        assert_eq!(with_brand.cpu_brand(), Some("Fake Brand"));
-        assert_eq!(without_brand.cpu_brand(), None);
+        assert_eq!(with_brand.brand(), Some("Fake Brand"));
+        assert_eq!(without_brand.brand(), None);
     }
 
     #[test]
@@ -561,14 +557,14 @@ mod tests {
     }
 
     #[test]
-    fn cpu_brand_flows_through_builder() {
+    fn brand_flows_through_builder() {
         let builder = HardwareBuilder::new()
-            .processor(ProcessorBuilder::new().id(0).cpu_brand("Configured Brand"))
+            .processor(ProcessorBuilder::new().id(0).brand("Configured Brand"))
             .processor(ProcessorBuilder::new().id(1));
         let backend = FakePlatform::from_builder(&builder);
 
         // Explicitly configured brand is preserved; the unconfigured one reports no brand.
-        assert_eq!(backend.processors[0].cpu_brand(), Some("Configured Brand"));
-        assert_eq!(backend.processors[1].cpu_brand(), None);
+        assert_eq!(backend.processors[0].brand(), Some("Configured Brand"));
+        assert_eq!(backend.processors[1].brand(), None);
     }
 }

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -17,7 +17,7 @@ use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 ///
 /// This is distinct from the test-only `FakeProcessor` in `pal/mocks.rs` because it needs
 /// to be available when `test-util` feature is enabled, not just in test mode.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct FakeProcessor {
     id: ProcessorId,
     memory_region_id: MemoryRegionId,

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -1,7 +1,7 @@
 //! Fake hardware backend implementation.
 
 use std::fmt::{self, Display};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::thread::ThreadId;
 
 use foldhash::{HashMap, HashMapExt};
@@ -17,12 +17,13 @@ use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 ///
 /// This is distinct from the test-only `FakeProcessor` in `pal/mocks.rs` because it needs
 /// to be available when `test-util` feature is enabled, not just in test mode.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct FakeProcessor {
     id: ProcessorId,
     memory_region_id: MemoryRegionId,
     efficiency_class: EfficiencyClass,
     relative_speed: RelativeSpeed,
+    cpu_brand: Option<Arc<str>>,
 }
 
 impl Display for FakeProcessor {
@@ -42,12 +43,14 @@ impl FakeProcessor {
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
         relative_speed: RelativeSpeed,
+        cpu_brand: Option<Arc<str>>,
     ) -> Self {
         Self {
             id,
             memory_region_id,
             efficiency_class,
             relative_speed,
+            cpu_brand,
         }
     }
 }
@@ -67,6 +70,10 @@ impl AbstractProcessor for FakeProcessor {
 
     fn relative_speed(&self) -> RelativeSpeed {
         self.relative_speed
+    }
+
+    fn cpu_brand(&self) -> Option<&str> {
+        self.cpu_brand.as_deref()
     }
 }
 
@@ -114,6 +121,7 @@ impl FakePlatform {
                     p.memory_region_id,
                     p.efficiency_class,
                     p.relative_speed,
+                    p.cpu_brand.clone(),
                 )
             })
             .collect();
@@ -199,7 +207,7 @@ impl Platform for FakePlatform {
         let facades: Vec<ProcessorFacade> = self
             .processors
             .iter()
-            .map(|p| ProcessorFacade::Fake(*p))
+            .map(|p| ProcessorFacade::Fake(p.clone()))
             .collect();
 
         NonEmpty::from_vec(facades).expect("at least one processor was configured")
@@ -368,13 +376,14 @@ mod tests {
 
         // Create a NonEmpty with a single processor facade.
         let processor = backend.get_all_processors().head;
+        let processor_id = processor.id();
         let processors = NonEmpty::singleton(processor);
 
         backend.pin_current_thread_to(&processors);
 
         // After pinning, current_processor_id should return the pinned processor.
         let id = backend.current_processor_id();
-        assert_eq!(id, processor.id());
+        assert_eq!(id, processor_id);
     }
 
     #[test]
@@ -395,8 +404,10 @@ mod tests {
         // Pin to processor 0 and 1.
         let all = backend.get_all_processors();
         let mut iter = all.iter();
-        let p0 = *iter.next().unwrap();
-        let p1 = *iter.next().unwrap();
+        let p0 = iter.next().unwrap().clone();
+        let p1 = iter.next().unwrap().clone();
+        let p0_id = p0.id();
+        let p1_id = p1.id();
         let pinned = NonEmpty::from((p0, vec![p1]));
 
         backend.pin_current_thread_to(&pinned);
@@ -404,8 +415,8 @@ mod tests {
         let thread_processors = backend.current_thread_processors();
 
         assert_eq!(thread_processors.len(), 2);
-        assert!(thread_processors.iter().any(|&id| id == p0.id()));
-        assert!(thread_processors.iter().any(|&id| id == p1.id()));
+        assert!(thread_processors.iter().any(|&id| id == p0_id));
+        assert!(thread_processors.iter().any(|&id| id == p1_id));
     }
 
     #[test]
@@ -415,9 +426,11 @@ mod tests {
 
         // Pin to processors 2 and 3 only.
         let all = backend.get_all_processors();
-        let processors_vec: Vec<_> = all.iter().copied().collect();
-        let p2 = processors_vec[2];
-        let p3 = processors_vec[3];
+        let processors_vec: Vec<_> = all.iter().cloned().collect();
+        let p2 = processors_vec[2].clone();
+        let p3 = processors_vec[3].clone();
+        let p2_id = p2.id();
+        let p3_id = p3.id();
         let pinned = NonEmpty::from((p2, vec![p3]));
 
         backend.pin_current_thread_to(&pinned);
@@ -425,7 +438,7 @@ mod tests {
         let id = backend.current_processor_id();
 
         // The returned ID must be one of the pinned processors.
-        assert!(id == p2.id() || id == p3.id());
+        assert!(id == p2_id || id == p3_id);
     }
 
     #[test]
@@ -435,6 +448,7 @@ mod tests {
             2,
             EfficiencyClass::Efficiency,
             RelativeSpeed::from_raw(3600),
+            None,
         );
 
         let display = format!("{processor}");
@@ -447,8 +461,20 @@ mod tests {
 
     #[test]
     fn fake_processor_efficiency_class_returns_configured_value() {
-        let perf = FakeProcessor::new(0, 0, EfficiencyClass::Performance, RelativeSpeed::SYNTHETIC);
-        let eff = FakeProcessor::new(1, 0, EfficiencyClass::Efficiency, RelativeSpeed::SYNTHETIC);
+        let perf = FakeProcessor::new(
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+            None,
+        );
+        let eff = FakeProcessor::new(
+            1,
+            0,
+            EfficiencyClass::Efficiency,
+            RelativeSpeed::SYNTHETIC,
+            None,
+        );
 
         assert_eq!(perf.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(eff.efficiency_class(), EfficiencyClass::Efficiency);
@@ -461,6 +487,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         assert_eq!(processor.id(), 42);
@@ -468,8 +495,13 @@ mod tests {
 
     #[test]
     fn fake_processor_memory_region_id_returns_configured_value() {
-        let processor =
-            FakeProcessor::new(0, 7, EfficiencyClass::Performance, RelativeSpeed::SYNTHETIC);
+        let processor = FakeProcessor::new(
+            0,
+            7,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+            None,
+        );
 
         assert_eq!(processor.memory_region_id(), 7);
     }
@@ -481,9 +513,31 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(2400),
+            None,
         );
 
-        assert_eq!(processor.relative_speed().as_u32(), 2400);
+        assert_eq!(processor.relative_speed().as_u64(), 2400);
+    }
+
+    #[test]
+    fn fake_processor_cpu_brand_returns_configured_value() {
+        let with_brand = FakeProcessor::new(
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+            Some(Arc::from("Fake Brand")),
+        );
+        let without_brand = FakeProcessor::new(
+            1,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+            None,
+        );
+
+        assert_eq!(with_brand.cpu_brand(), Some("Fake Brand"));
+        assert_eq!(without_brand.cpu_brand(), None);
     }
 
     #[test]
@@ -494,10 +548,22 @@ mod tests {
         let backend = FakePlatform::from_builder(&builder);
 
         // Explicitly configured speed is preserved; the unconfigured one falls back to synthetic.
-        assert_eq!(backend.processors[0].relative_speed().as_u32(), 1800);
+        assert_eq!(backend.processors[0].relative_speed().as_u64(), 1800);
         assert_eq!(
             backend.processors[1].relative_speed(),
             RelativeSpeed::SYNTHETIC
         );
+    }
+
+    #[test]
+    fn cpu_brand_flows_through_builder() {
+        let builder = HardwareBuilder::new()
+            .processor(ProcessorBuilder::new().id(0).cpu_brand("Configured Brand"))
+            .processor(ProcessorBuilder::new().id(1));
+        let backend = FakePlatform::from_builder(&builder);
+
+        // Explicitly configured brand is preserved; the unconfigured one reports no brand.
+        assert_eq!(backend.processors[0].cpu_brand(), Some("Configured Brand"));
+        assert_eq!(backend.processors[1].cpu_brand(), None);
     }
 }

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -30,8 +30,12 @@ impl Display for FakeProcessor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "FakeProcessor({} in region {}, {:?}, speed {})",
-            self.id, self.memory_region_id, self.efficiency_class, self.relative_speed
+            "FakeProcessor({} in region {}, {:?}, speed {}, brand {:?})",
+            self.id,
+            self.memory_region_id,
+            self.efficiency_class,
+            self.relative_speed,
+            self.cpu_brand
         )
     }
 }
@@ -448,7 +452,7 @@ mod tests {
             2,
             EfficiencyClass::Efficiency,
             RelativeSpeed::from_raw(3600),
-            None,
+            Some(Arc::from("Test Brand")),
         );
 
         let display = format!("{processor}");
@@ -457,6 +461,7 @@ mod tests {
         assert!(display.contains('2'));
         assert!(display.contains("Efficiency"));
         assert!(display.contains("3600"));
+        assert!(display.contains("Test Brand"));
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -23,15 +23,15 @@ pub(crate) struct FakeProcessor {
     memory_region_id: MemoryRegionId,
     efficiency_class: EfficiencyClass,
     relative_speed: RelativeSpeed,
-    brand: Option<Arc<str>>,
+    model: Option<Arc<str>>,
 }
 
 impl Display for FakeProcessor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "FakeProcessor({} in region {}, {:?}, speed {}, brand {:?})",
-            self.id, self.memory_region_id, self.efficiency_class, self.relative_speed, self.brand
+            "FakeProcessor({} in region {}, {:?}, speed {}, model {:?})",
+            self.id, self.memory_region_id, self.efficiency_class, self.relative_speed, self.model
         )
     }
 }
@@ -43,14 +43,14 @@ impl FakeProcessor {
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
         relative_speed: RelativeSpeed,
-        brand: Option<Arc<str>>,
+        model: Option<Arc<str>>,
     ) -> Self {
         Self {
             id,
             memory_region_id,
             efficiency_class,
             relative_speed,
-            brand,
+            model,
         }
     }
 }
@@ -72,8 +72,8 @@ impl AbstractProcessor for FakeProcessor {
         self.relative_speed
     }
 
-    fn brand(&self) -> Option<&str> {
-        self.brand.as_deref()
+    fn model(&self) -> Option<&str> {
+        self.model.as_deref()
     }
 }
 
@@ -121,7 +121,7 @@ impl FakePlatform {
                     p.memory_region_id,
                     p.efficiency_class,
                     p.relative_speed,
-                    p.brand.clone(),
+                    p.model.clone(),
                 )
             })
             .collect();
@@ -448,7 +448,7 @@ mod tests {
             2,
             EfficiencyClass::Efficiency,
             RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Test Brand")),
+            Some(Arc::from("Test Model")),
         );
 
         let display = format!("{processor}");
@@ -457,7 +457,7 @@ mod tests {
         assert!(display.contains('2'));
         assert!(display.contains("Efficiency"));
         assert!(display.contains("3600"));
-        assert!(display.contains("Test Brand"));
+        assert!(display.contains("Test Model"));
     }
 
     #[test]
@@ -521,15 +521,15 @@ mod tests {
     }
 
     #[test]
-    fn fake_processor_brand_returns_configured_value() {
-        let with_brand = FakeProcessor::new(
+    fn fake_processor_model_returns_configured_value() {
+        let with_model = FakeProcessor::new(
             0,
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
-            Some(Arc::from("Fake Brand")),
+            Some(Arc::from("Fake Model")),
         );
-        let without_brand = FakeProcessor::new(
+        let without_model = FakeProcessor::new(
             1,
             0,
             EfficiencyClass::Performance,
@@ -537,8 +537,8 @@ mod tests {
             None,
         );
 
-        assert_eq!(with_brand.brand(), Some("Fake Brand"));
-        assert_eq!(without_brand.brand(), None);
+        assert_eq!(with_model.model(), Some("Fake Model"));
+        assert_eq!(without_model.model(), None);
     }
 
     #[test]
@@ -557,14 +557,14 @@ mod tests {
     }
 
     #[test]
-    fn brand_flows_through_builder() {
+    fn model_flows_through_builder() {
         let builder = HardwareBuilder::new()
-            .processor(ProcessorBuilder::new().id(0).brand("Configured Brand"))
+            .processor(ProcessorBuilder::new().id(0).model("Configured Model"))
             .processor(ProcessorBuilder::new().id(1));
         let backend = FakePlatform::from_builder(&builder);
 
-        // Explicitly configured brand is preserved; the unconfigured one reports no brand.
-        assert_eq!(backend.processors[0].brand(), Some("Configured Brand"));
-        assert_eq!(backend.processors[1].brand(), None);
+        // Explicitly configured model is preserved; the unconfigured one reports no model.
+        assert_eq!(backend.processors[0].model(), Some("Configured Model"));
+        assert_eq!(backend.processors[1].model(), None);
     }
 }

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -466,14 +466,14 @@ mod tests {
             0,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
         let eff = FakeProcessor::new(
             1,
             0,
             EfficiencyClass::Efficiency,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -487,7 +487,7 @@ mod tests {
             42,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -500,7 +500,7 @@ mod tests {
             0,
             7,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -526,14 +526,14 @@ mod tests {
             0,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             Some(Arc::from("Fake Model")),
         );
         let without_model = FakeProcessor::new(
             1,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -548,11 +548,11 @@ mod tests {
             .processor(ProcessorBuilder::new().id(1));
         let backend = FakePlatform::from_builder(&builder);
 
-        // Explicitly configured speed is preserved; the unconfigured one falls back to synthetic.
+        // Explicitly configured speed is preserved; the unconfigured one uses the default of 1.
         assert_eq!(backend.processors[0].relative_speed().as_u64(), 1800);
         assert_eq!(
             backend.processors[1].relative_speed(),
-            RelativeSpeed::SYNTHETIC
+            RelativeSpeed::from_raw(1)
         );
     }
 

--- a/packages/many_cpus_impl/src/fake/platform.rs
+++ b/packages/many_cpus_impl/src/fake/platform.rs
@@ -11,7 +11,7 @@ use rand::rng;
 
 use crate::fake::HardwareBuilder;
 use crate::pal::{AbstractProcessor, Platform, ProcessorFacade};
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A fake processor for use in fake hardware.
 ///
@@ -22,14 +22,15 @@ pub(crate) struct FakeProcessor {
     id: ProcessorId,
     memory_region_id: MemoryRegionId,
     efficiency_class: EfficiencyClass,
+    relative_speed: RelativeSpeed,
 }
 
 impl Display for FakeProcessor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "FakeProcessor({} in region {}, {:?})",
-            self.id, self.memory_region_id, self.efficiency_class
+            "FakeProcessor({} in region {}, {:?}, speed {})",
+            self.id, self.memory_region_id, self.efficiency_class, self.relative_speed
         )
     }
 }
@@ -40,11 +41,13 @@ impl FakeProcessor {
         id: ProcessorId,
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
+        relative_speed: RelativeSpeed,
     ) -> Self {
         Self {
             id,
             memory_region_id,
             efficiency_class,
+            relative_speed,
         }
     }
 }
@@ -60,6 +63,10 @@ impl AbstractProcessor for FakeProcessor {
 
     fn efficiency_class(&self) -> EfficiencyClass {
         self.efficiency_class
+    }
+
+    fn relative_speed(&self) -> RelativeSpeed {
+        self.relative_speed
     }
 }
 
@@ -101,7 +108,14 @@ impl FakePlatform {
 
         let processors: Vec<FakeProcessor> = configured_processors
             .iter()
-            .map(|p| FakeProcessor::new(p.id, p.memory_region_id, p.efficiency_class))
+            .map(|p| {
+                FakeProcessor::new(
+                    p.id,
+                    p.memory_region_id,
+                    p.efficiency_class,
+                    p.relative_speed,
+                )
+            })
             .collect();
 
         let max_processor_id = processors.iter().map(|p| p.id).max().unwrap_or(0);
@@ -416,19 +430,25 @@ mod tests {
 
     #[test]
     fn fake_processor_display_includes_all_fields() {
-        let processor = FakeProcessor::new(5, 2, EfficiencyClass::Efficiency);
+        let processor = FakeProcessor::new(
+            5,
+            2,
+            EfficiencyClass::Efficiency,
+            RelativeSpeed::from_raw(3600),
+        );
 
         let display = format!("{processor}");
 
         assert!(display.contains('5'));
         assert!(display.contains('2'));
         assert!(display.contains("Efficiency"));
+        assert!(display.contains("3600"));
     }
 
     #[test]
     fn fake_processor_efficiency_class_returns_configured_value() {
-        let perf = FakeProcessor::new(0, 0, EfficiencyClass::Performance);
-        let eff = FakeProcessor::new(1, 0, EfficiencyClass::Efficiency);
+        let perf = FakeProcessor::new(0, 0, EfficiencyClass::Performance, RelativeSpeed::SYNTHETIC);
+        let eff = FakeProcessor::new(1, 0, EfficiencyClass::Efficiency, RelativeSpeed::SYNTHETIC);
 
         assert_eq!(perf.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(eff.efficiency_class(), EfficiencyClass::Efficiency);
@@ -436,15 +456,48 @@ mod tests {
 
     #[test]
     fn fake_processor_id_returns_configured_value() {
-        let processor = FakeProcessor::new(42, 0, EfficiencyClass::Performance);
+        let processor = FakeProcessor::new(
+            42,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         assert_eq!(processor.id(), 42);
     }
 
     #[test]
     fn fake_processor_memory_region_id_returns_configured_value() {
-        let processor = FakeProcessor::new(0, 7, EfficiencyClass::Performance);
+        let processor =
+            FakeProcessor::new(0, 7, EfficiencyClass::Performance, RelativeSpeed::SYNTHETIC);
 
         assert_eq!(processor.memory_region_id(), 7);
+    }
+
+    #[test]
+    fn fake_processor_relative_speed_returns_configured_value() {
+        let processor = FakeProcessor::new(
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(2400),
+        );
+
+        assert_eq!(processor.relative_speed().as_u32(), 2400);
+    }
+
+    #[test]
+    fn relative_speed_flows_through_builder() {
+        let builder = HardwareBuilder::new()
+            .processor(ProcessorBuilder::new().id(0).relative_speed(nz!(1800)))
+            .processor(ProcessorBuilder::new().id(1));
+        let backend = FakePlatform::from_builder(&builder);
+
+        // Explicitly configured speed is preserved; the unconfigured one falls back to synthetic.
+        assert_eq!(backend.processors[0].relative_speed().as_u32(), 1800);
+        assert_eq!(
+            backend.processors[1].relative_speed(),
+            RelativeSpeed::SYNTHETIC
+        );
     }
 }

--- a/packages/many_cpus_impl/src/fake/processor_builder.rs
+++ b/packages/many_cpus_impl/src/fake/processor_builder.rs
@@ -1,11 +1,14 @@
 //! Builder for configuring individual fake processors.
 
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use std::num::NonZero;
+
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// Builder for configuring an individual fake processor.
 ///
-/// Each fake processor has an ID, a memory region, and an efficiency class.
-/// By default, processors are placed in memory region 0 with [`EfficiencyClass::Performance`].
+/// Each fake processor has an ID, a memory region, an efficiency class and a relative speed.
+/// By default, processors are placed in memory region 0 with [`EfficiencyClass::Performance`]
+/// and the synthetic minimum relative speed.
 ///
 /// Processor IDs are assigned automatically by default. If you need a specific ID,
 /// use [`id()`][Self::id] to set it explicitly.
@@ -29,6 +32,7 @@ pub struct ProcessorBuilder {
     pub(crate) explicit_id: Option<ProcessorId>,
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
+    pub(crate) relative_speed: RelativeSpeed,
 }
 
 impl Default for ProcessorBuilder {
@@ -40,15 +44,16 @@ impl Default for ProcessorBuilder {
 impl ProcessorBuilder {
     /// Creates a new processor builder with automatic ID assignment.
     ///
-    /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`] by default.
-    /// The ID will be automatically assigned when the processor is added to a
-    /// [`HardwareBuilder`][super::HardwareBuilder].
+    /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`] and the
+    /// synthetic minimum relative speed by default. The ID will be automatically assigned when the
+    /// processor is added to a [`HardwareBuilder`][super::HardwareBuilder].
     #[must_use]
     pub fn new() -> Self {
         Self {
             explicit_id: None,
             memory_region_id: 0,
             efficiency_class: EfficiencyClass::Performance,
+            relative_speed: RelativeSpeed::SYNTHETIC,
         }
     }
 
@@ -80,6 +85,15 @@ impl ProcessorBuilder {
         self.efficiency_class = efficiency_class;
         self
     }
+
+    /// Sets the [relative speed][RelativeSpeed] reported for this processor.
+    ///
+    /// If not called, the processor reports the synthetic minimum relative speed.
+    #[must_use]
+    pub fn relative_speed(mut self, relative_speed: NonZero<u32>) -> Self {
+        self.relative_speed = RelativeSpeed::from_raw(relative_speed.get());
+        self
+    }
 }
 
 #[cfg(test)]
@@ -87,6 +101,7 @@ impl ProcessorBuilder {
 mod tests {
     use std::panic::{RefUnwindSafe, UnwindSafe};
 
+    use new_zealand::nz;
     use static_assertions::assert_impl_all;
 
     use super::*;
@@ -107,6 +122,7 @@ mod tests {
             default_builder.efficiency_class,
             new_builder.efficiency_class
         );
+        assert_eq!(default_builder.relative_speed, new_builder.relative_speed);
     }
 
     #[test]
@@ -116,6 +132,7 @@ mod tests {
         assert_eq!(builder.explicit_id, None);
         assert_eq!(builder.memory_region_id, 0);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Performance);
+        assert_eq!(builder.relative_speed, RelativeSpeed::SYNTHETIC);
     }
 
     #[test]
@@ -126,14 +143,23 @@ mod tests {
     }
 
     #[test]
+    fn relative_speed_is_respected() {
+        let builder = ProcessorBuilder::new().relative_speed(nz!(3600));
+
+        assert_eq!(builder.relative_speed.as_u32(), 3600);
+    }
+
+    #[test]
     fn builder_chaining() {
         let builder = ProcessorBuilder::new()
             .id(3)
             .memory_region(2)
-            .efficiency_class(EfficiencyClass::Efficiency);
+            .efficiency_class(EfficiencyClass::Efficiency)
+            .relative_speed(nz!(2400));
 
         assert_eq!(builder.explicit_id, Some(3));
         assert_eq!(builder.memory_region_id, 2);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Efficiency);
+        assert_eq!(builder.relative_speed.as_u32(), 2400);
     }
 }

--- a/packages/many_cpus_impl/src/fake/processor_builder.rs
+++ b/packages/many_cpus_impl/src/fake/processor_builder.rs
@@ -55,7 +55,7 @@ impl ProcessorBuilder {
             explicit_id: None,
             memory_region_id: 0,
             efficiency_class: EfficiencyClass::Performance,
-            relative_speed: RelativeSpeed::SYNTHETIC,
+            relative_speed: RelativeSpeed::from_raw(1),
             model: None,
         }
     }
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(builder.explicit_id, None);
         assert_eq!(builder.memory_region_id, 0);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Performance);
-        assert_eq!(builder.relative_speed, RelativeSpeed::SYNTHETIC);
+        assert_eq!(builder.relative_speed, RelativeSpeed::from_raw(1));
         assert_eq!(builder.model, None);
     }
 

--- a/packages/many_cpus_impl/src/fake/processor_builder.rs
+++ b/packages/many_cpus_impl/src/fake/processor_builder.rs
@@ -8,8 +8,8 @@ use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 /// Builder for configuring an individual fake processor.
 ///
 /// Each fake processor has an ID, a memory region, an efficiency class, a relative speed and an
-/// optional CPU brand string. By default, processors are placed in memory region 0 with
-/// [`EfficiencyClass::Performance`], the synthetic minimum relative speed and no CPU brand.
+/// optional brand string. By default, processors are placed in memory region 0 with
+/// [`EfficiencyClass::Performance`], the synthetic minimum relative speed and no brand.
 ///
 /// Processor IDs are assigned automatically by default. If you need a specific ID,
 /// use [`id()`][Self::id] to set it explicitly.
@@ -34,7 +34,7 @@ pub struct ProcessorBuilder {
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
-    pub(crate) cpu_brand: Option<Arc<str>>,
+    pub(crate) brand: Option<Arc<str>>,
 }
 
 impl Default for ProcessorBuilder {
@@ -47,7 +47,7 @@ impl ProcessorBuilder {
     /// Creates a new processor builder with automatic ID assignment.
     ///
     /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`], the
-    /// synthetic minimum relative speed and no CPU brand by default. The ID will be automatically
+    /// synthetic minimum relative speed and no brand by default. The ID will be automatically
     /// assigned when the processor is added to a [`HardwareBuilder`][super::HardwareBuilder].
     #[must_use]
     pub fn new() -> Self {
@@ -56,7 +56,7 @@ impl ProcessorBuilder {
             memory_region_id: 0,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::SYNTHETIC,
-            cpu_brand: None,
+            brand: None,
         }
     }
 
@@ -98,12 +98,12 @@ impl ProcessorBuilder {
         self
     }
 
-    /// Sets the CPU brand string reported for this processor.
+    /// Sets the brand string reported for this processor.
     ///
-    /// If not called, the processor reports no CPU brand.
+    /// If not called, the processor reports no brand.
     #[must_use]
-    pub fn cpu_brand(mut self, cpu_brand: &str) -> Self {
-        self.cpu_brand = Some(Arc::from(cpu_brand));
+    pub fn brand(mut self, brand: &str) -> Self {
+        self.brand = Some(Arc::from(brand));
         self
     }
 }
@@ -135,7 +135,7 @@ mod tests {
             new_builder.efficiency_class
         );
         assert_eq!(default_builder.relative_speed, new_builder.relative_speed);
-        assert_eq!(default_builder.cpu_brand, new_builder.cpu_brand);
+        assert_eq!(default_builder.brand, new_builder.brand);
     }
 
     #[test]
@@ -146,7 +146,7 @@ mod tests {
         assert_eq!(builder.memory_region_id, 0);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Performance);
         assert_eq!(builder.relative_speed, RelativeSpeed::SYNTHETIC);
-        assert_eq!(builder.cpu_brand, None);
+        assert_eq!(builder.brand, None);
     }
 
     #[test]
@@ -164,10 +164,10 @@ mod tests {
     }
 
     #[test]
-    fn cpu_brand_is_respected() {
-        let builder = ProcessorBuilder::new().cpu_brand("Example Brand");
+    fn brand_is_respected() {
+        let builder = ProcessorBuilder::new().brand("Example Brand");
 
-        assert_eq!(builder.cpu_brand.as_deref(), Some("Example Brand"));
+        assert_eq!(builder.brand.as_deref(), Some("Example Brand"));
     }
 
     #[test]
@@ -177,12 +177,12 @@ mod tests {
             .memory_region(2)
             .efficiency_class(EfficiencyClass::Efficiency)
             .relative_speed(nz!(2400))
-            .cpu_brand("Chained Brand");
+            .brand("Chained Brand");
 
         assert_eq!(builder.explicit_id, Some(3));
         assert_eq!(builder.memory_region_id, 2);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Efficiency);
         assert_eq!(builder.relative_speed.as_u64(), 2400);
-        assert_eq!(builder.cpu_brand.as_deref(), Some("Chained Brand"));
+        assert_eq!(builder.brand.as_deref(), Some("Chained Brand"));
     }
 }

--- a/packages/many_cpus_impl/src/fake/processor_builder.rs
+++ b/packages/many_cpus_impl/src/fake/processor_builder.rs
@@ -1,14 +1,15 @@
 //! Builder for configuring individual fake processors.
 
 use std::num::NonZero;
+use std::sync::Arc;
 
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// Builder for configuring an individual fake processor.
 ///
-/// Each fake processor has an ID, a memory region, an efficiency class and a relative speed.
-/// By default, processors are placed in memory region 0 with [`EfficiencyClass::Performance`]
-/// and the synthetic minimum relative speed.
+/// Each fake processor has an ID, a memory region, an efficiency class, a relative speed and an
+/// optional CPU brand string. By default, processors are placed in memory region 0 with
+/// [`EfficiencyClass::Performance`], the synthetic minimum relative speed and no CPU brand.
 ///
 /// Processor IDs are assigned automatically by default. If you need a specific ID,
 /// use [`id()`][Self::id] to set it explicitly.
@@ -33,6 +34,7 @@ pub struct ProcessorBuilder {
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
+    pub(crate) cpu_brand: Option<Arc<str>>,
 }
 
 impl Default for ProcessorBuilder {
@@ -44,9 +46,9 @@ impl Default for ProcessorBuilder {
 impl ProcessorBuilder {
     /// Creates a new processor builder with automatic ID assignment.
     ///
-    /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`] and the
-    /// synthetic minimum relative speed by default. The ID will be automatically assigned when the
-    /// processor is added to a [`HardwareBuilder`][super::HardwareBuilder].
+    /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`], the
+    /// synthetic minimum relative speed and no CPU brand by default. The ID will be automatically
+    /// assigned when the processor is added to a [`HardwareBuilder`][super::HardwareBuilder].
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -54,6 +56,7 @@ impl ProcessorBuilder {
             memory_region_id: 0,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::SYNTHETIC,
+            cpu_brand: None,
         }
     }
 
@@ -90,8 +93,17 @@ impl ProcessorBuilder {
     ///
     /// If not called, the processor reports the synthetic minimum relative speed.
     #[must_use]
-    pub fn relative_speed(mut self, relative_speed: NonZero<u32>) -> Self {
+    pub fn relative_speed(mut self, relative_speed: NonZero<u64>) -> Self {
         self.relative_speed = RelativeSpeed::from_raw(relative_speed.get());
+        self
+    }
+
+    /// Sets the CPU brand string reported for this processor.
+    ///
+    /// If not called, the processor reports no CPU brand.
+    #[must_use]
+    pub fn cpu_brand(mut self, cpu_brand: &str) -> Self {
+        self.cpu_brand = Some(Arc::from(cpu_brand));
         self
     }
 }
@@ -123,6 +135,7 @@ mod tests {
             new_builder.efficiency_class
         );
         assert_eq!(default_builder.relative_speed, new_builder.relative_speed);
+        assert_eq!(default_builder.cpu_brand, new_builder.cpu_brand);
     }
 
     #[test]
@@ -133,6 +146,7 @@ mod tests {
         assert_eq!(builder.memory_region_id, 0);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Performance);
         assert_eq!(builder.relative_speed, RelativeSpeed::SYNTHETIC);
+        assert_eq!(builder.cpu_brand, None);
     }
 
     #[test]
@@ -146,7 +160,14 @@ mod tests {
     fn relative_speed_is_respected() {
         let builder = ProcessorBuilder::new().relative_speed(nz!(3600));
 
-        assert_eq!(builder.relative_speed.as_u32(), 3600);
+        assert_eq!(builder.relative_speed.as_u64(), 3600);
+    }
+
+    #[test]
+    fn cpu_brand_is_respected() {
+        let builder = ProcessorBuilder::new().cpu_brand("Example Brand");
+
+        assert_eq!(builder.cpu_brand.as_deref(), Some("Example Brand"));
     }
 
     #[test]
@@ -155,11 +176,13 @@ mod tests {
             .id(3)
             .memory_region(2)
             .efficiency_class(EfficiencyClass::Efficiency)
-            .relative_speed(nz!(2400));
+            .relative_speed(nz!(2400))
+            .cpu_brand("Chained Brand");
 
         assert_eq!(builder.explicit_id, Some(3));
         assert_eq!(builder.memory_region_id, 2);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Efficiency);
-        assert_eq!(builder.relative_speed.as_u32(), 2400);
+        assert_eq!(builder.relative_speed.as_u64(), 2400);
+        assert_eq!(builder.cpu_brand.as_deref(), Some("Chained Brand"));
     }
 }

--- a/packages/many_cpus_impl/src/fake/processor_builder.rs
+++ b/packages/many_cpus_impl/src/fake/processor_builder.rs
@@ -8,8 +8,8 @@ use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 /// Builder for configuring an individual fake processor.
 ///
 /// Each fake processor has an ID, a memory region, an efficiency class, a relative speed and an
-/// optional brand string. By default, processors are placed in memory region 0 with
-/// [`EfficiencyClass::Performance`], the synthetic minimum relative speed and no brand.
+/// optional model string. By default, processors are placed in memory region 0 with
+/// [`EfficiencyClass::Performance`], a relative speed of 1 and no model.
 ///
 /// Processor IDs are assigned automatically by default. If you need a specific ID,
 /// use [`id()`][Self::id] to set it explicitly.
@@ -34,7 +34,7 @@ pub struct ProcessorBuilder {
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
-    pub(crate) brand: Option<Arc<str>>,
+    pub(crate) model: Option<Arc<str>>,
 }
 
 impl Default for ProcessorBuilder {
@@ -46,8 +46,8 @@ impl Default for ProcessorBuilder {
 impl ProcessorBuilder {
     /// Creates a new processor builder with automatic ID assignment.
     ///
-    /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`], the
-    /// synthetic minimum relative speed and no brand by default. The ID will be automatically
+    /// The processor is placed in memory region 0 with [`EfficiencyClass::Performance`], a
+    /// relative speed of 1 and no model by default. The ID will be automatically
     /// assigned when the processor is added to a [`HardwareBuilder`][super::HardwareBuilder].
     #[must_use]
     pub fn new() -> Self {
@@ -56,7 +56,7 @@ impl ProcessorBuilder {
             memory_region_id: 0,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::SYNTHETIC,
-            brand: None,
+            model: None,
         }
     }
 
@@ -91,19 +91,19 @@ impl ProcessorBuilder {
 
     /// Sets the [relative speed][RelativeSpeed] reported for this processor.
     ///
-    /// If not called, the processor reports the synthetic minimum relative speed.
+    /// If not called, the processor reports a relative speed of 1.
     #[must_use]
     pub fn relative_speed(mut self, relative_speed: NonZero<u64>) -> Self {
         self.relative_speed = RelativeSpeed::from_raw(relative_speed.get());
         self
     }
 
-    /// Sets the brand string reported for this processor.
+    /// Sets the model string reported for this processor.
     ///
-    /// If not called, the processor reports no brand.
+    /// If not called, the processor reports no model.
     #[must_use]
-    pub fn brand(mut self, brand: &str) -> Self {
-        self.brand = Some(Arc::from(brand));
+    pub fn model(mut self, model: &str) -> Self {
+        self.model = Some(Arc::from(model));
         self
     }
 }
@@ -135,7 +135,7 @@ mod tests {
             new_builder.efficiency_class
         );
         assert_eq!(default_builder.relative_speed, new_builder.relative_speed);
-        assert_eq!(default_builder.brand, new_builder.brand);
+        assert_eq!(default_builder.model, new_builder.model);
     }
 
     #[test]
@@ -146,7 +146,7 @@ mod tests {
         assert_eq!(builder.memory_region_id, 0);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Performance);
         assert_eq!(builder.relative_speed, RelativeSpeed::SYNTHETIC);
-        assert_eq!(builder.brand, None);
+        assert_eq!(builder.model, None);
     }
 
     #[test]
@@ -164,10 +164,10 @@ mod tests {
     }
 
     #[test]
-    fn brand_is_respected() {
-        let builder = ProcessorBuilder::new().brand("Example Brand");
+    fn model_is_respected() {
+        let builder = ProcessorBuilder::new().model("Example Model");
 
-        assert_eq!(builder.brand.as_deref(), Some("Example Brand"));
+        assert_eq!(builder.model.as_deref(), Some("Example Model"));
     }
 
     #[test]
@@ -177,12 +177,12 @@ mod tests {
             .memory_region(2)
             .efficiency_class(EfficiencyClass::Efficiency)
             .relative_speed(nz!(2400))
-            .brand("Chained Brand");
+            .model("Chained Model");
 
         assert_eq!(builder.explicit_id, Some(3));
         assert_eq!(builder.memory_region_id, 2);
         assert_eq!(builder.efficiency_class, EfficiencyClass::Efficiency);
         assert_eq!(builder.relative_speed.as_u64(), 2400);
-        assert_eq!(builder.brand.as_deref(), Some("Chained Brand"));
+        assert_eq!(builder.model.as_deref(), Some("Chained Model"));
     }
 }

--- a/packages/many_cpus_impl/src/pal/abstractions/processor.rs
+++ b/packages/many_cpus_impl/src/pal/abstractions/processor.rs
@@ -4,10 +4,14 @@ use std::hash::Hash;
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 pub(crate) trait AbstractProcessor:
-    Clone + Copy + Debug + Display + Eq + Hash + PartialEq + Send
+    Clone + Debug + Display + Eq + Hash + PartialEq + Send
 {
     fn id(&self) -> ProcessorId;
     fn memory_region_id(&self) -> MemoryRegionId;
     fn efficiency_class(&self) -> EfficiencyClass;
     fn relative_speed(&self) -> RelativeSpeed;
+
+    /// The best-effort CPU brand string of the processor, or `None` when the platform does not
+    /// report one.
+    fn cpu_brand(&self) -> Option<&str>;
 }

--- a/packages/many_cpus_impl/src/pal/abstractions/processor.rs
+++ b/packages/many_cpus_impl/src/pal/abstractions/processor.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 pub(crate) trait AbstractProcessor:
     Clone + Copy + Debug + Display + Eq + Hash + PartialEq + Send
@@ -9,4 +9,5 @@ pub(crate) trait AbstractProcessor:
     fn id(&self) -> ProcessorId;
     fn memory_region_id(&self) -> MemoryRegionId;
     fn efficiency_class(&self) -> EfficiencyClass;
+    fn relative_speed(&self) -> RelativeSpeed;
 }

--- a/packages/many_cpus_impl/src/pal/abstractions/processor.rs
+++ b/packages/many_cpus_impl/src/pal/abstractions/processor.rs
@@ -11,7 +11,7 @@ pub(crate) trait AbstractProcessor:
     fn efficiency_class(&self) -> EfficiencyClass;
     fn relative_speed(&self) -> RelativeSpeed;
 
-    /// The best-effort brand string of the processor, or `None` when the platform does not
+    /// The best-effort model string of the processor, or `None` when the platform does not
     /// report one.
-    fn brand(&self) -> Option<&str>;
+    fn model(&self) -> Option<&str>;
 }

--- a/packages/many_cpus_impl/src/pal/abstractions/processor.rs
+++ b/packages/many_cpus_impl/src/pal/abstractions/processor.rs
@@ -1,17 +1,13 @@
 use std::fmt::{Debug, Display};
-use std::hash::Hash;
 
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
-pub(crate) trait AbstractProcessor:
-    Clone + Debug + Display + Eq + Hash + PartialEq + Send
-{
+pub(crate) trait AbstractProcessor: Clone + Debug + Display + Send {
     fn id(&self) -> ProcessorId;
     fn memory_region_id(&self) -> MemoryRegionId;
     fn efficiency_class(&self) -> EfficiencyClass;
     fn relative_speed(&self) -> RelativeSpeed;
 
-    /// The best-effort model string of the processor, or `None` when the platform does not
-    /// report one.
+    /// The model name of the processor, or `None` when the platform does not report one.
     fn model(&self) -> Option<&str>;
 }

--- a/packages/many_cpus_impl/src/pal/abstractions/processor.rs
+++ b/packages/many_cpus_impl/src/pal/abstractions/processor.rs
@@ -11,7 +11,7 @@ pub(crate) trait AbstractProcessor:
     fn efficiency_class(&self) -> EfficiencyClass;
     fn relative_speed(&self) -> RelativeSpeed;
 
-    /// The best-effort CPU brand string of the processor, or `None` when the platform does not
+    /// The best-effort brand string of the processor, or `None` when the platform does not
     /// report one.
-    fn cpu_brand(&self) -> Option<&str>;
+    fn brand(&self) -> Option<&str>;
 }

--- a/packages/many_cpus_impl/src/pal/facade/processor.rs
+++ b/packages/many_cpus_impl/src/pal/facade/processor.rs
@@ -84,13 +84,13 @@ impl AbstractProcessor for ProcessorFacade {
         }
     }
 
-    fn brand(&self) -> Option<&str> {
+    fn model(&self) -> Option<&str> {
         match self {
-            Self::Target(p) => p.brand(),
+            Self::Target(p) => p.model(),
             #[cfg(test)]
-            Self::Fallback(p) => p.brand(),
+            Self::Fallback(p) => p.model(),
             #[cfg(any(test, feature = "test-util"))]
-            Self::Fake(p) => p.brand(),
+            Self::Fake(p) => p.model(),
         }
     }
 }

--- a/packages/many_cpus_impl/src/pal/facade/processor.rs
+++ b/packages/many_cpus_impl/src/pal/facade/processor.rs
@@ -84,13 +84,13 @@ impl AbstractProcessor for ProcessorFacade {
         }
     }
 
-    fn cpu_brand(&self) -> Option<&str> {
+    fn brand(&self) -> Option<&str> {
         match self {
-            Self::Target(p) => p.cpu_brand(),
+            Self::Target(p) => p.brand(),
             #[cfg(test)]
-            Self::Fallback(p) => p.cpu_brand(),
+            Self::Fallback(p) => p.brand(),
             #[cfg(any(test, feature = "test-util"))]
-            Self::Fake(p) => p.cpu_brand(),
+            Self::Fake(p) => p.brand(),
         }
     }
 }

--- a/packages/many_cpus_impl/src/pal/facade/processor.rs
+++ b/packages/many_cpus_impl/src/pal/facade/processor.rs
@@ -10,7 +10,7 @@ use crate::fake::platform::FakeProcessor;
 use crate::pal::fallback::ProcessorImpl as FallbackProcessor;
 use crate::pal::{AbstractProcessor, ProcessorImpl};
 
-#[derive(Clone, Copy, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Display, Eq, Hash, PartialEq)]
 pub(crate) enum ProcessorFacade {
     Target(ProcessorImpl),
 
@@ -81,6 +81,16 @@ impl AbstractProcessor for ProcessorFacade {
             Self::Fallback(p) => p.relative_speed(),
             #[cfg(any(test, feature = "test-util"))]
             Self::Fake(p) => p.relative_speed(),
+        }
+    }
+
+    fn cpu_brand(&self) -> Option<&str> {
+        match self {
+            Self::Target(p) => p.cpu_brand(),
+            #[cfg(test)]
+            Self::Fallback(p) => p.cpu_brand(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::Fake(p) => p.cpu_brand(),
         }
     }
 }

--- a/packages/many_cpus_impl/src/pal/facade/processor.rs
+++ b/packages/many_cpus_impl/src/pal/facade/processor.rs
@@ -10,7 +10,7 @@ use crate::fake::platform::FakeProcessor;
 use crate::pal::fallback::ProcessorImpl as FallbackProcessor;
 use crate::pal::{AbstractProcessor, ProcessorImpl};
 
-#[derive(Clone, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Display)]
 pub(crate) enum ProcessorFacade {
     Target(ProcessorImpl),
 

--- a/packages/many_cpus_impl/src/pal/facade/processor.rs
+++ b/packages/many_cpus_impl/src/pal/facade/processor.rs
@@ -73,6 +73,16 @@ impl AbstractProcessor for ProcessorFacade {
             Self::Fake(p) => p.efficiency_class(),
         }
     }
+
+    fn relative_speed(&self) -> crate::RelativeSpeed {
+        match self {
+            Self::Target(p) => p.relative_speed(),
+            #[cfg(test)]
+            Self::Fallback(p) => p.relative_speed(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::Fake(p) => p.relative_speed(),
+        }
+    }
 }
 
 impl From<ProcessorImpl> for ProcessorFacade {

--- a/packages/many_cpus_impl/src/pal/fallback/platform.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/platform.rs
@@ -222,10 +222,10 @@ mod tests {
     }
 
     #[test]
-    fn all_processors_have_synthetic_relative_speed() {
+    fn all_processors_have_fallback_relative_speed() {
         let platform = BuildTargetPlatform;
         for processor in platform.get_processors().iter() {
-            assert_eq!(processor.relative_speed(), RelativeSpeed::SYNTHETIC);
+            assert_eq!(processor.relative_speed(), RelativeSpeed::undetermined());
         }
     }
 

--- a/packages/many_cpus_impl/src/pal/fallback/platform.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/platform.rs
@@ -230,10 +230,10 @@ mod tests {
     }
 
     #[test]
-    fn no_processor_has_a_cpu_brand() {
+    fn no_processor_has_a_brand() {
         let platform = BuildTargetPlatform;
         for processor in platform.get_processors().iter() {
-            assert_eq!(processor.cpu_brand(), None);
+            assert_eq!(processor.brand(), None);
         }
     }
 

--- a/packages/many_cpus_impl/src/pal/fallback/platform.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/platform.rs
@@ -230,10 +230,10 @@ mod tests {
     }
 
     #[test]
-    fn no_processor_has_a_brand() {
+    fn no_processor_has_a_model() {
         let platform = BuildTargetPlatform;
         for processor in platform.get_processors().iter() {
-            assert_eq!(processor.brand(), None);
+            assert_eq!(processor.model(), None);
         }
     }
 

--- a/packages/many_cpus_impl/src/pal/fallback/platform.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/platform.rs
@@ -196,7 +196,7 @@ impl Platform for BuildTargetPlatform {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::EfficiencyClass;
+    use crate::{EfficiencyClass, RelativeSpeed};
 
     #[test]
     fn has_at_least_one_processor() {
@@ -218,6 +218,14 @@ mod tests {
         let platform = BuildTargetPlatform;
         for processor in platform.get_processors().iter() {
             assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
+        }
+    }
+
+    #[test]
+    fn all_processors_have_synthetic_relative_speed() {
+        let platform = BuildTargetPlatform;
+        for processor in platform.get_processors().iter() {
+            assert_eq!(processor.relative_speed(), RelativeSpeed::SYNTHETIC);
         }
     }
 

--- a/packages/many_cpus_impl/src/pal/fallback/platform.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/platform.rs
@@ -225,7 +225,7 @@ mod tests {
     fn all_processors_have_fallback_relative_speed() {
         let platform = BuildTargetPlatform;
         for processor in platform.get_processors().iter() {
-            assert_eq!(processor.relative_speed(), RelativeSpeed::undetermined());
+            assert_eq!(processor.relative_speed(), RelativeSpeed::UNDETERMINED);
         }
     }
 

--- a/packages/many_cpus_impl/src/pal/fallback/platform.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/platform.rs
@@ -230,6 +230,14 @@ mod tests {
     }
 
     #[test]
+    fn no_processor_has_a_cpu_brand() {
+        let platform = BuildTargetPlatform;
+        for processor in platform.get_processors().iter() {
+            assert_eq!(processor.cpu_brand(), None);
+        }
+    }
+
+    #[test]
     fn processor_ids_are_sequential() {
         let platform = BuildTargetPlatform;
         for (index, processor) in platform.get_processors().iter().enumerate() {

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -43,7 +43,7 @@ impl AbstractProcessor for ProcessorImpl {
     }
 
     #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
-    fn cpu_brand(&self) -> Option<&str> {
+    fn brand(&self) -> Option<&str> {
         // We do not have real brand information on the fallback platform.
         None
     }

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -41,4 +41,10 @@ impl AbstractProcessor for ProcessorImpl {
         // We do not have real speed information, so every processor reports the synthetic value.
         RelativeSpeed::SYNTHETIC
     }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn cpu_brand(&self) -> Option<&str> {
+        // We do not have real brand information on the fallback platform.
+        None
+    }
 }

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -43,8 +43,8 @@ impl AbstractProcessor for ProcessorImpl {
     }
 
     #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
-    fn brand(&self) -> Option<&str> {
-        // We do not have real brand information on the fallback platform.
+    fn model(&self) -> Option<&str> {
+        // We do not have real model information on the fallback platform.
         None
     }
 }

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -39,7 +39,7 @@ impl AbstractProcessor for ProcessorImpl {
     #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
     fn relative_speed(&self) -> RelativeSpeed {
         // We do not have real speed information, so every processor reports the fallback value.
-        RelativeSpeed::undetermined()
+        RelativeSpeed::UNDETERMINED
     }
 
     #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -38,8 +38,8 @@ impl AbstractProcessor for ProcessorImpl {
 
     #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
     fn relative_speed(&self) -> RelativeSpeed {
-        // We do not have real speed information, so every processor reports the synthetic value.
-        RelativeSpeed::SYNTHETIC
+        // We do not have real speed information, so every processor reports the fallback value.
+        RelativeSpeed::undetermined()
     }
 
     #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -1,7 +1,7 @@
 use derive_more::derive::Display;
 
 use crate::pal::AbstractProcessor;
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A fallback processor implementation for unsupported platforms.
 ///
@@ -34,5 +34,11 @@ impl AbstractProcessor for ProcessorImpl {
         // We do not have real topology information, so we assume all processors
         // are performance processors.
         EfficiencyClass::Performance
+    }
+
+    #[cfg_attr(test, mutants::skip)] // Some mutations are not testable due to simulated nature of this PAL.
+    fn relative_speed(&self) -> RelativeSpeed {
+        // We do not have real speed information, so every processor reports the synthetic value.
+        RelativeSpeed::SYNTHETIC
     }
 }

--- a/packages/many_cpus_impl/src/pal/fallback/processor.rs
+++ b/packages/many_cpus_impl/src/pal/fallback/processor.rs
@@ -7,7 +7,7 @@ use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 ///
 /// This processor always reports itself as being in memory region 0 with Performance efficiency
 /// class. The actual hardware topology is not inspected on unsupported platforms.
-#[derive(Clone, Copy, Debug, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Display)]
 #[display("ProcessorImpl({id})")]
 pub(crate) struct ProcessorImpl {
     id: ProcessorId,

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -9,7 +9,7 @@ use nonempty::NonEmpty;
 use crate::pal::linux::filesystem::FilesystemFacade;
 use crate::pal::linux::{Bindings, BindingsFacade, Filesystem};
 use crate::pal::{Platform, ProcessorFacade, ProcessorImpl};
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// Singleton instance of `BuildTargetPlatform`, used by public API types
 /// to hook up to the correct PAL implementation.
@@ -234,6 +234,7 @@ impl BuildTargetPlatform {
                 id: info.index,
                 memory_region_id: memory_region,
                 efficiency_class,
+                relative_speed: RelativeSpeed::from_raw(info.bogomips),
                 is_active: is_online,
             }
         });
@@ -682,17 +683,20 @@ mod tests {
             p0.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
+        assert_eq!(p0.as_target().relative_speed.as_u32(), 3400);
 
         let p1 = &processors[1];
         assert_eq!(p1.as_target().id, 1);
         assert_eq!(p1.as_target().memory_region_id, 0);
         assert_eq!(p1.as_target().efficiency_class, EfficiencyClass::Efficiency);
+        assert_eq!(p1.as_target().relative_speed.as_u32(), 2000);
 
         // Node 1
         let p2 = &processors[2];
         assert_eq!(p2.as_target().id, 2);
         assert_eq!(p2.as_target().memory_region_id, 1);
         assert_eq!(p2.as_target().efficiency_class, EfficiencyClass::Efficiency);
+        assert_eq!(p2.as_target().relative_speed.as_u32(), 2000);
 
         let p3 = &processors[3];
         assert_eq!(p3.as_target().id, 3);
@@ -701,6 +705,7 @@ mod tests {
             p3.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
+        assert_eq!(p3.as_target().relative_speed.as_u32(), 3400);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -235,7 +235,7 @@ impl BuildTargetPlatform {
                 memory_region_id: memory_region,
                 efficiency_class,
                 relative_speed: RelativeSpeed::from_os_metric(info.bogomips),
-                brand: info.model_name,
+                model: info.model_name,
                 is_active: is_online,
             }
         });
@@ -293,7 +293,7 @@ impl BuildTargetPlatform {
                             "bogomips" => {
                                 bogomips = value.parse::<f32>().map(|f| f.round() as u32).ok();
                             }
-                            // The processor brand. Absent on many non-x86 architectures, so it is optional.
+                            // The processor model. Absent on many non-x86 architectures, so it is optional.
                             "model name" if !value.is_empty() => {
                                 model_name = Some(Arc::from(value));
                             }
@@ -447,7 +447,7 @@ struct CpuInfo {
     /// cores and any with lower bogomips are considered efficiency cores.
     bogomips: u32,
 
-    /// Best-effort brand from the `model name` field, `None` when the field is absent (as it
+    /// Best-effort model from the `model name` field, `None` when the field is absent (as it
     /// commonly is on non-x86 architectures).
     model_name: Option<Arc<str>>,
 }
@@ -699,10 +699,10 @@ mod tests {
             RelativeSpeed::from_os_metric(3400)
         );
         // The layout simulator reports a `model name` for every processor, which surfaces as the
-        // processor brand.
+        // processor model.
         assert_eq!(
-            p0.as_target().brand.as_deref(),
-            Some("Test Processor Brand")
+            p0.as_target().model.as_deref(),
+            Some("Test Processor Model")
         );
 
         let p1 = &processors[1];
@@ -899,7 +899,7 @@ mod tests {
         for (processor_index, bogomips) in processor_index.iter().zip(bogomips_per_processor.iter())
         {
             writeln!(cpuinfo, "processor       : {processor_index}").unwrap();
-            writeln!(cpuinfo, "model name      : Test Processor Brand").unwrap();
+            writeln!(cpuinfo, "model name      : Test Processor Model").unwrap();
             writeln!(cpuinfo, "bogomips        : {bogomips}").unwrap();
             writeln!(cpuinfo, "whatever        : 123").unwrap();
             writeln!(cpuinfo, "other           : ignored").unwrap();
@@ -1659,8 +1659,8 @@ CPU revision    : 1
             p0.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
-        // This ARM-style cpuinfo has no `model name` field, so no brand is reported.
-        assert_eq!(p0.as_target().brand, None);
+        // This ARM-style cpuinfo has no `model name` field, so no model is reported.
+        assert_eq!(p0.as_target().model, None);
 
         let p1 = &processors[1];
         assert_eq!(p1.as_target().id, 1);
@@ -1672,9 +1672,9 @@ CPU revision    : 1
     }
 
     #[test]
-    fn cpuinfo_with_empty_model_name_reports_no_brand() {
+    fn cpuinfo_with_empty_model_name_reports_no_model() {
         // A `model name` field that is present but blank must be treated as absent rather than
-        // surfacing an empty brand string, so the guard that rejects an empty value matters.
+        // surfacing an empty model string, so the guard that rejects an empty value matters.
         let mut fs = MockFilesystem::new();
 
         let cpuinfo = "processor       : 0
@@ -1712,7 +1712,7 @@ model name      :
         let processors = platform.get_all_processors();
 
         assert_eq!(processors.len(), 1);
-        assert_eq!(processors[0].as_target().brand, None);
+        assert_eq!(processors[0].as_target().model, None);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -1,6 +1,6 @@
 use std::iter::once;
 use std::mem;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use foldhash::HashMap;
 use itertools::Itertools;
@@ -138,7 +138,7 @@ impl BuildTargetPlatform {
                 self.get_all_processors_impl()
                     .iter()
                     .filter(|p| p.is_active)
-                    .copied()
+                    .cloned()
                     .map(ProcessorFacade::Target)
                     .collect_vec())
                     .expect("found 0 active processors - impossible because this code is running on an active processor")
@@ -234,7 +234,8 @@ impl BuildTargetPlatform {
                 id: info.index,
                 memory_region_id: memory_region,
                 efficiency_class,
-                relative_speed: RelativeSpeed::from_raw(info.bogomips),
+                relative_speed: RelativeSpeed::from_os_metric(info.bogomips),
+                cpu_brand: info.model_name,
                 is_active: is_online,
             }
         });
@@ -276,6 +277,7 @@ impl BuildTargetPlatform {
 
                     let mut index = None;
                     let mut bogomips = None;
+                    let mut model_name = None;
 
                     for line in lines {
                         let (key, value) = line
@@ -291,6 +293,10 @@ impl BuildTargetPlatform {
                             "bogomips" => {
                                 bogomips = value.parse::<f32>().map(|f| f.round() as u32).ok();
                             }
+                            // The CPU brand. Absent on many non-x86 architectures, so it is optional.
+                            "model name" if !value.is_empty() => {
+                                model_name = Some(Arc::from(value));
+                            }
                             _ => {}
                         }
                     }
@@ -299,6 +305,7 @@ impl BuildTargetPlatform {
                         index: index.expect("processor index not found for processor"),
                         bogomips: bogomips
                             .expect("processor bogomips not found for processor"),
+                        model_name,
                     })
                 })
                 .collect_vec(),
@@ -439,6 +446,10 @@ struct CpuInfo {
     /// performance cores, where the processors with max bogomips are considered performance
     /// cores and any with lower bogomips are considered efficiency cores.
     bogomips: u32,
+
+    /// Best-effort CPU brand from the `model name` field, `None` when the field is absent (as it
+    /// commonly is on non-x86 architectures).
+    model_name: Option<Arc<str>>,
 }
 
 /// This is the relative path of the cgroup the current process belongs to (e.g. `/foo/bar`)
@@ -683,20 +694,35 @@ mod tests {
             p0.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
-        assert_eq!(p0.as_target().relative_speed.as_u32(), 3400);
+        assert_eq!(
+            p0.as_target().relative_speed,
+            RelativeSpeed::from_os_metric(3400)
+        );
+        // The layout simulator reports a `model name` for every processor, which surfaces as the
+        // CPU brand.
+        assert_eq!(
+            p0.as_target().cpu_brand.as_deref(),
+            Some("Test Processor Brand")
+        );
 
         let p1 = &processors[1];
         assert_eq!(p1.as_target().id, 1);
         assert_eq!(p1.as_target().memory_region_id, 0);
         assert_eq!(p1.as_target().efficiency_class, EfficiencyClass::Efficiency);
-        assert_eq!(p1.as_target().relative_speed.as_u32(), 2000);
+        assert_eq!(
+            p1.as_target().relative_speed,
+            RelativeSpeed::from_os_metric(2000)
+        );
 
         // Node 1
         let p2 = &processors[2];
         assert_eq!(p2.as_target().id, 2);
         assert_eq!(p2.as_target().memory_region_id, 1);
         assert_eq!(p2.as_target().efficiency_class, EfficiencyClass::Efficiency);
-        assert_eq!(p2.as_target().relative_speed.as_u32(), 2000);
+        assert_eq!(
+            p2.as_target().relative_speed,
+            RelativeSpeed::from_os_metric(2000)
+        );
 
         let p3 = &processors[3];
         assert_eq!(p3.as_target().id, 3);
@@ -705,7 +731,10 @@ mod tests {
             p3.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
-        assert_eq!(p3.as_target().relative_speed.as_u32(), 3400);
+        assert_eq!(
+            p3.as_target().relative_speed,
+            RelativeSpeed::from_os_metric(3400)
+        );
     }
 
     #[test]
@@ -870,6 +899,7 @@ mod tests {
         for (processor_index, bogomips) in processor_index.iter().zip(bogomips_per_processor.iter())
         {
             writeln!(cpuinfo, "processor       : {processor_index}").unwrap();
+            writeln!(cpuinfo, "model name      : Test Processor Brand").unwrap();
             writeln!(cpuinfo, "bogomips        : {bogomips}").unwrap();
             writeln!(cpuinfo, "whatever        : 123").unwrap();
             writeln!(cpuinfo, "other           : ignored").unwrap();
@@ -1629,6 +1659,8 @@ CPU revision    : 1
             p0.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
+        // This ARM-style cpuinfo has no `model name` field, so no brand is reported.
+        assert_eq!(p0.as_target().cpu_brand, None);
 
         let p1 = &processors[1];
         assert_eq!(p1.as_target().id, 1);
@@ -1637,6 +1669,50 @@ CPU revision    : 1
             p1.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
+    }
+
+    #[test]
+    fn cpuinfo_with_empty_model_name_reports_no_brand() {
+        // A `model name` field that is present but blank must be treated as absent rather than
+        // surfacing an empty brand string, so the guard that rejects an empty value matters.
+        let mut fs = MockFilesystem::new();
+
+        let cpuinfo = "processor       : 0
+bogomips        : 50.00
+model name      :
+";
+
+        fs.expect_get_cpuinfo_contents()
+            .times(1)
+            .return_const(cpuinfo.to_string());
+
+        fs.expect_get_numa_node_possible_contents()
+            .times(1)
+            .return_const(Some("0\n".to_string()));
+
+        fs.expect_get_numa_node_cpulist_contents()
+            .withf(move |n| *n == 0)
+            .times(1)
+            .return_const("0\n".to_string());
+
+        fs.expect_get_cpu_online_contents()
+            .withf(move |p| *p == 0)
+            .times(1)
+            .return_const(Some("1\n".to_string()));
+
+        fs.expect_get_proc_self_status_contents()
+            .times(1)
+            .return_const("Cpus_allowed_list: 0".to_string());
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 1);
+        assert_eq!(processors[0].as_target().cpu_brand, None);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -235,7 +235,7 @@ impl BuildTargetPlatform {
                 memory_region_id: memory_region,
                 efficiency_class,
                 relative_speed: RelativeSpeed::from_os_metric(info.bogomips),
-                cpu_brand: info.model_name,
+                brand: info.model_name,
                 is_active: is_online,
             }
         });
@@ -293,7 +293,7 @@ impl BuildTargetPlatform {
                             "bogomips" => {
                                 bogomips = value.parse::<f32>().map(|f| f.round() as u32).ok();
                             }
-                            // The CPU brand. Absent on many non-x86 architectures, so it is optional.
+                            // The processor brand. Absent on many non-x86 architectures, so it is optional.
                             "model name" if !value.is_empty() => {
                                 model_name = Some(Arc::from(value));
                             }
@@ -447,7 +447,7 @@ struct CpuInfo {
     /// cores and any with lower bogomips are considered efficiency cores.
     bogomips: u32,
 
-    /// Best-effort CPU brand from the `model name` field, `None` when the field is absent (as it
+    /// Best-effort brand from the `model name` field, `None` when the field is absent (as it
     /// commonly is on non-x86 architectures).
     model_name: Option<Arc<str>>,
 }
@@ -699,9 +699,9 @@ mod tests {
             RelativeSpeed::from_os_metric(3400)
         );
         // The layout simulator reports a `model name` for every processor, which surfaces as the
-        // CPU brand.
+        // processor brand.
         assert_eq!(
-            p0.as_target().cpu_brand.as_deref(),
+            p0.as_target().brand.as_deref(),
             Some("Test Processor Brand")
         );
 
@@ -1660,7 +1660,7 @@ CPU revision    : 1
             EfficiencyClass::Performance
         );
         // This ARM-style cpuinfo has no `model name` field, so no brand is reported.
-        assert_eq!(p0.as_target().cpu_brand, None);
+        assert_eq!(p0.as_target().brand, None);
 
         let p1 = &processors[1];
         assert_eq!(p1.as_target().id, 1);
@@ -1712,7 +1712,7 @@ model name      :
         let processors = platform.get_all_processors();
 
         assert_eq!(processors.len(), 1);
-        assert_eq!(processors[0].as_target().cpu_brand, None);
+        assert_eq!(processors[0].as_target().brand, None);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -140,7 +140,7 @@ mod tests {
             id: 7,
             memory_region_id: 9,
             efficiency_class: EfficiencyClass::Efficiency,
-            relative_speed: RelativeSpeed::SYNTHETIC,
+            relative_speed: RelativeSpeed::from_raw(1),
             model: None,
             is_active: false,
         };

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -1,15 +1,19 @@
 use std::fmt::Display;
+use std::sync::Arc;
 
 use crate::pal::AbstractProcessor;
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A processor present on the system and available to the current process.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ProcessorImpl {
     pub(crate) id: ProcessorId,
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
+
+    /// Best-effort CPU brand from the `model name` field of `/proc/cpuinfo`, `None` when absent.
+    pub(crate) cpu_brand: Option<Arc<str>>,
 
     pub(crate) is_active: bool,
 }
@@ -35,6 +39,10 @@ impl AbstractProcessor for ProcessorImpl {
 
     fn relative_speed(&self) -> RelativeSpeed {
         self.relative_speed
+    }
+
+    fn cpu_brand(&self) -> Option<&str> {
+        self.cpu_brand.as_deref()
     }
 }
 
@@ -68,19 +76,22 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
+            cpu_brand: Some(Arc::from("Test CPU 3000")),
             is_active: true,
         };
 
         assert_eq!(processor.id(), 2);
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
-        assert_eq!(processor.relative_speed().as_u32(), 4890);
+        assert_eq!(processor.relative_speed().as_u64(), 4890);
+        assert_eq!(processor.cpu_brand(), Some("Test CPU 3000"));
 
         let processor2 = ProcessorImpl {
             id: 2,
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
+            cpu_brand: Some(Arc::from("Test CPU 3000")),
             is_active: true,
         };
 
@@ -91,10 +102,12 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
+            cpu_brand: None,
             is_active: true,
         };
 
         assert_ne!(processor, processor3);
+        assert_eq!(processor3.cpu_brand(), None);
         assert!(processor < processor3);
         assert!(processor3 > processor);
     }
@@ -106,6 +119,7 @@ mod tests {
             memory_region_id: 2,
             efficiency_class: EfficiencyClass::Efficiency,
             relative_speed: RelativeSpeed::from_raw(2400),
+            cpu_brand: None,
             is_active: true,
         };
 
@@ -128,6 +142,7 @@ mod tests {
             memory_region_id: 1,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(3600),
+            cpu_brand: None,
             is_active: true,
         };
 

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -1,5 +1,4 @@
 use std::fmt::Display;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::pal::AbstractProcessor;
@@ -13,7 +12,7 @@ pub(crate) struct ProcessorImpl {
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
 
-    /// Best-effort model from the `model name` field of `/proc/cpuinfo`, `None` when absent.
+    /// Model from the `model name` field of `/proc/cpuinfo`, `None` when absent.
     pub(crate) model: Option<Arc<str>>,
 
     pub(crate) is_active: bool,
@@ -47,9 +46,9 @@ impl AbstractProcessor for ProcessorImpl {
     }
 }
 
-// A processor is uniquely identified by its `id`. The other fields are descriptive metadata that
-// never differs between two handles to the same processor, so equality, hashing, and ordering are
-// all keyed on `id` alone. Keeping them in agreement upholds the `Ord`/`Eq` contract:
+// Linux returns its processor list sorted by `id` (see `platform.rs`), so `ProcessorImpl` orders
+// by `id`. The other fields are descriptive metadata that never differs between two handles to the
+// same processor, so equality and ordering are both keyed on `id` alone, keeping them in agreement:
 // `cmp(a, b) == Equal` exactly when `a == b`.
 impl PartialEq for ProcessorImpl {
     fn eq(&self, other: &Self) -> bool {
@@ -58,12 +57,6 @@ impl PartialEq for ProcessorImpl {
 }
 
 impl Eq for ProcessorImpl {}
-
-impl Hash for ProcessorImpl {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-    }
-}
 
 impl PartialOrd for ProcessorImpl {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -133,10 +126,8 @@ mod tests {
 
     #[test]
     fn equal_ids_compare_equal_regardless_of_metadata() {
-        use std::hash::{DefaultHasher, Hash, Hasher};
-
         // Two handles to the same processor id are equal and order as Equal even when their
-        // descriptive metadata differs, keeping the Ord and Eq/Hash impls mutually consistent.
+        // descriptive metadata differs, keeping the Eq and Ord impls mutually consistent.
         let a = ProcessorImpl {
             id: 7,
             memory_region_id: 3,
@@ -156,18 +147,6 @@ mod tests {
 
         assert_eq!(a, b);
         assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
-
-        let mut hash_a = DefaultHasher::new();
-        a.hash(&mut hash_a);
-        let mut hash_b = DefaultHasher::new();
-        b.hash(&mut hash_b);
-        assert_eq!(hash_a.finish(), hash_b.finish());
-
-        // Hashing is keyed on `id` alone, so a processor hashes identically to its bare `id`.
-        // This also confirms the hash actually incorporates the id rather than being a no-op.
-        let mut id_hash = DefaultHasher::new();
-        a.id.hash(&mut id_hash);
-        assert_eq!(hash_a.finish(), id_hash.finish());
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -1,11 +1,12 @@
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::pal::AbstractProcessor;
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A processor present on the system and available to the current process.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct ProcessorImpl {
     pub(crate) id: ProcessorId,
     pub(crate) memory_region_id: MemoryRegionId,
@@ -43,6 +44,24 @@ impl AbstractProcessor for ProcessorImpl {
 
     fn cpu_brand(&self) -> Option<&str> {
         self.cpu_brand.as_deref()
+    }
+}
+
+// A processor is uniquely identified by its `id`. The other fields are descriptive metadata that
+// never differs between two handles to the same processor, so equality, hashing, and ordering are
+// all keyed on `id` alone. Keeping them in agreement upholds the `Ord`/`Eq` contract:
+// `cmp(a, b) == Equal` exactly when `a == b`.
+impl PartialEq for ProcessorImpl {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ProcessorImpl {}
+
+impl Hash for ProcessorImpl {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 
@@ -110,6 +129,39 @@ mod tests {
         assert_eq!(processor3.cpu_brand(), None);
         assert!(processor < processor3);
         assert!(processor3 > processor);
+    }
+
+    #[test]
+    fn equal_ids_compare_equal_regardless_of_metadata() {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        // Two handles to the same processor id are equal and order as Equal even when their
+        // descriptive metadata differs, keeping the Ord and Eq/Hash impls mutually consistent.
+        let a = ProcessorImpl {
+            id: 7,
+            memory_region_id: 3,
+            efficiency_class: EfficiencyClass::Performance,
+            relative_speed: RelativeSpeed::from_raw(3600),
+            cpu_brand: Some(Arc::from("Brand A")),
+            is_active: true,
+        };
+        let b = ProcessorImpl {
+            id: 7,
+            memory_region_id: 9,
+            efficiency_class: EfficiencyClass::Efficiency,
+            relative_speed: RelativeSpeed::SYNTHETIC,
+            cpu_brand: None,
+            is_active: false,
+        };
+
+        assert_eq!(a, b);
+        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
+
+        let mut hash_a = DefaultHasher::new();
+        a.hash(&mut hash_a);
+        let mut hash_b = DefaultHasher::new();
+        b.hash(&mut hash_b);
+        assert_eq!(hash_a.finish(), hash_b.finish());
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -13,8 +13,8 @@ pub(crate) struct ProcessorImpl {
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
 
-    /// Best-effort brand from the `model name` field of `/proc/cpuinfo`, `None` when absent.
-    pub(crate) brand: Option<Arc<str>>,
+    /// Best-effort model from the `model name` field of `/proc/cpuinfo`, `None` when absent.
+    pub(crate) model: Option<Arc<str>>,
 
     pub(crate) is_active: bool,
 }
@@ -42,8 +42,8 @@ impl AbstractProcessor for ProcessorImpl {
         self.relative_speed
     }
 
-    fn brand(&self) -> Option<&str> {
-        self.brand.as_deref()
+    fn model(&self) -> Option<&str> {
+        self.model.as_deref()
     }
 }
 
@@ -95,7 +95,7 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
-            brand: Some(Arc::from("Test CPU 3000")),
+            model: Some(Arc::from("Test CPU 3000")),
             is_active: true,
         };
 
@@ -103,14 +103,14 @@ mod tests {
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(processor.relative_speed().as_u64(), 4890);
-        assert_eq!(processor.brand(), Some("Test CPU 3000"));
+        assert_eq!(processor.model(), Some("Test CPU 3000"));
 
         let processor2 = ProcessorImpl {
             id: 2,
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
-            brand: Some(Arc::from("Test CPU 3000")),
+            model: Some(Arc::from("Test CPU 3000")),
             is_active: true,
         };
 
@@ -121,12 +121,12 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
-            brand: None,
+            model: None,
             is_active: true,
         };
 
         assert_ne!(processor, processor3);
-        assert_eq!(processor3.brand(), None);
+        assert_eq!(processor3.model(), None);
         assert!(processor < processor3);
         assert!(processor3 > processor);
     }
@@ -142,7 +142,7 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(3600),
-            brand: Some(Arc::from("Brand A")),
+            model: Some(Arc::from("Model A")),
             is_active: true,
         };
         let b = ProcessorImpl {
@@ -150,7 +150,7 @@ mod tests {
             memory_region_id: 9,
             efficiency_class: EfficiencyClass::Efficiency,
             relative_speed: RelativeSpeed::SYNTHETIC,
-            brand: None,
+            model: None,
             is_active: false,
         };
 
@@ -177,7 +177,7 @@ mod tests {
             memory_region_id: 2,
             efficiency_class: EfficiencyClass::Efficiency,
             relative_speed: RelativeSpeed::from_raw(2400),
-            brand: None,
+            model: None,
             is_active: true,
         };
 
@@ -200,7 +200,7 @@ mod tests {
             memory_region_id: 1,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(3600),
-            brand: None,
+            model: None,
             is_active: true,
         };
 

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -13,8 +13,8 @@ pub(crate) struct ProcessorImpl {
     pub(crate) efficiency_class: EfficiencyClass,
     pub(crate) relative_speed: RelativeSpeed,
 
-    /// Best-effort CPU brand from the `model name` field of `/proc/cpuinfo`, `None` when absent.
-    pub(crate) cpu_brand: Option<Arc<str>>,
+    /// Best-effort brand from the `model name` field of `/proc/cpuinfo`, `None` when absent.
+    pub(crate) brand: Option<Arc<str>>,
 
     pub(crate) is_active: bool,
 }
@@ -42,8 +42,8 @@ impl AbstractProcessor for ProcessorImpl {
         self.relative_speed
     }
 
-    fn cpu_brand(&self) -> Option<&str> {
-        self.cpu_brand.as_deref()
+    fn brand(&self) -> Option<&str> {
+        self.brand.as_deref()
     }
 }
 
@@ -95,7 +95,7 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
-            cpu_brand: Some(Arc::from("Test CPU 3000")),
+            brand: Some(Arc::from("Test CPU 3000")),
             is_active: true,
         };
 
@@ -103,14 +103,14 @@ mod tests {
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(processor.relative_speed().as_u64(), 4890);
-        assert_eq!(processor.cpu_brand(), Some("Test CPU 3000"));
+        assert_eq!(processor.brand(), Some("Test CPU 3000"));
 
         let processor2 = ProcessorImpl {
             id: 2,
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
-            cpu_brand: Some(Arc::from("Test CPU 3000")),
+            brand: Some(Arc::from("Test CPU 3000")),
             is_active: true,
         };
 
@@ -121,12 +121,12 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(4890),
-            cpu_brand: None,
+            brand: None,
             is_active: true,
         };
 
         assert_ne!(processor, processor3);
-        assert_eq!(processor3.cpu_brand(), None);
+        assert_eq!(processor3.brand(), None);
         assert!(processor < processor3);
         assert!(processor3 > processor);
     }
@@ -142,7 +142,7 @@ mod tests {
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(3600),
-            cpu_brand: Some(Arc::from("Brand A")),
+            brand: Some(Arc::from("Brand A")),
             is_active: true,
         };
         let b = ProcessorImpl {
@@ -150,7 +150,7 @@ mod tests {
             memory_region_id: 9,
             efficiency_class: EfficiencyClass::Efficiency,
             relative_speed: RelativeSpeed::SYNTHETIC,
-            cpu_brand: None,
+            brand: None,
             is_active: false,
         };
 
@@ -177,7 +177,7 @@ mod tests {
             memory_region_id: 2,
             efficiency_class: EfficiencyClass::Efficiency,
             relative_speed: RelativeSpeed::from_raw(2400),
-            cpu_brand: None,
+            brand: None,
             is_active: true,
         };
 
@@ -200,7 +200,7 @@ mod tests {
             memory_region_id: 1,
             efficiency_class: EfficiencyClass::Performance,
             relative_speed: RelativeSpeed::from_raw(3600),
-            cpu_brand: None,
+            brand: None,
             is_active: true,
         };
 

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -162,6 +162,12 @@ mod tests {
         let mut hash_b = DefaultHasher::new();
         b.hash(&mut hash_b);
         assert_eq!(hash_a.finish(), hash_b.finish());
+
+        // Hashing is keyed on `id` alone, so a processor hashes identically to its bare `id`.
+        // This also confirms the hash actually incorporates the id rather than being a no-op.
+        let mut id_hash = DefaultHasher::new();
+        a.id.hash(&mut id_hash);
+        assert_eq!(hash_a.finish(), id_hash.finish());
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/processor.rs
+++ b/packages/many_cpus_impl/src/pal/linux/processor.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::pal::AbstractProcessor;
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A processor present on the system and available to the current process.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -9,6 +9,7 @@ pub(crate) struct ProcessorImpl {
     pub(crate) id: ProcessorId,
     pub(crate) memory_region_id: MemoryRegionId,
     pub(crate) efficiency_class: EfficiencyClass,
+    pub(crate) relative_speed: RelativeSpeed,
 
     pub(crate) is_active: bool,
 }
@@ -30,6 +31,10 @@ impl AbstractProcessor for ProcessorImpl {
 
     fn efficiency_class(&self) -> EfficiencyClass {
         self.efficiency_class
+    }
+
+    fn relative_speed(&self) -> RelativeSpeed {
+        self.relative_speed
     }
 }
 
@@ -62,17 +67,20 @@ mod tests {
             id: 2,
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
+            relative_speed: RelativeSpeed::from_raw(4890),
             is_active: true,
         };
 
         assert_eq!(processor.id(), 2);
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
+        assert_eq!(processor.relative_speed().as_u32(), 4890);
 
         let processor2 = ProcessorImpl {
             id: 2,
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
+            relative_speed: RelativeSpeed::from_raw(4890),
             is_active: true,
         };
 
@@ -82,6 +90,7 @@ mod tests {
             id: 4,
             memory_region_id: 3,
             efficiency_class: EfficiencyClass::Performance,
+            relative_speed: RelativeSpeed::from_raw(4890),
             is_active: true,
         };
 
@@ -96,6 +105,7 @@ mod tests {
             id: 5,
             memory_region_id: 2,
             efficiency_class: EfficiencyClass::Efficiency,
+            relative_speed: RelativeSpeed::from_raw(2400),
             is_active: true,
         };
 
@@ -117,6 +127,7 @@ mod tests {
             id: 7,
             memory_region_id: 1,
             efficiency_class: EfficiencyClass::Performance,
+            relative_speed: RelativeSpeed::from_raw(3600),
             is_active: true,
         };
 

--- a/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
@@ -37,15 +37,13 @@ pub(crate) trait Bindings: Debug + Send + Sync + 'static {
 
     fn get_current_job_cpu_rate_control(&self) -> Option<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION>;
 
-    /// Returns the nominal maximum clock frequency in MHz of the processors in the processor group
-    /// identified by `group_number`, indexed by each processor's index within the group, for up to
-    /// `group_size` processors. Processors for which the platform reports no value hold 0.
+    /// Returns the nominal maximum clock frequency in MHz of each logical processor, indexed by
+    /// processor ID, for up to `max_processor_count` processors. Processors for which the platform
+    /// reports no value hold 0.
     ///
-    /// The underlying operating system query only reports the calling thread's processor group, so
-    /// this moves the calling thread into `group_number` for the duration of the query. The caller
-    /// must only pass a `group_number` that has at least one active processor and must query every
-    /// group in turn to obtain the values for all processors on the system.
-    fn get_processor_group_max_mhz(&self, group_number: u16, group_size: usize) -> Vec<u32>;
+    /// This is a passive read that covers every processor across all processor groups without
+    /// changing the affinity or any other runtime state of the calling thread.
+    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32>;
 
     fn get_current_thread_legacy_group_affinity(&self) -> GROUP_AFFINITY;
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
@@ -38,8 +38,11 @@ pub(crate) trait Bindings: Debug + Send + Sync + 'static {
     fn get_current_job_cpu_rate_control(&self) -> Option<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION>;
 
     /// Returns the nominal maximum clock frequency in MHz of each logical processor, indexed by
-    /// processor ID, for up to `max_processor_count` processors. Processors for which the platform
-    /// reports no value hold 0.
+    /// processor ID.
+    ///
+    /// The returned `Vec` always has length exactly `max_processor_count`, with entry `i` holding
+    /// the value for processor ID `i` (covering every processor ID in `0..max_processor_count`).
+    /// Processors for which the platform reports no value (for example offline processors) hold 0.
     ///
     /// This is a passive read that covers every processor across all processor groups without
     /// changing the affinity or any other runtime state of the calling thread.

--- a/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
@@ -37,5 +37,10 @@ pub(crate) trait Bindings: Debug + Send + Sync + 'static {
 
     fn get_current_job_cpu_rate_control(&self) -> Option<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION>;
 
+    /// Returns the nominal maximum clock frequency in MHz of each logical processor, indexed by
+    /// processor number, for up to `max_processor_count` processors. Processors for which the
+    /// platform reports no value hold 0.
+    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32>;
+
     fn get_current_thread_legacy_group_affinity(&self) -> GROUP_AFFINITY;
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
@@ -37,10 +37,15 @@ pub(crate) trait Bindings: Debug + Send + Sync + 'static {
 
     fn get_current_job_cpu_rate_control(&self) -> Option<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION>;
 
-    /// Returns the nominal maximum clock frequency in MHz of each logical processor, indexed by
-    /// processor number, for up to `max_processor_count` processors. Processors for which the
-    /// platform reports no value hold 0.
-    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32>;
+    /// Returns the nominal maximum clock frequency in MHz of the processors in the processor group
+    /// identified by `group_number`, indexed by each processor's index within the group, for up to
+    /// `group_size` processors. Processors for which the platform reports no value hold 0.
+    ///
+    /// The underlying operating system query only reports the calling thread's processor group, so
+    /// this moves the calling thread into `group_number` for the duration of the query. The caller
+    /// must only pass a `group_number` that has at least one active processor and must query every
+    /// group in turn to obtain the values for all processors on the system.
+    fn get_processor_group_max_mhz(&self, group_number: u16, group_size: usize) -> Vec<u32>;
 
     fn get_current_thread_legacy_group_affinity(&self) -> GROUP_AFFINITY;
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
@@ -48,11 +48,11 @@ pub(crate) trait Bindings: Debug + Send + Sync + 'static {
     /// changing the affinity or any other runtime state of the calling thread.
     fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32>;
 
-    /// Returns the brand string of each logical processor, indexed by processor ID.
+    /// Returns the model string of each logical processor, indexed by processor ID.
     ///
     /// The returned `Vec` always has length exactly `max_processor_count`, with entry `i` holding
     /// the value for processor ID `i` (covering every processor ID in `0..max_processor_count`).
-    /// Processors for which the platform reports no brand (for example offline processors) hold
+    /// Processors for which the platform reports no model (for example offline processors) hold
     /// `None`.
     ///
     /// This is a passive read that covers every processor across all processor groups without

--- a/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/abstractions.rs
@@ -48,5 +48,16 @@ pub(crate) trait Bindings: Debug + Send + Sync + 'static {
     /// changing the affinity or any other runtime state of the calling thread.
     fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32>;
 
+    /// Returns the brand string of each logical processor, indexed by processor ID.
+    ///
+    /// The returned `Vec` always has length exactly `max_processor_count`, with entry `i` holding
+    /// the value for processor ID `i` (covering every processor ID in `0..max_processor_count`).
+    /// Processors for which the platform reports no brand (for example offline processors) hold
+    /// `None`.
+    ///
+    /// This is a passive read that covers every processor across all processor groups without
+    /// changing the affinity or any other runtime state of the calling thread.
+    fn get_processor_name_strings(&self, max_processor_count: usize) -> Vec<Option<String>>;
+
     fn get_current_thread_legacy_group_affinity(&self) -> GROUP_AFFINITY;
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
@@ -150,6 +150,14 @@ impl Bindings for BindingsFacade {
             Self::Mock(bindings) => bindings.get_current_job_cpu_rate_control(),
         }
     }
+
+    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32> {
+        match self {
+            Self::Target(bindings) => bindings.get_processor_max_mhz(max_processor_count),
+            #[cfg(test)]
+            Self::Mock(bindings) => bindings.get_processor_max_mhz(max_processor_count),
+        }
+    }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))] // No API contract to test.

--- a/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
@@ -151,11 +151,13 @@ impl Bindings for BindingsFacade {
         }
     }
 
-    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32> {
+    fn get_processor_group_max_mhz(&self, group_number: u16, group_size: usize) -> Vec<u32> {
         match self {
-            Self::Target(bindings) => bindings.get_processor_max_mhz(max_processor_count),
+            Self::Target(bindings) => {
+                bindings.get_processor_group_max_mhz(group_number, group_size)
+            }
             #[cfg(test)]
-            Self::Mock(bindings) => bindings.get_processor_max_mhz(max_processor_count),
+            Self::Mock(bindings) => bindings.get_processor_group_max_mhz(group_number, group_size),
         }
     }
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
@@ -151,13 +151,11 @@ impl Bindings for BindingsFacade {
         }
     }
 
-    fn get_processor_group_max_mhz(&self, group_number: u16, group_size: usize) -> Vec<u32> {
+    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32> {
         match self {
-            Self::Target(bindings) => {
-                bindings.get_processor_group_max_mhz(group_number, group_size)
-            }
+            Self::Target(bindings) => bindings.get_processor_max_mhz(max_processor_count),
             #[cfg(test)]
-            Self::Mock(bindings) => bindings.get_processor_group_max_mhz(group_number, group_size),
+            Self::Mock(bindings) => bindings.get_processor_max_mhz(max_processor_count),
         }
     }
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
@@ -158,6 +158,14 @@ impl Bindings for BindingsFacade {
             Self::Mock(bindings) => bindings.get_processor_max_mhz(max_processor_count),
         }
     }
+
+    fn get_processor_name_strings(&self, max_processor_count: usize) -> Vec<Option<String>> {
+        match self {
+            Self::Target(bindings) => bindings.get_processor_name_strings(max_processor_count),
+            #[cfg(test)]
+            Self::Mock(bindings) => bindings.get_processor_name_strings(max_processor_count),
+        }
+    }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))] // No API contract to test.

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -327,6 +327,11 @@ fn read_processor_nominal_max_mhz(processor_id: usize) -> u32 {
 /// `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\<processor_id>\ProcessorNameString` and is
 /// populated by the kernel at boot for every logical processor, so this read is passive and covers
 /// all processor groups without touching any thread's affinity.
+//
+// Excluded from coverage because the failure branches (an unreadable or missing registry value, or
+// an empty brand string) cannot be exercised in automation: the kernel always records a non-empty
+// `ProcessorNameString` for every logical processor on the machines that run our tests.
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn read_processor_name_string(processor_id: usize) -> Option<String> {
     let subkey = to_nul_terminated_wide(&format!(
         "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\{processor_id}"

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -1,13 +1,12 @@
 use std::fmt::Debug;
+use std::iter;
 
 use windows::Win32::System::JobObjects::{
     IsProcessInJob, JOBOBJECT_CPU_RATE_CONTROL_INFORMATION, JobObjectCpuRateControlInformation,
     JobObjectGroupInformationEx, QueryInformationJobObject,
 };
 use windows::Win32::System::Kernel::PROCESSOR_NUMBER;
-use windows::Win32::System::Power::{
-    CallNtPowerInformation, PROCESSOR_POWER_INFORMATION, ProcessorInformation,
-};
+use windows::Win32::System::Registry::{HKEY_LOCAL_MACHINE, RRF_RT_REG_DWORD, RegGetValueW};
 use windows::Win32::System::SystemInformation::{
     GROUP_AFFINITY, GetLogicalProcessorInformationEx, LOGICAL_PROCESSOR_RELATIONSHIP,
     SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
@@ -16,9 +15,9 @@ use windows::Win32::System::Threading::{
     GetActiveProcessorCount, GetCurrentProcess, GetCurrentProcessorNumberEx, GetCurrentThread,
     GetMaximumProcessorCount, GetMaximumProcessorGroupCount, GetNumaHighestNodeNumber,
     GetProcessDefaultCpuSetMasks, GetThreadGroupAffinity, GetThreadSelectedCpuSetMasks,
-    SetThreadGroupAffinity, SetThreadSelectedCpuSetMasks,
+    SetThreadSelectedCpuSetMasks,
 };
-use windows::core::{BOOL, Result};
+use windows::core::{BOOL, PCWSTR, Result};
 
 use crate::pal::windows::Bindings;
 
@@ -212,75 +211,20 @@ impl Bindings for BuildTargetBindings {
         aff
     }
 
-    fn get_processor_group_max_mhz(&self, group_number: u16, group_size: usize) -> Vec<u32> {
-        // `CallNtPowerInformation(ProcessorInformation)` fills one PROCESSOR_POWER_INFORMATION per
-        // logical processor, ordered by the processor's index within its group. `MaxMhz` is the
-        // nominal maximum clock frequency which - unlike `CurrentMhz` - is stable and does not
-        // fluctuate with power management or thermal throttling, making it a reliable value for
-        // identifying processors.
+    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32> {
+        // Windows records the nominal maximum clock frequency of each logical processor in the
+        // registry under `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\<id>` as the `~MHz`
+        // value. The kernel populates these entries at boot for every logical processor across all
+        // processor groups, so reading them is a fully passive operation: it never changes the
+        // affinity or any other runtime state of the calling thread and it is not limited to the
+        // 64 processors of a single processor group the way the legacy power-information API is.
         //
-        // This is a legacy API that predates processor groups: it only reports the processors in
-        // the processor group that the calling thread currently belongs to. To read every group on
-        // systems with more than one processor group (more than 64 logical processors) we move this
-        // thread into `group_number` for the duration of the query and restore its original group
-        // affinity afterwards. The caller is responsible for querying every group in turn.
-
-        // SAFETY: No safety requirements. Does not require closing the handle.
-        let current_thread = unsafe { GetCurrentThread() };
-
-        // The caller guarantees the group has at least one active processor, and active processors
-        // occupy the low index positions, so the first processor in the group is always a valid
-        // target. We only need to enter the group to observe it, not to schedule real work.
-        let target_affinity = GROUP_AFFINITY {
-            Mask: 1,
-            Group: group_number,
-            ..Default::default()
-        };
-
-        let mut previous_affinity = GROUP_AFFINITY::default();
-
-        // SAFETY: All pointers we pass are valid for the duration of the call.
-        unsafe {
-            SetThreadGroupAffinity(
-                current_thread,
-                &raw const target_affinity,
-                Some(&raw mut previous_affinity),
-            )
-        }
-        .expect("platform refused to move the current thread to the target processor group");
-
-        let mut buffer = vec![PROCESSOR_POWER_INFORMATION::default(); group_size];
-
-        let buffer_len_bytes: u32 = group_size
-            .checked_mul(size_of::<PROCESSOR_POWER_INFORMATION>())
-            .and_then(|len| u32::try_from(len).ok())
-            .expect("processor power information buffer size overflowed u32");
-
-        // SAFETY: `ProcessorInformation` requires no input buffer; we provide an output buffer
-        // large enough for `group_size` entries and declare its exact size in bytes.
-        let query_result = unsafe {
-            CallNtPowerInformation(
-                ProcessorInformation,
-                None,
-                0,
-                Some(buffer.as_mut_ptr().cast()),
-                buffer_len_bytes,
-            )
-        }
-        .ok();
-
-        // Restore the original affinity before reacting to any query failure, so we never leave
-        // the thread stranded in a processor group it did not start in.
-        // SAFETY: The pointer we pass is valid for the duration of the call.
-        unsafe { SetThreadGroupAffinity(current_thread, &raw const previous_affinity, None) }
-            .expect("platform refused to restore the current thread's original processor group");
-
-        query_result.expect("platform refused to provide processor power information");
-
-        // The array holds one entry per processor in the group, ordered by the processor's index
-        // within the group, so we surface `MaxMhz` in that same order for the caller to map onto
-        // global processor IDs.
-        buffer.iter().map(|info| info.MaxMhz).collect()
+        // The `~MHz` value is the nominal maximum clock and - unlike a live "current MHz" reading -
+        // is stable and does not fluctuate with power management or thermal throttling, making it a
+        // reliable value for identifying processors.
+        (0..max_processor_count)
+            .map(read_processor_nominal_max_mhz)
+            .collect()
     }
 
     // Excluded from coverage because the "not in job" branches cannot be tested in automation,
@@ -323,4 +267,47 @@ impl Bindings for BuildTargetBindings {
 
         Some(result)
     }
+}
+
+/// Reads the nominal maximum clock frequency in MHz that Windows recorded for a single logical
+/// processor in the registry, returning 0 when the platform records no value for that processor.
+///
+/// The value lives at `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\<processor_id>\~MHz` and
+/// is populated by the kernel at boot for every logical processor, so this read is passive and
+/// covers all processor groups without touching any thread's affinity.
+fn read_processor_nominal_max_mhz(processor_id: usize) -> u32 {
+    let subkey = to_nul_terminated_wide(&format!(
+        "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\{processor_id}"
+    ));
+    let value_name = to_nul_terminated_wide("~MHz");
+
+    let mut value: u32 = 0;
+    let mut value_size_bytes: u32 =
+        u32::try_from(size_of::<u32>()).expect("the size of a u32 always fits in a u32");
+
+    // SAFETY: `subkey` and `value_name` are NUL-terminated UTF-16 strings that outlive the call.
+    // `value` and `value_size_bytes` are valid for writes for the duration of the call, and
+    // `value_size_bytes` truthfully declares the size of the `value` buffer. `RRF_RT_REG_DWORD`
+    // restricts the query to REG_DWORD values, matching the `u32` buffer we provide.
+    let status = unsafe {
+        RegGetValueW(
+            HKEY_LOCAL_MACHINE,
+            PCWSTR(subkey.as_ptr()),
+            PCWSTR(value_name.as_ptr()),
+            RRF_RT_REG_DWORD,
+            None,
+            Some((&raw mut value).cast()),
+            Some(&raw mut value_size_bytes),
+        )
+    };
+
+    // A missing or unreadable entry (for example an offline processor the kernel never populated)
+    // is reported as 0, which the caller maps onto the synthetic relative speed.
+    if status.is_ok() { value } else { 0 }
+}
+
+/// Encodes a string as a NUL-terminated wide (UTF-16) string, as expected by the wide-character
+/// Windows registry API.
+fn to_nul_terminated_wide(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(iter::once(0)).collect()
 }

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -6,7 +6,9 @@ use windows::Win32::System::JobObjects::{
     JobObjectGroupInformationEx, QueryInformationJobObject,
 };
 use windows::Win32::System::Kernel::PROCESSOR_NUMBER;
-use windows::Win32::System::Registry::{HKEY_LOCAL_MACHINE, RRF_RT_REG_DWORD, RegGetValueW};
+use windows::Win32::System::Registry::{
+    HKEY_LOCAL_MACHINE, RRF_RT_REG_DWORD, RRF_RT_REG_SZ, RegGetValueW,
+};
 use windows::Win32::System::SystemInformation::{
     GROUP_AFFINITY, GetLogicalProcessorInformationEx, LOGICAL_PROCESSOR_RELATIONSHIP,
     SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
@@ -227,6 +229,18 @@ impl Bindings for BuildTargetBindings {
             .collect()
     }
 
+    fn get_processor_name_strings(&self, max_processor_count: usize) -> Vec<Option<String>> {
+        // Windows records the brand string of each logical processor in the registry under
+        // `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\<id>` as the `ProcessorNameString`
+        // value. The kernel populates these entries at boot for every logical processor across all
+        // processor groups, so reading them is a fully passive operation: it never changes the
+        // affinity or any other runtime state of the calling thread and it is not limited to the
+        // 64 processors of a single processor group the way the legacy power-information API is.
+        (0..max_processor_count)
+            .map(read_processor_name_string)
+            .collect()
+    }
+
     // Excluded from coverage because the "not in job" branches cannot be tested in automation,
     // as automated test runs are always executed within a job.
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -304,6 +318,79 @@ fn read_processor_nominal_max_mhz(processor_id: usize) -> u32 {
     // A missing or unreadable entry (for example an offline processor the kernel never populated)
     // is reported as 0, which the caller maps onto the synthetic relative speed.
     if status.is_ok() { value } else { 0 }
+}
+
+/// Reads the brand string that Windows recorded for a single logical processor in the registry,
+/// returning `None` when the platform records no value for that processor.
+///
+/// The value lives at
+/// `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\<processor_id>\ProcessorNameString` and is
+/// populated by the kernel at boot for every logical processor, so this read is passive and covers
+/// all processor groups without touching any thread's affinity.
+fn read_processor_name_string(processor_id: usize) -> Option<String> {
+    let subkey = to_nul_terminated_wide(&format!(
+        "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\{processor_id}"
+    ));
+    let value_name = to_nul_terminated_wide("ProcessorNameString");
+
+    // First query how many bytes the value occupies so we can size the receiving buffer. Passing a
+    // null data pointer with a valid size-out pointer requests only the required size.
+    let mut value_size_bytes: u32 = 0;
+
+    // SAFETY: `subkey` and `value_name` are NUL-terminated UTF-16 strings that outlive the call.
+    // The data pointer is null (we only want the size) and `value_size_bytes` is valid for writes
+    // for the duration of the call. `RRF_RT_REG_SZ` restricts the query to REG_SZ values.
+    let status = unsafe {
+        RegGetValueW(
+            HKEY_LOCAL_MACHINE,
+            PCWSTR(subkey.as_ptr()),
+            PCWSTR(value_name.as_ptr()),
+            RRF_RT_REG_SZ,
+            None,
+            None,
+            Some(&raw mut value_size_bytes),
+        )
+    };
+
+    if status.is_err() || value_size_bytes == 0 {
+        return None;
+    }
+
+    // The size is in bytes but the buffer holds UTF-16 code units, so round up when dividing.
+    let mut buffer: Vec<u16> = vec![0; (value_size_bytes as usize).div_ceil(size_of::<u16>())];
+
+    // SAFETY: `subkey` and `value_name` are NUL-terminated UTF-16 strings that outlive the call.
+    // `buffer` is valid for writes of `value_size_bytes` bytes for the duration of the call and
+    // `value_size_bytes` truthfully declares the buffer size. `RRF_RT_REG_SZ` restricts the query
+    // to REG_SZ values, matching the UTF-16 buffer we provide.
+    let status = unsafe {
+        RegGetValueW(
+            HKEY_LOCAL_MACHINE,
+            PCWSTR(subkey.as_ptr()),
+            PCWSTR(value_name.as_ptr()),
+            RRF_RT_REG_SZ,
+            None,
+            Some(buffer.as_mut_ptr().cast()),
+            Some(&raw mut value_size_bytes),
+        )
+    };
+
+    if status.is_err() {
+        return None;
+    }
+
+    // Trim the trailing NUL terminator that the registry API guarantees, then trim any surrounding
+    // whitespace that some firmware pads the brand string with. Everything the API wrote after the
+    // NUL (and the zero-initialized tail of the buffer) is excluded by stopping at the first NUL.
+    let units: Vec<u16> = buffer.into_iter().take_while(|&unit| unit != 0).collect();
+    let text = String::from_utf16_lossy(&units);
+    let trimmed = text.trim();
+
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Encodes a string as a NUL-terminated wide (UTF-16) string, as expected by the wide-character

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -16,7 +16,7 @@ use windows::Win32::System::Threading::{
     GetActiveProcessorCount, GetCurrentProcess, GetCurrentProcessorNumberEx, GetCurrentThread,
     GetMaximumProcessorCount, GetMaximumProcessorGroupCount, GetNumaHighestNodeNumber,
     GetProcessDefaultCpuSetMasks, GetThreadGroupAffinity, GetThreadSelectedCpuSetMasks,
-    SetThreadSelectedCpuSetMasks,
+    SetThreadGroupAffinity, SetThreadSelectedCpuSetMasks,
 };
 use windows::core::{BOOL, Result};
 
@@ -212,26 +212,53 @@ impl Bindings for BuildTargetBindings {
         aff
     }
 
-    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32> {
+    fn get_processor_group_max_mhz(&self, group_number: u16, group_size: usize) -> Vec<u32> {
         // `CallNtPowerInformation(ProcessorInformation)` fills one PROCESSOR_POWER_INFORMATION per
-        // logical processor, ordered by processor number. `MaxMhz` is the nominal maximum clock
-        // frequency which - unlike `CurrentMhz` - is stable and does not fluctuate with power
-        // management or thermal throttling, making it a reliable value for identifying processors.
+        // logical processor, ordered by the processor's index within its group. `MaxMhz` is the
+        // nominal maximum clock frequency which - unlike `CurrentMhz` - is stable and does not
+        // fluctuate with power management or thermal throttling, making it a reliable value for
+        // identifying processors.
         //
-        // This is a legacy API that predates processor groups: on systems with more than one
-        // processor group (more than 64 logical processors) it only reports processors in the
-        // calling thread's group. Processors it does not report are left at 0, which the caller
-        // treats as "unknown".
-        let mut buffer = vec![PROCESSOR_POWER_INFORMATION::default(); max_processor_count];
+        // This is a legacy API that predates processor groups: it only reports the processors in
+        // the processor group that the calling thread currently belongs to. To read every group on
+        // systems with more than one processor group (more than 64 logical processors) we move this
+        // thread into `group_number` for the duration of the query and restore its original group
+        // affinity afterwards. The caller is responsible for querying every group in turn.
 
-        let buffer_len_bytes: u32 = max_processor_count
+        // SAFETY: No safety requirements. Does not require closing the handle.
+        let current_thread = unsafe { GetCurrentThread() };
+
+        // The caller guarantees the group has at least one active processor, and active processors
+        // occupy the low index positions, so the first processor in the group is always a valid
+        // target. We only need to enter the group to observe it, not to schedule real work.
+        let target_affinity = GROUP_AFFINITY {
+            Mask: 1,
+            Group: group_number,
+            ..Default::default()
+        };
+
+        let mut previous_affinity = GROUP_AFFINITY::default();
+
+        // SAFETY: All pointers we pass are valid for the duration of the call.
+        unsafe {
+            SetThreadGroupAffinity(
+                current_thread,
+                &raw const target_affinity,
+                Some(&raw mut previous_affinity),
+            )
+        }
+        .expect("platform refused to move the current thread to the target processor group");
+
+        let mut buffer = vec![PROCESSOR_POWER_INFORMATION::default(); group_size];
+
+        let buffer_len_bytes: u32 = group_size
             .checked_mul(size_of::<PROCESSOR_POWER_INFORMATION>())
             .and_then(|len| u32::try_from(len).ok())
             .expect("processor power information buffer size overflowed u32");
 
         // SAFETY: `ProcessorInformation` requires no input buffer; we provide an output buffer
-        // large enough for `max_processor_count` entries and declare its exact size in bytes.
-        unsafe {
+        // large enough for `group_size` entries and declare its exact size in bytes.
+        let query_result = unsafe {
             CallNtPowerInformation(
                 ProcessorInformation,
                 None,
@@ -240,23 +267,20 @@ impl Bindings for BuildTargetBindings {
                 buffer_len_bytes,
             )
         }
-        .ok()
-        .expect("platform refused to provide processor power information");
+        .ok();
 
-        let mut max_mhz_by_processor = vec![0_u32; max_processor_count];
+        // Restore the original affinity before reacting to any query failure, so we never leave
+        // the thread stranded in a processor group it did not start in.
+        // SAFETY: The pointer we pass is valid for the duration of the call.
+        unsafe { SetThreadGroupAffinity(current_thread, &raw const previous_affinity, None) }
+            .expect("platform refused to restore the current thread's original processor group");
 
-        for info in &buffer {
-            // Skip entries the platform did not fill - a real processor never reports 0 MHz.
-            if info.MaxMhz == 0 {
-                continue;
-            }
+        query_result.expect("platform refused to provide processor power information");
 
-            if let Some(slot) = max_mhz_by_processor.get_mut(info.Number as usize) {
-                *slot = info.MaxMhz;
-            }
-        }
-
-        max_mhz_by_processor
+        // The array holds one entry per processor in the group, ordered by the processor's index
+        // within the group, so we surface `MaxMhz` in that same order for the caller to map onto
+        // global processor IDs.
+        buffer.iter().map(|info| info.MaxMhz).collect()
     }
 
     // Excluded from coverage because the "not in job" branches cannot be tested in automation,

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -230,7 +230,7 @@ impl Bindings for BuildTargetBindings {
     }
 
     fn get_processor_name_strings(&self, max_processor_count: usize) -> Vec<Option<String>> {
-        // Windows records the brand string of each logical processor in the registry under
+        // Windows records the model string of each logical processor in the registry under
         // `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\<id>` as the `ProcessorNameString`
         // value. The kernel populates these entries at boot for every logical processor across all
         // processor groups, so reading them is a fully passive operation: it never changes the
@@ -320,7 +320,7 @@ fn read_processor_nominal_max_mhz(processor_id: usize) -> u32 {
     if status.is_ok() { value } else { 0 }
 }
 
-/// Reads the brand string that Windows recorded for a single logical processor in the registry,
+/// Reads the model string that Windows recorded for a single logical processor in the registry,
 /// returning `None` when the platform records no value for that processor.
 ///
 /// The value lives at
@@ -329,7 +329,7 @@ fn read_processor_nominal_max_mhz(processor_id: usize) -> u32 {
 /// all processor groups without touching any thread's affinity.
 //
 // Excluded from coverage because the failure branches (an unreadable or missing registry value, or
-// an empty brand string) cannot be exercised in automation: the kernel always records a non-empty
+// an empty model string) cannot be exercised in automation: the kernel always records a non-empty
 // `ProcessorNameString` for every logical processor on the machines that run our tests.
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn read_processor_name_string(processor_id: usize) -> Option<String> {
@@ -385,7 +385,7 @@ fn read_processor_name_string(processor_id: usize) -> Option<String> {
     }
 
     // Trim the trailing NUL terminator that the registry API guarantees, then trim any surrounding
-    // whitespace that some firmware pads the brand string with. Everything the API wrote after the
+    // whitespace that some firmware pads the model string with. Everything the API wrote after the
     // NUL (and the zero-initialized tail of the buffer) is excluded by stopping at the first NUL.
     let units: Vec<u16> = buffer.into_iter().take_while(|&unit| unit != 0).collect();
     let text = String::from_utf16_lossy(&units);

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -5,6 +5,9 @@ use windows::Win32::System::JobObjects::{
     JobObjectGroupInformationEx, QueryInformationJobObject,
 };
 use windows::Win32::System::Kernel::PROCESSOR_NUMBER;
+use windows::Win32::System::Power::{
+    CallNtPowerInformation, PROCESSOR_POWER_INFORMATION, ProcessorInformation,
+};
 use windows::Win32::System::SystemInformation::{
     GROUP_AFFINITY, GetLogicalProcessorInformationEx, LOGICAL_PROCESSOR_RELATIONSHIP,
     SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
@@ -207,6 +210,53 @@ impl Bindings for BuildTargetBindings {
             .expect("platform refused to provide the current thread's legacy processor affinity");
 
         aff
+    }
+
+    fn get_processor_max_mhz(&self, max_processor_count: usize) -> Vec<u32> {
+        // `CallNtPowerInformation(ProcessorInformation)` fills one PROCESSOR_POWER_INFORMATION per
+        // logical processor, ordered by processor number. `MaxMhz` is the nominal maximum clock
+        // frequency which - unlike `CurrentMhz` - is stable and does not fluctuate with power
+        // management or thermal throttling, making it a reliable value for identifying processors.
+        //
+        // This is a legacy API that predates processor groups: on systems with more than one
+        // processor group (more than 64 logical processors) it only reports processors in the
+        // calling thread's group. Processors it does not report are left at 0, which the caller
+        // treats as "unknown".
+        let mut buffer = vec![PROCESSOR_POWER_INFORMATION::default(); max_processor_count];
+
+        let buffer_len_bytes: u32 = max_processor_count
+            .checked_mul(size_of::<PROCESSOR_POWER_INFORMATION>())
+            .and_then(|len| u32::try_from(len).ok())
+            .expect("processor power information buffer size overflowed u32");
+
+        // SAFETY: `ProcessorInformation` requires no input buffer; we provide an output buffer
+        // large enough for `max_processor_count` entries and declare its exact size in bytes.
+        unsafe {
+            CallNtPowerInformation(
+                ProcessorInformation,
+                None,
+                0,
+                Some(buffer.as_mut_ptr().cast()),
+                buffer_len_bytes,
+            )
+        }
+        .ok()
+        .expect("platform refused to provide processor power information");
+
+        let mut max_mhz_by_processor = vec![0_u32; max_processor_count];
+
+        for info in &buffer {
+            // Skip entries the platform did not fill - a real processor never reports 0 MHz.
+            if info.MaxMhz == 0 {
+                continue;
+            }
+
+            if let Some(slot) = max_mhz_by_processor.get_mut(info.Number as usize) {
+                *slot = info.MaxMhz;
+            }
+        }
+
+        max_mhz_by_processor
     }
 
     // Excluded from coverage because the "not in job" branches cannot be tested in automation,

--- a/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/real.rs
@@ -316,7 +316,7 @@ fn read_processor_nominal_max_mhz(processor_id: usize) -> u32 {
     };
 
     // A missing or unreadable entry (for example an offline processor the kernel never populated)
-    // is reported as 0, which the caller maps onto the synthetic relative speed.
+    // is reported as 0, which the caller maps onto a fallback relative speed.
     if status.is_ok() { value } else { 0 }
 }
 

--- a/packages/many_cpus_impl/src/pal/windows/group_mask.rs
+++ b/packages/many_cpus_impl/src/pal/windows/group_mask.rs
@@ -70,7 +70,7 @@ mod tests {
             0,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
         let p7 = ProcessorImpl::new(
@@ -79,7 +79,7 @@ mod tests {
             7,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -97,7 +97,7 @@ mod tests {
             1,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -117,7 +117,7 @@ mod tests {
             0,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
         let p_g1 = ProcessorImpl::new(
@@ -126,7 +126,7 @@ mod tests {
             1,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -159,7 +159,7 @@ mod tests {
             0,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
         let p3 = ProcessorImpl::new(
@@ -168,7 +168,7 @@ mod tests {
             3,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
         let p7 = ProcessorImpl::new(
@@ -177,7 +177,7 @@ mod tests {
             7,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 

--- a/packages/many_cpus_impl/src/pal/windows/group_mask.rs
+++ b/packages/many_cpus_impl/src/pal/windows/group_mask.rs
@@ -71,6 +71,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
         let p7 = ProcessorImpl::new(
             0,
@@ -79,6 +80,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         mask.add(&p0);
@@ -96,6 +98,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         mask.add(&p0_g1);
@@ -115,6 +118,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
         let p_g1 = ProcessorImpl::new(
             1,
@@ -123,6 +127,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         mask.add(&p_g0);
@@ -155,6 +160,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
         let p3 = ProcessorImpl::new(
             0,
@@ -163,6 +169,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
         let p7 = ProcessorImpl::new(
             0,
@@ -171,6 +178,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         mask.add(&p0);

--- a/packages/many_cpus_impl/src/pal/windows/group_mask.rs
+++ b/packages/many_cpus_impl/src/pal/windows/group_mask.rs
@@ -57,15 +57,29 @@ impl GroupMask {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::EfficiencyClass;
+    use crate::{EfficiencyClass, RelativeSpeed};
 
     #[test]
     fn smoke_test() {
         let mut mask = GroupMask::none();
         assert_eq!(mask.value(), 0);
 
-        let p0 = ProcessorImpl::new(0, 0, 0, 0, EfficiencyClass::Performance);
-        let p7 = ProcessorImpl::new(0, 7, 7, 0, EfficiencyClass::Performance);
+        let p0 = ProcessorImpl::new(
+            0,
+            0,
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
+        let p7 = ProcessorImpl::new(
+            0,
+            7,
+            7,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         mask.add(&p0);
         assert_eq!(mask.value(), 1 << 0);
@@ -75,7 +89,14 @@ mod tests {
 
         let mut mask = GroupMask::none();
 
-        let p0_g1 = ProcessorImpl::new(1, 0, 1, 0, EfficiencyClass::Performance);
+        let p0_g1 = ProcessorImpl::new(
+            1,
+            0,
+            1,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         mask.add(&p0_g1);
         assert_eq!(mask.value(), 1 << 0);
@@ -87,8 +108,22 @@ mod tests {
         let mut mask = GroupMask::none();
         assert_eq!(mask.value(), 0);
 
-        let p_g0 = ProcessorImpl::new(0, 0, 0, 0, EfficiencyClass::Performance);
-        let p_g1 = ProcessorImpl::new(1, 0, 1, 0, EfficiencyClass::Performance);
+        let p_g0 = ProcessorImpl::new(
+            0,
+            0,
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
+        let p_g1 = ProcessorImpl::new(
+            1,
+            0,
+            1,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         mask.add(&p_g0);
         mask.add(&p_g1);
@@ -113,9 +148,30 @@ mod tests {
     fn contains_by_index_in_group() {
         // Create a mask with bits 0, 3, and 7 set
         let mut mask = GroupMask::none();
-        let p0 = ProcessorImpl::new(0, 0, 0, 0, EfficiencyClass::Performance);
-        let p3 = ProcessorImpl::new(0, 3, 3, 0, EfficiencyClass::Performance);
-        let p7 = ProcessorImpl::new(0, 7, 7, 0, EfficiencyClass::Performance);
+        let p0 = ProcessorImpl::new(
+            0,
+            0,
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
+        let p3 = ProcessorImpl::new(
+            0,
+            3,
+            3,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
+        let p7 = ProcessorImpl::new(
+            0,
+            7,
+            7,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         mask.add(&p0);
         mask.add(&p3);

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 use std::mem::offset_of;
 use std::num::NonZero;
 use std::ptr::NonNull;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use folo_ffi::NativeBuffer;
 use itertools::Itertools;
@@ -83,6 +83,7 @@ impl Platform for BuildTargetPlatform {
         let efficiency_classes = self.get_processor_efficiency_classes();
         let memory_regions = self.get_processor_memory_regions();
         let relative_speeds = self.get_processor_relative_speeds();
+        let brands = self.get_processor_brands();
         let allowed_processors = self.processors_allowed_by_job_constraints();
 
         // We are required to return all the processors ordered by the processor ID.
@@ -114,6 +115,8 @@ impl Platform for BuildTargetPlatform {
 
                 let relative_speed = *relative_speeds.get(processor_id as usize).expect("we expect to have the relative speed for every processor ID unless the platform lied to us at some point");
 
+                let cpu_brand = brands.get(processor_id as usize).expect("we expect to have the brand slot for every processor ID unless the platform lied to us at some point").clone();
+
                 Some(ProcessorImpl::new(
                     group_index
                         .try_into()
@@ -123,6 +126,7 @@ impl Platform for BuildTargetPlatform {
                     memory_region_index,
                     efficiency_class,
                     relative_speed,
+                    cpu_brand,
                 ))
             })
         ).expect(
@@ -610,12 +614,28 @@ impl BuildTargetPlatform {
         // The bindings surface each processor's nominal maximum clock frequency (MHz) by reading
         // the values Windows records in the registry for every logical processor across all
         // processor groups. This is a passive read that never changes any thread's affinity. The
-        // MHz value is surfaced directly as the relative speed; processors the platform reports no
-        // value for (0 MHz) map to the synthetic minimum via `RelativeSpeed::from_raw()`.
+        // MHz value is scaled into the abstract relative-speed domain by `from_os_metric`;
+        // processors the platform reports no value for (0 MHz) map to the synthetic minimum.
         self.bindings
             .get_processor_max_mhz(self.max_processor_count())
             .into_iter()
-            .map(RelativeSpeed::from_raw)
+            .map(RelativeSpeed::from_os_metric)
+            .collect_vec()
+            .into_boxed_slice()
+    }
+
+    /// Gets the CPU brand strings of all processors on the system, ordered by processor ID.
+    /// This also returns data for offline processors. Processors the platform reports no brand
+    /// for map to `None`.
+    #[must_use]
+    fn get_processor_brands(&self) -> Box<[Option<Arc<str>>]> {
+        // The bindings surface each processor's brand string by reading the `ProcessorNameString`
+        // value Windows records in the registry for every logical processor across all processor
+        // groups. This is a passive read that never changes any thread's affinity.
+        self.bindings
+            .get_processor_name_strings(self.max_processor_count())
+            .into_iter()
+            .map(|name| name.map(Arc::from))
             .collect_vec()
             .into_boxed_slice()
     }
@@ -971,8 +991,40 @@ mod tests {
         assert_eq!(processors.len(), 4);
 
         for (index, processor) in processors.iter().enumerate() {
-            let expected = (u32::try_from(index).unwrap() + 1) * 1000;
-            assert_eq!(processor.as_target().relative_speed.as_u32(), expected);
+            let expected_mhz = (u32::try_from(index).unwrap() + 1) * 1000;
+            assert_eq!(
+                processor.as_target().relative_speed,
+                RelativeSpeed::from_os_metric(expected_mhz)
+            );
+        }
+    }
+
+    #[test]
+    fn get_all_processors_reports_cpu_brand() {
+        // A simple single-group system with 4 logical processors. The simulated layout reports the
+        // same brand string for every processor, which must surface unchanged as the processor's
+        // CPU brand.
+        let mut bindings = MockBindings::new();
+        simulate_processor_layout(
+            &mut bindings,
+            [4],
+            [4],
+            [vec![0, 0, 0, 0]],
+            [vec![0, 0, 0, 0]],
+            None,
+        );
+
+        let platform = BuildTargetPlatform::new(BindingsFacade::from_mock(bindings));
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 4);
+
+        for processor in &processors {
+            assert_eq!(
+                processor.as_target().cpu_brand.as_deref(),
+                Some("Test Processor Brand")
+            );
         }
     }
 
@@ -1000,8 +1052,11 @@ mod tests {
         assert_eq!(processors.len(), 4);
 
         for (index, processor) in processors.iter().enumerate() {
-            let expected = (u32::try_from(index).unwrap() + 1) * 1000;
-            assert_eq!(processor.as_target().relative_speed.as_u32(), expected);
+            let expected_mhz = (u32::try_from(index).unwrap() + 1) * 1000;
+            assert_eq!(
+                processor.as_target().relative_speed,
+                RelativeSpeed::from_os_metric(expected_mhz)
+            );
         }
     }
 
@@ -1398,6 +1453,7 @@ mod tests {
             &efficiency_ratings_per_group,
         );
         simulate_get_relative_speeds(bindings);
+        simulate_get_brands(bindings);
 
         // Transform the booleans to IDs.
         let job_affinitized_processors_per_group =
@@ -1471,6 +1527,21 @@ mod tests {
                             u32::try_from(processor_id).expect("processor ID fits in u32");
                         (processor_id + 1) * 1000
                     })
+                    .collect_vec()
+            });
+    }
+
+    /// Registers a default `get_processor_name_strings` expectation that reports the same brand
+    /// string for every processor ID, mirroring a homogeneous machine. The binding surfaces one
+    /// value per processor across all processor groups, indexed directly by processor ID, so this
+    /// lets tests observe the brand flowing through `get_all_processors()` for processors in every
+    /// group.
+    fn simulate_get_brands(bindings: &mut MockBindings) {
+        bindings
+            .expect_get_processor_name_strings()
+            .returning(move |max_processor_count| {
+                std::iter::repeat_with(|| Some("Test Processor Brand".to_string()))
+                    .take(max_processor_count)
                     .collect_vec()
             });
     }

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -973,7 +973,9 @@ mod tests {
     fn get_all_processors_reports_relative_speed() {
         // A simple single-group system with 4 logical processors. The simulated layout reports a
         // distinct nominal clock speed per processor - processor `i` reports `(i + 1) * 1000` MHz -
-        // which must surface unchanged as the processor's relative speed.
+        // which is scaled by `RelativeSpeed::from_os_metric` into the processor's relative speed.
+        // The raw MHz figure is deliberately scaled (by pi), not surfaced unchanged, so the
+        // assertion below compares against `from_os_metric` rather than the raw MHz value.
         let mut bindings = MockBindings::new();
         simulate_processor_layout(
             &mut bindings,

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -607,45 +607,17 @@ impl BuildTargetPlatform {
     /// This also returns data for offline processors but the value for those is unspecified.
     #[must_use]
     fn get_processor_relative_speeds(&self) -> Box<[RelativeSpeed]> {
-        // The underlying `CallNtPowerInformation` API predates processor groups and only reports
-        // the processors in the calling thread's group, so we query each active group in turn and
-        // place every processor's value at its global processor ID. This covers all processors
-        // regardless of how many processor groups exist. The nominal maximum clock frequency (MHz)
-        // is surfaced directly as the relative speed; processors the platform reports no value for
-        // (0 MHz) map to the synthetic minimum via `RelativeSpeed::from_raw()`.
-        let group_metas = self.get_processor_group_metas();
-
-        let mut relative_speeds = vec![RelativeSpeed::SYNTHETIC; self.max_processor_count()];
-
-        for (group_index, meta) in group_metas.iter().enumerate() {
-            // A group with no active processors cannot be entered (there is nothing to schedule
-            // this thread onto) and has no processors to report, so we skip it.
-            if meta.active_processors == 0 {
-                continue;
-            }
-
-            let group_number = ProcessorGroupIndex::try_from(group_index)
-                .expect("processor group index cannot exceed the platform maximum of u16::MAX");
-
-            let group_max_mhz = self
-                .bindings
-                .get_processor_group_max_mhz(group_number, usize::from(meta.max_processors));
-
-            for (index_in_group, &max_mhz) in group_max_mhz.iter().enumerate() {
-                let index_in_group = ProcessorId::try_from(index_in_group)
-                    .expect("processor index within a group cannot exceed 64, so it always fits");
-
-                let processor_id = meta.start_offset.checked_add(index_in_group).expect(
-                    "processor ID overflowed - only possible if the platform lied about group sizes",
-                );
-
-                if let Some(slot) = relative_speeds.get_mut(processor_id as usize) {
-                    *slot = RelativeSpeed::from_raw(max_mhz);
-                }
-            }
-        }
-
-        relative_speeds.into_boxed_slice()
+        // The bindings surface each processor's nominal maximum clock frequency (MHz) by reading
+        // the values Windows records in the registry for every logical processor across all
+        // processor groups. This is a passive read that never changes any thread's affinity. The
+        // MHz value is surfaced directly as the relative speed; processors the platform reports no
+        // value for (0 MHz) map to the synthetic minimum via `RelativeSpeed::from_raw()`.
+        self.bindings
+            .get_processor_max_mhz(self.max_processor_count())
+            .into_iter()
+            .map(RelativeSpeed::from_raw)
+            .collect_vec()
+            .into_boxed_slice()
     }
 
     /// Gets the efficiency classes of all processors on the system, ordered by processor ID.
@@ -1006,10 +978,11 @@ mod tests {
 
     #[test]
     fn get_all_processors_reports_relative_speed_across_groups() {
-        // Two processor groups with two logical processors each. Windows reports processor power
-        // information one group at a time, so this proves that processors in every group - not just
-        // the first - receive their reported relative speed. Processor `i` (global ID) reports
-        // `(i + 1) * 1000` MHz, and the two groups occupy processor IDs 0..2 and 2..4.
+        // Two processor groups with two logical processors each. The registry-backed binding reports
+        // one nominal clock speed per processor across all groups at once, so this proves that
+        // processors in every group - not just the first - receive their reported relative speed.
+        // Processor `i` (global ID) reports `(i + 1) * 1000` MHz, and the two groups occupy processor
+        // IDs 0..2 and 2..4.
         let mut bindings = MockBindings::new();
         simulate_processor_layout(
             &mut bindings,
@@ -1424,7 +1397,7 @@ mod tests {
             &group_active_counts,
             &efficiency_ratings_per_group,
         );
-        simulate_get_relative_speeds(bindings, &group_max_counts);
+        simulate_get_relative_speeds(bindings);
 
         // Transform the booleans to IDs.
         let job_affinitized_processors_per_group =
@@ -1483,30 +1456,19 @@ mod tests {
         });
     }
 
-    /// Registers a default `get_processor_group_max_mhz` expectation that reports a distinct nominal
-    /// clock speed per *global* processor ID: processor `i` reports `(i + 1) * 1000` MHz. Because
-    /// the binding is queried one processor group at a time, we reconstruct each processor's global
-    /// ID from the group's start offset (the sum of the preceding groups' max sizes). This gives
-    /// every simulated processor a unique, non-synthetic relative speed so tests can observe the
-    /// value flowing through `get_all_processors()` for processors in every group.
-    fn simulate_get_relative_speeds(
-        bindings: &mut MockBindings,
-        group_max_counts: &Arc<[ProcessorIndexInGroup]>,
-    ) {
-        let group_max_counts = Arc::clone(group_max_counts);
-
+    /// Registers a default `get_processor_max_mhz` expectation that reports a distinct nominal clock
+    /// speed per processor ID: processor `i` reports `(i + 1) * 1000` MHz. The binding surfaces one
+    /// value per processor across all processor groups, indexed directly by processor ID, so this
+    /// gives every simulated processor a unique, non-synthetic relative speed and lets tests observe
+    /// the value flowing through `get_all_processors()` for processors in every group.
+    fn simulate_get_relative_speeds(bindings: &mut MockBindings) {
         bindings
-            .expect_get_processor_group_max_mhz()
-            .returning(move |group_number, group_size| {
-                let start_offset: u32 = group_max_counts[..group_number as usize]
-                    .iter()
-                    .map(|&count| u32::from(count))
-                    .sum();
-
-                (0..group_size)
-                    .map(|index_in_group| {
-                        let processor_id = start_offset
-                            + u32::try_from(index_in_group).expect("processor ID fits in u32");
+            .expect_get_processor_max_mhz()
+            .returning(move |max_processor_count| {
+                (0..max_processor_count)
+                    .map(|processor_id| {
+                        let processor_id =
+                            u32::try_from(processor_id).expect("processor ID fits in u32");
                         (processor_id + 1) * 1000
                     })
                     .collect_vec()

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -21,7 +21,7 @@ use windows::core::HRESULT;
 
 use crate::pal::windows::{Bindings, BindingsFacade, ProcessorGroupIndex, ProcessorIndexInGroup};
 use crate::pal::{GroupMask, Platform, ProcessorFacade, ProcessorImpl};
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// Singleton instance of `BuildTargetPlatform`, used by public API types
 /// to hook up to the correct PAL implementation.
@@ -82,6 +82,7 @@ impl Platform for BuildTargetPlatform {
 
         let efficiency_classes = self.get_processor_efficiency_classes();
         let memory_regions = self.get_processor_memory_regions();
+        let relative_speeds = self.get_processor_relative_speeds();
         let allowed_processors = self.processors_allowed_by_job_constraints();
 
         // We are required to return all the processors ordered by the processor ID.
@@ -111,6 +112,8 @@ impl Platform for BuildTargetPlatform {
 
                 let efficiency_class = *efficiency_classes.get(processor_id as usize).expect("we expect to have the efficiency class for every processor ID unless the platform lied to us at some point");
 
+                let relative_speed = *relative_speeds.get(processor_id as usize).expect("we expect to have the relative speed for every processor ID unless the platform lied to us at some point");
+
                 Some(ProcessorImpl::new(
                     group_index
                         .try_into()
@@ -118,7 +121,8 @@ impl Platform for BuildTargetPlatform {
                     index_in_group,
                     processor_id,
                     memory_region_index,
-                    efficiency_class
+                    efficiency_class,
+                    relative_speed,
                 ))
             })
         ).expect(
@@ -599,6 +603,21 @@ impl BuildTargetPlatform {
             .into_boxed_slice()
     }
 
+    /// Gets the relative speed of all processors on the system, ordered by processor ID.
+    /// This also returns data for offline processors but the value for those is unspecified.
+    #[must_use]
+    fn get_processor_relative_speeds(&self) -> Box<[RelativeSpeed]> {
+        // The underlying API reports the nominal maximum clock frequency (MHz) per processor,
+        // which we surface directly as the relative speed. Processors the platform reports no
+        // value for (0 MHz) map to the synthetic minimum via `RelativeSpeed::from_raw()`.
+        self.bindings
+            .get_processor_max_mhz(self.max_processor_count())
+            .into_iter()
+            .map(RelativeSpeed::from_raw)
+            .collect_vec()
+            .into_boxed_slice()
+    }
+
     /// Gets the efficiency classes of all processors on the system, ordered by processor ID.
     /// This also returns data for offline processors.
     #[must_use]
@@ -926,6 +945,33 @@ mod tests {
         assert_eq!(p3.as_target().group_index, 0);
         assert_eq!(p3.as_target().index_in_group, 3);
         assert_eq!(p3.as_target().memory_region_id, 0);
+    }
+
+    #[test]
+    fn get_all_processors_reports_relative_speed() {
+        // A simple single-group system with 4 logical processors. The simulated layout reports a
+        // distinct nominal clock speed per processor - processor `i` reports `(i + 1) * 1000` MHz -
+        // which must surface unchanged as the processor's relative speed.
+        let mut bindings = MockBindings::new();
+        simulate_processor_layout(
+            &mut bindings,
+            [4],
+            [4],
+            [vec![0, 0, 0, 0]],
+            [vec![0, 0, 0, 0]],
+            None,
+        );
+
+        let platform = BuildTargetPlatform::new(BindingsFacade::from_mock(bindings));
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 4);
+
+        for (index, processor) in processors.iter().enumerate() {
+            let expected = (u32::try_from(index).unwrap() + 1) * 1000;
+            assert_eq!(processor.as_target().relative_speed.as_u32(), expected);
+        }
     }
 
     #[test]
@@ -1320,6 +1366,7 @@ mod tests {
             &group_active_counts,
             &efficiency_ratings_per_group,
         );
+        simulate_get_relative_speeds(bindings);
 
         // Transform the booleans to IDs.
         let job_affinitized_processors_per_group =
@@ -1376,6 +1423,22 @@ mod tests {
 
             move |group_number| u32::from(group_max_counts[group_number as usize])
         });
+    }
+
+    /// Registers a default `get_processor_max_mhz` expectation that reports a distinct nominal
+    /// clock speed per processor ID: processor `i` reports `(i + 1) * 1000` MHz. This gives every
+    /// simulated processor a unique, non-synthetic relative speed so tests can observe the value
+    /// flowing through `get_all_processors()`.
+    fn simulate_get_relative_speeds(bindings: &mut MockBindings) {
+        bindings
+            .expect_get_processor_max_mhz()
+            .returning(|max_processor_count| {
+                (0..max_processor_count)
+                    .map(|processor_id| {
+                        (u32::try_from(processor_id).expect("processor ID fits in u32") + 1) * 1000
+                    })
+                    .collect_vec()
+            });
     }
 
     fn simulate_get_numa_relations(

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -83,7 +83,7 @@ impl Platform for BuildTargetPlatform {
         let efficiency_classes = self.get_processor_efficiency_classes();
         let memory_regions = self.get_processor_memory_regions();
         let relative_speeds = self.get_processor_relative_speeds();
-        let brands = self.get_processor_brands();
+        let models = self.get_processor_models();
         let allowed_processors = self.processors_allowed_by_job_constraints();
 
         // We are required to return all the processors ordered by the processor ID.
@@ -115,7 +115,7 @@ impl Platform for BuildTargetPlatform {
 
                 let relative_speed = *relative_speeds.get(processor_id as usize).expect("we expect to have the relative speed for every processor ID unless the platform lied to us at some point");
 
-                let brand = brands.get(processor_id as usize).expect("we expect to have the brand slot for every processor ID unless the platform lied to us at some point").clone();
+                let model = models.get(processor_id as usize).expect("we expect to have the model slot for every processor ID unless the platform lied to us at some point").clone();
 
                 Some(ProcessorImpl::new(
                     group_index
@@ -126,7 +126,7 @@ impl Platform for BuildTargetPlatform {
                     memory_region_index,
                     efficiency_class,
                     relative_speed,
-                    brand,
+                    model,
                 ))
             })
         ).expect(
@@ -624,12 +624,12 @@ impl BuildTargetPlatform {
             .into_boxed_slice()
     }
 
-    /// Gets the brand strings of all processors on the system, ordered by processor ID.
-    /// This also returns data for offline processors. Processors the platform reports no brand
+    /// Gets the model strings of all processors on the system, ordered by processor ID.
+    /// This also returns data for offline processors. Processors the platform reports no model
     /// for map to `None`.
     #[must_use]
-    fn get_processor_brands(&self) -> Box<[Option<Arc<str>>]> {
-        // The bindings surface each processor's brand string by reading the `ProcessorNameString`
+    fn get_processor_models(&self) -> Box<[Option<Arc<str>>]> {
+        // The bindings surface each processor's model string by reading the `ProcessorNameString`
         // value Windows records in the registry for every logical processor across all processor
         // groups. This is a passive read that never changes any thread's affinity.
         self.bindings
@@ -1002,10 +1002,10 @@ mod tests {
     }
 
     #[test]
-    fn get_all_processors_reports_brand() {
+    fn get_all_processors_reports_model() {
         // A simple single-group system with 4 logical processors. The simulated layout reports the
-        // same brand string for every processor, which must surface unchanged as the processor's
-        // brand.
+        // same model string for every processor, which must surface unchanged as the processor's
+        // model.
         let mut bindings = MockBindings::new();
         simulate_processor_layout(
             &mut bindings,
@@ -1024,8 +1024,8 @@ mod tests {
 
         for processor in &processors {
             assert_eq!(
-                processor.as_target().brand.as_deref(),
-                Some("Test Processor Brand")
+                processor.as_target().model.as_deref(),
+                Some("Test Processor Model")
             );
         }
     }
@@ -1455,7 +1455,7 @@ mod tests {
             &efficiency_ratings_per_group,
         );
         simulate_get_relative_speeds(bindings);
-        simulate_get_brands(bindings);
+        simulate_get_models(bindings);
 
         // Transform the booleans to IDs.
         let job_affinitized_processors_per_group =
@@ -1533,16 +1533,16 @@ mod tests {
             });
     }
 
-    /// Registers a default `get_processor_name_strings` expectation that reports the same brand
+    /// Registers a default `get_processor_name_strings` expectation that reports the same model
     /// string for every processor ID, mirroring a homogeneous machine. The binding surfaces one
     /// value per processor across all processor groups, indexed directly by processor ID, so this
-    /// lets tests observe the brand flowing through `get_all_processors()` for processors in every
+    /// lets tests observe the model flowing through `get_all_processors()` for processors in every
     /// group.
-    fn simulate_get_brands(bindings: &mut MockBindings) {
+    fn simulate_get_models(bindings: &mut MockBindings) {
         bindings
             .expect_get_processor_name_strings()
             .returning(move |max_processor_count| {
-                std::iter::repeat_with(|| Some("Test Processor Brand".to_string()))
+                std::iter::repeat_with(|| Some("Test Processor Model".to_string()))
                     .take(max_processor_count)
                     .collect_vec()
             });

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -607,15 +607,45 @@ impl BuildTargetPlatform {
     /// This also returns data for offline processors but the value for those is unspecified.
     #[must_use]
     fn get_processor_relative_speeds(&self) -> Box<[RelativeSpeed]> {
-        // The underlying API reports the nominal maximum clock frequency (MHz) per processor,
-        // which we surface directly as the relative speed. Processors the platform reports no
-        // value for (0 MHz) map to the synthetic minimum via `RelativeSpeed::from_raw()`.
-        self.bindings
-            .get_processor_max_mhz(self.max_processor_count())
-            .into_iter()
-            .map(RelativeSpeed::from_raw)
-            .collect_vec()
-            .into_boxed_slice()
+        // The underlying `CallNtPowerInformation` API predates processor groups and only reports
+        // the processors in the calling thread's group, so we query each active group in turn and
+        // place every processor's value at its global processor ID. This covers all processors
+        // regardless of how many processor groups exist. The nominal maximum clock frequency (MHz)
+        // is surfaced directly as the relative speed; processors the platform reports no value for
+        // (0 MHz) map to the synthetic minimum via `RelativeSpeed::from_raw()`.
+        let group_metas = self.get_processor_group_metas();
+
+        let mut relative_speeds = vec![RelativeSpeed::SYNTHETIC; self.max_processor_count()];
+
+        for (group_index, meta) in group_metas.iter().enumerate() {
+            // A group with no active processors cannot be entered (there is nothing to schedule
+            // this thread onto) and has no processors to report, so we skip it.
+            if meta.active_processors == 0 {
+                continue;
+            }
+
+            let group_number = ProcessorGroupIndex::try_from(group_index)
+                .expect("processor group index cannot exceed the platform maximum of u16::MAX");
+
+            let group_max_mhz = self
+                .bindings
+                .get_processor_group_max_mhz(group_number, usize::from(meta.max_processors));
+
+            for (index_in_group, &max_mhz) in group_max_mhz.iter().enumerate() {
+                let index_in_group = ProcessorId::try_from(index_in_group)
+                    .expect("processor index within a group cannot exceed 64, so it always fits");
+
+                let processor_id = meta.start_offset.checked_add(index_in_group).expect(
+                    "processor ID overflowed - only possible if the platform lied about group sizes",
+                );
+
+                if let Some(slot) = relative_speeds.get_mut(processor_id as usize) {
+                    *slot = RelativeSpeed::from_raw(max_mhz);
+                }
+            }
+        }
+
+        relative_speeds.into_boxed_slice()
     }
 
     /// Gets the efficiency classes of all processors on the system, ordered by processor ID.
@@ -959,6 +989,34 @@ mod tests {
             [4],
             [vec![0, 0, 0, 0]],
             [vec![0, 0, 0, 0]],
+            None,
+        );
+
+        let platform = BuildTargetPlatform::new(BindingsFacade::from_mock(bindings));
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 4);
+
+        for (index, processor) in processors.iter().enumerate() {
+            let expected = (u32::try_from(index).unwrap() + 1) * 1000;
+            assert_eq!(processor.as_target().relative_speed.as_u32(), expected);
+        }
+    }
+
+    #[test]
+    fn get_all_processors_reports_relative_speed_across_groups() {
+        // Two processor groups with two logical processors each. Windows reports processor power
+        // information one group at a time, so this proves that processors in every group - not just
+        // the first - receive their reported relative speed. Processor `i` (global ID) reports
+        // `(i + 1) * 1000` MHz, and the two groups occupy processor IDs 0..2 and 2..4.
+        let mut bindings = MockBindings::new();
+        simulate_processor_layout(
+            &mut bindings,
+            [2, 2],
+            [2, 2],
+            [vec![0, 0], vec![0, 0]],
+            [vec![0, 0], vec![1, 1]],
             None,
         );
 
@@ -1366,7 +1424,7 @@ mod tests {
             &group_active_counts,
             &efficiency_ratings_per_group,
         );
-        simulate_get_relative_speeds(bindings);
+        simulate_get_relative_speeds(bindings, &group_max_counts);
 
         // Transform the booleans to IDs.
         let job_affinitized_processors_per_group =
@@ -1425,17 +1483,31 @@ mod tests {
         });
     }
 
-    /// Registers a default `get_processor_max_mhz` expectation that reports a distinct nominal
-    /// clock speed per processor ID: processor `i` reports `(i + 1) * 1000` MHz. This gives every
-    /// simulated processor a unique, non-synthetic relative speed so tests can observe the value
-    /// flowing through `get_all_processors()`.
-    fn simulate_get_relative_speeds(bindings: &mut MockBindings) {
+    /// Registers a default `get_processor_group_max_mhz` expectation that reports a distinct nominal
+    /// clock speed per *global* processor ID: processor `i` reports `(i + 1) * 1000` MHz. Because
+    /// the binding is queried one processor group at a time, we reconstruct each processor's global
+    /// ID from the group's start offset (the sum of the preceding groups' max sizes). This gives
+    /// every simulated processor a unique, non-synthetic relative speed so tests can observe the
+    /// value flowing through `get_all_processors()` for processors in every group.
+    fn simulate_get_relative_speeds(
+        bindings: &mut MockBindings,
+        group_max_counts: &Arc<[ProcessorIndexInGroup]>,
+    ) {
+        let group_max_counts = Arc::clone(group_max_counts);
+
         bindings
-            .expect_get_processor_max_mhz()
-            .returning(|max_processor_count| {
-                (0..max_processor_count)
-                    .map(|processor_id| {
-                        (u32::try_from(processor_id).expect("processor ID fits in u32") + 1) * 1000
+            .expect_get_processor_group_max_mhz()
+            .returning(move |group_number, group_size| {
+                let start_offset: u32 = group_max_counts[..group_number as usize]
+                    .iter()
+                    .map(|&count| u32::from(count))
+                    .sum();
+
+                (0..group_size)
+                    .map(|index_in_group| {
+                        let processor_id = start_offset
+                            + u32::try_from(index_in_group).expect("processor ID fits in u32");
+                        (processor_id + 1) * 1000
                     })
                     .collect_vec()
             });

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -615,7 +615,7 @@ impl BuildTargetPlatform {
         // the values Windows records in the registry for every logical processor across all
         // processor groups. This is a passive read that never changes any thread's affinity. The
         // MHz value is scaled into the abstract relative-speed domain by `from_os_metric`;
-        // processors the platform reports no value for (0 MHz) map to the synthetic minimum.
+        // processors the platform reports no value for (0 MHz) map to a fallback value.
         self.bindings
             .get_processor_max_mhz(self.max_processor_count())
             .into_iter()
@@ -1517,8 +1517,8 @@ mod tests {
     /// Registers a default `get_processor_max_mhz` expectation that reports a distinct nominal clock
     /// speed per processor ID: processor `i` reports `(i + 1) * 1000` MHz. The binding surfaces one
     /// value per processor across all processor groups, indexed directly by processor ID, so this
-    /// gives every simulated processor a unique, non-synthetic relative speed and lets tests observe
-    /// the value flowing through `get_all_processors()` for processors in every group.
+    /// gives every simulated processor a unique, real (non-fallback) relative speed and lets tests
+    /// observe the value flowing through `get_all_processors()` for processors in every group.
     fn simulate_get_relative_speeds(bindings: &mut MockBindings) {
         bindings
             .expect_get_processor_max_mhz()

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -115,7 +115,7 @@ impl Platform for BuildTargetPlatform {
 
                 let relative_speed = *relative_speeds.get(processor_id as usize).expect("we expect to have the relative speed for every processor ID unless the platform lied to us at some point");
 
-                let cpu_brand = brands.get(processor_id as usize).expect("we expect to have the brand slot for every processor ID unless the platform lied to us at some point").clone();
+                let brand = brands.get(processor_id as usize).expect("we expect to have the brand slot for every processor ID unless the platform lied to us at some point").clone();
 
                 Some(ProcessorImpl::new(
                     group_index
@@ -126,7 +126,7 @@ impl Platform for BuildTargetPlatform {
                     memory_region_index,
                     efficiency_class,
                     relative_speed,
-                    cpu_brand,
+                    brand,
                 ))
             })
         ).expect(
@@ -624,7 +624,7 @@ impl BuildTargetPlatform {
             .into_boxed_slice()
     }
 
-    /// Gets the CPU brand strings of all processors on the system, ordered by processor ID.
+    /// Gets the brand strings of all processors on the system, ordered by processor ID.
     /// This also returns data for offline processors. Processors the platform reports no brand
     /// for map to `None`.
     #[must_use]
@@ -1002,10 +1002,10 @@ mod tests {
     }
 
     #[test]
-    fn get_all_processors_reports_cpu_brand() {
+    fn get_all_processors_reports_brand() {
         // A simple single-group system with 4 logical processors. The simulated layout reports the
         // same brand string for every processor, which must surface unchanged as the processor's
-        // CPU brand.
+        // brand.
         let mut bindings = MockBindings::new();
         simulate_processor_layout(
             &mut bindings,
@@ -1024,7 +1024,7 @@ mod tests {
 
         for processor in &processors {
             assert_eq!(
-                processor.as_target().cpu_brand.as_deref(),
+                processor.as_target().brand.as_deref(),
                 Some("Test Processor Brand")
             );
         }

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -115,7 +115,7 @@ mod tests {
             7,
             0,
             EfficiencyClass::Performance,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 
@@ -139,7 +139,7 @@ mod tests {
             5,
             1,
             EfficiencyClass::Efficiency,
-            RelativeSpeed::SYNTHETIC,
+            RelativeSpeed::from_raw(1),
             None,
         );
 

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -1,10 +1,11 @@
 use std::fmt::Display;
+use std::sync::Arc;
 
 use crate::pal::AbstractProcessor;
 use crate::pal::windows::{ProcessorGroupIndex, ProcessorIndexInGroup};
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ProcessorImpl {
     pub(crate) group_index: ProcessorGroupIndex,
     pub(crate) index_in_group: ProcessorIndexInGroup,
@@ -17,6 +18,8 @@ pub(crate) struct ProcessorImpl {
     pub(crate) efficiency_class: EfficiencyClass,
 
     pub(crate) relative_speed: RelativeSpeed,
+
+    pub(crate) cpu_brand: Option<Arc<str>>,
 }
 
 impl ProcessorImpl {
@@ -27,6 +30,7 @@ impl ProcessorImpl {
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
         relative_speed: RelativeSpeed,
+        cpu_brand: Option<Arc<str>>,
     ) -> Self {
         Self {
             group_index,
@@ -35,6 +39,7 @@ impl ProcessorImpl {
             memory_region_id,
             efficiency_class,
             relative_speed,
+            cpu_brand,
         }
     }
 }
@@ -64,6 +69,10 @@ impl AbstractProcessor for ProcessorImpl {
 
     fn relative_speed(&self) -> RelativeSpeed {
         self.relative_speed
+    }
+
+    fn cpu_brand(&self) -> Option<&str> {
+        self.cpu_brand.as_deref()
     }
 }
 
@@ -99,12 +108,14 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
+            Some(Arc::from("Test Brand")),
         );
 
         assert_eq!(processor.id(), 2);
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
-        assert_eq!(processor.relative_speed().as_u32(), 3600);
+        assert_eq!(processor.relative_speed().as_u64(), 3600);
+        assert_eq!(processor.cpu_brand(), Some("Test Brand"));
 
         let processor2 = ProcessorImpl::new(
             0,
@@ -113,6 +124,7 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
+            Some(Arc::from("Test Brand")),
         );
         assert_eq!(processor, processor2);
 
@@ -123,6 +135,7 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
+            Some(Arc::from("Test Brand")),
         );
         assert_ne!(processor, processor3);
         assert!(processor < processor3);
@@ -139,6 +152,7 @@ mod tests {
             0,
             EfficiencyClass::Performance,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         let display_output = processor.to_string();
@@ -162,6 +176,7 @@ mod tests {
             1,
             EfficiencyClass::Efficiency,
             RelativeSpeed::SYNTHETIC,
+            None,
         );
 
         let processor_ref: &ProcessorImpl = processor.as_ref();
@@ -169,5 +184,6 @@ mod tests {
         assert_eq!(processor_ref.id, processor.id);
         assert_eq!(processor_ref.group_index, processor.group_index);
         assert_eq!(processor_ref.index_in_group, processor.index_in_group);
+        assert_eq!(processor_ref.cpu_brand(), None);
     }
 }

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -1,5 +1,4 @@
 use std::fmt::Display;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::pal::AbstractProcessor;
@@ -83,36 +82,6 @@ impl AsRef<Self> for ProcessorImpl {
     }
 }
 
-// A processor is uniquely identified by its `id`. The other fields are descriptive metadata that
-// never differs between two handles to the same processor, so equality, hashing, and ordering are
-// all keyed on `id` alone. Keeping them in agreement upholds the `Ord`/`Eq` contract:
-// `cmp(a, b) == Equal` exactly when `a == b`.
-impl PartialEq for ProcessorImpl {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for ProcessorImpl {}
-
-impl Hash for ProcessorImpl {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-    }
-}
-
-impl PartialOrd for ProcessorImpl {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ProcessorImpl {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.id.cmp(&other.id)
-    }
-}
-
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -135,71 +104,6 @@ mod tests {
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(processor.relative_speed().as_u64(), 3600);
         assert_eq!(processor.model(), Some("Test Model"));
-
-        let processor2 = ProcessorImpl::new(
-            0,
-            1,
-            2,
-            3,
-            EfficiencyClass::Performance,
-            RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Test Model")),
-        );
-        assert_eq!(processor, processor2);
-
-        let processor3 = ProcessorImpl::new(
-            0,
-            1,
-            4,
-            3,
-            EfficiencyClass::Performance,
-            RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Test Model")),
-        );
-        assert_ne!(processor, processor3);
-        assert!(processor < processor3);
-        assert!(processor3 > processor);
-    }
-
-    #[test]
-    fn equal_ids_compare_equal_regardless_of_metadata() {
-        use std::hash::{DefaultHasher, Hash, Hasher};
-
-        // Two handles to the same processor id are equal and order as Equal even when their
-        // descriptive metadata differs, keeping the Ord and Eq/Hash impls mutually consistent.
-        let a = ProcessorImpl::new(
-            0,
-            1,
-            7,
-            3,
-            EfficiencyClass::Performance,
-            RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Model A")),
-        );
-        let b = ProcessorImpl::new(
-            2,
-            4,
-            7,
-            9,
-            EfficiencyClass::Efficiency,
-            RelativeSpeed::SYNTHETIC,
-            None,
-        );
-
-        assert_eq!(a, b);
-        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
-
-        let mut hash_a = DefaultHasher::new();
-        a.hash(&mut hash_a);
-        let mut hash_b = DefaultHasher::new();
-        b.hash(&mut hash_b);
-        assert_eq!(hash_a.finish(), hash_b.finish());
-
-        // Hashing is keyed on `id` alone, so a processor hashes identically to its bare `id`.
-        // This also confirms the hash actually incorporates the id rather than being a no-op.
-        let mut id_hash = DefaultHasher::new();
-        a.id.hash(&mut id_hash);
-        assert_eq!(hash_a.finish(), id_hash.finish());
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -20,7 +20,7 @@ pub(crate) struct ProcessorImpl {
 
     pub(crate) relative_speed: RelativeSpeed,
 
-    pub(crate) brand: Option<Arc<str>>,
+    pub(crate) model: Option<Arc<str>>,
 }
 
 impl ProcessorImpl {
@@ -31,7 +31,7 @@ impl ProcessorImpl {
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
         relative_speed: RelativeSpeed,
-        brand: Option<Arc<str>>,
+        model: Option<Arc<str>>,
     ) -> Self {
         Self {
             group_index,
@@ -40,7 +40,7 @@ impl ProcessorImpl {
             memory_region_id,
             efficiency_class,
             relative_speed,
-            brand,
+            model,
         }
     }
 }
@@ -72,8 +72,8 @@ impl AbstractProcessor for ProcessorImpl {
         self.relative_speed
     }
 
-    fn brand(&self) -> Option<&str> {
-        self.brand.as_deref()
+    fn model(&self) -> Option<&str> {
+        self.model.as_deref()
     }
 }
 
@@ -127,14 +127,14 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Test Brand")),
+            Some(Arc::from("Test Model")),
         );
 
         assert_eq!(processor.id(), 2);
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(processor.relative_speed().as_u64(), 3600);
-        assert_eq!(processor.brand(), Some("Test Brand"));
+        assert_eq!(processor.model(), Some("Test Model"));
 
         let processor2 = ProcessorImpl::new(
             0,
@@ -143,7 +143,7 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Test Brand")),
+            Some(Arc::from("Test Model")),
         );
         assert_eq!(processor, processor2);
 
@@ -154,7 +154,7 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Test Brand")),
+            Some(Arc::from("Test Model")),
         );
         assert_ne!(processor, processor3);
         assert!(processor < processor3);
@@ -174,7 +174,7 @@ mod tests {
             3,
             EfficiencyClass::Performance,
             RelativeSpeed::from_raw(3600),
-            Some(Arc::from("Brand A")),
+            Some(Arc::from("Model A")),
         );
         let b = ProcessorImpl::new(
             2,
@@ -244,6 +244,6 @@ mod tests {
         assert_eq!(processor_ref.id, processor.id);
         assert_eq!(processor_ref.group_index, processor.group_index);
         assert_eq!(processor_ref.index_in_group, processor.index_in_group);
-        assert_eq!(processor_ref.brand(), None);
+        assert_eq!(processor_ref.model(), None);
     }
 }

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -20,7 +20,7 @@ pub(crate) struct ProcessorImpl {
 
     pub(crate) relative_speed: RelativeSpeed,
 
-    pub(crate) cpu_brand: Option<Arc<str>>,
+    pub(crate) brand: Option<Arc<str>>,
 }
 
 impl ProcessorImpl {
@@ -31,7 +31,7 @@ impl ProcessorImpl {
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
         relative_speed: RelativeSpeed,
-        cpu_brand: Option<Arc<str>>,
+        brand: Option<Arc<str>>,
     ) -> Self {
         Self {
             group_index,
@@ -40,7 +40,7 @@ impl ProcessorImpl {
             memory_region_id,
             efficiency_class,
             relative_speed,
-            cpu_brand,
+            brand,
         }
     }
 }
@@ -72,8 +72,8 @@ impl AbstractProcessor for ProcessorImpl {
         self.relative_speed
     }
 
-    fn cpu_brand(&self) -> Option<&str> {
-        self.cpu_brand.as_deref()
+    fn brand(&self) -> Option<&str> {
+        self.brand.as_deref()
     }
 }
 
@@ -134,7 +134,7 @@ mod tests {
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
         assert_eq!(processor.relative_speed().as_u64(), 3600);
-        assert_eq!(processor.cpu_brand(), Some("Test Brand"));
+        assert_eq!(processor.brand(), Some("Test Brand"));
 
         let processor2 = ProcessorImpl::new(
             0,
@@ -244,6 +244,6 @@ mod tests {
         assert_eq!(processor_ref.id, processor.id);
         assert_eq!(processor_ref.group_index, processor.group_index);
         assert_eq!(processor_ref.index_in_group, processor.index_in_group);
-        assert_eq!(processor_ref.cpu_brand(), None);
+        assert_eq!(processor_ref.brand(), None);
     }
 }

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -1,11 +1,12 @@
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::pal::AbstractProcessor;
 use crate::pal::windows::{ProcessorGroupIndex, ProcessorIndexInGroup};
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct ProcessorImpl {
     pub(crate) group_index: ProcessorGroupIndex,
     pub(crate) index_in_group: ProcessorIndexInGroup,
@@ -82,6 +83,24 @@ impl AsRef<Self> for ProcessorImpl {
     }
 }
 
+// A processor is uniquely identified by its `id`. The other fields are descriptive metadata that
+// never differs between two handles to the same processor, so equality, hashing, and ordering are
+// all keyed on `id` alone. Keeping them in agreement upholds the `Ord`/`Eq` contract:
+// `cmp(a, b) == Equal` exactly when `a == b`.
+impl PartialEq for ProcessorImpl {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ProcessorImpl {}
+
+impl Hash for ProcessorImpl {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
 impl PartialOrd for ProcessorImpl {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
@@ -140,6 +159,41 @@ mod tests {
         assert_ne!(processor, processor3);
         assert!(processor < processor3);
         assert!(processor3 > processor);
+    }
+
+    #[test]
+    fn equal_ids_compare_equal_regardless_of_metadata() {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        // Two handles to the same processor id are equal and order as Equal even when their
+        // descriptive metadata differs, keeping the Ord and Eq/Hash impls mutually consistent.
+        let a = ProcessorImpl::new(
+            0,
+            1,
+            7,
+            3,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(3600),
+            Some(Arc::from("Brand A")),
+        );
+        let b = ProcessorImpl::new(
+            2,
+            4,
+            7,
+            9,
+            EfficiencyClass::Efficiency,
+            RelativeSpeed::SYNTHETIC,
+            None,
+        );
+
+        assert_eq!(a, b);
+        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
+
+        let mut hash_a = DefaultHasher::new();
+        a.hash(&mut hash_a);
+        let mut hash_b = DefaultHasher::new();
+        b.hash(&mut hash_b);
+        assert_eq!(hash_a.finish(), hash_b.finish());
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::pal::AbstractProcessor;
 use crate::pal::windows::{ProcessorGroupIndex, ProcessorIndexInGroup};
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ProcessorImpl {
@@ -15,6 +15,8 @@ pub(crate) struct ProcessorImpl {
     pub(crate) memory_region_id: MemoryRegionId,
 
     pub(crate) efficiency_class: EfficiencyClass,
+
+    pub(crate) relative_speed: RelativeSpeed,
 }
 
 impl ProcessorImpl {
@@ -24,6 +26,7 @@ impl ProcessorImpl {
         id: ProcessorId,
         memory_region_id: MemoryRegionId,
         efficiency_class: EfficiencyClass,
+        relative_speed: RelativeSpeed,
     ) -> Self {
         Self {
             group_index,
@@ -31,6 +34,7 @@ impl ProcessorImpl {
             id,
             memory_region_id,
             efficiency_class,
+            relative_speed,
         }
     }
 }
@@ -56,6 +60,10 @@ impl AbstractProcessor for ProcessorImpl {
 
     fn efficiency_class(&self) -> EfficiencyClass {
         self.efficiency_class
+    }
+
+    fn relative_speed(&self) -> RelativeSpeed {
+        self.relative_speed
     }
 }
 
@@ -84,16 +92,38 @@ mod tests {
 
     #[test]
     fn smoke_test() {
-        let processor = ProcessorImpl::new(0, 1, 2, 3, EfficiencyClass::Performance);
+        let processor = ProcessorImpl::new(
+            0,
+            1,
+            2,
+            3,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(3600),
+        );
 
         assert_eq!(processor.id(), 2);
         assert_eq!(processor.memory_region_id(), 3);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Performance);
+        assert_eq!(processor.relative_speed().as_u32(), 3600);
 
-        let processor2 = ProcessorImpl::new(0, 1, 2, 3, EfficiencyClass::Performance);
+        let processor2 = ProcessorImpl::new(
+            0,
+            1,
+            2,
+            3,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(3600),
+        );
         assert_eq!(processor, processor2);
 
-        let processor3 = ProcessorImpl::new(0, 1, 4, 3, EfficiencyClass::Performance);
+        let processor3 = ProcessorImpl::new(
+            0,
+            1,
+            4,
+            3,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(3600),
+        );
         assert_ne!(processor, processor3);
         assert!(processor < processor3);
         assert!(processor3 > processor);
@@ -102,7 +132,14 @@ mod tests {
     #[test]
     fn display_shows_processor_id_and_group_info() {
         // group_index=1, index_in_group=3, id=7
-        let processor = ProcessorImpl::new(1, 3, 7, 0, EfficiencyClass::Performance);
+        let processor = ProcessorImpl::new(
+            1,
+            3,
+            7,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         let display_output = processor.to_string();
 
@@ -118,7 +155,14 @@ mod tests {
 
     #[test]
     fn as_ref_returns_self() {
-        let processor = ProcessorImpl::new(0, 2, 5, 1, EfficiencyClass::Efficiency);
+        let processor = ProcessorImpl::new(
+            0,
+            2,
+            5,
+            1,
+            EfficiencyClass::Efficiency,
+            RelativeSpeed::SYNTHETIC,
+        );
 
         let processor_ref: &ProcessorImpl = processor.as_ref();
 

--- a/packages/many_cpus_impl/src/pal/windows/processor.rs
+++ b/packages/many_cpus_impl/src/pal/windows/processor.rs
@@ -194,6 +194,12 @@ mod tests {
         let mut hash_b = DefaultHasher::new();
         b.hash(&mut hash_b);
         assert_eq!(hash_a.finish(), hash_b.finish());
+
+        // Hashing is keyed on `id` alone, so a processor hashes identically to its bare `id`.
+        // This also confirms the hash actually incorporates the id rather than being a no-op.
+        let mut id_hash = DefaultHasher::new();
+        a.id.hash(&mut id_hash);
+        assert_eq!(hash_a.finish(), id_hash.finish());
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/primitive_types.rs
+++ b/packages/many_cpus_impl/src/primitive_types.rs
@@ -56,17 +56,8 @@ pub enum EfficiencyClass {
 ///
 /// The value is only meaningful *within a single system*, where a larger value indicates a
 /// nominally faster processor. It is **not** comparable across different systems or operating
-/// systems because the underlying platform metrics differ:
-///
-/// * On Linux the value is derived from the `bogomips` reported by `/proc/cpuinfo`.
-/// * On Windows the value is derived from the nominal maximum clock frequency (MHz).
-/// * On platforms without a suitable metric (including the fallback platform and when running
-///   under Miri) every processor reports the same synthetic value.
-///
-/// Where a real metric is available it is scaled by an abstract constant before being stored, so
-/// the number deliberately does not equal any raw MHz-style figure. Never interpret the value as a
-/// physical unit and never compare a `RelativeSpeed` obtained on one machine to one obtained on
-/// another.
+/// systems, and it is not a physical unit - never interpret it as a clock frequency or compare
+/// a `RelativeSpeed` obtained on one machine to one obtained on another.
 ///
 /// [1]: crate::Processor::id
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/packages/many_cpus_impl/src/primitive_types.rs
+++ b/packages/many_cpus_impl/src/primitive_types.rs
@@ -1,3 +1,8 @@
+// Only the real Linux and Windows platforms scale OS speed metrics by pi (see
+// `RelativeSpeed::from_os_metric`); everything else reports synthetic speeds, so this import is
+// gated to those builds to avoid an unused-import warning elsewhere (for example under Miri).
+#[cfg(any(test, all(not(miri), any(target_os = "linux", windows))))]
+use std::f64::consts::PI;
 use std::fmt::{self, Display};
 use std::num::NonZero;
 
@@ -83,8 +88,6 @@ impl RelativeSpeed {
     #[cfg(any(test, all(not(miri), any(target_os = "linux", windows))))]
     #[must_use]
     pub(crate) fn from_os_metric(metric: u32) -> Self {
-        use std::f64::consts::PI;
-
         // A u32 scaled by pi is at most about 1.35e10, which is always a non-negative whole number
         // well within u64, so the conversion below neither loses the sign nor overflows.
         #[expect(

--- a/packages/many_cpus_impl/src/primitive_types.rs
+++ b/packages/many_cpus_impl/src/primitive_types.rs
@@ -1,3 +1,6 @@
+use std::fmt::{self, Display};
+use std::num::NonZero;
+
 /// Identifies a specific processor.
 ///
 /// This will match the numeric identifier used by standard tooling of the operating system.
@@ -35,6 +38,63 @@ pub enum EfficiencyClass {
     Performance,
 }
 
+/// A relative indicator of a processor's nominal speed, used to distinguish processors on the
+/// same system more finely than [`EfficiencyClass`] alone.
+///
+/// The intended use is *identification*: on a heterogeneous system this value helps tell apart
+/// processors of different underlying types (for example a cluster of fast cores from a cluster
+/// of slower cores) that would otherwise look identical when described only by their memory
+/// region and efficiency class. Processors of the same underlying type report the same value, so
+/// this does not uniquely identify an individual processor - use [`Processor::id()`][1] for that.
+///
+/// # Comparability
+///
+/// The value is only meaningful *within a single system*, where a larger value indicates a
+/// nominally faster processor. It is **not** comparable across different systems or operating
+/// systems because the underlying platform metrics differ:
+///
+/// * On Linux the value is derived from the `bogomips` reported by `/proc/cpuinfo`.
+/// * On Windows the value is the nominal maximum clock frequency in MHz.
+/// * On platforms without a suitable metric (including the fallback platform and when running
+///   under Miri) every processor reports the same synthetic value.
+///
+/// Because the metrics differ, never compare a `RelativeSpeed` obtained on one machine to one
+/// obtained on another, and never interpret the number as a physical unit.
+///
+/// [1]: crate::Processor::id
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RelativeSpeed(NonZero<u32>);
+
+impl RelativeSpeed {
+    /// The value reported when no real speed information is available for a processor.
+    pub(crate) const SYNTHETIC: Self = Self(NonZero::<u32>::MIN);
+
+    /// Constructs a value from a raw platform metric, mapping a missing metric (zero) to the
+    /// synthetic minimum so the value is always non-zero.
+    #[must_use]
+    pub(crate) fn from_raw(value: u32) -> Self {
+        match NonZero::new(value) {
+            Some(value) => Self(value),
+            None => Self::SYNTHETIC,
+        }
+    }
+
+    /// The underlying numeric value.
+    ///
+    /// This is only meaningful for comparing or identifying processors on the same system - see
+    /// the [type-level documentation][Self] for details.
+    #[must_use]
+    pub fn as_u32(self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl Display for RelativeSpeed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -45,4 +105,26 @@ mod tests {
     use super::*;
 
     assert_impl_all!(EfficiencyClass: UnwindSafe, RefUnwindSafe);
+    assert_impl_all!(RelativeSpeed: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn relative_speed_from_raw_preserves_positive_value() {
+        assert_eq!(RelativeSpeed::from_raw(4890).as_u32(), 4890);
+    }
+
+    #[test]
+    fn relative_speed_from_raw_maps_zero_to_synthetic() {
+        assert_eq!(RelativeSpeed::from_raw(0), RelativeSpeed::SYNTHETIC);
+        assert_eq!(RelativeSpeed::from_raw(0).as_u32(), 1);
+    }
+
+    #[test]
+    fn relative_speed_orders_by_value() {
+        assert!(RelativeSpeed::from_raw(2400) < RelativeSpeed::from_raw(3600));
+    }
+
+    #[test]
+    fn relative_speed_display_writes_the_number() {
+        assert_eq!(format!("{}", RelativeSpeed::from_raw(3600)), "3600");
+    }
 }

--- a/packages/many_cpus_impl/src/primitive_types.rs
+++ b/packages/many_cpus_impl/src/primitive_types.rs
@@ -1,5 +1,5 @@
 // Only the real Linux and Windows platforms scale OS speed metrics by pi (see
-// `RelativeSpeed::from_os_metric`); everything else reports synthetic speeds, so this import is
+// `RelativeSpeed::from_os_metric`); everything else reports fallback speeds, so this import is
 // gated to those builds to avoid an unused-import warning elsewhere (for example under Miri).
 #[cfg(any(test, all(not(miri), any(target_os = "linux", windows))))]
 use std::f64::consts::PI;
@@ -64,18 +64,15 @@ pub enum EfficiencyClass {
 pub struct RelativeSpeed(NonZero<u64>);
 
 impl RelativeSpeed {
-    /// The value reported when no real speed information is available for a processor.
-    pub(crate) const SYNTHETIC: Self = Self(NonZero::<u64>::MIN);
-
     /// Constructs a value from a raw OS-reported speed metric, such as the Linux `bogomips` or the
     /// Windows nominal maximum clock frequency in MHz.
     ///
     /// A `RelativeSpeed` is an abstract relative indicator, not a physical clock-frequency reading,
     /// so the raw metric is scaled by pi before it is stored. This removes any obvious numeric
     /// resemblance to the underlying MHz-style figure while preserving the ordering between
-    /// processors. A missing metric (zero) stays zero and maps to the synthetic minimum.
+    /// processors. A missing metric (zero) has no real speed behind it and maps to a fallback value.
     // Only the real Linux and Windows platforms feed OS metrics in; the fallback (used on other
-    // platforms and under Miri) reports synthetic speeds, so gate this out there to avoid dead code.
+    // platforms and under Miri) reports fallback speeds, so gate this out there to avoid dead code.
     #[cfg(any(test, all(not(miri), any(target_os = "linux", windows))))]
     #[must_use]
     pub(crate) fn from_os_metric(metric: u32) -> Self {
@@ -91,14 +88,28 @@ impl RelativeSpeed {
         Self::from_raw(scaled)
     }
 
-    /// Constructs a value from a raw numeric value, mapping a missing value (zero) to the synthetic
-    /// minimum so the value is always non-zero.
+    /// Constructs a value from a raw numeric value. A missing value (zero) has no real speed metric
+    /// behind it, so it maps to the `undetermined` fallback to keep the value non-zero.
     #[must_use]
     pub(crate) fn from_raw(value: u64) -> Self {
         match NonZero::new(value) {
             Some(value) => Self(value),
-            None => Self::SYNTHETIC,
+            None => Self::undetermined(),
         }
+    }
+
+    /// The value reported for a processor whose nominal speed the operating system does not
+    /// disclose.
+    ///
+    /// This is derived from the current process ID, so the specific value varies between runs.
+    /// Nothing may depend on it - it exists only to provide a non-zero value when no real speed
+    /// metric is available.
+    #[cfg_attr(test, mutants::skip)] // Derives from the process ID, an environment value with no fixed contract to assert.
+    #[must_use]
+    pub(crate) fn undetermined() -> Self {
+        // A running process always has a non-zero ID, but uphold the NonZero invariant defensively
+        // rather than assume it.
+        Self(NonZero::new(u64::from(std::process::id())).unwrap_or(NonZero::<u64>::MIN))
     }
 
     /// The underlying numeric value.
@@ -135,9 +146,8 @@ mod tests {
     }
 
     #[test]
-    fn relative_speed_from_raw_maps_zero_to_synthetic() {
-        assert_eq!(RelativeSpeed::from_raw(0), RelativeSpeed::SYNTHETIC);
-        assert_eq!(RelativeSpeed::from_raw(0).as_u64(), 1);
+    fn relative_speed_from_raw_maps_zero_to_undetermined() {
+        assert_eq!(RelativeSpeed::from_raw(0), RelativeSpeed::undetermined());
     }
 
     #[test]
@@ -149,8 +159,11 @@ mod tests {
     }
 
     #[test]
-    fn relative_speed_from_os_metric_maps_zero_to_synthetic() {
-        assert_eq!(RelativeSpeed::from_os_metric(0), RelativeSpeed::SYNTHETIC);
+    fn relative_speed_from_os_metric_maps_zero_to_undetermined() {
+        assert_eq!(
+            RelativeSpeed::from_os_metric(0),
+            RelativeSpeed::undetermined()
+        );
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/primitive_types.rs
+++ b/packages/many_cpus_impl/src/primitive_types.rs
@@ -54,25 +54,53 @@ pub enum EfficiencyClass {
 /// systems because the underlying platform metrics differ:
 ///
 /// * On Linux the value is derived from the `bogomips` reported by `/proc/cpuinfo`.
-/// * On Windows the value is the nominal maximum clock frequency in MHz.
+/// * On Windows the value is derived from the nominal maximum clock frequency (MHz).
 /// * On platforms without a suitable metric (including the fallback platform and when running
 ///   under Miri) every processor reports the same synthetic value.
 ///
-/// Because the metrics differ, never compare a `RelativeSpeed` obtained on one machine to one
-/// obtained on another, and never interpret the number as a physical unit.
+/// Where a real metric is available it is scaled by an abstract constant before being stored, so
+/// the number deliberately does not equal any raw MHz-style figure. Never interpret the value as a
+/// physical unit and never compare a `RelativeSpeed` obtained on one machine to one obtained on
+/// another.
 ///
 /// [1]: crate::Processor::id
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct RelativeSpeed(NonZero<u32>);
+pub struct RelativeSpeed(NonZero<u64>);
 
 impl RelativeSpeed {
     /// The value reported when no real speed information is available for a processor.
-    pub(crate) const SYNTHETIC: Self = Self(NonZero::<u32>::MIN);
+    pub(crate) const SYNTHETIC: Self = Self(NonZero::<u64>::MIN);
 
-    /// Constructs a value from a raw platform metric, mapping a missing metric (zero) to the
-    /// synthetic minimum so the value is always non-zero.
+    /// Constructs a value from a raw OS-reported speed metric, such as the Linux `bogomips` or the
+    /// Windows nominal maximum clock frequency in MHz.
+    ///
+    /// A `RelativeSpeed` is an abstract relative indicator, not a physical clock-frequency reading,
+    /// so the raw metric is scaled by pi before it is stored. This removes any obvious numeric
+    /// resemblance to the underlying MHz-style figure while preserving the ordering between
+    /// processors. A missing metric (zero) stays zero and maps to the synthetic minimum.
+    // Only the real Linux and Windows platforms feed OS metrics in; the fallback (used on other
+    // platforms and under Miri) reports synthetic speeds, so gate this out there to avoid dead code.
+    #[cfg(any(test, all(not(miri), any(target_os = "linux", windows))))]
     #[must_use]
-    pub(crate) fn from_raw(value: u32) -> Self {
+    pub(crate) fn from_os_metric(metric: u32) -> Self {
+        use std::f64::consts::PI;
+
+        // A u32 scaled by pi is at most about 1.35e10, which is always a non-negative whole number
+        // well within u64, so the conversion below neither loses the sign nor overflows.
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "a u32 scaled by pi is non-negative and far below u64::MAX"
+        )]
+        let scaled = (f64::from(metric) * PI) as u64;
+
+        Self::from_raw(scaled)
+    }
+
+    /// Constructs a value from a raw numeric value, mapping a missing value (zero) to the synthetic
+    /// minimum so the value is always non-zero.
+    #[must_use]
+    pub(crate) fn from_raw(value: u64) -> Self {
         match NonZero::new(value) {
             Some(value) => Self(value),
             None => Self::SYNTHETIC,
@@ -84,7 +112,7 @@ impl RelativeSpeed {
     /// This is only meaningful for comparing or identifying processors on the same system - see
     /// the [type-level documentation][Self] for details.
     #[must_use]
-    pub fn as_u32(self) -> u32 {
+    pub fn as_u64(self) -> u64 {
         self.0.get()
     }
 }
@@ -109,13 +137,26 @@ mod tests {
 
     #[test]
     fn relative_speed_from_raw_preserves_positive_value() {
-        assert_eq!(RelativeSpeed::from_raw(4890).as_u32(), 4890);
+        assert_eq!(RelativeSpeed::from_raw(4890).as_u64(), 4890);
     }
 
     #[test]
     fn relative_speed_from_raw_maps_zero_to_synthetic() {
         assert_eq!(RelativeSpeed::from_raw(0), RelativeSpeed::SYNTHETIC);
-        assert_eq!(RelativeSpeed::from_raw(0).as_u32(), 1);
+        assert_eq!(RelativeSpeed::from_raw(0).as_u64(), 1);
+    }
+
+    #[test]
+    fn relative_speed_from_os_metric_scales_by_pi() {
+        // The raw metric is multiplied by pi, then truncated: 1000 * pi = 3141.59..., 2000 * pi =
+        // 6283.18.... This deliberately makes the stored number unlike the raw MHz-style figure.
+        assert_eq!(RelativeSpeed::from_os_metric(1000).as_u64(), 3141);
+        assert_eq!(RelativeSpeed::from_os_metric(2000).as_u64(), 6283);
+    }
+
+    #[test]
+    fn relative_speed_from_os_metric_maps_zero_to_synthetic() {
+        assert_eq!(RelativeSpeed::from_os_metric(0), RelativeSpeed::SYNTHETIC);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/primitive_types.rs
+++ b/packages/many_cpus_impl/src/primitive_types.rs
@@ -64,6 +64,14 @@ pub enum EfficiencyClass {
 pub struct RelativeSpeed(NonZero<u64>);
 
 impl RelativeSpeed {
+    /// The value reported for a processor whose nominal speed the operating system does not
+    /// disclose.
+    ///
+    /// This is a sentinel (`u64::MAX`) chosen to be unmistakably not a real speed reading, so it
+    /// cannot be confused with the small values that genuine metrics or tests produce. Nothing may
+    /// depend on the specific value.
+    pub(crate) const UNDETERMINED: Self = Self(NonZero::<u64>::MAX);
+
     /// Constructs a value from a raw OS-reported speed metric, such as the Linux `bogomips` or the
     /// Windows nominal maximum clock frequency in MHz.
     ///
@@ -76,8 +84,9 @@ impl RelativeSpeed {
     #[cfg(any(test, all(not(miri), any(target_os = "linux", windows))))]
     #[must_use]
     pub(crate) fn from_os_metric(metric: u32) -> Self {
-        // A u32 scaled by pi is at most about 1.35e10, which is always a non-negative whole number
-        // well within u64, so the conversion below neither loses the sign nor overflows.
+        // A u32 scaled by pi is non-negative and at most about 1.35e10, far below u64::MAX, so the
+        // cast below only drops the fractional part (the truncation we intend) without losing the
+        // sign or overflowing.
         #[expect(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
@@ -89,27 +98,13 @@ impl RelativeSpeed {
     }
 
     /// Constructs a value from a raw numeric value. A missing value (zero) has no real speed metric
-    /// behind it, so it maps to the `undetermined` fallback to keep the value non-zero.
+    /// behind it, so it maps to the `UNDETERMINED` sentinel to keep the value non-zero.
     #[must_use]
     pub(crate) fn from_raw(value: u64) -> Self {
         match NonZero::new(value) {
             Some(value) => Self(value),
-            None => Self::undetermined(),
+            None => Self::UNDETERMINED,
         }
-    }
-
-    /// The value reported for a processor whose nominal speed the operating system does not
-    /// disclose.
-    ///
-    /// This is derived from the current process ID, so the specific value varies between runs.
-    /// Nothing may depend on it - it exists only to provide a non-zero value when no real speed
-    /// metric is available.
-    #[cfg_attr(test, mutants::skip)] // Derives from the process ID, an environment value with no fixed contract to assert.
-    #[must_use]
-    pub(crate) fn undetermined() -> Self {
-        // A running process always has a non-zero ID, but uphold the NonZero invariant defensively
-        // rather than assume it.
-        Self(NonZero::new(u64::from(std::process::id())).unwrap_or(NonZero::<u64>::MIN))
     }
 
     /// The underlying numeric value.
@@ -147,7 +142,7 @@ mod tests {
 
     #[test]
     fn relative_speed_from_raw_maps_zero_to_undetermined() {
-        assert_eq!(RelativeSpeed::from_raw(0), RelativeSpeed::undetermined());
+        assert_eq!(RelativeSpeed::from_raw(0), RelativeSpeed::UNDETERMINED);
     }
 
     #[test]
@@ -162,7 +157,7 @@ mod tests {
     fn relative_speed_from_os_metric_maps_zero_to_undetermined() {
         assert_eq!(
             RelativeSpeed::from_os_metric(0),
-            RelativeSpeed::undetermined()
+            RelativeSpeed::UNDETERMINED
         );
     }
 

--- a/packages/many_cpus_impl/src/processor.rs
+++ b/packages/many_cpus_impl/src/processor.rs
@@ -1,9 +1,11 @@
+use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 
 use derive_more::derive::AsRef;
 
 use crate::pal::{AbstractProcessor, ProcessorFacade};
+use crate::system_hardware::HardwareId;
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// Model string reported for a processor whose model the operating system does not
@@ -14,14 +16,19 @@ const UNKNOWN_MODEL: &str = "unknown";
 /// A processor present on the system and available to the current process.
 #[derive(AsRef, Clone)]
 pub struct Processor {
+    /// Identity of the [`SystemHardware`][crate::SystemHardware] instance that produced this
+    /// handle. Two handles are equal only when they come from the same instance, so processors
+    /// from different fake hardware (or from fake versus real hardware) never compare equal.
+    hardware_id: HardwareId,
+
     #[as_ref]
     inner: ProcessorFacade,
 }
 
 impl Processor {
     #[must_use]
-    pub(crate) fn new(inner: ProcessorFacade) -> Self {
-        Self { inner }
+    pub(crate) fn new(hardware_id: HardwareId, inner: ProcessorFacade) -> Self {
+        Self { hardware_id, inner }
     }
 
     /// The unique numeric ID of the processor, matching the ID used by operating system tools.
@@ -132,20 +139,11 @@ impl Processor {
         self.inner.relative_speed()
     }
 
-    /// The best-effort model string of the processor.
+    /// The model name of the processor.
     ///
-    /// This is intended for *identification* and diagnostics, not comparison. The exact text is
-    /// platform-specific:
-    ///
-    /// * On Linux it is the `model name` field of `/proc/cpuinfo`.
-    /// * On Windows it is the `ProcessorNameString` the firmware records in the registry.
-    ///
-    /// When the operating system does not disclose a model (for example many ARM Linux systems
-    /// report no `model name`, and the fallback platform and Miri never report one), this returns
-    /// `"unknown"` so callers always have a string to key on.
-    ///
-    /// Because the value originates from different sources per platform, never compare a model read
-    /// on one operating system to one read on another.
+    /// This is intended for *identification* and diagnostics, not comparison. The value is only
+    /// meaningful within a single system and is **not** comparable across systems or operating
+    /// systems.
     ///
     /// # Example
     ///
@@ -165,21 +163,44 @@ impl Processor {
     }
 }
 
+impl Processor {
+    /// The identity of this processor: which [`SystemHardware`][crate::SystemHardware] instance
+    /// produced it, plus its processor ID within that instance. Equality, hashing, and ordering
+    /// all derive from this pair so they stay mutually consistent.
+    #[inline]
+    fn identity(&self) -> (HardwareId, ProcessorId) {
+        (self.hardware_id, self.inner.id())
+    }
+}
+
 impl PartialEq for Processor {
-    #[cfg_attr(test, mutants::skip)] // Trivial delegation, do not waste time on mutation.
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
+        self.identity() == other.identity()
     }
 }
 
 impl Eq for Processor {}
 
 impl Hash for Processor {
-    #[cfg_attr(test, mutants::skip)] // Trivial delegation, do not waste time on mutation.
+    #[cfg_attr(test, mutants::skip)] // Hashing has no observable contract to mutate against.
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner.hash(state);
+        self.identity().hash(state);
+    }
+}
+
+impl PartialOrd for Processor {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Processor {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.identity().cmp(&other.identity())
     }
 }
 
@@ -223,7 +244,7 @@ mod tests {
             Some(std::sync::Arc::from("Example Model")),
         );
 
-        let processor = Processor::new(pal_processor.into());
+        let processor = Processor::new(HardwareId::from_raw(1), pal_processor.into());
 
         // Getters appear to get the expected values.
         assert_eq!(processor.id(), 42);
@@ -266,8 +287,69 @@ mod tests {
             None,
         );
 
-        let processor = Processor::new(pal_processor.into());
+        let processor = Processor::new(HardwareId::from_raw(1), pal_processor.into());
 
         assert_eq!(processor.model(), "unknown");
+    }
+
+    /// Builds a fake processor handle with the given hardware and processor identity. Metadata is
+    /// fixed because only the identity matters for these equality and ordering checks.
+    fn processor_with(hardware_id: HardwareId, id: ProcessorId) -> Processor {
+        let pal_processor = FakeProcessor::new(
+            id,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(3600),
+            Some(std::sync::Arc::from("Shared Model")),
+        );
+
+        Processor::new(hardware_id, pal_processor.into())
+    }
+
+    #[test]
+    fn processors_from_different_hardware_are_not_equal() {
+        // Same processor ID and identical metadata, but produced by different hardware instances.
+        let from_a = processor_with(HardwareId::from_raw(1), 7);
+        let from_b = processor_with(HardwareId::from_raw(2), 7);
+
+        assert_ne!(from_a, from_b);
+
+        // Being unequal, both coexist in a set rather than collapsing into one entry.
+        let set: std::collections::HashSet<Processor> = [from_a, from_b].into_iter().collect();
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn processors_from_same_hardware_with_same_id_are_equal() {
+        let hardware_id = HardwareId::from_raw(1);
+        let first = processor_with(hardware_id, 7);
+        let second = processor_with(hardware_id, 7);
+
+        assert_eq!(first, second);
+
+        let mut hasher1 = DefaultHasher::new();
+        first.hash(&mut hasher1);
+        let mut hasher2 = DefaultHasher::new();
+        second.hash(&mut hasher2);
+        assert_eq!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn ordering_sorts_by_hardware_then_processor_id() {
+        let hardware_a = HardwareId::from_raw(1);
+        let hardware_b = HardwareId::from_raw(2);
+
+        // Within one hardware instance, ordering follows the processor ID.
+        assert!(processor_with(hardware_a, 1) < processor_with(hardware_a, 2));
+
+        // Across instances, the hardware identity is the primary sort key, so a lower-id processor
+        // from a later instance still orders after any processor from an earlier instance.
+        assert!(processor_with(hardware_a, 9) < processor_with(hardware_b, 0));
+
+        // Ordering is consistent with equality: equal identities compare as `Equal`.
+        assert_eq!(
+            processor_with(hardware_a, 3).cmp(&processor_with(hardware_a, 3)),
+            Ordering::Equal
+        );
     }
 }

--- a/packages/many_cpus_impl/src/processor.rs
+++ b/packages/many_cpus_impl/src/processor.rs
@@ -145,6 +145,9 @@ impl Processor {
     /// meaningful within a single system and is **not** comparable across systems or operating
     /// systems.
     ///
+    /// The exact string may change between versions of `many_cpus`; the same processor can report a
+    /// different model after an upgrade, and such a change is not considered a breaking change.
+    ///
     /// # Example
     ///
     /// ```

--- a/packages/many_cpus_impl/src/processor.rs
+++ b/packages/many_cpus_impl/src/processor.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use derive_more::derive::AsRef;
 
 use crate::pal::{AbstractProcessor, ProcessorFacade};
-use crate::{EfficiencyClass, MemoryRegionId, ProcessorId};
+use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
 /// A processor present on the system and available to the current process.
 #[derive(AsRef, Clone)]
@@ -94,6 +94,38 @@ impl Processor {
     pub fn efficiency_class(&self) -> EfficiencyClass {
         self.inner.efficiency_class()
     }
+
+    /// A relative indicator of the processor's nominal speed.
+    ///
+    /// This refines [`efficiency_class()`][Self::efficiency_class] with a finer-grained value that
+    /// helps distinguish processors of different underlying types on the same system. Processors
+    /// of the same type report the same value, so it does not uniquely identify a processor - use
+    /// [`id()`][Self::id] for that.
+    ///
+    /// The value is only meaningful within a single system and is **not** comparable across
+    /// systems or operating systems. See [`RelativeSpeed`] for details.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use many_cpus::SystemHardware;
+    ///
+    /// let processors = SystemHardware::current().processors();
+    ///
+    /// for processor in processors {
+    ///     println!(
+    ///         "Processor {} has relative speed {}",
+    ///         processor.id(),
+    ///         processor.relative_speed(),
+    ///     );
+    /// }
+    /// ```
+    #[cfg_attr(test, mutants::skip)] // Trivial delegation, do not waste time on mutation.
+    #[inline]
+    #[must_use]
+    pub fn relative_speed(&self) -> RelativeSpeed {
+        self.inner.relative_speed()
+    }
 }
 
 impl PartialEq for Processor {
@@ -146,7 +178,12 @@ mod tests {
 
     #[test]
     fn smoke_test() {
-        let pal_processor = FakeProcessor::new(42, 13, EfficiencyClass::Efficiency);
+        let pal_processor = FakeProcessor::new(
+            42,
+            13,
+            EfficiencyClass::Efficiency,
+            RelativeSpeed::from_raw(3600),
+        );
 
         let processor = Processor::new(pal_processor.into());
 
@@ -154,6 +191,7 @@ mod tests {
         assert_eq!(processor.id(), 42);
         assert_eq!(processor.memory_region_id(), 13);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Efficiency);
+        assert_eq!(processor.relative_speed().as_u32(), 3600);
 
         // A clone is a legit clone.
         let processor_clone = processor.clone();

--- a/packages/many_cpus_impl/src/processor.rs
+++ b/packages/many_cpus_impl/src/processor.rs
@@ -6,6 +6,11 @@ use derive_more::derive::AsRef;
 use crate::pal::{AbstractProcessor, ProcessorFacade};
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
+/// Model string reported for a processor whose model the operating system does not
+/// disclose. The value is metadata for identification only, so a fixed placeholder
+/// spares every caller from inventing its own substitute.
+const UNKNOWN_MODEL: &str = "unknown";
+
 /// A processor present on the system and available to the current process.
 #[derive(AsRef, Clone)]
 pub struct Processor {
@@ -127,19 +132,19 @@ impl Processor {
         self.inner.relative_speed()
     }
 
-    /// The best-effort brand string of the processor, or `None` when the operating system does
-    /// not report one.
+    /// The best-effort model string of the processor.
     ///
-    /// This is intended for *identification* and diagnostics, not comparison. The exact text and
-    /// its availability are platform-specific:
+    /// This is intended for *identification* and diagnostics, not comparison. The exact text is
+    /// platform-specific:
     ///
-    /// * On Linux it is the `model name` field of `/proc/cpuinfo`, which is commonly absent on
-    ///   non-x86 architectures (for example many ARM systems report no `model name`).
+    /// * On Linux it is the `model name` field of `/proc/cpuinfo`.
     /// * On Windows it is the `ProcessorNameString` the firmware records in the registry.
-    /// * On other platforms (including the fallback platform and when running under Miri) it is
-    ///   always `None`.
     ///
-    /// Because the value originates from different sources per platform, never compare a brand read
+    /// When the operating system does not disclose a model (for example many ARM Linux systems
+    /// report no `model name`, and the fallback platform and Miri never report one), this returns
+    /// `"unknown"` so callers always have a string to key on.
+    ///
+    /// Because the value originates from different sources per platform, never compare a model read
     /// on one operating system to one read on another.
     ///
     /// # Example
@@ -150,17 +155,13 @@ impl Processor {
     /// let processors = SystemHardware::current().processors();
     ///
     /// for processor in processors {
-    ///     match processor.brand() {
-    ///         Some(brand) => println!("Processor {} is a {brand}", processor.id()),
-    ///         None => println!("Processor {} has no reported brand", processor.id()),
-    ///     }
+    ///     println!("Processor {} is a {}", processor.id(), processor.model());
     /// }
     /// ```
-    #[cfg_attr(test, mutants::skip)] // Trivial delegation, do not waste time on mutation.
     #[inline]
     #[must_use]
-    pub fn brand(&self) -> Option<&str> {
-        self.inner.brand()
+    pub fn model(&self) -> &str {
+        self.inner.model().unwrap_or(UNKNOWN_MODEL)
     }
 }
 
@@ -219,7 +220,7 @@ mod tests {
             13,
             EfficiencyClass::Efficiency,
             RelativeSpeed::from_raw(3600),
-            Some(std::sync::Arc::from("Example Brand")),
+            Some(std::sync::Arc::from("Example Model")),
         );
 
         let processor = Processor::new(pal_processor.into());
@@ -229,7 +230,7 @@ mod tests {
         assert_eq!(processor.memory_region_id(), 13);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Efficiency);
         assert_eq!(processor.relative_speed().as_u64(), 3600);
-        assert_eq!(processor.brand(), Some("Example Brand"));
+        assert_eq!(processor.model(), "Example Model");
 
         // A clone is a legit clone.
         let processor_clone = processor.clone();
@@ -253,5 +254,20 @@ mod tests {
         // Debug writes something (anything - as long as it writes something and does not panic).
         let debugged = format!("{processor:?}");
         assert!(!debugged.is_empty());
+    }
+
+    #[test]
+    fn model_falls_back_to_unknown_when_absent() {
+        let pal_processor = FakeProcessor::new(
+            0,
+            0,
+            EfficiencyClass::Performance,
+            RelativeSpeed::from_raw(1),
+            None,
+        );
+
+        let processor = Processor::new(pal_processor.into());
+
+        assert_eq!(processor.model(), "unknown");
     }
 }

--- a/packages/many_cpus_impl/src/processor.rs
+++ b/packages/many_cpus_impl/src/processor.rs
@@ -126,6 +126,42 @@ impl Processor {
     pub fn relative_speed(&self) -> RelativeSpeed {
         self.inner.relative_speed()
     }
+
+    /// The best-effort CPU brand string of the processor, or `None` when the operating system does
+    /// not report one.
+    ///
+    /// This is intended for *identification* and diagnostics, not comparison. The exact text and
+    /// its availability are platform-specific:
+    ///
+    /// * On Linux it is the `model name` field of `/proc/cpuinfo`, which is commonly absent on
+    ///   non-x86 architectures (for example many ARM systems report no `model name`).
+    /// * On Windows it is the `ProcessorNameString` the firmware records in the registry.
+    /// * On other platforms (including the fallback platform and when running under Miri) it is
+    ///   always `None`.
+    ///
+    /// Because the value originates from different sources per platform, never compare a brand read
+    /// on one operating system to one read on another.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use many_cpus::SystemHardware;
+    ///
+    /// let processors = SystemHardware::current().processors();
+    ///
+    /// for processor in processors {
+    ///     match processor.cpu_brand() {
+    ///         Some(brand) => println!("Processor {} is a {brand}", processor.id()),
+    ///         None => println!("Processor {} has no reported brand", processor.id()),
+    ///     }
+    /// }
+    /// ```
+    #[cfg_attr(test, mutants::skip)] // Trivial delegation, do not waste time on mutation.
+    #[inline]
+    #[must_use]
+    pub fn cpu_brand(&self) -> Option<&str> {
+        self.inner.cpu_brand()
+    }
 }
 
 impl PartialEq for Processor {
@@ -183,6 +219,7 @@ mod tests {
             13,
             EfficiencyClass::Efficiency,
             RelativeSpeed::from_raw(3600),
+            Some(std::sync::Arc::from("Example Brand")),
         );
 
         let processor = Processor::new(pal_processor.into());
@@ -191,7 +228,8 @@ mod tests {
         assert_eq!(processor.id(), 42);
         assert_eq!(processor.memory_region_id(), 13);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Efficiency);
-        assert_eq!(processor.relative_speed().as_u32(), 3600);
+        assert_eq!(processor.relative_speed().as_u64(), 3600);
+        assert_eq!(processor.cpu_brand(), Some("Example Brand"));
 
         // A clone is a legit clone.
         let processor_clone = processor.clone();

--- a/packages/many_cpus_impl/src/processor.rs
+++ b/packages/many_cpus_impl/src/processor.rs
@@ -127,7 +127,7 @@ impl Processor {
         self.inner.relative_speed()
     }
 
-    /// The best-effort CPU brand string of the processor, or `None` when the operating system does
+    /// The best-effort brand string of the processor, or `None` when the operating system does
     /// not report one.
     ///
     /// This is intended for *identification* and diagnostics, not comparison. The exact text and
@@ -150,7 +150,7 @@ impl Processor {
     /// let processors = SystemHardware::current().processors();
     ///
     /// for processor in processors {
-    ///     match processor.cpu_brand() {
+    ///     match processor.brand() {
     ///         Some(brand) => println!("Processor {} is a {brand}", processor.id()),
     ///         None => println!("Processor {} has no reported brand", processor.id()),
     ///     }
@@ -159,8 +159,8 @@ impl Processor {
     #[cfg_attr(test, mutants::skip)] // Trivial delegation, do not waste time on mutation.
     #[inline]
     #[must_use]
-    pub fn cpu_brand(&self) -> Option<&str> {
-        self.inner.cpu_brand()
+    pub fn brand(&self) -> Option<&str> {
+        self.inner.brand()
     }
 }
 
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(processor.memory_region_id(), 13);
         assert_eq!(processor.efficiency_class(), EfficiencyClass::Efficiency);
         assert_eq!(processor.relative_speed().as_u64(), 3600);
-        assert_eq!(processor.cpu_brand(), Some("Example Brand"));
+        assert_eq!(processor.brand(), Some("Example Brand"));
 
         // A clone is a legit clone.
         let processor_clone = processor.clone();

--- a/packages/many_cpus_impl/src/processor_set_builder.rs
+++ b/packages/many_cpus_impl/src/processor_set_builder.rs
@@ -888,10 +888,11 @@ impl ProcessorSetBuilder {
     fn all_processors(&self) -> NonEmpty<Processor> {
         // Cheap conversion, reasonable to do it inline since we do not expect
         // processor set logic to be on the hot path anyway.
+        let hardware_id = self.hardware.hardware_id();
         self.hardware
             .platform()
             .get_all_processors()
-            .map(Processor::new)
+            .map(|inner| Processor::new(hardware_id, inner))
     }
 
     fn resource_quota_processor_count_limit(&self) -> Option<usize> {

--- a/packages/many_cpus_impl/src/system_hardware.rs
+++ b/packages/many_cpus_impl/src/system_hardware.rs
@@ -293,8 +293,9 @@ impl SystemHardware {
         let mut all_processors = vec![None; max_processor_count];
 
         for processor in all_pal_processors {
+            let processor_id = processor.id() as usize;
             *all_processors
-                .get_mut(processor.id() as usize)
+                .get_mut(processor_id)
                 .expect("encountered processor with ID above max_processor_id") =
                 Some(Processor::new(processor));
         }

--- a/packages/many_cpus_impl/src/system_hardware.rs
+++ b/packages/many_cpus_impl/src/system_hardware.rs
@@ -31,8 +31,31 @@ static CURRENT_HARDWARE: OnceLock<SystemHardware> = OnceLock::new();
 ///
 /// Each instance gets a distinct ID so that per-thread pin state (stored in the `PIN_STATES`
 /// thread-local) can be keyed by instance without different instances aliasing each other on
-/// the same thread. IDs are never reused.
-static NEXT_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
+/// the same thread, and so that processor handles carry the identity of the instance that
+/// produced them. IDs are never reused.
+static NEXT_HARDWARE_ID: AtomicU64 = AtomicU64::new(0);
+
+/// Identifies a `SystemHardware` instance within the current process.
+///
+/// A [`Processor`] handle is scoped to the instance that produced it, so this participates in
+/// processor identity: handles from different instances never compare equal even when their
+/// processor IDs and other metadata match. Clones of a `SystemHardware` share their ID because
+/// they share the underlying instance.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct HardwareId(u64);
+
+impl HardwareId {
+    /// Allocates the next unused hardware ID.
+    fn next() -> Self {
+        Self(NEXT_HARDWARE_ID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Constructs a specific hardware ID for tests that need deterministic instance identities.
+    #[cfg(test)]
+    pub(crate) const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+}
 
 thread_local! {
     /// Per-thread pin state, keyed by `SystemHardware` instance ID.
@@ -94,10 +117,10 @@ struct SystemHardwareInner {
     /// The platform abstraction layer implementation.
     platform: PlatformFacade,
 
-    /// Unique ID of this instance, used to key its per-thread pin state in the `PIN_STATES`
-    /// thread-local. Clones share this ID (and therefore their pin state) because they share
-    /// the `Arc<SystemHardwareInner>`.
-    instance_id: u64,
+    /// Unique ID of this instance. Keys its per-thread pin state in the `PIN_STATES` thread-local
+    /// and scopes the identity of the [`Processor`] handles it produces. Clones share this ID
+    /// (and therefore their pin state) because they share the `Arc<SystemHardwareInner>`.
+    hardware_id: HardwareId,
 
     /// Processors indexed by processor ID for O(1) lookup.
     ///
@@ -138,10 +161,10 @@ struct ThreadState {
 /// This deliberately uses a linear-scan `Vec` instead of a `HashMap`. The standard choice
 /// would be a hash map, but it is the wrong tool here: in non-test builds this map holds
 /// exactly one entry per thread — the [`current()`][SystemHardware::current] singleton — and
-/// only a handful even in tests with fake instances. Hashing the `u64` key on every lookup
-/// (this is the hot read path of `region_cached` / `region_local`) costs more than comparing
-/// against one or two stored keys, and a `Vec` keeps the whole map inline without a hash-table
-/// control-byte probe. A `HashMap` would only pay off with many entries, which never happens.
+/// only a handful even in tests with fake instances. Hashing the key on every lookup (this is
+/// the hot read path of `region_cached` / `region_local`) costs more than comparing against one
+/// or two stored keys, and a `Vec` keeps the whole map inline without a hash-table control-byte
+/// probe. A `HashMap` would only pay off with many entries, which never happens.
 #[derive(Default)]
 struct PinStateMap {
     // A `SmallVec<[_; 1]>` inline slot looks like the obvious next step — store the single
@@ -151,30 +174,30 @@ struct PinStateMap {
     // repeatedly, so the `Vec`'s heap buffer stays hot in L1 and the indirection is an
     // already-cached load, whereas `SmallVec` adds an inline-vs-spilled discriminant branch to
     // every access that costs more than the load it removes. A plain `Vec` is faster and simpler.
-    entries: Vec<(u64, ThreadState)>,
+    entries: Vec<(HardwareId, ThreadState)>,
 }
 
 impl PinStateMap {
-    /// Returns the pin state for the given instance ID, if present.
-    fn get(&self, instance_id: u64) -> Option<ThreadState> {
+    /// Returns the pin state for the given hardware ID, if present.
+    fn get(&self, hardware_id: HardwareId) -> Option<ThreadState> {
         self.entries
             .iter()
-            .find_map(|&(id, state)| (id == instance_id).then_some(state))
+            .find_map(|&(id, state)| (id == hardware_id).then_some(state))
     }
 
-    /// Inserts or updates the pin state for the given instance ID.
-    fn set(&mut self, instance_id: u64, state: ThreadState) {
-        if let Some(entry) = self.entries.iter_mut().find(|(id, _)| *id == instance_id) {
+    /// Inserts or updates the pin state for the given hardware ID.
+    fn set(&mut self, hardware_id: HardwareId, state: ThreadState) {
+        if let Some(entry) = self.entries.iter_mut().find(|(id, _)| *id == hardware_id) {
             entry.1 = state;
         } else {
-            self.entries.push((instance_id, state));
+            self.entries.push((hardware_id, state));
         }
     }
 
-    /// Removes the pin state for the given instance ID, if present.
-    fn remove(&mut self, instance_id: u64) {
-        if let Some(index) = self.entries.iter().position(|(id, _)| *id == instance_id) {
-            // Order is irrelevant: lookups match by instance ID, never by position.
+    /// Removes the pin state for the given hardware ID, if present.
+    fn remove(&mut self, hardware_id: HardwareId) {
+        if let Some(index) = self.entries.iter().position(|(id, _)| *id == hardware_id) {
+            // Order is irrelevant: lookups match by hardware ID, never by position.
             _ = self.entries.swap_remove(index);
         }
     }
@@ -190,7 +213,7 @@ impl Drop for SystemHardwareInner {
         //    from other threads, each of those threads holds its own `PIN_STATES` entry for this
         //    instance ID that we cannot touch from here, so those entries linger until the
         //    respective thread exits. This cannot cause incorrect behavior because instance IDs
-        //    are never reused (`NEXT_INSTANCE_ID` only ever increments), so a future instance can
+        //    are never reused (`NEXT_HARDWARE_ID` only ever increments), so a future instance can
         //    never collide with a stale entry left by a previous one. The leftover memory is
         //    bounded by the number of instances a thread has seen and is reclaimed at thread
         //    exit. In production only the singleton instance exists and it lives for the whole
@@ -201,7 +224,7 @@ impl Drop for SystemHardwareInner {
         //    that case instead of panicking; there is simply nothing to clean up because the
         //    whole map is already gone.
         _ = PIN_STATES.try_with(|states| {
-            states.borrow_mut().remove(self.instance_id);
+            states.borrow_mut().remove(self.hardware_id);
         });
     }
 }
@@ -237,6 +260,11 @@ impl SystemHardware {
     /// fake instances to coexist in parallel tests without interference. Clones
     /// are equivalent and represent the same fake hardware.
     ///
+    /// Because each instance is distinct, [`Processor`] handles are scoped to the instance that
+    /// produced them: a processor from one fake instance never compares equal to a processor from
+    /// another fake instance, nor to a processor from real hardware, even when their IDs and other
+    /// metadata are identical.
+    ///
     /// # Example
     ///
     /// ```
@@ -270,19 +298,19 @@ impl SystemHardware {
         Self::from_platform(PlatformFacade::Fallback(&BUILD_TARGET_PLATFORM))
     }
 
-    /// Returns the unique ID of this instance, for use in tests that inspect `PIN_STATES`.
-    #[cfg(test)]
-    pub(crate) fn instance_id(&self) -> u64 {
-        self.inner.instance_id
+    /// Returns the unique ID of the hardware instance this handle refers to.
+    pub(crate) fn hardware_id(&self) -> HardwareId {
+        self.inner.hardware_id
     }
 
-    /// Returns whether the current thread holds a `PIN_STATES` entry for the given instance ID.
+    /// Returns whether the current thread holds a `PIN_STATES` entry for the given hardware ID.
     #[cfg(test)]
-    pub(crate) fn current_thread_has_pin_state(instance_id: u64) -> bool {
-        PIN_STATES.with_borrow(|states| states.get(instance_id).is_some())
+    pub(crate) fn current_thread_has_pin_state(hardware_id: HardwareId) -> bool {
+        PIN_STATES.with_borrow(|states| states.get(hardware_id).is_some())
     }
 
     fn from_platform(platform: PlatformFacade) -> Self {
+        let hardware_id = HardwareId::next();
         let all_pal_processors = platform.get_all_processors();
         let max_processor_id = platform.max_processor_id();
         let max_memory_region_id = platform.max_memory_region_id();
@@ -297,13 +325,13 @@ impl SystemHardware {
             *all_processors
                 .get_mut(processor_id)
                 .expect("encountered processor with ID above max_processor_id") =
-                Some(Processor::new(processor));
+                Some(Processor::new(hardware_id, processor));
         }
 
         Self {
             inner: Arc::new(SystemHardwareInner {
                 platform,
-                instance_id: NEXT_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
+                hardware_id,
                 all_processors_slice: all_processors.into_boxed_slice(),
                 max_processor_id,
                 max_memory_region_id,
@@ -709,7 +737,7 @@ impl SystemHardware {
 
         PIN_STATES.with_borrow_mut(|states| {
             states.set(
-                self.inner.instance_id,
+                self.inner.hardware_id,
                 ThreadState {
                     pinned_processor_id: processor_id,
                     pinned_memory_region_id: memory_region_id,
@@ -720,12 +748,12 @@ impl SystemHardware {
 
     /// Gets the pinned processor ID for the current thread, if any.
     fn get_pinned_processor_id(&self) -> Option<ProcessorId> {
-        PIN_STATES.with_borrow(|states| states.get(self.inner.instance_id)?.pinned_processor_id)
+        PIN_STATES.with_borrow(|states| states.get(self.inner.hardware_id)?.pinned_processor_id)
     }
 
     /// Gets the pinned memory region ID for the current thread, if any.
     fn get_pinned_memory_region_id(&self) -> Option<MemoryRegionId> {
-        PIN_STATES.with_borrow(|states| states.get(self.inner.instance_id)?.pinned_memory_region_id)
+        PIN_STATES.with_borrow(|states| states.get(self.inner.hardware_id)?.pinned_memory_region_id)
     }
 
     /// Gets a processor by ID, with fallback to any available processor if not found.
@@ -909,18 +937,18 @@ mod tests {
     #[test]
     fn drop_removes_pin_state_on_current_thread() {
         let hardware = SystemHardware::fallback();
-        let instance_id = hardware.instance_id();
+        let hardware_id = hardware.hardware_id();
 
         // No entry exists until the current thread records pin state for this instance.
-        assert!(!SystemHardware::current_thread_has_pin_state(instance_id));
+        assert!(!SystemHardware::current_thread_has_pin_state(hardware_id));
 
         hardware.update_pin_status(Some(0), Some(0));
-        assert!(SystemHardware::current_thread_has_pin_state(instance_id));
+        assert!(SystemHardware::current_thread_has_pin_state(hardware_id));
 
         drop(hardware);
 
         // The destructor removed this thread's entry for the dropped instance.
-        assert!(!SystemHardware::current_thread_has_pin_state(instance_id));
+        assert!(!SystemHardware::current_thread_has_pin_state(hardware_id));
     }
 }
 


### PR DESCRIPTION
[Copilot speaking]

## Why

We want finer-grained *identification* of processors than just `(memory_region_id, efficiency_class)` gives us. Two machines can agree on processor and memory-region counts yet be materially different hardware. This PR exposes two new per-processor signals in `many_cpus` and folds them into the `cargo-bench-history` machine key so those machines hash to distinct fingerprints.

## What changed

### many_cpus: `RelativeSpeed`

- New public `Processor::relative_speed() -> RelativeSpeed` newtype. It is meant purely for *same-system* relative comparison / identification, never for cross-system or cross-OS comparison.
- Data sources: Linux `bogomips` from `/proc/cpuinfo`; Windows nominal `MaxMhz` read passively across **all** processor groups (see notes); other platforms / Miri report a fallback value.
- OS-reported metrics are scaled by pi before being stored, so the value carries no obvious numeric resemblance to the underlying MHz-style figure while preserving per-processor ordering.
- `RelativeSpeed` wraps a `NonZero<u64>` (widened from `u32`) so that summing speeds across many processors cannot run out of integer space. The value returned when the OS discloses no usable metric is not part of the API contract; internally it is a fixed sentinel (`u64::MAX`) chosen to be unmistakably not a real reading, so nothing can rely on a specific number.
- Fake hardware exposes a `ProcessorBuilder::relative_speed(NonZero<u64>)` setter.

### many_cpus: `model`

- New per-processor `Processor::model() -> &str` attribute. When a platform reports nothing, the value is a fixed placeholder so callers always have a string to key on and never have to invent their own fallback.
- Named `model` (not `brand`, and not `cpu_brand`): it matches the underlying sources and the crate avoids the word "cpu" outside its own package name.
- Fake hardware exposes a `ProcessorBuilder::model(&str)` setter.

### many_cpus: instance-scoped `Processor` identity

- `Processor` equality, hashing, and ordering are now scoped to the `SystemHardware` instance that produced the handle, keyed on an internal `HardwareId` plus the processor ID. Previously equality compared by processor ID alone, so a processor from real hardware and an equivalently-numbered processor from fake hardware compared equal, which is wrong. Real hardware keeps a stable singleton ID, so its behavior is unchanged; only cross-instance comparisons (fake vs fake, fake vs real) now correctly differ.
- `Processor` also gains `Ord`/`PartialOrd`, natural given that every processor has a unique ID.
- With identity moved into the `Processor` wrapper, the PAL no longer needs derived equality: the internal `AbstractProcessor` trait drops its `Eq + Hash + PartialEq` supertraits and the facade, fake, and fallback processors drop the now-dead derives. Linux keeps id-based ordering (its processor list is sorted); Windows, which never sorts, drops its unused identity impls.

### cargo-bench-history: machine key

- Fold the per-processor relative-speed histogram and the set of `many_cpus`-sourced processor models into the machine fingerprint. Every fingerprint factor now comes from a single, consistent hardware source (`many_cpus`).
- The model factor is the **distinct set of processor models** rendered as a sorted, deduplicated, comma-joined list. This is stable regardless of processor ordering or duplicates (unlike a first-wins pick), so machines with a mixed set of models still hash consistently.
- This introduces `FINGERPRINT_VERSION` `mk2`. **All machine keys change**, which is expected and accepted.
- Removed the old per-platform brand probing and the now-unused `tokio` dependency from `cbh_probe`; `system_profile` is now synchronous.

## Notes for reviewers

- **No runtime tampering.** Processor metadata (including the Windows speed read) is gathered passively. We do **not** change the calling thread's affinity to enumerate processors, and we cover all processor groups regardless of logical processor count.
- **Why pi-scaling.** `RelativeSpeed` is an abstract relative indicator. Multiplying OS values by pi deliberately removes any obvious correlation to real MHz figures so callers are not tempted to read it as a clock speed, while ordering between processors on the same system is preserved.
- **API docs describe contract only.** `Processor::model()` and `RelativeSpeed` document only what callers may rely on, not where the values come from. The model string may even change between versions of `many_cpus` for the same processor (not a breaking change), and the speed reported when the OS discloses nothing is deliberately left unspecified.
- **Model parity is not guaranteed across platforms.** On an AMD Ryzen 9 5950X the Windows and Linux model strings match after trimming (Windows pads the registry value with trailing spaces), but the two values originate from different firmware/OS sources, so the API is documented for identification only and must not be compared across operating systems.
- Validated on both Windows (native) and Linux (WSL) through the full `validate-local` pipeline, including mutation testing with zero missed mutants on each platform.