### PR TITLE
Remove machine-independent ("synthetic") benchmark concept

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -130,8 +130,8 @@ jobs:
           Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
           Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
-      # The deterministic engines (Callgrind, allocation/time counters) are hardware-independent; the
-      # wall-clock engines are partitioned by each runner's OWN real hardware fingerprint (see the
+      # Every engine — Callgrind and the allocation/time counters included — is partitioned by each
+      # runner's OWN real hardware fingerprint (see the
       # gh-collect-bench-history recipe) so a heterogeneous runner pool splits into one clean series
       # per SKU rather than one jittery mixed series. RECOLLECT_COMMIT_ID (empty on a push/plain
       # dispatch) switches the recipe from appending the pushed commit to re-measuring and OVERWRITING

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -7,13 +7,14 @@
 
 # Collects the whole workspace's benchmark history (excluding the slow, special-purpose
 # `benchmarks` package) into the prod Azure store, keyed by the current commit. The machine
-# partition for noisy wall-clock engines is the runner's OWN auto-detected hardware fingerprint,
+# partition for every engine is the runner's OWN auto-detected hardware fingerprint,
 # NOT a fixed key: the GitHub-hosted runner pool is heterogeneous, and pinning every SKU onto one
-# synthetic series just mixes incomparable machines and jitters daily. Letting each runner stamp
+# shared series just mixes incomparable machines and jitters daily. Letting each runner stamp
 # its real fingerprint splits the data into one clean series per hardware type; the analyze job is
 # fed the exact fingerprints collected this run (see gh-analyze-bench-history) so it surveys only
-# those series. Deterministic engines (Callgrind, allocation/time counters) are hardware-independent
-# and ignore the key. `--best-of 3` counteracts the same runner noise from the other direction: the
+# those series. Every engine is partitioned this way — even Callgrind and the allocation/time
+# counters, whose simulated figures still vary across microarchitectures as libraries dispatch to
+# different code paths. `--best-of 3` counteracts the same runner noise from the other direction: the
 # suite runs three times and each metric keeps its minimum sample, since benchmark interference
 # on a shared runner is one-sided (it only ever makes a case slower) and the runs are spaced far
 # enough apart in time that a transient slowdown is unlikely to hit every one. This roughly
@@ -146,9 +147,10 @@ gh-write-bench-history-machine-key file:
 # repeated `--machine-key <fingerprint>` args via the Pester-tested Get-MachineKeyArgument (see
 # scripts/bench-history/BenchHistoryMachineKey.psm1). Threading the exact keys (rather than
 # `--machine-key all`) keeps the survey scoped to the machines that actually measured this commit and
-# never mixes in a stray key some other machine inserted into the shared store. Only hardware-
-# DEPENDENT engines partition by machine key; deterministic engines (Callgrind, alloc/time counters)
-# are exempt from the machine-key filter inside the tool, so they are analyzed regardless.
+# never mixes in a stray key some other machine inserted into the shared store. Every engine
+# partitions by machine key now — Callgrind and the alloc/time counters included, since their
+# simulated figures still vary across microarchitectures — so the threaded fingerprints scope the
+# whole survey uniformly to the machines that measured this commit.
 #
 # {{keydir}} may be EMPTY when every collect leg failed (a total collect failure uploads nothing):
 # there is then no new data at this commit to survey, so the recipe writes a non-notable placeholder

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -3,8 +3,8 @@
 //! Each mode is run through the real public [`run_with_overrides`] entry point, so
 //! the measured path is exactly production data-loading and detection — only the
 //! data underneath is synthetic. The facet filters are forced to `all` because the
-//! seeded triples and the `synthetic` machine key never match the host the harness
-//! runs on; without that every object would be filtered out.
+//! seeded triples and the seeded machine key never match the host the harness runs
+//! on; without that every object would be filtered out.
 
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
@@ -106,7 +106,7 @@ pub(crate) async fn measure(
     let options = build_options(workspace, repo, mode, storage, logger.verbose());
     logger.step(&format!("analyzing in {} mode", mode.keyword()));
     logger.detail_with(|| format!(
-        "context={}, base={}, facets forced to all (seeded triples and the synthetic machine key \
+        "context={}, base={}, facets forced to all (seeded triples and the seeded machine key \
          never match the host), repeats={repeat}",
         options.context.as_deref().unwrap_or(""),
         options.base.as_deref().unwrap_or(""),

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -105,12 +105,14 @@ pub(crate) async fn measure(
 ) -> Result<MeasureResult, Error> {
     let options = build_options(workspace, repo, mode, storage, logger.verbose());
     logger.step(&format!("analyzing in {} mode", mode.keyword()));
-    logger.detail_with(|| format!(
-        "context={}, base={}, facets forced to all (seeded triples and the seeded machine key \
+    logger.detail_with(|| {
+        format!(
+            "context={}, base={}, facets forced to all (seeded triples and the seeded machine key \
          never match the host), repeats={repeat}",
-        options.context.as_deref().unwrap_or(""),
-        options.base.as_deref().unwrap_or(""),
-    ));
+            options.context.as_deref().unwrap_or(""),
+            options.base.as_deref().unwrap_or(""),
+        )
+    });
 
     let command = Command::Analyze(options);
 

--- a/packages/cargo-bench-history-stress/src/scenario.rs
+++ b/packages/cargo-bench-history-stress/src/scenario.rs
@@ -128,8 +128,8 @@ const TRIPLES: [&str; 6] = [
     "aarch64-apple-darwin",
 ];
 
-/// Machine key for the hardware-dependent engines, whose series are partitioned
-/// per machine. The synthetic dataset attributes them all to one fixed rig.
+/// Machine key every engine partitions under, since every series is per-machine.
+/// The stress dataset attributes them all to one fixed rig.
 const MACHINE_KEY: &str = "stress-rig";
 
 /// Whether `triple` targets Linux — the only platform Callgrind can run on (it
@@ -142,20 +142,18 @@ fn targets_linux(triple: &str) -> bool {
 /// triples it can run on.
 ///
 /// Callgrind is gated to Linux because Valgrind runs there only; the other engines
-/// span all six triples. Hardware-dependent engines (Criterion, `all_the_time`)
-/// carry a [`MACHINE_KEY`]; the hardware-independent ones (Callgrind,
-/// `alloc_tracker`) use the literal `synthetic` machine key. The data is not meant
-/// to be realistic across engines — the point is that every engine's partition is
-/// populated so `analyze` exercises each one.
+/// span all six triples. Every engine is machine-keyed, so every set carries the
+/// [`MACHINE_KEY`]. The data is not meant to be realistic across engines — the
+/// point is that every engine's partition is populated so `analyze` exercises each
+/// one.
 pub(crate) fn discriminant_sets() -> Vec<DiscriminantSet> {
     let mut sets = Vec::new();
     for engine in Engine::ALL {
-        let machine = engine.is_hardware_dependent().then_some(MACHINE_KEY);
         for triple in TRIPLES {
             if engine == Engine::Callgrind && !targets_linux(triple) {
                 continue;
             }
-            sets.push(DiscriminantSet::new(engine, triple, machine));
+            sets.push(DiscriminantSet::new(engine, triple, MACHINE_KEY));
         }
     }
     sets
@@ -165,10 +163,12 @@ pub(crate) fn discriminant_sets() -> Vec<DiscriminantSet> {
 ///
 /// Deterministic engines record an exact integer count with no dispersion; noisy
 /// engines record the estimate plus a tight confidence band, mirroring a real run
-/// so the noise-aware gates have the dispersion they need.
+/// so the noise-aware gates have the dispersion they need. This split is a
+/// property of the stress dataset only, not a claim about which engines are
+/// machine-dependent (every engine is).
 pub(crate) fn metric_for(engine: Engine, value: f64) -> Metric {
     let kind = primary_metric(engine);
-    if engine.is_hardware_dependent() {
+    if matches!(engine, Engine::Criterion | Engine::AllTheTime) {
         let std_dev = value * NOISE_FRACTION;
         let half = std_dev * NOISE_CI_Z;
         Metric::new(kind, value).with_dispersion(
@@ -429,14 +429,9 @@ mod tests {
             }
         }
 
-        // Hardware-dependent engines carry the machine key; the others are synthetic.
+        // Every engine is machine-keyed, so every set carries the machine key.
         for set in &sets {
-            let engine = Engine::from_name(&set.engine).expect("known engine");
-            if engine.is_hardware_dependent() {
-                assert_eq!(set.machine_key, MACHINE_KEY, "{}", set.engine);
-            } else {
-                assert!(set.is_synthetic(), "{}", set.engine);
-            }
+            assert_eq!(set.machine_key, MACHINE_KEY, "{}", set.engine);
         }
 
         // No two sets collide on their storage key.

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -399,7 +399,7 @@ mod tests {
         let sets = vec![DiscriminantSet::new(
             Engine::Callgrind,
             "x86_64-unknown-linux-gnu",
-            None,
+            "stress-rig",
         )];
         let repo = main_only_repo(4);
         let scenario = Scenario {

--- a/packages/cargo-bench-history/README.md
+++ b/packages/cargo-bench-history/README.md
@@ -23,9 +23,9 @@ Analyzed project folo (branch mode)
   commit: 4f2a1c9
   runs: 218 (9c1d0ab → 4f2a1c9)  regressions: 1  improvements: 1
 
-callgrind/x86_64-unknown-linux-gnu/synthetic
+callgrind/x86_64-unknown-linux-gnu/a1b2c3d4e5f60718
   runs: 218  regressions: 1  improvements: 1
-  filter: --engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic
+  filter: --engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key a1b2c3d4e5f60718
 
 many_cpus/hardware_info/query
   +13.00% instruction_count (99% confidence)

--- a/packages/cargo-bench-history/book/src/commands/collect.md
+++ b/packages/cargo-bench-history/book/src/commands/collect.md
@@ -51,5 +51,5 @@ verbatim.
 
 Regardless of `--verbose`, `collect` prints a one-line effective-partition summary to
 stderr naming the storage partition its results land in: the target triple and the machine
-key that hardware-dependent engines use, marked as auto-detected or as coming from
+key every engine is partitioned by, marked as auto-detected or as coming from
 `--machine-key`.

--- a/packages/cargo-bench-history/book/src/commands/machine-key.md
+++ b/packages/cargo-bench-history/book/src/commands/machine-key.md
@@ -1,16 +1,17 @@
 # machine-key
 
-Prints this machine's hardware fingerprint — the key that hardware-dependent history is
-partitioned by.
+Prints this machine's hardware fingerprint — the key every engine's history is partitioned
+by.
 
 ```console
 cargo bench-history machine-key
 ```
 
-Hardware-dependent engines (Criterion wall-clock time, `all_the_time` CPU time) are only
-comparable across runs on the same class of hardware, so their history is partitioned by this
-machine key. Hardware-independent engines (Callgrind instruction counts, `alloc_tracker`
-allocations) use a literal `synthetic` placeholder instead.
+Every engine's numbers are machine-dependent in practice — Criterion wall-clock time and
+`all_the_time` CPU time obviously, but Callgrind instruction counts and `alloc_tracker`
+allocations too, because libraries dispatch to different code paths on different
+microarchitectures. So every engine's history is partitioned by this machine key, and runs
+from different machines are never mixed.
 
 `--verbose` additionally reports the factors behind the key on standard error, for tracing a
 key change to the hardware detail that moved.

--- a/packages/cargo-bench-history/book/src/concepts/comparability.md
+++ b/packages/cargo-bench-history/book/src/concepts/comparability.md
@@ -10,10 +10,11 @@ is `{ project, engine, target_triple, machine_key }`:
 
 - **`project`** — workspace identity (configured, defaulting to the repository directory name).
 - **`engine`** — different units and semantics never mix.
-- **`target_triple`** — even hardware-independent counts are not comparable across
+- **`target_triple`** — even simulated counts are not comparable across
   architectures.
-- **`machine_key`** — always present: the machine fingerprint for hardware-dependent engines,
-  and the literal `synthetic` for hardware-independent ones. See [machine-key](../commands/machine-key.md).
+- **`machine_key`** — always present: a fingerprint of the host the benchmark ran on. Every
+  engine is partitioned by it, because every engine's numbers vary with the hardware in
+  practice. See [machine-key](../commands/machine-key.md).
 
 Deliberately **metadata, not partition** — so a change shows up as a timeline step, which is
 the whole point of the tool — are the toolchain versions, OS/libc, commit, branch, and

--- a/packages/cargo-bench-history/book/src/concepts/engines.md
+++ b/packages/cargo-bench-history/book/src/concepts/engines.md
@@ -1,18 +1,19 @@
 # Benchmark engines
 
 `cargo-bench-history` supports four benchmark engines. It does not run them by name — it
-enables the combined environment they all need and harvests whichever produced output. The
-engines split along two axes that drive the whole data model: **hardware-dependent vs.
-hardware-independent** (which decides partitioning), and **whether each measurement carries a
-confidence interval** (which decides how dispersion is gated). No engine is exempt from
-run-to-run noise.
+enables the combined environment they all need and harvests whichever produced output. What
+drives the data model is **whether each measurement carries a confidence interval** (which
+decides how dispersion is gated). No engine is exempt from run-to-run noise, and every
+engine's numbers are machine-dependent in practice — even simulated instruction counts and
+allocation figures vary with the host, because libraries dispatch to different code paths on
+different microarchitectures — so every engine is partitioned by machine key.
 
-| Engine | Measures | Hardware | Confidence interval |
-|---|---|---|---|
-| **Criterion** | Wall-clock time | Dependent | Yes |
-| **Callgrind** (via Gungraun) | Simulated instruction / branch counts | Independent | No (single value) |
-| **`alloc_tracker`** | Heap allocations (bytes and counts) | Independent | Yes |
-| **`all_the_time`** | Processor (CPU) time | Dependent | Yes |
+| Engine | Measures | Confidence interval |
+|---|---|---|
+| **Criterion** | Wall-clock time | Yes |
+| **Callgrind** (via Gungraun) | Simulated instruction / branch counts | No (single value) |
+| **`alloc_tracker`** | Heap allocations (bytes and counts) | Yes |
+| **`all_the_time`** | Processor (CPU) time | Yes |
 
 ## Why no engine is deterministic
 
@@ -35,6 +36,6 @@ never parsed or persisted.
 
 ## Shared shape
 
-Despite differing in units, noise, and hardware-dependence, all four engines reduce to the
+Despite differing in units and noise, all four engines reduce to the
 same shape: *a stable benchmark identity → a set of named numeric metrics*. Every persisted
 metric is **lower-is-better**, so a rise is always a regression and a fall an improvement.

--- a/packages/cargo-bench-history/book/src/getting-started.md
+++ b/packages/cargo-bench-history/book/src/getting-started.md
@@ -34,7 +34,7 @@ cargo bench-history analyze --local=./bench-history
 cargo bench-history examine --local=./bench-history \
     --benchmark my_pkg/my_group/my_case --metric instruction_count
 
-# Print this machine's hardware fingerprint (the key that hardware-dependent history is
+# Print this machine's hardware fingerprint (the key every engine's history is
 # partitioned by).
 cargo bench-history machine-key
 ```

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -17,10 +17,12 @@ not otherwise comparable. Its commands are `collect`, `install`, `analyze`, `exa
 ## 1. Benchmark engines and what they emit
 
 Understanding the producers is mandatory: comparability and parsing both depend on it.
-Four engines are supported, and they split along two axes that drive the whole data
-model — **hardware-dependent vs. hardware-independent** (which decides partitioning), and
-**whether each measurement carries a confidence interval** (which decides how dispersion is
-gated). No engine is exempt from run-to-run noise.
+Four engines are supported. The axis that drives the data model is **whether each
+measurement carries a confidence interval** (which decides how dispersion is gated). No
+engine is exempt from run-to-run noise, and every engine's numbers are machine-dependent
+in practice — even simulated instruction counts and allocation figures vary with the host,
+because libraries dispatch to different code paths on different microarchitectures — so
+every engine is partitioned by machine key (see §3).
 
 * **Criterion** — wall-clock time. Hardware-dependent and noisy. Each measured case
   yields a stable identity (group / function / value) and a point estimate (the
@@ -28,19 +30,21 @@ gated). No engine is exempt from run-to-run noise.
   deviation and bootstrap confidence interval. It records no timestamp, commit, machine,
   or package, so the tool supplies all run context.
 * **Callgrind (via Gungraun)** — simulated instruction and branch-execution counts.
-  Hardware-independent but not exact: a CPU simulator is low-noise, yet its counts still
-  drift by a few percent run to run. Only the build-stable events are tracked — the
-  instruction count (`Ir`) and the two branch-execution counts (`Bc`, `Bi`). Gungraun also
-  emits cache-simulation counts (`L1hits`/`LLhits`/`RamHits`), the derived `EstimatedCycles`,
+  Low-noise but not exact: a CPU simulator is low-noise, yet its counts still drift by a
+  few percent run to run, and they vary across microarchitectures as libraries dispatch to
+  different code paths. Only the build-stable events are tracked — the instruction count
+  (`Ir`) and the two branch-execution counts (`Bc`, `Bi`). Gungraun also emits
+  cache-simulation counts (`L1hits`/`LLhits`/`RamHits`), the derived `EstimatedCycles`,
   and the branch-misprediction counts (`Bcm`/`Bim`), but those are **not** parsed or
   persisted: at microbenchmark magnitudes they track binary layout rather than the code under
   test, so they cannot be compared across builds (see §8). Its machine-readable summary is the
   one output that must be opted into with an environment variable — the narrow "special need"
   that justifies `collect` existing at all.
-* **`alloc_tracker`** — heap allocations (bytes and counts). Hardware-independent but not
-  deterministic: warmup and buffer-resize allocations are amortized over a Criterion-chosen
-  iteration count, so the per-iteration figures jitter. It prefers a warmup-robust slope and
-  records a bootstrap confidence interval over its measured spans when its output carries one.
+* **`alloc_tracker`** — heap allocations (bytes and counts). Not deterministic: warmup and
+  buffer-resize allocations are amortized over a Criterion-chosen iteration count, so the
+  per-iteration figures jitter, and they too vary with the host's library code paths. It
+  prefers a warmup-robust slope and records a bootstrap confidence interval over its
+  measured spans when its output carries one.
 * **`all_the_time`** — processor (CPU) time. Hardware-dependent and noisy, carrying a
   bootstrap confidence interval like Criterion.
 
@@ -48,7 +52,7 @@ The two workspace-local crates (`alloc_tracker`, `all_the_time`) each auto-emit 
 JSON file per operation on drop, so they need no opt-in and the operation name alone
 identifies the series.
 
-Despite differing in units, noise, and hardware-dependence, all four reduce to the same
+Despite differing in units and noise, all four reduce to the same
 shape: *a stable benchmark identity → a set of named numeric metrics*. That shared shape
 is the foundation of the model.
 
@@ -93,23 +97,23 @@ flowchart LR
   timestamp override.
 * **Discriminant set** — the partition under which a series accumulates. Two results are
   comparable exactly when their discriminant sets match.
-* **Machine key** — a stable hardware fingerprint used only by hardware-dependent
-  engines.
+* **Machine key** — a stable hardware fingerprint that partitions every engine's data by
+  the host it ran on.
 
 ## 3. Comparability and storage partitioning
 
 The central tenet: **partition only by what makes results fundamentally incomparable;
 record everything else as metadata so the analysis can see its effect over time.**
 
-A discriminant set is `{ project, engine, target_triple, machine_key? }`:
+A discriminant set is `{ project, engine, target_triple, machine_key }`:
 
 * `project` — workspace identity (configured, defaulting to the repository directory
   name).
 * `engine` — different units and semantics never mix.
-* `target_triple` — even hardware-independent counts are not comparable across
+* `target_triple` — even simulated counts are not comparable across
   architectures (`…-windows-msvc` and `…-windows-gnu` are genuinely different binaries).
-* `machine_key` — present only for hardware-dependent engines; a literal `synthetic`
-  placeholder for the hardware-independent ones.
+* `machine_key` — a stable fingerprint of the host the benchmark ran on; every engine is
+  partitioned by it, because every engine's numbers vary with the hardware in practice.
 
 Deliberately **metadata, not partition** — so a change shows up as a timeline step, which
 is the whole point of the tool — are the toolchain versions, OS/libc, commit, branch, and
@@ -135,7 +139,7 @@ filesystem and a blob container (no read-modify-write races in concurrent CI). T
 shape is:
 
 ```
-<root>/v1/<project>/objects/<engine>/<target_triple>/<machine|synthetic>/<commit>/
+<root>/v1/<project>/objects/<engine>/<target_triple>/<machine>/<commit>/
     clean.json                    # ≤1 per commit — the canonical point for a clean tree
     dirty-<observation_unix>.json # 0..N snapshots taken on top of this base commit
 ```
@@ -177,15 +181,11 @@ dimension confused users — filter on the triple directly.)
 Each facet is repeatable, unions its values, and accepts the literal `all` to widen past a
 dimension. Omitting a facet **auto-detects the current machine**: the triple defaults to
 the host triple and the machine key to the host fingerprint, so a bare query reports *this*
-machine's data; engine has no machine-derived value, so it defaults to all engines. A
-`synthetic` set always passes the **machine-key** facet regardless of its value (it carries
-no machine), so auto-detecting the host fingerprint still includes the hardware-independent
-sets. It still obeys the **target-triple** facet, though — a per-architecture instruction
-count or allocation profile is a distinct measurement — so a bare query mixes in only the
-synthetic sets built for *this* triple, never foreign-triple ones. Because that inclusion is
-easy to overlook, a query whose machine-key facet was auto-detected prints a one-line notice
-that machine-independent `synthetic` benchmarks ride along. A facet that matches several
-sets yields one report per set — parallel data sets analyzed individually.
+machine's data; engine has no machine-derived value, so it defaults to all engines. Every
+engine is partitioned by machine key, so a bare query scopes every engine uniformly to
+*this* host's fingerprint — nothing rides along across machines, and no set is exempt from
+the machine-key facet. A facet that matches several sets yields one report per set —
+parallel data sets analyzed individually.
 
 The commands divide into **create** and **query** roles. `collect` and `backfill` record
 new data into exactly one machine's reality, so they auto-detect every facet and accept
@@ -211,7 +211,16 @@ Because the key is persisted and compared across machines and tool versions, it 
 truncated to a compact path segment, and a golden test pins a fixed profile to its digest
 so an accidental change to the canonical form is caught. A command-line override wins over
 the computed fingerprint (it is CLI-only — a committed config would carry a machine key
-wrong for some checkouts). The key is computed only for hardware-dependent engines.
+wrong for some checkouts). The key is computed for every run, because every engine is
+partitioned by it.
+
+There is no machine-independent partition: every engine — Callgrind instruction counts and
+`alloc_tracker` allocations included — is keyed by the host fingerprint, because those
+figures vary with the microarchitecture in practice. The string `synthetic` carries no
+special meaning; it is an ordinary machine-key value like any other. Historical data that
+earlier tool versions stored under a literal `synthetic` placeholder is not migrated: those
+series restart under the runner's real fingerprint at the changeover, and the old objects
+stay reachable only via an explicit `--machine-key synthetic` (or `--machine-key all`).
 
 The individual factors behind the fingerprint (the version tag, processor and memory-region
 counts, processor models, and the per-processor speed histogram) are surfaced for debugging:
@@ -413,7 +422,7 @@ commit.
 
 Regardless of `--verbose`, `collect` prints a one-line **effective-partition** summary to
 stderr naming the storage partition its results land in: the target triple (always the
-toolchain host) and the machine key hardware-dependent engines use — marked as
+toolchain host) and the machine key every engine is partitioned by — marked as
 auto-detected or as coming from `--machine-key`. This makes the otherwise-invisible
 auto-detected partition self-describing on every run. `backfill` reuses the same `collect`
 path and so emits the line per commit, each reflecting that commit's own probed toolchain.
@@ -671,14 +680,14 @@ opts into dirty-snapshot keying.
 Four overrides let a caller attribute an imported run to a context other than the current
 host, and they touch **only key-affecting discriminants** — body provenance stays real.
 `--target-triple` sets both the storage-partition triple and the recorded toolchain target
-triple. `--machine-key` sets the machine partition of the hardware-dependent engines only
-(Callgrind and `alloc_tracker` remain `synthetic`); the recorded `MachineInfo` stays the
-real host's. `--commit` is **resolved through git** (an unknown commit is a hard error) and
-keys the run to any existing commit — typically an ancestor — **without checking it out**,
-clearing the branch to `None`; this lets a test attribute a whole synthetic series across
-history from a single HEAD position. `--dirty` records the run as a dirty snapshot rather
-than a clean point. The commit must still exist: `import` never invents git topology, so
-real integration testing still requires a real history.
+triple. `--machine-key` sets the machine partition of every engine (every engine is
+machine-keyed); the recorded `MachineInfo` stays the real host's. `--commit` is **resolved
+through git** (an unknown commit is a hard error) and keys the run to any existing commit —
+typically an ancestor — **without checking it out**, clearing the branch to `None`; this
+lets a test attribute a whole synthetic series across history from a single HEAD position.
+`--dirty` records the run as a dirty snapshot rather than a clean point. The commit must
+still exist: `import` never invents git topology, so real integration testing still requires
+a real history.
 
 ## 8. Analysis
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -222,9 +222,3 @@ other selection-driven commands emit the same line through one shared announceme
 the `bless` / `unbless` mutation commands name the facets and the context commit they act at
 (`bless` also names its base branch), so the wording is identical wherever auto-detection can
 surprise you.
-
-When the machine-key facet was auto-detected, the same channel adds one more line noting that
-machine-independent `synthetic` benchmarks (Callgrind, `alloc_tracker`) ride along: they carry
-no machine key, so the host-fingerprint default cannot exclude them. They still obey the
-target-triple facet, so this only mixes in the synthetic sets built for the queried triple —
-the notice explains an inclusion that is otherwise easy to miss.

--- a/packages/cargo-bench-history/docs/book.md
+++ b/packages/cargo-bench-history/docs/book.md
@@ -99,14 +99,14 @@ concept pages link up into the commands that exercise them.
 | `list` | Preview the exact data set `analyze` would consume (`runs` / `discriminants` / `blessings`) without analyzing. |
 | `prune` | Delete a chosen scope of stored data; never touches base-branch history without an explicit confirm. |
 | `bless` / `unbless` | Manually accept an intentional change so history stops re-flagging it; per-benchmark; honored only in history mode. |
-| `machine-key` | Print the hardware fingerprint that hardware-dependent history is partitioned by; `--verbose` explains the factors. |
+| `machine-key` | Print the hardware fingerprint that all history is partitioned by; `--verbose` explains the factors. |
 
 ### Part 3 — Concepts
 
 #### Benchmark engines
 
-- **Goal**: the four engines and the two axes that drive the data model.
-- **Teach**: hardware-dependent vs. -independent (drives partitioning) and confidence-interval vs.
+- **Goal**: the four engines and the axis that drives the data model.
+- **Teach**: every engine is machine-keyed (so partitioning is uniform) and confidence-interval vs.
   single-value (drives dispersion gating); *why no engine is deterministic* (tenet 2); what
   Callgrind deliberately persists vs. discards; the shared identity→metrics shape and
   lower-is-better.

--- a/packages/cargo-bench-history/src/commands/backfill.rs
+++ b/packages/cargo-bench-history/src/commands/backfill.rs
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn commit_of_clean_key_extracts_the_commit_only_for_clean_objects() {
         assert_eq!(
-            commit_of_clean_key("v1/proj/objects/callgrind/triple/synthetic/abc123/clean.json"),
+            commit_of_clean_key("v1/proj/objects/callgrind/triple/m1/abc123/clean.json"),
             Some("abc123")
         );
         // A dirty snapshot is not a backfilled commit.
@@ -991,7 +991,7 @@ mod tests {
         // Two engines record c0 (under different partitions); c1 has only a dirty
         // snapshot; a different project's clean run must not leak in.
         block_on(storage.put(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json",
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json",
             b"{}",
         ))
         .unwrap();
@@ -1006,7 +1006,7 @@ mod tests {
         ))
         .unwrap();
         block_on(storage.put(
-            "v1/other/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c9/clean.json",
+            "v1/other/objects/callgrind/x86_64-unknown-linux-gnu/m1/c9/clean.json",
             b"{}",
         ))
         .unwrap();
@@ -1175,7 +1175,7 @@ mod tests {
         assert_eq!(empty, CommitOutcome::SkippedEmpty);
 
         let duplicate = map_collect_result(Err(RunError::Duplicate {
-            key: "v1/p/objects/callgrind/t/synthetic/abc/clean.json".to_owned(),
+            key: "v1/p/objects/callgrind/t/m1/abc/clean.json".to_owned(),
         }))
         .unwrap();
         assert_eq!(duplicate, CommitOutcome::SkippedExisting);

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -227,7 +227,7 @@ pub(crate) struct SharedContext {
     /// host triple `rustc` reports for `collect`, or an `import --target-triple`
     /// override. It feeds both the partition key and `ToolchainInfo.target_triple`.
     pub(crate) target_triple: String,
-    /// Host hardware profile, fingerprinted for hardware-dependent engines.
+    /// Host hardware profile, fingerprinted into the machine key.
     pub(crate) hardware: HardwareProfile,
 }
 
@@ -281,8 +281,8 @@ pub(crate) struct FinalizeDeps<'a, S> {
 /// `--dirty` by `import`), keeping the stored body and its key coherent by
 /// construction.
 pub(crate) struct StoreParams<'a> {
-    /// Explicit machine-key override for hardware-dependent engines; `None` uses
-    /// the auto-detected fingerprint.
+    /// Explicit machine-key override applied to every engine; `None` uses the
+    /// auto-detected fingerprint.
     pub(crate) machine_key: Option<&'a str>,
     /// Replace an existing object in place instead of failing on a collision.
     pub(crate) overwrite: bool,
@@ -494,10 +494,10 @@ where
 {
     // The always-on effective-partition announcement: one line, printed regardless
     // of `--verbose`, naming the storage partition this run's results land in (the
-    // target triple, always the toolchain host, and the machine key hardware-
-    // dependent engines use — an explicit `--machine-key` or the auto-detected
-    // fingerprint). It mirrors the query commands' effective-selection summary so
-    // the partition a run writes and an `analyze` reads is stated the same way.
+    // target triple, always the toolchain host, and the machine key every engine
+    // uses — an explicit `--machine-key` or the auto-detected fingerprint). It
+    // mirrors the query commands' effective-selection summary so the partition a
+    // run writes and an `analyze` reads is stated the same way.
     let effective_machine_key = resolve_machine_key(params.machine_key, &shared.hardware);
     store.reporter.announce(&partition_selection_summary(
         operation,
@@ -548,9 +548,9 @@ where
 }
 
 /// Builds the always-on, one-line summary of a run's effective storage partition:
-/// the target triple its results are keyed under and the machine key
-/// hardware-dependent engines use — an explicit `--machine-key` override or the
-/// auto-detected hardware fingerprint.
+/// the target triple its results are keyed under and the machine key every engine
+/// uses — an explicit `--machine-key` override or the auto-detected hardware
+/// fingerprint.
 ///
 /// `operation` is the gerund naming the action ("collecting"/"importing").
 /// `triple_note` qualifies the triple in parentheses ("toolchain host" for a
@@ -583,7 +583,7 @@ fn partition_selection_summary(
     };
     format!(
         "{operation}: target-triple={triple}{triple_suffix}; \
-         machine-key={machine_key} ({machine_source}), used by hardware-dependent engines"
+         machine-key={machine_key} ({machine_source})"
     )
 }
 
@@ -798,14 +798,11 @@ where
     context.machine = Some(machine_info(&shared.hardware));
     let run = Run::new(context, records);
 
-    // Hardware-dependent engines (such as Criterion) partition their history by a
-    // machine fingerprint so only equivalent machines share a series. An explicit
-    // `--machine-key` overrides the computed fingerprint. Hardware-independent
-    // engines (such as Callgrind) use no machine key.
-    let machine_key = engine
-        .is_hardware_dependent()
-        .then(|| resolve_machine_key(params.machine_key, &shared.hardware));
-    let key = DiscriminantSet::new(engine, target_triple, machine_key.as_deref());
+    // Every engine partitions its history by a machine key so only equivalent
+    // machines share a series. An explicit `--machine-key` overrides the computed
+    // hardware fingerprint.
+    let machine_key = resolve_machine_key(params.machine_key, &shared.hardware);
+    let key = DiscriminantSet::new(engine, target_triple, &machine_key);
     // History is organized by commit, so the full commit ID names the directory
     // (`analyze` resolves which commits to read from git topology). A clean run is
     // keyed solely by its commit and so is deterministic; a dirty snapshot adds its
@@ -819,12 +816,9 @@ where
 
     store.reporter.note_with(|| {
         format!(
-            "{engine}: {} at commit {commit} ({}){} -> {object_key}",
+            "{engine}: {} at commit {commit} ({}), machine {machine_key} -> {object_key}",
             count_noun(count, "case"),
             if dirty { "dirty" } else { "clean" },
-            machine_key
-                .as_deref()
-                .map_or_else(String::new, |key| format!(", machine {key}")),
         )
     });
 
@@ -1509,6 +1503,13 @@ mod tests {
         }
     }
 
+    /// The auto-detected machine key every engine partitions under for the
+    /// [`FakeProbe`] hardware profile. Every engine is machine-keyed, so a probed
+    /// run with no `--machine-key` override lands under this fingerprint.
+    fn probe_machine_key() -> String {
+        resolve_machine_key(None, &FakeProbe::new().hardware)
+    }
+
     #[derive(Clone, Default)]
     struct FakeOutput {
         callgrind: Vec<RawSummary>,
@@ -1855,13 +1856,13 @@ mod tests {
         assert!(message.contains("Stored 1"), "{message}");
 
         let keys = storage.keys();
+        let machine = probe_machine_key();
         assert_eq!(
             keys,
-            vec![
-                "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/\
+            vec![format!(
+                "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/{machine}/\
                  deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/clean.json"
-                    .to_owned()
-            ]
+            )]
         );
 
         let bytes = block_on(storage.get(&keys[0])).unwrap();
@@ -1915,10 +1916,11 @@ mod tests {
             &storage,
         )
         .unwrap();
-        let original = block_on(storage.get(
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/\
+        let machine = probe_machine_key();
+        let original = block_on(storage.get(&format!(
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/{machine}/\
              deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/clean.json",
-        ))
+        )))
         .unwrap();
 
         // A re-run of the same commit under --skip-existing succeeds without a
@@ -2007,8 +2009,11 @@ mod tests {
             &storage,
         )
         .unwrap();
-        let commit_dir = "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/\
-                          deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let machine = probe_machine_key();
+        let commit_dir = format!(
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/{machine}/\
+             deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        );
         let bless_key = format!("{commit_dir}/bless-100.json");
         let record = BlessingRecord::new(
             "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_owned(),
@@ -2073,8 +2078,11 @@ mod tests {
         // Blessings accept the clean run's data point, so a blessing sidecar on the
         // commit must survive when only a dirty snapshot of that commit is rewritten;
         // invalidation is reserved for a clean overwrite that discards the point.
-        let commit_dir = "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/\
-                          deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let machine = probe_machine_key();
+        let commit_dir = format!(
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/{machine}/\
+             deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        );
         let bless_key = format!("{commit_dir}/bless-100.json");
         let record = BlessingRecord::new(
             "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_owned(),
@@ -2296,18 +2304,19 @@ mod tests {
         };
         assert!(message.contains("Stored 2"), "{message}");
 
-        // Callgrind partitions under `synthetic`; Criterion partitions under the
-        // machine fingerprint of the probed hardware. Both sets are stored.
+        // Every engine partitions under the machine fingerprint of the probed
+        // hardware. Both sets are stored under the same machine key.
+        let machine = probe_machine_key();
         let keys = storage.keys();
         assert_eq!(keys.len(), 2, "{keys:?}");
         assert!(
             keys.iter()
-                .any(|key| key.contains("/callgrind/") && key.contains("/synthetic/")),
+                .any(|key| key.contains("/callgrind/") && key.contains(&format!("/{machine}/"))),
             "{keys:?}"
         );
         assert!(
             keys.iter()
-                .any(|key| key.contains("/criterion/") && !key.contains("/synthetic/")),
+                .any(|key| key.contains("/criterion/") && key.contains(&format!("/{machine}/"))),
             "{keys:?}"
         );
     }
@@ -2431,7 +2440,7 @@ mod tests {
     }
 
     #[test]
-    fn alloc_tracker_output_is_stored_in_a_synthetic_partition() {
+    fn alloc_tracker_output_is_stored_under_the_machine_key() {
         let storage = MemoryStorage::new();
         let outcome = drive(
             &CollectOptions::default(),
@@ -2447,12 +2456,13 @@ mod tests {
         };
         assert!(message.contains("Stored 1"), "{message}");
 
-        // Allocation counts are hardware-independent, so the partition is
-        // `synthetic` rather than a machine key.
+        // Allocation counts are machine-dependent (allocator behaviour varies by
+        // build and platform), so the partition is the machine fingerprint.
+        let machine = probe_machine_key();
         let keys = storage.keys();
         assert_eq!(keys.len(), 1, "{keys:?}");
         assert!(keys[0].contains("/alloc_tracker/"), "{keys:?}");
-        assert!(keys[0].contains("/synthetic/"), "{keys:?}");
+        assert!(keys[0].contains(&format!("/{machine}/")), "{keys:?}");
 
         let bytes = block_on(storage.get(&keys[0])).unwrap();
         let set = Run::from_json(&String::from_utf8(bytes).unwrap()).unwrap();

--- a/packages/cargo-bench-history/src/commands/import.rs
+++ b/packages/cargo-bench-history/src/commands/import.rs
@@ -285,7 +285,7 @@ mod tests {
 
     use cbh_engines::{Harvest, RawOperationFile, RawSummary};
     use cbh_git::{FakeGitHistory, parse_git_info};
-    use cbh_probe::{HardwareProfile, RustcInfo};
+    use cbh_probe::{HardwareProfile, RustcInfo, resolve_machine_key};
     use cbh_storage::MemoryStorage;
     use futures::executor::block_on;
 
@@ -340,6 +340,12 @@ mod tests {
         }
     }
 
+    /// The auto-detected machine key every engine partitions under for the
+    /// [`FakeProbe`] hardware profile, when no `--machine-key` override applies.
+    fn probe_machine_key() -> String {
+        resolve_machine_key(None, &FakeProbe::new().hardware)
+    }
+
     /// A curated-tree stand-in that hands back canned per-engine output, so a test
     /// drives the harvest without a real `target/` directory. `import` gates
     /// nothing, so the modification-time cutoff is ignored.
@@ -385,9 +391,8 @@ mod tests {
         }
     }
 
-    /// A curated tree carrying both a hardware-independent (Callgrind) and a
-    /// hardware-dependent (`all_the_time`) engine's output, to prove `--machine-key`
-    /// repartitions only the latter.
+    /// A curated tree carrying both a Callgrind and an `all_the_time` engine's
+    /// output, to prove `--machine-key` repartitions every engine.
     fn callgrind_and_time_output() -> FakeOutput {
         FakeOutput {
             time: vec![RawOperationFile {
@@ -467,17 +472,17 @@ mod tests {
         assert!(message.contains("Stored 1"), "{message}");
 
         // Format canary: the exact storage key and decompressed body an importer
-        // must produce for the single-case Callgrind harvest. Callgrind is
-        // hardware-independent, so the machine segment is `synthetic`; the commit
-        // and triple come from the probed host.
+        // must produce for the single-case Callgrind harvest. Every engine is
+        // machine-keyed, so the machine segment is the probed host fingerprint; the
+        // commit and triple come from the probed host.
+        let machine = probe_machine_key();
         let keys = storage.keys();
         assert_eq!(
             keys,
-            vec![
-                "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/\
+            vec![format!(
+                "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/{machine}/\
                  deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/clean.json"
-                    .to_owned()
-            ]
+            )]
         );
 
         let run = only_stored_run(&storage);
@@ -736,7 +741,7 @@ mod tests {
     }
 
     #[test]
-    fn machine_key_override_only_repartitions_hardware_dependent_engines() {
+    fn machine_key_override_repartitions_every_engine() {
         let storage = MemoryStorage::new();
         let options = ImportOptions {
             machine_key: Some("lab-runner-7".to_owned()),
@@ -754,14 +759,13 @@ mod tests {
 
         let keys = storage.keys();
         assert_eq!(keys.len(), 2, "{keys:?}");
-        // Callgrind is hardware-independent: it stays under `synthetic`, ignoring
-        // the override.
+        // Callgrind is machine-keyed: the override names its partition.
         assert!(
             keys.iter()
-                .any(|key| key.contains("/callgrind/") && key.contains("/synthetic/")),
+                .any(|key| key.contains("/callgrind/") && key.contains("/lab-runner-7/")),
             "{keys:?}"
         );
-        // `all_the_time` is hardware-dependent: the override names its partition.
+        // `all_the_time` is machine-keyed too: the override names its partition.
         assert!(
             keys.iter()
                 .any(|key| key.contains("/all_the_time/") && key.contains("/lab-runner-7/")),

--- a/packages/cargo-bench-history/src/commands/machine_key.rs
+++ b/packages/cargo-bench-history/src/commands/machine_key.rs
@@ -1,7 +1,7 @@
 //! The `machine-key` command: print this machine's hardware fingerprint.
 //!
-//! The key is what hardware-dependent engines partition their history by, so it
-//! is printed to standard output (clean, one line) for CI to capture and thread
+//! Every engine partitions its history by this key, so it is printed to standard
+//! output (clean, one line) for CI to capture and thread
 //! into an `analyze` selection. Under `--verbose`, the individual factors that
 //! make up the fingerprint are emitted to standard error so a change in the key
 //! can be traced to the specific factor that changed.

--- a/packages/cargo-bench-history/src/dispatch.rs
+++ b/packages/cargo-bench-history/src/dispatch.rs
@@ -42,7 +42,7 @@ pub struct Overrides {
     /// The auto-detected discriminant facets (host target triple + machine key) the
     /// query commands default to when a facet is omitted. `None` probes the host;
     /// integration tests inject fixed values so the suite is independent of the host
-    /// it runs on (a `synthetic` set's inclusion now depends on the auto triple).
+    /// it runs on.
     pub auto_facets: Option<AutoFacets>,
 }
 

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -177,16 +177,16 @@
 //!
 //! ## `machine-key`
 //!
-//! Prints this machine's hardware fingerprint — the machine key that
-//! hardware-dependent engines partition their history by — to standard output as a
-//! single clean line, and exits. It probes only the host's hardware: no repository,
-//! git, config, or storage is touched. This is the key `collect` stamps its
-//! hardware-dependent results with, so CI captures it to thread the exact keys a
-//! collection produced into the matching `analyze` selection (see the per-push and
-//! per-PR workflows). Under `--verbose` the individual factors behind the
-//! fingerprint (processor count, memory regions, processor models, the per-processor
-//! speed histogram, and the factor-set version tag) are written to standard error, so
-//! a change in the key can be traced to the specific factor that moved.
+//! Prints this machine's hardware fingerprint — the machine key every engine
+//! partitions its history by — to standard output as a single clean line, and exits.
+//! It probes only the host's hardware: no repository, git, config, or storage is
+//! touched. This is the key `collect` stamps every result with, so CI captures it and
+//! threads the exact keys a collection produced into the matching `analyze` selection
+//! (see the per-push and per-PR workflows). Under `--verbose` the individual factors
+//! behind the fingerprint (processor count, memory regions, processor models, the
+//! per-processor speed histogram, and the factor-set version tag) are written to
+//! standard error, so a change in the key can be traced to the specific factor that
+//! moved.
 //!
 //! # Selecting data: options shared by the query commands
 //!

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -52,12 +52,12 @@
 //! * **engine** — the benchmark system (`callgrind`, `criterion`, `alloc_tracker`,
 //!   `all_the_time`), since their numbers are not comparable to each other.
 //! * **target triple** — for example `x86_64-unknown-linux-gnu`.
-//! * **machine key** — a hardware fingerprint, but *only* for engines whose
-//!   results depend on hardware. Deterministic engines (Callgrind instruction
-//!   counts, `alloc_tracker` allocations) are hardware-independent and share a
-//!   single `synthetic` partition; noisy engines (Criterion wall-clock,
-//!   `all_the_time` processor time) are partitioned by machine key so results from
-//!   different machines are never mixed.
+//! * **machine key** — a hardware fingerprint of the host the benchmark ran on.
+//!   Every engine is partitioned by it (Callgrind instruction counts and
+//!   `alloc_tracker` allocations included), because even those figures vary with
+//!   the hardware in practice — libraries dispatch to different code paths on
+//!   different microarchitectures — so results from different machines are never
+//!   mixed.
 //!
 //! Everything else — toolchain version, OS, commit, CI provider — is recorded as
 //! metadata rather than forking history, so its effect stays *visible* as a step

--- a/packages/cargo-bench-history/src/outcome.rs
+++ b/packages/cargo-bench-history/src/outcome.rs
@@ -289,14 +289,14 @@ mod tests {
     #[test]
     fn duplicate_error_mentions_overwrite_and_has_no_source() {
         let error = RunError::Duplicate {
-            key: "v1/folo/objects/callgrind/t/synthetic/abc/clean.json".to_owned(),
+            key: "v1/folo/objects/callgrind/t/m1/abc/clean.json".to_owned(),
         };
         assert!(error.to_string().contains("already stored"), "{error}");
         assert!(error.to_string().contains("--overwrite"), "{error}");
         assert!(
             error
                 .to_string()
-                .contains("v1/folo/objects/callgrind/t/synthetic/abc/clean.json"),
+                .contains("v1/folo/objects/callgrind/t/m1/abc/clean.json"),
             "{error}"
         );
         assert!(error.source().is_none());

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -245,7 +245,7 @@ async fn analyze_markdown_summary_renders_a_flat_report() {
     // so a reader who loses the per-set grouping still knows how to query the exact set.
     assert!(
         summary.contains(
-            "_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`"
+            "_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key harness-auto-machine`"
         ),
         "{summary}"
     );
@@ -1352,8 +1352,8 @@ async fn analyze_target_triple_facet_isolates_linux_from_windows() {
         ("2024-01-06", "c6", 130.0, 50.0),
     ] {
         workspace.commit_dated(date, label);
-        workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", label, linux);
-        workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", label, windows);
+        workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, linux);
+        workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, label, windows);
     }
 
     // The Linux triple sees the regression.
@@ -1570,8 +1570,8 @@ async fn analyze_target_triple_facet_selects_one_set() {
         ("2024-01-06", "c6", 130.0, 50.0),
     ] {
         workspace.commit_dated(date, label);
-        workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", label, x64);
-        workspace.seed_callgrind_in("aarch64-unknown-linux-gnu", "synthetic", label, arm);
+        workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, x64);
+        workspace.seed_callgrind_in("aarch64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, arm);
     }
 
     let RunOutcome::Analyzed { regressions, .. } = workspace

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1352,8 +1352,18 @@ async fn analyze_target_triple_facet_isolates_linux_from_windows() {
         ("2024-01-06", "c6", 130.0, 50.0),
     ] {
         workspace.commit_dated(date, label);
-        workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, linux);
-        workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, label, windows);
+        workspace.seed_callgrind_in(
+            "x86_64-unknown-linux-gnu",
+            HARNESS_AUTO_MACHINE_KEY,
+            label,
+            linux,
+        );
+        workspace.seed_callgrind_in(
+            "x86_64-pc-windows-msvc",
+            HARNESS_AUTO_MACHINE_KEY,
+            label,
+            windows,
+        );
     }
 
     // The Linux triple sees the regression.
@@ -1570,8 +1580,18 @@ async fn analyze_target_triple_facet_selects_one_set() {
         ("2024-01-06", "c6", 130.0, 50.0),
     ] {
         workspace.commit_dated(date, label);
-        workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, x64);
-        workspace.seed_callgrind_in("aarch64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, arm);
+        workspace.seed_callgrind_in(
+            "x86_64-unknown-linux-gnu",
+            HARNESS_AUTO_MACHINE_KEY,
+            label,
+            x64,
+        );
+        workspace.seed_callgrind_in(
+            "aarch64-unknown-linux-gnu",
+            HARNESS_AUTO_MACHINE_KEY,
+            label,
+            arm,
+        );
     }
 
     let RunOutcome::Analyzed { regressions, .. } = workspace

--- a/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
@@ -22,14 +22,22 @@ async fn backfill_stores_one_clean_object_per_commit_and_restores_checkout() {
     assert!(message.contains("2 stored"), "{message}");
 
     // One clean object per commit, keyed by that commit's full ID. `backfill`
-    // auto-detects the target triple, so derive it from a stored object to keep
-    // the key assertions correct on every platform CI runs on.
+    // auto-detects the target triple and machine key, so derive both from a stored
+    // object to keep the key assertions correct on every platform CI runs on.
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 2, "{objects:?}");
     let triple = objects[0].1.context.toolchain.target_triple.clone();
+    let machine = objects[0]
+        .1
+        .context
+        .machine
+        .as_ref()
+        .expect("backfill records host-hardware provenance")
+        .fingerprint
+        .clone();
     for commit_id in [&c1, &c2] {
         let expected =
-            format!("v1/testproj/objects/callgrind/{triple}/synthetic/{commit_id}/clean.json");
+            format!("v1/testproj/objects/callgrind/{triple}/{machine}/{commit_id}/clean.json");
         assert!(
             objects.iter().any(|(key, _)| key == &expected),
             "missing {expected} in {objects:?}"
@@ -80,9 +88,17 @@ async fn backfill_spans_a_merge_commit_along_first_parent() {
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 3, "{objects:?}");
     let triple = objects[0].1.context.toolchain.target_triple.clone();
+    let machine = objects[0]
+        .1
+        .context
+        .machine
+        .as_ref()
+        .expect("backfill records host-hardware provenance")
+        .fingerprint
+        .clone();
     for commit_id in [&c1, &m, &c3] {
         let expected =
-            format!("v1/testproj/objects/callgrind/{triple}/synthetic/{commit_id}/clean.json");
+            format!("v1/testproj/objects/callgrind/{triple}/{machine}/{commit_id}/clean.json");
         assert!(
             objects.iter().any(|(key, _)| key == &expected),
             "missing {expected} in {objects:?}"

--- a/packages/cargo-bench-history/tests/cbh_integration/collect.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/collect.rs
@@ -16,28 +16,32 @@ async fn collect_callgrind_end_to_end_stores_results() {
 
     let (key, set) = workspace.single_object();
 
-    // Synthetic partition (Callgrind is hardware-independent) under the resolved
-    // triple. `collect` auto-detects the host triple, so derive it from the stored
-    // context to keep the assertion host-portable. The temp workspace is outside
-    // any git repository, so the commit resolves to the `unknown` fallback and the
-    // clean tree yields `clean.json`.
+    // Every engine is machine-keyed under the resolved triple and the auto-detected
+    // host fingerprint. `collect` auto-detects both, so derive them from the stored
+    // context to keep the assertion host-portable. The temp workspace is outside any
+    // git repository, so the commit resolves to the `unknown` fallback and the clean
+    // tree yields `clean.json`.
+    //
+    // The host-hardware provenance is recorded on every stored run (write-only); its
+    // fingerprint is the machine key the run partitions under, a 16-char lowercase
+    // hex digest of the probed factors.
     let triple = &set.context.toolchain.target_triple;
-    assert_eq!(
-        key,
-        format!("v1/testproj/objects/callgrind/{triple}/synthetic/unknown/clean.json")
-    );
-
-    assert_eq!(set.schema_version, SCHEMA_VERSION);
-    assert_eq!(set.context.tool_version, TOOL_VERSION);
-
-    // The host-hardware provenance is recorded on every stored run (write-only),
-    // even for a hardware-independent engine: its fingerprint is the auto-detected
-    // machine key, a 16-char lowercase hex digest of the probed factors.
     let machine = set
         .context
         .machine
         .as_ref()
         .expect("collect records host-hardware provenance");
+    assert_eq!(
+        key,
+        format!(
+            "v1/testproj/objects/callgrind/{triple}/{fingerprint}/unknown/clean.json",
+            fingerprint = machine.fingerprint
+        )
+    );
+
+    assert_eq!(set.schema_version, SCHEMA_VERSION);
+    assert_eq!(set.context.tool_version, TOOL_VERSION);
+
     assert!(machine.processors >= 1, "{machine:?}");
     assert!(machine.memory_regions >= 1, "{machine:?}");
     assert_eq!(machine.fingerprint.len(), 16, "{machine:?}");
@@ -278,10 +282,16 @@ async fn collect_criterion_stores_results() {
     assert!(matches!(outcome, RunOutcome::Completed { .. }));
 
     let (key, set) = workspace.single_object();
-    // Criterion partitions by the host triple and a machine fingerprint (never the
-    // `synthetic` segment Callgrind uses).
+    // Criterion is machine-keyed: it partitions by the host triple and the
+    // auto-detected machine fingerprint.
+    let fingerprint = &set
+        .context
+        .machine
+        .as_ref()
+        .expect("collect records host-hardware provenance")
+        .fingerprint;
     assert!(key.contains("/criterion/"), "{key}");
-    assert!(!key.contains("/synthetic/"), "{key}");
+    assert!(key.contains(&format!("/{fingerprint}/")), "{key}");
     assert_eq!(set.results.len(), 1);
     let metric = &set.results[0].metrics[0];
     assert_eq!(metric.kind, MetricKind::WallTime);
@@ -317,39 +327,26 @@ async fn collect_harvests_every_engine_that_produced_output() {
 
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 4, "{objects:?}");
-    // Hardware-independent engines (Callgrind instruction counts, allocation
-    // statistics) land in the `synthetic` partition; hardware-dependent engines
-    // (Criterion wall time, `all_the_time` processor time) carry a machine
-    // fingerprint.
-    assert!(
-        objects
-            .iter()
-            .any(|(key, _)| key.contains("/callgrind/") && key.contains("/synthetic/")),
-        "{objects:?}"
-    );
-    assert!(
-        objects
-            .iter()
-            .any(|(key, _)| key.contains("/criterion/") && !key.contains("/synthetic/")),
-        "{objects:?}"
-    );
-    assert!(
-        objects
-            .iter()
-            .any(|(key, _)| key.contains("/alloc_tracker/") && key.contains("/synthetic/")),
-        "{objects:?}"
-    );
-    assert!(
-        objects
-            .iter()
-            .any(|(key, _)| key.contains("/all_the_time/") && !key.contains("/synthetic/")),
-        "{objects:?}"
-    );
+    // Every engine is machine-keyed, so all four sets land under the same
+    // auto-detected host fingerprint, each in its own engine partition.
+    let fingerprint = objects
+        .first()
+        .and_then(|(_, set)| set.context.machine.as_ref())
+        .expect("collect records host-hardware provenance")
+        .fingerprint
+        .clone();
+    for engine in ["callgrind", "criterion", "alloc_tracker", "all_the_time"] {
+        assert!(
+            objects.iter().any(|(key, _)| {
+                key.contains(&format!("/{engine}/")) && key.contains(&format!("/{fingerprint}/"))
+            }),
+            "{engine}: {objects:?}"
+        );
+    }
 }
 
-/// An `alloc_tracker` run stores allocation statistics in the `synthetic`
-/// partition (allocation behavior depends on the code, not the hardware),
-/// carrying both the byte and the count metric.
+/// An `alloc_tracker` run stores allocation statistics in a machine-fingerprinted
+/// partition, carrying both the byte and the count metric.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn collect_alloc_tracker_stores_results() {
@@ -361,7 +358,13 @@ async fn collect_alloc_tracker_stores_results() {
 
     let (key, set) = workspace.single_object();
     assert!(key.contains("/alloc_tracker/"), "{key}");
-    assert!(key.contains("/synthetic/"), "{key}");
+    let fingerprint = &set
+        .context
+        .machine
+        .as_ref()
+        .expect("collect records host-hardware provenance")
+        .fingerprint;
+    assert!(key.contains(&format!("/{fingerprint}/")), "{key}");
     assert_eq!(set.results.len(), 1);
     let record = &set.results[0];
     assert_eq!(record.id.qualified(), "allocate_vec");
@@ -377,8 +380,7 @@ async fn collect_alloc_tracker_stores_results() {
 }
 
 /// An `all_the_time` run stores processor time in a machine-fingerprinted
-/// partition (processor time is hardware-dependent), and `--machine-key` overrides
-/// the fingerprint.
+/// partition, and `--machine-key` overrides the fingerprint.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn collect_all_the_time_is_partitioned_by_machine_key() {
@@ -396,7 +398,6 @@ async fn collect_all_the_time_is_partitioned_by_machine_key() {
         key.contains(&format!("/all_the_time/{triple}/ci-pool-b/")),
         "{key}"
     );
-    assert!(!key.contains("/synthetic/"), "{key}");
     assert_eq!(set.results.len(), 1);
     let record = &set.results[0];
     assert_eq!(record.id.qualified(), "read_cell");

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -196,13 +196,14 @@ async fn examine_selects_only_the_named_metric() {
 async fn examine_facet_selection_mirrors_analyze() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
-    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 50.0);
+    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
+    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, "c1", 50.0);
 
     // Across triples (`--target-triple all`), both comparable sets pivot. An
-    // auto-detected triple would scope to the host's set alone — even for these
-    // machine-independent synthetic sets, which obey the target-triple facet — so
-    // widening to `all` is what surfaces both pools here.
+    // auto-detected triple would scope to the host's set alone — every set obeys the
+    // target-triple facet — so widening to `all` is what surfaces both pools here.
+    // Both pools share the harness's auto-detected machine key, so the machine-key
+    // facet admits them.
     let message = workspace
         .drive_json(&[
             "examine",

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -196,8 +196,18 @@ async fn examine_selects_only_the_named_metric() {
 async fn examine_facet_selection_mirrors_analyze() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
-    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, "c1", 50.0);
+    workspace.seed_callgrind_in(
+        "x86_64-unknown-linux-gnu",
+        HARNESS_AUTO_MACHINE_KEY,
+        "c1",
+        100.0,
+    );
+    workspace.seed_callgrind_in(
+        "x86_64-pc-windows-msvc",
+        HARNESS_AUTO_MACHINE_KEY,
+        "c1",
+        50.0,
+    );
 
     // Across triples (`--target-triple all`), both comparable sets pivot. An
     // auto-detected triple would scope to the host's set alone — every set obeys the

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -1090,7 +1090,12 @@ impl Workspace {
     /// own git committer date, so the test owns the topology the window is decided
     /// from.
     pub(crate) fn seed_callgrind(&self, label: &str, value: f64) {
-        self.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, value);
+        self.seed_callgrind_in(
+            "x86_64-unknown-linux-gnu",
+            HARNESS_AUTO_MACHINE_KEY,
+            label,
+            value,
+        );
     }
 
     /// Seeds one clean Callgrind result set into the `triple`/`machine` partition

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -25,17 +25,18 @@ use tick::Clock;
 pub(crate) const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The target triple the harness pins the auto-detected facet to, matching the
-/// triple the seed helpers write their synthetic partitions under. Pinning it
-/// keeps the suite host-independent: synthetic sets now obey the target-triple
-/// facet (a `list`/`analyze` with an auto triple no longer sees foreign-triple
-/// data), so a bare query must auto-detect the seeded triple regardless of the
-/// host the test runs on.
+/// triple the seed helpers write their partitions under. Pinning it keeps the
+/// suite host-independent: sets obey the target-triple facet (a `list`/`analyze`
+/// with an auto triple never sees foreign-triple data), so a bare query must
+/// auto-detect the seeded triple regardless of the host the test runs on.
 pub(crate) const HARNESS_AUTO_TRIPLE: &str = "x86_64-unknown-linux-gnu";
 
-/// The machine key the harness pins the auto-detected facet to. Chosen not to
-/// collide with any seeded machine key, so an auto machine-key query still
-/// matches only the machine-key-exempt synthetic sets, never a hardware-keyed
-/// partition (which the tests always select with an explicit `--machine-key`).
+/// The machine key the harness pins the auto-detected facet to. Every engine is
+/// machine-keyed, so a bare query must auto-detect a machine key the seeded sets
+/// share; the callgrind/alloc seed helpers plant their objects under this key so a
+/// default query matches them regardless of the host the test runs on. Tests that
+/// exercise per-machine isolation seed additional, explicit machine keys and
+/// select them with an explicit `--machine-key`.
 pub(crate) const HARNESS_AUTO_MACHINE_KEY: &str = "harness-auto-machine";
 
 /// Canonical faker `--callgrind` identity/metric fragments, kept in lockstep with
@@ -1065,7 +1066,7 @@ impl Workspace {
         let key = seed_clean_key(
             Engine::Callgrind,
             "x86_64-unknown-linux-gnu",
-            None,
+            HARNESS_AUTO_MACHINE_KEY,
             &commit_id,
         );
         let mut object: serde_json::Value = serde_json::from_str(
@@ -1089,7 +1090,7 @@ impl Workspace {
     /// own git committer date, so the test owns the topology the window is decided
     /// from.
     pub(crate) fn seed_callgrind(&self, label: &str, value: f64) {
-        self.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", label, value);
+        self.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, label, value);
     }
 
     /// Seeds one clean Callgrind result set into the `triple`/`machine` partition
@@ -1098,7 +1099,7 @@ impl Workspace {
     pub(crate) fn seed_callgrind_in(&self, triple: &str, machine: &str, label: &str, value: f64) {
         let commit_id = self.commit_id(label);
         let observed = self.committer_time(&commit_id);
-        let key = seed_clean_key(Engine::Callgrind, triple, Some(machine), &commit_id);
+        let key = seed_clean_key(Engine::Callgrind, triple, machine, &commit_id);
         self.seed(
             &key,
             &ir_result_set(observed.as_second(), &commit_id, value),
@@ -1116,7 +1117,7 @@ impl Workspace {
         let key = seed_dirty_key(
             Engine::Callgrind,
             "x86_64-unknown-linux-gnu",
-            None,
+            HARNESS_AUTO_MACHINE_KEY,
             &commit_id,
             effective.as_second(),
         );
@@ -1134,7 +1135,7 @@ impl Workspace {
         let key = seed_clean_key(
             Engine::Callgrind,
             "x86_64-unknown-linux-gnu",
-            None,
+            HARNESS_AUTO_MACHINE_KEY,
             &commit_id,
         );
         self.seed(
@@ -1197,14 +1198,14 @@ impl Workspace {
 
     /// Seeds one Callgrind result set carrying one `Ir` benchmark per entry in
     /// `values` for the previously created commit `label`, all in the shared
-    /// `x86_64`/`synthetic` partition.
+    /// `x86_64`/[`HARNESS_AUTO_MACHINE_KEY`] partition.
     pub(crate) fn seed_many_callgrind(&self, label: &str, values: &[f64]) {
         let commit_id = self.commit_id(label);
         let observed = self.committer_time(&commit_id);
         let key = seed_clean_key(
             Engine::Callgrind,
             "x86_64-unknown-linux-gnu",
-            None,
+            HARNESS_AUTO_MACHINE_KEY,
             &commit_id,
         );
         self.seed(
@@ -1221,7 +1222,7 @@ impl Workspace {
         let key = seed_clean_key(
             Engine::Criterion,
             "x86_64-pc-windows-msvc",
-            Some(machine),
+            machine,
             &commit_id,
         );
         self.seed(
@@ -1246,7 +1247,7 @@ impl Workspace {
         let key = seed_dirty_key(
             Engine::Criterion,
             "x86_64-pc-windows-msvc",
-            Some(machine),
+            machine,
             &commit_id,
             effective.as_second(),
         );
@@ -1287,7 +1288,7 @@ impl Workspace {
         let key = seed_clean_key(
             Engine::Callgrind,
             "x86_64-unknown-linux-gnu",
-            None,
+            HARNESS_AUTO_MACHINE_KEY,
             &commit_id,
         );
         self.seed(
@@ -1298,15 +1299,14 @@ impl Workspace {
 
     /// Seeds one clean `alloc_tracker` result set for `operation` on the previously
     /// created commit `label`, recording `bytes` mean bytes and `allocs` mean
-    /// allocations per iteration. Allocation counts are hardware-independent, so the
-    /// partition is `synthetic` (no machine key).
+    /// allocations per iteration in the [`HARNESS_AUTO_MACHINE_KEY`] partition.
     pub(crate) fn seed_alloc_tracker(&self, label: &str, operation: &str, bytes: f64, allocs: f64) {
         let commit_id = self.commit_id(label);
         let observed = self.committer_time(&commit_id);
         let key = seed_clean_key(
             Engine::AllocTracker,
             "x86_64-unknown-linux-gnu",
-            None,
+            HARNESS_AUTO_MACHINE_KEY,
             &commit_id,
         );
         self.seed(
@@ -1317,8 +1317,7 @@ impl Workspace {
 
     /// Seeds one clean `all_the_time` result set for `operation` on the previously
     /// created commit `label`, recording `nanos` mean processor-time nanoseconds
-    /// per iteration in the `machine`-keyed partition (processor time is
-    /// hardware-dependent).
+    /// per iteration in the `machine`-keyed partition.
     pub(crate) fn seed_all_the_time(
         &self,
         label: &str,
@@ -1331,7 +1330,7 @@ impl Workspace {
         let key = seed_clean_key(
             Engine::AllTheTime,
             "x86_64-unknown-linux-gnu",
-            Some(machine),
+            machine,
             &commit_id,
         );
         self.seed(
@@ -1357,7 +1356,7 @@ impl Workspace {
         let key = seed_clean_key(
             Engine::AllTheTime,
             "x86_64-unknown-linux-gnu",
-            Some(machine),
+            machine,
             &commit_id,
         );
         self.seed(
@@ -1380,7 +1379,7 @@ const SEED_PROJECT: &str = "testproj";
 /// Builds a clean-object storage key through the model's key builder — the exact
 /// code path `run` writes under — so a seed helper cannot drift from the
 /// production storage layout by hand-formatting a key string.
-fn seed_clean_key(engine: Engine, triple: &str, machine: Option<&str>, commit: &str) -> String {
+fn seed_clean_key(engine: Engine, triple: &str, machine: &str, commit: &str) -> String {
     DiscriminantSet::new(engine, triple, machine).clean_key(SEED_PROJECT, commit)
 }
 
@@ -1389,7 +1388,7 @@ fn seed_clean_key(engine: Engine, triple: &str, machine: Option<&str>, commit: &
 fn seed_dirty_key(
     engine: Engine,
     triple: &str,
-    machine: Option<&str>,
+    machine: &str,
     commit: &str,
     observation_unix: i64,
 ) -> String {

--- a/packages/cargo-bench-history/tests/cbh_integration/import.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/import.rs
@@ -37,11 +37,11 @@ fn run_faker_binary(target_dir: &Path, args: &[&str]) {
 /// through the production entry, keying the run to `commit` via `--commit` so no
 /// checkout is needed to attribute the imported data to a historical commit.
 ///
-/// The run is keyed under [`HARNESS_AUTO_TRIPLE`] via `--target-triple` so the
-/// synthetic callgrind set matches the auto-detected target-triple facet a drive
-/// injects into the reporting commands. That makes the round-trip host-independent
-/// (the real host triple would only match on Linux), rather than relying on the
-/// probed toolchain host.
+/// The run is keyed under [`HARNESS_AUTO_TRIPLE`]/[`HARNESS_AUTO_MACHINE_KEY`] via
+/// `--target-triple`/`--machine-key` so the imported callgrind set matches the
+/// target-triple and machine-key facets a reporting drive injects. That makes the
+/// round-trip host-independent (the real host triple and fingerprint would only
+/// match on the collecting host), rather than relying on the probed toolchain host.
 async fn import_for_commit(workspace: &Workspace, target_dir: &Path, commit: &str) -> String {
     let outcome = workspace
         .drive(&[
@@ -52,6 +52,8 @@ async fn import_for_commit(workspace: &Workspace, target_dir: &Path, commit: &st
             commit,
             "--target-triple",
             HARNESS_AUTO_TRIPLE,
+            "--machine-key",
+            HARNESS_AUTO_MACHINE_KEY,
         ])
         .await
         .unwrap();
@@ -152,7 +154,9 @@ async fn importing_real_faker_binary_output_surfaces_in_list_under_the_overridde
 
     // Import an overridden triple so the discriminant is deterministic regardless of
     // the host this test runs on, proving `--target-triple` reaches the storage key
-    // through the real command line.
+    // through the real command line. Every engine is machine-keyed now, so pin the
+    // machine key too (to the one the harness's reporting drives auto-detect) so the
+    // imported runs land in the partition `list runs` queries.
     for (index, commit) in commits.iter().enumerate() {
         let tree = workspace
             .root()
@@ -167,6 +171,8 @@ async fn importing_real_faker_binary_output_surfaces_in_list_under_the_overridde
                 tree.to_str().unwrap(),
                 "--target-triple",
                 "x86_64-unknown-linux-gnu",
+                "--machine-key",
+                HARNESS_AUTO_MACHINE_KEY,
                 "--commit",
                 commit,
             ])
@@ -194,9 +200,12 @@ async fn importing_real_faker_binary_output_surfaces_in_list_under_the_overridde
         sets[0]["target_triple"], "x86_64-unknown-linux-gnu",
         "the --target-triple override should key the partition: {discriminants}"
     );
-    // Callgrind is hardware-independent, so it stays in the `synthetic` machine
-    // partition even though the real host was probed for provenance.
-    assert_eq!(sets[0]["machine_key"], "synthetic", "{discriminants}");
+    // Callgrind is machine-keyed like every other engine, so the `--machine-key`
+    // override reaches its partition key through the real command line.
+    assert_eq!(
+        sets[0]["machine_key"], HARNESS_AUTO_MACHINE_KEY,
+        "the --machine-key override should key the partition: {discriminants}"
+    );
 }
 
 /// The faker's callgrind value core produces output the *real* parser reads back

--- a/packages/cargo-bench-history/tests/cbh_integration/list.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/list.rs
@@ -8,8 +8,18 @@ async fn list_discriminants_lists_present_sets() {
     let workspace = Workspace::repo(&storage_only_config());
     // One commit, but two comparable sets: a Linux and a Windows callgrind pool.
     workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
-    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
+    workspace.seed_callgrind_in(
+        "x86_64-unknown-linux-gnu",
+        HARNESS_AUTO_MACHINE_KEY,
+        "c1",
+        100.0,
+    );
+    workspace.seed_callgrind_in(
+        "x86_64-pc-windows-msvc",
+        HARNESS_AUTO_MACHINE_KEY,
+        "c1",
+        100.0,
+    );
 
     let message = workspace.drive_json(&["list", "discriminants"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
@@ -66,8 +76,18 @@ async fn list_previews_the_analyzed_data_set() {
 async fn list_facet_selection_mirrors_analyze() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
-    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, "c1", 50.0);
+    workspace.seed_callgrind_in(
+        "x86_64-unknown-linux-gnu",
+        HARNESS_AUTO_MACHINE_KEY,
+        "c1",
+        100.0,
+    );
+    workspace.seed_callgrind_in(
+        "x86_64-pc-windows-msvc",
+        HARNESS_AUTO_MACHINE_KEY,
+        "c1",
+        50.0,
+    );
 
     let message = workspace
         .drive_json(&[

--- a/packages/cargo-bench-history/tests/cbh_integration/list.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/list.rs
@@ -8,8 +8,8 @@ async fn list_discriminants_lists_present_sets() {
     let workspace = Workspace::repo(&storage_only_config());
     // One commit, but two comparable sets: a Linux and a Windows callgrind pool.
     workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
-    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 100.0);
+    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
+    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
 
     let message = workspace.drive_json(&["list", "discriminants"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
@@ -66,8 +66,8 @@ async fn list_previews_the_analyzed_data_set() {
 async fn list_facet_selection_mirrors_analyze() {
     let workspace = Workspace::repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
-    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", "synthetic", "c1", 100.0);
-    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", "synthetic", "c1", 50.0);
+    workspace.seed_callgrind_in("x86_64-unknown-linux-gnu", HARNESS_AUTO_MACHINE_KEY, "c1", 100.0);
+    workspace.seed_callgrind_in("x86_64-pc-windows-msvc", HARNESS_AUTO_MACHINE_KEY, "c1", 50.0);
 
     let message = workspace
         .drive_json(&[

--- a/packages/cargo-bench-history/tests/cbh_integration/prune.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/prune.rs
@@ -218,8 +218,9 @@ async fn prune_dirty_removes_runs_across_multiple_discriminant_sets() {
     workspace.seed_dirty_criterion("2024-01-02", "f1", "m1", 20.0);
 
     // Text format exercises the plural "discriminant sets" summary branch. The
-    // facets widen to every triple/machine so the synthetic callgrind set and the
-    // windows-keyed criterion set are both in scope regardless of host.
+    // facets widen to every triple/machine so the callgrind set (under the harness
+    // machine key) and the `m1`-keyed criterion set are both in scope regardless of
+    // host.
     let RunOutcome::Completed { message } = workspace
         .drive(&[
             "prune",

--- a/packages/cbh_analyze/src/announce.rs
+++ b/packages/cbh_analyze/src/announce.rs
@@ -9,70 +9,18 @@
 //! (see [`ReporterExt::announce`](cbh_diag::ReporterExt::announce)), so a plain run
 //! never hides a value it defaulted.
 
-use cbh_detect::{DiscriminantSetQuery, FacetFilter};
+use cbh_detect::DiscriminantSetQuery;
 use cbh_diag::{Reporter, ReporterExt};
-use cbh_model::Engine;
 use jiff::Timestamp;
 
 use super::facets::describe_effective_facets;
 
-/// The always-on notice explaining that machine-independent (`synthetic`)
-/// benchmarks are included alongside this machine's data — or `None` when it does
-/// not apply.
+/// Emits the always-on effective-selection `summary`.
 ///
-/// It applies exactly when the machine-key facet was auto-detected *and* the
-/// engine facet still admits a synthetic-producing engine (Callgrind or
-/// `alloc_tracker`). A `synthetic` set carries no machine key, so it rides along
-/// whatever the detected key is — but only the hardware-independent engines
-/// produce one, so an explicit `--engine criterion` (or `all_the_time`) filters
-/// every synthetic set out and the notice would promise data that is not in
-/// scope. Naming the inclusion keeps a plain run from silently mixing in data the
-/// user did not obviously ask for, without over-promising when it cannot apply.
-pub(crate) fn machine_independent_inclusion_notice(
-    facets: &DiscriminantSetQuery,
-) -> Option<&'static str> {
-    let machine_key_auto = matches!(facets.machine_key, FacetFilter::Auto(_));
-    (machine_key_auto && engine_admits_synthetic(&facets.engine)).then_some(
-        "Machine-independent benchmarks targeting the 'synthetic' machine key are also \
-         included when using auto-detected machine key",
-    )
-}
-
-/// Whether the engine facet still lets a synthetic-producing engine through.
-///
-/// The hardware-independent engines — Callgrind and `alloc_tracker` — are the
-/// only ones whose sets land in the `synthetic` machine-key partition. `All`
-/// admits every engine; an explicit list admits synthetic sets only when it names
-/// at least one hardware-independent engine.
-fn engine_admits_synthetic(engine: &FacetFilter) -> bool {
-    match engine {
-        FacetFilter::All => true,
-        FacetFilter::Auto(value) => names_synthetic_engine(value),
-        FacetFilter::Explicit(values) => values.iter().any(|value| names_synthetic_engine(value)),
-    }
-}
-
-/// Whether a single engine facet value names a hardware-independent (synthetic)
-/// engine.
-fn names_synthetic_engine(value: &str) -> bool {
-    Engine::from_name(value).is_some_and(|engine| !engine.is_hardware_dependent())
-}
-
-/// Emits the always-on effective-selection `summary`, then the
-/// machine-independent-inclusion notice when it applies (see
-/// [`machine_independent_inclusion_notice`]).
-///
-/// Every command's selection announcement flows through here so the notice appears
-/// on its own line wherever the summary does.
-pub(crate) fn announce_selection(
-    reporter: &dyn Reporter,
-    facets: &DiscriminantSetQuery,
-    summary: &str,
-) {
+/// Every command's selection announcement flows through here so the wording is
+/// identical everywhere and there is a single formatter to maintain.
+pub(crate) fn announce_selection(reporter: &dyn Reporter, summary: &str) {
     reporter.announce(summary);
-    if let Some(notice) = machine_independent_inclusion_notice(facets) {
-        reporter.announce(notice);
-    }
 }
 
 /// The resolved base branch a run split history against, for the announcement.
@@ -247,82 +195,6 @@ mod tests {
         assert!(
             no_cutoff.contains("; since=none (no default look-back)"),
             "{no_cutoff}"
-        );
-    }
-
-    #[test]
-    fn machine_key_auto_triggers_the_synthetic_inclusion_notice() {
-        // Auto-detected machine key: synthetic sets ride along, so the notice fires.
-        let auto = DiscriminantSetQuery {
-            engine: FacetFilter::All,
-            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
-            machine_key: FacetFilter::Auto("abcd".to_owned()),
-        };
-        assert_eq!(
-            machine_independent_inclusion_notice(&auto),
-            Some(
-                "Machine-independent benchmarks targeting the 'synthetic' machine key are also \
-                 included when using auto-detected machine key"
-            )
-        );
-
-        // Explicit or unconstrained machine key: no auto default to explain.
-        let explicit = DiscriminantSetQuery {
-            machine_key: FacetFilter::Explicit(nonempty!["abcd".to_owned()]),
-            ..DiscriminantSetQuery::default()
-        };
-        assert_eq!(machine_independent_inclusion_notice(&explicit), None);
-        assert_eq!(
-            machine_independent_inclusion_notice(&DiscriminantSetQuery::default()),
-            None
-        );
-    }
-
-    #[test]
-    fn engine_facet_gates_the_synthetic_inclusion_notice() {
-        let notice = "Machine-independent benchmarks targeting the 'synthetic' machine key are \
-                      also included when using auto-detected machine key";
-        let with_engine = |engine: FacetFilter| DiscriminantSetQuery {
-            engine,
-            target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
-            machine_key: FacetFilter::Auto("abcd".to_owned()),
-        };
-
-        // An engine facet scoped to a hardware-dependent engine filters every
-        // synthetic set out, so the notice would over-promise and must not fire.
-        assert_eq!(
-            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
-                "criterion".to_owned()
-            ]))),
-            None
-        );
-        assert_eq!(
-            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
-                "all_the_time".to_owned()
-            ]))),
-            None
-        );
-
-        // A synthetic-producing engine (Callgrind / alloc_tracker), alone or
-        // alongside a hardware-dependent one, keeps synthetic sets in scope.
-        assert_eq!(
-            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
-                "callgrind".to_owned()
-            ]))),
-            Some(notice)
-        );
-        assert_eq!(
-            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
-                "alloc_tracker".to_owned()
-            ]))),
-            Some(notice)
-        );
-        assert_eq!(
-            machine_independent_inclusion_notice(&with_engine(FacetFilter::Explicit(nonempty![
-                "criterion".to_owned(),
-                "callgrind".to_owned()
-            ]))),
-            Some(notice)
         );
     }
 

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -195,11 +195,9 @@ where
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and context commit, so a plain run never hides a value it defaulted.
     // Emitted before the base-branch guard so even that refusal states what was
-    // selected. When the machine key was auto-detected, a follow-up notice states
-    // that the machine-independent `synthetic` sets are included regardless.
+    // selected.
     announce_selection(
         reporter,
-        &facets,
         &selection_announcement(
             &facets,
             Some(AnnouncedBase {
@@ -316,12 +314,9 @@ where
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition and the
     // context commit whose blessings are being removed. `unbless` acts purely at a
-    // commit and never resolves a base branch, so no base segment appears. When the
-    // machine key was auto-detected, a follow-up notice states that the
-    // machine-independent `synthetic` sets are unblessed regardless.
+    // commit and never resolves a base branch, so no base segment appears.
     announce_selection(
         reporter,
-        &facets,
         &selection_announcement(
             &facets,
             None,
@@ -398,11 +393,11 @@ mod tests {
         Config::default()
     }
 
-    /// The auto-detected facets for the default synthetic partition the tests seed.
+    /// The auto-detected facets the tests seed their default partition under.
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -432,7 +427,7 @@ mod tests {
     }
 
     fn clean_key(commit: &str) -> String {
-        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json")
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json")
     }
 
     /// A linear master history `c0 - c1 - c2`, HEAD at the tip `c2`.
@@ -776,7 +771,7 @@ mod tests {
             reporter.announcements()
         );
         assert!(
-            reporter.announced("machine-key=synthetic (auto-detected)"),
+            reporter.announced("machine-key=m1 (auto-detected)"),
             "{:?}",
             reporter.announcements()
         );
@@ -810,7 +805,7 @@ mod tests {
         ))
         .unwrap();
         assert!(
-            reporter.announced("machine-key=synthetic (auto-detected)"),
+            reporter.announced("machine-key=m1 (auto-detected)"),
             "{:?}",
             reporter.announcements()
         );

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -195,11 +195,8 @@ where
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and look-back window a plain run would otherwise resolve silently.
-    // When the machine key was auto-detected, a follow-up notice states that the
-    // machine-independent `synthetic` sets ride along regardless of that key.
     announce_selection(
         reporter,
-        &facets,
         &effective_selection_summary(
             &facets,
             &base_name,

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -619,9 +619,7 @@ mod tests {
     }
 
     fn dirty_key(commit: &str, unix: i64) -> String {
-        format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
-        )
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json")
     }
 
     fn store(storage: &MemoryStorage, key: &str, run: &Run) {

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -537,11 +537,11 @@ mod tests {
         Config::default()
     }
 
-    /// The auto-detected facets for the default synthetic partition the tests seed.
+    /// The auto-detected facets the tests seed their default partition under.
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -615,12 +615,12 @@ mod tests {
     }
 
     fn clean_key(commit: &str) -> String {
-        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json")
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json")
     }
 
     fn dirty_key(commit: &str, unix: i64) -> String {
         format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/dirty-{unix}.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
         )
     }
 
@@ -1079,7 +1079,7 @@ mod tests {
         );
         store(
             &storage,
-            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/synthetic/c0/clean.json",
+            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/m1/c0/clean.json",
             &single_metric_run(0, "c0", 200.0),
         );
         let git = linear_git();

--- a/packages/cbh_analyze/src/list.rs
+++ b/packages/cbh_analyze/src/list.rs
@@ -899,11 +899,11 @@ mod tests {
         Config::default()
     }
 
-    /// The auto-detected facets for the default synthetic partition the tests seed.
+    /// The auto-detected facets the tests seed their default partition under.
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -1001,7 +1001,7 @@ mod tests {
     }
 
     fn clean_key(commit: &str) -> String {
-        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json")
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json")
     }
 
     fn store(storage: &MemoryStorage, key: &str, set: &Run) {
@@ -1013,7 +1013,7 @@ mod tests {
         DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -1026,7 +1026,7 @@ mod tests {
         DiscriminantSet {
             engine: "criterion".to_owned(),
             target_triple: "aarch64-apple-darwin".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -1091,7 +1091,7 @@ mod tests {
             "{text}"
         );
         assert!(
-            text.contains("callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            text.contains("callgrind/x86_64-unknown-linux-gnu/m1"),
             "{text}"
         );
         assert!(
@@ -1287,7 +1287,7 @@ mod tests {
         let report = list(&storage, &git, &options());
         assert!(report.contains("Data set for project folo"), "{report}");
         assert!(
-            report.contains("callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            report.contains("callgrind/x86_64-unknown-linux-gnu/m1"),
             "{report}"
         );
         // "series" must not be pluralized into "seriess".
@@ -1394,7 +1394,7 @@ mod tests {
         store(&storage, &clean_key("c0"), &two_metric_set(0, "c0"));
         store(
             &storage,
-            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/synthetic/c0/clean.json",
+            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/m1/c0/clean.json",
             &two_metric_set(0, "c0"),
         );
         let git = linear_git();
@@ -1485,9 +1485,9 @@ mod tests {
         assert!(engines.contains(&"callgrind"), "{report}");
         assert!(engines.contains(&"criterion"), "{report}");
 
-        // An explicit facet still narrows the catalog. (`--engine` is the facet
-        // that always discriminates: synthetic partitions are exempt from the
-        // triple and machine-key filters, but never from the engine filter.)
+        // An explicit facet still narrows the catalog. The discriminants catalog
+        // lists every stored partition regardless of the auto-detected triple or
+        // machine key, but an explicit `--engine` still filters it.
         let opts = ListOptions {
             subject: ListSubject::Discriminants,
             engine: vec!["criterion".to_owned()],
@@ -1546,7 +1546,7 @@ mod tests {
         let report = list(&storage, &git, &opts);
         assert!(report.contains("Discriminant sets:"), "{report}");
         assert!(
-            report.contains("callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            report.contains("callgrind/x86_64-unknown-linux-gnu/m1"),
             "{report}"
         );
     }
@@ -1567,7 +1567,7 @@ mod tests {
             "{report}"
         );
         assert!(
-            report.contains("| callgrind | x86_64-unknown-linux-gnu | synthetic |"),
+            report.contains("| callgrind | x86_64-unknown-linux-gnu | m1 |"),
             "{report}"
         );
     }
@@ -1614,7 +1614,7 @@ mod tests {
     /// The blessing-sidecar key in the same partition as [`clean_key`].
     fn bless_key(commit: &str, issued_unix: i64) -> String {
         format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/bless-{issued_unix}.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/bless-{issued_unix}.json"
         )
     }
 

--- a/packages/cbh_analyze/src/load.rs
+++ b/packages/cbh_analyze/src/load.rs
@@ -423,7 +423,7 @@ mod tests {
         let set = DiscriminantSet {
             engine: "criterion".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
         let mut index = RunIndex::new();
         assert!(index.is_empty(), "a fresh index admits no runs");
@@ -454,12 +454,12 @@ mod tests {
         let set = DiscriminantSet {
             engine: "criterion".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
         let other_set = DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
 
         // The reference index folds every run in one pass.
@@ -509,12 +509,12 @@ mod tests {
         let set = DiscriminantSet {
             engine: "criterion".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
         let other_set = DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
 
         let mut index = RunIndex::new();
@@ -539,7 +539,7 @@ mod tests {
         let set = DiscriminantSet {
             engine: "criterion".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
         let mut index = RunIndex::new();
         index.record(&set, 0, "solo", false);

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -455,9 +455,7 @@ mod tests {
 
     /// A dirty snapshot key for `commit` taken at `unix`.
     fn dirty_key(commit: &str, unix: i64) -> String {
-        format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
-        )
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json")
     }
 
     /// Stores a value at `key` in `storage`, panicking on failure (test helper).
@@ -781,8 +779,7 @@ mod tests {
             "0.0.1".to_owned(),
         );
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
-                .to_owned();
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json".to_owned();
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
 
         let reporter = RecordingReporter::new();
@@ -843,8 +840,7 @@ mod tests {
             "0.0.1".to_owned(),
         );
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
-                .to_owned();
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json".to_owned();
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
 
         let reporter = RecordingReporter::new();
@@ -910,8 +906,7 @@ mod tests {
         seed_linear_step(&storage);
         // c3 is on the linear6 history, so history mode loads its sidecar.
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
-                .to_owned();
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json".to_owned();
         block_on(storage.put(&bless_key, &[0xff, 0xfe, 0x00])).unwrap();
         let error = analyze_blessing_error(&storage);
         match error {
@@ -927,8 +922,7 @@ mod tests {
         let storage = MemoryStorage::new();
         seed_linear_step(&storage);
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
-                .to_owned();
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json".to_owned();
         block_on(storage.put(&bless_key, b"{ not a blessing record")).unwrap();
         let error = analyze_blessing_error(&storage);
         match error {
@@ -955,8 +949,7 @@ mod tests {
             "0.0.1".to_owned(),
         );
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/z9/bless-3.json"
-                .to_owned();
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/z9/bless-3.json".to_owned();
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
 
         let reporter = RecordingReporter::new();

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -416,7 +416,7 @@ mod tests {
 
     /// The clean object key for `commit` in the callgrind/linux partition.
     fn clean_key(commit: &str) -> String {
-        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json")
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json")
     }
 
     /// The clean object key for `commit` in an arbitrary engine/triple/machine-key partition.
@@ -456,7 +456,7 @@ mod tests {
     /// A dirty snapshot key for `commit` taken at `unix`.
     fn dirty_key(commit: &str, unix: i64) -> String {
         format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/dirty-{unix}.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
         )
     }
 
@@ -598,12 +598,12 @@ mod tests {
         Timestamp::from_second(0).unwrap()
     }
 
-    /// The auto-detected facets for the default synthetic partition the unit-test
-    /// data is seeded under (`x86_64-unknown-linux-gnu`, `synthetic` machine).
+    /// The auto-detected facets the unit-test data is seeded under
+    /// (`x86_64-unknown-linux-gnu`, `m1` machine).
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -781,7 +781,7 @@ mod tests {
             "0.0.1".to_owned(),
         );
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c3/bless-3.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
                 .to_owned();
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
 
@@ -843,7 +843,7 @@ mod tests {
             "0.0.1".to_owned(),
         );
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c3/bless-3.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
                 .to_owned();
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
 
@@ -910,7 +910,7 @@ mod tests {
         seed_linear_step(&storage);
         // c3 is on the linear6 history, so history mode loads its sidecar.
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c3/bless-3.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
                 .to_owned();
         block_on(storage.put(&bless_key, &[0xff, 0xfe, 0x00])).unwrap();
         let error = analyze_blessing_error(&storage);
@@ -927,7 +927,7 @@ mod tests {
         let storage = MemoryStorage::new();
         seed_linear_step(&storage);
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c3/bless-3.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c3/bless-3.json"
                 .to_owned();
         block_on(storage.put(&bless_key, b"{ not a blessing record")).unwrap();
         let error = analyze_blessing_error(&storage);
@@ -955,7 +955,7 @@ mod tests {
             "0.0.1".to_owned(),
         );
         let bless_key =
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/z9/bless-3.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/z9/bless-3.json"
                 .to_owned();
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
 
@@ -986,7 +986,7 @@ mod tests {
         // Both sets run through the `linear_git` tip (`c3`) so neither benchmark is a
         // ghost there and the always-on tip filter keeps every series.
         //
-        // Set A — callgrind/linux/synthetic: three runs (c1..c3), each carrying two
+        // Set A — callgrind/linux/m1: three runs (c1..c3), each carrying two
         // metrics so the set reconstructs two distinct series.
         for index in 1..4 {
             let commit = format!("c{index}");
@@ -997,7 +997,7 @@ mod tests {
                 &two_metric_set(second, &commit, 100.0, 200.0),
             );
         }
-        // Set B — callgrind/darwin/synthetic: two runs (c2..c3), each carrying one
+        // Set B — callgrind/darwin/m1: two runs (c2..c3), each carrying one
         // metric so the set reconstructs a single series. Distinct run AND series
         // counts from set A make an `==`/`!=` swap in either per-set tally observable.
         for index in 2..4 {
@@ -1005,13 +1005,13 @@ mod tests {
             let second = i64::from(index);
             store(
                 &storage,
-                &clean_key_in("callgrind", "aarch64-apple-darwin", "synthetic", &commit),
+                &clean_key_in("callgrind", "aarch64-apple-darwin", "m1", &commit),
                 &ir_set(second, &commit, 100.0),
             );
         }
 
         let git = linear_git();
-        // The two sets live under different triples, and synthetic sets obey the
+        // The two sets live under different triples, and every set obeys the
         // target-triple facet, so an auto-detected triple would report only its own.
         // Widen to `all` to exercise the per-set tallies across both partitions.
         let opts = AnalyzeOptions {
@@ -1551,7 +1551,7 @@ mod tests {
         store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
             &storage,
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c3/clean.json",
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/m1/c3/clean.json",
             &ir_set(3, "c3", 100.0),
         );
         let git = linear_git();
@@ -1578,7 +1578,7 @@ mod tests {
         store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
             &storage,
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c3/clean.json",
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/m1/c3/clean.json",
             &ir_set(3, "c3", 100.0),
         );
         let git = linear_git();
@@ -1601,13 +1601,13 @@ mod tests {
     fn two_sets_produce_two_report_sections() {
         // Both sets are seeded at the `linear_git` tip (`c3`) so the tip filter keeps
         // each and every partition is reported. They differ only by triple, and
-        // synthetic sets obey the target-triple facet, so the query widens to
+        // every set obeys the target-triple facet, so the query widens to
         // `--target-triple all` to search both partitions rather than just the host's.
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
         store(
             &storage,
-            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/synthetic/c3/clean.json",
+            "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/m1/c3/clean.json",
             &ir_set(3, "c3", 100.0),
         );
         let git = linear_git();
@@ -1629,7 +1629,7 @@ mod tests {
         store(&storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
         store(
             &storage,
-            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/synthetic/c0/clean.json",
+            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/m1/c0/clean.json",
             &ir_set(0, "c0", 100.0),
         );
         let git = linear_git();
@@ -1813,7 +1813,7 @@ mod tests {
             let commit = format!("c{index}");
             let second = i64::try_from(index).unwrap();
             let key = format!(
-                "v1/{sanitized}/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
+                "v1/{sanitized}/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json"
             );
             store(&storage, &key, &ir_set(second, &commit, value));
         }

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -203,11 +203,9 @@ where
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and `--since` cutoff a plain run would otherwise resolve silently.
     // Emitted before the `--prune-base` guard so even that refusal states what was
-    // selected. When the machine key was auto-detected, a follow-up notice states
-    // that the machine-independent `synthetic` sets are pruned along with it.
+    // selected.
     announce_selection(
         reporter,
-        &facets,
         &selection_announcement(
             &facets,
             Some(AnnouncedBase {
@@ -733,11 +731,11 @@ mod tests {
         Config::default()
     }
 
-    /// The auto-detected facets for the default synthetic partition the tests seed.
+    /// The auto-detected facets the tests seed their default partition under.
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -778,18 +776,18 @@ mod tests {
     }
 
     fn clean_key(commit: &str) -> String {
-        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json")
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json")
     }
 
     fn dirty_key(commit: &str, unix: i64) -> String {
         format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/dirty-{unix}.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
         )
     }
 
     fn bless_key(commit: &str, unix: i64) -> String {
         format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/bless-{unix}.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/bless-{unix}.json"
         )
     }
 
@@ -972,7 +970,7 @@ mod tests {
             reporter.announcements()
         );
         assert!(
-            reporter.announced("machine-key=synthetic (auto-detected)"),
+            reporter.announced("machine-key=m1 (auto-detected)"),
             "{:?}",
             reporter.announcements()
         );
@@ -1428,7 +1426,7 @@ mod tests {
         // A criterion dirty run on the same commit must survive an engine-scoped
         // callgrind prune.
         let criterion_dirty =
-            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/synthetic/f1/dirty-200.json";
+            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/m1/f1/dirty-200.json";
         store(&storage, criterion_dirty, &set("f1"));
         let git = feature_git();
 
@@ -1590,7 +1588,7 @@ mod tests {
         let set = DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         };
         // Two clean runs (c0, c1) plus one blessing on c0: an asymmetric mix so a
         // run/blessing miscount diverges from the truth.

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -780,15 +780,11 @@ mod tests {
     }
 
     fn dirty_key(commit: &str, unix: i64) -> String {
-        format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
-        )
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json")
     }
 
     fn bless_key(commit: &str, unix: i64) -> String {
-        format!(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/bless-{unix}.json"
-        )
+        format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/bless-{unix}.json")
     }
 
     fn store(storage: &MemoryStorage, key: &str, value: &Run) {

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -325,8 +325,8 @@ struct CollectCommand {
     #[command(flatten)]
     env: EnvArgs,
 
-    /// Override the machine fingerprint used to partition hardware-dependent
-    /// results (for example, a CI machine-pool name).
+    /// Override the machine key used to partition every engine's results (for
+    /// example, a CI machine-pool name).
     #[arg(long, value_name = "KEY", help_heading = HEADING_DISCRIMINANT)]
     machine_key: Option<String>,
 
@@ -432,8 +432,8 @@ struct ImportCommand {
     #[arg(long, value_name = "PATH", help_heading = HEADING_ENV)]
     target_dir: PathBuf,
 
-    /// Override the machine fingerprint used to partition hardware-dependent
-    /// results (for example, a CI machine-pool name).
+    /// Override the machine key used to partition every engine's results (for
+    /// example, a CI machine-pool name).
     #[arg(long, value_name = "KEY", help_heading = HEADING_DISCRIMINANT)]
     machine_key: Option<String>,
 
@@ -866,8 +866,8 @@ struct BackfillCommand {
     #[command(flatten)]
     env: EnvArgs,
 
-    /// Override the machine fingerprint used to partition hardware-dependent
-    /// results (for example, a CI machine-pool name).
+    /// Override the machine key used to partition every engine's results (for
+    /// example, a CI machine-pool name).
     #[arg(long, value_name = "KEY", help_heading = HEADING_DISCRIMINANT)]
     machine_key: Option<String>,
 

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -71,8 +71,9 @@ pub enum Command {
     Bless(BlessOptions),
     /// Remove blessings recorded at the current commit.
     Unbless(UnblessOptions),
-    /// Print this machine's hardware fingerprint (the machine key
-    /// hardware-dependent engines partition by).
+    /// Print this machine's hardware fingerprint.
+    ///
+    /// Every benchmark engine partitions its history by this key.
     MachineKey(MachineKeyOptions),
 }
 
@@ -103,7 +104,7 @@ pub struct CollectOptions {
     pub all_features: bool,
     /// Disable the default cargo feature set (`--no-default-features`).
     pub no_default_features: bool,
-    /// Override for the machine fingerprint (hardware-dependent engines), if set.
+    /// Override for the machine key used to partition every engine, if set.
     pub machine_key: Option<String>,
     /// Harvest and build results without storing them.
     pub no_store: bool,
@@ -174,7 +175,7 @@ pub struct ImportOptions {
     /// leftovers from unrelated runs into one import, so the caller must name the
     /// tree it curated.
     pub target_dir: PathBuf,
-    /// Override for the machine fingerprint (hardware-dependent engines), if set.
+    /// Override for the machine key used to partition every engine, if set.
     pub machine_key: Option<String>,
     /// Override for the partition target triple, if set. Applied to both the
     /// partition key and the recorded `ToolchainInfo.target_triple` so the stored
@@ -539,7 +540,7 @@ pub struct BackfillOptions {
     pub all_features: bool,
     /// Disable the default cargo feature set (`--no-default-features`).
     pub no_default_features: bool,
-    /// Override for the machine fingerprint (hardware-dependent engines), if set.
+    /// Override for the machine key used to partition every engine, if set.
     pub machine_key: Option<String>,
     /// Replace already-stored results for the backfilled commits instead of
     /// skipping them as duplicates.

--- a/packages/cbh_detect/src/detect/discriminant.rs
+++ b/packages/cbh_detect/src/detect/discriminant.rs
@@ -19,8 +19,7 @@ use nonempty::NonEmpty;
 /// filtering — [`DiscriminantSetQuery::matches`] treats [`Auto`](Self::Auto)
 /// and [`Explicit`](Self::Explicit) alike, matching by value equality — but it
 /// drives user-facing diagnostics: marking an auto-detected value in the
-/// verbose selection trail and phrasing the machine-independent inclusion
-/// notice.
+/// verbose selection trail.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum FacetFilter {
     /// Unconstrained: every set passes. Produced by the `all` keyword, and by
@@ -38,15 +37,7 @@ pub enum FacetFilter {
 
 impl FacetFilter {
     /// Whether `actual` passes this filter.
-    ///
-    /// `exempt` marks a set that ignores this facet entirely (used for the
-    /// machine-key facet on a `synthetic` set — `synthetic` means "no machine",
-    /// so its results belong to every machine's universe regardless of whether
-    /// the facet was auto-detected or explicit).
-    fn passes(&self, actual: &str, exempt: bool) -> bool {
-        if exempt {
-            return true;
-        }
+    fn passes(&self, actual: &str) -> bool {
         match self {
             Self::All => true,
             Self::Auto(value) => value.eq_ignore_ascii_case(actual),
@@ -78,18 +69,15 @@ pub struct DiscriminantSetQuery {
 impl DiscriminantSetQuery {
     /// Whether `set` passes every facet filter.
     ///
-    /// Hardware-independent (`synthetic`) sets — Callgrind and `alloc_tracker` —
-    /// are exempt from the machine-key facet entirely: their results are not tied
-    /// to any one machine, so they belong to every machine's universe. They still
-    /// obey the target-triple facet, because even hardware-independent counts are
-    /// not comparable across architectures (a per-architecture instruction count
-    /// or allocation profile is a different measurement).
+    /// Every set is machine-keyed, so the machine-key facet applies uniformly.
+    /// Sets still obey the target-triple facet, because counts are not comparable
+    /// across architectures (a per-architecture instruction count or allocation
+    /// profile is a different measurement).
     #[must_use]
     pub fn matches(&self, set: &DiscriminantSet) -> bool {
-        let synthetic = set.is_synthetic();
-        self.engine.passes(&set.engine, false)
-            && self.target_triple.passes(&set.target_triple, false)
-            && self.machine_key.passes(&set.machine_key, synthetic)
+        self.engine.passes(&set.engine)
+            && self.target_triple.passes(&set.target_triple)
+            && self.machine_key.passes(&set.machine_key)
     }
 }
 
@@ -104,7 +92,7 @@ mod tests {
         DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: triple.to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -117,7 +105,7 @@ mod tests {
                 target_triple: FacetFilter::Explicit(nonempty![
                     "x86_64-pc-windows-msvc".to_owned()
                 ]),
-                machine_key: FacetFilter::Explicit(nonempty!["synthetic".to_owned()]),
+                machine_key: FacetFilter::Explicit(nonempty!["m1".to_owned()]),
                 ..DiscriminantSetQuery::default()
             }
             .matches(&windows)
@@ -153,45 +141,54 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_set_is_exempt_from_the_machine_key_facet() {
-        let synthetic = set("x86_64-unknown-linux-gnu"); // machine = synthetic
-        // Even an explicit, non-matching machine key includes a synthetic set.
+    fn set_obeys_the_machine_key_facet() {
+        let machine = set("x86_64-unknown-linux-gnu"); // machine = m1
+        // A non-matching explicit machine key excludes the set.
         assert!(
-            DiscriminantSetQuery {
+            !DiscriminantSetQuery {
                 machine_key: FacetFilter::Explicit(nonempty!["some-other-machine".to_owned()]),
                 ..DiscriminantSetQuery::default()
             }
-            .matches(&synthetic)
+            .matches(&machine)
         );
-        // And an auto-detected host fingerprint includes it too.
+        // A non-matching auto-detected host fingerprint excludes it too.
         assert!(
-            DiscriminantSetQuery {
+            !DiscriminantSetQuery {
                 machine_key: FacetFilter::Auto("host-fingerprint".to_owned()),
                 ..DiscriminantSetQuery::default()
             }
-            .matches(&synthetic)
+            .matches(&machine)
+        );
+        // Its own machine key includes it.
+        assert!(
+            DiscriminantSetQuery {
+                machine_key: FacetFilter::Explicit(nonempty!["m1".to_owned()]),
+                ..DiscriminantSetQuery::default()
+            }
+            .matches(&machine)
         );
     }
 
     #[test]
-    fn synthetic_set_obeys_the_target_triple_facet() {
-        let synthetic = set("x86_64-unknown-linux-gnu"); // machine = synthetic
+    fn set_obeys_the_target_triple_facet() {
+        let machine = set("x86_64-unknown-linux-gnu");
         // A matching auto-detected triple includes it.
         assert!(
             DiscriminantSetQuery {
                 target_triple: FacetFilter::Auto("x86_64-unknown-linux-gnu".to_owned()),
+                machine_key: FacetFilter::Auto("m1".to_owned()),
                 ..DiscriminantSetQuery::default()
             }
-            .matches(&synthetic)
+            .matches(&machine)
         );
-        // A different auto-detected triple excludes it: even hardware-independent
-        // counts are not comparable across architectures.
+        // A different auto-detected triple excludes it: counts are not comparable
+        // across architectures.
         assert!(
             !DiscriminantSetQuery {
                 target_triple: FacetFilter::Auto("x86_64-pc-windows-msvc".to_owned()),
                 ..DiscriminantSetQuery::default()
             }
-            .matches(&synthetic)
+            .matches(&machine)
         );
         // An explicit non-matching triple also excludes it.
         assert!(
@@ -201,12 +198,12 @@ mod tests {
                 ]),
                 ..DiscriminantSetQuery::default()
             }
-            .matches(&synthetic)
+            .matches(&machine)
         );
     }
 
     #[test]
-    fn hardware_dependent_set_obeys_the_auto_detected_machine_key() {
+    fn set_obeys_the_auto_detected_machine_key() {
         let machine = DiscriminantSet {
             engine: "criterion".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1283,7 +1283,7 @@ mod tests {
             set: DiscriminantSet {
                 engine: "callgrind".to_owned(),
                 target_triple: "t".to_owned(),
-                machine_key: "synthetic".to_owned(),
+                machine_key: "m1".to_owned(),
             },
             id: BenchmarkId::new(nonempty!["group".to_owned(), "case".to_owned()]),
             kind,
@@ -1338,7 +1338,7 @@ mod tests {
                 set: DiscriminantSet {
                     engine: "callgrind".to_owned(),
                     target_triple: "t".to_owned(),
-                    machine_key: "synthetic".to_owned(),
+                    machine_key: "m1".to_owned(),
                 },
                 id: BenchmarkId::new(nonempty!["group".to_owned(), "case".to_owned()]),
                 kind: MetricKind::InstructionCount,
@@ -2034,7 +2034,7 @@ mod tests {
             set: DiscriminantSet {
                 engine: "callgrind".to_owned(),
                 target_triple: "t".to_owned(),
-                machine_key: "synthetic".to_owned(),
+                machine_key: "m1".to_owned(),
             },
             id: BenchmarkId::new(nonempty!["group".to_owned(), "case".to_owned()]),
             kind: MetricKind::InstructionCount,

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -628,7 +628,7 @@ mod tests {
     /// A clean object at `commit` carrying the given instruction-count value.
     fn clean_object(commit: &str, observation: i64, value: f64) -> LoadedObject {
         let object_key = format!(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json"
         );
         LoadedObject {
             key: parse_key(&object_key).unwrap(),
@@ -640,7 +640,7 @@ mod tests {
     /// A dirty snapshot at `commit` taken at `unix`, carrying the given value.
     fn dirty_object(commit: &str, unix: i64, value: f64) -> LoadedObject {
         let object_key = format!(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/dirty-{unix}.json"
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/dirty-{unix}.json"
         );
         LoadedObject {
             key: parse_key(&object_key).unwrap(),
@@ -677,7 +677,7 @@ mod tests {
             .map(|(package, commit, topo_index, dirty, ordinal, value)| {
                 let run = run_for_package(ts(1), commit, value, Some(package));
                 let object_key = format!(
-                    "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
+                    "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json"
                 );
                 let key = parse_key(&object_key).unwrap();
                 (
@@ -826,7 +826,7 @@ mod tests {
     fn build_series_separates_sets() {
         // A second run in a different triple is a different (incomparable) series.
         let other_key =
-            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/synthetic/c0/clean.json"
+            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/m1/c0/clean.json"
                 .to_owned();
         let other = LoadedObject {
             key: parse_key(&other_key).unwrap(),
@@ -843,9 +843,9 @@ mod tests {
         // Two results share group/case/kind and set but belong to different
         // packages, so they must form two series rather than silently merging.
         let foo_key =
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json".to_owned();
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json".to_owned();
         let bar_key =
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c1/clean.json".to_owned();
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c1/clean.json".to_owned();
         let objects = vec![
             LoadedObject {
                 key: parse_key(&foo_key).unwrap(),
@@ -866,9 +866,9 @@ mod tests {
     fn build_series_applies_prefix_filter() {
         // Two benchmarks in different packages; a prefix selects only one family.
         let foo_key =
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json".to_owned();
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json".to_owned();
         let bar_key =
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c1/clean.json".to_owned();
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c1/clean.json".to_owned();
         let objects = vec![
             LoadedObject {
                 key: parse_key(&foo_key).unwrap(),
@@ -983,7 +983,7 @@ mod tests {
         // A blessing recorded only for a *different* set (a different target triple),
         // so the lookup for this series' set misses.
         let other_set = parse_key(
-            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/synthetic/c0/clean.json",
+            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/m1/c0/clean.json",
         )
         .unwrap()
         .set;
@@ -1013,7 +1013,7 @@ mod tests {
         benches: &[(&str, f64)],
     ) -> LoadedObject {
         let object_key =
-            format!("v1/proj/objects/callgrind/{triple}/synthetic/{commit}/{filename}");
+            format!("v1/proj/objects/callgrind/{triple}/m1/{commit}/{filename}");
         let context = RunContext::new(
             ts(observation),
             GitInfo {
@@ -1121,7 +1121,7 @@ mod tests {
         metrics: &[(MetricKind, f64)],
     ) -> LoadedObject {
         let object_key = format!(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/{commit}/clean.json"
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json"
         );
         let context = RunContext::new(
             ts(observation),
@@ -1262,7 +1262,7 @@ mod tests {
         // distinct id survives as its own series across both resize paths.
         let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(Vec::new());
         let key =
-            parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json")
+            parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json")
                 .unwrap();
 
         let mut first = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
@@ -1330,7 +1330,7 @@ mod tests {
         );
         let run = Run::new(context, vec![record]);
         let key =
-            parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/c0/clean.json")
+            parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json")
                 .unwrap();
 
         let mut builder = SeriesBuilder::new(SeriesFilter::default());

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -627,9 +627,8 @@ mod tests {
 
     /// A clean object at `commit` carrying the given instruction-count value.
     fn clean_object(commit: &str, observation: i64, value: f64) -> LoadedObject {
-        let object_key = format!(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json"
-        );
+        let object_key =
+            format!("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json");
         LoadedObject {
             key: parse_key(&object_key).unwrap(),
             object_key,
@@ -826,8 +825,7 @@ mod tests {
     fn build_series_separates_sets() {
         // A second run in a different triple is a different (incomparable) series.
         let other_key =
-            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/m1/c0/clean.json"
-                .to_owned();
+            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/m1/c0/clean.json".to_owned();
         let other = LoadedObject {
             key: parse_key(&other_key).unwrap(),
             object_key: other_key,
@@ -982,11 +980,10 @@ mod tests {
         let mut series = four_commit_series();
         // A blessing recorded only for a *different* set (a different target triple),
         // so the lookup for this series' set misses.
-        let other_set = parse_key(
-            "v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/m1/c0/clean.json",
-        )
-        .unwrap()
-        .set;
+        let other_set =
+            parse_key("v1/proj/objects/callgrind/aarch64-unknown-linux-gnu/m1/c0/clean.json")
+                .unwrap()
+                .set;
         let mut map = HashMap::new();
         map.insert(
             other_set,
@@ -1012,8 +1009,7 @@ mod tests {
         observation: i64,
         benches: &[(&str, f64)],
     ) -> LoadedObject {
-        let object_key =
-            format!("v1/proj/objects/callgrind/{triple}/m1/{commit}/{filename}");
+        let object_key = format!("v1/proj/objects/callgrind/{triple}/m1/{commit}/{filename}");
         let context = RunContext::new(
             ts(observation),
             GitInfo {
@@ -1120,9 +1116,8 @@ mod tests {
         package: &str,
         metrics: &[(MetricKind, f64)],
     ) -> LoadedObject {
-        let object_key = format!(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json"
-        );
+        let object_key =
+            format!("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/{commit}/clean.json");
         let context = RunContext::new(
             ts(observation),
             GitInfo {
@@ -1261,9 +1256,8 @@ mod tests {
         // rehash closure would silently drop or conflate series, so check that every
         // distinct id survives as its own series across both resize paths.
         let prefixes: Arc<[BenchmarkIdPrefix]> = Arc::from(Vec::new());
-        let key =
-            parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json")
-                .unwrap();
+        let key = parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json")
+            .unwrap();
 
         let mut first = SeriesBuilder::with_prefixes(Arc::clone(&prefixes));
         for index in 0_u32..64 {
@@ -1329,9 +1323,8 @@ mod tests {
             ],
         );
         let run = Run::new(context, vec![record]);
-        let key =
-            parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json")
-                .unwrap();
+        let key = parse_key("v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json")
+            .unwrap();
 
         let mut builder = SeriesBuilder::new(SeriesFilter::default());
         builder.push(&key.set, 0, false, 0, &key.commit, &RunPoints::from(&run));

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -297,7 +297,7 @@ fn curated_series(values: &[f64], kind: MetricKind) -> Series {
         set: DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "t".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         },
         id: BenchmarkId::new(nonempty!["signal".to_owned(), "case".to_owned()]),
         kind,

--- a/packages/cbh_engines/src/bench/all_the_time.rs
+++ b/packages/cbh_engines/src/bench/all_the_time.rs
@@ -5,14 +5,12 @@
 //! recording the per-iteration processor time a benchmark spends together with a
 //! per-iteration slope and its confidence interval estimated over the operation's
 //! measured spans. Processor time depends on the host hardware, so this engine
-//! partitions its history by a machine key (see [`Engine::is_hardware_dependent`]).
-//! The committed fixtures under `tests/fixtures/all_the_time/` are representative
+//! partitions its history by a machine key. The committed fixtures under
+//! `tests/fixtures/all_the_time/` are representative
 //! samples of the current schema; the authoritative schema-drift guard is the
 //! `super::schema_roundtrip` test, which feeds real producer output through this
 //! parser so a field renamed or dropped on either side of the boundary fails the
 //! build.
-//!
-//! [`Engine::is_hardware_dependent`]: cbh_model::Engine::is_hardware_dependent
 
 use std::error::Error;
 use std::fmt;

--- a/packages/cbh_engines/src/bench/alloc_tracker.rs
+++ b/packages/cbh_engines/src/bench/alloc_tracker.rs
@@ -4,9 +4,10 @@
 //! `alloc_tracker` writes one file per operation under `target/alloc_tracker/`,
 //! recording how many bytes and how many allocations a benchmark performs per
 //! iteration, together with a per-iteration slope and its confidence interval
-//! estimated over the operation's measured spans. Allocation behavior does not
-//! depend on the host hardware, so this engine stores its history without a
-//! machine key (see [`Engine::is_hardware_dependent`]). It is *not* deterministic,
+//! estimated over the operation's measured spans. Allocation behavior can vary
+//! across microarchitectures — for example when a dependency dispatches to a
+//! different code path per CPU — so this engine partitions its history by a
+//! machine key. It is *not* deterministic,
 //! however: warmup and buffer-resize allocations are amortized over a
 //! Criterion-chosen iteration count, so the per-iteration figures jitter run to
 //! run. The adapter therefore reads the warmup-robust per-iteration slope. Every
@@ -17,8 +18,6 @@
 //! guard is the `super::schema_roundtrip` test, which feeds real producer output
 //! through this parser so a field renamed or dropped on either side of the
 //! boundary fails the build.
-//!
-//! [`Engine::is_hardware_dependent`]: cbh_model::Engine::is_hardware_dependent
 
 use std::error::Error;
 use std::fmt;

--- a/packages/cbh_model/benches/cbh_model.rs
+++ b/packages/cbh_model/benches/cbh_model.rs
@@ -45,7 +45,7 @@ fn storage_key(c: &mut Criterion) {
         b.iter(|| black_box(sanitize_segment(black_box("x86_64-unknown-linux-gnu"))));
     });
 
-    let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+    let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
     group.bench_function("clean_key", |b| {
         b.iter(|| {
             black_box(black_box(&set).clean_key(
@@ -55,7 +55,7 @@ fn storage_key(c: &mut Criterion) {
         });
     });
 
-    let key = "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/\
+    let key = "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/\
                deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/clean.json";
     group.bench_function("parse_key", |b| {
         b.iter(|| black_box(parse_key(black_box(key))));

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -3,9 +3,8 @@
 //!
 //! The guiding rule (see the *Comparability & storage partitioning* section of
 //! `DESIGN.md`) is to partition only by what makes results *fundamentally*
-//! incomparable — project, engine, target triple, and (for hardware-dependent
-//! engines) a machine key — and to record everything else as metadata so its
-//! effect stays visible in the timeline.
+//! incomparable — project, engine, target triple, and a machine key — and to
+//! record everything else as metadata so its effect stays visible in the timeline.
 
 use std::fmt;
 
@@ -13,18 +12,20 @@ use serde::Serialize;
 
 use super::constants::{OBJECTS_SEGMENT, STORAGE_VERSION};
 
-/// A benchmark engine, distinguished by whether its results depend on hardware.
+/// A benchmark engine: the measurement tool whose output a series accumulates.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Engine {
-    /// Criterion wall-clock benchmarks: hardware-dependent and noisy.
+    /// Criterion wall-clock benchmarks: noisy, with a confidence interval.
     Criterion,
-    /// Callgrind (via Gungraun) instruction counts: simulated, hardware-independent.
+    /// Callgrind (via Gungraun) instruction counts: simulated and low-noise, yet
+    /// still machine-dependent (microarchitecture-specific library dispatch moves
+    /// the counts), so its history is partitioned by machine key like every engine.
     Callgrind,
-    /// `alloc_tracker` allocation counts and bytes: hardware-independent but not
-    /// deterministic — warmup and buffer-resize allocations jitter the per-iteration
-    /// figure, which is amortized over a Criterion-chosen iteration count.
+    /// `alloc_tracker` allocation counts and bytes: not deterministic — warmup and
+    /// buffer-resize allocations jitter the per-iteration figure, which is amortized
+    /// over a Criterion-chosen iteration count.
     AllocTracker,
-    /// `all_the_time` processor-time measurements: hardware-dependent and noisy.
+    /// `all_the_time` processor-time measurements: noisy, with a confidence interval.
     AllTheTime,
 }
 
@@ -61,20 +62,6 @@ impl Engine {
             _ => None,
         }
     }
-
-    /// Whether results from this engine depend on the host hardware.
-    ///
-    /// Hardware-dependent engines require a machine key in their partition;
-    /// hardware-independent ones use the literal `synthetic` instead. Allocation
-    /// counts and bytes are a property of the code, not the machine, so
-    /// `alloc_tracker` is hardware-independent; processor time obviously is not.
-    #[must_use]
-    pub fn is_hardware_dependent(self) -> bool {
-        match self {
-            Self::Criterion | Self::AllTheTime => true,
-            Self::Callgrind | Self::AllocTracker => false,
-        }
-    }
 }
 
 impl fmt::Display for Engine {
@@ -96,7 +83,8 @@ pub struct DiscriminantSet {
     pub engine: String,
     /// Resolved target triple the run was recorded under.
     pub target_triple: String,
-    /// Machine key (`synthetic` for hardware-independent engines).
+    /// Machine key: a stable hardware fingerprint (or an explicit override). Every
+    /// engine is machine-keyed.
     pub machine_key: String,
 }
 
@@ -108,27 +96,20 @@ impl DiscriminantSet {
     /// alphanumeric, `-`, `_`, or `.` is replaced with `_`, and a segment that
     /// would otherwise be empty or consist only of dots becomes `_`. This keeps a
     /// stray `/` (or other surprising input) from silently splitting a storage key
-    /// into the wrong number of segments. A `None` machine key becomes the literal
-    /// `synthetic`, used for hardware-independent engines.
+    /// into the wrong number of segments.
     #[must_use]
-    pub fn new(engine: Engine, target_triple: &str, machine_key: Option<&str>) -> Self {
+    pub fn new(engine: Engine, target_triple: &str, machine_key: &str) -> Self {
         Self {
             engine: engine.as_str().to_owned(),
             target_triple: sanitize_segment(target_triple),
-            machine_key: machine_key.map_or_else(|| "synthetic".to_owned(), sanitize_segment),
+            machine_key: sanitize_segment(machine_key),
         }
-    }
-
-    /// Whether this is a hardware-independent (`synthetic`) set.
-    #[must_use]
-    pub fn is_synthetic(&self) -> bool {
-        self.machine_key == "synthetic"
     }
 
     /// The storage prefix that all runs in this series share, within `project`.
     ///
     /// Layout:
-    /// `{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{target_triple}/{machine|synthetic}`.
+    /// `{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{target_triple}/{machine}`.
     /// The fixed `objects` segment separates the data subtree from a project's
     /// metadata siblings (e.g. the cache-invalidation marker); below this prefix the
     /// history is organized by commit (see [`clean_key`] and [`dirty_key`]) so
@@ -333,22 +314,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hardware_dependence_matches_engine() {
-        assert!(Engine::Criterion.is_hardware_dependent());
-        assert!(Engine::AllTheTime.is_hardware_dependent());
-        assert!(!Engine::Callgrind.is_hardware_dependent());
-        assert!(!Engine::AllocTracker.is_hardware_dependent());
-    }
-
-    #[test]
-    fn alloc_tracker_uses_a_synthetic_partition() {
-        // Allocation counts are a property of the code, not the machine, so
-        // `alloc_tracker` carries no machine key.
-        let set = DiscriminantSet::new(Engine::AllocTracker, "x86_64-pc-windows-msvc", None);
-        assert!(set.is_synthetic());
+    fn every_engine_partitions_by_machine_key() {
+        // Every engine is machine-keyed: even the low-noise simulated counts differ
+        // by microarchitecture, so a machine key always appears in the partition.
+        let set =
+            DiscriminantSet::new(Engine::AllocTracker, "x86_64-pc-windows-msvc", "abc123");
         assert_eq!(
             set.partition_prefix("folo"),
-            "v1/folo/objects/alloc_tracker/x86_64-pc-windows-msvc/synthetic"
+            "v1/folo/objects/alloc_tracker/x86_64-pc-windows-msvc/abc123"
         );
     }
 
@@ -357,7 +330,7 @@ mod tests {
         // Processor time depends on the machine, so `all_the_time` carries a
         // machine fingerprint.
         let set =
-            DiscriminantSet::new(Engine::AllTheTime, "x86_64-pc-windows-msvc", Some("abc123"));
+            DiscriminantSet::new(Engine::AllTheTime, "x86_64-pc-windows-msvc", "abc123");
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/all_the_time/x86_64-pc-windows-msvc/abc123"
@@ -366,7 +339,7 @@ mod tests {
 
     #[test]
     fn machine_key_appears_in_partition() {
-        let set = DiscriminantSet::new(Engine::Criterion, "x86_64-pc-windows-msvc", Some("abc123"));
+        let set = DiscriminantSet::new(Engine::Criterion, "x86_64-pc-windows-msvc", "abc123");
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/criterion/x86_64-pc-windows-msvc/abc123"
@@ -374,66 +347,50 @@ mod tests {
     }
 
     #[test]
-    fn is_synthetic_is_false_for_a_machine_keyed_set() {
-        // A machine-dependent engine carries a real fingerprint, so the set is not
-        // synthetic even though synthetic sets share the same type.
-        let set =
-            DiscriminantSet::new(Engine::AllTheTime, "x86_64-pc-windows-msvc", Some("abc123"));
-        assert!(!set.is_synthetic());
-    }
-
-    #[test]
     fn display_formats_engine_triple_and_machine_key() {
-        let set = DiscriminantSet::new(Engine::Criterion, "x86_64-pc-windows-msvc", Some("abc123"));
+        let set = DiscriminantSet::new(Engine::Criterion, "x86_64-pc-windows-msvc", "abc123");
         assert_eq!(set.to_string(), "criterion/x86_64-pc-windows-msvc/abc123");
-
-        // A synthetic set renders the literal `synthetic` machine segment.
-        let synthetic = DiscriminantSet::new(Engine::AllocTracker, "x86_64-pc-windows-msvc", None);
-        assert_eq!(
-            synthetic.to_string(),
-            "alloc_tracker/x86_64-pc-windows-msvc/synthetic"
-        );
     }
 
     #[test]
     fn clean_key_is_named_by_commit() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "abc123");
         assert_eq!(
             set.clean_key("folo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/\
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/abc123/\
              deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/clean.json"
         );
     }
 
     #[test]
     fn dirty_key_is_named_by_commit_and_observation_time() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "abc123");
         assert_eq!(
             set.dirty_key(
                 "folo",
                 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
                 1_700_000_000
             ),
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/\
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/abc123/\
              deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/dirty-1700000000.json"
         );
     }
 
     #[test]
     fn bless_key_targets_the_commit_directory() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
         assert_eq!(
             set.bless_key("folo", "abc123", 1_700_000_000),
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/abc123/bless-1700000000.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/bless-1700000000.json"
         );
     }
 
     #[test]
     fn commit_prefix_enumerates_one_commit_directory() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
         assert_eq!(
             set.commit_prefix("folo", "dead/beef"),
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/dead_beef/"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/dead_beef/"
         );
     }
 
@@ -480,7 +437,7 @@ mod tests {
 
     #[test]
     fn new_sanitizes_partition_components() {
-        let set = DiscriminantSet::new(Engine::Criterion, "weird/triple", Some("machine/one"));
+        let set = DiscriminantSet::new(Engine::Criterion, "weird/triple", "machine/one");
         assert_eq!(
             set.partition_prefix("team/app"),
             "v1/team_app/objects/criterion/weird_triple/machine_one"
@@ -491,11 +448,11 @@ mod tests {
 
     #[test]
     fn clean_key_sanitizes_the_commit() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
         let object = set.clean_key("folo", "dead/beef");
         assert_eq!(
             object,
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/dead_beef/clean.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/dead_beef/clean.json"
         );
         // Exactly the eight canonical key segments survive sanitization.
         assert_eq!(object.split('/').count(), 8);
@@ -503,11 +460,11 @@ mod tests {
 
     #[test]
     fn dirty_key_sanitizes_the_commit() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", None);
+        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
         let object = set.dirty_key("folo", "dead/beef", 1_700_000_000);
         assert_eq!(
             object,
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/dead_beef/dirty-1700000000.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/dead_beef/dirty-1700000000.json"
         );
         // Exactly the eight canonical key segments survive sanitization.
         assert_eq!(object.split('/').count(), 8);
@@ -516,13 +473,13 @@ mod tests {
     #[test]
     fn parse_key_decomposes_a_clean_key() {
         let parsed = parse_key(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/abc123/clean.json",
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json",
         )
         .unwrap();
         assert_eq!(parsed.project, "folo");
         assert_eq!(parsed.set.engine, "callgrind");
         assert_eq!(parsed.set.target_triple, "x86_64-unknown-linux-gnu");
-        assert_eq!(parsed.set.machine_key, "synthetic");
+        assert_eq!(parsed.set.machine_key, "m1");
         assert_eq!(parsed.commit, "abc123");
         assert_eq!(parsed.file, "clean.json");
         assert!(!parsed.is_dirty());
@@ -543,7 +500,7 @@ mod tests {
     #[test]
     fn parse_key_recognizes_a_blessing_sidecar() {
         let parsed = parse_key(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/abc123/bless-1700000000.json",
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/bless-1700000000.json",
         )
         .unwrap();
         assert!(parsed.is_bless());
@@ -554,12 +511,12 @@ mod tests {
     #[test]
     fn bless_key_targets_the_sets_commit_directory() {
         let parsed = parse_key(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/abc123/clean.json",
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json",
         )
         .unwrap();
         assert_eq!(
             parsed.bless_key(1_700_000_000),
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/synthetic/abc123/bless-1700000000.json"
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/bless-1700000000.json"
         );
     }
 

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -317,8 +317,7 @@ mod tests {
     fn every_engine_partitions_by_machine_key() {
         // Every engine is machine-keyed: even the low-noise simulated counts differ
         // by microarchitecture, so a machine key always appears in the partition.
-        let set =
-            DiscriminantSet::new(Engine::AllocTracker, "x86_64-pc-windows-msvc", "abc123");
+        let set = DiscriminantSet::new(Engine::AllocTracker, "x86_64-pc-windows-msvc", "abc123");
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/alloc_tracker/x86_64-pc-windows-msvc/abc123"
@@ -329,8 +328,7 @@ mod tests {
     fn all_the_time_partitions_by_machine_key() {
         // Processor time depends on the machine, so `all_the_time` carries a
         // machine fingerprint.
-        let set =
-            DiscriminantSet::new(Engine::AllTheTime, "x86_64-pc-windows-msvc", "abc123");
+        let set = DiscriminantSet::new(Engine::AllTheTime, "x86_64-pc-windows-msvc", "abc123");
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/all_the_time/x86_64-pc-windows-msvc/abc123"
@@ -472,10 +470,9 @@ mod tests {
 
     #[test]
     fn parse_key_decomposes_a_clean_key() {
-        let parsed = parse_key(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json",
-        )
-        .unwrap();
+        let parsed =
+            parse_key("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json")
+                .unwrap();
         assert_eq!(parsed.project, "folo");
         assert_eq!(parsed.set.engine, "callgrind");
         assert_eq!(parsed.set.target_triple, "x86_64-unknown-linux-gnu");
@@ -510,10 +507,9 @@ mod tests {
 
     #[test]
     fn bless_key_targets_the_sets_commit_directory() {
-        let parsed = parse_key(
-            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json",
-        )
-        .unwrap();
+        let parsed =
+            parse_key("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json")
+                .unwrap();
         assert_eq!(
             parsed.bless_key(1_700_000_000),
             "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/bless-1700000000.json"

--- a/packages/cbh_model/src/metric.rs
+++ b/packages/cbh_model/src/metric.rs
@@ -92,12 +92,10 @@ pub enum MetricKind {
     ConditionalBranches,
     /// Executed indirect branches (Callgrind); low-noise but not exact.
     IndirectBranches,
-    /// Bytes allocated per iteration (`alloc_tracker`); hardware-independent but
-    /// not deterministic (warmup and buffer-resize allocations jitter the
-    /// per-iteration figure).
+    /// Bytes allocated per iteration (`alloc_tracker`); not deterministic (warmup
+    /// and buffer-resize allocations jitter the per-iteration figure).
     AllocatedBytes,
-    /// Allocation count per iteration (`alloc_tracker`); hardware-independent but
-    /// not deterministic.
+    /// Allocation count per iteration (`alloc_tracker`); not deterministic.
     AllocationCount,
 }
 

--- a/packages/cbh_probe/README.md
+++ b/packages/cbh_probe/README.md
@@ -2,5 +2,5 @@
 
 Implementation crate for [`cargo-bench-history`](https://github.com/folo-rs/folo). Do
 not depend on this directly — it carries the environment probe (git and toolchain facts)
-and the machine fingerprint that partitions hardware-dependent results, and has no stable
+and the machine fingerprint that partitions benchmark results, and has no stable
 public API. Use the `cargo-bench-history` tool instead.

--- a/packages/cbh_probe/src/lib.rs
+++ b/packages/cbh_probe/src/lib.rs
@@ -14,7 +14,7 @@
 //! The environment and hardware probe. The environment probe port discovers the git and
 //! toolchain facts of a run (shelling out to `git` and `rustc`), and the machine
 //! fingerprint derives a stable, reproducible key from the host's hardware so that
-//! hardware-dependent results are only ever compared across equivalent machines. Split
+//! benchmark results are only ever compared across equivalent machines. Split
 //! out of the `cargo-bench-history` shell so this environment-sensing code is isolated
 //! for mutation testing.
 //!

--- a/packages/cbh_probe/src/lib.rs
+++ b/packages/cbh_probe/src/lib.rs
@@ -14,7 +14,7 @@
 //! The environment and hardware probe. The environment probe port discovers the git and
 //! toolchain facts of a run (shelling out to `git` and `rustc`), and the machine
 //! fingerprint derives a stable, reproducible key from the host's hardware so that
-//! benchmark results are only ever compared across equivalent machines. Split
+//! benchmark results are only ever compared across equivalent machines. It is split
 //! out of the `cargo-bench-history` shell so this environment-sensing code is isolated
 //! for mutation testing.
 //!

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -1,6 +1,4 @@
-//! Machine fingerprint: a stable hash of the host's hardware characteristics,
-//! used to partition hardware-dependent (Criterion) results so that only runs
-//! from equivalent machines share a series.
+//! Stable machine fingerprint for partitioning benchmark results.
 //!
 //! The fingerprint must be reproducible across tool versions and across the
 //! equivalent machines of a single pool, so it is a fixed SHA-256 over a
@@ -11,7 +9,7 @@
 //! but equivalent hardware.
 //!
 //! The key is surfaced two ways for operators. [`resolve_machine_key`] yields the
-//! key itself (what `collect` stamps hardware-dependent results with and the
+//! key itself (what `collect` stamps every result with and the
 //! `machine-key` command prints), while [`describe_fingerprint_components`] renders
 //! the individual factors that fed the hash, so a change in the key can be traced —
 //! in verbose logs — to the specific hardware detail that moved.
@@ -33,8 +31,7 @@ const FINGERPRINT_VERSION: &str = "mk2";
 /// collisions between distinct hardware profiles are not a practical concern.
 const FINGERPRINT_HEX_LEN: usize = 16;
 
-/// Hardware facts that identify a machine for partitioning hardware-dependent
-/// benchmark results.
+/// Hardware facts that identify a machine for partitioning benchmark results.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HardwareProfile {
     /// Maximum number of logical processors the system reports.

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -140,7 +140,7 @@ struct JsonSet<'a> {
     engine: &'a str,
     /// Resolved target triple.
     target_triple: &'a str,
-    /// Machine key (`synthetic` for hardware-independent engines).
+    /// Machine key: the fingerprint of the machine that produced the runs.
     machine_key: &'a str,
     /// Stored runs loaded for this set.
     runs: usize,
@@ -1090,7 +1090,7 @@ mod tests {
         DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m1".to_owned(),
         }
     }
 
@@ -1300,7 +1300,7 @@ mod tests {
 
         let report = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
 
-        let footer = "_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`";
+        let footer = "_Filter:_ `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key m1`";
         assert!(report.contains(footer), "{report}");
         // The footer trails the finding headline rather than leading it.
         let headline_at = report.find("mover_a").expect("headline present");
@@ -1332,7 +1332,7 @@ mod tests {
 
         assert!(
             report.contains(
-                "--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic"
+                "--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key m1"
             ),
             "{report}"
         );
@@ -1440,14 +1440,14 @@ mod tests {
         let report = render(&input, ReportFormat::Text, false);
         assert!(report.contains("regressions: 1"), "{report}");
         assert!(
-            report.contains("callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            report.contains("callgrind/x86_64-unknown-linux-gnu/m1"),
             "the set heading drops the redundant `Set ` prefix: {report}"
         );
         // The set header names the facet flags that reproduce exactly this partition,
         // so a reader who spots a finding knows how to query it directly.
         assert!(
             report.contains(
-                "  filter: --engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic"
+                "  filter: --engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key m1"
             ),
             "{report}"
         );
@@ -1606,7 +1606,7 @@ mod tests {
             "{report}"
         );
         assert!(
-            report.contains("## callgrind/x86_64-unknown-linux-gnu/synthetic"),
+            report.contains("## callgrind/x86_64-unknown-linux-gnu/m1"),
             "the set heading drops the redundant `Set ` prefix: {report}"
         );
         // The per-set tally mirrors the JSON metadata and the text header.
@@ -1614,7 +1614,7 @@ mod tests {
         // The set header names the facet flags that reproduce exactly this partition.
         assert!(
             report.contains(
-                "- Filter: `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key synthetic`"
+                "- Filter: `--engine callgrind --target-triple x86_64-unknown-linux-gnu --machine-key m1`"
             ),
             "{report}"
         );
@@ -2361,7 +2361,7 @@ mod tests {
         DiscriminantSet {
             engine: "callgrind".to_owned(),
             target_triple: "aarch64-apple-darwin".to_owned(),
-            machine_key: "synthetic".to_owned(),
+            machine_key: "m2".to_owned(),
         }
     }
 

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -140,7 +140,8 @@ struct JsonSet<'a> {
     engine: &'a str,
     /// Resolved target triple.
     target_triple: &'a str,
-    /// Machine key: the fingerprint of the machine that produced the runs.
+    /// Machine key: the partition value the runs were stored under (a hardware
+    /// fingerprint, or an explicit `--machine-key` override such as a pool label).
     machine_key: &'a str,
     /// Stored runs loaded for this set.
     runs: usize,


### PR DESCRIPTION
[Copilot speaking]

## What & why

Real-world data has shown that even benchmarks we believed to be machine-independent — the ones stored under the special `synthetic` machine key (Callgrind instruction counts, `alloc_tracker` allocations) — are actually machine-dependent, because libraries dispatch to microarchitecture-specific code paths. To avoid confusion when interpreting mixed data sets, this removes the concept entirely: **every** engine is now machine-keyed, and the literal string `synthetic` carries no special meaning.

## Changes

- **Model** (`cbh_model`): `DiscriminantSet::new` now takes a required `machine_key: &str` (no `Option`, no `synthetic` fallback). Removed `Engine::is_hardware_dependent` and `DiscriminantSet::is_synthetic`. Storage layout segment is always `{machine}`.
- **Write side** (`collect`/`import`/`backfill`): every engine partitions under the resolved machine key.
- **Read side** (`cbh_detect`): removed the machine-key facet *exemption* that let synthetic sets ride along in every query; the machine-key facet now applies uniformly.
- **Announce** (`cbh_analyze`): dropped the "machine-independent benchmarks ride along" inclusion notice.
- **Stress harness**: attaches the machine key to every engine.
- **Docs / book / automation** (`DESIGN.md`, book pages, `README.md`, crate docs, justfile, `bench-history.yml`): describe the uniform machine-keyed model.

## Migration: accepted discontinuity

No migration code. Storage version stays **v1**. Callgrind/`alloc_tracker` series that earlier tool versions wrote under `.../<triple>/synthetic/...` restart under the runner's real fingerprint at the changeover commit. The old objects are never lost — they stay reachable via `--machine-key synthetic` (or `--machine-key all`). `synthetic` is now just an ordinary key. This is documented in `DESIGN.md §4` and the book.

## Validation

- Test suites green: `cbh_model` (62), `cbh_detect`, `cbh_analyze` (180), `cargo-bench-history` (127 unit + 137 integration + 11 azure + 1 real-engine), `cargo-bench-history-stress` (62 + 8 smoke), `cargo-bench-history-faker` (34).
- `cargo clippy --all-targets -- -D warnings` clean; `cargo doc -D warnings` clean (removed intra-doc links to the deleted classifier).
- Grep sweep confirms no residual machine-key-sense `synthetic` / `is_hardware_dependent` / `is_synthetic` / `hardware-independent`; only the unrelated fabricated-data and committer-second senses remain.