### PR TITLE
Rename bench-history `resolve` job to `resolve-alert`

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -48,7 +48,7 @@ concurrency:
 
 # Title of the rolling failure-alert issue, defined once and shared by the two jobs that
 # reference it: the `alert` job files it under this exact title (via the shared
-# gh-file-rolling-issue recipe), and the `resolve` job matches on it to close that issue.
+# gh-file-rolling-issue recipe), and the `resolve-alert` job matches on it to close that issue.
 # The rolling-issue filing dedups solely by exact title, so this string is the alert's
 # identity; a single definition keeps the open and close paths from drifting apart.
 env:
@@ -390,11 +390,11 @@ jobs:
       # Compose the failure-alert body (interpolating the failed run's URL) into the runner temp
       # dir, then file it with the same Publish-RollingIssue seam the regression path uses - one
       # rolling issue keyed on $FAILURE_ISSUE_TITLE, updated rather than duplicated on each failing
-      # run, and auto-closed by the `resolve` job once the workflow is green again. The ci-failure
-      # label is what `resolve` narrows its close search to. The module is imported directly (not
+      # run, and auto-closed by the `resolve-alert` job once the workflow is green again. The ci-failure
+      # label is what `resolve-alert` narrows its close search to. The module is imported directly (not
       # via `just`) because this lightweight notifier deliberately skips the build-environment
       # setup - the same shape (checkout + preinstalled gh CLI + module import, no build-env setup)
-      # as the sibling `resolve` job's own close step.
+      # as the sibling `resolve-alert` job's own close step.
       - name: Open or update failure issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -428,7 +428,7 @@ jobs:
             -Verbose
           Write-Host "Failure alert issue: $url"
 
-  resolve:
+  resolve-alert:
     # Mirror of `alert`: when collection AND analysis are green again, auto-close the
     # rolling failure issue (if one is open) so a fixed run does not leave a stale
     # alert rotting open. Gated on the needs' results explicitly (rather than the implicit

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -544,7 +544,7 @@ jobs:
   # comment left by an EARLIER iteration of the same PR - e.g. a benchmarked change that was later
   # reverted - so a stale, misleading comment does not linger. A no-op when there is no such comment.
   # Deliberately lightweight (checkout + preinstalled gh + direct module import, no build-env setup,
-  # no Azure, no history), mirroring bench-history.yml's alert/resolve jobs.
+  # no Azure, no history), mirroring bench-history.yml's alert/resolve-alert jobs.
   cleanup:
     needs: delta
     if: needs.delta.outputs.skip_all == 'true'

--- a/scripts/bench-history/BenchHistoryIssue.psm1
+++ b/scripts/bench-history/BenchHistoryIssue.psm1
@@ -74,7 +74,7 @@ function Invoke-GhCapture {
 function Get-OpenIssueByTitle {
     # Returns the first OPEN issue whose title equals $Title exactly, or $null when none matches.
     # The list is narrowed to $Label so only a handful of issues come back, then the exact-title
-    # match is done client-side - the same list-then-match approach the workflow's `resolve` job
+    # match is done client-side - the same list-then-match approach the workflow's `resolve-alert` job
     # uses to find the failure-alert issue, which avoids the eventual-consistency lag of the GitHub
     # search index that a `gh issue list --search`/`gh search issues` query would hit. Isolates the
     # real `gh issue list` call so the tests can mock it.
@@ -141,7 +141,7 @@ function Publish-RollingIssue {
 
 function Close-RollingIssue {
     # Closes EVERY open issue whose title equals $Title exactly among those carrying $Label, each
-    # with an audit $Comment. The mirror image of Publish-RollingIssue: the workflow's `resolve` job
+    # with an audit $Comment. The mirror image of Publish-RollingIssue: the workflow's `resolve-alert` job
     # calls this once the pipeline is green again so a fixed run does not leave the rolling
     # failure-alert issue rotting open. Closing ALL matches (not just the first) sweeps any backlog
     # of historical duplicates in one pass - the same list-then-exact-title approach


### PR DESCRIPTION
[Copilot speaking]

Renames the push-flow bench-history workflow's terminal cleanup job from `resolve` to `resolve-alert`.

## Why

The job that closes the rolling CI-failure issue was named `resolve`, which is ambiguous about *what* gets resolved. Renaming it to `resolve-alert` makes it read as the symmetric counterpart of its sibling `alert` job (which opens the same issue): `alert` files the failure issue, `resolve-alert` closes it.

## What

- `.github/workflows/bench-history.yml` — the `resolve:` job key becomes `resolve-alert:`, plus the four comment references to it.
- `scripts/bench-history/BenchHistoryIssue.psm1` — two comment references updated.
- `.github/workflows/pr-bench-history.yml` — one cross-reference comment updated.

Comment-and-job-name only; no behavioral change. The job is terminal (nothing has `needs: resolve`), so no other job wiring is affected. `just validate-workflows` (actionlint) passes.

This is unrelated cleanup extracted out of an in-progress design branch to keep that diff focused.
