### PR TITLE
Add absolute-value noise gate for quantized benchmark metrics

### DIFF
--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -776,10 +776,24 @@ movement must clear the practical floor and exceed the residual scatter about th
 line; the confidence-interval-width gate is applied additionally when intervals are present,
 again only able to suppress a candidate and never to create one.
 
-The **practical-magnitude floor** is a single hard threshold below which no finding surfaces,
+The **practical-magnitude floor** is a hard threshold below which no finding surfaces,
 regardless of engine, direction, or how confidently it was measured. A change too small to
 warrant a human's attention is dropped even when the statistics are certain — this is what
-keeps a low-noise engine like Callgrind from surfacing sub-threshold trivia.
+keeps a low-noise engine like Callgrind from surfacing sub-threshold trivia. It has two
+parts, composed by conjunction so a move must clear both: a **relative floor**
+(`practical_relative`, a minimum percentage) applied to every metric, and an **absolute
+floor** (`practical_absolute`) applied only to *quantized* metrics — the Callgrind integer
+counts, which move in whole units with no confidence interval. Because such a count changes
+in discrete steps, a single-unit run-to-run wobble on a small baseline is a large
+*percentage* move that the relative floor alone would admit; requiring the move to also span
+a minimum number of those units suppresses that quantization jitter. Continuous,
+dispersion-bearing metrics (wall and processor time, `alloc_tracker` figures) are exempt from
+the absolute floor.
+
+Every default gate threshold — both floors, the significance levels, the windows — is a named
+constant gathered in one place (`cbh_detect`'s `noise_gates` module), which
+`AnalysisConfig::default` is assembled from, so the whole gating policy can be read and tuned
+together.
 
 ### 8.3 Multiple-comparison discipline
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -780,20 +780,17 @@ The **practical-magnitude floor** is a hard threshold below which no finding sur
 regardless of engine, direction, or how confidently it was measured. A change too small to
 warrant a human's attention is dropped even when the statistics are certain — this is what
 keeps a low-noise engine like Callgrind from surfacing sub-threshold trivia. It has two
-parts, composed by conjunction so a move must clear both: a **relative floor**
-(`practical_relative`, a minimum percentage) applied to every metric, and an **absolute
-floor** (`practical_absolute`) applied only to *quantized* metrics — the Callgrind integer
-counts, which move in whole units with no confidence interval. Because such a count changes
-in discrete steps, a single-unit run-to-run wobble on a small baseline is a large
-*percentage* move that the relative floor alone would admit; requiring the move to also span
-a minimum number of those units suppresses that quantization jitter. Continuous,
-dispersion-bearing metrics (wall and processor time, `alloc_tracker` figures) are exempt from
-the absolute floor.
+parts, composed by conjunction so a move must clear both: a **relative floor** (a minimum
+percentage) applied to every metric, and an **absolute floor** applied only to *quantized*
+metrics — the Callgrind integer counts, which move in whole units with no confidence
+interval. Because such a count changes in discrete steps, a single-unit run-to-run wobble on
+a small baseline is a large *percentage* move that the relative floor alone would admit;
+requiring the move to also span a minimum number of those units suppresses that quantization
+jitter. Continuous, dispersion-bearing metrics (wall and processor time, `alloc_tracker`
+figures) are exempt from the absolute floor.
 
-Every default gate threshold — both floors, the significance levels, the windows — is a named
-constant gathered in one place (`cbh_detect`'s `noise_gates` module), which
-`AnalysisConfig::default` is assembled from, so the whole gating policy can be read and tuned
-together.
+The gate thresholds are centralized as a single policy rather than embedded throughout the
+detectors, so maintainers can review and tune the complete policy together.
 
 ### 8.3 Multiple-comparison discipline
 

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -26,6 +26,10 @@
 //! * A Mann–Whitney rank test must then confirm the two regimes differ, the move
 //!   must clear a practical-magnitude floor, and it must exceed the series' own
 //!   between-commit residual scatter (the primary, series-intrinsic noise gate).
+//!   The practical-magnitude floor is relative (a minimum percentage), with an
+//!   absolute floor additionally applied to quantized metrics (the Callgrind integer
+//!   counts, see [`MetricKind::is_quantized`]) so a single-quantum run-to-run wobble
+//!   on a tiny count cannot read as a large-percentage regression.
 //! * Where the engine reports a per-point confidence interval (Criterion,
 //!   `all_the_time`, `alloc_tracker`) the two regimes' intervals must also be
 //!   disjoint; if they overlap this veto *withholds* the finding, treating the
@@ -53,7 +57,7 @@ use cbh_stats as stats;
 use serde::Serialize;
 
 use crate::detect::parallel::{balanced_chunk_sizes, worker_count};
-use crate::detect::{Series, SeriesPoint};
+use crate::detect::{Series, SeriesPoint, noise_gates};
 
 /// Tunable parameters of the engine-aware analysis.
 #[derive(Clone, Copy, Debug)]
@@ -75,6 +79,15 @@ pub struct AnalysisConfig {
     /// Minimum relative magnitude (3%) a noisy move must reach to matter in
     /// practice, regardless of statistical significance.
     pub practical_relative: f64,
+    /// Minimum absolute magnitude, in the metric's own units, a move on a *quantized*
+    /// metric must reach to matter in practice. Composed by conjunction with
+    /// [`practical_relative`](Self::practical_relative): a quantized metric such as a
+    /// Callgrind count moves in whole integer units, so at a small baseline a
+    /// single-unit run-to-run wobble is a large *percentage* move that the relative
+    /// floor alone would let through; requiring an absolute span as well suppresses
+    /// that jitter. Continuous metrics (see [`MetricKind::is_quantized`]) are exempt —
+    /// only the relative floor applies to them.
+    pub practical_absolute: f64,
     /// How many recent base-side points form the level a branch's latest state is
     /// compared against (branch mode).
     pub compare_window: usize,
@@ -110,17 +123,18 @@ pub struct AnalysisConfig {
 impl Default for AnalysisConfig {
     fn default() -> Self {
         Self {
-            min_regime: 2,
-            change_alpha: 0.05,
-            fdr_q: 0.10,
-            drift_min_points: 6,
-            drift_alpha: 0.05,
-            practical_relative: 0.03,
-            compare_window: 8,
-            branch_practical_relative: 0.05,
-            branch_noise_multiple: 2.0,
-            residual_noise_multiple: 3.0,
-            min_regime_separation: 0.85,
+            min_regime: noise_gates::MIN_REGIME,
+            change_alpha: noise_gates::CHANGE_ALPHA,
+            fdr_q: noise_gates::FDR_Q,
+            drift_min_points: noise_gates::DRIFT_MIN_POINTS,
+            drift_alpha: noise_gates::DRIFT_ALPHA,
+            practical_relative: noise_gates::PRACTICAL_RELATIVE,
+            practical_absolute: noise_gates::PRACTICAL_ABSOLUTE,
+            compare_window: noise_gates::COMPARE_WINDOW,
+            branch_practical_relative: noise_gates::BRANCH_PRACTICAL_RELATIVE,
+            branch_noise_multiple: noise_gates::BRANCH_NOISE_MULTIPLE,
+            residual_noise_multiple: noise_gates::RESIDUAL_NOISE_MULTIPLE,
+            min_regime_separation: noise_gates::MIN_REGIME_SEPARATION,
         }
     }
 }
@@ -367,6 +381,20 @@ fn relative_delta_of(delta: f64, baseline: f64) -> f64 {
     }
 }
 
+/// Whether a move clears the absolute-magnitude floor for `series`.
+///
+/// Continuous metrics carry no quantization, so their percentage move is trustworthy
+/// at any magnitude and this gate exempts them (returns `true`). A quantized metric
+/// (see [`MetricKind::is_quantized`]) moves in whole integer units with no confidence
+/// interval, so `delta` must span at least
+/// [`practical_absolute`](AnalysisConfig::practical_absolute) of those units;
+/// otherwise a single-quantum wobble on a tiny baseline would clear the relative
+/// floor and read as a regression. The gate composes with the relative floor by
+/// conjunction and can only *suppress*, never promote, a move.
+fn clears_absolute_floor(series: &Series, delta: f64, config: &AnalysisConfig) -> bool {
+    !series.kind.is_quantized() || delta.abs() >= config.practical_absolute
+}
+
 /// The representative confidence interval of a regime: the median of its points'
 /// lower and upper bounds, available only when the engine reports dispersion.
 fn regime_interval(points: &[&SeriesPoint]) -> Option<(f64, f64)> {
@@ -529,7 +557,8 @@ fn arbitrate(
 /// short series, so it is not used as a significance gate); both regimes must hold
 /// at least `min_regime` points (persistence). The move must then be confirmed by a
 /// significant Mann–Whitney rank-sum difference between the regimes, clear the
-/// practical-magnitude floor, stand above the series' own between-commit residual
+/// practical-magnitude floor (relative, plus an absolute floor on quantized
+/// metrics), stand above the series' own between-commit residual
 /// scatter, separate the two regimes as populations (the Mann–Whitney effect-size
 /// gate that rejects a noisy-but-stable series whose levels interleave), and — when
 /// the engine reports per-point confidence intervals — separate the two regimes'
@@ -566,6 +595,9 @@ fn evaluate_change_point(
         return None;
     }
     if relative_delta.abs() < config.practical_relative {
+        return None;
+    }
+    if !clears_absolute_floor(series, delta, config) {
         return None;
     }
     if !exceeds_residual_noise(delta, step_model_residual(values, tau), config) {
@@ -618,7 +650,8 @@ fn evaluate_change_point(
 ///
 /// The trend is established by the Mann–Kendall test and quantified by the
 /// Theil–Sen line, so a single outlier cannot manufacture a drift. The total
-/// movement must clear the practical-magnitude floor and stand above the series'
+/// movement must clear the practical-magnitude floor (relative, plus an absolute
+/// floor on quantized metrics) and stand above the series'
 /// own residual scatter about the fitted line; where the engine reports confidence
 /// intervals it must additionally exceed the per-measurement noise floor (twice the
 /// median half-width), so jitter does not read as a trend.
@@ -643,6 +676,9 @@ fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> O
     }
     let relative_delta = relative_delta_of(delta, baseline);
     if relative_delta.abs() < config.practical_relative {
+        return None;
+    }
+    if !clears_absolute_floor(series, delta, config) {
         return None;
     }
     if !exceeds_residual_noise(delta, line_model_residual(values, slope, intercept), config) {
@@ -745,7 +781,8 @@ fn latest_commit_points<'a>(branch: &[&'a SeriesPoint]) -> Vec<&'a SeriesPoint> 
 /// Compares a `before` sample against an `after` sample on the same series and, if
 /// the noise-aware gates pass, returns a change-point [`Candidate`].
 ///
-/// The relative move must clear `practical_floor` and stand above the two samples'
+/// The relative move must clear `practical_floor` and, on a quantized metric, also
+/// span the absolute floor; the move must then stand above the two samples'
 /// own between-commit residual scatter (the primary, series-intrinsic noise gate,
 /// which for a single-run engine like Callgrind is the only dispersion available).
 /// It must then either — when both samples have at least two points — pass a
@@ -775,6 +812,9 @@ fn compare_samples(
     let relative_delta = relative_delta_of(delta, baseline);
 
     if relative_delta.abs() < practical_floor {
+        return None;
+    }
+    if !clears_absolute_floor(series, delta, config) {
         return None;
     }
     if !exceeds_residual_noise(
@@ -930,7 +970,8 @@ const RESOLVED_SPIKE_MAX_POINTS: usize = 200;
 /// the level rose, `flipped_at` where it recovered, `baseline` the pre-spike level,
 /// and `latest` the spike's own level (its magnitude is what is notable). Both the
 /// rise and the recovery must be Mann–Whitney significant, the plateau must clear
-/// the practical-magnitude floor, and the deviation must stand above the rise's own
+/// the practical-magnitude floor (relative, plus an absolute floor on quantized
+/// metrics), and the deviation must stand above the rise's own
 /// residual scatter.
 fn evaluate_resolved_spike(
     series: &Series,
@@ -980,6 +1021,7 @@ fn evaluate_resolved_spike(
     let (rise, recovery, level, deviation) = best?;
     if deviation.abs() <= 0.0
         || relative_delta_of(deviation, baseline).abs() < config.practical_relative
+        || !clears_absolute_floor(series, deviation, config)
     {
         return None;
     }
@@ -1747,6 +1789,38 @@ mod tests {
     }
 
     #[test]
+    fn change_point_below_the_absolute_floor_is_suppressed() {
+        // On a quantized metric a 4-count move clears the relative floor (4/60 ≈ 6.7%
+        // ≥ 3%) and every other gate — significant 3-vs-3 separation, zero residual —
+        // yet is suppressed because it falls short of the absolute floor of 5, where a
+        // single-quantum wobble on a tiny count would otherwise read as a regression.
+        let series = series_of(&[60.0, 60.0, 60.0, 64.0, 64.0, 64.0]);
+        assert!(changes(&[series]).is_empty());
+    }
+
+    #[test]
+    fn change_point_at_the_absolute_floor_is_flagged() {
+        // The absolute floor is a `>=` gate, so a 5-count move exactly at the floor is
+        // still reported (a `>`/`==` mutant would suppress or misgate it).
+        let series = series_of(&[60.0, 60.0, 60.0, 65.0, 65.0, 65.0]);
+        let finding = only(changes(&[series]));
+        assert_eq!(finding.method, FindingMethod::ChangePoint);
+        assert_eq!(finding.delta, 5.0);
+    }
+
+    #[test]
+    fn change_point_absolute_floor_exempts_continuous_metrics() {
+        // The absolute floor only applies to quantized metrics. The same 4-count move
+        // on a continuous wall-time series (which carries dispersion, not quantization)
+        // clears its relative floor and is reported, proving the exemption: were the
+        // gate applied unconditionally, this move would be suppressed too.
+        let series = wall_series(&[60.0, 60.0, 60.0, 64.0, 64.0, 64.0], 0.5);
+        let finding = only(changes(&[series]));
+        assert_eq!(finding.method, FindingMethod::ChangePoint);
+        assert_eq!(finding.delta, 4.0);
+    }
+
+    #[test]
     fn branch_count_rise_is_a_regression() {
         // Branch-execution counts are lower-is-better, so a sustained rise is a
         // regression.
@@ -2132,6 +2206,40 @@ mod tests {
     }
 
     #[test]
+    fn branch_mode_below_the_absolute_floor_is_suppressed() {
+        // A quantized branch tip 4 counts above a small base (60 -> 64) clears the 5%
+        // branch relative floor (6.7%) and the residual gate, but not the absolute
+        // floor of 5, so it is suppressed. Without the gate this single-quantum-scale
+        // move would flag on the pull request.
+        let series = placed_series(&[
+            (0, 60.0, false),
+            (1, 60.0, false),
+            (2, 60.0, false),
+            (3, 64.0, false),
+            (4, 64.0, false),
+            (5, 64.0, false),
+        ]);
+        assert!(branch_changes(&[series], Some(2)).is_empty());
+    }
+
+    #[test]
+    fn branch_mode_at_the_absolute_floor_is_flagged() {
+        // The same shape with a 5-count move (60 -> 65) clears the absolute floor and
+        // is reported, pinning the gate's `>=` boundary in branch mode.
+        let series = placed_series(&[
+            (0, 60.0, false),
+            (1, 60.0, false),
+            (2, 60.0, false),
+            (3, 65.0, false),
+            (4, 65.0, false),
+            (5, 65.0, false),
+        ]);
+        let finding = only(branch_changes(&[series], Some(2)));
+        assert_eq!(finding.direction, Direction::Regression);
+        assert_eq!(finding.latest, 65.0);
+    }
+
+    #[test]
     fn branch_mode_is_silent_for_a_benchmark_new_on_the_branch() {
         // Every point is past the merge-base: no base-side baseline to compare to.
         let series = placed_series(&[(3, 130.0, false), (4, 130.0, false), (5, 130.0, false)]);
@@ -2437,6 +2545,27 @@ mod tests {
     }
 
     #[test]
+    fn drift_below_the_absolute_floor_is_suppressed() {
+        // A clean upward drift on a quantized metric totalling only 4 counts (100 ->
+        // 104). Its relative move (4%) clears the relative floor and the trend is
+        // significant with zero residual, so only the absolute floor of 5 suppresses
+        // it. Removing that gate would let a sub-quantum-scale drift flag.
+        let series = series_of(&[100.0, 100.8, 101.6, 102.4, 103.2, 104.0]);
+        assert!(evaluate_drift(&series, &values_of(&series), &AnalysisConfig::default()).is_none());
+    }
+
+    #[test]
+    fn drift_at_the_absolute_floor_is_flagged() {
+        // The same clean drift totalling exactly 5 counts (100 -> 105) clears the
+        // absolute floor and is flagged, pinning the gate's `>=` boundary.
+        let series = series_of(&[100.0, 101.0, 102.0, 103.0, 104.0, 105.0]);
+        let candidate =
+            evaluate_drift(&series, &values_of(&series), &AnalysisConfig::default()).unwrap();
+        assert_eq!(candidate.finding.method, FindingMethod::Drift);
+        assert_eq!(candidate.finding.delta, 5.0);
+    }
+
+    #[test]
     fn noisy_drift_within_the_measurement_noise_floor_is_suppressed() {
         // The same climb on a noisy engine, but the endpoints (delta 20) do not
         // separate by more than twice the confidence half-width (12): jitter, not a
@@ -2579,15 +2708,40 @@ mod tests {
 
     #[test]
     fn resolved_spike_exactly_at_the_practical_floor_is_a_spike() {
-        // A plateau (103) exactly 3% above baseline (100) meets the floor; the
+        // A plateau (1030) exactly 3% above baseline (1000) meets the floor; the
         // `relative < floor` gate must be a strict `<` (a `<=`/`==` mutant suppresses
-        // it).
-        let series = recovered_spike(100.0, 103.0, 8);
+        // it). The magnitudes are scaled well past the absolute floor so only the
+        // relative gate's strictness is under test here.
+        let series = recovered_spike(1000.0, 1030.0, 8);
         let config = AnalysisConfig {
             practical_relative: 3.0 / 100.0,
             ..AnalysisConfig::default()
         };
         assert!(evaluate_resolved_spike(&series, &values_of(&series), &config).is_some());
+    }
+
+    #[test]
+    fn resolved_spike_below_the_absolute_floor_is_not_a_spike() {
+        // A recovered spike whose plateau rose only 4 counts above a small baseline
+        // (60 -> 64 -> 60) clears the relative floor (6.7%) and the rise/recovery rank
+        // tests, but not the absolute floor of 5, so it is not reported. Without the
+        // gate a single-quantum blip on a tiny count would surface as an inactive spike.
+        let series = recovered_spike(60.0, 64.0, 8);
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolved_spike_at_the_absolute_floor_is_a_spike() {
+        // The same spike raised to a 5-count plateau (60 -> 65 -> 60) clears the
+        // absolute floor and is reported, pinning the gate's `>=` boundary.
+        let series = recovered_spike(60.0, 65.0, 8);
+        assert!(
+            evaluate_resolved_spike(&series, &values_of(&series), &AnalysisConfig::default())
+                .is_some()
+        );
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -958,10 +958,6 @@ pub fn short_commit(commit: &str) -> String {
     commit.get(..12).unwrap_or(commit).to_owned()
 }
 
-/// Largest interior window size resolved-spike search will scan; longer histories
-/// skip the (quadratic) search rather than stall.
-const RESOLVED_SPIKE_MAX_POINTS: usize = 200;
-
 /// Locates a *recovered* spike in a (re-baselined) history series: a sustained
 /// interior regime that deviated from baseline and has since returned to it.
 ///
@@ -980,7 +976,7 @@ fn evaluate_resolved_spike(
 ) -> Option<Candidate> {
     let points = &series.points;
     let n = points.len();
-    if n > RESOLVED_SPIKE_MAX_POINTS {
+    if n > noise_gates::RESOLVED_SPIKE_MAX_POINTS {
         return None;
     }
     let min = config.min_regime.max(1);
@@ -2667,9 +2663,9 @@ mod tests {
     )]
     fn resolved_spike_at_the_search_size_limit_is_flagged() {
         // A 200-point history (the inclusive search ceiling) with a recovered plateau
-        // still analyses: the `n > RESOLVED_SPIKE_MAX_POINTS` guard must be a strict
-        // `>`.
-        let mut values = vec![10.0_f64; RESOLVED_SPIKE_MAX_POINTS];
+        // still analyses: the `n > noise_gates::RESOLVED_SPIKE_MAX_POINTS` guard
+        // must be a strict `>`.
+        let mut values = vec![10.0_f64; noise_gates::RESOLVED_SPIKE_MAX_POINTS];
         for value in values.get_mut(90..110).unwrap() {
             *value = 20.0;
         }
@@ -2687,8 +2683,9 @@ mod tests {
     )]
     fn resolved_spike_beyond_the_search_size_limit_is_skipped() {
         // One point past the inclusive search ceiling is rejected outright: the
-        // `n > RESOLVED_SPIKE_MAX_POINTS` guard caps the quadratic plateau search.
-        let mut values = vec![10.0_f64; RESOLVED_SPIKE_MAX_POINTS + 1];
+        // `n > noise_gates::RESOLVED_SPIKE_MAX_POINTS` guard caps the quadratic
+        // plateau search.
+        let mut values = vec![10.0_f64; noise_gates::RESOLVED_SPIKE_MAX_POINTS + 1];
         for value in values.get_mut(90..110).unwrap() {
             *value = 20.0;
         }

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -2546,11 +2546,16 @@ mod tests {
 
     #[test]
     fn drift_below_the_absolute_floor_is_suppressed() {
-        // A clean upward drift on a quantized metric totalling only 4 counts (100 ->
-        // 104). Its relative move (4%) clears the relative floor and the trend is
-        // significant with zero residual, so only the absolute floor of 5 suppresses
-        // it. Removing that gate would let a sub-quantum-scale drift flag.
-        let series = series_of(&[100.0, 100.8, 101.6, 102.4, 103.2, 104.0]);
+        // An upward drift on a quantized metric totalling only 4 counts (100 -> 104).
+        // Its relative move (4%) clears the relative floor and the trend is
+        // significant, so disabling the absolute floor admits it; the default floor
+        // of 5 is the gate that suppresses it.
+        let series = series_of(&[100.0, 101.0, 101.0, 102.0, 103.0, 104.0]);
+        let without_absolute_floor = AnalysisConfig {
+            practical_absolute: 0.0,
+            ..AnalysisConfig::default()
+        };
+        assert!(evaluate_drift(&series, &values_of(&series), &without_absolute_floor).is_some());
         assert!(evaluate_drift(&series, &values_of(&series), &AnalysisConfig::default()).is_none());
     }
 

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -10,6 +10,7 @@
 
 pub(crate) mod discriminant;
 pub(crate) mod findings;
+mod noise_gates;
 pub(crate) mod parallel;
 pub(crate) mod run_points;
 pub(crate) mod selection;

--- a/packages/cbh_detect/src/detect/noise_gates.rs
+++ b/packages/cbh_detect/src/detect/noise_gates.rs
@@ -11,49 +11,49 @@
 
 /// Default `min_regime`: each side of a change must hold at least this many points
 /// for the step to be trusted, so a one-off blip on the latest point cannot flag.
-pub(super) const MIN_REGIME: usize = 2;
+pub(crate) const MIN_REGIME: usize = 2;
 
 /// Default `change_alpha`: the significance level a change-point's Mann–Whitney
 /// rank test must clear.
-pub(super) const CHANGE_ALPHA: f64 = 0.05;
+pub(crate) const CHANGE_ALPHA: f64 = 0.05;
 
 /// Default `fdr_q`: the Benjamini–Hochberg target false-discovery rate over a batch
 /// of candidates.
-pub(super) const FDR_Q: f64 = 0.10;
+pub(crate) const FDR_Q: f64 = 0.10;
 
 /// Default `drift_min_points`: a series needs at least this many points before a
 /// slow-drift finding is considered.
-pub(super) const DRIFT_MIN_POINTS: usize = 6;
+pub(crate) const DRIFT_MIN_POINTS: usize = 6;
 
 /// Default `drift_alpha`: the significance level a drift's Mann–Kendall trend must
 /// clear.
-pub(super) const DRIFT_ALPHA: f64 = 0.05;
+pub(crate) const DRIFT_ALPHA: f64 = 0.05;
 
 /// Default `practical_relative`: a history move must shift the level by at least
 /// this fraction (3%) to matter in practice, regardless of significance.
-pub(super) const PRACTICAL_RELATIVE: f64 = 0.03;
+pub(crate) const PRACTICAL_RELATIVE: f64 = 0.03;
 
 /// Default `practical_absolute`: a move on a quantized metric must span at least
 /// this many of its integer units, so a single-quantum run-to-run wobble on a tiny
 /// baseline never flags as a large percentage regression.
-pub(super) const PRACTICAL_ABSOLUTE: f64 = 5.0;
+pub(crate) const PRACTICAL_ABSOLUTE: f64 = 5.0;
 
 /// Default `compare_window`: how many recent base-side points form the level a
 /// branch tip is compared against.
-pub(super) const COMPARE_WINDOW: usize = 8;
+pub(crate) const COMPARE_WINDOW: usize = 8;
 
 /// Default `branch_practical_relative`: a branch move must reach this fraction
 /// (5%), raised above the history floor, to keep pull-request false positives down.
-pub(super) const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
+pub(crate) const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
 
 /// Default `branch_noise_multiple`: multiple of the per-measurement noise floor a
 /// branch move with too few points to rank-test must exceed.
-pub(super) const BRANCH_NOISE_MULTIPLE: f64 = 2.0;
+pub(crate) const BRANCH_NOISE_MULTIPLE: f64 = 2.0;
 
 /// Default `residual_noise_multiple`: multiple of a series' own between-commit
 /// residual scatter a move must exceed to clear the primary noise gate.
-pub(super) const RESIDUAL_NOISE_MULTIPLE: f64 = 3.0;
+pub(crate) const RESIDUAL_NOISE_MULTIPLE: f64 = 3.0;
 
 /// Default `min_regime_separation`: the Mann–Whitney probability-of-superiority a
 /// level shift's two regimes must reach to be trusted.
-pub(super) const MIN_REGIME_SEPARATION: f64 = 0.85;
+pub(crate) const MIN_REGIME_SEPARATION: f64 = 0.85;

--- a/packages/cbh_detect/src/detect/noise_gates.rs
+++ b/packages/cbh_detect/src/detect/noise_gates.rs
@@ -1,0 +1,59 @@
+//! Default thresholds for the noise-aware analysis gates, gathered in one place.
+//!
+//! Every floor, significance level, and window the detectors apply has its default
+//! value here as a named constant, so the whole gating policy can be read — and
+//! tuned — in one file rather than hunted for across the detectors. The
+//! [`AnalysisConfig`] default is assembled entirely from these; a test that needs a
+//! different policy builds an [`AnalysisConfig`] explicitly instead of editing a
+//! constant.
+//!
+//! [`AnalysisConfig`]: super::AnalysisConfig
+
+/// Default `min_regime`: each side of a change must hold at least this many points
+/// for the step to be trusted, so a one-off blip on the latest point cannot flag.
+pub(super) const MIN_REGIME: usize = 2;
+
+/// Default `change_alpha`: the significance level a change-point's Mann–Whitney
+/// rank test must clear.
+pub(super) const CHANGE_ALPHA: f64 = 0.05;
+
+/// Default `fdr_q`: the Benjamini–Hochberg target false-discovery rate over a batch
+/// of candidates.
+pub(super) const FDR_Q: f64 = 0.10;
+
+/// Default `drift_min_points`: a series needs at least this many points before a
+/// slow-drift finding is considered.
+pub(super) const DRIFT_MIN_POINTS: usize = 6;
+
+/// Default `drift_alpha`: the significance level a drift's Mann–Kendall trend must
+/// clear.
+pub(super) const DRIFT_ALPHA: f64 = 0.05;
+
+/// Default `practical_relative`: a history move must shift the level by at least
+/// this fraction (3%) to matter in practice, regardless of significance.
+pub(super) const PRACTICAL_RELATIVE: f64 = 0.03;
+
+/// Default `practical_absolute`: a move on a quantized metric must span at least
+/// this many of its integer units, so a single-quantum run-to-run wobble on a tiny
+/// baseline never flags as a large percentage regression.
+pub(super) const PRACTICAL_ABSOLUTE: f64 = 5.0;
+
+/// Default `compare_window`: how many recent base-side points form the level a
+/// branch tip is compared against.
+pub(super) const COMPARE_WINDOW: usize = 8;
+
+/// Default `branch_practical_relative`: a branch move must reach this fraction
+/// (5%), raised above the history floor, to keep pull-request false positives down.
+pub(super) const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
+
+/// Default `branch_noise_multiple`: multiple of the per-measurement noise floor a
+/// branch move with too few points to rank-test must exceed.
+pub(super) const BRANCH_NOISE_MULTIPLE: f64 = 2.0;
+
+/// Default `residual_noise_multiple`: multiple of a series' own between-commit
+/// residual scatter a move must exceed to clear the primary noise gate.
+pub(super) const RESIDUAL_NOISE_MULTIPLE: f64 = 3.0;
+
+/// Default `min_regime_separation`: the Mann–Whitney probability-of-superiority a
+/// level shift's two regimes must reach to be trusted.
+pub(super) const MIN_REGIME_SEPARATION: f64 = 0.85;

--- a/packages/cbh_detect/src/detect/noise_gates.rs
+++ b/packages/cbh_detect/src/detect/noise_gates.rs
@@ -57,3 +57,7 @@ pub(crate) const RESIDUAL_NOISE_MULTIPLE: f64 = 3.0;
 /// Default `min_regime_separation`: the Mann–Whitney probability-of-superiority a
 /// level shift's two regimes must reach to be trusted.
 pub(crate) const MIN_REGIME_SEPARATION: f64 = 0.85;
+
+/// Largest interior window size resolved-spike search will scan; longer histories
+/// skip the quadratic search rather than stall.
+pub(crate) const RESOLVED_SPIKE_MAX_POINTS: usize = 200;

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -27,12 +27,11 @@
 //!   past the split) but not a sustained historical trend to history.
 //!   Branch mode also needs a base side to compare against at all — a case with an empty
 //!   base side leaves it quiet.
-//! * **Absolute scale (dimension 2).** Every case is analysed both as-is and scaled up
-//!   by a large constant. The analysis is scale-invariant except for an
-//!   absolute-magnitude floor on quantized metrics, and that floor only ever
-//!   *suppresses* tiny moves — so scaling *up* can never change a verdict: the as-is
-//!   verdict is checked against the case's expectation, and every scaled verdict is
-//!   checked against that as-is reference, so a scale-sensitivity regression fails here.
+//! * **Absolute scale (dimension 2).** Every case is analysed as a continuous metric,
+//!   both as-is and scaled up by a large constant. The absolute-magnitude floor does
+//!   not apply to continuous metrics, so every scaled verdict must match its as-is
+//!   reference. A separate quantized-metric case pins the intentional exception:
+//!   scaling can promote a move when it carries the absolute delta across that floor.
 //!
 //! Both directions are still exercised without a polarity dimension: every metric is
 //! lower-is-better, so a curated rise is a regression (reported by every mode) and a
@@ -324,8 +323,8 @@ fn scaled(values: &[f64], scale: f64) -> Vec<f64> {
 #[test]
 fn curated_signals_match_expected_verdicts() {
     // Scale multiples applied on top of each as-is series; the as-is verdict is the
-    // reference every scaled verdict must match. The analysis is relative, so no
-    // multiple may change the outcome.
+    // reference every scaled verdict must match. The matrix uses a continuous metric,
+    // so the absolute floor is inapplicable and no multiple may change the outcome.
     let scale_multiples = [1000.0_f64];
 
     for case in cases() {
@@ -334,8 +333,9 @@ fn curated_signals_match_expected_verdicts() {
             let context = mode.context(case.merge_base_index());
             let expected = case.expected_outcome(mode).is_finding(mode);
             // Every metric is lower-is-better; a curated fall only surfaces where the
-            // mode reports improvements. Instruction count is a representative kind.
-            let kind = MetricKind::InstructionCount;
+            // mode reports improvements. Wall time represents the continuous metrics
+            // for which scale invariance remains part of the contract.
+            let kind = MetricKind::WallTime;
 
             // Dimension 1: the as-is verdict under this mode matches the hand-picked
             // expectation.
@@ -346,17 +346,40 @@ fn curated_signals_match_expected_verdicts() {
                 case.name,
             );
 
-            // Dimension 2: scaling the whole series by any constant leaves the verdict
-            // unchanged, because every comparison the analysis makes is relative.
+            // Dimension 2: scaling a continuous series leaves the verdict unchanged.
             for scale in scale_multiples {
                 let scaled_verdict = raises_finding(&scaled(&values, scale), kind, &context);
                 assert_eq!(
                     scaled_verdict, reference,
                     "case '{}' mode={mode:?}: scaling by {scale} changed the verdict \
-                     (absolute scale must not matter)",
+                     for a continuous metric",
                     case.name,
                 );
             }
         }
+    }
+}
+
+#[test]
+fn scaling_a_quantized_move_can_clear_the_absolute_floor() {
+    // A 60 -> 64 instruction-count step clears both relative floors but not the
+    // five-count absolute floor. Scaling preserves its shape and relative magnitude
+    // while lifting the absolute delta above the floor, so both analysis modes may
+    // legitimately change from quiet to finding.
+    let values = [run_of(60.0, 50), run_of(64.0, 50)].concat();
+    let scaled_values = scaled(&values, 1000.0);
+
+    for mode in Mode::ALL {
+        let context = mode.context(Some(49));
+        assert!(!raises_finding(
+            &values,
+            MetricKind::InstructionCount,
+            &context
+        ));
+        assert!(raises_finding(
+            &scaled_values,
+            MetricKind::InstructionCount,
+            &context
+        ));
     }
 }

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -28,10 +28,11 @@
 //!   Branch mode also needs a base side to compare against at all — a case with an empty
 //!   base side leaves it quiet.
 //! * **Absolute scale (dimension 2).** Every case is analysed both as-is and scaled up
-//!   by a large constant. All of the analysis is relative, so the absolute scale must
-//!   not change the verdict: the as-is verdict is checked against the case's
-//!   expectation, and every scaled verdict is checked against that as-is reference, so
-//!   a scale-sensitivity regression fails here.
+//!   by a large constant. The analysis is scale-invariant except for an
+//!   absolute-magnitude floor on quantized metrics, and that floor only ever
+//!   *suppresses* tiny moves — so scaling *up* can never change a verdict: the as-is
+//!   verdict is checked against the case's expectation, and every scaled verdict is
+//!   checked against that as-is reference, so a scale-sensitivity regression fails here.
 //!
 //! Both directions are still exercised without a polarity dimension: every metric is
 //! lower-is-better, so a curated rise is a regression (reported by every mode) and a

--- a/packages/cbh_model/src/metric.rs
+++ b/packages/cbh_model/src/metric.rs
@@ -152,6 +152,26 @@ impl MetricKind {
             | Self::AllocationCount => "count",
         }
     }
+
+    /// Whether this kind moves in discrete integer steps with no dispersion.
+    ///
+    /// The Callgrind counts (instructions and branches) are exact integers for a
+    /// fixed binary and input, reported without a confidence interval, so they can
+    /// only move by whole units. At a small baseline a single-unit run-to-run
+    /// difference is therefore a large *percentage* move that a purely relative gate
+    /// would misread as a regression, so the analysis holds these kinds to an
+    /// absolute-magnitude floor in addition to the relative one. The time and
+    /// `alloc_tracker` metrics are continuous slopes carrying dispersion, so they are
+    /// not quantized and only the relative gate applies.
+    #[must_use]
+    pub fn is_quantized(self) -> bool {
+        match self {
+            Self::InstructionCount | Self::ConditionalBranches | Self::IndirectBranches => true,
+            Self::WallTime | Self::ProcessorTime | Self::AllocatedBytes | Self::AllocationCount => {
+                false
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -196,6 +216,20 @@ mod tests {
         assert_eq!(MetricKind::AllocatedBytes.as_unit(), "bytes");
         assert_eq!(MetricKind::InstructionCount.as_unit(), "count");
         assert_eq!(MetricKind::ConditionalBranches.as_unit(), "count");
+    }
+
+    #[test]
+    fn only_the_callgrind_counts_are_quantized() {
+        // The Callgrind integer counts move in whole units with no dispersion, so
+        // they earn the absolute-magnitude floor; the continuous, dispersion-bearing
+        // metrics do not.
+        assert!(MetricKind::InstructionCount.is_quantized());
+        assert!(MetricKind::ConditionalBranches.is_quantized());
+        assert!(MetricKind::IndirectBranches.is_quantized());
+        assert!(!MetricKind::WallTime.is_quantized());
+        assert!(!MetricKind::ProcessorTime.is_quantized());
+        assert!(!MetricKind::AllocatedBytes.is_quantized());
+        assert!(!MetricKind::AllocationCount.is_quantized());
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## Why

Some benchmark metrics are quantized: the Callgrind integer counts (instruction count, conditional branches, indirect branches) are exact for a fixed binary and input and are reported with no confidence interval, so they can only move in whole units. On a small baseline a single-quantum run-to-run wobble is a large *percentage* move, and the purely relative practical-magnitude floor would misread that irrelevant jitter as a regression. This adds an absolute-value floor to those metrics so a tiny-count wobble no longer surfaces as a finding.

## Approach

The practical-magnitude floor becomes two parts, composed by conjunction (a move must clear both):

- a **relative floor** (`practical_relative`), applied to every metric, as before; and
- an **absolute floor** (`practical_absolute`, default 5 units), applied only to *quantized* metrics.

Quantization is a property of the metric kind, so `MetricKind::is_quantized()` classifies it: the three Callgrind counts are quantized; wall/processor time and the `alloc_tracker` figures are continuous (they carry dispersion) and remain exempt. A small `clears_absolute_floor` helper returns `true` for continuous metrics and otherwise requires `|delta| >= practical_absolute`; it is wired into all four detectors (change-point, drift, sample comparison, resolved spike) and can only ever *suppress* a finding, never create one.

To make the gating policy easy to find and tune, every default gate threshold, both floors, the significance levels, and the windows, is now a named constant gathered in a new `cbh_detect::detect::noise_gates` module, and `AnalysisConfig::default` is assembled entirely from those constants.

## Notes for reviewers

- The same absolute floor applies in both history and branch modes: it reflects the metric's quantization, not the mode, so unlike the relative floors it is not raised for branch/PR analysis.
- The drift detector reports the *fitted* Theil-Sen span as its delta, not the raw endpoint difference, so the drift fixtures are built around the fitted span rather than endpoints.
- Behavioral tests pin the `>=` boundary for each detector (suppressed at 4 units, flagged at 5) and prove the exemption for continuous metrics. The signal-validation scale-invariance matrix now runs on a continuous metric, with a separate quantized case pinning the intentional exception that scaling can carry a move across the absolute floor.
- `docs/DESIGN.md` (section 8.2) documents the two-part floor and points at the `noise_gates` module.

Validated with the affected packages' tests, clippy, nightly fmt, and mutation testing.