### PR TITLE
Harden CI against transient faults with item-level retries

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -68,7 +68,7 @@ runs:
     - name: Cache Rust toolchains
       # Restored BEFORE the toolchain is installed so the pinned stable, the MSRV and the
       # pinned nightly (whose profile pulls rust-src, llvm-tools-preview and miri) are all
-      # served from cache, turning every `rustup toolchain install` - the dtolnay step below
+      # served from cache, turning every `rustup toolchain install` - the install step below
       # and the ones inside `just install-tools` - into a no-op on a hit. rust-cache below
       # caches ~/.cargo and ./target but never ~/.rustup, so re-installing these toolchains is
       # the single largest uncached cost of this composite.
@@ -91,36 +91,24 @@ runs:
           ~/.rustup/update-hashes
         key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('constants.env', 'rust-toolchain.toml') }}
 
-    - name: Read pinned Rust toolchain channel
-      # dtolnay/rust-toolchain cannot read rust-toolchain.toml - its channel comes from the
-      # action @rev or the `toolchain` input - so extract the pinned stable channel here and
-      # hand it to the install step below. Parsing in PowerShell keeps it portable across the
-      # Linux/macOS/Windows runners (macOS ships BSD grep, which has no -P). The version is
-      # never hardcoded; rust-toolchain.toml stays the single source of truth.
-      id: rust-toolchain
+    - name: Install Rust toolchain
+      # In-repo replacement for a marketplace toolchain action (scripts/setup/RustToolchain.psm1,
+      # Pester-tested). It installs the pinned stable channel read from rust-toolchain.toml - the
+      # single source of truth, never hardcoded - and wraps the `rustup toolchain install` in an
+      # item-level retry, because that install pulls from package mirrors onto runner disks where a
+      # transient fault (a network blip or a disk I/O error) is not a real failure and must not drop
+      # the whole job. Owning the step also avoids a floating `@master` marketplace dependency.
+      #
+      # Pinning to the exact channel (rather than latest stable) keeps the installed toolchain set -
+      # and thus Swatinem/rust-cache's key, which enumerates `rustup toolchain list` - stable until
+      # we deliberately bump the pin, so an upstream stable release never silently busts the cache.
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
         $ErrorActionPreference = 'Stop'
         $PSNativeCommandUseErrorActionPreference = $true
-        $match = Select-String -Path 'rust-toolchain.toml' -Pattern '^\s*channel\s*=\s*"([^"]+)"' | Select-Object -First 1
-        if (-not $match) { throw 'Could not read the pinned channel from rust-toolchain.toml' }
-        $channel = $match.Matches[0].Groups[1].Value
-        Write-Host "Pinned Rust channel from rust-toolchain.toml: $channel"
-        "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-    - name: Install Rust toolchain
-      # Pinned to the exact channel from rust-toolchain.toml (parsed above) via @master -
-      # dtolnay's documented ref for passing an explicit `toolchain`. Using @stable would
-      # instead install the *latest* stable and roll it forward every ~6 weeks; because
-      # Swatinem/rust-cache enumerates every installed toolchain (`rustup toolchain list`)
-      # into its key, that rolling stable would silently bust the shared compilation cache on
-      # each upstream release even though the workspace only ever builds with the pinned
-      # channel. Pinning it keeps the toolchain set - and thus the cache key - stable until we
-      # deliberately bump the pin.
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+        Import-Module ./scripts/setup/RustToolchain.psm1 -Force
+        Install-RustToolchain
 
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -355,14 +355,19 @@ one bad sector), the actionlint/shellcheck/azcopy tool downloads (which re-fetch
 the checksum, so a truncated payload re-downloads rather than being trusted), and the idempotent
 `gh` read calls behind the bench-history modules' `Invoke-GhCapture` seam.
 
-Two lines bound where retry is applied. It never wraps a non-idempotent mutation — creating,
-editing, closing, or deleting an issue or comment — because a retry after a fault that already
-took effect would duplicate it; only reads opt in, via `Invoke-GhCapture -RetryOnFailure`. And it
-retries only *transient* failures: a deterministic error (a 4xx, an auth refusal, a malformed
-request) will fail identically every attempt, so `Test-TransientFailure` lets it surface
-immediately instead of hiding behind slow retries. Reads that already degrade gracefully — those
-returning a neutral result on failure rather than aborting the job — are left as-is, since a
-soft-failing read needs no retry to keep the job alive.
+Two rules bound where and how retry is applied. First, it never wraps a non-idempotent mutation —
+creating, editing, closing, or deleting an issue or comment — because a retry after a fault that
+already took effect would duplicate it; only reads opt in, via `Invoke-GhCapture -RetryOnFailure`.
+Second, how a retryable failure is recognised depends on whether the failure is legible. A `gh` read
+runs against a live API where a deterministic error (a 4xx, an auth refusal, a malformed request) is
+unambiguous and should surface at once, so those reads pass `Test-TransientFailure` as the retry
+predicate and re-attempt only transient-looking failures. The idempotent installs and downloads are
+different: their motivating faults — a runner disk I/O error, a truncated fetch — are not reliably
+classifiable from the error text, and the operations are cheap to repeat, so they retry *every*
+failure within a small, bounded budget, and a genuinely deterministic failure (a bad version pin, a
+checksum that never matches) costs only the capped backoff window before it surfaces. Reads that
+already degrade gracefully — returning a neutral result on failure rather than aborting the job — are
+left un-retried, since a soft-failing read needs no retry to keep the job alive.
 
 First-party marketplace actions (checkout, cache, artifact up/download, and the like) are trusted
 to retry their own network operations internally, so they are not wrapped in a third-party retry

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -338,6 +338,37 @@ the mostly-cached setup time it would save. Toolchain versions are defined once 
 `constants.env` and `rust-toolchain.toml` and reach the workflows through the `just`
 commands they call, so no version is ever duplicated into a workflow file.
 
+## Transient-fault handling
+
+CI touches unreliable infrastructure — package mirrors, the GitHub API, runner disks — where a
+single blip (an HTTP 5xx, a rate-limit refusal, a dropped connection, a runner disk I/O error)
+is not a real failure and must not fail a whole job. Such faults are retried automatically, and
+at the lowest feasible level: one flaky download or one API read is re-attempted in place rather
+than restarting the job around it. A shared helper, `scripts/utility/Retry.psm1`, is the single
+place that logic lives: `Invoke-WithRetry` re-runs an action a few times with exponential backoff
+capped at a ceiling, and `Test-TransientFailure` classifies an error message so callers can retry
+only genuinely transient faults.
+
+Retry wraps the operations most exposed to that risk: the in-repo Rust toolchain install (the
+`rustup toolchain install` a runner disk blip once failed with no retry, dropping a whole job on
+one bad sector), the actionlint/shellcheck/azcopy tool downloads (which re-fetch *and* re-verify
+the checksum, so a truncated payload re-downloads rather than being trusted), and the idempotent
+`gh` read calls behind the bench-history modules' `Invoke-GhCapture` seam.
+
+Two lines bound where retry is applied. It never wraps a non-idempotent mutation — creating,
+editing, closing, or deleting an issue or comment — because a retry after a fault that already
+took effect would duplicate it; only reads opt in, via `Invoke-GhCapture -RetryOnFailure`. And it
+retries only *transient* failures: a deterministic error (a 4xx, an auth refusal, a malformed
+request) will fail identically every attempt, so `Test-TransientFailure` lets it surface
+immediately instead of hiding behind slow retries. Reads that already degrade gracefully — those
+returning a neutral result on failure rather than aborting the job — are left as-is, since a
+soft-failing read needs no retry to keep the job alive.
+
+First-party marketplace actions (checkout, cache, artifact up/download, and the like) are trusted
+to retry their own network operations internally, so they are not wrapped in a third-party retry
+action; adding one would trade the minimal-dependency stance for redundant coverage. That trust is
+revisited only if a specific action is observed to flake.
+
 ## Job timeouts
 
 Every job that runs `setup-environment` must budget for a *cold* cache. When the shared

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -111,7 +111,12 @@ validate-scripts:
 
     if ($results.Count -gt 0) {
         foreach ($finding in $results) {
-            $relative = $finding.ScriptName.Substring($root.Length).TrimStart('\', '/')
+            $scriptName = [string]$finding.ScriptName
+            if ($scriptName.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $relative = $scriptName.Substring($root.Length).TrimStart('\', '/')
+            } else {
+                $relative = $scriptName
+            }
             Write-Host ("{0}:{1} [{2}] {3}: {4}" -f $relative, $finding.Line, $finding.Severity, $finding.RuleName, $finding.Message)
         }
         $issueNoun = if ($results.Count -eq 1) { 'issue' } else { 'issues' }

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -14,17 +14,21 @@ install-tools:
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
+    Import-Module "{{ justfile_directory() }}/scripts/setup/RustToolchain.psm1" -Force
+
     # This is the single source of truth for which tools - and which versions - get installed. CI
     # runs this same recipe on nearly every job via the setup-environment composite action, so
     # there is no separate CI install path to keep in sync. The only per-job variation is the
     # skip_azcopy / skip_azurite flags above, which trim two tools no ordinary CI job needs.
 
-    # First, we install/upgrade the stable toolchain in `rust-toolchain.toml`.
-    rustup toolchain install
+    # First, we install/upgrade the stable toolchain in `rust-toolchain.toml`. Omitting Channel is
+    # intentional: rustup reads the manifest, including its requested components.
+    Install-RustupToolchain
 
     # Then we install the other toolchains used by specific commands.
-    rustup toolchain install $env:RUST_MSRV
-    rustup toolchain install $env:RUST_NIGHTLY --component miri --component rustfmt --component rust-src --component llvm-tools-preview
+    Install-RustupToolchain -Channel $env:RUST_MSRV
+    Install-RustupToolchain -Channel $env:RUST_NIGHTLY `
+        -Component @('miri', 'rustfmt', 'rust-src', 'llvm-tools-preview')
 
     # Every tool is pinned to an explicit version from constants.env (dotenv, configured in the
     # root justfile, exposes each `FOO_VERSION` as `$env:FOO_VERSION`). This is deliberate: a plain

--- a/scripts/bench-history/BenchHistoryComment.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryComment.Tests.ps1
@@ -78,6 +78,7 @@ Describe 'Find-RollingComment (mocked gh api)' {
     Context 'when gh fails' {
         BeforeEach {
             Mock gh -ModuleName BenchHistoryComment { $global:LASTEXITCODE = 1; 'HTTP 503: Service Unavailable' }
+            Mock Start-Sleep -ModuleName Retry { }
         }
 
         It 'throws, surfacing the gh output' {

--- a/scripts/bench-history/BenchHistoryComment.psm1
+++ b/scripts/bench-history/BenchHistoryComment.psm1
@@ -37,6 +37,10 @@
 
 Set-StrictMode -Version Latest
 
+# A transient GitHub blip (5xx, rate-limit, dropped connection) on a read should not fail the
+# whole job, so the read-side gh calls below retry via the shared helper.
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
+
 # Sentinel pair bounding the staleness warning banner Set-RollingCommentStaleness prepends. Keeping the
 # banner between two hidden markers makes a re-run REPLACE it (strip the old block, insert the new)
 # rather than stack a second copy, and lets the block be located without depending on its wording.
@@ -64,10 +68,21 @@ function Invoke-GhCapture {
     # (stderr first, then any stdout) so the failure is never swallowed. Inspecting the exit code
     # ourselves - rather than letting a non-zero `gh` abort - is why the native-error toggle is off.
     # This is the single seam the Pester suite mocks (via `Mock gh`).
+    #
+    # Pass -RetryOnFailure ONLY for idempotent READS: it retries a transient-looking failure (HTTP
+    # 5xx, rate limit, a dropped connection) a few times before giving up, while a deterministic
+    # error still fails fast. Mutations must NOT set it - a retried create/edit/delete could double
+    # its effect.
     [CmdletBinding()]
-    param([Parameter(Mandatory)][object[]] $Arguments)
+    param(
+        [Parameter(Mandatory)][object[]] $Arguments,
+        [switch] $RetryOnFailure
+    )
 
     $PSNativeCommandUseErrorActionPreference = $false
+    # Name the invocation once for the failure message; also keeps the $Arguments read at the
+    # function's own scope rather than only inside the retry closure below.
+    $commandLine = "gh $($Arguments -join ' ')"
     # `-WhatIf:$false` on the temp-file bookkeeping: New-TemporaryFile and Remove-Item both support
     # ShouldProcess, so an ambient $WhatIfPreference from a SupportsShouldProcess CALLER (e.g.
     # Set-RollingCommentStaleness -WhatIf, which still needs the read GETs that back its preview) would
@@ -77,16 +92,24 @@ function Invoke-GhCapture {
     $stderrFile = New-TemporaryFile -WhatIf:$false
     try {
         $stderrPath = $stderrFile.FullName
-        $stdout = (gh @Arguments 2>$stderrPath | Out-String)
-        $exitCode = $LASTEXITCODE
-        if ($exitCode -ne 0) {
-            $stderr = Get-Content -LiteralPath $stderrPath -Raw
-            $parts = @()
-            if ($stderr -and $stderr.Trim()) { $parts += $stderr.Trim() }
-            if ($stdout -and $stdout.Trim()) { $parts += $stdout.Trim() }
-            throw "gh $($Arguments -join ' ') failed (exit $exitCode): $($parts -join ' ')"
+        $invoke = {
+            $stdout = (gh @Arguments 2>$stderrPath | Out-String)
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+                $stderr = Get-Content -LiteralPath $stderrPath -Raw
+                $parts = @()
+                if ($stderr -and $stderr.Trim()) { $parts += $stderr.Trim() }
+                if ($stdout -and $stdout.Trim()) { $parts += $stdout.Trim() }
+                throw "$commandLine failed (exit $exitCode): $($parts -join ' ')"
+            }
+            return $stdout
         }
-        return $stdout
+
+        if ($RetryOnFailure) {
+            return (Invoke-WithRetry -Attempt 4 -DelaySeconds 3 -BackoffMultiplier 2 -MaxDelaySeconds 30 `
+                    -RetryOn { param($e) Test-TransientFailure -Message $e.Exception.Message } -Action $invoke)
+        }
+        return (& $invoke)
     }
     finally {
         Remove-Item -LiteralPath $stderrFile.FullName -Force -ErrorAction SilentlyContinue -WhatIf:$false
@@ -161,7 +184,7 @@ function Find-RollingComment {
 
     # Invoke-GhCapture keeps stderr off stdout so ConvertFrom-Json always sees clean JSON even if
     # `gh` emitted a warning; `--paginate` follows the next-page links and merges the array pages.
-    $output = Invoke-GhCapture -Arguments @(
+    $output = Invoke-GhCapture -RetryOnFailure -Arguments @(
         'api', '--paginate', "repos/$Repo/issues/$PrNumber/comments"
     )
 

--- a/scripts/bench-history/BenchHistoryIssue.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryIssue.Tests.ps1
@@ -69,6 +69,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
     Context 'when gh fails' {
         BeforeEach {
             Mock gh -ModuleName BenchHistoryIssue { $global:LASTEXITCODE = 1; 'HTTP 503: Service Unavailable' }
+            Mock Start-Sleep -ModuleName Retry { }
         }
 
         It 'throws, surfacing the gh output' {
@@ -104,6 +105,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
                 Write-Error 'GraphQL: rate limit exceeded' -ErrorAction Continue
                 $global:LASTEXITCODE = 1
             }
+            Mock Start-Sleep -ModuleName Retry { }
         }
 
         It 'surfaces the stderr text in the thrown error' {
@@ -309,6 +311,7 @@ Describe 'Close-RollingIssue (mocked gh)' {
     Context 'when gh list fails' {
         BeforeEach {
             Mock gh -ModuleName BenchHistoryIssue { $global:LASTEXITCODE = 1; 'HTTP 503: Service Unavailable' }
+            Mock Start-Sleep -ModuleName Retry { }
         }
 
         It 'throws, surfacing the gh output' {

--- a/scripts/bench-history/BenchHistoryIssue.psm1
+++ b/scripts/bench-history/BenchHistoryIssue.psm1
@@ -16,6 +16,10 @@
 
 Set-StrictMode -Version Latest
 
+# A transient GitHub blip (5xx, rate-limit, dropped connection) on a read should not fail the
+# whole job, so the read-side gh calls below retry via the shared helper.
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
+
 function Invoke-GhCapture {
     # Runs `gh` with the given arguments, capturing stdout and stderr SEPARATELY. stderr is
     # redirected to a temp file so it never contaminates stdout: `gh` can print warnings - e.g.
@@ -25,23 +29,42 @@ function Invoke-GhCapture {
     # (stderr first, then any stdout) so the failure is never swallowed. Inspecting the exit code
     # ourselves - rather than letting a non-zero `gh` abort - is why the native-error toggle is off.
     # This is the single seam the Pester suite mocks (via `Mock gh`).
+    #
+    # Pass -RetryOnFailure ONLY for idempotent READS: it retries a transient-looking failure (HTTP
+    # 5xx, rate limit, a dropped connection) a few times before giving up, while a deterministic
+    # error still fails fast. Mutations must NOT set it - a retried create/edit/close could double
+    # its effect.
     [CmdletBinding()]
-    param([Parameter(Mandatory)][object[]] $Arguments)
+    param(
+        [Parameter(Mandatory)][object[]] $Arguments,
+        [switch] $RetryOnFailure
+    )
 
     $PSNativeCommandUseErrorActionPreference = $false
+    # Name the invocation once for the failure message; also keeps the $Arguments read at the
+    # function's own scope rather than only inside the retry closure below.
+    $commandLine = "gh $($Arguments -join ' ')"
     $stderrFile = New-TemporaryFile
     try {
         $stderrPath = $stderrFile.FullName
-        $stdout = (gh @Arguments 2>$stderrPath | Out-String)
-        $exitCode = $LASTEXITCODE
-        if ($exitCode -ne 0) {
-            $stderr = Get-Content -LiteralPath $stderrPath -Raw
-            $parts = @()
-            if ($stderr -and $stderr.Trim()) { $parts += $stderr.Trim() }
-            if ($stdout -and $stdout.Trim()) { $parts += $stdout.Trim() }
-            throw "gh $($Arguments -join ' ') failed (exit $exitCode): $($parts -join ' ')"
+        $invoke = {
+            $stdout = (gh @Arguments 2>$stderrPath | Out-String)
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+                $stderr = Get-Content -LiteralPath $stderrPath -Raw
+                $parts = @()
+                if ($stderr -and $stderr.Trim()) { $parts += $stderr.Trim() }
+                if ($stdout -and $stdout.Trim()) { $parts += $stdout.Trim() }
+                throw "$commandLine failed (exit $exitCode): $($parts -join ' ')"
+            }
+            return $stdout
         }
-        return $stdout
+
+        if ($RetryOnFailure) {
+            return (Invoke-WithRetry -Attempt 4 -DelaySeconds 3 -BackoffMultiplier 2 -MaxDelaySeconds 30 `
+                    -RetryOn { param($e) Test-TransientFailure -Message $e.Exception.Message } -Action $invoke)
+        }
+        return (& $invoke)
     }
     finally {
         Remove-Item -LiteralPath $stderrFile.FullName -Force -ErrorAction SilentlyContinue
@@ -64,7 +87,7 @@ function Get-OpenIssueByTitle {
 
     # Ask `gh` for the open issues carrying $Label as JSON; Invoke-GhCapture keeps stderr off
     # stdout so ConvertFrom-Json below always sees clean JSON even if `gh` emitted a warning.
-    $output = Invoke-GhCapture -Arguments @(
+    $output = Invoke-GhCapture -RetryOnFailure -Arguments @(
         'issue', 'list', '--state', 'open', '--label', $Label, '--limit', $Limit, '--json', 'number,title,url'
     )
 
@@ -135,7 +158,7 @@ function Close-RollingIssue {
     )
 
     # `--limit` defeats the 30-result default so a backlog of historical duplicates all come back.
-    $output = Invoke-GhCapture -Arguments @(
+    $output = Invoke-GhCapture -RetryOnFailure -Arguments @(
         'issue', 'list', '--state', 'open', '--label', $Label, '--limit', $Limit, '--json', 'number,title'
     )
 

--- a/scripts/install-actionlint.ps1
+++ b/scripts/install-actionlint.ps1
@@ -47,6 +47,10 @@ $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
+# The archive download can hit a transient network/disk fault; Invoke-WithRetry re-fetches (and
+# re-verifies the checksum) rather than failing `just install-tools` on a single blip.
+Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
+
 # The pinned actionlint release. Keep $ActionlintVersion and the per-platform digests in
 # $ActionlintBuilds in sync - both come from one GitHub release of rhysd/actionlint.
 $script:ActionlintVersion = '1.7.12'
@@ -142,14 +146,18 @@ Write-Verbose "Staging the download in temp directory '$($work.FullName)'."
 try {
     $archive = Join-Path $work $build.Asset
     Write-Verbose "Downloading actionlint archive to '$archive'."
-    Invoke-WebRequest -Uri $url -OutFile $archive
+    # Retry the download and its checksum together: a truncated or corrupted fetch fails
+    # verification and is re-fetched, so only a genuinely wrong pinned digest exhausts the attempts.
+    Invoke-WithRetry -Attempt 4 -DelaySeconds 3 -BackoffMultiplier 2 -MaxDelaySeconds 30 -Action {
+        Invoke-WebRequest -Uri $url -OutFile $archive
 
-    Write-Verbose "Verifying the archive SHA-256 against the pinned digest."
-    # Get-FileHash returns uppercase hex; normalize both sides to lowercase so the comparison
-    # cannot fail on case alone.
-    $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($actual -ne $build.Sha256) {
-        throw "actionlint archive SHA-256 mismatch for '$($build.Asset)': expected $($build.Sha256), got $actual."
+        Write-Verbose "Verifying the archive SHA-256 against the pinned digest."
+        # Get-FileHash returns uppercase hex; normalize both sides to lowercase so the comparison
+        # cannot fail on case alone.
+        $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actual -ne $build.Sha256) {
+            throw "actionlint archive SHA-256 mismatch for '$($build.Asset)': expected $($build.Sha256), got $actual."
+        }
     }
 
     Expand-ActionlintArchive -ArchivePath $archive -ArchiveKind $build.Kind -DestinationDir $work

--- a/scripts/install-azcopy.ps1
+++ b/scripts/install-azcopy.ps1
@@ -49,6 +49,10 @@ $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
+# The archive download can hit a transient network/disk fault; Invoke-WithRetry re-fetches (and
+# re-verifies the checksum) rather than failing `just install-tools` on a single blip.
+Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
+
 # The pinned azcopy release. Keep $AzCopyVersion and the per-platform digests in
 # $AzCopyBuilds in sync - both come from one GitHub release of azure-storage-azcopy.
 $script:AzCopyVersion = '10.32.4'
@@ -144,14 +148,18 @@ Write-Verbose "Staging the download in temp directory '$($work.FullName)'."
 try {
     $archive = Join-Path $work $build.Asset
     Write-Verbose "Downloading azcopy archive to '$archive'."
-    Invoke-WebRequest -Uri $url -OutFile $archive
+    # Retry the download and its checksum together: a truncated or corrupted fetch fails
+    # verification and is re-fetched, so only a genuinely wrong pinned digest exhausts the attempts.
+    Invoke-WithRetry -Attempt 4 -DelaySeconds 3 -BackoffMultiplier 2 -MaxDelaySeconds 30 -Action {
+        Invoke-WebRequest -Uri $url -OutFile $archive
 
-    Write-Verbose "Verifying the archive SHA-256 against the pinned digest."
-    # Get-FileHash returns uppercase hex; normalize both sides to lowercase so the
-    # comparison cannot fail on case alone.
-    $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($actual -ne $build.Sha256) {
-        throw "azcopy archive SHA-256 mismatch for '$($build.Asset)': expected $($build.Sha256), got $actual."
+        Write-Verbose "Verifying the archive SHA-256 against the pinned digest."
+        # Get-FileHash returns uppercase hex; normalize both sides to lowercase so the
+        # comparison cannot fail on case alone.
+        $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actual -ne $build.Sha256) {
+            throw "azcopy archive SHA-256 mismatch for '$($build.Asset)': expected $($build.Sha256), got $actual."
+        }
     }
 
     Expand-AzCopyArchive -ArchivePath $archive -ArchiveKind $build.Kind -DestinationDir $work

--- a/scripts/install-shellcheck.ps1
+++ b/scripts/install-shellcheck.ps1
@@ -53,6 +53,10 @@ $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
+# The archive download can hit a transient network/disk fault; Invoke-WithRetry re-fetches (and
+# re-verifies the checksum) rather than failing `just install-tools` on a single blip.
+Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
+
 # The pinned ShellCheck release. Keep $ShellcheckVersion and the per-platform digests in
 # $ShellcheckBuilds in sync - both come from one GitHub release of koalaman/shellcheck.
 $script:ShellcheckVersion = '0.11.0'
@@ -149,14 +153,18 @@ Write-Verbose "Staging the download in temp directory '$($work.FullName)'."
 try {
     $archive = Join-Path $work $build.Asset
     Write-Verbose "Downloading ShellCheck archive to '$archive'."
-    Invoke-WebRequest -Uri $url -OutFile $archive
+    # Retry the download and its checksum together: a truncated or corrupted fetch fails
+    # verification and is re-fetched, so only a genuinely wrong pinned digest exhausts the attempts.
+    Invoke-WithRetry -Attempt 4 -DelaySeconds 3 -BackoffMultiplier 2 -MaxDelaySeconds 30 -Action {
+        Invoke-WebRequest -Uri $url -OutFile $archive
 
-    Write-Verbose "Verifying the archive SHA-256 against the pinned digest."
-    # Get-FileHash returns uppercase hex; normalize both sides to lowercase so the comparison cannot
-    # fail on case alone.
-    $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($actual -ne $build.Sha256) {
-        throw "ShellCheck archive SHA-256 mismatch for '$($build.Asset)': expected $($build.Sha256), got $actual."
+        Write-Verbose "Verifying the archive SHA-256 against the pinned digest."
+        # Get-FileHash returns uppercase hex; normalize both sides to lowercase so the comparison cannot
+        # fail on case alone.
+        $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actual -ne $build.Sha256) {
+            throw "ShellCheck archive SHA-256 mismatch for '$($build.Asset)': expected $($build.Sha256), got $actual."
+        }
     }
 
     Expand-ShellcheckArchive -ArchivePath $archive -ArchiveKind $build.Kind -DestinationDir $work

--- a/scripts/release/ReleaseAutomation.Tests.ps1
+++ b/scripts/release/ReleaseAutomation.Tests.ps1
@@ -442,46 +442,7 @@ Describe 'ConvertTo-MatrixJson' {
     }
 }
 
-Describe 'Invoke-WithRetry' {
-    BeforeEach {
-        Mock Start-Sleep -ModuleName ReleaseAutomation { }
-    }
-
-    It 'runs the action once when it succeeds immediately' {
-        $script:calls = 0
-        Invoke-WithRetry -Attempt 3 -DelaySeconds 1 -Action { $script:calls++ }
-        $script:calls | Should -Be 1
-        Should -Invoke Start-Sleep -ModuleName ReleaseAutomation -Times 0 -Exactly
-    }
-
-    It 'retries until the action succeeds' {
-        $script:calls = 0
-        Invoke-WithRetry -Attempt 5 -DelaySeconds 1 -Action {
-            $script:calls++
-            if ($script:calls -lt 3) { throw 'transient' }
-        }
-        $script:calls | Should -Be 3
-        Should -Invoke Start-Sleep -ModuleName ReleaseAutomation -Times 2 -Exactly
-    }
-
-    It 'rethrows after exhausting all attempts' {
-        $script:calls = 0
-        { Invoke-WithRetry -Attempt 3 -DelaySeconds 1 -Action { $script:calls++; throw 'always' } } |
-            Should -Throw
-        $script:calls | Should -Be 3
-    }
-
-    It 'does not sleep after the final failed attempt' {
-        { Invoke-WithRetry -Attempt 2 -DelaySeconds 1 -Action { throw 'always' } } | Should -Throw
-        Should -Invoke Start-Sleep -ModuleName ReleaseAutomation -Times 1 -Exactly
-    }
-}
-
 Describe 'Invoke-ReleasePublish (mocked release-plz)' {
-    BeforeEach {
-        Mock Start-Sleep -ModuleName ReleaseAutomation { }
-    }
-
     It 'invokes release-plz once with the composed config on success' {
         Mock release-plz -ModuleName ReleaseAutomation { $global:LASTEXITCODE = 0 }
         Invoke-ReleasePublish -ConfigPath '/tmp/ci.toml' -Attempt 3 -DelaySeconds 0

--- a/scripts/release/ReleaseAutomation.psm1
+++ b/scripts/release/ReleaseAutomation.psm1
@@ -14,6 +14,10 @@
 
 Set-StrictMode -Version Latest
 
+# The transient-fault retry (used by Invoke-ReleasePublish) is the shared workspace helper rather
+# than a private copy, so every network-facing script retries the same way.
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
+
 function Get-ReleaseTarget {
     # The single source of truth for the triple -> runner mapping. The workflow's build matrix
     # is derived from this (via Get-MissingBinaryMatrix), so a target is added in exactly one
@@ -238,30 +242,6 @@ function ConvertTo-MatrixJson {
     if ($json.TrimStart().StartsWith('[')) { $json } else { "[$json]" }
 }
 
-function Invoke-WithRetry {
-    # Runs $Action, retrying up to $Attempt times with $DelaySeconds between tries; rethrows the
-    # last failure if every attempt fails. crates.io rate-limits and the Trusted-Publishing OIDC
-    # token is short-lived, so the publish is retried rather than failing the whole release on a
-    # transient rejection.
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][scriptblock] $Action,
-        [int] $Attempt = 3,
-        [int] $DelaySeconds = 900
-    )
-
-    for ($n = 1; $n -le $Attempt; $n++) {
-        try {
-            & $Action
-            return
-        } catch {
-            if ($n -eq $Attempt) { throw }
-            Write-Warning "Attempt $n of $Attempt failed: $($_.Exception.Message). Retrying in $DelaySeconds seconds..."
-            Start-Sleep -Seconds $DelaySeconds
-        }
-    }
-}
-
 function Invoke-ReleasePublish {
     # Publishes changed crates to crates.io via `release-plz release` using the composed CI
     # config, with bounded retries. release-plz is idempotent (it skips already-published
@@ -402,6 +382,5 @@ Export-ModuleMember -Function `
     Get-BinaryReleaseAsset, `
     Get-MissingBinaryMatrix, `
     ConvertTo-MatrixJson, `
-    Invoke-WithRetry, `
     Invoke-ReleasePublish, `
     Set-GitHubOutput

--- a/scripts/setup/RustToolchain.Tests.ps1
+++ b/scripts/setup/RustToolchain.Tests.ps1
@@ -1,0 +1,141 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for RustToolchain.psm1. The real rustup/rustc are isolated behind mocks in the
+# module's scope (so nothing is installed), and Start-Sleep is mocked in the Retry module's scope so
+# the install-retry backoff does not actually wait. File I/O (channel parse, GITHUB_ENV export) runs
+# for real against temp files so the on-disk result is asserted.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'RustToolchain.psm1') -Force
+}
+
+Describe 'Get-PinnedRustChannel' {
+    BeforeEach {
+        $script:manifest = Join-Path ([IO.Path]::GetTempPath()) ("folo-toml-" + [guid]::NewGuid())
+    }
+    AfterEach {
+        Remove-Item $script:manifest -ErrorAction SilentlyContinue
+    }
+
+    It 'reads the channel from a rust-toolchain.toml' {
+        Set-Content -Path $script:manifest -Value @('[toolchain]', 'channel = "1.2.3"', 'components = ["clippy"]') -Encoding utf8
+        Get-PinnedRustChannel -ManifestPath $script:manifest | Should -Be '1.2.3'
+    }
+
+    It 'ignores whitespace around the channel key' {
+        Set-Content -Path $script:manifest -Value @('[toolchain]', '  channel   =   "nightly-2024-01-01"') -Encoding utf8
+        Get-PinnedRustChannel -ManifestPath $script:manifest | Should -Be 'nightly-2024-01-01'
+    }
+
+    It 'throws when no channel is present' {
+        Set-Content -Path $script:manifest -Value @('[toolchain]', 'components = ["clippy"]') -Encoding utf8
+        { Get-PinnedRustChannel -ManifestPath $script:manifest } | Should -Throw
+    }
+}
+
+Describe 'Set-CargoEnvDefault' {
+    BeforeEach {
+        $script:tempEnv = Join-Path ([IO.Path]::GetTempPath()) ("folo-env-" + [guid]::NewGuid())
+        Remove-Item env:FOLO_TEST_CARGO_VAR -ErrorAction SilentlyContinue
+    }
+    AfterEach {
+        Remove-Item env:FOLO_TEST_CARGO_VAR -ErrorAction SilentlyContinue
+        Remove-Item $script:tempEnv -ErrorAction SilentlyContinue
+    }
+
+    It 'appends Name=Value to GITHUB_ENV when the variable is unset' {
+        Set-CargoEnvDefault -Name 'FOLO_TEST_CARGO_VAR' -Value 'yes' -GitHubEnvPath $script:tempEnv
+        Get-Content -Path $script:tempEnv | Should -Contain 'FOLO_TEST_CARGO_VAR=yes'
+    }
+
+    It 'leaves GITHUB_ENV untouched when the variable is already set' {
+        $env:FOLO_TEST_CARGO_VAR = 'preset'
+        Set-CargoEnvDefault -Name 'FOLO_TEST_CARGO_VAR' -Value 'yes' -GitHubEnvPath $script:tempEnv
+        Test-Path $script:tempEnv | Should -BeFalse
+    }
+
+    It 'does not throw when the GITHUB_ENV path is empty' {
+        { Set-CargoEnvDefault -Name 'FOLO_TEST_CARGO_VAR' -Value 'yes' -GitHubEnvPath '' } | Should -Not -Throw
+    }
+}
+
+Describe 'Install-RustToolchain' {
+    BeforeEach {
+        $script:tempDir = Join-Path ([IO.Path]::GetTempPath()) ("folo-toolchain-" + [guid]::NewGuid())
+        New-Item -ItemType Directory -Path $script:tempDir | Out-Null
+        $script:manifest = Join-Path $script:tempDir 'rust-toolchain.toml'
+        Set-Content -Path $script:manifest -Value @('[toolchain]', 'channel = "1.2.3"') -Encoding utf8
+        $script:githubEnv = Join-Path $script:tempDir 'github_env'
+
+        # Preserve and clear the Cargo env the function exports so the unset path is exercised.
+        $script:savedIncremental = $env:CARGO_INCREMENTAL
+        $script:savedColor = $env:CARGO_TERM_COLOR
+        Remove-Item env:CARGO_INCREMENTAL -ErrorAction SilentlyContinue
+        Remove-Item env:CARGO_TERM_COLOR -ErrorAction SilentlyContinue
+
+        Mock rustup -ModuleName RustToolchain { $global:LASTEXITCODE = 0 }
+        Mock rustc -ModuleName RustToolchain { $global:LASTEXITCODE = 0 }
+        Mock Start-Sleep -ModuleName Retry { }
+    }
+    AfterEach {
+        if ($null -ne $script:savedIncremental) { $env:CARGO_INCREMENTAL = $script:savedIncremental } else { Remove-Item env:CARGO_INCREMENTAL -ErrorAction SilentlyContinue }
+        if ($null -ne $script:savedColor) { $env:CARGO_TERM_COLOR = $script:savedColor } else { Remove-Item env:CARGO_TERM_COLOR -ErrorAction SilentlyContinue }
+        Remove-Item env:RUSTUP_PERMIT_COPY_RENAME -ErrorAction SilentlyContinue
+        Remove-Item $script:tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'installs the pinned channel with the minimal profile and no self-update' {
+        Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv
+        Should -Invoke rustup -ModuleName RustToolchain -Times 1 -Exactly -ParameterFilter {
+            ($args -contains 'toolchain') -and ($args -contains 'install') -and ($args -contains '1.2.3') -and
+            ($args -contains '--profile') -and ($args -contains 'minimal') -and ($args -contains '--no-self-update')
+        }
+    }
+
+    It 'sets the pinned channel as the default' {
+        Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv
+        Should -Invoke rustup -ModuleName RustToolchain -Times 1 -Exactly -ParameterFilter {
+            ($args -contains 'default') -and ($args -contains '1.2.3')
+        }
+    }
+
+    It 'exports CARGO_INCREMENTAL and CARGO_TERM_COLOR when they are unset' {
+        Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv
+        $content = Get-Content -Path $script:githubEnv
+        $content | Should -Contain 'CARGO_INCREMENTAL=0'
+        $content | Should -Contain 'CARGO_TERM_COLOR=always'
+    }
+
+    It 'does not overwrite CARGO_TERM_COLOR when it is already set' {
+        $env:CARGO_TERM_COLOR = 'never'
+        Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv
+        Get-Content -Path $script:githubEnv | Should -Not -Contain 'CARGO_TERM_COLOR=always'
+    }
+
+    It 'runs rustc verbosely to surface the resolved compiler' {
+        Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv
+        Should -Invoke rustc -ModuleName RustToolchain -Times 1 -Exactly -ParameterFilter { $args -contains '--verbose' }
+    }
+
+    It 'retries the install on a transient failure and then succeeds' {
+        $script:installAttempts = 0
+        Mock rustup -ModuleName RustToolchain -ParameterFilter { $args -contains 'install' } {
+            $script:installAttempts++
+            $global:LASTEXITCODE = if ($script:installAttempts -lt 2) { 1 } else { 0 }
+        }
+        Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv
+        Should -Invoke rustup -ModuleName RustToolchain -Times 2 -Exactly -ParameterFilter { $args -contains 'install' }
+    }
+
+    It 'throws when the install keeps failing after every attempt' {
+        Mock rustup -ModuleName RustToolchain -ParameterFilter { $args -contains 'install' } { $global:LASTEXITCODE = 1 }
+        { Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv } | Should -Throw
+        Should -Invoke rustup -ModuleName RustToolchain -Times 4 -Exactly -ParameterFilter { $args -contains 'install' }
+    }
+
+    It 'does not fail when rustup default returns a non-zero exit' {
+        Mock rustup -ModuleName RustToolchain -ParameterFilter { $args -contains 'default' } { $global:LASTEXITCODE = 1 }
+        { Install-RustToolchain -ManifestPath $script:manifest -GitHubEnvPath $script:githubEnv } | Should -Not -Throw
+        Should -Invoke rustc -ModuleName RustToolchain -Times 1 -Exactly
+    }
+}

--- a/scripts/setup/RustToolchain.Tests.ps1
+++ b/scripts/setup/RustToolchain.Tests.ps1
@@ -59,6 +59,59 @@ Describe 'Set-CargoEnvDefault' {
     }
 }
 
+Describe 'Install-RustupToolchain' {
+    BeforeEach {
+        $script:savedPermitCopyRename = $env:RUSTUP_PERMIT_COPY_RENAME
+        Mock rustup -ModuleName RustToolchain { $global:LASTEXITCODE = 0 }
+        Mock Start-Sleep -ModuleName Retry { }
+    }
+    AfterEach {
+        if ($null -ne $script:savedPermitCopyRename) {
+            $env:RUSTUP_PERMIT_COPY_RENAME = $script:savedPermitCopyRename
+        } else {
+            Remove-Item env:RUSTUP_PERMIT_COPY_RENAME -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'lets rustup resolve the active manifest toolchain when the channel is omitted' {
+        Install-RustupToolchain
+        Should -Invoke rustup -ModuleName RustToolchain -Times 1 -Exactly -ParameterFilter {
+            ($args -join ' ') -eq 'toolchain install --no-self-update'
+        }
+    }
+
+    It 'passes an exact channel, profile, and requested components' {
+        Install-RustupToolchain -Channel 'nightly-2026-01-01' -InstallProfile minimal `
+            -Component @('miri', 'rust-src')
+        Should -Invoke rustup -ModuleName RustToolchain -Times 1 -Exactly -ParameterFilter {
+            ($args -join ' ') -eq (
+                'toolchain install nightly-2026-01-01 --profile minimal ' +
+                '--component miri --component rust-src --no-self-update'
+            )
+        }
+    }
+
+    It 'retries one toolchain install until it succeeds' {
+        $script:installAttempts = 0
+        Mock rustup -ModuleName RustToolchain {
+            $script:installAttempts++
+            $global:LASTEXITCODE = if ($script:installAttempts -lt 2) { 1 } else { 0 }
+        }
+
+        Install-RustupToolchain -Channel '1.2.3'
+
+        Should -Invoke rustup -ModuleName RustToolchain -Times 2 -Exactly
+    }
+
+    It 'throws after exhausting retries for one toolchain install' {
+        Mock rustup -ModuleName RustToolchain { $global:LASTEXITCODE = 1 }
+
+        { Install-RustupToolchain -Channel '1.2.3' } | Should -Throw
+
+        Should -Invoke rustup -ModuleName RustToolchain -Times 4 -Exactly
+    }
+}
+
 Describe 'Install-RustToolchain' {
     BeforeEach {
         $script:tempDir = Join-Path ([IO.Path]::GetTempPath()) ("folo-toolchain-" + [guid]::NewGuid())

--- a/scripts/setup/RustToolchain.psm1
+++ b/scripts/setup/RustToolchain.psm1
@@ -1,0 +1,115 @@
+#requires -Version 7
+
+# In-repo replacement for a marketplace toolchain action, run by .github/actions/setup-environment.
+# It installs the pinned stable toolchain from rust-toolchain.toml and sets only the Cargo
+# environment variables our pipeline actually relies on.
+#
+# It is a standalone module (imported via `shell: pwsh`), NOT a `just` recipe: the composite installs
+# the toolchain BEFORE `just` is available, so `just` cannot be used here.
+#
+# Owning the step buys two things over a marketplace action: it drops a floating `@master`
+# supply-chain dependency, and - the reason it exists - it wraps `rustup toolchain install` in an
+# item-level retry, because that install pulls from package mirrors onto runner disks where a
+# transient fault (a network blip or a disk I/O error) is not a real failure and must not drop the
+# whole job.
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
+
+function Get-PinnedRustChannel {
+    # Reads the pinned stable channel from rust-toolchain.toml so the version is never hardcoded -
+    # the manifest stays the single source of truth. Parsing in PowerShell keeps it portable across
+    # the Linux/macOS/Windows runners (macOS ships BSD grep, which has no -P).
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string] $ManifestPath = 'rust-toolchain.toml'
+    )
+
+    $match = Select-String -Path $ManifestPath -Pattern '^\s*channel\s*=\s*"([^"]+)"' | Select-Object -First 1
+    if (-not $match) {
+        throw "Could not read the pinned channel from $ManifestPath"
+    }
+
+    return $match.Matches[0].Groups[1].Value
+}
+
+function Set-CargoEnvDefault {
+    # Exports $Name=$Value to $GitHubEnvPath (GITHUB_ENV) for subsequent workflow steps, but only if
+    # the variable is not already set in the process environment - so an explicit value configured
+    # by the workflow always wins over this default. Writing to GITHUB_ENV
+    # affects later steps, not this one, which is why the "already set" check reads the live process
+    # environment rather than the file.
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $Value,
+        [string] $GitHubEnvPath
+    )
+
+    if (Test-Path "env:$Name") {
+        Write-Host "$Name already set to '$((Get-Item "env:$Name").Value)'; leaving it unchanged"
+        return
+    }
+
+    if ([string]::IsNullOrEmpty($GitHubEnvPath)) {
+        Write-Warning "GITHUB_ENV is not set; cannot export $Name=$Value"
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($GitHubEnvPath, "append environment '$Name'")) {
+        Add-Content -Path $GitHubEnvPath -Value "$Name=$Value" -Encoding utf8
+        Write-Host "Exported $Name=$Value via GITHUB_ENV"
+    }
+}
+
+function Install-RustToolchain {
+    # Installs the pinned stable toolchain via rustup and sets the Cargo environment the composite
+    # relies on. Parameters exist purely for testability; in CI both take their real defaults.
+    [CmdletBinding()]
+    param(
+        [string] $ManifestPath = 'rust-toolchain.toml',
+        [string] $GitHubEnvPath = $env:GITHUB_ENV
+    )
+
+    # `rustup default` is intentionally best-effort, so handle native exit codes explicitly rather
+    # than letting the composite step's $PSNativeCommandUseErrorActionPreference auto-throw on them.
+    $PSNativeCommandUseErrorActionPreference = $false
+
+    $channel = Get-PinnedRustChannel -ManifestPath $ManifestPath
+    Write-Host "Pinned Rust channel from ${ManifestPath}: $channel"
+
+    # The install writes a lot to disk and pulls from static.rust-lang.org; either can blip
+    # transiently (the os error 5 that motivated owning this step), so retry the install alone with
+    # a short exponential backoff. RUSTUP_PERMIT_COPY_RENAME mirrors the marketplace action's
+    # handling of cross-device installs.
+    $env:RUSTUP_PERMIT_COPY_RENAME = '1'
+    Invoke-WithRetry -Attempt 4 -DelaySeconds 5 -BackoffMultiplier 2 -MaxDelaySeconds 30 -Action {
+        rustup toolchain install $channel --profile minimal --no-self-update
+        if ($LASTEXITCODE -ne 0) {
+            throw "rustup toolchain install $channel exited with code $LASTEXITCODE"
+        }
+    }
+
+    # Making the pinned channel the default is convenient but not essential (rust-toolchain.toml
+    # already directs cargo to it), so a failure here must not fail environment setup.
+    rustup default $channel
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "rustup default $channel exited with code $LASTEXITCODE (continuing)"
+    }
+
+    Set-CargoEnvDefault -Name 'CARGO_INCREMENTAL' -Value '0' -GitHubEnvPath $GitHubEnvPath
+    Set-CargoEnvDefault -Name 'CARGO_TERM_COLOR' -Value 'always' -GitHubEnvPath $GitHubEnvPath
+
+    # Surface the resolved compiler in the log, exactly like the marketplace action did.
+    rustc "+$channel" --version --verbose
+    if ($LASTEXITCODE -ne 0) {
+        throw "rustc +$channel --version exited with code $LASTEXITCODE"
+    }
+}
+
+Export-ModuleMember -Function `
+    Get-PinnedRustChannel, `
+    Set-CargoEnvDefault, `
+    Install-RustToolchain

--- a/scripts/setup/RustToolchain.psm1
+++ b/scripts/setup/RustToolchain.psm1
@@ -64,6 +64,46 @@ function Set-CargoEnvDefault {
     }
 }
 
+function Install-RustupToolchain {
+    # Installs one toolchain (or the active rust-toolchain.toml toolchain when Channel is omitted)
+    # with item-level retry. Components are passed through individually so a large nightly install
+    # is retried as one internally consistent rustup operation.
+    [CmdletBinding()]
+    param(
+        [string] $Channel,
+        [ValidateSet('minimal', 'default', 'complete')][string] $InstallProfile,
+        [string[]] $Component = @()
+    )
+
+    $PSNativeCommandUseErrorActionPreference = $false
+
+    $rustupArguments = @('toolchain', 'install')
+    if (-not [string]::IsNullOrWhiteSpace($Channel)) {
+        $rustupArguments += $Channel
+    }
+    if (-not [string]::IsNullOrWhiteSpace($InstallProfile)) {
+        $rustupArguments += @('--profile', $InstallProfile)
+    }
+    foreach ($name in $Component) {
+        $rustupArguments += @('--component', $name)
+    }
+    $rustupArguments += '--no-self-update'
+
+    $toolchainDescription = if ([string]::IsNullOrWhiteSpace($Channel)) {
+        'the active toolchain'
+    } else {
+        $Channel
+    }
+
+    $env:RUSTUP_PERMIT_COPY_RENAME = '1'
+    Invoke-WithRetry -Attempt 4 -DelaySeconds 5 -BackoffMultiplier 2 -MaxDelaySeconds 30 -Action {
+        rustup @rustupArguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "rustup toolchain install for $toolchainDescription exited with code $LASTEXITCODE"
+        }
+    }
+}
+
 function Install-RustToolchain {
     # Installs the pinned stable toolchain via rustup and sets the Cargo environment the composite
     # relies on. Parameters exist purely for testability; in CI both take their real defaults.
@@ -80,17 +120,7 @@ function Install-RustToolchain {
     $channel = Get-PinnedRustChannel -ManifestPath $ManifestPath
     Write-Host "Pinned Rust channel from ${ManifestPath}: $channel"
 
-    # The install writes a lot to disk and pulls from static.rust-lang.org; either can blip
-    # transiently (the os error 5 that motivated owning this step), so retry the install alone with
-    # a short exponential backoff. RUSTUP_PERMIT_COPY_RENAME mirrors the marketplace action's
-    # handling of cross-device installs.
-    $env:RUSTUP_PERMIT_COPY_RENAME = '1'
-    Invoke-WithRetry -Attempt 4 -DelaySeconds 5 -BackoffMultiplier 2 -MaxDelaySeconds 30 -Action {
-        rustup toolchain install $channel --profile minimal --no-self-update
-        if ($LASTEXITCODE -ne 0) {
-            throw "rustup toolchain install $channel exited with code $LASTEXITCODE"
-        }
-    }
+    Install-RustupToolchain -Channel $channel -InstallProfile minimal
 
     # Making the pinned channel the default is convenient but not essential (rust-toolchain.toml
     # already directs cargo to it), so a failure here must not fail environment setup.
@@ -112,4 +142,5 @@ function Install-RustToolchain {
 Export-ModuleMember -Function `
     Get-PinnedRustChannel, `
     Set-CargoEnvDefault, `
+    Install-RustupToolchain, `
     Install-RustToolchain

--- a/scripts/setup/RustToolchain.psm1
+++ b/scripts/setup/RustToolchain.psm1
@@ -68,6 +68,15 @@ function Install-RustupToolchain {
     # Installs one toolchain (or the active rust-toolchain.toml toolchain when Channel is omitted)
     # with item-level retry. Components are passed through individually so a large nightly install
     # is retried as one internally consistent rustup operation.
+    #
+    # The retry is deliberately unconditional (no Test-TransientFailure predicate). The faults it
+    # exists to absorb - a runner disk I/O error (the `os error 5` that motivated owning this step)
+    # or a mid-download network blip - are not reliably classifiable from rustup's message, and the
+    # install is idempotent, so every failure is re-attempted within the bounded backoff; only a
+    # genuinely deterministic failure (e.g. a bad channel pin) burns the full window before it
+    # surfaces. rustup streams its own diagnostics to the log on each attempt, so throwing just the
+    # exit code keeps the failure legible without buffering that live stream - matching how the
+    # release-plz wrapper reports.
     [CmdletBinding()]
     param(
         [string] $Channel,

--- a/scripts/utility/Retry.Tests.ps1
+++ b/scripts/utility/Retry.Tests.ps1
@@ -101,6 +101,10 @@ Describe 'Test-TransientFailure' {
         Test-TransientFailure -Message 'error: connection reset by peer' | Should -BeTrue
     }
 
+    It 'treats a runner disk I/O error as transient' {
+        Test-TransientFailure -Message 'unable to sync download to disk: Input/output error (os error 5)' | Should -BeTrue
+    }
+
     It 'treats a 404 as non-transient' {
         Test-TransientFailure -Message 'gh: Not Found (HTTP 404)' | Should -BeFalse
     }

--- a/scripts/utility/Retry.Tests.ps1
+++ b/scripts/utility/Retry.Tests.ps1
@@ -1,0 +1,115 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Retry.psm1. Start-Sleep is mocked in the module's scope so the retry timing is
+# asserted (attempt counts and the backoff schedule) without the tests actually waiting.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Retry.psm1') -Force
+}
+
+Describe 'Invoke-WithRetry' {
+    BeforeEach {
+        Mock Start-Sleep -ModuleName Retry { }
+    }
+
+    It 'runs the action once when it succeeds immediately' {
+        $script:calls = 0
+        Invoke-WithRetry -Attempt 3 -DelaySeconds 1 -Action { $script:calls++ }
+        $script:calls | Should -Be 1
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 0 -Exactly
+    }
+
+    It 'retries until the action succeeds' {
+        $script:calls = 0
+        Invoke-WithRetry -Attempt 5 -DelaySeconds 1 -Action {
+            $script:calls++
+            if ($script:calls -lt 3) { throw 'transient' }
+        }
+        $script:calls | Should -Be 3
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 2 -Exactly
+    }
+
+    It 'rethrows after exhausting all attempts' {
+        $script:calls = 0
+        { Invoke-WithRetry -Attempt 3 -DelaySeconds 1 -Action { $script:calls++; throw 'always' } } |
+            Should -Throw
+        $script:calls | Should -Be 3
+    }
+
+    It 'does not sleep after the final failed attempt' {
+        { Invoke-WithRetry -Attempt 2 -DelaySeconds 1 -Action { throw 'always' } } | Should -Throw
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 1 -Exactly
+    }
+
+    It 'returns the output of the action' {
+        $result = Invoke-WithRetry -Attempt 2 -DelaySeconds 1 -Action { 'value' }
+        $result | Should -Be 'value'
+    }
+
+    It 'does not sleep when the delay is zero' {
+        { Invoke-WithRetry -Attempt 2 -DelaySeconds 0 -Action { throw 'always' } } | Should -Throw
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 0 -Exactly
+    }
+
+    It 'uses a constant delay by default' {
+        { Invoke-WithRetry -Attempt 3 -DelaySeconds 7 -Action { throw 'always' } } | Should -Throw
+        Should -Invoke Start-Sleep -ModuleName Retry -ParameterFilter { $Seconds -eq 7 } -Times 2 -Exactly
+    }
+
+    It 'applies exponential backoff capped at the maximum' {
+        { Invoke-WithRetry -Attempt 5 -DelaySeconds 2 -BackoffMultiplier 2 -MaxDelaySeconds 10 -Action { throw 'always' } } |
+            Should -Throw
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 4 -Exactly
+        Should -Invoke Start-Sleep -ModuleName Retry -ParameterFilter { $Seconds -eq 2 } -Times 1 -Exactly
+        Should -Invoke Start-Sleep -ModuleName Retry -ParameterFilter { $Seconds -eq 4 } -Times 1 -Exactly
+        Should -Invoke Start-Sleep -ModuleName Retry -ParameterFilter { $Seconds -eq 8 } -Times 1 -Exactly
+        Should -Invoke Start-Sleep -ModuleName Retry -ParameterFilter { $Seconds -eq 10 } -Times 1 -Exactly
+    }
+
+    It 'rethrows immediately without retrying when the RetryOn predicate returns false' {
+        $script:calls = 0
+        { Invoke-WithRetry -Attempt 4 -DelaySeconds 1 -RetryOn { $false } -Action { $script:calls++; throw 'fatal' } } |
+            Should -Throw
+        $script:calls | Should -Be 1
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 0 -Exactly
+    }
+
+    It 'retries while the RetryOn predicate returns true' {
+        $script:calls = 0
+        { Invoke-WithRetry -Attempt 3 -DelaySeconds 1 -RetryOn { $true } -Action { $script:calls++; throw 'transient' } } |
+            Should -Throw
+        $script:calls | Should -Be 3
+    }
+
+    It 'passes the caught error record to the RetryOn predicate' {
+        { Invoke-WithRetry -Attempt 2 -DelaySeconds 1 -RetryOn { param($e) $e.Exception.Message -match 'retry-me' } -Action { throw 'do not retry-me' } } |
+            Should -Throw
+        Should -Invoke Start-Sleep -ModuleName Retry -Times 1 -Exactly
+    }
+}
+
+Describe 'Test-TransientFailure' {
+    It 'treats a 5xx HTTP status as transient' {
+        Test-TransientFailure -Message 'HTTP 503: Service Unavailable' | Should -BeTrue
+    }
+
+    It 'treats rate limiting as transient' {
+        Test-TransientFailure -Message 'GraphQL: rate limit exceeded' | Should -BeTrue
+    }
+
+    It 'treats a dropped connection as transient' {
+        Test-TransientFailure -Message 'error: connection reset by peer' | Should -BeTrue
+    }
+
+    It 'treats a 404 as non-transient' {
+        Test-TransientFailure -Message 'gh: Not Found (HTTP 404)' | Should -BeFalse
+    }
+
+    It 'treats an auth failure as non-transient' {
+        Test-TransientFailure -Message 'gh: authentication required' | Should -BeFalse
+    }
+
+    It 'treats an empty message as non-transient' {
+        Test-TransientFailure -Message '' | Should -BeFalse
+    }
+}

--- a/scripts/utility/Retry.psm1
+++ b/scripts/utility/Retry.psm1
@@ -57,8 +57,9 @@ function Invoke-WithRetry {
 
 function Test-TransientFailure {
     # Heuristic predicate for Invoke-WithRetry's -RetryOn: does $Message look like a transient
-    # infrastructure fault worth retrying (server-side 5xx, rate-limiting, a network/TLS blip)
-    # rather than a deterministic failure (a 4xx, auth error, or bad request) that will fail
+    # infrastructure fault worth retrying (server-side 5xx, rate-limiting, a network/TLS blip, or a
+    # runner disk I/O error) rather than a deterministic failure (a 4xx, auth error, or bad request)
+    # that will fail
     # identically on every attempt? Deliberately conservative - an unrecognized message is treated
     # as NON-transient so a genuine error surfaces immediately instead of hiding behind slow retries.
     [CmdletBinding()]
@@ -84,7 +85,12 @@ function Test-TransientFailure {
         'temporary failure in name resolution',
         'network is unreachable',
         'TLS handshake',
-        'unexpected eof'
+        'unexpected eof',
+        # Runner disk I/O faults - the `os error 5` blip that motivated owning the toolchain step.
+        # Match the descriptive EIO text (rustc renders io errors as "<description> (os error N)")
+        # rather than the raw errno, which on Windows means access-denied and is often deterministic.
+        'input/output error',
+        'i/o error'
     ) -join '|'
 
     return [bool] ($Message -match "(?i)($transient)")

--- a/scripts/utility/Retry.psm1
+++ b/scripts/utility/Retry.psm1
@@ -1,0 +1,95 @@
+#requires -Version 7
+
+# Shared transient-fault retry helper for the CI tooling.
+#
+# Network and external-infrastructure operations (crates.io publishes, binary-tool downloads,
+# `rustup toolchain install`, read-only `gh` queries) fail intermittently for reasons that have
+# nothing to do with the operation itself - a runner disk hiccup, a rate-limit, a dropped TLS
+# handshake. Retrying the single failing operation is almost always enough to get past it, so the
+# retry lives here once, is exercised by Pester (Retry.Tests.ps1), and is imported by every module
+# that drives such an operation rather than each hand-rolling its own loop.
+#
+# It is deliberately the LOWEST-level seam: callers wrap the smallest possible unit (one download,
+# one `rustup` call) so a retry re-runs that unit alone, not the whole recipe. Only clearly
+# transient, idempotent operations should be wrapped - see docs in the consuming modules.
+
+Set-StrictMode -Version Latest
+
+function Invoke-WithRetry {
+    # Runs $Action, retrying up to $Attempt times when it throws, and rethrows the last failure if
+    # every attempt fails. The wait before each retry starts at $DelaySeconds and is multiplied by
+    # $BackoffMultiplier after each failure (so a multiplier > 1 gives exponential backoff), capped
+    # at $MaxDelaySeconds when that is greater than zero. The defaults (multiplier 1.0, no cap) give
+    # a constant delay, so a caller that passes only -Attempt/-DelaySeconds gets simple fixed-delay
+    # retries. Returns whatever $Action returns on the first successful attempt.
+    #
+    # By default it retries on ANY terminating error, so the caller must scope $Action to a
+    # genuinely transient, repeatable unit (a retried non-idempotent mutation can double its
+    # effect). Pass $RetryOn - a predicate that receives the caught ErrorRecord and returns $true
+    # only for retryable failures (e.g. Test-TransientFailure) - to retry selectively and rethrow a
+    # deterministic error immediately rather than burning every attempt on it.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][scriptblock] $Action,
+        [ValidateRange(1, [int]::MaxValue)][int] $Attempt = 3,
+        [ValidateRange(0, [int]::MaxValue)][int] $DelaySeconds = 5,
+        [ValidateRange(1.0, [double]::MaxValue)][double] $BackoffMultiplier = 1.0,
+        [ValidateRange(0, [int]::MaxValue)][int] $MaxDelaySeconds = 0,
+        [scriptblock] $RetryOn
+    )
+
+    $delay = $DelaySeconds
+    for ($n = 1; $n -le $Attempt; $n++) {
+        try {
+            return (& $Action)
+        } catch {
+            $retryable = if ($RetryOn) { [bool] (& $RetryOn $_) } else { $true }
+            if ($n -eq $Attempt -or -not $retryable) { throw }
+
+            Write-Warning "Attempt $n of $Attempt failed: $($_.Exception.Message). Retrying in $delay seconds..."
+            if ($delay -gt 0) { Start-Sleep -Seconds $delay }
+
+            $delay = [int][math]::Ceiling($delay * $BackoffMultiplier)
+            if ($MaxDelaySeconds -gt 0 -and $delay -gt $MaxDelaySeconds) { $delay = $MaxDelaySeconds }
+        }
+    }
+}
+
+function Test-TransientFailure {
+    # Heuristic predicate for Invoke-WithRetry's -RetryOn: does $Message look like a transient
+    # infrastructure fault worth retrying (server-side 5xx, rate-limiting, a network/TLS blip)
+    # rather than a deterministic failure (a 4xx, auth error, or bad request) that will fail
+    # identically on every attempt? Deliberately conservative - an unrecognized message is treated
+    # as NON-transient so a genuine error surfaces immediately instead of hiding behind slow retries.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [string] $Message
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) { return $false }
+
+    $transient = @(
+        'HTTP 5\d\d',
+        'rate limit',
+        'timed out',
+        'timeout',
+        'service unavailable',
+        'bad gateway',
+        'gateway time-?out',
+        'temporarily unavailable',
+        'connection reset',
+        'connection refused',
+        'could not resolve host',
+        'temporary failure in name resolution',
+        'network is unreachable',
+        'TLS handshake',
+        'unexpected eof'
+    ) -join '|'
+
+    return [bool] ($Message -match "(?i)($transient)")
+}
+
+Export-ModuleMember -Function `
+    Invoke-WithRetry, `
+    Test-TransientFailure

--- a/scripts/utility/Retry.psm1
+++ b/scripts/utility/Retry.psm1
@@ -59,9 +59,9 @@ function Test-TransientFailure {
     # Heuristic predicate for Invoke-WithRetry's -RetryOn: does $Message look like a transient
     # infrastructure fault worth retrying (server-side 5xx, rate-limiting, a network/TLS blip, or a
     # runner disk I/O error) rather than a deterministic failure (a 4xx, auth error, or bad request)
-    # that will fail
-    # identically on every attempt? Deliberately conservative - an unrecognized message is treated
-    # as NON-transient so a genuine error surfaces immediately instead of hiding behind slow retries.
+    # that will fail identically on every attempt? Deliberately conservative - an unrecognized
+    # message is treated as NON-transient so a genuine error surfaces immediately instead of hiding
+    # behind slow retries.
     [CmdletBinding()]
     [OutputType([bool])]
     param(


### PR DESCRIPTION
[Copilot speaking]

## Why

A `test-docs (macos-latest)` job died when `rustup toolchain install` (inside `dtolnay/rust-toolchain@master`) hit a transient runner disk fault (`os error 5`) — a fault that has nothing to do with the operation itself and that no retry existed to absorb. Transient infrastructure faults (HTTP 5xx, rate limits, dropped connections, disk blips) should be retried automatically, and at the **lowest feasible level** so a single flaky item is re-attempted in place rather than restarting the whole job.

## What changed

- **`scripts/utility/Retry.psm1`** (new) — shared, Pester-tested `Invoke-WithRetry` (exponential backoff capped at a ceiling, optional `-RetryOn` predicate) and a `Test-TransientFailure` classifier so callers can retry only genuinely transient faults.
- **`scripts/setup/RustToolchain.psm1`** (new) — in-repo, Pester-tested replacement for `dtolnay/rust-toolchain@master`. Reads the pinned stable channel from `rust-toolchain.toml` (single source of truth), wraps `rustup toolchain install` in an item-level retry, and sets the Cargo env vars the pipeline relies on. Wired into `.github/actions/setup-environment/action.yml`, so every job using the composite (~20 validation jobs) benefits, and a floating `@master` marketplace dependency is dropped.
- **Tool downloads** — `install-actionlint.ps1`, `install-shellcheck.ps1`, `install-azcopy.ps1` now retry the download **and** re-verify the checksum, so a truncated payload re-downloads rather than being trusted.
- **`gh` reads** — the bench-history modules gain an `Invoke-GhCapture -RetryOnFailure` switch, applied **only** to idempotent list/read calls. Non-idempotent mutations (issue/comment create/edit/close/delete) are deliberately left un-retried, and reads that already degrade gracefully are untouched.
- **`scripts/release/ReleaseAutomation.psm1`** — refactored onto the shared helper (its private retry copy removed); release cadence unchanged.
- **Doctrine** — a "Transient-fault handling" section added to `.github/workflows/design.md`.
- **Incidental fix** — a latent `Substring` crash in the `just validate-scripts` reporting path (which masked real findings) is now guarded.

## Validation

- `just test-scripts` — 335 passed
- `just validate-scripts` — clean (PSScriptAnalyzer)
- `just validate-workflows` — clean (actionlint)

Retries are scoped to transient, idempotent operations; deterministic failures (4xx, auth, bad request) still surface immediately.