### PR TITLE
Synchronize benchmark tracking-operation names with Criterion IDs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -57,7 +57,11 @@ Benchmark file names, Criterion group names, and Callgrind group/function names
 follow strict conventions documented in [`docs/naming.md`](naming.md): the file
 basename prefixes Criterion group names, Callgrind files require a paired
 Criterion file, and Callgrind identifiers mirror Criterion ones with `/`
-substituted by `_`.
+substituted by `_`. In particular, when a benchmark tracks allocations or
+processor time, the `alloc_tracker`/`all_the_time` operation name **must equal
+the full Criterion benchmark identifier** (`<group>/<bench>`) so the two reports
+correlate — see the tracking-session operation-name rule in
+[`docs/naming.md`](naming.md).
 
 ## Stack pin vs. `Box::pin` on the measured path
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -59,7 +59,8 @@ basename prefixes Criterion group names, Callgrind files require a paired
 Criterion file, and Callgrind identifiers mirror Criterion ones with `/`
 substituted by `_`. In particular, when a benchmark tracks allocations or
 processor time, the `alloc_tracker`/`all_the_time` operation name **must equal
-the full Criterion benchmark identifier** (`<group>/<bench>`) so the two reports
+the full Criterion benchmark identifier** (`<group>/<bench_function name>`, where
+the `bench_function` name may itself contain `/` segments) so the two reports
 correlate — see the tracking-session operation-name rule in
 [`docs/naming.md`](naming.md).
 

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -93,17 +93,21 @@ benchmark identifier** it measures — that is:
 ```
 
 which, given the group-naming rule above, always expands to
-`<file-basename>/<subgroup>/<bench>`. The tracking name is not free-form: it is
-the join key that lets the emitted allocation/time report line up one-to-one
-with the Criterion report for the same benchmark. A mismatched name silently
-produces two reports that cannot be correlated, which is worse than useless.
+`<file-basename>/<subgroup>/<bench_function name>`. Note that
+`<bench_function name>` is the exact string passed to `bench_function(...)` and
+may itself contain `/` separators (for example `events/embedded/AutoResetEvent`);
+reproduce it in full rather than appending only its final segment. The tracking
+name is not free-form: it is the join key that lets the emitted allocation/time
+report line up one-to-one with the Criterion report for the same benchmark. A
+mismatched name silently produces two reports that cannot be correlated, which
+is worse than useless.
 
 Example for `foo/benches/foo_something.rs`:
 
 ```rust
 let mut group = c.benchmark_group("foo_something/reads"); // <group>
-let op = allocs.operation("foo_something/reads/warm_cache"); // <group>/<bench>
-group.bench_function("warm_cache", |b| { /* ... */ });      // <bench>
+let op = allocs.operation("foo_something/reads/warm_cache"); // <group>/<bench_function name>
+group.bench_function("warm_cache", |b| { /* ... */ });      // <bench_function name>
 ```
 
 Watch out for these traps:

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -71,6 +71,63 @@ Avoid `::` or other custom separators between segments — Criterion already
 uses `/` as the hierarchical separator and that is the only separator that
 should appear in group names.
 
+### Tracking-session operation names must equal the Criterion identifier
+
+> **This is the naming rule most easily overlooked. Read it before touching any
+> benchmark that tracks allocations or processor time.**
+
+Many Criterion benchmarks pair their timing with an
+[`alloc_tracker`](../packages/alloc_tracker) or
+[`all_the_time`](../packages/all_the_time) tracking session. Each tracked
+operation is registered with a call such as:
+
+```rust
+let op = allocs.operation("<name>");
+```
+
+The `<name>` string **must be identical to the fully qualified Criterion
+benchmark identifier** it measures — that is:
+
+```
+<criterion group name>/<bench_function name>
+```
+
+which, given the group-naming rule above, always expands to
+`<file-basename>/<subgroup>/<bench>`. The tracking name is not free-form: it is
+the join key that lets the emitted allocation/time report line up one-to-one
+with the Criterion report for the same benchmark. A mismatched name silently
+produces two reports that cannot be correlated, which is worse than useless.
+
+Example for `foo/benches/foo_something.rs`:
+
+```rust
+let mut group = c.benchmark_group("foo_something/reads"); // <group>
+let op = allocs.operation("foo_something/reads/warm_cache"); // <group>/<bench>
+group.bench_function("warm_cache", |b| { /* ... */ });      // <bench>
+```
+
+Watch out for these traps:
+
+* **Use the `bench_function` name, not a paraphrase.** The operation leaf must
+  be the exact string passed to `bench_function(...)`. When the two were
+  written to differ (e.g. an operation called `empty_thread_span` measuring a
+  bench named `thread_span_empty`), the operation name must be corrected to
+  match the bench — the join key is the Criterion identifier, never the old
+  operation label.
+* **Include every segment.** Missing the `<file-basename>/` prefix (or any
+  intermediate segment the `bench_function` name carries) breaks the match.
+  The name must reproduce the Criterion identifier in full, even where that
+  makes a segment look redundant.
+
+**Exception — operations that name the workload under test.** When a benchmark
+exercises a tracking session *as the thing being measured* (for example a
+report-lifecycle bench that populates a session with synthetic operations), the
+`operation(...)` calls on that inner session name the workload, not the
+enclosing Criterion benchmark, and are deliberately independent of the Criterion
+identifier (e.g. `session.operation(format!("op_{op_idx}"))`). Only the
+*outer* tracking session that correlates with the Criterion report follows the
+rule above.
+
 ### Callgrind benchmark files
 
 Callgrind benchmark files (suffix `_cg.rs`) live alongside the Criterion

--- a/packages/all_the_time/benches/all_the_time_example.rs
+++ b/packages/all_the_time/benches/all_the_time_example.rs
@@ -23,7 +23,7 @@ fn entrypoint(c: &mut Criterion) {
     let mut group = c.benchmark_group("all_the_time_example/example");
 
     let cell = Cell::new(1234);
-    let read_cell_op = cpu_time.operation("read_cell");
+    let read_cell_op = cpu_time.operation("all_the_time_example/example/read_cell");
 
     group.bench_function("read_cell", |b| {
         b.iter_custom(|iters| {
@@ -41,7 +41,7 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let string_op = cpu_time.operation("string_formatting");
+    let string_op = cpu_time.operation("all_the_time_example/example/string_formatting");
 
     group.bench_function("string_formatting", |b| {
         b.iter_custom(|iters| {
@@ -62,7 +62,7 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let computation_op = cpu_time.operation("computation");
+    let computation_op = cpu_time.operation("all_the_time_example/example/computation");
 
     group.bench_function("computation", |b| {
         b.iter_custom(|iters| {

--- a/packages/all_the_time/benches/all_the_time_tracking_overhead.rs
+++ b/packages/all_the_time/benches/all_the_time_tracking_overhead.rs
@@ -34,7 +34,7 @@ fn entrypoint(c: &mut Criterion) {
         // its own stdout and file output on drop.
         let time_session = Session::new().no_stdout().no_file();
 
-        let thread_op = time_session.operation("empty_thread_span");
+        let thread_op = time_session.operation("all_the_time_tracking_overhead/overhead/thread_span_empty");
         group.bench_function("thread_span_empty", |b| {
             b.iter(|| {
                 let _span = thread_op.measure_thread().iterations(1);
@@ -43,7 +43,7 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let process_op = time_session.operation("empty_process_span");
+        let process_op = time_session.operation("all_the_time_tracking_overhead/overhead/process_span_empty");
         group.bench_function("process_span_empty", |b| {
             b.iter(|| {
                 let _span = process_op.measure_process().iterations(1);
@@ -53,7 +53,7 @@ fn entrypoint(c: &mut Criterion) {
         });
 
         // Test batch overhead with different iteration counts
-        let batch_op_10 = time_session.operation("empty_batch_span_10");
+        let batch_op_10 = time_session.operation("all_the_time_tracking_overhead/overhead/batch_span_empty_10_iterations");
         group.bench_function("batch_span_empty_10_iterations", |b| {
             b.iter(|| {
                 let _span = batch_op_10.measure_thread().iterations(10);
@@ -62,7 +62,7 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let batch_op_100 = time_session.operation("empty_batch_span_100");
+        let batch_op_100 = time_session.operation("all_the_time_tracking_overhead/overhead/batch_span_empty_100_iterations");
         group.bench_function("batch_span_empty_100_iterations", |b| {
             b.iter(|| {
                 let _span = batch_op_100.measure_thread().iterations(100);
@@ -71,7 +71,7 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let batch_op_1000 = time_session.operation("empty_batch_span_1000");
+        let batch_op_1000 = time_session.operation("all_the_time_tracking_overhead/overhead/batch_span_empty_1000_iterations");
         group.bench_function("batch_span_empty_1000_iterations", |b| {
             b.iter(|| {
                 let _span = batch_op_1000.measure_thread().iterations(1000);

--- a/packages/all_the_time/benches/all_the_time_tracking_overhead.rs
+++ b/packages/all_the_time/benches/all_the_time_tracking_overhead.rs
@@ -34,7 +34,8 @@ fn entrypoint(c: &mut Criterion) {
         // its own stdout and file output on drop.
         let time_session = Session::new().no_stdout().no_file();
 
-        let thread_op = time_session.operation("all_the_time_tracking_overhead/overhead/thread_span_empty");
+        let thread_op =
+            time_session.operation("all_the_time_tracking_overhead/overhead/thread_span_empty");
         group.bench_function("thread_span_empty", |b| {
             b.iter(|| {
                 let _span = thread_op.measure_thread().iterations(1);
@@ -43,7 +44,8 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let process_op = time_session.operation("all_the_time_tracking_overhead/overhead/process_span_empty");
+        let process_op =
+            time_session.operation("all_the_time_tracking_overhead/overhead/process_span_empty");
         group.bench_function("process_span_empty", |b| {
             b.iter(|| {
                 let _span = process_op.measure_process().iterations(1);
@@ -53,7 +55,8 @@ fn entrypoint(c: &mut Criterion) {
         });
 
         // Test batch overhead with different iteration counts
-        let batch_op_10 = time_session.operation("all_the_time_tracking_overhead/overhead/batch_span_empty_10_iterations");
+        let batch_op_10 = time_session
+            .operation("all_the_time_tracking_overhead/overhead/batch_span_empty_10_iterations");
         group.bench_function("batch_span_empty_10_iterations", |b| {
             b.iter(|| {
                 let _span = batch_op_10.measure_thread().iterations(10);
@@ -62,7 +65,8 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let batch_op_100 = time_session.operation("all_the_time_tracking_overhead/overhead/batch_span_empty_100_iterations");
+        let batch_op_100 = time_session
+            .operation("all_the_time_tracking_overhead/overhead/batch_span_empty_100_iterations");
         group.bench_function("batch_span_empty_100_iterations", |b| {
             b.iter(|| {
                 let _span = batch_op_100.measure_thread().iterations(100);
@@ -71,7 +75,8 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let batch_op_1000 = time_session.operation("all_the_time_tracking_overhead/overhead/batch_span_empty_1000_iterations");
+        let batch_op_1000 = time_session
+            .operation("all_the_time_tracking_overhead/overhead/batch_span_empty_1000_iterations");
         group.bench_function("batch_span_empty_1000_iterations", |b| {
             b.iter(|| {
                 let _span = batch_op_1000.measure_thread().iterations(1000);

--- a/packages/alloc_tracker/benches/alloc_tracker_example.rs
+++ b/packages/alloc_tracker/benches/alloc_tracker_example.rs
@@ -22,7 +22,7 @@ fn entrypoint(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("alloc_tracker_example/example");
 
-    let string_op = allocs.operation("string_formatting");
+    let string_op = allocs.operation("alloc_tracker_example/example/string_formatting");
     group.bench_function("string_formatting", |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
@@ -42,7 +42,7 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let vector_op = allocs.operation("vector_creation");
+    let vector_op = allocs.operation("alloc_tracker_example/example/vector_creation");
     group.bench_function("vector_creation", |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();

--- a/packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs
+++ b/packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs
@@ -37,7 +37,7 @@ fn entrypoint(c: &mut Criterion) {
         // its own stdout and file output on drop.
         let alloc_session = Session::new().no_stdout().no_file();
 
-        let process_op = alloc_session.operation("empty_process_span");
+        let process_op = alloc_session.operation("alloc_tracker_tracking_overhead/overhead/process_span_empty");
         group.bench_function("process_span_empty", |b| {
             b.iter(|| {
                 let _span = process_op.measure_process().iterations(1);
@@ -46,7 +46,7 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let thread_op = alloc_session.operation("empty_thread_span");
+        let thread_op = alloc_session.operation("alloc_tracker_tracking_overhead/overhead/thread_span_empty");
         group.bench_function("thread_span_empty", |b| {
             b.iter(|| {
                 let _span = thread_op.measure_thread().iterations(1);

--- a/packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs
+++ b/packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs
@@ -37,7 +37,8 @@ fn entrypoint(c: &mut Criterion) {
         // its own stdout and file output on drop.
         let alloc_session = Session::new().no_stdout().no_file();
 
-        let process_op = alloc_session.operation("alloc_tracker_tracking_overhead/overhead/process_span_empty");
+        let process_op =
+            alloc_session.operation("alloc_tracker_tracking_overhead/overhead/process_span_empty");
         group.bench_function("process_span_empty", |b| {
             b.iter(|| {
                 let _span = process_op.measure_process().iterations(1);
@@ -46,7 +47,8 @@ fn entrypoint(c: &mut Criterion) {
             });
         });
 
-        let thread_op = alloc_session.operation("alloc_tracker_tracking_overhead/overhead/thread_span_empty");
+        let thread_op =
+            alloc_session.operation("alloc_tracker_tracking_overhead/overhead/thread_span_empty");
         group.bench_function("thread_span_empty", |b| {
             b.iter(|| {
                 let _span = thread_op.measure_thread().iterations(1);

--- a/packages/events/benches/events_uncontended.rs
+++ b/packages/events/benches/events_uncontended.rs
@@ -122,7 +122,8 @@ fn creation_boxed(c: &mut Criterion, allocs: &AllocSession) {
 fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
     let mut group = c.benchmark_group("events_uncontended/creation_embedded");
 
-    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/ManualResetEvent");
+    let op =
+        allocs.operation("events_uncontended/creation_embedded/events/embedded/ManualResetEvent");
     group.bench_function("events/embedded/ManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -136,7 +137,8 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/AutoResetEvent");
+    let op =
+        allocs.operation("events_uncontended/creation_embedded/events/embedded/AutoResetEvent");
     group.bench_function("events/embedded/AutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -150,7 +152,8 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/LocalManualResetEvent");
+    let op = allocs
+        .operation("events_uncontended/creation_embedded/events/embedded/LocalManualResetEvent");
     group.bench_function("events/embedded/LocalManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -164,7 +167,8 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/LocalAutoResetEvent");
+    let op = allocs
+        .operation("events_uncontended/creation_embedded/events/embedded/LocalAutoResetEvent");
     group.bench_function("events/embedded/LocalAutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -283,7 +287,8 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/signal_round_trip/events/embedded/ManualResetEvent");
+    let op =
+        allocs.operation("events_uncontended/signal_round_trip/events/embedded/ManualResetEvent");
     group.bench_function("events/embedded/ManualResetEvent", |b| {
         let container = pin!(EmbeddedManualResetEvent::new());
         let manual = unsafe { ManualResetEvent::embedded(container.as_ref()) };
@@ -298,7 +303,8 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/signal_round_trip/events/embedded/AutoResetEvent");
+    let op =
+        allocs.operation("events_uncontended/signal_round_trip/events/embedded/AutoResetEvent");
     group.bench_function("events/embedded/AutoResetEvent", |b| {
         let container = pin!(EmbeddedAutoResetEvent::new());
         let auto = unsafe { AutoResetEvent::embedded(container.as_ref()) };
@@ -330,7 +336,8 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/signal_round_trip/event_listener/Event (listener!)");
+    let op =
+        allocs.operation("events_uncontended/signal_round_trip/event_listener/Event (listener!)");
     group.bench_function("event_listener/Event (listener!)", |b| {
         let el_event = ElEvent::<()>::new();
         let waker = Waker::noop();
@@ -451,7 +458,8 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/async_poll_ready/events/embedded/ManualResetEvent");
+    let op =
+        allocs.operation("events_uncontended/async_poll_ready/events/embedded/ManualResetEvent");
     group.bench_function("events/embedded/ManualResetEvent", |b| {
         let container = pin!(EmbeddedManualResetEvent::new());
         let manual = unsafe { ManualResetEvent::embedded(container.as_ref()) };
@@ -501,7 +509,8 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("events_uncontended/async_poll_ready/event_listener/Event (listener!)");
+    let op =
+        allocs.operation("events_uncontended/async_poll_ready/event_listener/Event (listener!)");
     group.bench_function("event_listener/Event (listener!)", |b| {
         let el_event = ElEvent::<()>::new();
         let mut cx = Context::from_waker(waker);

--- a/packages/events/benches/events_uncontended.rs
+++ b/packages/events/benches/events_uncontended.rs
@@ -67,7 +67,7 @@ fn entrypoint(c: &mut Criterion) {
 fn creation_boxed(c: &mut Criterion, allocs: &AllocSession) {
     let mut group = c.benchmark_group("events_uncontended/creation_boxed");
 
-    let op = allocs.operation("creation_boxed/events/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/creation_boxed/events/ManualResetEvent");
     group.bench_function("events/ManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -79,7 +79,7 @@ fn creation_boxed(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_boxed/events/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/creation_boxed/events/AutoResetEvent");
     group.bench_function("events/AutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -91,7 +91,7 @@ fn creation_boxed(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_boxed/events/LocalManualResetEvent");
+    let op = allocs.operation("events_uncontended/creation_boxed/events/LocalManualResetEvent");
     group.bench_function("events/LocalManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -103,7 +103,7 @@ fn creation_boxed(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_boxed/events/LocalAutoResetEvent");
+    let op = allocs.operation("events_uncontended/creation_boxed/events/LocalAutoResetEvent");
     group.bench_function("events/LocalAutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -122,7 +122,7 @@ fn creation_boxed(c: &mut Criterion, allocs: &AllocSession) {
 fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
     let mut group = c.benchmark_group("events_uncontended/creation_embedded");
 
-    let op = allocs.operation("creation_embedded/events/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/ManualResetEvent");
     group.bench_function("events/embedded/ManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -136,7 +136,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_embedded/events/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/AutoResetEvent");
     group.bench_function("events/embedded/AutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -150,7 +150,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_embedded/events/LocalManualResetEvent");
+    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/LocalManualResetEvent");
     group.bench_function("events/embedded/LocalManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -164,7 +164,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_embedded/events/LocalAutoResetEvent");
+    let op = allocs.operation("events_uncontended/creation_embedded/events/embedded/LocalAutoResetEvent");
     group.bench_function("events/embedded/LocalAutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -178,7 +178,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_embedded/rsevents/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/creation_embedded/rsevents/ManualResetEvent");
     group.bench_function("rsevents/ManualResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -190,7 +190,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_embedded/rsevents/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/creation_embedded/rsevents/AutoResetEvent");
     group.bench_function("rsevents/AutoResetEvent", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -202,7 +202,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("creation_embedded/event_listener/Event");
+    let op = allocs.operation("events_uncontended/creation_embedded/event_listener/Event");
     group.bench_function("event_listener/Event", |b| {
         b.iter_custom(|iters| {
             let _span = op.measure_thread().iterations(iters);
@@ -227,7 +227,7 @@ fn creation_embedded(c: &mut Criterion, allocs: &AllocSession) {
 fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
     let mut group = c.benchmark_group("events_uncontended/signal_round_trip");
 
-    let op = allocs.operation("signal_round_trip/events/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/events/ManualResetEvent");
     group.bench_function("events/ManualResetEvent", |b| {
         let manual = ManualResetEvent::boxed();
         manual.set();
@@ -241,7 +241,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/events/LocalManualResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/events/LocalManualResetEvent");
     group.bench_function("events/LocalManualResetEvent", |b| {
         let local_manual = LocalManualResetEvent::boxed();
         local_manual.set();
@@ -255,7 +255,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/events/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/events/AutoResetEvent");
     group.bench_function("events/AutoResetEvent", |b| {
         let auto = AutoResetEvent::boxed();
         b.iter_custom(|iters| {
@@ -269,7 +269,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/events/LocalAutoResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/events/LocalAutoResetEvent");
     group.bench_function("events/LocalAutoResetEvent", |b| {
         let local_auto = LocalAutoResetEvent::boxed();
         b.iter_custom(|iters| {
@@ -283,7 +283,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/events/embedded/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/events/embedded/ManualResetEvent");
     group.bench_function("events/embedded/ManualResetEvent", |b| {
         let container = pin!(EmbeddedManualResetEvent::new());
         let manual = unsafe { ManualResetEvent::embedded(container.as_ref()) };
@@ -298,7 +298,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/events/embedded/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/events/embedded/AutoResetEvent");
     group.bench_function("events/embedded/AutoResetEvent", |b| {
         let container = pin!(EmbeddedAutoResetEvent::new());
         let auto = unsafe { AutoResetEvent::embedded(container.as_ref()) };
@@ -313,7 +313,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/event_listener/Event");
+    let op = allocs.operation("events_uncontended/signal_round_trip/event_listener/Event");
     group.bench_function("event_listener/Event", |b| {
         let el_event = ElEvent::<()>::new();
         let waker = Waker::noop();
@@ -330,7 +330,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/event_listener/Event (listener!)");
+    let op = allocs.operation("events_uncontended/signal_round_trip/event_listener/Event (listener!)");
     group.bench_function("event_listener/Event (listener!)", |b| {
         let el_event = ElEvent::<()>::new();
         let waker = Waker::noop();
@@ -348,7 +348,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/rsevents/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/rsevents/ManualResetEvent");
     group.bench_function("rsevents/ManualResetEvent", |b| {
         let rs_manual = RsManualReset::new(EventState::Set);
         b.iter_custom(|iters| {
@@ -361,7 +361,7 @@ fn signal_round_trip(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("signal_round_trip/rsevents/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/signal_round_trip/rsevents/AutoResetEvent");
     group.bench_function("rsevents/AutoResetEvent", |b| {
         let rs_auto = RsAutoReset::new(EventState::Unset);
         b.iter_custom(|iters| {
@@ -387,7 +387,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
     let mut group = c.benchmark_group("events_uncontended/async_poll_ready");
     let waker = Waker::noop();
 
-    let op = allocs.operation("async_poll_ready/events/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/async_poll_ready/events/ManualResetEvent");
     group.bench_function("events/ManualResetEvent", |b| {
         let manual = ManualResetEvent::boxed();
         manual.set();
@@ -403,7 +403,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/events/LocalManualResetEvent");
+    let op = allocs.operation("events_uncontended/async_poll_ready/events/LocalManualResetEvent");
     group.bench_function("events/LocalManualResetEvent", |b| {
         let local_manual = LocalManualResetEvent::boxed();
         local_manual.set();
@@ -419,7 +419,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/events/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/async_poll_ready/events/AutoResetEvent");
     group.bench_function("events/AutoResetEvent", |b| {
         let auto = AutoResetEvent::boxed();
         let mut cx = Context::from_waker(waker);
@@ -435,7 +435,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/events/LocalAutoResetEvent");
+    let op = allocs.operation("events_uncontended/async_poll_ready/events/LocalAutoResetEvent");
     group.bench_function("events/LocalAutoResetEvent", |b| {
         let local_auto = LocalAutoResetEvent::boxed();
         let mut cx = Context::from_waker(waker);
@@ -451,7 +451,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/events/embedded/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/async_poll_ready/events/embedded/ManualResetEvent");
     group.bench_function("events/embedded/ManualResetEvent", |b| {
         let container = pin!(EmbeddedManualResetEvent::new());
         let manual = unsafe { ManualResetEvent::embedded(container.as_ref()) };
@@ -468,7 +468,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/events/embedded/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/async_poll_ready/events/embedded/AutoResetEvent");
     group.bench_function("events/embedded/AutoResetEvent", |b| {
         let container = pin!(EmbeddedAutoResetEvent::new());
         let auto = unsafe { AutoResetEvent::embedded(container.as_ref()) };
@@ -485,7 +485,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/event_listener/Event");
+    let op = allocs.operation("events_uncontended/async_poll_ready/event_listener/Event");
     group.bench_function("event_listener/Event", |b| {
         let el_event = ElEvent::<()>::new();
         let mut cx = Context::from_waker(waker);
@@ -501,7 +501,7 @@ fn async_poll_ready(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("async_poll_ready/event_listener/Event (listener!)");
+    let op = allocs.operation("events_uncontended/async_poll_ready/event_listener/Event (listener!)");
     group.bench_function("event_listener/Event (listener!)", |b| {
         let el_event = ElEvent::<()>::new();
         let mut cx = Context::from_waker(waker);
@@ -546,7 +546,7 @@ fn many_waiters(c: &mut Criterion, allocs: &AllocSession) {
     let mut group = c.benchmark_group("events_uncontended/many_waiters");
     let waker = Waker::noop();
 
-    let op = allocs.operation("many_waiters/events/ManualResetEvent");
+    let op = allocs.operation("events_uncontended/many_waiters/events/ManualResetEvent");
     group.bench_function("events/ManualResetEvent", |b| {
         let mut cx = Context::from_waker(waker);
         let mut futures = Vec::new();
@@ -571,7 +571,7 @@ fn many_waiters(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("many_waiters/events/LocalManualResetEvent");
+    let op = allocs.operation("events_uncontended/many_waiters/events/LocalManualResetEvent");
     group.bench_function("events/LocalManualResetEvent", |b| {
         let mut cx = Context::from_waker(waker);
         let mut futures = Vec::new();
@@ -595,7 +595,7 @@ fn many_waiters(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("many_waiters/events/AutoResetEvent");
+    let op = allocs.operation("events_uncontended/many_waiters/events/AutoResetEvent");
     group.bench_function("events/AutoResetEvent", |b| {
         let mut cx = Context::from_waker(waker);
         let mut futures = Vec::new();
@@ -619,7 +619,7 @@ fn many_waiters(c: &mut Criterion, allocs: &AllocSession) {
         });
     });
 
-    let op = allocs.operation("many_waiters/events/LocalAutoResetEvent");
+    let op = allocs.operation("events_uncontended/many_waiters/events/LocalAutoResetEvent");
     group.bench_function("events/LocalAutoResetEvent", |b| {
         let mut cx = Context::from_waker(waker);
         let mut futures = Vec::new();
@@ -646,7 +646,7 @@ fn many_waiters(c: &mut Criterion, allocs: &AllocSession) {
     // rsevents uses synchronous blocking and cannot register multiple
     // async waiters, so it is excluded from this benchmark group.
 
-    let op = allocs.operation("many_waiters/event_listener/Event");
+    let op = allocs.operation("events_uncontended/many_waiters/event_listener/Event");
     group.bench_function("event_listener/Event", |b| {
         let mut cx = Context::from_waker(waker);
         let mut futures = Vec::new();

--- a/packages/infinity_pool/benches/infinity_pool_vs_std.rs
+++ b/packages/infinity_pool/benches/infinity_pool_vs_std.rs
@@ -51,7 +51,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     group.sample_size(2000);
 
     // Box::pin() baseline with churn (insertion + removal pattern)
-    let allocs_op = allocs.operation("Box::pin()");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/Box::pin()");
     group.bench_function("Box::pin()", |b| {
         b.iter_custom(|iters| {
             let mut all_boxes = Vec::with_capacity(iters as usize);
@@ -95,7 +95,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // Rc::pin() baseline with churn (insertion + removal pattern)
-    let allocs_op = allocs.operation("Rc::pin()");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/Rc::pin()");
     group.bench_function("Rc::pin()", |b| {
         b.iter_custom(|iters| {
             let mut all_rcs = Vec::with_capacity(iters as usize);
@@ -139,7 +139,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // Arc::pin() baseline with churn (insertion + removal pattern)
-    let allocs_op = allocs.operation("Arc::pin()");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/Arc::pin()");
     group.bench_function("Arc::pin()", |b| {
         b.iter_custom(|iters| {
             let mut all_arcs = Vec::with_capacity(iters as usize);
@@ -183,7 +183,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // PinnedPool<T> (thread-safe, reference counted) with churn
-    let allocs_op = allocs.operation("PinnedPool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/PinnedPool");
     group.bench_function("PinnedPool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -228,7 +228,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // LocalPinnedPool<T> (single-threaded, reference counted) with churn
-    let allocs_op = allocs.operation("LocalPinnedPool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/LocalPinnedPool");
     group.bench_function("LocalPinnedPool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -273,7 +273,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // RawPinnedPool<T> (raw, manual lifetime management) with churn
-    let allocs_op = allocs.operation("RawPinnedPool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/RawPinnedPool");
     group.bench_function("RawPinnedPool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -321,7 +321,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // OpaquePool (thread-safe, reference counted, type-erased) with churn
-    let allocs_op = allocs.operation("OpaquePool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/OpaquePool");
     group.bench_function("OpaquePool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -366,7 +366,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // LocalOpaquePool (single-threaded, reference counted, type-erased) with churn
-    let allocs_op = allocs.operation("LocalOpaquePool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/LocalOpaquePool");
     group.bench_function("LocalOpaquePool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -411,7 +411,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // RawOpaquePool (raw, manual lifetime management, type-erased) with churn
-    let allocs_op = allocs.operation("RawOpaquePool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/RawOpaquePool");
     group.bench_function("RawOpaquePool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -459,7 +459,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // BlindPool (thread-safe, reference counted, multiple types) with churn
-    let allocs_op = allocs.operation("BlindPool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/BlindPool");
     group.bench_function("BlindPool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -504,7 +504,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // LocalBlindPool (single-threaded, reference counted, multiple types) with churn
-    let allocs_op = allocs.operation("LocalBlindPool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/LocalBlindPool");
     group.bench_function("LocalBlindPool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);
@@ -549,7 +549,7 @@ fn churn_insertion_benchmark(c: &mut Criterion) {
     });
 
     // RawBlindPool (raw, manual lifetime management, multiple types) with churn
-    let allocs_op = allocs.operation("RawBlindPool");
+    let allocs_op = allocs.operation("infinity_pool_vs_std/churn_insertion/RawBlindPool");
     group.bench_function("RawBlindPool", |b| {
         b.iter_custom(|iters| {
             let mut all_pools = Vec::with_capacity(iters as usize);

--- a/packages/vicinal/benches/vicinal.rs
+++ b/packages/vicinal/benches/vicinal.rs
@@ -46,8 +46,8 @@ fn entrypoint(c: &mut Criterion) {
 
     let mut g = c.benchmark_group("vicinal/spawn");
 
-    let spawn_single_alloc = allocs.operation("spawn_single");
-    let spawn_single_time = times.operation("spawn_single");
+    let spawn_single_alloc = allocs.operation("vicinal/spawn/spawn_single");
+    let spawn_single_time = times.operation("vicinal/spawn/spawn_single");
 
     g.bench_function("spawn_single", |b| {
         let pool = Pool::new();
@@ -67,8 +67,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_100_alloc = allocs.operation("spawn_100");
-    let spawn_100_time = times.operation("spawn_100");
+    let spawn_100_alloc = allocs.operation("vicinal/spawn/spawn_100");
+    let spawn_100_time = times.operation("vicinal/spawn/spawn_100");
 
     g.bench_function("spawn_100", |b| {
         let pool = Pool::new();
@@ -99,8 +99,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_urgent_single_alloc = allocs.operation("spawn_urgent_single");
-    let spawn_urgent_single_time = times.operation("spawn_urgent_single");
+    let spawn_urgent_single_alloc = allocs.operation("vicinal/spawn/spawn_urgent_single");
+    let spawn_urgent_single_time = times.operation("vicinal/spawn/spawn_urgent_single");
 
     g.bench_function("spawn_urgent_single", |b| {
         let pool = Pool::new();
@@ -124,8 +124,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_urgent_100_alloc = allocs.operation("spawn_urgent_100");
-    let spawn_urgent_100_time = times.operation("spawn_urgent_100");
+    let spawn_urgent_100_alloc = allocs.operation("vicinal/spawn/spawn_urgent_100");
+    let spawn_urgent_100_time = times.operation("vicinal/spawn/spawn_urgent_100");
 
     g.bench_function("spawn_urgent_100", |b| {
         let pool = Pool::new();
@@ -160,8 +160,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let thread_single_alloc = allocs.operation("thread_single");
-    let thread_single_time = times.operation("thread_single");
+    let thread_single_alloc = allocs.operation("vicinal/spawn/thread_single");
+    let thread_single_time = times.operation("vicinal/spawn/thread_single");
 
     g.bench_function("thread_single", |b| {
         b.iter_custom(|iterations| {
@@ -178,8 +178,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let thread_100_alloc = allocs.operation("thread_100");
-    let thread_100_time = times.operation("thread_100");
+    let thread_100_alloc = allocs.operation("vicinal/spawn/thread_100");
+    let thread_100_time = times.operation("vicinal/spawn/thread_100");
 
     g.bench_function("thread_100", |b| {
         b.iter_custom(|iterations| {
@@ -207,8 +207,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let threadpool_single_alloc = allocs.operation("threadpool_single");
-    let threadpool_single_time = times.operation("threadpool_single");
+    let threadpool_single_alloc = allocs.operation("vicinal/spawn/threadpool_single");
+    let threadpool_single_time = times.operation("vicinal/spawn/threadpool_single");
 
     g.bench_function("threadpool_single", |b| {
         // Vicinal pool defaults to 2 threads per processor, so we match.
@@ -250,8 +250,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let threadpool_100_alloc = allocs.operation("threadpool_100");
-    let threadpool_100_time = times.operation("threadpool_100");
+    let threadpool_100_alloc = allocs.operation("vicinal/spawn/threadpool_100");
+    let threadpool_100_time = times.operation("vicinal/spawn/threadpool_100");
 
     g.bench_function("threadpool_100", |b| {
         // Vicinal pool defaults to 2 threads per processor, so we match.
@@ -309,8 +309,8 @@ fn entrypoint(c: &mut Criterion) {
     // This group includes both regular spawn (with event) and spawn_and_forget for fair comparison.
     let mut g = c.benchmark_group("vicinal/fire_and_forget");
 
-    let spawn_with_event_single_alloc = allocs.operation("spawn_with_event_single");
-    let spawn_with_event_single_time = times.operation("spawn_with_event_single");
+    let spawn_with_event_single_alloc = allocs.operation("vicinal/fire_and_forget/spawn_with_event_single");
+    let spawn_with_event_single_time = times.operation("vicinal/fire_and_forget/spawn_with_event_single");
 
     g.bench_function("spawn_with_event_single", |b| {
         let pool = Pool::new();
@@ -340,8 +340,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_with_event_100_alloc = allocs.operation("spawn_with_event_100");
-    let spawn_with_event_100_time = times.operation("spawn_with_event_100");
+    let spawn_with_event_100_alloc = allocs.operation("vicinal/fire_and_forget/spawn_with_event_100");
+    let spawn_with_event_100_time = times.operation("vicinal/fire_and_forget/spawn_with_event_100");
 
     g.bench_function("spawn_with_event_100", |b| {
         let pool = Pool::new();
@@ -383,8 +383,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_and_forget_single_alloc = allocs.operation("spawn_and_forget_single");
-    let spawn_and_forget_single_time = times.operation("spawn_and_forget_single");
+    let spawn_and_forget_single_alloc = allocs.operation("vicinal/fire_and_forget/spawn_and_forget_single");
+    let spawn_and_forget_single_time = times.operation("vicinal/fire_and_forget/spawn_and_forget_single");
 
     g.bench_function("spawn_and_forget_single", |b| {
         let pool = Pool::new();
@@ -413,8 +413,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_and_forget_100_alloc = allocs.operation("spawn_and_forget_100");
-    let spawn_and_forget_100_time = times.operation("spawn_and_forget_100");
+    let spawn_and_forget_100_alloc = allocs.operation("vicinal/fire_and_forget/spawn_and_forget_100");
+    let spawn_and_forget_100_time = times.operation("vicinal/fire_and_forget/spawn_and_forget_100");
 
     g.bench_function("spawn_and_forget_100", |b| {
         let pool = Pool::new();

--- a/packages/vicinal/benches/vicinal.rs
+++ b/packages/vicinal/benches/vicinal.rs
@@ -309,8 +309,10 @@ fn entrypoint(c: &mut Criterion) {
     // This group includes both regular spawn (with event) and spawn_and_forget for fair comparison.
     let mut g = c.benchmark_group("vicinal/fire_and_forget");
 
-    let spawn_with_event_single_alloc = allocs.operation("vicinal/fire_and_forget/spawn_with_event_single");
-    let spawn_with_event_single_time = times.operation("vicinal/fire_and_forget/spawn_with_event_single");
+    let spawn_with_event_single_alloc =
+        allocs.operation("vicinal/fire_and_forget/spawn_with_event_single");
+    let spawn_with_event_single_time =
+        times.operation("vicinal/fire_and_forget/spawn_with_event_single");
 
     g.bench_function("spawn_with_event_single", |b| {
         let pool = Pool::new();
@@ -340,7 +342,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_with_event_100_alloc = allocs.operation("vicinal/fire_and_forget/spawn_with_event_100");
+    let spawn_with_event_100_alloc =
+        allocs.operation("vicinal/fire_and_forget/spawn_with_event_100");
     let spawn_with_event_100_time = times.operation("vicinal/fire_and_forget/spawn_with_event_100");
 
     g.bench_function("spawn_with_event_100", |b| {
@@ -383,8 +386,10 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_and_forget_single_alloc = allocs.operation("vicinal/fire_and_forget/spawn_and_forget_single");
-    let spawn_and_forget_single_time = times.operation("vicinal/fire_and_forget/spawn_and_forget_single");
+    let spawn_and_forget_single_alloc =
+        allocs.operation("vicinal/fire_and_forget/spawn_and_forget_single");
+    let spawn_and_forget_single_time =
+        times.operation("vicinal/fire_and_forget/spawn_and_forget_single");
 
     g.bench_function("spawn_and_forget_single", |b| {
         let pool = Pool::new();
@@ -413,7 +418,8 @@ fn entrypoint(c: &mut Criterion) {
         });
     });
 
-    let spawn_and_forget_100_alloc = allocs.operation("vicinal/fire_and_forget/spawn_and_forget_100");
+    let spawn_and_forget_100_alloc =
+        allocs.operation("vicinal/fire_and_forget/spawn_and_forget_100");
     let spawn_and_forget_100_time = times.operation("vicinal/fire_and_forget/spawn_and_forget_100");
 
     g.bench_function("spawn_and_forget_100", |b| {


### PR DESCRIPTION
[Copilot speaking]

## Summary

Benchmarks that track allocations or processor time register operations via `alloc_tracker`/`all_the_time` `session.operation(NAME)`. For the emitted allocation/time report to correlate 1:1 with the Criterion report, `NAME` must equal the full Criterion benchmark identifier — `<group>/<bench_function>`. Several benches used leaf-only or partial names, so their tracking reports could not be lined up with their Criterion counterparts.

This PR fixes every non-conformant tracking-operation name across the workspace and documents the requirement so it is not missed again.

## Operation-name fixes

| File | Ops fixed |
|---|---|
| `packages/vicinal/benches/vicinal.rs` | 12 (each an alloc + time pair) |
| `packages/events/benches/events_uncontended.rs` | 34 |
| `packages/infinity_pool/benches/infinity_pool_vs_std.rs` | 12 |
| `packages/all_the_time/benches/all_the_time_example.rs` | 3 |
| `packages/all_the_time/benches/all_the_time_tracking_overhead.rs` | 5 |
| `packages/alloc_tracker/benches/alloc_tracker_example.rs` | 2 |
| `packages/alloc_tracker/benches/alloc_tracker_tracking_overhead.rs` | 2 |

Notes:

- For the `tracking_overhead` benches, the operation leaf now matches the `bench_function` name (e.g. `thread_span_empty`), not the previous descriptive label (`empty_thread_span`) — the join key is the Criterion identifier.
- Workload operations that name the object *under test* (e.g. `session.operation(format!("op_{idx}"))` in the report-lifecycle benches) are intentionally left independent of the Criterion identifier; only the outer correlating tracking session follows the rule.
- Already-conformant benches (`cbh_codec`, both `report_lifecycle` outer sessions) were unchanged.

## Docs

- `docs/naming.md`: added a prominent subsection, "Tracking-session operation names must equal the Criterion identifier", covering the rule, an example, the two common traps (use the `bench_function` name; include every segment), and the workload-under-test exception.
- `docs/benchmarks.md`: cross-referenced the new rule.

## Validation

- No leaf-only tracking names remain (workspace grep).
- All 7 touched Criterion benches compile via `cargo bench --no-run`.
- Spot-checked vicinal: every operation string matches its `<group>/<bench>` 1:1.

The `_cg.rs` Callgrind benches were already conformant and require Linux/valgrind, so were not rebuilt here.