### PR TITLE
Make all_the_time real-platform span tests robust under CPU load

### DIFF
--- a/packages/all_the_time/tests/all_the_time_integration.rs
+++ b/packages/all_the_time/tests/all_the_time_integration.rs
@@ -25,9 +25,9 @@ const WORK_PROCESSOR_TIME_TARGET: Duration = Duration::from_millis(100);
 /// so a heavily loaded host cannot let real time elapse without the work being
 /// counted.
 ///
-/// Thread processor time is a subset of process processor time, so reaching the
-/// target on this thread guarantees the process-wide clock has advanced by at
-/// least as much — making the bound valid for both thread and process spans.
+/// Thread processor time is a subset of process-wide processor time, so reaching
+/// the target on this thread guarantees the process-wide clock has advanced by at
+/// least as much, making the bound valid for both thread and process spans.
 ///
 /// Returns the number of operations performed.
 fn perform_measurable_cpu_work() -> u64 {

--- a/packages/all_the_time/tests/all_the_time_integration.rs
+++ b/packages/all_the_time/tests/all_the_time_integration.rs
@@ -98,7 +98,8 @@ fn real_platform_thread_span_measures_nonzero_time() {
     // Verify that the span recorded measurable processor time
     let total_time = report_processor_time(&session, "thread_work");
 
-    // With 50ms+ of intensive work, we must get a non-zero measurement
+    // The work loop consumes WORK_PROCESSOR_TIME_TARGET of processor time, so we
+    // must get a non-zero measurement.
     assert!(
         total_time > Duration::ZERO,
         "Expected measurable processor time for intensive work, but got {total_time:?}"
@@ -136,7 +137,8 @@ fn real_platform_process_span_measures_nonzero_time() {
     // Verify that the span recorded measurable processor time
     let total_time = report_processor_time(&session, "process_work");
 
-    // With 50ms+ of intensive work, we must get a non-zero measurement
+    // The work loop consumes WORK_PROCESSOR_TIME_TARGET of processor time, so we
+    // must get a non-zero measurement.
     assert!(
         total_time > Duration::ZERO,
         "Expected measurable processor time for intensive work, but got {total_time:?}"

--- a/packages/all_the_time/tests/all_the_time_integration.rs
+++ b/packages/all_the_time/tests/all_the_time_integration.rs
@@ -4,25 +4,39 @@
 //! processor time. All tests require non-zero measurements to pass.
 
 use std::hint::black_box;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use all_the_time::Session;
+use cpu_time::ThreadTime;
 
-/// Performs intensive CPU work that should be measurable as processor time.
+/// Processor time the measurable work loop consumes before it stops.
 ///
-/// This function performs enough work to ensure reliable measurement
-/// on any platform that supports processor time tracking.
+/// The value sits far above both the tests' 1 ms assertion floor and the coarse
+/// (~15.6 ms) resolution of the Windows processor-time clocks, so the recorded
+/// measurement stays comfortably non-zero even after quantization.
+const WORK_PROCESSOR_TIME_TARGET: Duration = Duration::from_millis(100);
+
+/// Performs intensive CPU work that reliably registers as processor time.
+///
+/// The loop keeps working until the current thread has consumed
+/// [`WORK_PROCESSOR_TIME_TARGET`] of processor time. Bounding on consumed
+/// processor time rather than wall-clock time keeps the amount of *measurable*
+/// work constant regardless of how the operating system schedules this thread,
+/// so a heavily loaded host cannot let real time elapse without the work being
+/// counted.
+///
+/// Thread processor time is a subset of process processor time, so reaching the
+/// target on this thread guarantees the process-wide clock has advanced by at
+/// least as much — making the bound valid for both thread and process spans.
 ///
 /// Returns the number of operations performed.
 fn perform_measurable_cpu_work() -> u64 {
-    let start = Instant::now();
+    let start = ThreadTime::now();
     let mut iterations = 0_u64;
     let mut accumulator = 0_u64;
 
-    // Perform intensive work for at least 50ms of real time
-    // This should be easily measurable as processor time
     loop {
-        // Intensive arithmetic that cannot be optimized away
+        // Intensive arithmetic that cannot be optimized away.
         for i in 0..50_000_u32 {
             accumulator = accumulator
                 .wrapping_add(u64::from(i))
@@ -34,13 +48,12 @@ fn perform_measurable_cpu_work() -> u64 {
             let temp = accumulator.wrapping_pow(2);
             accumulator = accumulator.wrapping_add(temp);
 
-            // Additional complex operations
             accumulator = accumulator.rotate_left(1).wrapping_sub(i.into());
         }
-        iterations = iterations.wrapping_add(50000);
+        iterations = iterations.wrapping_add(50_000);
         black_box(accumulator);
 
-        if start.elapsed() >= Duration::from_millis(50) {
+        if start.elapsed() >= WORK_PROCESSOR_TIME_TARGET {
             break;
         }
     }


### PR DESCRIPTION
[Copilot speaking]

## Why

`real_platform_process_span_measures_nonzero_time` (and its thread-span sibling) were flaky under load. When the host was busy, the tests could record too little processor time and, on Windows, sometimes zero, tripping the `> ZERO` and `>= 1ms` assertions.

## Root cause

`perform_measurable_cpu_work()` ran its busy loop for a fixed amount of *wall-clock* time (50ms). Under CPU contention the test thread only gets scheduled for brief slices during that window, so real time elapses without the process accumulating a matching amount of measurable processor time. On Windows this is amplified because the process/thread CPU clocks (`GetProcessTimes`/`GetThreadTimes`) are quantized to the ~15.6ms scheduler tick, so a sparsely scheduled slice can read as 0.

## Approach

Bound the work loop on *consumed processor time* instead of wall-clock time, using `cpu_time::ThreadTime` (the same crate the real platform layer already uses). The loop now keeps doing arithmetic until the thread has actually burned a fixed CPU-time budget (100ms), so the amount of measurable work stays constant no matter how the OS schedules the thread. A loaded host simply takes more wall-clock time to reach the same budget.

Thread CPU time is a subset of process CPU time, so hitting the target on the thread guarantees the process-wide clock has advanced by at least as much, keeping the bound valid for both the thread-span and process-span tests.

The 100ms target sits about 6x above the Windows clock quantization and 100x above the 1ms assertion floor, giving solid margin against clock noise while staying well under the tests' upper bounds.

## Validation

- `cargo test -p all_the_time --test all_the_time_integration` passes (verified across repeated runs).
- `cargo clippy -p all_the_time --all-targets` is clean.