### PR TITLE
Filter synthetic benchmark sets by target triple

### DIFF
--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -285,6 +285,7 @@ fn overrides(workspace: &Path, anchor: Timestamp) -> Overrides {
         bench_command: None,
         clock: Some(Clock::new_frozen_at(anchor)),
         storage_override: None,
+        auto_facets: None,
     }
 }
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -178,10 +178,14 @@ Each facet is repeatable, unions its values, and accepts the literal `all` to wi
 dimension. Omitting a facet **auto-detects the current machine**: the triple defaults to
 the host triple and the machine key to the host fingerprint, so a bare query reports *this*
 machine's data; engine has no machine-derived value, so it defaults to all engines. A
-`synthetic` set always passes the machine-key facet regardless of its value, so
-auto-detecting the host fingerprint still includes every hardware-independent set. A facet
-that matches several sets yields one report per set — parallel data sets analyzed
-individually.
+`synthetic` set always passes the **machine-key** facet regardless of its value (it carries
+no machine), so auto-detecting the host fingerprint still includes the hardware-independent
+sets. It still obeys the **target-triple** facet, though — a per-architecture instruction
+count or allocation profile is a distinct measurement — so a bare query mixes in only the
+synthetic sets built for *this* triple, never foreign-triple ones. Because that inclusion is
+easy to overlook, a query whose machine-key facet was auto-detected prints a one-line notice
+that machine-independent `synthetic` benchmarks ride along. A facet that matches several
+sets yields one report per set — parallel data sets analyzed individually.
 
 The commands divide into **create** and **query** roles. `collect` and `backfill` record
 new data into exactly one machine's reality, so they auto-detect every facet and accept

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -222,3 +222,9 @@ other selection-driven commands emit the same line through one shared announceme
 the `bless` / `unbless` mutation commands name the facets and the context commit they act at
 (`bless` also names its base branch), so the wording is identical wherever auto-detection can
 surprise you.
+
+When the machine-key facet was auto-detected, the same channel adds one more line noting that
+machine-independent `synthetic` benchmarks (Callgrind, `alloc_tracker`) ride along: they carry
+no machine key, so the host-fingerprint default cannot exclude them. They still obey the
+target-triple facet, so this only mixes in the synthetic sets built for the queried triple —
+the notice explains an inclusion that is otherwise easy to miss.

--- a/packages/cargo-bench-history/src/commands/reporting.rs
+++ b/packages/cargo-bench-history/src/commands/reporting.rs
@@ -11,7 +11,7 @@
 
 use std::path::Path;
 
-use cbh_analyze::RenderedReports;
+use cbh_analyze::{AutoFacets, RenderedReports};
 use cbh_diag::StderrReporter;
 use cbh_storage::StorageFacade;
 use tick::Clock;
@@ -32,9 +32,10 @@ pub(crate) async fn analyze(
     workspace_dir: &Path,
     clock: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_facets: Option<AutoFacets>,
 ) -> Result<RunOutcome, RunError> {
     let (rendered, regressions) =
-        cbh_analyze::analyze(options, workspace_dir, clock, storage_override).await?;
+        cbh_analyze::analyze(options, workspace_dir, clock, storage_override, auto_facets).await?;
     write_rendered(
         workspace_dir,
         options.verbose,
@@ -60,8 +61,10 @@ pub(crate) async fn list(
     workspace_dir: &Path,
     clock: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_facets: Option<AutoFacets>,
 ) -> Result<RunOutcome, RunError> {
-    let rendered = cbh_analyze::list(options, workspace_dir, clock, storage_override).await?;
+    let rendered =
+        cbh_analyze::list(options, workspace_dir, clock, storage_override, auto_facets).await?;
     write_rendered(
         workspace_dir,
         options.verbose,
@@ -86,8 +89,10 @@ pub(crate) async fn examine(
     workspace_dir: &Path,
     clock: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_facets: Option<AutoFacets>,
 ) -> Result<RunOutcome, RunError> {
-    let rendered = cbh_analyze::examine(options, workspace_dir, clock, storage_override).await?;
+    let rendered =
+        cbh_analyze::examine(options, workspace_dir, clock, storage_override, auto_facets).await?;
     write_rendered(
         workspace_dir,
         options.verbose,
@@ -112,8 +117,10 @@ pub(crate) async fn prune(
     workspace_dir: &Path,
     clock: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_facets: Option<AutoFacets>,
 ) -> Result<RunOutcome, RunError> {
-    let rendered = cbh_analyze::prune(options, workspace_dir, clock, storage_override).await?;
+    let rendered =
+        cbh_analyze::prune(options, workspace_dir, clock, storage_override, auto_facets).await?;
     write_rendered(
         workspace_dir,
         options.verbose,
@@ -138,8 +145,9 @@ pub(crate) async fn bless(
     options: &BlessOptions,
     workspace_dir: &Path,
     clock: Option<Clock>,
+    auto_facets: Option<AutoFacets>,
 ) -> Result<RunOutcome, RunError> {
-    let message = cbh_analyze::bless(options, workspace_dir, clock).await?;
+    let message = cbh_analyze::bless(options, workspace_dir, clock, auto_facets).await?;
     Ok(RunOutcome::Completed { message })
 }
 
@@ -152,8 +160,9 @@ pub(crate) async fn bless(
 pub(crate) async fn unbless(
     options: &UnblessOptions,
     workspace_dir: &Path,
+    auto_facets: Option<AutoFacets>,
 ) -> Result<RunOutcome, RunError> {
-    let message = cbh_analyze::unbless(options, workspace_dir).await?;
+    let message = cbh_analyze::unbless(options, workspace_dir, auto_facets).await?;
     Ok(RunOutcome::Completed { message })
 }
 

--- a/packages/cargo-bench-history/src/dispatch.rs
+++ b/packages/cargo-bench-history/src/dispatch.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 
+use cbh_analyze::AutoFacets;
 use cbh_storage::StorageOverride;
 use tick::Clock;
 
@@ -38,6 +39,11 @@ pub struct Overrides {
     /// against an Azurite backend behind a locally-faked Entra token and a
     /// certificate-trusting transport, which no configuration could produce.
     pub storage_override: Option<StorageOverride>,
+    /// The auto-detected discriminant facets (host target triple + machine key) the
+    /// query commands default to when a facet is omitted. `None` probes the host;
+    /// integration tests inject fixed values so the suite is independent of the host
+    /// it runs on (a `synthetic` set's inclusion now depends on the auto triple).
+    pub auto_facets: Option<AutoFacets>,
 }
 
 /// Executes a parsed command.
@@ -78,6 +84,7 @@ pub async fn run_with_overrides(
         bench_command,
         clock,
         storage_override,
+        auto_facets,
     } = overrides;
     let workspace_dir = match workspace_dir {
         Some(dir) => dir,
@@ -98,22 +105,24 @@ pub async fn run_with_overrides(
         }
         Command::Install(options) => commands::install(options, workspace_dir).await,
         Command::Analyze(options) => {
-            commands::analyze(options, workspace_dir, clock, storage_override).await
+            commands::analyze(options, workspace_dir, clock, storage_override, auto_facets).await
         }
         Command::List(options) => {
-            commands::list(options, workspace_dir, clock, storage_override).await
+            commands::list(options, workspace_dir, clock, storage_override, auto_facets).await
         }
         Command::Examine(options) => {
-            commands::examine(options, workspace_dir, clock, storage_override).await
+            commands::examine(options, workspace_dir, clock, storage_override, auto_facets).await
         }
         Command::Prune(options) => {
-            commands::prune(options, workspace_dir, clock, storage_override).await
+            commands::prune(options, workspace_dir, clock, storage_override, auto_facets).await
         }
         Command::Backfill(options) => {
             commands::backfill(options, workspace_dir, bench_command).await
         }
-        Command::Bless(options) => commands::bless(options, workspace_dir, clock).await,
-        Command::Unbless(options) => commands::unbless(options, workspace_dir).await,
+        Command::Bless(options) => {
+            commands::bless(options, workspace_dir, clock, auto_facets).await
+        }
+        Command::Unbless(options) => commands::unbless(options, workspace_dir, auto_facets).await,
         Command::MachineKey(options) => commands::machine_key(options).await,
     }
 }

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -312,6 +312,7 @@ mod dispatch;
 mod outcome;
 mod output;
 
+pub use cbh_analyze::AutoFacets;
 pub use cbh_cli::{Cli, EarlyExit};
 pub use cbh_command::{
     AnalyzeOptions, BackfillOptions, BlessOptions, CacheSelection, CollectOptions, Command,

--- a/packages/cargo-bench-history/tests/cbh_azure.rs
+++ b/packages/cargo-bench-history/tests/cbh_azure.rs
@@ -535,6 +535,7 @@ impl AzureWorkspace {
                 bench_command: Some(bench_command),
                 clock: None,
                 storage_override,
+                auto_facets: None,
             },
         )
         .await

--- a/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
@@ -6,8 +6,9 @@ use crate::harness::*;
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn backfill_stores_one_clean_object_per_commit_and_restores_checkout() {
-    let workspace =
-        Workspace::clean_repo(&storage_only_config()).with_bench(&["--summary", "grp=single"]);
+    let workspace = Workspace::clean_repo(&storage_only_config())
+        .with_bench(&["--summary", "grp=single"])
+        .with_real_auto_facets();
     let c1 = workspace.commit("c1");
     let c2 = workspace.commit("c2");
     let branch_before = workspace.current_branch();

--- a/packages/cargo-bench-history/tests/cbh_integration/collect.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/collect.rs
@@ -517,7 +517,8 @@ async fn collect_criterion_collects_distinct_cases_as_records() {
 #[cfg_attr(miri, ignore)]
 async fn collect_then_analyze_round_trips_a_sanitizing_project_id() {
     let workspace = Workspace::clean_repo(&storage_only_config_with_id("my proj/sub"))
-        .with_bench(&["--summary", "grp=single"]);
+        .with_bench(&["--summary", "grp=single"])
+        .with_real_auto_facets();
 
     workspace.drive(&["collect"]).await.unwrap();
 
@@ -551,7 +552,8 @@ async fn collect_then_analyze_round_trips_a_sanitizing_project_id() {
 #[cfg_attr(miri, ignore)]
 async fn collect_then_analyze_preserves_unusual_identity_characters() {
     let workspace = Workspace::clean_repo(&storage_only_config())
-        .with_bench(&["--criterion", "time.capture|mide tiempo|tamaño 4=18.5"]);
+        .with_bench(&["--criterion", "time.capture|mide tiempo|tamaño 4=18.5"])
+        .with_real_auto_facets();
 
     workspace
         .drive(&["collect", "--machine-key", "pool"])

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -199,7 +199,10 @@ async fn examine_facet_selection_mirrors_analyze() {
     workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
     workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 50.0);
 
-    // Unfiltered, both comparable sets pivot.
+    // Across triples (`--target-triple all`), both comparable sets pivot. An
+    // auto-detected triple would scope to the host's set alone — even for these
+    // machine-independent synthetic sets, which obey the target-triple facet — so
+    // widening to `all` is what surfaces both pools here.
     let message = workspace
         .drive_json(&[
             "examine",
@@ -207,6 +210,8 @@ async fn examine_facet_selection_mirrors_analyze() {
             "nm/nm::observe/pull",
             "--metric",
             "instruction_count",
+            "--target-triple",
+            "all",
         ])
         .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -8,8 +8,8 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) use cargo_bench_history::{
-    BenchmarkId, BenchmarkResult, Cli, Command, EnvironmentInfo, GitInfo, Metric, MetricKind,
-    Overrides, Run, RunContext, RunError, RunOutcome, SCHEMA_VERSION, ToolchainInfo,
+    AutoFacets, BenchmarkId, BenchmarkResult, Cli, Command, EnvironmentInfo, GitInfo, Metric,
+    MetricKind, Overrides, Run, RunContext, RunError, RunOutcome, SCHEMA_VERSION, ToolchainInfo,
     default_template, run, run_with_overrides,
 };
 use cbh_codec as codec;
@@ -22,6 +22,20 @@ use tick::Clock;
 /// The tool version recorded with each run. The integration test compiles within
 /// the package, so its `CARGO_PKG_VERSION` matches the version `collect` records.
 pub(crate) const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The target triple the harness pins the auto-detected facet to, matching the
+/// triple the seed helpers write their synthetic partitions under. Pinning it
+/// keeps the suite host-independent: synthetic sets now obey the target-triple
+/// facet (a `list`/`analyze` with an auto triple no longer sees foreign-triple
+/// data), so a bare query must auto-detect the seeded triple regardless of the
+/// host the test runs on.
+pub(crate) const HARNESS_AUTO_TRIPLE: &str = "x86_64-unknown-linux-gnu";
+
+/// The machine key the harness pins the auto-detected facet to. Chosen not to
+/// collide with any seeded machine key, so an auto machine-key query still
+/// matches only the machine-key-exempt synthetic sets, never a hardware-keyed
+/// partition (which the tests always select with an explicit `--machine-key`).
+pub(crate) const HARNESS_AUTO_MACHINE_KEY: &str = "harness-auto-machine";
 
 /// A process-global base repository template: a `master`-branch repo carrying the
 /// volatile-directory excludes and one empty `root` commit, built once via the real
@@ -395,6 +409,14 @@ pub(crate) struct Workspace {
     /// tests that exercise the no-storage-configured error path, and azure tests use
     /// their own workspace type entirely.
     inject_local: bool,
+    /// Whether [`drive`](Self::drive) uses real host auto-detection for the query
+    /// facets instead of the pinned [`HARNESS_AUTO_TRIPLE`]/[`HARNESS_AUTO_MACHINE_KEY`].
+    /// The standard constructors pin the facets so seeded-partition tests are
+    /// host-independent; [`with_real_auto_facets`](Self::with_real_auto_facets)
+    /// enables real detection for the `collect`→`analyze` round-trip tests, whose
+    /// whole point is that a real `collect` (which stamps the host triple) and a
+    /// bare `analyze` resolve the *same* host partition.
+    real_auto_facets: bool,
 }
 
 impl Drop for Workspace {
@@ -419,6 +441,7 @@ impl Workspace {
             bench: Vec::new(),
             graph: RefCell::new(GitGraph::new(root, "master")),
             inject_local: true,
+            real_auto_facets: false,
         };
         let cargo_dir = workspace.root().join(".cargo");
         fs::create_dir_all(&cargo_dir).unwrap();
@@ -454,6 +477,7 @@ impl Workspace {
             bench: Vec::new(),
             graph: RefCell::new(GitGraph::new(root, "master")),
             inject_local: false,
+            real_auto_facets: false,
         }
     }
 
@@ -468,6 +492,7 @@ impl Workspace {
             bench: Vec::new(),
             graph: RefCell::new(GitGraph::new(root, "master")),
             inject_local: true,
+            real_auto_facets: false,
         };
         let path = workspace.root().join(relative);
         fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -490,6 +515,32 @@ impl Workspace {
     pub(crate) fn without_local_storage(mut self) -> Self {
         self.inject_local = false;
         self
+    }
+
+    /// Uses real host auto-detection for the query facets instead of the pinned
+    /// harness defaults (consuming builder). Reserved for `collect`→`analyze`
+    /// round-trip tests: a real `collect` stamps the host triple, so a bare
+    /// `analyze` must auto-detect that same host triple to find the run. Every
+    /// other test seeds a fixed-triple partition and relies on the pin.
+    pub(crate) fn with_real_auto_facets(mut self) -> Self {
+        self.real_auto_facets = true;
+        self
+    }
+
+    /// The auto-detected facet override a drive injects through `Overrides`.
+    ///
+    /// Pinned to [`HARNESS_AUTO_TRIPLE`]/[`HARNESS_AUTO_MACHINE_KEY`] by default so
+    /// the suite is host-independent; `None` (real detection) when
+    /// [`with_real_auto_facets`](Self::with_real_auto_facets) opted in.
+    fn auto_facets_override(&self) -> Option<AutoFacets> {
+        if self.real_auto_facets {
+            None
+        } else {
+            Some(AutoFacets {
+                triple: HARNESS_AUTO_TRIPLE.to_owned(),
+                machine_key: HARNESS_AUTO_MACHINE_KEY.to_owned(),
+            })
+        }
     }
 
     /// Builds the effective CLI arguments for a drive, injecting `--verbose` for
@@ -823,6 +874,7 @@ impl Workspace {
                 bench_command: Some(bench_command),
                 clock: Some(Clock::new_frozen_at(analysis_now())),
                 storage_override: None,
+                auto_facets: self.auto_facets_override(),
             },
         )
         .await
@@ -861,6 +913,7 @@ impl Workspace {
                 bench_command: Some(bench_command),
                 clock: Some(Clock::new_frozen_at(analysis_now())),
                 storage_override: None,
+                auto_facets: self.auto_facets_override(),
             },
         )
         .await

--- a/packages/cbh_analyze/src/announce.rs
+++ b/packages/cbh_analyze/src/announce.rs
@@ -9,10 +9,45 @@
 //! (see [`ReporterExt::announce`](cbh_diag::ReporterExt::announce)), so a plain run
 //! never hides a value it defaulted.
 
-use cbh_detect::DiscriminantSetQuery;
+use cbh_detect::{DiscriminantSetQuery, FacetFilter};
+use cbh_diag::{Reporter, ReporterExt};
 use jiff::Timestamp;
 
 use super::facets::describe_effective_facets;
+
+/// The always-on notice explaining that machine-independent (`synthetic`)
+/// benchmarks are included alongside this machine's data — or `None` when it does
+/// not apply.
+///
+/// It applies exactly when the machine-key facet was auto-detected: a `synthetic`
+/// set carries no machine key, so it is included whatever the detected key is.
+/// Naming that keeps a plain run from silently mixing in data the user did not
+/// obviously ask for.
+pub(crate) fn machine_independent_inclusion_notice(
+    facets: &DiscriminantSetQuery,
+) -> Option<&'static str> {
+    matches!(facets.machine_key, FacetFilter::Auto(_)).then_some(
+        "Machine-independent benchmarks targeting the 'synthetic' machine key are also \
+         included when using auto-detected machine key",
+    )
+}
+
+/// Emits the always-on effective-selection `summary`, then the
+/// machine-independent-inclusion notice when it applies (see
+/// [`machine_independent_inclusion_notice`]).
+///
+/// Every command's selection announcement flows through here so the notice appears
+/// on its own line wherever the summary does.
+pub(crate) fn announce_selection(
+    reporter: &dyn Reporter,
+    facets: &DiscriminantSetQuery,
+    summary: &str,
+) {
+    reporter.announce(summary);
+    if let Some(notice) = machine_independent_inclusion_notice(facets) {
+        reporter.announce(notice);
+    }
+}
 
 /// The resolved base branch a run split history against, for the announcement.
 pub(crate) struct AnnouncedBase<'a> {
@@ -186,6 +221,34 @@ mod tests {
         assert!(
             no_cutoff.contains("; since=none (no default look-back)"),
             "{no_cutoff}"
+        );
+    }
+
+    #[test]
+    fn machine_key_auto_triggers_the_synthetic_inclusion_notice() {
+        // Auto-detected machine key: synthetic sets ride along, so the notice fires.
+        let auto = DiscriminantSetQuery {
+            engine: FacetFilter::All,
+            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
+            machine_key: FacetFilter::Auto("abcd".to_owned()),
+        };
+        assert_eq!(
+            machine_independent_inclusion_notice(&auto),
+            Some(
+                "Machine-independent benchmarks targeting the 'synthetic' machine key are also \
+                 included when using auto-detected machine key"
+            )
+        );
+
+        // Explicit or unconstrained machine key: no auto default to explain.
+        let explicit = DiscriminantSetQuery {
+            machine_key: FacetFilter::Explicit(nonempty!["abcd".to_owned()]),
+            ..DiscriminantSetQuery::default()
+        };
+        assert_eq!(machine_independent_inclusion_notice(&explicit), None);
+        assert_eq!(
+            machine_independent_inclusion_notice(&DiscriminantSetQuery::default()),
+            None
         );
     }
 

--- a/packages/cbh_analyze/src/announce.rs
+++ b/packages/cbh_analyze/src/announce.rs
@@ -11,6 +11,7 @@
 
 use cbh_detect::{DiscriminantSetQuery, FacetFilter};
 use cbh_diag::{Reporter, ReporterExt};
+use cbh_model::Engine;
 use jiff::Timestamp;
 
 use super::facets::describe_effective_facets;
@@ -19,17 +20,42 @@ use super::facets::describe_effective_facets;
 /// benchmarks are included alongside this machine's data — or `None` when it does
 /// not apply.
 ///
-/// It applies exactly when the machine-key facet was auto-detected: a `synthetic`
-/// set carries no machine key, so it is included whatever the detected key is.
-/// Naming that keeps a plain run from silently mixing in data the user did not
-/// obviously ask for.
+/// It applies exactly when the machine-key facet was auto-detected *and* the
+/// engine facet still admits a synthetic-producing engine (Callgrind or
+/// `alloc_tracker`). A `synthetic` set carries no machine key, so it rides along
+/// whatever the detected key is — but only the hardware-independent engines
+/// produce one, so an explicit `--engine criterion` (or `all_the_time`) filters
+/// every synthetic set out and the notice would promise data that is not in
+/// scope. Naming the inclusion keeps a plain run from silently mixing in data the
+/// user did not obviously ask for, without over-promising when it cannot apply.
 pub(crate) fn machine_independent_inclusion_notice(
     facets: &DiscriminantSetQuery,
 ) -> Option<&'static str> {
-    matches!(facets.machine_key, FacetFilter::Auto(_)).then_some(
+    let machine_key_auto = matches!(facets.machine_key, FacetFilter::Auto(_));
+    (machine_key_auto && engine_admits_synthetic(&facets.engine)).then_some(
         "Machine-independent benchmarks targeting the 'synthetic' machine key are also \
          included when using auto-detected machine key",
     )
+}
+
+/// Whether the engine facet still lets a synthetic-producing engine through.
+///
+/// The hardware-independent engines — Callgrind and `alloc_tracker` — are the
+/// only ones whose sets land in the `synthetic` machine-key partition. `All`
+/// admits every engine; an explicit list admits synthetic sets only when it names
+/// at least one hardware-independent engine.
+fn engine_admits_synthetic(engine: &FacetFilter) -> bool {
+    match engine {
+        FacetFilter::All => true,
+        FacetFilter::Auto(value) => names_synthetic_engine(value),
+        FacetFilter::Explicit(values) => values.iter().any(|value| names_synthetic_engine(value)),
+    }
+}
+
+/// Whether a single engine facet value names a hardware-independent (synthetic)
+/// engine.
+fn names_synthetic_engine(value: &str) -> bool {
+    Engine::from_name(value).is_some_and(|engine| !engine.is_hardware_dependent())
 }
 
 /// Emits the always-on effective-selection `summary`, then the
@@ -249,6 +275,54 @@ mod tests {
         assert_eq!(
             machine_independent_inclusion_notice(&DiscriminantSetQuery::default()),
             None
+        );
+    }
+
+    #[test]
+    fn engine_facet_gates_the_synthetic_inclusion_notice() {
+        let notice = "Machine-independent benchmarks targeting the 'synthetic' machine key are \
+                      also included when using auto-detected machine key";
+        let with_engine = |engine: FacetFilter| DiscriminantSetQuery {
+            engine,
+            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
+            machine_key: FacetFilter::Auto("abcd".to_owned()),
+        };
+
+        // An engine facet scoped to a hardware-dependent engine filters every
+        // synthetic set out, so the notice would over-promise and must not fire.
+        assert_eq!(
+            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
+                "criterion".to_owned()
+            ]))),
+            None
+        );
+        assert_eq!(
+            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
+                "all_the_time".to_owned()
+            ]))),
+            None
+        );
+
+        // A synthetic-producing engine (Callgrind / alloc_tracker), alone or
+        // alongside a hardware-dependent one, keeps synthetic sets in scope.
+        assert_eq!(
+            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
+                "callgrind".to_owned()
+            ]))),
+            Some(notice)
+        );
+        assert_eq!(
+            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
+                "alloc_tracker".to_owned()
+            ]))),
+            Some(notice)
+        );
+        assert_eq!(
+            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
+                "criterion".to_owned(),
+                "callgrind".to_owned()
+            ]))),
+            Some(notice)
         );
     }
 

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -31,10 +31,12 @@ use cbh_storage::{Storage, build_storage, finish_with_flush};
 use jiff::Timestamp;
 use tick::Clock;
 
-use super::announce::{AnnouncedBase, AnnouncedContext, selection_announcement};
+use super::announce::{
+    AnnouncedBase, AnnouncedContext, announce_selection, selection_announcement,
+};
 use super::history::resolve_base;
 use super::{
-    AutoFacets, Selection, detect_auto_facets, facet_filtered_candidates, resolve_facets,
+    AutoFacets, Selection, facet_filtered_candidates, resolve_auto_facets, resolve_facets,
     resolve_now,
 };
 use crate::AnalyzeError;
@@ -55,6 +57,7 @@ pub async fn bless(
     options: &BlessOptions,
     workspace_dir: &Path,
     clock_override: Option<Clock>,
+    auto_override: Option<AutoFacets>,
 ) -> Result<String, AnalyzeError> {
     let reporter = StderrReporter::new(options.verbose);
 
@@ -67,7 +70,7 @@ pub async fn bless(
     let storage = build_storage(local.as_deref(), &config, workspace_dir, None)?;
 
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
-    let auto = detect_auto_facets().await?;
+    let auto = resolve_auto_facets(auto_override).await?;
 
     let now = resolve_now(clock_override);
     let result = bless_with(
@@ -103,6 +106,7 @@ pub async fn bless(
 pub async fn unbless(
     options: &UnblessOptions,
     workspace_dir: &Path,
+    auto_override: Option<AutoFacets>,
 ) -> Result<String, AnalyzeError> {
     let reporter = StderrReporter::new(options.verbose);
 
@@ -115,7 +119,7 @@ pub async fn unbless(
     let storage = build_storage(local.as_deref(), &config, workspace_dir, None)?;
 
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
-    let auto = detect_auto_facets().await?;
+    let auto = resolve_auto_facets(auto_override).await?;
 
     let result = unbless_with(
         &git,
@@ -191,19 +195,24 @@ where
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and context commit, so a plain run never hides a value it defaulted.
     // Emitted before the base-branch guard so even that refusal states what was
-    // selected.
-    reporter.announce(&selection_announcement(
+    // selected. When the machine key was auto-detected, a follow-up notice states
+    // that the machine-independent `synthetic` sets are included regardless.
+    announce_selection(
+        reporter,
         &facets,
-        Some(AnnouncedBase {
-            name: &base.name,
-            auto: options.base.is_none(),
-        }),
-        Some(AnnouncedContext {
-            short,
-            defaulted_head: options.context.is_none(),
-        }),
-        None,
-    ));
+        &selection_announcement(
+            &facets,
+            Some(AnnouncedBase {
+                name: &base.name,
+                auto: options.base.is_none(),
+            }),
+            Some(AnnouncedContext {
+                short,
+                defaulted_head: options.context.is_none(),
+            }),
+            None,
+        ),
+    );
 
     let on_base = git
         .merge_base(&head, &base.commit)
@@ -307,16 +316,22 @@ where
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition and the
     // context commit whose blessings are being removed. `unbless` acts purely at a
-    // commit and never resolves a base branch, so no base segment appears.
-    reporter.announce(&selection_announcement(
+    // commit and never resolves a base branch, so no base segment appears. When the
+    // machine key was auto-detected, a follow-up notice states that the
+    // machine-independent `synthetic` sets are unblessed regardless.
+    announce_selection(
+        reporter,
         &facets,
-        None,
-        Some(AnnouncedContext {
-            short,
-            defaulted_head: options.context.is_none(),
-        }),
-        None,
-    ));
+        &selection_announcement(
+            &facets,
+            None,
+            Some(AnnouncedContext {
+                short,
+                defaulted_head: options.context.is_none(),
+            }),
+            None,
+        ),
+    );
 
     let candidates = facet_filtered_candidates(storage, project_id, &facets, reporter).await?;
     let blessings_at_head: Vec<String> = candidates

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -14,7 +14,7 @@ use cbh_model::{BenchmarkIdPrefix, BlessingRecord, DiscriminantSet, StorageKey};
 use cbh_storage::Storage;
 use jiff::Timestamp;
 
-use super::announce::{AnnouncedBase, AnnouncedSince, selection_announcement};
+use super::announce::{AnnouncedBase, AnnouncedSince, announce_selection, selection_announcement};
 use super::facets::{
     AutoFacets, describe_effective_facets, facets_are_unconstrained, resolve_facets,
 };
@@ -195,14 +195,20 @@ where
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and look-back window a plain run would otherwise resolve silently.
-    reporter.announce(&effective_selection_summary(
+    // When the machine key was auto-detected, a follow-up notice states that the
+    // machine-independent `synthetic` sets ride along regardless of that key.
+    announce_selection(
+        reporter,
         &facets,
-        &base_name,
-        selection.base.is_none(),
-        since,
-        selection.since.is_some(),
-        mode,
-    ));
+        &effective_selection_summary(
+            &facets,
+            &base_name,
+            selection.base.is_none(),
+            since,
+            selection.since.is_some(),
+            mode,
+        ),
+    );
 
     // Tally why candidates do not enter the analysis, so a `0 runs` outcome can
     // explain itself (via `--verbose` per object, and via a summary hint when

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -39,7 +39,7 @@ use tick::Clock;
 
 use super::{
     AutoFacets, ChartColor, ReportFormat, Selection, Series, SeriesFilter, chart,
-    detect_auto_facets, dirty_base_exception_warning, empty_history_hint, format_value,
+    dirty_base_exception_warning, empty_history_hint, format_value, resolve_auto_facets,
     resolve_now, select_dataset,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
@@ -65,6 +65,7 @@ pub async fn execute(
     workspace_dir: &Path,
     clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_override: Option<AutoFacets>,
 ) -> Result<RenderedReports, AnalyzeError> {
     let reporter = StderrReporter::new(options.verbose);
 
@@ -86,7 +87,7 @@ pub async fn execute(
     storage.synchronize_cache(&project_id, &reporter).await?;
 
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
-    let auto = detect_auto_facets().await?;
+    let auto = resolve_auto_facets(auto_override).await?;
 
     let now = resolve_now(clock_override);
     // The object-load work shares the ambient Tokio worker threads (mirrors

--- a/packages/cbh_analyze/src/facets.rs
+++ b/packages/cbh_analyze/src/facets.rs
@@ -17,12 +17,16 @@ use crate::AnalyzeError;
 /// the hardware fingerprint); tests pass deterministic literals. There is no auto
 /// engine — a bare query analyzes every engine — so only the triple and machine
 /// key are detected.
+///
+/// Exposed so integration tests can inject deterministic values through the
+/// binary's `Overrides` test hook, keeping the suite independent of the host it
+/// runs on.
 #[derive(Clone, Debug)]
-pub(crate) struct AutoFacets {
+pub struct AutoFacets {
     /// The host target triple (`rustc -vV` host).
-    pub(crate) triple: String,
+    pub triple: String,
     /// The host machine fingerprint.
-    pub(crate) machine_key: String,
+    pub machine_key: String,
 }
 
 /// Resolves one facet's raw command-line values into a [`FacetFilter`].

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -54,14 +54,15 @@ pub(crate) use cbh_render::{ChartColor, ReportFormat, chart, format_value};
 pub(crate) use dataset::{empty_history_hint, select_dataset};
 pub use error::AnalyzeError;
 pub use examine::execute as examine;
-pub(crate) use facets::{AutoFacets, resolve_facets};
+pub use facets::AutoFacets;
+pub(crate) use facets::resolve_facets;
 pub(crate) use history::{
     DirtyTipPolicy, ResolvedHistory, dirty_base_exception_warning, resolve_history,
 };
 pub use list::execute as list;
 pub(crate) use load::{RunIndex, facet_filtered_candidates};
 pub use pipeline::execute as analyze;
-pub(crate) use pipeline::{detect_auto_facets, resolve_now};
+pub(crate) use pipeline::{resolve_auto_facets, resolve_now};
 pub use prune::execute as prune;
 pub use report::RenderedReports;
 pub(crate) use report::ReportRequest;

--- a/packages/cbh_analyze/src/list.rs
+++ b/packages/cbh_analyze/src/list.rs
@@ -31,8 +31,8 @@ use tick::Clock;
 
 use super::{
     AutoFacets, ReportFormat, RunIndex, Selection, Series, SeriesFilter, apply_blessings,
-    detect_auto_facets, dirty_base_exception_warning, empty_history_hint,
-    facet_filtered_candidates, resolve_facets, resolve_now, select_dataset,
+    dirty_base_exception_warning, empty_history_hint, facet_filtered_candidates,
+    resolve_auto_facets, resolve_facets, resolve_now, select_dataset,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 
@@ -52,6 +52,7 @@ pub async fn execute(
     workspace_dir: &Path,
     clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_override: Option<AutoFacets>,
 ) -> Result<RenderedReports, AnalyzeError> {
     let reporter = StderrReporter::new(options.verbose);
 
@@ -73,7 +74,7 @@ pub async fn execute(
     storage.synchronize_cache(&project_id, &reporter).await?;
 
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
-    let auto = detect_auto_facets().await?;
+    let auto = resolve_auto_facets(auto_override).await?;
 
     let now = resolve_now(clock_override);
     // The object-load and detection work shares the ambient Tokio worker threads

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -56,6 +56,7 @@ pub async fn execute(
     workspace_dir: &Path,
     clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_override: Option<AutoFacets>,
 ) -> Result<(RenderedReports, usize), AnalyzeError> {
     // Per-object notes follow `--verbose`; stage timings are emitted under either
     // `--verbose` or the programmatic `timing` flag (the stress harness sets the
@@ -82,7 +83,7 @@ pub async fn execute(
     storage.synchronize_cache(&project_id, &reporter).await?;
 
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
-    let auto = detect_auto_facets().await?;
+    let auto = resolve_auto_facets(auto_override).await?;
 
     let now = resolve_now(clock_override);
     let color = should_colorize(
@@ -147,6 +148,22 @@ pub(crate) async fn detect_auto_facets() -> Result<AutoFacets, AnalyzeError> {
         triple: toolchain.host.unwrap_or_default(),
         machine_key: resolve_machine_key(None, &hardware),
     })
+}
+
+/// Resolves the auto-detect facets for a query command, preferring an injected
+/// override over probing the host.
+///
+/// Production passes `None` and probes via [`detect_auto_facets`]; the binary's
+/// integration tests inject deterministic [`AutoFacets`] through the `Overrides`
+/// test hook so the suite is independent of the host it runs on.
+#[cfg_attr(test, mutants::skip)] // Trivial override-or-probe selection; the probe path is host-dependent.
+pub(crate) async fn resolve_auto_facets(
+    auto_override: Option<AutoFacets>,
+) -> Result<AutoFacets, AnalyzeError> {
+    match auto_override {
+        Some(auto) => Ok(auto),
+        None => detect_auto_facets().await,
+    }
 }
 
 /// Storage- and git-generic `analyze`: facet-filter the stored objects, resolve
@@ -994,7 +1011,14 @@ mod tests {
         }
 
         let git = linear_git();
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        // The two sets live under different triples, and synthetic sets obey the
+        // target-triple facet, so an auto-detected triple would report only its own.
+        // Widen to `all` to exercise the per-set tallies across both partitions.
+        let opts = AnalyzeOptions {
+            target_triple: vec!["all".to_owned()],
+            ..options()
+        };
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
 
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let sets = parsed["sets"].as_array().unwrap();
@@ -1576,7 +1600,9 @@ mod tests {
     #[test]
     fn two_sets_produce_two_report_sections() {
         // Both sets are seeded at the `linear_git` tip (`c3`) so the tip filter keeps
-        // each and every partition is reported.
+        // each and every partition is reported. They differ only by triple, and
+        // synthetic sets obey the target-triple facet, so the query widens to
+        // `--target-triple all` to search both partitions rather than just the host's.
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
@@ -1586,7 +1612,11 @@ mod tests {
         );
         let git = linear_git();
 
-        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let opts = AnalyzeOptions {
+            target_triple: vec!["all".to_owned()],
+            ..options()
+        };
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &opts);
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["sets"].as_array().unwrap().len(), 2, "{report}");
     }

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -34,10 +34,10 @@ use jiff::Timestamp;
 use serde::Serialize;
 use tick::Clock;
 
-use super::announce::{AnnouncedBase, AnnouncedSince, selection_announcement};
+use super::announce::{AnnouncedBase, AnnouncedSince, announce_selection, selection_announcement};
 use super::{
     AutoFacets, DirtyTipPolicy, ReportFormat, ResolvedHistory, Selection, before_since_cutoff,
-    detect_auto_facets, facet_filtered_candidates, parse_since, resolve_facets, resolve_history,
+    facet_filtered_candidates, parse_since, resolve_auto_facets, resolve_facets, resolve_history,
     resolve_now,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
@@ -109,6 +109,7 @@ pub async fn execute(
     workspace_dir: &Path,
     clock_override: Option<Clock>,
     storage_override: Option<StorageFacade>,
+    auto_override: Option<AutoFacets>,
 ) -> Result<RenderedReports, AnalyzeError> {
     let reporter = StderrReporter::new(options.verbose);
 
@@ -130,7 +131,7 @@ pub async fn execute(
     storage.synchronize_cache(&project_id, &reporter).await?;
 
     let git = SystemGitHistory::new(resolve_repo(workspace_dir, options.repo.as_deref()));
-    let auto = detect_auto_facets().await?;
+    let auto = resolve_auto_facets(auto_override).await?;
 
     let now = resolve_now(clock_override);
     let result = prune_with(
@@ -202,19 +203,24 @@ where
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and `--since` cutoff a plain run would otherwise resolve silently.
     // Emitted before the `--prune-base` guard so even that refusal states what was
-    // selected.
-    reporter.announce(&selection_announcement(
+    // selected. When the machine key was auto-detected, a follow-up notice states
+    // that the machine-independent `synthetic` sets are pruned along with it.
+    announce_selection(
+        reporter,
         &facets,
-        Some(AnnouncedBase {
-            name: &base_name,
-            auto: options.base.is_none(),
-        }),
-        None,
-        Some(AnnouncedSince {
-            cutoff: since,
-            reason: prune_since_reason(options.since.is_some()),
-        }),
-    ));
+        &selection_announcement(
+            &facets,
+            Some(AnnouncedBase {
+                name: &base_name,
+                auto: options.base.is_none(),
+            }),
+            None,
+            Some(AnnouncedSince {
+                cutoff: since,
+                reason: prune_since_reason(options.since.is_some()),
+            }),
+        ),
+    );
 
     // The `--prune-base` guard: when the context resolves onto the base branch
     // itself (`context == base`), the whole selection is base-branch history.

--- a/packages/cbh_detect/src/detect/discriminant.rs
+++ b/packages/cbh_detect/src/detect/discriminant.rs
@@ -15,8 +15,12 @@ use nonempty::NonEmpty;
 /// A resolved filter for one discriminant facet (engine, target triple, or
 /// machine key).
 ///
-/// The variant records how the value was supplied so [`DiscriminantSetQuery::matches`]
-/// can distinguish an auto-detected default from a deliberate user scope.
+/// The variant records how the value was supplied. This does not change
+/// filtering — [`DiscriminantSetQuery::matches`] treats [`Auto`](Self::Auto)
+/// and [`Explicit`](Self::Explicit) alike, matching by value equality — but it
+/// drives user-facing diagnostics: marking an auto-detected value in the
+/// verbose selection trail and phrasing the machine-independent inclusion
+/// notice.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum FacetFilter {
     /// Unconstrained: every set passes. Produced by the `all` keyword, and by

--- a/packages/cbh_detect/src/detect/discriminant.rs
+++ b/packages/cbh_detect/src/detect/discriminant.rs
@@ -16,7 +16,7 @@ use nonempty::NonEmpty;
 /// machine key).
 ///
 /// The variant records how the value was supplied so [`DiscriminantSetQuery::matches`]
-/// can apply the hardware-independent exemption only where intended.
+/// can distinguish an auto-detected default from a deliberate user scope.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum FacetFilter {
     /// Unconstrained: every set passes. Produced by the `all` keyword, and by
@@ -24,8 +24,6 @@ pub enum FacetFilter {
     #[default]
     All,
     /// The auto-detected current-machine value, used when the facet is omitted.
-    /// A `synthetic` set is exempt, so a bare query still surfaces
-    /// engine-independent history alongside this machine's data.
     Auto(String),
     /// Explicit user-provided values; a set passes if it equals one of them
     /// (case-insensitive). Never empty — an omitted facet resolves to
@@ -37,20 +35,20 @@ pub enum FacetFilter {
 impl FacetFilter {
     /// Whether `actual` passes this filter.
     ///
-    /// `synthetic` marks a hardware-independent set; `exempt_explicit` controls
-    /// whether such a set is also exempt from explicit values (true for the
-    /// machine-key facet — `synthetic` means "no machine" — false for the target
-    /// triple, where an explicit value is a deliberate scope).
-    fn passes(&self, actual: &str, synthetic: bool, exempt_explicit: bool) -> bool {
+    /// `exempt` marks a set that ignores this facet entirely (used for the
+    /// machine-key facet on a `synthetic` set — `synthetic` means "no machine",
+    /// so its results belong to every machine's universe regardless of whether
+    /// the facet was auto-detected or explicit).
+    fn passes(&self, actual: &str, exempt: bool) -> bool {
+        if exempt {
+            return true;
+        }
         match self {
             Self::All => true,
-            Self::Auto(value) => synthetic || value.eq_ignore_ascii_case(actual),
-            Self::Explicit(values) => {
-                (exempt_explicit && synthetic)
-                    || values
-                        .iter()
-                        .any(|value| value.eq_ignore_ascii_case(actual))
-            }
+            Self::Auto(value) => value.eq_ignore_ascii_case(actual),
+            Self::Explicit(values) => values
+                .iter()
+                .any(|value| value.eq_ignore_ascii_case(actual)),
         }
     }
 }
@@ -77,19 +75,17 @@ impl DiscriminantSetQuery {
     /// Whether `set` passes every facet filter.
     ///
     /// Hardware-independent (`synthetic`) sets — Callgrind and `alloc_tracker` —
-    /// are exempt from the machine-key facet entirely (their results belong to
-    /// every machine's universe) and from an *auto-detected* target-triple facet
-    /// (the recorded triple is an artifact, e.g. Callgrind pins Linux). An
-    /// explicit `--target-triple` still filters them, as the user asked for that
-    /// precise slice.
+    /// are exempt from the machine-key facet entirely: their results are not tied
+    /// to any one machine, so they belong to every machine's universe. They still
+    /// obey the target-triple facet, because even hardware-independent counts are
+    /// not comparable across architectures (a per-architecture instruction count
+    /// or allocation profile is a different measurement).
     #[must_use]
     pub fn matches(&self, set: &DiscriminantSet) -> bool {
         let synthetic = set.is_synthetic();
-        self.engine.passes(&set.engine, false, false)
-            && self
-                .target_triple
-                .passes(&set.target_triple, synthetic, false)
-            && self.machine_key.passes(&set.machine_key, synthetic, true)
+        self.engine.passes(&set.engine, false)
+            && self.target_triple.passes(&set.target_triple, false)
+            && self.machine_key.passes(&set.machine_key, synthetic)
     }
 }
 
@@ -174,17 +170,26 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_set_is_exempt_from_an_auto_detected_triple_but_not_an_explicit_one() {
+    fn synthetic_set_obeys_the_target_triple_facet() {
         let synthetic = set("x86_64-unknown-linux-gnu"); // machine = synthetic
-        // An auto-detected (omitted) triple does not hide engine-independent data.
+        // A matching auto-detected triple includes it.
         assert!(
             DiscriminantSetQuery {
+                target_triple: FacetFilter::Auto("x86_64-unknown-linux-gnu".to_owned()),
+                ..DiscriminantSetQuery::default()
+            }
+            .matches(&synthetic)
+        );
+        // A different auto-detected triple excludes it: even hardware-independent
+        // counts are not comparable across architectures.
+        assert!(
+            !DiscriminantSetQuery {
                 target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
                 ..DiscriminantSetQuery::default()
             }
             .matches(&synthetic)
         );
-        // An explicit triple is a deliberate scope and filters even synthetic sets.
+        // An explicit non-matching triple also excludes it.
         assert!(
             !DiscriminantSetQuery {
                 target_triple: FacetFilter::Explicit(nonempty![


### PR DESCRIPTION
[Copilot speaking]

## Problem

`cargo-bench-history list runs` (and `analyze`/`examine`/`prune`/`bless`/`unbless`) auto-detects the current target triple and machine key, but synthetic sets (callgrind, `alloc_tracker`; `machine_key = "synthetic"`) were exempt from **both** the machine-key facet and the auto-detected target-triple facet. That meant a Windows/x86_64 host running a bare `list runs` would surface e.g. `aarch64-pc-windows-msvc` `alloc_tracker` data — even though instruction/allocation counts are not comparable across architectures.

## Fix

- Synthetic sets now **obey the target-triple facet** (both auto-detected and explicit). They remain exempt **only** from the machine-key facet, which is the property that actually makes them machine-independent.
- When the machine-key facet is auto-detected, the reporting commands now print a notice: *"Machine-independent benchmarks targeting the 'synthetic' machine key are also included when using auto-detected machine key."*
- Auto-detected facets are now injectable through `Overrides`, so the integration suite pins them to a fixed triple + machine key and stays hermetic with respect to the host platform.

## Behavior change

A developer running bare `analyze`/`list` on one platform will no longer see synthetic data collected on other target triples unless they pass `--target-triple all`.

## Validation

- **Windows**: format-check, clippy (dev + release), tests, test-docs, docs, docs-default-features, machete, default-features-check, release build, Miri, and mutants (695 mutants: 585 caught, 110 unviable, 0 missed).
- **Linux (WSL)**: scoped test suite 563/563 passed — confirms the pinned auto-facet harness is host-independent on a genuinely-Linux host.