### PR TITLE
Reduce Markdown summary cap to 10 findings

### DIFF
--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -252,13 +252,13 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
 }
 
 /// When an analysis produces more findings than the summary cap, `--markdown-summary`
-/// keeps only the top 20 by magnitude and states the total, while a full `--markdown`
+/// keeps only the top 10 by magnitude and states the total, while a full `--markdown`
 /// report from the same run still lists every finding.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn analyze_markdown_summary_caps_findings_and_names_the_total() {
     let workspace = Workspace::repo(&storage_only_config());
-    // Seed more distinct rising benchmarks than the top-20 cap so truncation engages.
+    // Seed more distinct rising benchmarks than the top-10 cap so truncation engages.
     workspace.seed_many_rising_callgrind_history(25);
 
     let outcome = workspace
@@ -288,14 +288,14 @@ async fn analyze_markdown_summary_caps_findings_and_names_the_total() {
     assert!(summary.contains("- Regressions: 25"), "{summary}");
     // The truncation note names how many of the total are shown.
     assert!(
-        summary.contains("Showing the top 20 of 25 findings by magnitude."),
+        summary.contains("Showing the top 10 of 25 findings by magnitude."),
         "{summary}"
     );
     // Exactly the cap of finding headlines survives in the summary. Each finding
     // headline carries the confidence, which appears nowhere else, so it counts blocks.
     let summary_blocks = summary.matches("% confidence)").count();
     assert_eq!(
-        summary_blocks, 20,
+        summary_blocks, 10,
         "summary should keep only the cap: {summary}"
     );
     // The full report from the same run still lists every finding.

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -38,7 +38,7 @@ const BRANCH_CHART_MAX_POINTS: usize = 30;
 /// Enough to convey the most significant movers while keeping the rendered report
 /// comfortably within a GitHub issue body's size limit even when an analysis flags
 /// many changes.
-pub const DEFAULT_SUMMARY_LIMIT: NonZero<usize> = NonZero::new(20).expect("20 is non-zero");
+pub const DEFAULT_SUMMARY_LIMIT: NonZero<usize> = NonZero::new(10).expect("10 is non-zero");
 
 /// The selectable output format of an analysis report.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
[Copilot speaking]

The `cargo-bench-history` Markdown summary (`--markdown-summary`) kept the top 20 findings by default, which was occasionally too spammy. This lowers the default cap to 10 so the summary stays focused on the most significant movers while still naming the true total.

## Changes

- `packages/cbh_render/src/report.rs` — `DEFAULT_SUMMARY_LIMIT` reduced from `20` to `10`.
- `packages/cargo-bench-history/tests/cbh_integration/analyze.rs` — updated the integration test pinning the cap (truncation note now `top 10 of 25`, retained block count `10`) and its doc/inline comments.

The full `--markdown` report is unaffected and still lists every finding.

## Validation

- `cargo test -p cbh_render --lib markdown_summary` — 8 passed
- `cargo test -p cargo-bench-history --test cbh_integration analyze_markdown_summary_caps_findings_and_names_the_total` — passed