### PR TITLE
Avoid syscalls in vicinal benchmark workload

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -33,6 +33,26 @@ benchmark function and in the same benchmark group.
 
 Do not forget to register benchmarks in `Cargo.toml`.
 
+## Avoid syscalls unless I/O is the thing being measured
+
+Unless the benchmark's *purpose* is to measure I/O or some other
+operating-system service, keep syscalls out of the measured path. Syscalls
+(opening files, network access, reading the real-time clock, and so on) have
+unpredictable latency that depends on kernel scheduling, filesystem and device
+state, caches, and unrelated processes on the machine. That is noise which has
+nothing to do with the code under test and which varies from run to run and from
+machine to machine.
+
+When a benchmark needs a stand-in "workload" to represent the body of a task,
+use a small, deterministic, CPU-only computation seeded with `black_box` (so the
+optimizer cannot fold it away) rather than a syscall standing in as busywork.
+
+Some syscalls are genuinely unavoidable — spawning a thread, for example, is
+inherently a kernel operation and is the very thing a worker-pool benchmark
+exists to measure. Even then, minimize them: perform the unavoidable syscalls
+once during setup where possible, and keep them out of the per-iteration
+workload.
+
 Benchmark file names, Criterion group names, and Callgrind group/function names
 follow strict conventions documented in [`docs/naming.md`](naming.md): the file
 basename prefixes Criterion group names, Callgrind files require a paired

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -37,7 +37,7 @@ Do not forget to register benchmarks in `Cargo.toml`.
 
 Unless the benchmark's *purpose* is to measure I/O or some other
 operating-system service, keep syscalls out of the measured path. Syscalls
-(opening files, network access, reading the real-time clock, and so on) have
+(opening files, accessing the network, spawning processes, and so on) have
 unpredictable latency that depends on kernel scheduling, filesystem and device
 state, caches, and unrelated processes on the machine. That is noise which has
 nothing to do with the code under test and which varies from run to run and from

--- a/packages/vicinal/benches/vicinal.rs
+++ b/packages/vicinal/benches/vicinal.rs
@@ -1,6 +1,5 @@
 #![expect(missing_docs, reason = "benchmarks")]
 
-use std::fs::File;
 use std::hint::black_box;
 use std::thread;
 use std::time::Instant;
@@ -18,9 +17,19 @@ use vicinal::Pool;
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
+/// A small, deterministic, CPU-only stand-in for a real task body.
+///
+/// These benchmarks measure the overhead of *dispatching* work onto a worker,
+/// so the task body must be cheap and predictable. It performs no syscalls (see
+/// `docs/benchmarks.md`), which would otherwise inject kernel and filesystem
+/// noise unrelated to the scheduling under test. A handful of LCG steps seeded
+/// with `black_box` gives a fixed cost the optimizer cannot fold away.
 fn simulate_work() -> u32 {
-    drop(File::open("Q:\\non_existent_file.txt"));
-    42
+    let mut value = black_box(42_u32);
+    for _ in 0..32 {
+        value = value.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    }
+    value
 }
 
 fn entrypoint(c: &mut Criterion) {


### PR DESCRIPTION
[Copilot speaking]

## Problem

The vicinal benchmarks used a failing `File::open("Q:\\non_existent_file.txt")` as the stand-in "workload" for a task body. That is a real syscall on the measured path, and its latency depends on kernel scheduling, filesystem/device state, and unrelated activity on the machine — noise that has nothing to do with the task dispatching these benchmarks exist to measure.

## Changes

- **`docs/benchmarks.md`**: added a section *"Avoid syscalls unless I/O is the thing being measured"*. Unless a benchmark's purpose is I/O, syscalls stay out of the measured path; use a small, deterministic, `black_box`-seeded CPU workload as a task stand-in. Genuinely unavoidable syscalls (e.g. thread spawning) should be minimized and pushed into setup where possible.
- **`packages/vicinal/benches/vicinal.rs`**: replaced `simulate_work()` with a deterministic, CPU-only computation (a short LCG loop seeded with `black_box` so the optimizer cannot fold it away) and dropped the now-unused `std::fs::File` import.

## Why this workload

These benchmarks compare dispatch mechanisms (vicinal scheduler vs. `std::thread` vs. `threadpool`), so the task body should be cheap, predictable, and non-elidable, letting scheduling overhead dominate. The LCG loop is nanosecond-scale, deterministic across runs and machines, and allocation- and syscall-free.

## Validation

- `cargo build -p vicinal --benches` — clean
- `cargo clippy -p vicinal --benches` — zero warnings