### PR TITLE
Clarify bench-history scope wording: impacted, not changed

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -210,7 +210,7 @@ workflow files; the comment lives and dies with the pull request. The comment is
 advisory — findings never affect the check's exit code, so a regression note never blocks a
 merge — and it reports detected improvements alongside regressions, or a plain "no regressions"
 state. It also states its **collection scope** — which packages were benchmarked — so a clean
-result is never mistaken for the whole suite being clean when only the changed subset was
+result is never mistaken for the whole suite being clean when only the impacted subset was
 measured. A run *failure* surfaces only as the red check, with no issue and no failure comment,
 because a PR failure is a transient condition, not the persistent one the issue lifecycle
 tracks.
@@ -239,13 +239,14 @@ skips a still-empty placeholder (it has no results to age), leaving the placehol
 the seeding pass. `mark-stale` is gated on the same non-empty delta as collect, so it never races the
 cleanup path that *deletes* the comment when the PR no longer touches anything benchmarkable.
 
-Collection is **delta-scoped**: a preflight job diffs the PR against `main` and benchmarks only
-the touched packages, since re-measuring the whole workspace on every PR push would be
-wasteful. Analysis, by contrast, is deliberately **not** package-scoped — yet it stays correctly
-scoped anyway, by construction rather than by a name filter. `analyze` by default considers only
+Collection is **delta-scoped**: a preflight job runs cargo-delta against `main` and benchmarks only
+the impacted packages — those the PR changed, plus their dependents — since re-measuring the whole
+workspace on every PR push would be wasteful. Analysis, by contrast, is deliberately **not**
+package-scoped — yet it stays correctly scoped anyway, by construction rather than by a name
+filter. `analyze` by default considers only
 benchmarks **present at the context commit** (the PR head), dropping any "ghost" benchmark with
-no run there *before* detection. Because only the touched packages are collected at the PR's
-branch-unique head commit, only they are present there, so every untouched package is excluded
+no run there *before* detection. Because only the impacted packages are collected at the PR's
+branch-unique head commit, only they are present there, so every other package is excluded
 as a ghost automatically — for *every* measurement engine — leaving exactly the collected set to
 analyze. Package scoping thus falls out of *what gets collected*, with no need to filter analysis
 by name, which would in fact be wrong: benchmark identities are engine-dependent (some engines
@@ -256,7 +257,7 @@ re-admit every historical benchmark and defeat the scoping. As a side benefit th
 also drops a benchmark the PR itself *removed*, so a deletion is never mis-reported as a
 regression.
 
-When a PR touches no benchmarkable package — including a PR that touched one earlier and then
+When a PR impacts no benchmarkable package — including a PR that impacted one earlier and then
 reverted it — a lightweight cleanup path removes any rolling comment a prior push left behind
 and posts nothing, so a stale, misleading comment never lingers; it is a no-op when there was
 no comment. PR runs read the shared history cache **restore-only** (never saving), keeping the

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -2,10 +2,11 @@ name: PR Benchmark history
 
 # Per-push benchmark feedback on pull requests: the PR counterpart of bench-history.yml. Where that
 # workflow collects on every push to `main` and files a rolling ISSUE about long-range trends, this
-# one runs on every push to a PR branch, benchmarks only the packages the PR touched (cargo-delta
-# scoped), compares the PR head's benchmark level against `main` in BRANCH mode, and posts/updates a
-# rolling PR COMMENT with the findings. PR-head points are written into the SAME prod Azure store as
-# the `main` baseline (branch-mode comparison reads a single backend); PR commits are
+# one runs on every push to a PR branch, benchmarks only the packages the PR impacts (the changed
+# packages plus their dependents, cargo-delta scoped), compares the PR head's benchmark level
+# against `main` in BRANCH mode, and posts/updates a rolling PR COMMENT with the findings. PR-head
+# points are written into the SAME prod Azure store as the `main` baseline (branch-mode comparison
+# reads a single backend); PR commits are
 # topologically branch-unique, so they never enter `main`'s history analysis. Findings are advisory:
 # they never gate the merge, only inform. See .github/workflows/design.md (Benchmark history).
 on:
@@ -38,8 +39,9 @@ env:
   PR_COMMIT_MARKER_PREFIX: "<!-- folo-bench-history-commit:"
 
 jobs:
-  # Compute which packages the PR touched (cargo-delta vs origin/main), filtered to the
-  # benchmarkable set (everything except the slow, special-purpose `benchmarks` crate). The result
+  # Compute which packages the PR impacts (cargo-delta vs origin/main: the changed packages plus
+  # their dependents), filtered to the benchmarkable set (everything except the slow,
+  # special-purpose `benchmarks` crate). The result
   # gates the whole workflow: a non-empty set drives collect+analyze, an empty set routes to
   # cleanup. Runs only for same-repo PRs - fork runs cannot federate into Azure (no secrets), so
   # like bench-history.yml's fork gate they are skipped silently; because every downstream job
@@ -86,15 +88,15 @@ jobs:
           # the module analyzes origin/main in a throwaway worktree and cleans up after itself.
           $affected = @(Invoke-CargoDelta -SkipFetch)
           # Drop the excluded `benchmarks` crate BEFORE shaping the outputs, so `skip_all` reflects
-          # the benchmarkable set: a PR that touches only `benchmarks` (or nothing) collects nothing
+          # the benchmarkable set: a PR that impacts only `benchmarks` (or nothing) collects nothing
           # and instead has its stale comment (if any) cleaned up.
           $benchmarkable = @(Select-BenchmarkablePackage -Package $affected)
           $output = Get-DeltaOutput -Affected $benchmarkable
 
           if ($benchmarkable.Count -eq 0) {
-            Write-Host 'No benchmarkable packages touched by this PR; collection will be skipped and any stale rolling comment removed.'
+            Write-Host 'No benchmarkable packages impacted by this PR; collection will be skipped and any stale rolling comment removed.'
           } else {
-            Write-Host "Benchmarkable packages touched by this PR: $($output.Packages)"
+            Write-Host "Benchmarkable packages impacted by this PR: $($output.Packages)"
           }
 
           @(
@@ -190,8 +192,8 @@ jobs:
             Write-Host "No placeholder change needed (the PR already has a rolling comment with results, or the placeholder is current)."
           }
 
-  # Benchmark ONLY the touched packages across the full platform matrix, keyed by the PR head
-  # commit, appending the results into the prod store. Skipped when the PR touches nothing
+  # Benchmark ONLY the impacted packages across the full platform matrix, keyed by the PR head
+  # commit, appending the results into the prod store. Skipped when the PR impacts nothing
   # benchmarkable (delta.skip_all). Mirrors bench-history.yml's collect job, differing only in the
   # checkout (real head SHA, full history) and the package-scoped recipe.
   collect:
@@ -436,12 +438,13 @@ jobs:
           $analyzedLine = "**Analyzed commit:** $env:HEAD_SHA"
 
           # Disclose the collection scope so a reader never mistakes a clean result for the whole
-          # suite: PR runs benchmark ONLY the packages this PR changed (cargo-delta scoped), and the
-          # analyze ghost filter narrows the report to exactly that set. List them explicitly.
+          # suite: PR runs benchmark ONLY the packages this PR impacts - the changed packages plus
+          # their dependents (cargo-delta scoped) - and the analyze ghost filter narrows the report
+          # to exactly that set. List them explicitly.
           $packages = @(($env:PACKAGES -split '\s+') | Where-Object { $_ } | Sort-Object -Unique)
           $renderedPackages = ($packages | ForEach-Object { '`' + $_ + '`' }) -join ', '
           $packageNoun = if ($packages.Count -eq 1) { 'package' } else { 'packages' }
-          $scope = "**Collection scope:** benchmarked the $($packages.Count) $packageNoun this PR changed ($renderedPackages)."
+          $scope = "**Collection scope:** benchmarked the $($packages.Count) $packageNoun impacted by this PR ($renderedPackages)."
           if ($env:NOTABLE -eq 'true') {
             $summary = (Get-Content (Join-Path $env:SCRATCH_DIR 'summary.md') -Raw).TrimEnd()
             $fullReport = "**Full report:** the complete Markdown and JSON reports are attached to this workflow run. [Download the full report bundle]($env:REPORT_ARTIFACT_URL)."

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -62,9 +62,10 @@ gh-collect-bench-history:
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
 
 # The PR counterpart of `gh-collect-bench-history`: collects benchmark history for ONLY the
-# packages a pull request touched (the pr-bench-history.yml `delta` job computes them from
-# cargo-delta and passes them here space-separated, already filtered to the benchmarkable set), into
-# the SAME prod Azure store, keyed by the PR head commit. Scoping to the touched packages is a pure
+# packages a pull request impacts (the pr-bench-history.yml `delta` job computes them from
+# cargo-delta - the changed packages plus their dependents - and passes them here space-separated,
+# already filtered to the benchmarkable set), into the SAME prod Azure store, keyed by the PR head
+# commit. Scoping to the impacted packages is a pure
 # cost optimisation - a PR rarely changes every crate, and the full 4-platform matrix is expensive -
 # and it is safe because branch-mode `analyze` only ever flags a series that has a data point at the
 # branch-unique head commit, i.e. exactly the packages collected here (see
@@ -87,14 +88,14 @@ gh-collect-pr-bench-history packages:
 
     Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
 
-    # The delta job passes the touched packages space-separated (the same shape validation.yml's
+    # The delta job passes the impacted packages space-separated (the same shape validation.yml's
     # `just package="..."` gating uses); split them into the array the module scopes on.
     $packageList = @('{{packages}}'.Split([char[]]@(' ', "`t", "`n"), [StringSplitOptions]::RemoveEmptyEntries))
     if ($packageList.Count -eq 0) {
         throw "gh-collect-pr-bench-history requires at least one package to collect; got an empty list. The pr-bench-history workflow must gate this recipe on a non-empty benchmarkable delta."
     }
 
-    Write-Verbose "Collecting PR benchmark history scoped to the touched packages: $($packageList -join ', ')." -Verbose
+    Write-Verbose "Collecting PR benchmark history scoped to the packages impacted by this PR: $($packageList -join ', ')." -Verbose
     $toolArgs = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package $packageList -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
 
@@ -236,9 +237,9 @@ gh-analyze-bench-history dir keydir:
 # filter (only positional id-prefix subjects), and benchmark ids are engine-dependent (Callgrind
 # carries the package, Criterion group ids are crate-prefixed, but alloc_tracker/all_the_time use a
 # bare operation name), so an id-prefix filter would silently drop the measurement-engine series for
-# a touched package. The scoping is instead enforced by `analyze`'s DEFAULT ghost exclusion: it
+# an impacted package. The scoping is instead enforced by `analyze`'s DEFAULT ghost exclusion: it
 # analyzes only benchmarks present at the context commit (HEAD, the PR head), and only the collected
-# (touched) packages have a run there, so every untouched package is dropped as a "ghost" before
+# (impacted) packages have a run there, so every other package is dropped as a "ghost" before
 # detection - for EVERY engine. This recipe therefore MUST NOT pass `--include-ghosts`: that flag
 # re-admits every historical benchmark in the store and would defeat the scoping. As a bonus the
 # same default also drops a benchmark this PR removed, so a deletion is never mis-flagged as a

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -19,7 +19,7 @@
 #
 # Collection scope is orthogonal to the mode: with no explicit package list the whole workspace is
 # benched except the special-purpose `benchmarks` crate (the push-to-main default); the PR workflow
-# instead passes the delta-affected packages so it benches only what the PR touched.
+# instead passes the delta-affected packages so it benches only what the PR impacts.
 # Select-BenchmarkablePackage is the shared helper that drops `benchmarks` from a delta-affected set
 # before both the scope decision and the "is there anything to bench at all" gate.
 
@@ -88,7 +88,7 @@ function Get-BenchHistoryCollectCommand {
     # debuggable from the log alone.
     $packages = @($Package | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     if ($packages.Count -gt 0) {
-        # Explicit package scoping (PR workflow): one `--package <name>` per touched crate.
+        # Explicit package scoping (PR workflow): one `--package <name>` per impacted crate.
         $selection = @()
         foreach ($name in $packages) { $selection += @('--package', $name) }
         Write-Verbose ("Scoping collection to the delta-affected packages: " +

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -830,17 +830,17 @@ Describe 'Publish-InProgressComment (mocked gh api)' {
 }
 
 Describe 'Format-InProgressBody (unexported string transform)' {
-    It 'renders a single changed package with singular wording' {
+    It 'renders a single impacted package with singular wording' {
         InModuleScope BenchHistoryComment {
             $body = Format-InProgressBody -Marker '<!-- folo-bench-history-pr -->' -Packages 'solo'
-            $body.Contains('benchmarking the 1 package this PR changed (`solo`).') | Should -BeTrue
+            $body.Contains('benchmarking the 1 package impacted by this PR (`solo`).') | Should -BeTrue
         }
     }
 
-    It 'sorts and de-duplicates multiple changed packages with plural wording' {
+    It 'sorts and de-duplicates multiple impacted packages with plural wording' {
         InModuleScope BenchHistoryComment {
             $body = Format-InProgressBody -Marker '<!-- folo-bench-history-pr -->' -Packages 'beta alpha beta'
-            $body.Contains('benchmarking the 2 packages this PR changed (`alpha`, `beta`).') | Should -BeTrue
+            $body.Contains('benchmarking the 2 packages impacted by this PR (`alpha`, `beta`).') | Should -BeTrue
         }
     }
 

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -538,7 +538,7 @@ function Format-InProgressBody {
     # posting a duplicate) and the hidden in-progress marker (so Set-RollingCommentStaleness and
     # Publish-InProgressComment can tell a still-empty placeholder from a comment carrying real results).
     # Mirrors the analyze comment's header and "Collection scope" line - listing exactly the packages
-    # this PR changed, sorted and de-duped the same way - so the placeholder reads as an early form of the
+    # this PR impacts, sorted and de-duped the same way - so the placeholder reads as an early form of the
     # very comment analyze will later overwrite. Factored out (and kept unexported) so the rendering is
     # one testable place, mirroring Add-StalenessBanner.
     [CmdletBinding()]
@@ -555,7 +555,7 @@ function Format-InProgressBody {
     $names = @(($Packages -split '\s+') | Where-Object { $_ } | Sort-Object -Unique)
     $renderedPackages = ($names | ForEach-Object { '`' + $_ + '`' }) -join ', '
     $packageNoun = if ($names.Count -eq 1) { 'package' } else { 'packages' }
-    $scope = "**Collection scope:** benchmarking the $($names.Count) $packageNoun this PR changed ($renderedPackages)."
+    $scope = "**Collection scope:** benchmarking the $($names.Count) $packageNoun impacted by this PR ($renderedPackages)."
 
     $lines = @(
         $Marker


### PR DESCRIPTION
[Copilot speaking]

## Problem

The PR bench-history rolling comment reported its collection scope as:

> **Collection scope:** benchmarked the 27 packages this PR changed (...)

This is misleading. PR benchmark collection is delta-scoped via `cargo-delta`, which selects the packages that are **directly changed by the PR plus their dependents** (indirectly affected via dependency chains). Describing the scope as the packages the PR "changed" (or "touched") understates it — a package can be in scope purely because it depends on something the PR changed.

## Change

Reword the scope description to say the packages the PR **impacts** across all the places that carried the imprecise wording:

- The rolling PR comment (`benchmarked the N packages impacted by this PR`)
- The in-progress placeholder comment (`benchmarking the N packages impacted by this PR`)
- CI log messages (`Benchmarkable packages impacted by this PR: …`)
- `.github/workflows/design.md` and `pr-bench-history.yml` header/comments
- `justfiles/just_automation.just` recipe comments and verbose log
- The two `scripts/bench-history` PowerShell modules and their tests

No behavioral change — collection scope is unchanged; only the wording describing it is corrected.

## Validation

- `just test-scripts` — 281 passed, 0 failed (includes the updated `Format-InProgressBody` assertions)
- `just validate-workflows` — actionlint clean
- `just validate-scripts` — PSScriptAnalyzer clean