### PR TITLE
Remove the --include-ghosts escape hatch

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -251,8 +251,8 @@ analyze. Package scoping thus falls out of *what gets collected*, with no need t
 by name, which would in fact be wrong: benchmark identities are engine-dependent (some engines
 identify a series by bare operation name with no package prefix), so a name filter would silently
 drop those series and turn a real regression into a false negative. The PR analysis therefore
-relies on that default ghost exclusion and must never pass `--include-ghosts`, which would
-re-admit every historical benchmark and defeat the scoping. As a side benefit the same filter
+relies on that ghost exclusion, which is unconditional and cannot be turned off. As a side
+benefit the same filter
 also drops a benchmark the PR itself *removed*, so a deletion is never mis-reported as a
 regression.
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -242,7 +242,7 @@ cleanup path that *deletes* the comment when the PR no longer touches anything b
 Collection is **delta-scoped**: a preflight job diffs the PR against `main` and benchmarks only
 the touched packages, since re-measuring the whole workspace on every PR push would be
 wasteful. Analysis, by contrast, is deliberately **not** package-scoped — yet it stays correctly
-scoped anyway, by construction rather than by a name filter. `analyze` by default considers only
+scoped anyway, by construction rather than by a name filter. `analyze` considers only
 benchmarks **present at the context commit** (the PR head), dropping any "ghost" benchmark with
 no run there *before* detection. Because only the touched packages are collected at the PR's
 branch-unique head commit, only they are present there, so every untouched package is excluded

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -370,7 +370,8 @@ jobs:
           path: ${{ steps.scratch.outputs.dir }}/machine-keys
 
       # the PR head are analyzed) restricts it to exactly the collected packages, so no per-package
-      # filter is needed - the recipe must not pass `--include-ghosts`. See the recipe / design.md.
+      # filter is needed - and the ghost exclusion is unconditional, so it can never be turned off.
+      # See the recipe / design.md.
       # The third argument is the downloaded machine-key directory whose fingerprints scope the
       # analysis.
       - name: Analyze PR benchmark history

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -352,11 +352,6 @@ jobs:
           restore-keys: |
             bench-history-cache-
 
-      # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
-      # top-findings Markdown) and notable.txt into the scratch directory, in BRANCH mode (PR head
-      # vs origin/main), including improvements as well as regressions. Findings never fail the
-      # recipe (the tool always exits 0); the PR comment is advisory, not a gate. Analysis is
-      # deliberately run UNSCOPED: `analyze`'s default ghost-exclusion (only benchmarks present at
       # Download every collect leg's machine-key file (one per-platform artifact) into a single
       # directory so the analysis can thread the EXACT fingerprints collected this run into its
       # `--machine-key` filter. The default (no merge-multiple) keeps one subdirectory per artifact;
@@ -369,6 +364,11 @@ jobs:
           pattern: pr-bench-history-machine-key-*
           path: ${{ steps.scratch.outputs.dir }}/machine-keys
 
+      # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
+      # top-findings Markdown) and notable.txt into the scratch directory, in BRANCH mode (PR head
+      # vs origin/main), including improvements as well as regressions. Findings never fail the
+      # recipe (the tool always exits 0); the PR comment is advisory, not a gate. Analysis is
+      # deliberately run UNSCOPED: `analyze`'s always-on ghost-exclusion (only benchmarks present at
       # the PR head are analyzed) restricts it to exactly the collected packages, so no per-package
       # filter is needed - and the ghost exclusion is unconditional, so it can never be turned off.
       # See the recipe / design.md.

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -239,9 +239,9 @@ gh-analyze-bench-history dir keydir:
 # a touched package. The scoping is instead enforced by `analyze`'s DEFAULT ghost exclusion: it
 # analyzes only benchmarks present at the context commit (HEAD, the PR head), and only the collected
 # (touched) packages have a run there, so every untouched package is dropped as a "ghost" before
-# detection - for EVERY engine. This recipe therefore MUST NOT pass `--include-ghosts`: that flag
-# re-admits every historical benchmark in the store and would defeat the scoping. As a bonus the
-# same default also drops a benchmark this PR removed, so a deletion is never mis-flagged as a
+# detection - for EVERY engine. This exclusion is unconditional and cannot be turned off, so the
+# scoping can never be accidentally defeated. As a bonus the
+# same filter also drops a benchmark this PR removed, so a deletion is never mis-flagged as a
 # regression. See .github/workflows/design.md for the full invariant.
 #
 # {{dir}} is a scratch directory OUTSIDE the repo checkout (the `analyze` job passes the runner temp

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -236,7 +236,7 @@ gh-analyze-bench-history dir keydir:
 # filter (only positional id-prefix subjects), and benchmark ids are engine-dependent (Callgrind
 # carries the package, Criterion group ids are crate-prefixed, but alloc_tracker/all_the_time use a
 # bare operation name), so an id-prefix filter would silently drop the measurement-engine series for
-# a touched package. The scoping is instead enforced by `analyze`'s DEFAULT ghost exclusion: it
+# a touched package. The scoping is instead enforced by `analyze`'s always-on ghost exclusion: it
 # analyzes only benchmarks present at the context commit (HEAD, the PR head), and only the collected
 # (touched) packages have a run there, so every untouched package is dropped as a "ghost" before
 # detection - for EVERY engine. This exclusion is unconditional and cannot be turned off, so the

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -272,7 +272,6 @@ fn build_options(
         markdown_summary: None,
         include_improvements: true,
         include_inactive: false,
-        include_ghosts: true,
         verbose: false,
         timing,
     }

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -53,10 +53,10 @@ New per-series logic must be side-effect-free. Flow and rationale: [`docs/analyz
 (`list.rs`, `prune.rs`, `examine.rs`, each `pub(crate) mod`; `bless`/`unbless` in `bless.rs`
 reuse the same facet selection). **A selection parameter added to one must be added to all
 four** unless genuinely inapplicable. The analysis-only flags
-(`--include-improvements`, `--include-inactive`, `--include-ghosts`) and the
+(`--include-improvements`, `--include-inactive`) and the
 analyze-only condensed `--markdown-summary` output are **not** part of the lockstep —
 only `analyze` detects; `list`/`prune`/`examine` reuse the selection but never analyze.
-`--include-ghosts` in particular changes only *which reconstructed series are detected
+The always-on **ghost filter** likewise changes only *which reconstructed series are detected
 on* (it drops benchmarks absent at the context commit), not which runs are *selected*,
 so `list runs` may report more series than `analyze` now analyzes. Each is
 generic over the `GitHistory` + `Storage` ports so tests drive it with fakes + `block_on`.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -465,19 +465,18 @@ omitted. Positional prefix subjects scope the analysis to benchmarks
 whose id starts with a prefix; there is no metric filter, since metrics are an internal
 detail users are not expected to know.
 
-By default `analyze` also drops **ghost benchmarks** — benchmark identities that appear in
+`analyze` also drops **ghost benchmarks** — benchmark identities that appear in
 the selected data set but have no run at the **context commit** (the resolved `--context`,
 `HEAD` by default). In a long-lived project benchmarks are renamed, removed, or replaced, and
 re-flagging a change on a benchmark that no longer exists is noise; presence is judged
 per discriminant set (a set behind on collection at the context commit legitimately differs
 from another) and a present benchmark keeps all its metric-kind series. The filter runs
 before detection, so ghosts never contribute p-values to the false-discovery-rate correction.
-`--include-ghosts` opts back in and analyzes every benchmark in the data set. If a set has no
-runs at the context commit at all (`HEAD` was never collected or a collect failed),
-every benchmark is a ghost and the set analyzes empty with a dedicated
-hint pointing at `--include-ghosts` — an empty outcome the tool explains rather than guesses
+If a set has no runs at the context commit at all (`HEAD` was never collected or a collect
+failed), every benchmark is a ghost and the set analyzes empty with a dedicated
+hint — an empty outcome the tool explains rather than guesses
 around. Because it changes only which reconstructed series are detected on (not which runs
-are selected), `--include-ghosts` is analyze-only and outside the selection lockstep (§8.5).
+are selected), the ghost filter is analyze-only and outside the selection lockstep (§8.5).
 
 Output toggles select which renderings one analysis pass emits — text to stdout by default,
 with file toggles that compose so a single pass can emit text, Markdown, and JSON at once;
@@ -797,8 +796,8 @@ Modes apply to `analyze` only; `list`, `prune`, and `examine` reuse the same dat
 *selection* but never analyze, so the mode selection and improvement/inactive flags are
 analyze-only and not part of the selection lockstep. The **ghost filter** (§7.3) is likewise
 analyze-only and outside the lockstep: it applies in both modes, dropping — before detection
-— any benchmark absent at the context commit (the analyzed tip) unless `--include-ghosts` is
-passed. In branch mode a benchmark removed on the branch is a ghost and a benchmark newly
+— any benchmark absent at the context commit (the analyzed tip). In branch mode a benchmark
+removed on the branch is a ghost and a benchmark newly
 added on the branch is present and kept; dirty snapshots at the branch tip count as present
 via the base-tip dirty exception.
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -27,7 +27,7 @@ reactor-free and unchanged under Miri while still scaling on real hardware.
 flowchart TD
   EXEC["analyze"] --> SD["select data set (the load)"]
   SD --> DS[("series + run tallies + blessings")]
-  DS --> GF["drop ghost benchmarks\n(absent at context commit; unless --include-ghosts)"]
+  DS --> GF["drop ghost benchmarks\n(absent at context commit)"]
   GF --> AB["apply blessings (history re-baseline)"]
   AB --> FC["detect changes (per series)"]
   FC --> SUM["per-set summaries"]
@@ -39,7 +39,7 @@ else is bookkeeping. The **ghost filter** between the load and detect is a cheap
 per-series pass: it drops every reconstructed series whose benchmark has no run at the
 context commit (the analyzed tip), so a benchmark that no longer exists is not re-flagged.
 It runs before blessings and detection so ghosts never enter the false-discovery
-correction; `--include-ghosts` skips it. Each analysis mode (`history`, `branch`) is a
+correction. Each analysis mode (`history`, `branch`) is a
 separate
 invocation with its own load — there is no dataset cache across modes — and the mode is
 auto-detected once per run from git topology.

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -39,10 +39,9 @@ else is bookkeeping. The **ghost filter** between the load and detect is a cheap
 per-series pass: it drops every reconstructed series whose benchmark has no run at the
 context commit (the analyzed tip), so a benchmark that no longer exists is not re-flagged.
 It runs before blessings and detection so ghosts never enter the false-discovery
-correction. Each analysis mode (`history`, `branch`) is a
-separate
-invocation with its own load — there is no dataset cache across modes — and the mode is
-auto-detected once per run from git topology.
+correction. Each analysis mode (`history`, `branch`) is a separate invocation with its own
+load — there is no dataset cache across modes — and the mode is auto-detected once per run
+from git topology.
 
 The read-only `examine` command is a **lighter consumer of the same load**: it runs Phase 1
 and Phase 2/3 through the identical `select_dataset` pipeline, then narrows to a single

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1719,7 +1719,7 @@ async fn analyze_criterion_feature_branch_admits_dirty_snapshots() {
 /// commit — so a regression on a since-removed benchmark is not re-flagged.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_excludes_ghost_benchmarks_by_default() {
+async fn analyze_excludes_ghost_benchmarks() {
     let workspace = Workspace::repo(&storage_only_config());
     // `bench_000` runs flat through the tip; `bench_001` climbs into a regression but
     // is dropped from the suite at the tip commit, so it is a ghost there.

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -731,23 +731,22 @@ async fn analyze_alloc_tracker_ignores_gaps_in_a_sparse_history() {
     // `allocate_vec` is measured only at every other commit; the intervening
     // commits measure `free_box` instead, leaving `allocate_vec` unobserved there.
     // Its step spans the gaps: three baseline observations, then three raised ones.
+    // The history ends on an `allocate_vec` commit so that series is present at the
+    // tip and survives the ghost filter (`free_box` is the ghost here, and being
+    // flat it produces no finding regardless).
     let mut day = 1;
     for bytes in [200.0, 200.0, 200.0, 260.0, 260.0, 260.0] {
         workspace.commit_dated(&format!("2024-04-{day:02}"), &format!("g{day}"));
-        workspace.seed_alloc_tracker(&format!("g{day}"), "allocate_vec", bytes, 2.0);
+        workspace.seed_alloc_tracker(&format!("g{day}"), "free_box", 8.0, 1.0);
         day += 1;
         workspace.commit_dated(&format!("2024-04-{day:02}"), &format!("g{day}"));
-        workspace.seed_alloc_tracker(&format!("g{day}"), "free_box", 8.0, 1.0);
+        workspace.seed_alloc_tracker(&format!("g{day}"), "allocate_vec", bytes, 2.0);
         day += 1;
     }
 
     // Only `allocate_vec`'s allocated-bytes step is a finding. A gap read as a drop
     // to zero would manufacture wild swings; instead the series is contiguous.
-    //
-    // The sparse history ends on a `free_box` commit, so `allocate_vec` is absent at
-    // the tip and the default ghost filter would drop it. This test is about gap
-    // reconstruction, not tip presence, so it analyzes every benchmark.
-    let report = workspace.drive_json(&["analyze", "--include-ghosts"]).await;
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(
         parsed["regressions"], 1,
@@ -1524,16 +1523,13 @@ async fn analyze_feature_that_merged_master_admits_dirty_off_chain_merge_base() 
 #[cfg_attr(miri, ignore)]
 async fn analyze_criterion_machine_keys_stay_isolated() {
     let workspace = Workspace::repo(&storage_only_config());
-    // Same commits, same Windows/x86_64 triple, two distinct machine keys.
+    // Same commits, same Windows/x86_64 triple, two distinct machine keys. `mk-flat`
+    // stays flat across the full d1..d8 history (the same commits the rising machine
+    // uses), so it is present at the tip and never regresses.
     workspace.seed_rising_criterion_history("mk-rising");
-    workspace.commit_dated("2024-02-01", "d1");
-    workspace.seed_criterion("d1", "mk-flat", 20.0);
-    workspace.commit_dated("2024-02-02", "d2");
-    workspace.seed_criterion("d2", "mk-flat", 20.0);
-    workspace.commit_dated("2024-02-03", "d3");
-    workspace.seed_criterion("d3", "mk-flat", 20.0);
-    workspace.commit_dated("2024-02-04", "d4");
-    workspace.seed_criterion("d4", "mk-flat", 20.0);
+    for label in ["d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8"] {
+        workspace.seed_criterion(label, "mk-flat", 20.0);
+    }
 
     let report = workspace
         .drive_json(&[
@@ -1542,10 +1538,6 @@ async fn analyze_criterion_machine_keys_stay_isolated() {
             "x86_64-pc-windows-msvc",
             "--machine-key",
             "all",
-            // The flat machine stops collecting at d4 while the rising history runs to
-            // d8, so `mk-flat` is a ghost at the tip. This test is about machine-key
-            // isolation, not tip presence, so it analyzes every benchmark.
-            "--include-ghosts",
         ])
         .await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1723,9 +1715,8 @@ async fn analyze_criterion_feature_branch_admits_dirty_snapshots() {
     );
 }
 
-/// By default `analyze` ignores "ghost" benchmarks — ones no longer present at the
-/// context commit — so a regression on a since-removed benchmark is not re-flagged.
-/// `--include-ghosts` opts back in and the removed benchmark's regression surfaces.
+/// `analyze` ignores "ghost" benchmarks — ones no longer present at the context
+/// commit — so a regression on a since-removed benchmark is not re-flagged.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_excludes_ghost_benchmarks_by_default() {
@@ -1747,7 +1738,7 @@ async fn analyze_excludes_ghost_benchmarks_by_default() {
     workspace.commit_dated("2024-01-07", "c7");
     workspace.seed_many_callgrind("c7", &[100.0]);
 
-    // Default: the ghost's regression is filtered out, and the JSON reports the count.
+    // The ghost's regression is filtered out, and the JSON reports the count.
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["regressions"], 0, "{report}");
@@ -1755,15 +1746,5 @@ async fn analyze_excludes_ghost_benchmarks_by_default() {
     assert!(
         !report.contains("many::bench_001"),
         "the ghost benchmark must not appear: {report}"
-    );
-
-    // --include-ghosts analyzes the removed benchmark and surfaces its regression.
-    let report = workspace.drive_json(&["analyze", "--include-ghosts"]).await;
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-    assert_eq!(parsed["regressions"], 1, "{report}");
-    assert_eq!(parsed["ghosts_excluded"], 0, "{report}");
-    assert!(
-        report.contains("many::bench_001"),
-        "the removed benchmark's regression must surface: {report}"
     );
 }

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -197,16 +197,13 @@ where
 
     let mut series = dataset.series;
 
-    // Ghost filtering (default): analyze only benchmarks that still exist at the
-    // context commit. A benchmark that appears only for past commits — renamed,
-    // removed, or replaced — is a "ghost"; re-flagging it is noise. Dropping
-    // ghosts *before* detection also keeps them out of the false-discovery-rate
+    // Ghost filtering: analyze only benchmarks that still exist at the context
+    // commit. A benchmark that appears only for past commits — renamed, removed,
+    // or replaced — is a "ghost"; re-flagging it is noise. Dropping ghosts
+    // *before* detection also keeps them out of the false-discovery-rate
     // correction, so a removed benchmark cannot dilute the correction for real
-    // ones. `--include-ghosts` opts out and analyzes every benchmark in the data
-    // set. Presence is read from the raw points, independent of re-baselining.
-    let ghosts_excluded = if options.include_ghosts {
-        0
-    } else {
+    // ones. Presence is read from the raw points, independent of re-baselining.
+    let ghosts_excluded = {
         let ghost_started = Instant::now();
         let ghosts = retain_present_at_context(&mut series, &dataset.tip_commit);
         for (set, id) in &ghosts {
@@ -340,8 +337,7 @@ fn all_ghosts_hint(tip_commit: &str) -> String {
         "Runs were analyzed, but every benchmark was filtered as a ghost — none is \
          present at the context commit {}. This usually means the context commit has \
         no stored runs (collect at the context commit), or its benchmark set differs \
-        from history. Pass --include-ghosts to analyze every benchmark, including \
-        removed ones.",
+        from history.",
         short_commit(tip_commit)
     )
 }
@@ -575,18 +571,6 @@ mod tests {
 
     fn options() -> AnalyzeOptions {
         AnalyzeOptions::default()
-    }
-
-    /// Options that also analyze ghost benchmarks — ones absent at the context
-    /// commit. Several counting/faceting fixtures seed history that stops short of
-    /// the `linear_git` tip (`c3` carries no runs), so the default ghost filter
-    /// would empty the analysis; these tests exercise loading and tallying over the
-    /// full data set, not tip-presence, so they opt the filter off.
-    fn ghost_options() -> AnalyzeOptions {
-        AnalyzeOptions {
-            include_ghosts: true,
-            ..AnalyzeOptions::default()
-        }
     }
 
     /// A fixed clock anchor for the history-mode default `--since` window in unit
@@ -982,9 +966,12 @@ mod tests {
     #[test]
     fn per_set_report_counts_runs_and_series_independently() {
         let storage = MemoryStorage::new();
-        // Set A — callgrind/linux/synthetic: three runs (c0..c2), each carrying two
+        // Both sets run through the `linear_git` tip (`c3`) so neither benchmark is a
+        // ghost there and the always-on tip filter keeps every series.
+        //
+        // Set A — callgrind/linux/synthetic: three runs (c1..c3), each carrying two
         // metrics so the set reconstructs two distinct series.
-        for index in 0..3 {
+        for index in 1..4 {
             let commit = format!("c{index}");
             let second = i64::from(index);
             store(
@@ -993,10 +980,10 @@ mod tests {
                 &two_metric_set(second, &commit, 100.0, 200.0),
             );
         }
-        // Set B — callgrind/darwin/synthetic: two runs (c0..c1), each carrying one
+        // Set B — callgrind/darwin/synthetic: two runs (c2..c3), each carrying one
         // metric so the set reconstructs a single series. Distinct run AND series
         // counts from set A make an `==`/`!=` swap in either per-set tally observable.
-        for index in 0..2 {
+        for index in 2..4 {
             let commit = format!("c{index}");
             let second = i64::from(index);
             store(
@@ -1007,7 +994,7 @@ mod tests {
         }
 
         let git = linear_git();
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &ghost_options());
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let sets = parsed["sets"].as_array().unwrap();
@@ -1056,7 +1043,7 @@ mod tests {
     }
 
     #[test]
-    fn a_ghost_benchmark_is_excluded_by_default_and_kept_with_the_flag() {
+    fn a_ghost_benchmark_is_excluded() {
         // `kept` is measured through the tip (c0..c3); `ghost` disappears after c2.
         // The tip is c3, so `ghost` is no longer part of the current suite there.
         let storage = MemoryStorage::new();
@@ -1082,8 +1069,8 @@ mod tests {
         );
         let git = linear_git();
 
-        // Default: the ghost is filtered out before detection, and the verbose trail
-        // names it and the context commit it is absent from.
+        // The ghost is filtered out before detection, and the verbose trail names it
+        // and the context commit it is absent from.
         let (report, _, reporter) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["ghosts_excluded"], 1, "{report}");
@@ -1098,18 +1085,12 @@ mod tests {
             "{:?}",
             reporter.notes()
         );
-
-        // --include-ghosts analyzes both benchmarks and drops nothing.
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &ghost_options());
-        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-        assert_eq!(parsed["ghosts_excluded"], 0, "{report}");
-        assert_eq!(parsed["series"], 2, "both benchmarks analyzed, {report}");
     }
 
     #[test]
     fn an_all_ghosts_analysis_emits_the_dedicated_hint() {
         // Every benchmark disappears before the tip (data stops at c2, tip is c3), so
-        // the default filter empties the analysis. The empty outcome must read as an
+        // the filter empties the analysis. The empty outcome must read as an
         // all-ghosts case, distinct from a bare "no data".
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
@@ -1124,7 +1105,10 @@ mod tests {
         assert_eq!(parsed["runs"], 3, "the runs still loaded, {report}");
         let hint = parsed["hint"].as_str().unwrap_or_default();
         assert!(hint.contains("filtered as a ghost"), "{report}");
-        assert!(hint.contains("--include-ghosts"), "{report}");
+        assert!(
+            hint.contains("context commit"),
+            "the hint names the context commit: {report}"
+        );
     }
 
     #[test]
@@ -1538,18 +1522,19 @@ mod tests {
     fn target_triple_facet_selects_the_windows_set() {
         // Two sets differing only by triple; an explicit `--target-triple` reports
         // just the matching one, even though the auto-detected default is Linux.
+        // Both are seeded at the `linear_git` tip (`c3`) so the tip filter keeps them.
         let storage = MemoryStorage::new();
-        store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
+        store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
             &storage,
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c0/clean.json",
-            &ir_set(0, "c0", 100.0),
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c3/clean.json",
+            &ir_set(3, "c3", 100.0),
         );
         let git = linear_git();
 
         let opts = AnalyzeOptions {
             target_triple: vec!["x86_64-pc-windows-msvc".to_owned()],
-            ..ghost_options()
+            ..options()
         };
         let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1564,18 +1549,19 @@ mod tests {
     #[test]
     fn target_triple_facet_selects_one_set() {
         // Two sets differing only by triple; `--target-triple` reports just the one.
+        // Both are seeded at the `linear_git` tip (`c3`) so the tip filter keeps them.
         let storage = MemoryStorage::new();
-        store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
+        store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
             &storage,
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c0/clean.json",
-            &ir_set(0, "c0", 100.0),
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c3/clean.json",
+            &ir_set(3, "c3", 100.0),
         );
         let git = linear_git();
 
         let opts = AnalyzeOptions {
             target_triple: vec!["x86_64-unknown-linux-gnu".to_owned()],
-            ..ghost_options()
+            ..options()
         };
         let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
@@ -1589,16 +1575,18 @@ mod tests {
 
     #[test]
     fn two_sets_produce_two_report_sections() {
+        // Both sets are seeded at the `linear_git` tip (`c3`) so the tip filter keeps
+        // each and every partition is reported.
         let storage = MemoryStorage::new();
-        store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
+        store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
             &storage,
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c0/clean.json",
-            &ir_set(0, "c0", 100.0),
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c3/clean.json",
+            &ir_set(3, "c3", 100.0),
         );
         let git = linear_git();
 
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &ghost_options());
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["sets"].as_array().unwrap().len(), 2, "{report}");
     }

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -487,13 +487,6 @@ struct AnalyzeCommand {
     #[arg(long, help_heading = HEADING_ANALYSIS)]
     include_inactive: bool,
 
-    /// Analyze every benchmark in the data set, including "ghosts" no longer
-    /// present at the context commit. By default only benchmarks measured at the
-    /// context commit (the current suite) are analyzed, so a renamed or removed
-    /// benchmark is not re-flagged.
-    #[arg(long, help_heading = HEADING_ANALYSIS)]
-    include_ghosts: bool,
-
     /// Also write a condensed Markdown summary — only the most significant findings
     /// — to this path (a relative path resolves against the working directory). The
     /// full `--markdown` report carries every finding; this summary is capped so a
@@ -523,7 +516,6 @@ impl AnalyzeCommand {
             markdown_summary: self.markdown_summary,
             include_improvements: self.include_improvements,
             include_inactive: self.include_inactive,
-            include_ghosts: self.include_ghosts,
             verbose: self.env.verbose,
             timing: false,
         }
@@ -1578,22 +1570,6 @@ mod tests {
             panic!("expected analyze command");
         };
         assert!(!options.include_inactive);
-    }
-
-    #[test]
-    fn analyze_parses_include_ghosts_switch() {
-        let Command::Analyze(options) = parse(&["analyze", "--include-ghosts"]) else {
-            panic!("expected analyze command");
-        };
-        assert!(options.include_ghosts);
-
-        let Command::Analyze(options) = parse(&["analyze"]) else {
-            panic!("expected analyze command");
-        };
-        assert!(
-            !options.include_ghosts,
-            "ghost filtering is on by default (the flag opts out of it)"
-        );
     }
 
     #[test]

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -223,11 +223,6 @@ pub struct AnalyzeOptions {
     /// state no longer reflects (a regression that later recovered). Hidden by
     /// default since they need no action.
     pub include_inactive: bool,
-    /// Analyze every benchmark found in the data set, including "ghosts" — ones
-    /// no longer present at the context commit. By default only benchmarks
-    /// measured at the context commit (the current suite) are analyzed, so a
-    /// renamed or removed benchmark is not re-flagged.
-    pub include_ghosts: bool,
     /// Emit detailed diagnostic notes to standard error describing each step.
     pub verbose: bool,
     /// Emit per-stage wall-clock timings to standard error, independent of

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -1159,7 +1159,7 @@ mod tests {
     fn retain_present_at_context_empties_when_the_context_has_no_runs() {
         // c2 is an analyzed commit that carries no runs. Every benchmark is a ghost,
         // so the list empties — the caller turns this into the "collect at the
-        // context commit / --include-ghosts" hint.
+        // context commit" hint.
         let objects = vec![
             clean_multi("c0", 100, &[("pkga", 10.0)]),
             clean_multi("c1", 200, &[("pkga", 11.0)]),

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -268,7 +268,7 @@ fn cases() -> Vec<SignalCase> {
             branch: [run_of(200.0, 49), run_of(100.0, 1)].concat(),
             expected_history: Outcome::Rise,
             expected_branch: Outcome::Quiet,
-        }
+        },
     ]
 }
 

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -110,10 +110,10 @@ pub struct ReportInput<'a> {
     /// tip (the working-tree-dirty exception). Absent in the normal case.
     pub warning: Option<&'a str>,
     /// How many benchmarks were dropped as "ghosts" — present only for past commits,
-    /// not at the context commit — before detection. Zero when `--include-ghosts`
-    /// disabled the filter or nothing was dropped. Carried for the JSON report so a
-    /// machine consumer sees that scoping happened; the text and Markdown reports
-    /// surface it only through the verbose trail and the empty-outcome hint.
+    /// not at the context commit — before detection. Zero when nothing was dropped.
+    /// Carried for the JSON report so a machine consumer sees that scoping happened;
+    /// the text and Markdown reports surface it only through the verbose trail and the
+    /// empty-outcome hint.
     pub ghosts_excluded: usize,
 }
 
@@ -234,7 +234,7 @@ struct JsonReport<'a> {
     /// Number of flagged improvements.
     improvements: usize,
     /// Benchmarks dropped as ghosts (present only for past commits, not at the
-    /// context commit) before detection. Zero when `--include-ghosts` was passed.
+    /// context commit) before detection. Zero when nothing was dropped.
     ghosts_excluded: usize,
     /// A diagnostic hint when stored runs existed but none were analyzed.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
[Copilot speaking]

## Summary

Ghost filtering in `cargo-bench-history analyze` was default-on with an `--include-ghosts` opt-out that re-admitted every historical benchmark. The opt-out added CLI, API and pipeline complexity for a case production never uses — the PR analysis relies on the filter always running. This removes the escape hatch and makes ghost exclusion **unconditional**.

The valuable behavior is unchanged: the ghost filter (`retain_present_at_context`), the `ghosts_excluded` reporting, and the dedicated all-ghosts hint all stay. Only the way to *bypass* the filter is gone.

## Changes

**Production code**
- `cbh_cli/src/cli.rs` — removed the `--include-ghosts` `#[arg]` field and its `into_options()` mapping (and the parse test for it).
- `cbh_command/src/command.rs` — removed the `include_ghosts` field from `AnalyzeOptions`.
- `cbh_analyze/src/pipeline.rs` — collapsed the `if options.include_ghosts { 0 } else { … }` branch into an always-on filter; reworded the comment and the all-ghosts hint.
- `cbh_render/src/report.rs` — updated the `ghosts_excluded` doc comments (field kept).
- `cargo-bench-history-stress/src/measure.rs` — dropped `include_ghosts: true`.

**Tests** — reworked the tests that opted into ghosts so they seed data at the tip commit, letting their benchmarks survive the now-unconditional filter (3 integration tests in `analyze.rs` plus several `pipeline.rs` unit tests).

**Docs & CI comments** — `DESIGN.md`, `analyze.md`, `AGENTS.md`, `.github/workflows/design.md`, `pr-bench-history.yml`, and `just_automation.just` now describe the filter as unconditional.

**Incidental** — fixed a pre-existing trailing-comma format violation in `cbh_detect/src/detect/signal_validation.rs` that was failing the repo-wide `format-check` gate.

## Validation

`build`, `clippy`, unit tests, integration tests, `format-check`, doctests, and `docs` all pass with zero warnings. In-diff mutation testing found no new mutable surface (expected for a pure removal).