### PR TITLE
Flag already-stale results in the PR bench-history workflow

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -244,6 +244,20 @@ skips a still-empty placeholder (it has no results to age), leaving the placehol
 the seeding pass. `mark-stale` is gated on the same non-empty delta as collect, so it never races the
 cleanup path that *deletes* the comment when the PR no longer touches anything benchmarkable.
 
+That start-of-run banner only helps a *later* run flag an *earlier* run's results; a run must also not
+publish results that are *already* stale by the time it finishes. Two mechanisms cover the finish side.
+First, the `analyze` job is gated on `!cancelled()`, **not** `always()`: a partially-failed collect
+(one platform red) is not a cancellation, so analysis still runs and reports whatever landed, but a run
+*superseded* by a newer push — which concurrency `cancel-in-progress` cancels — does **not** analyze or
+post, because `always()` would run even when cancelled and publish results for a head SHA the PR has
+already moved past. Second, as defense-in-depth for the narrow window where a push races a run's *final
+post* faster than the cancellation can stop it, the `analyze` job re-reads the **live PR head** just
+before posting and, when it no longer matches the analyzed (frozen) head SHA, injects that same
+staleness banner into the composed body first — so a superseded result is never published looking fresh.
+Both this self-check and `mark-stale` word the banner through one shared helper so they cannot drift,
+and both degrade to posting/leaving the body untouched rather than failing the advisory comment if the
+live head or compare distance cannot be read.
+
 Collection is **delta-scoped**: a preflight job runs cargo-delta against `main` and benchmarks only
 the impacted packages — those the PR changed, plus their dependents — since re-measuring the whole
 workspace on every PR push would be wasteful. Analysis, by contrast, is deliberately **not**

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -285,12 +285,16 @@ jobs:
 
   # Compare the PR head against `main` in branch mode and post/update the rolling PR comment. Runs
   # after every platform finishes (even partially: fail-fast is off) so the comparison reflects
-  # whatever landed. Uses always() so a partially-failed collect still analyzes, but the explicit
-  # same-repo + skip_all gates keep it from running on forks or empty deltas.
+  # whatever landed. Uses `!cancelled()` (NOT always()) so a partially-failed collect still analyzes -
+  # a failed leg is not a cancellation - while a run SUPERSEDED by a newer push (concurrency
+  # cancel-in-progress) does NOT: always() would run even when cancelled and publish results for the now
+  # stale head SHA, exactly the "stale results, no warning" case this workflow guards against (the
+  # analyze post path's own live-head self-check backstops the narrow window where cancellation races the
+  # final post). The explicit same-repo + skip_all gates keep it from running on forks or empty deltas.
   analyze:
     needs: [delta, collect]
     if: >-
-      always()
+      !cancelled()
       && github.repository == 'folo-rs/folo'
       && github.event.pull_request.head.repo.full_name == github.repository
       && needs.delta.outputs.skip_all != 'true'
@@ -501,6 +505,26 @@ jobs:
           $commitMarker = "$env:COMMIT_MARKER_PREFIX$env:HEAD_SHA -->"
           $body = @($env:MARKER, $commitMarker, '') + $parts
           Set-Content -Path (Join-Path $env:SCRATCH_DIR 'comment-body.md') -Value ($body -join "`n") -Encoding utf8
+
+      # Defense-in-depth against publishing already-stale results. The comment composed above describes
+      # the head SHA frozen when this run was triggered, but a benchmark run takes hours. A newer push
+      # normally supersedes this run before it posts (concurrency cancel-in-progress, and the analyze
+      # gate above is `!cancelled()` so a superseded run never reaches here), yet a push that RACES this
+      # final post could still publish numbers for a commit that is no longer the PR tip. This reads the
+      # LIVE PR head and, when it no longer matches the analyzed SHA, injects the same staleness banner
+      # the mark-stale job uses into the composed body BEFORE it is posted, so a superseded result never
+      # appears fresh. Best-effort - a `gh` hiccup leaves the body as composed and never fails the
+      # advisory comment. Lands right before the post so it sees the final body.
+      - name: Flag composed comment stale if the PR advanced
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: ${{ env.PR_COMMENT_MARKER }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
+        run: just gh-flag-pr-comment-if-stale "$env:REPO" "$env:PR_NUMBER" "$env:MARKER" "$env:HEAD_SHA" (Join-Path $env:SCRATCH_DIR 'comment-body.md')
 
       # One rolling comment per PR, updated in place (deduped by the hidden marker) so repeated pushes
       # never spam the thread. Posted via `gh` through the shared gh-file-pr-comment recipe (the

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -340,6 +340,38 @@ gh-file-pr-comment repo pr marker body_file:
         -Verbose
     Write-Verbose "Rolling PR comment is available at $url." -Verbose
 
+# Defense-in-depth for the analyze post path (see .github/workflows/pr-bench-history.yml and
+# .github/workflows/design.md): a PR benchmark run takes hours, and although a newer push normally
+# supersedes the in-flight run before it posts, a push that RACES this run's final post could still
+# publish results for a commit that is no longer the PR tip. Called right BEFORE gh-file-pr-comment, this
+# reads the LIVE PR head and, when it no longer matches `analyzed_sha` (the head SHA frozen when the run
+# started), injects the same "N commits behind HEAD" / "out of date" staleness banner the mark-stale job
+# uses into the composed `body_file`, so a superseded result is never posted looking fresh. Best-effort:
+# it leaves the body untouched (and never fails) if the live head cannot be read. `repo` is `owner/name`
+# and `pr` the PR number (both validated in the module). Needs GH_TOKEN in the environment (the workflow
+# supplies it).
+[group('automation')]
+[script]
+gh-flag-pr-comment-if-stale repo pr marker analyzed_sha body_file:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/bench-history/BenchHistoryComment.psm1 -Force
+
+    Write-Verbose "Checking whether the composed benchmark comment for {{repo}} PR #{{pr}} is already stale (analyzed {{analyzed_sha}}) before posting." -Verbose
+    $flagged = Add-StalenessBannerIfBehind `
+        -Repo '{{repo}}' `
+        -PrNumber '{{pr}}' `
+        -Marker '{{marker}}' `
+        -AnalyzedSha '{{analyzed_sha}}' `
+        -BodyFile '{{body_file}}' `
+        -Verbose
+    if ($flagged) {
+        Write-Verbose "The PR advanced during the run; a staleness banner was injected into the comment before posting." -Verbose
+    } else {
+        Write-Verbose "The composed results still describe the PR head (or the live head could not be read); posting as composed." -Verbose
+    }
+
 # The release-automation logic lives in scripts/release/ReleaseAutomation.psm1, with a Pester
 # suite (scripts/release/ReleaseAutomation.Tests.ps1) that exercises it against fixtures via
 # `just test-scripts`. The recipes below are thin wrappers that import the module and call its

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -675,6 +675,208 @@ Describe 'Add-StalenessBanner (unexported string transform)' {
     }
 }
 
+Describe 'Format-StalenessWarning (unexported string transform)' {
+    Context 'given a related, positive distance' {
+        It 'words the plural and singular forms' {
+            InModuleScope BenchHistoryComment {
+                (Format-StalenessWarning -Distance @{ Related = $true; Behind = 3 }) | Should -BeLike '*3 commits behind HEAD*'
+                (Format-StalenessWarning -Distance @{ Related = $true; Behind = 1 }) | Should -BeLike '*1 commit behind HEAD*'
+                (Format-StalenessWarning -Distance @{ Related = $true; Behind = 1 }) | Should -Not -BeLike '*1 commits*'
+            }
+        }
+    }
+
+    Context 'given an unrelated, zero, or null distance' {
+        It 'falls back to the numberless "out of date" wording' {
+            InModuleScope BenchHistoryComment {
+                # Unrelated histories, a non-positive distance, and a null (failed-lookup) distance all
+                # collapse to the same numberless wording - the branch both staleness paths rely on.
+                (Format-StalenessWarning -Distance @{ Related = $false; Behind = 0 }) | Should -BeLike '*out of date*'
+                (Format-StalenessWarning -Distance @{ Related = $true;  Behind = 0 }) | Should -BeLike '*out of date*'
+                (Format-StalenessWarning -Distance $null) | Should -BeLike '*out of date*'
+                (Format-StalenessWarning -Distance $null) | Should -Not -BeLike '*behind HEAD*'
+            }
+        }
+    }
+}
+
+Describe 'Add-StalenessBannerIfBehind (mocked gh api)' {
+    BeforeAll {
+        $script:SelfMarker       = '<!-- folo-bench-history-pr -->'
+        $script:SelfCommitPrefix = '<!-- folo-bench-history-commit:'
+        $script:SelfAnalyzed     = '1111111111111111111111111111111111111111'
+    }
+
+    BeforeEach {
+        # A freshly composed results body - the dedup marker, the hidden analyzed-commit marker, then
+        # findings - rewritten IN PLACE by the function, so each test starts from a clean copy on disk.
+        $script:SelfBodyFile = Join-Path ([System.IO.Path]::GetTempPath()) ("bh-selfcheck-$([guid]::NewGuid().ToString('n')).md")
+        $composed = @(
+            '<!-- folo-bench-history-pr -->'
+            '<!-- folo-bench-history-commit:1111111111111111111111111111111111111111 -->'
+            ''
+            '### Performance impact (vs `main`)'
+            ''
+            '✅ No benchmark regressions detected against `main`.'
+        ) -join "`n"
+        Set-Content -LiteralPath $script:SelfBodyFile -Value $composed -Encoding utf8 -NoNewline
+    }
+
+    AfterEach {
+        Remove-Item -LiteralPath $script:SelfBodyFile -ErrorAction SilentlyContinue
+    }
+
+    Context 'when the PR has advanced past the analyzed commit' {
+        BeforeEach {
+            # The live PR head has moved on (pulls .head.sha) and is three commits ahead of the analyzed
+            # commit (compare ahead_by), so the composed results are already stale.
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 0; return '2222222222222222222222222222222222222222' } }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":3}' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'injects an N-commits-behind banner and preserves the analyzed-commit marker and findings' {
+            $result = Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile
+            $result | Should -BeTrue
+            $body = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $body | Should -BeLike '*3 commits behind HEAD*'
+            $body | Should -BeLike '*[!WARNING]*'
+            # The hidden analyzed-commit marker must survive so a later run can still parse it.
+            $body | Should -BeLike "*$($script:SelfCommitPrefix)$($script:SelfAnalyzed)*"
+            # The findings themselves are preserved, not clobbered by the banner.
+            $body | Should -BeLike '*No benchmark regressions detected*'
+        }
+    }
+
+    Context 'when the PR advanced by exactly one commit' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 0; return '2222222222222222222222222222222222222222' } }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 0; return '{"status":"ahead","ahead_by":1}' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'uses the singular "commit"' {
+            Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile | Out-Null
+            $body = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $body | Should -BeLike '*1 commit behind HEAD*'
+            $body | Should -Not -BeLike '*1 commits behind*'
+        }
+    }
+
+    Context 'when the PR head shares no history with the analyzed commit (force-push)' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 0; return '2222222222222222222222222222222222222222' } }
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 1; return 'gh: No common ancestor for the two commits (HTTP 404)' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'injects a numberless "out of date" banner' {
+            $result = Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile
+            $result | Should -BeTrue
+            $body = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $body | Should -BeLike '*out of date*'
+            $body | Should -Not -BeLike '*behind HEAD*'
+        }
+    }
+
+    Context 'when the compare lookup fails for a transient reason' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 0; return '2222222222222222222222222222222222222222' } }
+                # A non-404 compare failure is a genuine error Get-CommitsBehind rethrows; the self-check
+                # is best-effort and must degrade to the numberless wording rather than fail the post.
+                foreach ($a in $args) { if ($a -like 'repos/*/compare/*') { $global:LASTEXITCODE = 1; return 'HTTP 500: Internal Server Error' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'degrades to the numberless "out of date" banner instead of throwing' {
+            $result = Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile
+            $result | Should -BeTrue
+            $body = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $body | Should -BeLike '*out of date*'
+        }
+    }
+
+    Context 'when the PR still points at the analyzed commit' {
+        BeforeEach {
+            # pulls .head.sha returns the SAME sha the run analyzed: the results are current, so the body
+            # must be posted untouched and no compare call is made.
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 0; return '1111111111111111111111111111111111111111' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'leaves the body unchanged, returns false, and never calls the compare api' {
+            $before = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $result = Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile
+            $result | Should -BeFalse
+            (Get-Content -LiteralPath $script:SelfBodyFile -Raw) | Should -BeExactly $before
+            Should -Invoke gh -ModuleName BenchHistoryComment -ParameterFilter { [bool]($args | Where-Object { $_ -like 'repos/*/compare/*' }) } -Times 0 -Exactly
+        }
+    }
+
+    Context 'when the live PR head cannot be read' {
+        BeforeEach {
+            # The pulls lookup fails (a transient gh/API hiccup): best-effort means post as composed.
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 1; return 'HTTP 503: Service Unavailable' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'leaves the body unchanged and returns false without throwing' {
+            $before = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $result = Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile
+            $result | Should -BeFalse
+            (Get-Content -LiteralPath $script:SelfBodyFile -Raw) | Should -BeExactly $before
+        }
+    }
+
+    Context 'when the live head comes back malformed' {
+        BeforeEach {
+            Mock gh -ModuleName BenchHistoryComment {
+                foreach ($a in $args) { if ($a -like 'repos/*/pulls/*') { $global:LASTEXITCODE = 0; return 'not-a-sha' } }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It 'posts as composed (false) rather than guessing at staleness' {
+            $before = Get-Content -LiteralPath $script:SelfBodyFile -Raw
+            $result = Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $script:SelfBodyFile
+            $result | Should -BeFalse
+            (Get-Content -LiteralPath $script:SelfBodyFile -Raw) | Should -BeExactly $before
+        }
+    }
+
+    Context 'input validation' {
+        It 'rejects a non-hex analyzed SHA' {
+            { Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha 'nope' -BodyFile $script:SelfBodyFile } |
+                Should -Throw '*40-character hex*'
+        }
+
+        It 'throws when the body file is missing' {
+            $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("bh-missing-$([guid]::NewGuid().ToString('n')).md")
+            { Add-StalenessBannerIfBehind -Repo 'o/r' -PrNumber '5' -Marker $script:SelfMarker -AnalyzedSha $script:SelfAnalyzed -BodyFile $missing } |
+                Should -Throw '*does not exist*'
+        }
+    }
+}
+
 Describe 'Publish-InProgressComment (mocked gh api)' {
     BeforeAll {
         # An unsorted, duplicate-free-after-sort package list so the assertions also prove the rendering

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -15,15 +15,20 @@
 #
 # A benchmark run takes many hours, and a new push cancels the in-flight one, so on the FIRST run of a
 # PR there is nothing on display yet and on later runs the comment a reader sees can lag the PR tip by
-# a long way. Three seams keep that honest, all driven by the lightweight mark-stale job that fires at
-# the START of a new run. First, before any comment exists, Publish-InProgressComment seeds a
-# "benchmarking in progress" placeholder (carrying the in-progress marker above) so the author knows
-# results are coming; it refreshes that placeholder's disclosed scope on re-runs and steps aside once
-# real findings land. Second, the analyze job embeds a hidden "analyzed commit" marker in the body
-# (which commit the numbers describe). Third, once results exist, Set-RollingCommentStaleness prepends
-# a warning banner stating how far behind HEAD those numbers now are (via Get-CommitsBehind), so nobody
-# mistakes hours-old results for the current state; it skips the still-empty placeholder, which has no
-# results to stale. The banner clears itself when the next analyze rewrites the body with fresh results.
+# a long way. Four seams keep that honest. The first three fire from the lightweight mark-stale job at
+# the START of a new run: before any comment exists, Publish-InProgressComment seeds a "benchmarking in
+# progress" placeholder (carrying the in-progress marker above) so the author knows results are coming,
+# refreshing its disclosed scope on re-runs and stepping aside once real findings land; the analyze job
+# embeds a hidden "analyzed commit" marker in the body recording which commit the numbers describe; and
+# once results exist, Set-RollingCommentStaleness prepends a warning banner stating how far behind HEAD
+# those numbers now are (via Get-CommitsBehind), skipping the still-empty placeholder, which has no
+# results to stale. The fourth fires at the END of a run, from the analyze job itself, right before it
+# posts: Add-StalenessBannerIfBehind re-reads the LIVE PR head and, when the results it is about to
+# publish already describe a superseded commit (a push that raced this run's post despite the concurrency
+# cancellation and the analyze job's `!cancelled()` gate), injects that SAME banner into the composed
+# body first - so a superseded result is never published looking fresh. Both staleness paths share one
+# wording helper (Format-StalenessWarning) so their banners cannot drift, and every banner clears itself
+# when the next analyze rewrites the body with fresh results.
 #
 # Every GitHub-touching call goes through `gh api` behind the single Invoke-GhCapture seam the
 # Pester suite (BenchHistoryComment.Tests.ps1) mocks, so the find/update/create/delete logic is
@@ -418,6 +423,26 @@ function Add-StalenessBanner {
     return ($assembled -join "`n")
 }
 
+function Format-StalenessWarning {
+    # Pure wording shared by the two staleness paths - Set-RollingCommentStaleness (start-of-run marking)
+    # and Add-StalenessBannerIfBehind (post-time self-check) - so the banner text cannot drift between
+    # them. Given a Get-CommitsBehind result (or $null when the distance could not be computed), returns
+    # the warning sentence: a concrete, related distance yields "N commit(s) behind HEAD"; anything else
+    # (unrelated histories, a null/failed lookup, or a non-positive distance) yields the numberless
+    # "out of date" wording. Kept unexported, mirroring Add-StalenessBanner and Format-InProgressBody.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [hashtable] $Distance
+    )
+
+    if ($Distance -and $Distance.Related -and $Distance.Behind -gt 0) {
+        $noun = if ($Distance.Behind -eq 1) { 'commit' } else { 'commits' }
+        return "Benchmark results are $($Distance.Behind) $noun behind HEAD. This comment will be updated when newer results are available."
+    }
+    return 'Benchmark results are out of date. This comment will be updated when newer results are available.'
+}
+
 function Set-RollingCommentStaleness {
     # Called at the START of a new PR benchmark run (the mark-stale job) to flag that the rolling
     # comment's currently-displayed findings now lag the PR tip and a fresh run is underway, so a reader
@@ -495,13 +520,13 @@ function Set-RollingCommentStaleness {
                 "unmarked.")
             return $false
         }
-        if ($distance -and $distance.Related) {
-            $noun = if ($distance.Behind -eq 1) { 'commit' } else { 'commits' }
-            $warning = "Benchmark results are $($distance.Behind) $noun behind HEAD. This comment will be updated when newer results are available."
-        }
+        # Shared wording (Format-StalenessWarning) so this banner cannot drift from the one the post-time
+        # self-check (Add-StalenessBannerIfBehind) injects: a related distance yields "N commit(s) behind
+        # HEAD", anything else (unrelated histories or a failed lookup) the numberless fallback.
+        $warning = Format-StalenessWarning -Distance $distance
     }
     if (-not $warning) {
-        $warning = 'Benchmark results are out of date. This comment will be updated when newer results are available.'
+        $warning = Format-StalenessWarning -Distance $null
     }
 
     $newBody = Add-StalenessBanner -Body $body -Warning $warning -Marker $Marker
@@ -529,6 +554,92 @@ function Set-RollingCommentStaleness {
     finally {
         Remove-Item -LiteralPath $tempBodyFile.FullName -Force -ErrorAction SilentlyContinue
     }
+    return $true
+}
+
+function Add-StalenessBannerIfBehind {
+    # Defense-in-depth for the analyze POST path. The rolling-comment body the analyze job composes
+    # describes $AnalyzedSha - the PR head SHA frozen when the run was triggered. A benchmark run takes
+    # hours; if a new push lands during it, concurrency normally cancels this run before it posts (and the
+    # analyze job's `!cancelled()` gate keeps a superseded run from analyzing at all), but a push that
+    # races this job's final post could still publish the composed body, showing fresh-looking numbers for
+    # a commit that is no longer the tip with no way for a reader to tell. This reads the LIVE PR head and,
+    # when it differs from $AnalyzedSha, injects the SAME staleness banner the mark-stale job uses (the
+    # shared Add-StalenessBanner + Format-StalenessWarning helpers) into $BodyFile BEFORE it is posted, so a
+    # superseded result is never published unwarned. The banner is inserted after the dedup $Marker line and
+    # leaves the hidden analyzed-commit marker intact, so the next run can still parse it. Best-effort: any
+    # failure to determine the live head leaves the body untouched (the run still posts; it just cannot
+    # self-flag) rather than failing the advisory comment. Rewrites $BodyFile in place; returns $true when a
+    # banner was injected. Isolates the real `gh` calls behind Invoke-GhCapture so the Pester suite drives
+    # it with a mocked head.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][string] $PrNumber,
+        [Parameter(Mandatory)][string] $Marker,
+        [Parameter(Mandatory)][string] $AnalyzedSha,
+        [Parameter(Mandatory)][string] $BodyFile
+    )
+
+    Assert-RepoAndPr -Repo $Repo -PrNumber $PrNumber
+    Assert-CommitSha -Sha $AnalyzedSha -Label 'Analyzed'
+
+    if (-not (Test-Path -LiteralPath $BodyFile)) {
+        throw "Comment body file '$BodyFile' does not exist."
+    }
+
+    # Read the LIVE PR head SHA (`.head.sha` off the pull request). Best-effort: a transient `gh` failure
+    # must not fail the advisory comment, so degrade to "post as composed" rather than throwing.
+    $currentSha = $null
+    try {
+        $output = Invoke-GhCapture -Arguments @(
+            'api', "repos/$Repo/pulls/$PrNumber", '--jq', '.head.sha'
+        )
+        $currentSha = $output.Trim()
+    }
+    catch {
+        Write-Verbose ("Could not read the live head of PR #$PrNumber to check whether the composed " +
+            "benchmark results are already stale; posting them as composed. Error: $($_.Exception.Message)")
+        return $false
+    }
+
+    # A head that is not a 40-hex SHA (an empty or garbled response) is unusable for a compare; degrade to
+    # posting as composed rather than guessing at staleness.
+    if ($currentSha -notmatch '^[0-9a-fA-F]{40}$') {
+        Write-Verbose ("Live head of PR #$PrNumber came back as '$currentSha', not a 40-char SHA; posting " +
+            "the composed benchmark results without a self-staleness check.")
+        return $false
+    }
+
+    # The overwhelmingly common case: the PR has not moved since the run was triggered, so the composed
+    # results describe the current tip and need no banner. A plain string compare avoids a needless
+    # compare-API round-trip on every post.
+    if ($currentSha -eq $AnalyzedSha) {
+        Write-Verbose ("Composed benchmark results describe the live head of PR #$PrNumber ($AnalyzedSha); " +
+            "no staleness banner needed.")
+        return $false
+    }
+
+    # The PR advanced (or was force-pushed) while this run benchmarked $AnalyzedSha. Word the banner with
+    # the concrete distance when the two commits are related, else the numberless fallback - via the shared
+    # Format-StalenessWarning so it matches the mark-stale job's wording exactly. Any compare failure is
+    # best-effort: a null distance simply yields the numberless wording rather than failing the post.
+    $distance = $null
+    try {
+        $distance = Get-CommitsBehind -Repo $Repo -BaseSha $AnalyzedSha -HeadSha $currentSha
+    }
+    catch {
+        Write-Verbose ("Compare lookup failed for analyzed commit $AnalyzedSha (live head $currentSha) on " +
+            "PR #$PrNumber; using generic out-of-date wording. Error: $($_.Exception.Message)")
+    }
+    $warning = Format-StalenessWarning -Distance $distance
+
+    $body = Get-Content -LiteralPath $BodyFile -Raw
+    $newBody = Add-StalenessBanner -Body $body -Warning $warning -Marker $Marker
+    Set-Content -LiteralPath $BodyFile -Value $newBody -Encoding utf8 -NoNewline
+    Write-Verbose ("PR #$PrNumber advanced from analyzed commit $AnalyzedSha to live head $currentSha " +
+        "during the run; injected a staleness banner into the composed benchmark comment before posting.")
     return $true
 }
 
@@ -653,4 +764,4 @@ function Publish-InProgressComment {
     return $true
 }
 
-Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment, Get-CommitsBehind, Set-RollingCommentStaleness, Publish-InProgressComment
+Export-ModuleMember -Function Find-RollingComment, Publish-RollingComment, Remove-RollingComment, Get-CommitsBehind, Set-RollingCommentStaleness, Add-StalenessBannerIfBehind, Publish-InProgressComment

--- a/scripts/build/Delta.Tests.ps1
+++ b/scripts/build/Delta.Tests.ps1
@@ -42,6 +42,28 @@ Describe 'Read-DeltaAffectedPackage' {
     }
 }
 
+Describe 'Invoke-CargoDelta empty-result composition (regression)' {
+    # Invoke-CargoDelta itself drives real cargo/git and is CI-covered, but its internal hand-off
+    # from Read-DeltaAffectedPackage to Select-ExistingPackage is pure and reproduced here: a
+    # "nothing affected" report must survive that hand-off instead of failing the delta job on a
+    # PR that touches no crate (docs, workflows or scripts only).
+    It 'wraps an empty affected list so Select-ExistingPackage never binds null' {
+        # Read-DeltaAffectedPackage returns @() here, which PowerShell collapses to $null on a bare
+        # assignment; the @() wrap Invoke-CargoDelta applies keeps it an array so the Mandatory
+        # -Affected parameter binds instead of throwing "argument is null".
+        $affected = @(Read-DeltaAffectedPackage -DeltaJson '{"Affected":[]}')
+        { Select-ExistingPackage -Affected $affected -WorkspacePackage @('here') } |
+            Should -Not -Throw
+    }
+
+    It 'produces a skip_all output for a report that affects nothing' {
+        $affected = @(Read-DeltaAffectedPackage -DeltaJson '{"Affected":[]}')
+        $existing = Select-ExistingPackage -Affected $affected -WorkspacePackage @('here')
+        (Get-DeltaOutput -Affected @($existing)).SkipAll | Should -Be 'true'
+    }
+}
+
+
 Describe 'Select-ExistingPackage' {
     It 'drops packages that no longer exist in the workspace' {
         $result = Select-ExistingPackage `

--- a/scripts/build/Delta.psm1
+++ b/scripts/build/Delta.psm1
@@ -154,7 +154,11 @@ function Invoke-CargoDelta {
         # to stderr and emits no stdout, which the parser treats as "nothing affected".
         $deltaJson = cargo delta -c $ConfigPath run --baseline $baselineJson --current $currentJson | Out-String
 
-        $affected = Read-DeltaAffectedPackage -DeltaJson $deltaJson
+        # Re-wrap in @(): Read-DeltaAffectedPackage returns an empty array for a "nothing affected"
+        # report, but PowerShell collapses a bare empty-array return to $null on assignment, and
+        # Select-ExistingPackage's -Affected is Mandatory (rejects $null). Without this a PR that
+        # touches no crate - docs, workflows or scripts only - would fail the delta job outright.
+        $affected = @(Read-DeltaAffectedPackage -DeltaJson $deltaJson)
         return Select-ExistingPackage -Affected $affected -WorkspacePackage (Get-WorkspacePackage)
     } finally {
         Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
[Copilot speaking]

## Problem

The `analyze` job in `.github/workflows/pr-bench-history.yml` used `if: always()`. GitHub evaluates `always()` as true **even when a run is cancelled** by concurrency `cancel-in-progress`. So when a PR moved on and a newer push superseded an in-flight benchmark run, the superseded run's `analyze` job still ran and posted benchmark numbers for its frozen (now **stale**) head SHA — with no staleness warning.

This is exactly the situation the start-of-run `mark-stale` banner guards against, but it was only handled at the *start* of a run, not when an existing run *finished*. The user's expectation was that stale results are either never published or published with a "stale" warning; neither held on the finish side.

The main `bench-history.yml` is **not** affected — it is keyed per-SHA and does not cancel superseded runs.

## Fix

Two finish-side defenses:

1. **Gate the `analyze` job with `!cancelled()` instead of `always()`.** A run superseded by a newer push (concurrency cancellation) now stops before analyzing, while a merely partially-failed collect still analyzes — a failed leg is not a cancellation. This mirrors the pattern already used in `validation.yml`.

2. **Post-time live-head self-check** (`Add-StalenessBannerIfBehind`, wired through the new `gh-flag-pr-comment-if-stale` recipe). Right before posting, it re-reads the **live** PR head and, when the composed results already describe a superseded commit, injects the same staleness banner the `mark-stale` job uses into the composed body — backstopping the narrow window where a push races the final post. It is best-effort: any `gh` hiccup leaves the body as composed rather than failing the advisory comment.

Both staleness paths now share a single wording helper (`Format-StalenessWarning`) so the banners cannot drift.

## Incidental fix: delta job on zero-crate PRs

This PR touches no crate (only workflow/script/doc files), which surfaced a pre-existing latent bug: `Invoke-CargoDelta` assigned `Read-DeltaAffectedPackage`'s result straight to a variable. For a "nothing affected" report that returns an empty array, which PowerShell collapses to `$null` on a bare assignment, and the next call passes it to `Select-ExistingPackage`, whose `Mandatory` `-Affected` parameter rejects `$null`. Any docs/workflow/scripts-only PR therefore failed the `delta` job outright. Fixed by re-wrapping the result in `@()` (matching the `@(Invoke-CargoDelta …)` idiom the workflows already use), with a regression test.

## Changes

- `.github/workflows/pr-bench-history.yml` — `analyze` gate `always()` → `!cancelled()`; new "Flag composed comment stale if the PR advanced" step before the post.
- `scripts/bench-history/BenchHistoryComment.psm1` — new exported `Add-StalenessBannerIfBehind`; shared `Format-StalenessWarning` helper; `Set-RollingCommentStaleness` refactored onto it; module header updated ("Four seams").
- `justfiles/just_automation.just` — new `gh-flag-pr-comment-if-stale` recipe.
- `.github/workflows/design.md` — documents the finish-side defenses.
- `scripts/build/Delta.psm1` — `@()`-wrap fix for the zero-crate delta failure.
- `scripts/bench-history/BenchHistoryComment.Tests.ps1` + `scripts/build/Delta.Tests.ps1` — 13 new Pester tests.

## Validation

- `just test-scripts` — all passing (13 new)
- `just validate-scripts` (PSScriptAnalyzer) — clean
- `just validate-workflows` (actionlint) — clean