### PR TITLE
Drop ARM and macOS from automatic benchmarking workflows

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -3,9 +3,9 @@ name: Benchmark history
 # Per-commit collection of the workspace's benchmark results into the long-lived Azure
 # history store (account folohistory, baked into .cargo/bench_history.toml; see also
 # infra/azure-bench-history-prod/). Each push to `main` benchmarks the whole workspace
-# EXCEPT the slow, special-purpose `benchmarks` package, on every supported OS/architecture,
-# and appends the results keyed by the pushed commit. Over time this builds the performance
-# history that `cargo-bench-history analyze` reads to spot regressions.
+# EXCEPT the slow, special-purpose `benchmarks` package, on the x86_64 Linux and Windows
+# runners, and appends the results keyed by the pushed commit. Over time this builds the
+# performance history that `cargo-bench-history analyze` reads to spot regressions.
 #
 # Runs per-push rather than on a nightly schedule: a nightly run re-benchmarks an unchanged
 # tip for no gain and misses intermediate same-day commits, whereas per-push collects one
@@ -68,7 +68,10 @@ jobs:
       # commit; each platform stores into its own partition independently.
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
+        # x86_64 Linux and Windows only. ARM and macOS are only nominally supported (they must
+        # pass tests, see validation.yml) but are deliberately left out of benchmarking so we do
+        # not spend runner minutes measuring platforms whose performance we do not track.
+        platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     # 360 minutes is GitHub's hard per-job ceiling for hosted runners, so this is as

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -164,6 +164,11 @@ times per commit and keeps, per metric, the minimum sample: runner interference 
 time, so the minimum is the reading least perturbed by transient noise. This trades a
 proportionally longer collection job for a more stable series.
 
+Both this workflow and its PR variant benchmark only the x86_64 Linux and Windows runners.
+ARM and macOS are only nominally supported — they must pass tests (see the Platform strategy
+section) but their performance is not tracked — so benchmarking them would spend runner
+minutes producing series no one reads.
+
 Even with those defences, a single day of a badly degraded runner can still leave one commit's
 data point corrupted. Collection is therefore also manually re-runnable against a specific
 historical commit: a `workflow_dispatch` with a `recollect_commit_id` re-measures just that

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -192,7 +192,7 @@ jobs:
             Write-Host "No placeholder change needed (the PR already has a rolling comment with results, or the placeholder is current)."
           }
 
-  # Benchmark ONLY the impacted packages across the full platform matrix, keyed by the PR head
+  # Benchmark ONLY the impacted packages across the benchmark platform matrix, keyed by the PR head
   # commit, appending the results into the prod store. Skipped when the PR impacts nothing
   # benchmarkable (delta.skip_all). Mirrors bench-history.yml's collect job, differing only in the
   # checkout (real head SHA, full history) and the package-scoped recipe.
@@ -205,7 +205,10 @@ jobs:
       # platform stores into its own partition independently.
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
+        # x86_64 Linux and Windows only, matching bench-history.yml: ARM and macOS are only
+        # nominally supported (test-pass parity, see validation.yml) and are kept out of
+        # benchmarking so we do not spend runner minutes on platforms we do not track.
+        platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     # Same ceiling as the main collect: `--best-of 3` roughly triples the ~60-75 min suite, and the


### PR DESCRIPTION
[Copilot speaking]

## What

Trims the two automatic benchmarking workflows so they only collect on the x86_64 Linux and Windows runners:

- **`bench-history.yml`** (push-to-`main` collection): drop `ubuntu-24.04-arm` and `windows-11-arm` from the `collect` matrix.
- **`pr-bench-history.yml`** (per-PR collection): same matrix trim.
- **`design.md`**: record the platform-scope decision in the Benchmark history section.

## Why

ARM and macOS are only nominally supported — passing tests is good enough, and their performance is not tracked. Benchmarking them just burns runner minutes producing series no one reads.

## Notes

- macOS was never in the benchmark matrices to begin with (GitHub's `macos-latest` is Apple Silicon and rides the ARM test pass), so in practice this removes the two ARM legs; the design doc now states the x86_64-only scope explicitly.
- The `analyze` jobs are matrix-agnostic — they thread whatever machine keys the `collect` legs produce — so dropping legs is mechanically safe.
- `cache-warmup.yml` is intentionally left untouched: `validation.yml` still exercises ARM/macOS on push to `main`, so keeping those caches warm is still worthwhile.
- Test/docs coverage for ARM and macOS in `validation.yml` is unchanged — only benchmarking was trimmed.

`just validate-workflows` (actionlint) passes.