### PR TITLE
Trim per-commit noise in `list runs` text output

### DIFF
--- a/packages/cbh_analyze/src/list.rs
+++ b/packages/cbh_analyze/src/list.rs
@@ -273,6 +273,27 @@ fn series_noun(count: usize) -> String {
     format!("{count} series")
 }
 
+/// Renders one commit's line for the text listing, annotating only the runs that
+/// deviate from the norm.
+///
+/// Almost every commit carries exactly one clean run and no dirty snapshot, so that
+/// case renders as the bare commit with no counts. A clean count other than one, or
+/// any dirty snapshots, is spelled out so the exception stands out instead of being
+/// buried in noise repeated on every line.
+fn commit_line(commit: &CommitEntry) -> String {
+    let clean = if commit.clean == 1 {
+        String::new()
+    } else {
+        format!("  {}", count_noun(commit.clean, "clean run"))
+    };
+    let dirty = if commit.dirty == 0 {
+        String::new()
+    } else {
+        format!(" + {}", count_noun(commit.dirty, "dirty run"))
+    };
+    format!("    {}{clean}{dirty}", commit.commit)
+}
+
 /// Renders the data-set preview in the requested format, appending the diagnostic
 /// hint and ephemeral-data warning (if any).
 fn render_listing(
@@ -304,13 +325,7 @@ fn render_listing_text(listing: &Listing, hint: Option<&str>, warning: Option<&s
                 count_noun(set.commits.len(), "commit")
             ));
             for commit in &set.commits {
-                lines.push(format!(
-                    "    {}  {} ({} clean, {} dirty)",
-                    commit.commit,
-                    count_noun(commit.runs, "run"),
-                    commit.clean,
-                    commit.dirty
-                ));
+                lines.push(commit_line(commit));
             }
         }
         lines.push(String::new());
@@ -1278,6 +1293,62 @@ mod tests {
         assert!(report.contains("2 series"), "{report}");
         assert!(!report.contains("seriess"), "{report}");
         assert!(report.contains("1 discriminant set"), "{report}");
+    }
+
+    #[test]
+    fn commit_line_omits_counts_for_a_single_clean_run() {
+        let line = commit_line(&CommitEntry {
+            commit: "abc123".to_owned(),
+            runs: 1,
+            clean: 1,
+            dirty: 0,
+        });
+        // The overwhelming common case: no counts, just the commit.
+        assert_eq!(line, "    abc123");
+    }
+
+    #[test]
+    fn commit_line_appends_only_dirty_runs_when_clean_is_the_norm() {
+        let line = commit_line(&CommitEntry {
+            commit: "abc123".to_owned(),
+            runs: 4,
+            clean: 1,
+            dirty: 3,
+        });
+        assert_eq!(line, "    abc123 + 3 dirty runs");
+    }
+
+    #[test]
+    fn commit_line_singularizes_a_lone_dirty_run() {
+        let line = commit_line(&CommitEntry {
+            commit: "abc123".to_owned(),
+            runs: 2,
+            clean: 1,
+            dirty: 1,
+        });
+        assert_eq!(line, "    abc123 + 1 dirty run");
+    }
+
+    #[test]
+    fn commit_line_spells_out_a_non_unit_clean_count() {
+        let line = commit_line(&CommitEntry {
+            commit: "abc123".to_owned(),
+            runs: 2,
+            clean: 2,
+            dirty: 0,
+        });
+        assert_eq!(line, "    abc123  2 clean runs");
+    }
+
+    #[test]
+    fn commit_line_reports_both_clean_and_dirty_deviations() {
+        let line = commit_line(&CommitEntry {
+            commit: "abc123".to_owned(),
+            runs: 3,
+            clean: 0,
+            dirty: 1,
+        });
+        assert_eq!(line, "    abc123  0 clean runs + 1 dirty run");
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## Why

In `cargo-bench-history list runs`, the text listing repeated `1 run (1 clean, 0 dirty)` on every commit line. That is the overwhelming common case, so the counts are pure noise that buries the one thing a reader is scanning for: the exceptions.

## What

The per-commit text line now shows just the bare commit when it carries exactly one clean run and no dirty snapshots. Counts are spelled out only when they deviate from that norm:

- `1 clean, 0 dirty` -> `abc123`
- `1 clean, 3 dirty` -> `abc123 + 3 dirty runs`
- `2 clean, 0 dirty` -> `abc123  2 clean runs`
- `0 clean, 1 dirty` -> `abc123  0 clean runs + 1 dirty run`

This is text-output only. The Markdown table and JSON outputs are structured formats where the full clean/dirty columns belong, so they are unchanged.

## Notes

The rendering is factored into a small `commit_line` helper covered by focused unit tests for each branch (bare, dirty-only, singular/plural, non-unit clean, and both deviations). All existing `list::` tests and clippy pass; integration tests assert on JSON and are unaffected.