### PR TITLE
Warn when a branch finding's comparison base lags the merge-base

### DIFF
--- a/packages/cargo-bench-history/book/src/commands/analyze.md
+++ b/packages/cargo-bench-history/book/src/commands/analyze.md
@@ -57,6 +57,20 @@ Text goes to stdout by default. File toggles compose, so a single pass can emit 
 Markdown, and JSON at once; requesting no output at all is an error. A derived, condensed
 Markdown **summary** is also available for a size-limited downstream consumer.
 
+> **Comparison-base warnings (branch mode)**
+> On rotating CI machine pools the newest base commits may carry data only under a different
+> machine key, so the PR runner's key compares its tip against base data a few commits behind
+> the merge-base. When that happens, the affected discriminant set carries a warning naming how
+> far behind and why:
+>
+> - *discriminant set mismatch* — newer base data exists, but under a different machine key
+>   (pool rotation); counts are never compared across machine keys.
+> - *no base data at more recent commits* — no newer base run exists for that series at all.
+>
+> The warning appears in every format (per set in text, Markdown, and the summary; a
+> `comparison_base_lags` array on each JSON set). It is advisory only and never changes which
+> findings are reported or the exit code.
+
 **Findings never affect the exit code**: the process exits non-zero only when the analysis
 fails to *run*. A finding is advisory; the machine-readable signal lives in the JSON report,
 which downstream automation should read rather than the exit status.

--- a/packages/cargo-bench-history/book/src/concepts/analysis.md
+++ b/packages/cargo-bench-history/book/src/concepts/analysis.md
@@ -58,6 +58,24 @@ modes, auto-detected from git topology (there is no flag to force a mode):
   base, reporting both directions. Only the tip commit lands in the base on merge, so the
   branch's own intermediate history is ignored.
 
+## Comparison-base lag
+
+Branch mode compares the tip against the recent base-side points of the **same** discriminant
+set — same project, engine, target triple, and [machine key](../commands/machine-key.md).
+Measurements are never compared across machine keys, so on rotating CI pools, where the newest
+base commits may have run on a different machine, the branch runner's key can have usable base
+data only a few commits behind the merge-base. The comparison quietly reaches back in history.
+
+`analyze` discloses this per affected discriminant set, naming how far behind the comparison
+base is and why:
+
+- **discriminant set mismatch** — a newer base run for the benchmark and metric exists, but
+  under a different machine key. This is pool rotation, not a gap in coverage.
+- **no base data at more recent commits** — no newer base run exists for that series at all.
+
+The warning is advisory metadata: it explains *what the tip was actually compared against* and
+never changes which findings are reported or the exit code.
+
 ## Re-baselining
 
 History mode distinguishes a change **still in effect** from one **already addressed**, so a

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -930,6 +930,42 @@ Because it exists to
 fit a downstream cap rather than to present the analysis, it is offered only by `analyze`,
 never by the enumerating commands, and the retained-count is a fixed policy of the renderer.
 
+### 8.8 Comparison-base lag (branch mode)
+
+Branch mode compares the tip against the recent base-side points of the *same* discriminant set.
+On rotating CI machine pools (§4) the newest base commits may carry data only under a different
+machine key, so the branch runner's key has usable base data only several commits behind the
+merge-base — the comparison silently reaches back in history. Counts are never compared across
+machine keys, so the tool cannot bridge that gap; it only **discloses** it.
+
+Each surviving branch finding records the first-parent index of the newest base-side point it was
+actually compared against — its **comparison base**. A finding whose comparison base sits behind
+the merge-base *lags*, by the first-parent distance between the two. History mode has no single
+comparison base and never lags. The lag is measured from the detector's real comparison point, not
+from raw run occupancy: a partial run can be newer than the point a particular series was compared
+against, so occupancy would overstate coverage.
+
+A lag is classified by *why* the newer base commits were unusable:
+
+* **discriminant set mismatch** — a newer base-side clean run for the same benchmark and metric
+  exists, but under a different machine key: pool rotation, not missing measurements.
+* **no base data at more recent commits** — no newer base-side run for that series exists at all.
+
+Mismatch evidence is satisfied from the already-loaded series first (the whole story under
+`--machine-key all`, where every key is resident) and otherwise from the base-side clean runs under
+other machine keys found in the same partition listing, fetched lazily and only when a lagging
+finding could use them. Raw storage occupancy is only a discovery index — a partial run may omit the
+affected benchmark or metric — so a mismatch is asserted only from a parsed payload that actually
+carries the finding's benchmark and metric.
+
+Because partial runs can leave different findings in one set with different comparison bases or
+reasons, the lag is reported **per discriminant set** as a deduplicated, deterministically ordered
+list rather than a single value; the normal whole-suite case yields exactly one warning line per
+affected set. It is per-set metadata, distinct from the top-level dirty-base-tip warning, surfaced
+in every format (§8.7) — after each affected set's header in text and Markdown, once per affected
+set in the condensed summary, and as an optional `comparison_base_lags` array on each JSON set — and
+never changes finding selection or the exit code.
+
 ## 9. Architecture
 
 The tool is a **shell** (the CLI binary and its library) plus a family of small, private-use

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -956,7 +956,9 @@ Mismatch evidence is satisfied from the already-loaded series first (the whole s
 other machine keys found in the same partition listing, fetched lazily and only when a lagging
 finding could use them. Raw storage occupancy is only a discovery index — a partial run may omit the
 affected benchmark or metric — so a mismatch is asserted only from a parsed payload that actually
-carries the finding's benchmark and metric.
+carries the finding's benchmark and metric. Because the warning is advisory, a failure to fetch or
+parse that optional evidence is noted and degrades the affected findings to the generic reason
+rather than failing the analysis run.
 
 Because partial runs can leave different findings in one set with different comparison bases or
 reasons, the lag is reported **per discriminant set** as a deduplicated, deterministically ordered

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -157,7 +157,9 @@ second listing:
   unresolved are the sibling objects that could fall in its gap fetched — deduplicated, through
   the same bounded-concurrency loader the main load uses — then parsed with the same lean
   projection to confirm the benchmark and metric are actually present rather than trusting raw key
-  occupancy. A run with no surviving lag, an all-ghost set, or history mode fetches nothing.
+  occupancy. A run with no surviving lag, an all-ghost set, or history mode fetches nothing. The
+  warning is advisory, so a failure to fetch or parse that optional evidence is noted and degrades
+  the affected findings to the generic reason instead of failing the run.
 
 ## The full parallelism / serial map
 

--- a/packages/cargo-bench-history/docs/analyze.md
+++ b/packages/cargo-bench-history/docs/analyze.md
@@ -137,6 +137,28 @@ an in-place unstable sort for the median (no scratch buffer, and ties are bit-id
 reordering cannot change the result), pre-sized buffers for the pairwise Theil–Sen slope,
 and a single sort for the false-discovery filter across all noisy candidates.
 
+## Comparison-base lag (branch mode)
+
+After detection, branch mode discloses when a finding's comparison base lags the merge-base
+(DESIGN.md §8.8). The classification reuses the pipeline's existing seams rather than adding a
+second listing:
+
+* **Phase 1 already retained the candidates.** The single project listing splits its keys into
+  the facet-selected candidates *and* the machine-relaxed clean-run siblings — exact `clean.json`
+  objects sharing the engine and triple under a machine key the selection does not cover. The
+  sibling keys pass the same on-history, base-side, and `--since` admission as the selection, so
+  classification starts from a compact, already-vetted key list without a second `list`
+  round-trip.
+* **Evidence comes from loaded data first.** A lagging finding is a machine-key mismatch if a
+  newer base-side clean point for its benchmark and metric exists under a sibling key. Under
+  `--machine-key all` every key is already resident, so this is answered from the loaded series
+  with no fetch at all.
+* **Foreign payloads are fetched lazily and once.** Only when the loaded series leave a lag
+  unresolved are the sibling objects that could fall in its gap fetched — deduplicated, through
+  the same bounded-concurrency loader the main load uses — then parsed with the same lean
+  projection to confirm the benchmark and metric are actually present rather than trusting raw key
+  occupancy. A run with no surviving lag, an all-ghost set, or history mode fetches nothing.
+
 ## The full parallelism / serial map
 
 | Stage | Concurrency type | Unit of work |

--- a/packages/cbh_analyze/src/comparison_base.rs
+++ b/packages/cbh_analyze/src/comparison_base.rs
@@ -1,0 +1,747 @@
+//! Branch-mode comparison-base lag classification.
+//!
+//! In branch mode each surviving finding is compared against the newest base-side
+//! point of its own discriminant set. On rotating CI machine pools the newest base
+//! commits may carry data only under a different machine key, so the branch runner's
+//! machine key has usable base data only several commits behind the merge-base — the
+//! comparison silently reaches back in history.
+//!
+//! This module measures that lag per finding from the detector's actual comparison
+//! point ([`Finding::comparison_base_index`]) and classifies why it lags:
+//!
+//! - [`ComparisonBaseLagReason::DiscriminantSetMismatch`] — a newer base-side run for
+//!   the same benchmark and metric exists, but under a different machine key
+//!   (machine-pool rotation);
+//! - [`ComparisonBaseLagReason::NoRecentBaseData`] — no newer base-side run for the
+//!   affected series exists at all.
+//!
+//! Evidence is drawn from the already reconstructed series first (which covers
+//! `--machine-key all`, where every machine key is already loaded), and only then
+//! from a lazy, deduplicated fetch of the sibling clean-run objects that could fall in
+//! a lagging finding's gap. Sets with no lagging finding never trigger a fetch.
+
+use std::collections::HashMap;
+use std::num::NonZero;
+
+use cbh_detect::{Finding, RunPoints, Series};
+use cbh_diag::{Reporter, ReporterExt, count_noun};
+use cbh_model::{BenchmarkId, DiscriminantSet, MetricKind, StorageKey};
+use cbh_render::{ComparisonBaseLag, ComparisonBaseLagReason};
+use cbh_storage::Storage;
+
+use super::dataset::SiblingObservation;
+use super::load::load_objects_concurrently;
+use crate::AnalyzeError;
+
+/// A surviving branch finding whose comparison base sits behind the merge-base.
+struct LaggingFinding<'a> {
+    /// The finding's discriminant set (the affected set the warning attaches to).
+    set: &'a DiscriminantSet,
+    /// The benchmark identity the comparison covered.
+    id: &'a BenchmarkId,
+    /// The metric kind the comparison covered.
+    kind: MetricKind,
+    /// Topological index of the comparison base — the exclusive lower bound of the
+    /// gap a newer sibling observation would have to fall into.
+    comparison_base_index: usize,
+    /// First-parent distance from the comparison base to the merge-base.
+    commits_behind: NonZero<usize>,
+}
+
+/// A fetched sibling clean run reduced to the identity evidence classification reads.
+struct SiblingEvidence {
+    /// The sibling's discriminant set (a machine key the selection did not cover).
+    set: DiscriminantSet,
+    /// First-parent topological index of the sibling's commit.
+    topo_index: usize,
+    /// The sibling's fold-relevant payload, for benchmark-and-metric presence.
+    points: RunPoints,
+}
+
+/// Classifies the comparison-base lag of every surviving branch finding and groups
+/// the deterministic, deduplicated warnings by discriminant set.
+///
+/// Returns an empty map in history mode (unknown merge-base) and when no finding's
+/// comparison base lags. Only fetches foreign sibling payloads that could classify a
+/// still-unresolved lagging finding, reusing the shared bounded-concurrency loader.
+///
+/// # Errors
+///
+/// Returns an error if a needed sibling object cannot be fetched, decoded as UTF-8, or
+/// parsed as a result set — surfaced rather than silently guessing a reason.
+pub(crate) async fn classify_comparison_base_lags<S>(
+    storage: &S,
+    findings: &[Finding],
+    series: &[Series],
+    merge_base_index: Option<usize>,
+    siblings: &[SiblingObservation],
+    reporter: &dyn Reporter,
+) -> Result<HashMap<DiscriminantSet, Vec<ComparisonBaseLag>>, AnalyzeError>
+where
+    S: Storage,
+{
+    let Some(merge_base) = merge_base_index else {
+        return Ok(HashMap::new());
+    };
+
+    let lagging: Vec<LaggingFinding<'_>> = findings
+        .iter()
+        .filter_map(|finding| {
+            let comparison_base_index = finding.comparison_base_index?;
+            let commits_behind = merge_base
+                .checked_sub(comparison_base_index)
+                .and_then(NonZero::new)?;
+            Some(LaggingFinding {
+                set: &finding.set,
+                id: &finding.id,
+                kind: finding.kind,
+                comparison_base_index,
+                commits_behind,
+            })
+        })
+        .collect();
+    if lagging.is_empty() {
+        return Ok(HashMap::new());
+    }
+    reporter.note_with(|| {
+        format!(
+            "classifying comparison-base lag for {}",
+            count_noun(lagging.len(), "lagging finding")
+        )
+    });
+
+    // Satisfy evidence from the already loaded series first: a newer base-side clean
+    // point for the same benchmark and metric under a sibling machine key proves a
+    // discriminant-set mismatch without any fetch. This is the whole story under
+    // `--machine-key all`, where every machine key is already resident.
+    let mut unresolved: Vec<&LaggingFinding<'_>> = Vec::new();
+    let mut reasons: HashMap<usize, ComparisonBaseLagReason> = HashMap::new();
+    for (index, finding) in lagging.iter().enumerate() {
+        if loaded_series_prove_mismatch(finding, series, merge_base) {
+            reasons.insert(index, ComparisonBaseLagReason::DiscriminantSetMismatch);
+        } else {
+            unresolved.push(finding);
+        }
+    }
+
+    // Only fetch the sibling objects that could still change a verdict: exact
+    // clean-run keys sharing a still-unresolved finding's comparable axes and falling
+    // inside its gap. Deduplicate so an object shared by several findings loads once.
+    let evidence = if unresolved.is_empty() {
+        Vec::new()
+    } else {
+        load_sibling_evidence(storage, &unresolved, siblings, merge_base, reporter).await?
+    };
+
+    let mut lags: HashMap<&DiscriminantSet, Vec<ComparisonBaseLag>> = HashMap::new();
+    for (index, finding) in lagging.iter().enumerate() {
+        let reason = reasons.get(&index).copied().unwrap_or_else(|| {
+            if evidence_proves_mismatch(finding, &evidence, merge_base) {
+                ComparisonBaseLagReason::DiscriminantSetMismatch
+            } else {
+                ComparisonBaseLagReason::NoRecentBaseData
+            }
+        });
+        lags.entry(finding.set)
+            .or_default()
+            .push(ComparisonBaseLag {
+                commits_behind: finding.commits_behind,
+                reason,
+            });
+    }
+
+    // Partial runs can leave findings in one set with different gaps or reasons.
+    // Deduplicate exact pairs and order deterministically (largest gap first, then
+    // mismatch before generic) so a set's warnings render stably.
+    let mut classified: HashMap<DiscriminantSet, Vec<ComparisonBaseLag>> = HashMap::new();
+    for (set, mut set_lags) in lags {
+        set_lags.sort_by(|left, right| {
+            right
+                .commits_behind
+                .cmp(&left.commits_behind)
+                .then_with(|| reason_rank(left.reason).cmp(&reason_rank(right.reason)))
+        });
+        set_lags.dedup();
+        classified.insert(set.clone(), set_lags);
+    }
+    Ok(classified)
+}
+
+/// Whether an already loaded sibling series proves a machine-key mismatch for
+/// `finding`: a series sharing the finding's engine, target triple, benchmark, and
+/// metric, but under a different machine key, with a clean point strictly newer than
+/// the comparison base and no newer than the merge-base.
+fn loaded_series_prove_mismatch(
+    finding: &LaggingFinding<'_>,
+    series: &[Series],
+    merge_base: usize,
+) -> bool {
+    series.iter().any(|candidate| {
+        is_sibling_set(&candidate.set, finding.set)
+            && &candidate.id == finding.id
+            && candidate.kind == finding.kind
+            && candidate.points.iter().any(|point| {
+                !point.dirty
+                    && point.topo_index > finding.comparison_base_index
+                    && point.topo_index <= merge_base
+            })
+    })
+}
+
+/// Whether a fetched sibling payload proves a machine-key mismatch for `finding`.
+fn evidence_proves_mismatch(
+    finding: &LaggingFinding<'_>,
+    evidence: &[SiblingEvidence],
+    merge_base: usize,
+) -> bool {
+    evidence.iter().any(|sibling| {
+        is_sibling_set(&sibling.set, finding.set)
+            && sibling.topo_index > finding.comparison_base_index
+            && sibling.topo_index <= merge_base
+            && sibling.points.results().iter().any(|result| {
+                &result.id == finding.id
+                    && result
+                        .metrics
+                        .iter()
+                        .any(|metric| metric.kind == finding.kind)
+            })
+    })
+}
+
+/// Loads the sibling clean-run payloads that could still classify an unresolved
+/// lagging finding, deduplicated so each object is fetched at most once.
+async fn load_sibling_evidence<S>(
+    storage: &S,
+    unresolved: &[&LaggingFinding<'_>],
+    siblings: &[SiblingObservation],
+    merge_base: usize,
+    reporter: &dyn Reporter,
+) -> Result<Vec<SiblingEvidence>, AnalyzeError>
+where
+    S: Storage,
+{
+    let mut needed: Vec<(String, StorageKey)> = Vec::new();
+    let mut topo_by_key: HashMap<String, usize> = HashMap::new();
+    for sibling in siblings {
+        let relevant = unresolved.iter().any(|finding| {
+            is_sibling_set(&sibling.parsed.set, finding.set)
+                && sibling.topo_index > finding.comparison_base_index
+                && sibling.topo_index <= merge_base
+        });
+        if relevant && !topo_by_key.contains_key(&sibling.key) {
+            topo_by_key.insert(sibling.key.clone(), sibling.topo_index);
+            needed.push((sibling.key.clone(), sibling.parsed.clone()));
+        }
+    }
+    if needed.is_empty() {
+        return Ok(Vec::new());
+    }
+    reporter.note_with(|| {
+        format!(
+            "fetching {} to classify comparison-base lag",
+            count_noun(needed.len(), "sibling clean-run object")
+        )
+    });
+
+    let loaded = load_objects_concurrently(storage, needed, |key, bytes| {
+        let text = str::from_utf8(&bytes).map_err(|error| AnalyzeError::Analyze {
+            message: format!("stored object {key} is not valid UTF-8: {error}"),
+        })?;
+        RunPoints::from_json(text).map_err(|error| AnalyzeError::Analyze {
+            message: format!("stored object {key} is not a valid result set: {error}"),
+        })
+    })
+    .await?;
+
+    Ok(loaded
+        .into_iter()
+        .map(|(key, parsed, points)| SiblingEvidence {
+            set: parsed.set,
+            topo_index: topo_by_key
+                .get(&key)
+                .copied()
+                .expect("fetched key came from the sibling inventory"),
+            points,
+        })
+        .collect())
+}
+
+/// Whether `candidate` is a sibling of `target`: same engine and target triple, but a
+/// different machine key. The comparable axes must match for the counts to belong to
+/// the same measurement; the machine key must differ for it to be a rotation sibling.
+fn is_sibling_set(candidate: &DiscriminantSet, target: &DiscriminantSet) -> bool {
+    candidate.engine == target.engine
+        && candidate.target_triple == target.target_triple
+        && candidate.machine_key != target.machine_key
+}
+
+/// Deterministic reason ordering for a set's warnings: mismatch before generic.
+fn reason_rank(reason: ComparisonBaseLagReason) -> u8 {
+    match reason {
+        ComparisonBaseLagReason::DiscriminantSetMismatch => 0,
+        ComparisonBaseLagReason::NoRecentBaseData => 1,
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
+
+    use cbh_detect::{Direction, FindingMethod, SeriesPoint};
+    use cbh_diag::RecordingReporter;
+    use cbh_model::{
+        BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, Run, RunContext,
+        ToolchainInfo, parse_key,
+    };
+    use cbh_storage::MemoryStorage;
+    use futures::executor::block_on;
+    use jiff::Timestamp;
+    use nonempty::nonempty;
+
+    use super::*;
+
+    /// The discriminant set for `machine`, sharing every other comparable axis.
+    fn set(machine: &str) -> DiscriminantSet {
+        DiscriminantSet {
+            engine: "callgrind".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: machine.to_owned(),
+        }
+    }
+
+    /// The benchmark identity every fixture shares.
+    fn bench_id() -> BenchmarkId {
+        BenchmarkId::new(nonempty![
+            "nm".to_owned(),
+            "observe".to_owned(),
+            "pull".to_owned(),
+        ])
+    }
+
+    /// A branch finding stamped with `comparison_base_index`, in `machine`'s set.
+    fn finding(machine: &str, comparison_base_index: Option<usize>) -> Finding {
+        Finding {
+            set: set(machine),
+            id: bench_id(),
+            kind: MetricKind::InstructionCount,
+            method: FindingMethod::ChangePoint,
+            direction: Direction::Regression,
+            baseline: 100.0,
+            latest: 130.0,
+            delta: 30.0,
+            relative_delta: 0.3,
+            confidence: 0.99,
+            commit: Some("f2".to_owned()),
+            flipped_at: None,
+            active: true,
+            active_from: 0,
+            blessed_at: None,
+            blessed_commit_time: None,
+            series: Vec::new(),
+            comparison_base_index,
+        }
+    }
+
+    /// A branch finding for a specific benchmark `id`, otherwise like [`finding`].
+    fn finding_for(
+        machine: &str,
+        id: BenchmarkId,
+        comparison_base_index: Option<usize>,
+    ) -> Finding {
+        let mut finding = finding(machine, comparison_base_index);
+        finding.id = id;
+        finding
+    }
+
+    /// A loaded series in `machine`'s set carrying one point at `topo_index` with the
+    /// given cleanliness, for the given benchmark and metric.
+    fn loaded_series(
+        machine: &str,
+        id: BenchmarkId,
+        kind: MetricKind,
+        topo_index: usize,
+        dirty: bool,
+    ) -> Series {
+        Series {
+            set: set(machine),
+            id,
+            kind,
+            points: vec![SeriesPoint {
+                topo_index,
+                dirty,
+                object_ordinal: 0,
+                commit: None,
+                value: 100.0,
+                interval_low: None,
+                interval_high: None,
+            }],
+            active_start: 0,
+            blessing: None,
+        }
+    }
+
+    /// A stored clean run at `commit` carrying `id` with one `kind` metric.
+    fn run_with(id: BenchmarkId, kind: MetricKind) -> Run {
+        let context = RunContext::new(
+            Timestamp::from_second(0).unwrap(),
+            GitInfo {
+                commit: Some("c".to_owned()),
+                branch: Some("main".to_owned()),
+                dirty: false,
+            },
+            EnvironmentInfo::default(),
+            ToolchainInfo::default(),
+            "0.0.1".to_owned(),
+        );
+        let record = BenchmarkResult::new(id, vec![Metric::new(kind, 100.0)]);
+        Run::new(context, vec![record])
+    }
+
+    /// Stores `run` under `machine`'s clean key for `commit` and returns the matching
+    /// sibling observation positioned at `topo_index`.
+    fn store_sibling(
+        storage: &MemoryStorage,
+        machine: &str,
+        commit: &str,
+        topo_index: usize,
+        run: &Run,
+    ) -> SiblingObservation {
+        let key = format!(
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/{machine}/{commit}/clean.json"
+        );
+        block_on(storage.put(&key, run.to_json().unwrap().as_bytes())).unwrap();
+        let parsed = parse_key(&key).unwrap();
+        SiblingObservation {
+            key,
+            parsed,
+            topo_index,
+        }
+    }
+
+    /// A sibling observation whose object is *not* in storage — fetching it would
+    /// error, so it doubles as a probe that classification never fetched.
+    fn absent_sibling(machine: &str, commit: &str, topo_index: usize) -> SiblingObservation {
+        let key = format!(
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/{machine}/{commit}/clean.json"
+        );
+        let parsed = parse_key(&key).unwrap();
+        SiblingObservation {
+            key,
+            parsed,
+            topo_index,
+        }
+    }
+
+    /// Classifies with a recording reporter, unwrapping the result.
+    fn classify(
+        storage: &MemoryStorage,
+        findings: &[Finding],
+        series: &[Series],
+        merge_base_index: Option<usize>,
+        siblings: &[SiblingObservation],
+    ) -> HashMap<DiscriminantSet, Vec<ComparisonBaseLag>> {
+        block_on(classify_comparison_base_lags(
+            storage,
+            findings,
+            series,
+            merge_base_index,
+            siblings,
+            &RecordingReporter::new(),
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn history_mode_yields_no_lags() {
+        // No merge-base: history mode has no single comparison base, so nothing lags.
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], None, &[]);
+        assert!(lags.is_empty(), "{lags:?}");
+    }
+
+    #[test]
+    fn a_comparison_base_reaching_the_merge_base_is_not_a_lag() {
+        // The comparison base is the merge-base itself (index 3 == merge-base 3).
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(3))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[]);
+        assert!(lags.is_empty(), "{lags:?}");
+    }
+
+    #[test]
+    fn a_history_finding_without_a_comparison_base_is_not_a_lag() {
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", None)];
+        let lags = classify(&storage, &findings, &[], Some(3), &[]);
+        assert!(lags.is_empty(), "{lags:?}");
+    }
+
+    #[test]
+    fn a_loaded_sibling_series_proves_a_mismatch_without_fetching() {
+        // `--machine-key all`: the sibling machine's series is already resident, so a
+        // newer clean point under it proves a mismatch. The lone sibling observation
+        // is absent from storage — reaching for it would error, so a clean Ok proves
+        // classification never fetched.
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2))];
+        let series = [loaded_series(
+            "m2",
+            bench_id(),
+            MetricKind::InstructionCount,
+            3,
+            false,
+        )];
+        let siblings = [absent_sibling("m2", "c3", 3)];
+        let lags = classify(&storage, &findings, &series, Some(3), &siblings);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 1);
+        assert_eq!(set_lags[0].commits_behind.get(), 1);
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::DiscriminantSetMismatch
+        );
+    }
+
+    #[test]
+    fn a_dirty_loaded_sibling_point_does_not_prove_a_mismatch() {
+        // Only clean runs can serve as a comparison base, so a dirty sibling point is
+        // not evidence of a usable newer base-side run.
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2))];
+        let series = [loaded_series(
+            "m2",
+            bench_id(),
+            MetricKind::InstructionCount,
+            3,
+            true,
+        )];
+        let lags = classify(&storage, &findings, &series, Some(3), &[]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn no_newer_base_data_anywhere_is_the_generic_reason() {
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 1);
+        assert_eq!(set_lags[0].commits_behind.get(), 1);
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn a_fetched_sibling_with_the_benchmark_and_metric_is_a_mismatch() {
+        let storage = MemoryStorage::new();
+        let sibling = store_sibling(
+            &storage,
+            "m2",
+            "c3",
+            3,
+            &run_with(bench_id(), MetricKind::InstructionCount),
+        );
+        let findings = [finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::DiscriminantSetMismatch
+        );
+    }
+
+    #[test]
+    fn a_fetched_sibling_missing_the_benchmark_is_generic() {
+        // The newer sibling run exists but omits the affected benchmark, so it is not
+        // evidence a comparable newer base-side measurement existed.
+        let storage = MemoryStorage::new();
+        let other = BenchmarkId::new(nonempty!["nm".to_owned(), "other".to_owned()]);
+        let sibling = store_sibling(
+            &storage,
+            "m2",
+            "c3",
+            3,
+            &run_with(other, MetricKind::InstructionCount),
+        );
+        let findings = [finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn a_fetched_sibling_missing_the_metric_is_generic() {
+        // The newer sibling run carries the benchmark but only a different metric.
+        let storage = MemoryStorage::new();
+        let sibling = store_sibling(
+            &storage,
+            "m2",
+            "c3",
+            3,
+            &run_with(bench_id(), MetricKind::ConditionalBranches),
+        );
+        let findings = [finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn a_sibling_at_or_before_the_comparison_base_is_ignored() {
+        // A sibling at the comparison base (index 2, not strictly newer) is not
+        // evidence of a *newer* base-side run and never triggers a fetch.
+        let storage = MemoryStorage::new();
+        let sibling = absent_sibling("m2", "c2", 2);
+        let findings = [finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn identical_lags_in_one_set_deduplicate() {
+        // Two findings in the same set with the same gap and reason collapse to one
+        // warning line rather than repeating.
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2)), finding("m1", Some(2))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 1);
+    }
+
+    #[test]
+    fn distinct_lags_in_one_set_are_ordered_by_distance_descending() {
+        // Partial runs can leave two findings in one set at different comparison
+        // bases; both distinct lags are kept, largest gap first.
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2)), finding("m1", Some(1))];
+        let lags = classify(&storage, &findings, &[], Some(3), &[]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 2);
+        assert_eq!(set_lags[0].commits_behind.get(), 2);
+        assert_eq!(set_lags[1].commits_behind.get(), 1);
+    }
+
+    #[test]
+    fn a_loaded_sibling_point_at_the_comparison_base_does_not_prove_a_mismatch() {
+        // Evidence must be strictly newer than the comparison base. A loaded sibling
+        // point exactly at the comparison base (index 2) is the same commit, not a
+        // newer base-side run, so the reason stays generic.
+        let storage = MemoryStorage::new();
+        let findings = [finding("m1", Some(2))];
+        let series = [loaded_series(
+            "m2",
+            bench_id(),
+            MetricKind::InstructionCount,
+            2,
+            false,
+        )];
+        let lags = classify(&storage, &findings, &series, Some(3), &[]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn a_fetched_sibling_at_a_findings_comparison_base_does_not_prove_its_mismatch() {
+        // One fetched object at index 3 is newer evidence for the finding whose gap it
+        // falls in (comparison base 2), but sits exactly at the other finding's
+        // comparison base (3). The strict lower bound is judged per finding, so the
+        // shared object proves only the first finding's mismatch.
+        let storage = MemoryStorage::new();
+        let sibling = store_sibling(
+            &storage,
+            "m2",
+            "c3",
+            3,
+            &run_with(bench_id(), MetricKind::InstructionCount),
+        );
+        let findings = [finding("m1", Some(2)), finding("m1", Some(3))];
+        let lags = classify(&storage, &findings, &[], Some(4), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 2);
+        assert_eq!(set_lags[0].commits_behind.get(), 2);
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::DiscriminantSetMismatch
+        );
+        assert_eq!(set_lags[1].commits_behind.get(), 1);
+        assert_eq!(
+            set_lags[1].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+
+    #[test]
+    fn a_set_is_a_sibling_only_when_the_machine_key_differs() {
+        // Rotation evidence must share the comparable axes (engine and target triple)
+        // and differ only in machine key. The same machine key is the finding's own
+        // set, and a different engine or triple is not comparable.
+        let target = set("m1");
+        assert!(is_sibling_set(&set("m2"), &target), "different machine key");
+        assert!(!is_sibling_set(&set("m1"), &target), "same machine key");
+        let other_engine = DiscriminantSet {
+            engine: "criterion".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+            machine_key: "m2".to_owned(),
+        };
+        assert!(!is_sibling_set(&other_engine, &target), "different engine");
+        let other_triple = DiscriminantSet {
+            engine: "callgrind".to_owned(),
+            target_triple: "aarch64-apple-darwin".to_owned(),
+            machine_key: "m2".to_owned(),
+        };
+        assert!(!is_sibling_set(&other_triple, &target), "different triple");
+    }
+
+    #[test]
+    fn equal_gaps_in_one_set_order_mismatch_before_generic() {
+        // Two findings in one set at the same distance but different reasons keep a
+        // deterministic order: the mismatch renders before the generic reason even when
+        // the generic finding is discovered first.
+        let storage = MemoryStorage::new();
+        let other = BenchmarkId::new(nonempty!["nm".to_owned(), "other".to_owned()]);
+        let generic = finding_for("m1", other, Some(2));
+        let mismatch = finding("m1", Some(2));
+        let series = [loaded_series(
+            "m2",
+            bench_id(),
+            MetricKind::InstructionCount,
+            3,
+            false,
+        )];
+        let findings = [generic, mismatch];
+        let lags = classify(&storage, &findings, &series, Some(3), &[]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 2);
+        assert_eq!(set_lags[0].commits_behind.get(), 1);
+        assert_eq!(set_lags[1].commits_behind.get(), 1);
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::DiscriminantSetMismatch
+        );
+        assert_eq!(
+            set_lags[1].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+    }
+}

--- a/packages/cbh_analyze/src/comparison_base.rs
+++ b/packages/cbh_analyze/src/comparison_base.rs
@@ -19,6 +19,10 @@
 //! `--machine-key all`, where every machine key is already loaded), and only then
 //! from a lazy, deduplicated fetch of the sibling clean-run objects that could fall in
 //! a lagging finding's gap. Sets with no lagging finding never trigger a fetch.
+//!
+//! Comparison-base warnings are advisory: if the optional sibling evidence cannot be
+//! fetched or parsed, the failure is noted and the affected findings degrade to the
+//! generic reason rather than failing the analysis run.
 
 use std::collections::HashMap;
 use std::num::NonZero;
@@ -65,10 +69,10 @@ struct SiblingEvidence {
 /// comparison base lags. Only fetches foreign sibling payloads that could classify a
 /// still-unresolved lagging finding, reusing the shared bounded-concurrency loader.
 ///
-/// # Errors
-///
-/// Returns an error if a needed sibling object cannot be fetched, decoded as UTF-8, or
-/// parsed as a result set — surfaced rather than silently guessing a reason.
+/// Comparison-base warnings are advisory and never fail the analysis run. If the
+/// optional sibling evidence cannot be fetched or parsed, the failure is noted and the
+/// affected findings fall through to the generic reason rather than aborting — a
+/// mismatch is only ever asserted from positive evidence we could actually read.
 pub(crate) async fn classify_comparison_base_lags<S>(
     storage: &S,
     findings: &[Finding],
@@ -76,12 +80,12 @@ pub(crate) async fn classify_comparison_base_lags<S>(
     merge_base_index: Option<usize>,
     siblings: &[SiblingObservation],
     reporter: &dyn Reporter,
-) -> Result<HashMap<DiscriminantSet, Vec<ComparisonBaseLag>>, AnalyzeError>
+) -> HashMap<DiscriminantSet, Vec<ComparisonBaseLag>>
 where
     S: Storage,
 {
     let Some(merge_base) = merge_base_index else {
-        return Ok(HashMap::new());
+        return HashMap::new();
     };
 
     let lagging: Vec<LaggingFinding<'_>> = findings
@@ -101,7 +105,7 @@ where
         })
         .collect();
     if lagging.is_empty() {
-        return Ok(HashMap::new());
+        return HashMap::new();
     }
     reporter.note_with(|| {
         format!(
@@ -127,10 +131,20 @@ where
     // Only fetch the sibling objects that could still change a verdict: exact
     // clean-run keys sharing a still-unresolved finding's comparable axes and falling
     // inside its gap. Deduplicate so an object shared by several findings loads once.
+    // A fetch or parse failure is advisory-only: note it and leave the affected
+    // findings to fall through to the generic reason, never aborting the analysis.
     let evidence = if unresolved.is_empty() {
         Vec::new()
     } else {
-        load_sibling_evidence(storage, &unresolved, siblings, merge_base, reporter).await?
+        match load_sibling_evidence(storage, &unresolved, siblings, merge_base, reporter).await {
+            Ok(evidence) => evidence,
+            Err(error) => {
+                reporter.note_with(move || {
+                    format!("skipping comparison-base mismatch evidence: {error}")
+                });
+                Vec::new()
+            }
+        }
     };
 
     let mut lags: HashMap<&DiscriminantSet, Vec<ComparisonBaseLag>> = HashMap::new();
@@ -164,7 +178,7 @@ where
         set_lags.dedup();
         classified.insert(set.clone(), set_lags);
     }
-    Ok(classified)
+    classified
 }
 
 /// Whether an already loaded sibling series proves a machine-key mismatch for
@@ -433,7 +447,7 @@ mod tests {
         }
     }
 
-    /// Classifies with a recording reporter, unwrapping the result.
+    /// Classifies with a recording reporter.
     fn classify(
         storage: &MemoryStorage,
         findings: &[Finding],
@@ -441,15 +455,31 @@ mod tests {
         merge_base_index: Option<usize>,
         siblings: &[SiblingObservation],
     ) -> HashMap<DiscriminantSet, Vec<ComparisonBaseLag>> {
-        block_on(classify_comparison_base_lags(
+        classify_reported(storage, findings, series, merge_base_index, siblings).0
+    }
+
+    /// Classifies and returns the recording reporter so a test can inspect whether a
+    /// sibling fetch was attempted or an evidence failure was noted.
+    fn classify_reported(
+        storage: &MemoryStorage,
+        findings: &[Finding],
+        series: &[Series],
+        merge_base_index: Option<usize>,
+        siblings: &[SiblingObservation],
+    ) -> (
+        HashMap<DiscriminantSet, Vec<ComparisonBaseLag>>,
+        RecordingReporter,
+    ) {
+        let reporter = RecordingReporter::new();
+        let lags = block_on(classify_comparison_base_lags(
             storage,
             findings,
             series,
             merge_base_index,
             siblings,
-            &RecordingReporter::new(),
-        ))
-        .unwrap()
+            &reporter,
+        ));
+        (lags, reporter)
     }
 
     #[test]
@@ -581,6 +611,26 @@ mod tests {
     }
 
     #[test]
+    fn a_failed_sibling_fetch_degrades_to_the_generic_reason() {
+        // The only mismatch evidence for this lagging finding would come from a
+        // relevant sibling object that is missing from storage, so fetching it fails.
+        // Advisory classification must not abort: it notes the failure and degrades to
+        // the generic reason.
+        let storage = MemoryStorage::new();
+        let sibling = absent_sibling("m2", "c3", 3);
+        let findings = [finding("m1", Some(2))];
+        let (lags, reporter) = classify_reported(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(set_lags.len(), 1);
+        assert_eq!(set_lags[0].commits_behind.get(), 1);
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+        assert!(reporter.contains("skipping comparison-base mismatch evidence"));
+    }
+
+    #[test]
     fn a_fetched_sibling_missing_the_metric_is_generic() {
         // The newer sibling run carries the benchmark but only a different metric.
         let storage = MemoryStorage::new();
@@ -607,12 +657,45 @@ mod tests {
         let storage = MemoryStorage::new();
         let sibling = absent_sibling("m2", "c2", 2);
         let findings = [finding("m1", Some(2))];
-        let lags = classify(&storage, &findings, &[], Some(3), &[sibling]);
+        let (lags, reporter) = classify_reported(&storage, &findings, &[], Some(3), &[sibling]);
         let set_lags = &lags[&set("m1")];
         assert_eq!(
             set_lags[0].reason,
             ComparisonBaseLagReason::NoRecentBaseData
         );
+        assert!(!reporter.contains("fetching"), "no fetch was attempted");
+    }
+
+    #[test]
+    fn a_sibling_newer_than_the_merge_base_is_not_fetched() {
+        // Evidence must be no newer than the merge-base. A sibling past the merge-base
+        // (index 5, merge-base 3) is outside the finding's gap and never fetched.
+        let storage = MemoryStorage::new();
+        let sibling = absent_sibling("m2", "c5", 5);
+        let findings = [finding("m1", Some(2))];
+        let (lags, reporter) = classify_reported(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+        assert!(!reporter.contains("fetching"), "no fetch was attempted");
+    }
+
+    #[test]
+    fn a_same_machine_key_observation_is_not_fetched() {
+        // An observation under the finding's own machine key is the finding's own set,
+        // not a rotation sibling, so even a newer clean point never triggers a fetch.
+        let storage = MemoryStorage::new();
+        let sibling = absent_sibling("m1", "c3", 3);
+        let findings = [finding("m1", Some(2))];
+        let (lags, reporter) = classify_reported(&storage, &findings, &[], Some(3), &[sibling]);
+        let set_lags = &lags[&set("m1")];
+        assert_eq!(
+            set_lags[0].reason,
+            ComparisonBaseLagReason::NoRecentBaseData
+        );
+        assert!(!reporter.contains("fetching"), "no fetch was attempted");
     }
 
     #[test]

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -20,7 +20,8 @@ use super::facets::{
 };
 use super::history::{DirtyTipPolicy, ResolvedHistory, resolve_history};
 use super::load::{
-    RunIndex, WorkerFold, facet_filtered_candidates, fold_runs_chunked, load_objects_concurrently,
+    CandidateListing, RunIndex, WorkerFold, fold_runs_chunked, list_candidates,
+    load_objects_concurrently,
 };
 use super::selection::Selection;
 use super::window::{auto_mode, before_since_cutoff, resolve_since, since_cutoff_reason};
@@ -70,6 +71,28 @@ pub(crate) struct SelectedDataSet {
     /// history-mode re-baselining picks, per series, the latest matching blessing.
     /// Empty in branch mode (it ignores blessings).
     pub(crate) blessings: HashMap<DiscriminantSet, Vec<BlessingPlacement>>,
+    /// Base-side clean-run observations under machine keys the selection does not
+    /// cover, retained (branch mode only) so the analysis can classify why a finding's
+    /// comparison base lags the merge-base. Empty in history mode and when the
+    /// selection already spans every machine key (`--machine-key all`). Each entry
+    /// carries the storage key, discriminant set, and first-parent topological index;
+    /// the payload is fetched lazily by the pipeline only when a lagging finding needs
+    /// it.
+    pub(crate) sibling_observations: Vec<SiblingObservation>,
+}
+
+/// A base-side clean run under a machine key the selection does not cover, retained
+/// for branch-mode comparison-base lag classification.
+#[derive(Clone, Debug)]
+pub(crate) struct SiblingObservation {
+    /// The object's storage key, for the lazy payload fetch.
+    pub(crate) key: String,
+    /// The parsed storage key, carrying the sibling's discriminant set (a machine key
+    /// the selection did not cover). Retained so the lazy fetch reuses it without a
+    /// re-parse.
+    pub(crate) parsed: StorageKey,
+    /// First-parent topological index of the sibling's commit.
+    pub(crate) topo_index: usize,
 }
 
 /// Resolves the git topology, selects the comparable commits, and loads the
@@ -97,7 +120,10 @@ where
 {
     let facets = resolve_facets(selection, Some(auto))?;
     let listing_started = Instant::now();
-    let candidates = facet_filtered_candidates(storage, project_id, &facets, reporter).await?;
+    let CandidateListing {
+        selected: candidates,
+        siblings: sibling_candidates,
+    } = list_candidates(storage, project_id, &facets, true, reporter).await?;
     reporter.timing(
         "candidate listing + facet filter (includes storage.list)",
         listing_started.elapsed(),
@@ -191,6 +217,21 @@ where
             since_cutoff_reason(selection.since.is_some(), mode)
         )
     });
+
+    // Retain the base-side sibling observations branch mode uses to explain a lagging
+    // comparison base. Only clean runs up to the merge-base can serve as a comparison
+    // base, and the same on-history and `--since` admission the selection uses applies.
+    // History mode has no single comparison base, so it keeps none. This is key-only
+    // work (no fetches); the payloads are read lazily only if a finding actually lags.
+    let sibling_observations = admit_sibling_observations(
+        sibling_candidates,
+        mode,
+        merge_base_index,
+        &order,
+        &commit_times,
+        since,
+        reporter,
+    );
 
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
@@ -421,7 +462,68 @@ where
         mode,
         merge_base_index,
         blessings,
+        sibling_observations,
     })
+}
+
+/// Admits the base-side sibling observations branch mode uses to explain a lagging
+/// comparison base, applying the same on-history and `--since` admission the
+/// selection uses. Key-only work — no payloads are fetched. History mode, or an
+/// unknown merge-base, yields none: neither has a single comparison base to lag.
+fn admit_sibling_observations(
+    candidates: Vec<(String, StorageKey)>,
+    mode: AnalysisMode,
+    merge_base_index: Option<usize>,
+    order: &HashMap<String, usize>,
+    commit_times: &HashMap<String, Timestamp>,
+    since: Option<Timestamp>,
+    reporter: &dyn Reporter,
+) -> Vec<SiblingObservation> {
+    let (AnalysisMode::Branch, Some(merge_base)) = (mode, merge_base_index) else {
+        return Vec::new();
+    };
+    let mut observations = Vec::new();
+    for (key, parsed) in candidates {
+        let Some(&topo_index) = order.get(&parsed.commit) else {
+            reporter.note_with(|| {
+                format!(
+                    "skipping sibling {key}: commit {} is not on the analyzed history",
+                    parsed.commit
+                )
+            });
+            continue;
+        };
+        if topo_index > merge_base {
+            reporter.note_with(|| {
+                format!(
+                    "skipping sibling {key}: commit {} is on the branch side of the merge-base",
+                    parsed.commit
+                )
+            });
+            continue;
+        }
+        if before_since_cutoff(commit_times.get(&parsed.commit).copied(), since) {
+            reporter.note_with(|| {
+                format!(
+                    "skipping sibling {key}: commit {} is before the --since cutoff",
+                    parsed.commit
+                )
+            });
+            continue;
+        }
+        observations.push(SiblingObservation {
+            key,
+            parsed,
+            topo_index,
+        });
+    }
+    reporter.note_with(|| {
+        format!(
+            "retained {} for comparison-base classification",
+            count_noun(observations.len(), "base-side sibling observation")
+        )
+    });
+    observations
 }
 
 /// Builds the always-on, one-line summary of a run's effective selection: the
@@ -715,6 +817,127 @@ mod tests {
         assert!(
             summary.contains("no default look-back window outside history mode"),
             "{summary}"
+        );
+    }
+
+    /// A clean sibling storage key parsed for `commit` under machine `m2`.
+    fn sibling_key(commit: &str) -> (String, StorageKey) {
+        let key =
+            format!("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/{commit}/clean.json");
+        let parsed = cbh_model::parse_key(&key).unwrap();
+        (key, parsed)
+    }
+
+    /// The first-parent order and committer times for a `c0..c3` line.
+    fn topology() -> (HashMap<String, usize>, HashMap<String, Timestamp>) {
+        let mut order = HashMap::new();
+        let mut times = HashMap::new();
+        for index in 0..=3 {
+            let commit = format!("c{index}");
+            order.insert(commit.clone(), index);
+            times.insert(
+                commit,
+                Timestamp::from_second(i64::try_from(index).unwrap()).unwrap(),
+            );
+        }
+        (order, times)
+    }
+
+    #[test]
+    fn sibling_admission_keeps_on_history_base_side_commits() {
+        // c2 is on-history and at/before the c3 merge-base, so it is admitted with its
+        // topological index; c3 (the merge-base itself) is also base-side and kept.
+        let (order, times) = topology();
+        let candidates = vec![sibling_key("c2"), sibling_key("c3")];
+        let observations = admit_sibling_observations(
+            candidates,
+            AnalysisMode::Branch,
+            Some(3),
+            &order,
+            &times,
+            None,
+            &cbh_diag::RecordingReporter::new(),
+        );
+        let indices: Vec<usize> = observations.iter().map(|obs| obs.topo_index).collect();
+        assert_eq!(indices, vec![2, 3]);
+    }
+
+    #[test]
+    fn sibling_admission_drops_off_history_and_branch_side_commits() {
+        // An unknown commit is off the analyzed history; a commit past the merge-base
+        // is branch-side. Neither can serve as a base-side comparison point.
+        let (mut order, times) = topology();
+        order.insert("f1".to_owned(), 4);
+        let candidates = vec![
+            sibling_key("unknown-commit"),
+            sibling_key("c2"),
+            sibling_key("f1"),
+        ];
+        let observations = admit_sibling_observations(
+            candidates,
+            AnalysisMode::Branch,
+            Some(3),
+            &order,
+            &times,
+            None,
+            &cbh_diag::RecordingReporter::new(),
+        );
+        let indices: Vec<usize> = observations.iter().map(|obs| obs.topo_index).collect();
+        assert_eq!(
+            indices,
+            vec![2],
+            "only the on-history base-side c2 survives"
+        );
+    }
+
+    #[test]
+    fn sibling_admission_drops_commits_before_the_since_cutoff() {
+        // A `--since` cutoff excludes commits committed before it, exactly as the
+        // selection's own admission does.
+        let (order, times) = topology();
+        let candidates = vec![sibling_key("c0"), sibling_key("c2")];
+        let observations = admit_sibling_observations(
+            candidates,
+            AnalysisMode::Branch,
+            Some(3),
+            &order,
+            &times,
+            Some(Timestamp::from_second(2).unwrap()),
+            &cbh_diag::RecordingReporter::new(),
+        );
+        let indices: Vec<usize> = observations.iter().map(|obs| obs.topo_index).collect();
+        assert_eq!(indices, vec![2], "c0 is before the since cutoff");
+    }
+
+    #[test]
+    fn sibling_admission_is_empty_outside_branch_mode_or_without_a_merge_base() {
+        let (order, times) = topology();
+        let reporter = cbh_diag::RecordingReporter::new();
+        assert!(
+            admit_sibling_observations(
+                vec![sibling_key("c2")],
+                AnalysisMode::History,
+                Some(3),
+                &order,
+                &times,
+                None,
+                &reporter,
+            )
+            .is_empty(),
+            "history mode has no single comparison base"
+        );
+        assert!(
+            admit_sibling_observations(
+                vec![sibling_key("c2")],
+                AnalysisMode::Branch,
+                None,
+                &order,
+                &times,
+                None,
+                &reporter,
+            )
+            .is_empty(),
+            "an unknown merge-base cannot anchor a lag"
         );
     }
 }

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -35,6 +35,7 @@
 
 mod announce;
 mod bless;
+mod comparison_base;
 mod dataset;
 mod error;
 mod examine;

--- a/packages/cbh_analyze/src/load.rs
+++ b/packages/cbh_analyze/src/load.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use anyspawn::Spawner;
 use cbh_detect::{
-    DiscriminantSetQuery, RunPoints, SeriesBuilder, balanced_chunk_sizes, worker_count,
+    DiscriminantSetQuery, FacetFilter, RunPoints, SeriesBuilder, balanced_chunk_sizes, worker_count,
 };
 use cbh_diag::{Reporter, ReporterExt, count_noun};
 use cbh_model::{
@@ -157,6 +157,23 @@ impl RunIndex {
     }
 }
 
+/// The recognized objects a single project listing produced.
+///
+/// A large history is listed once (a single [`Storage::list`] round-trip); this
+/// splits its keys into the facet-selected candidates and, when requested, the
+/// machine-relaxed clean-run siblings used to explain a lagging branch comparison
+/// base.
+pub(crate) struct CandidateListing {
+    /// Objects whose discriminant set matches every facet filter — the selection the
+    /// analysis (or listing) operates on.
+    pub(crate) selected: Vec<(String, StorageKey)>,
+    /// Potential sibling observations for branch-mode comparison-base lag
+    /// classification: exact `clean.json` objects that match the engine and
+    /// target-triple facets but whose machine key the selection does not cover. Empty
+    /// unless siblings were requested (`collect_siblings`).
+    pub(crate) siblings: Vec<(String, StorageKey)>,
+}
+
 /// Lists the stored objects under the project's partition and keeps the ones whose
 /// discriminant set matches the facet filters. Shared by the topology-aware
 /// selection and the discriminant listing (which needs no repository).
@@ -166,6 +183,30 @@ pub(crate) async fn facet_filtered_candidates<S: Storage>(
     facets: &DiscriminantSetQuery,
     reporter: &dyn Reporter,
 ) -> Result<Vec<(String, StorageKey)>, AnalyzeError> {
+    Ok(
+        list_candidates(storage, project_id, facets, false, reporter)
+            .await?
+            .selected,
+    )
+}
+
+/// Lists the project's stored objects once and partitions the recognized keys into
+/// the facet-selected candidates and, when `collect_siblings` is set, the
+/// machine-relaxed clean-run siblings (same engine and target triple, under a machine
+/// key the selection does not cover).
+///
+/// Sibling discovery relaxes only the machine-key facet, so it never widens the
+/// selection: the selected set is exactly what [`facet_filtered_candidates`] returns.
+/// It exists solely to let branch-mode analysis discover whether a newer base-side run
+/// for a lagging finding exists under a different machine key, without a second list
+/// round-trip.
+pub(crate) async fn list_candidates<S: Storage>(
+    storage: &S,
+    project_id: &str,
+    facets: &DiscriminantSetQuery,
+    collect_siblings: bool,
+    reporter: &dyn Reporter,
+) -> Result<CandidateListing, AnalyzeError> {
     // The listing prefix must use the same sanitized project segment that
     // `DiscriminantSet` writes its storage keys under. A project id containing a
     // character that sanitizes (a space, `/`, a non-ASCII letter, ...) is stored
@@ -186,7 +227,17 @@ pub(crate) async fn facet_filtered_candidates<S: Storage>(
     reporter.timing("storage.list(prefix) round-trip", list_started.elapsed());
     reporter.note_with(|| format!("storage returned {}", count_noun(keys.len(), "object key")));
 
-    let mut candidates: Vec<(String, StorageKey)> = Vec::new();
+    // Sibling discovery keeps the engine and target-triple facets but relaxes the
+    // machine key, so a run under any machine key that shares the comparable axes can
+    // surface as a potential newer base-side observation.
+    let sibling_query = collect_siblings.then(|| DiscriminantSetQuery {
+        engine: facets.engine.clone(),
+        target_triple: facets.target_triple.clone(),
+        machine_key: FacetFilter::All,
+    });
+
+    let mut selected: Vec<(String, StorageKey)> = Vec::new();
+    let mut siblings: Vec<(String, StorageKey)> = Vec::new();
     for key in keys {
         if !key.ends_with(".json") {
             reporter.note_with(|| format!("skipping {key}: not a .json object"));
@@ -198,24 +249,44 @@ pub(crate) async fn facet_filtered_candidates<S: Storage>(
             });
             continue;
         };
-        if !facets.matches(&parsed.set) {
+        let matches_selection = facets.matches(&parsed.set);
+        // A sibling is a clean run the selection does not cover but that shares the
+        // comparable axes — the only base-side evidence that could explain a lagging
+        // comparison base by machine-key rotation. `--machine-key all` selects every
+        // key, so this stays empty and classification falls back to loaded series.
+        if let Some(query) = &sibling_query
+            && !matches_selection
+            && parsed.file == "clean.json"
+            && query.matches(&parsed.set)
+        {
+            siblings.push((key.clone(), parsed.clone()));
+        }
+        if matches_selection {
+            selected.push((key, parsed));
+        } else {
             reporter.note_with(|| {
                 format!(
                     "skipping {key}: discriminant {} does not match the facet filters",
                     parsed.set
                 )
             });
-            continue;
         }
-        candidates.push((key, parsed));
     }
     reporter.note_with(|| {
         format!(
             "{} match the facet filters",
-            count_noun(candidates.len(), "object")
+            count_noun(selected.len(), "object")
         )
     });
-    Ok(candidates)
+    if sibling_query.is_some() {
+        reporter.note_with(|| {
+            format!(
+                "{} retained as machine-relaxed sibling candidates",
+                count_noun(siblings.len(), "clean-run object")
+            )
+        });
+    }
+    Ok(CandidateListing { selected, siblings })
 }
 
 /// How many stored objects to fetch concurrently while loading a data set.
@@ -563,5 +634,104 @@ mod tests {
             ordinal_of(usize::try_from(u32::MAX).expect("u32 fits in usize")),
             u32::MAX
         );
+    }
+
+    /// A discriminant-set query pinned to one engine/triple and machine key.
+    fn query(engine: &str, triple: &str, machine: &str) -> DiscriminantSetQuery {
+        DiscriminantSetQuery {
+            engine: FacetFilter::Auto(engine.to_owned()),
+            target_triple: FacetFilter::Auto(triple.to_owned()),
+            machine_key: FacetFilter::Auto(machine.to_owned()),
+        }
+    }
+
+    /// Lists candidates and siblings from `storage`, unwrapping the result.
+    fn list(
+        storage: &cbh_storage::MemoryStorage,
+        facets: &DiscriminantSetQuery,
+    ) -> CandidateListing {
+        futures::executor::block_on(list_candidates(
+            storage,
+            "folo",
+            facets,
+            true,
+            &cbh_diag::RecordingReporter::new(),
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn sibling_listing_relaxes_only_the_machine_key() {
+        // The selection covers only m1, but a clean run under m2 that shares the
+        // engine and triple is retained as a machine-relaxed sibling — never as a
+        // selected candidate.
+        let storage = cbh_storage::MemoryStorage::new();
+        let put = |key: &str| {
+            futures::executor::block_on(storage.put(key, b"{}")).unwrap();
+        };
+        put("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json");
+        put("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/c0/clean.json");
+
+        let listing = list(
+            &storage,
+            &query("callgrind", "x86_64-unknown-linux-gnu", "m1"),
+        );
+        assert_eq!(listing.selected.len(), 1, "only m1 is selected");
+        assert_eq!(listing.selected.first().unwrap().1.set.machine_key, "m1");
+        assert_eq!(listing.siblings.len(), 1, "m2 is a sibling");
+        assert_eq!(listing.siblings.first().unwrap().1.set.machine_key, "m2");
+    }
+
+    #[test]
+    fn sibling_listing_keeps_only_exact_clean_runs_under_other_engines_or_triples() {
+        // A sibling must be an exact clean.json under the same engine and triple. A
+        // dirty snapshot, a blessing sidecar, and a run under a different engine or
+        // triple are all rejected even though their machine key differs from m1.
+        let storage = cbh_storage::MemoryStorage::new();
+        let put = |key: &str| {
+            futures::executor::block_on(storage.put(key, b"{}")).unwrap();
+        };
+        put("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/c0/clean.json");
+        put("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/c0/dirty-5.json");
+        put("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/c0/bless-5.json");
+        put("v1/folo/objects/criterion/x86_64-unknown-linux-gnu/m2/c0/clean.json");
+        put("v1/folo/objects/callgrind/aarch64-apple-darwin/m2/c0/clean.json");
+
+        let listing = list(
+            &storage,
+            &query("callgrind", "x86_64-unknown-linux-gnu", "m1"),
+        );
+        assert!(listing.selected.is_empty(), "nothing matches m1");
+        assert_eq!(
+            listing.siblings.len(),
+            1,
+            "only the exact clean run under the same engine and triple is a sibling"
+        );
+        let sibling = &listing.siblings.first().unwrap().1;
+        assert_eq!(sibling.file, "clean.json");
+        assert_eq!(sibling.set.engine, "callgrind");
+        assert_eq!(sibling.set.target_triple, "x86_64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn sibling_listing_is_empty_without_collection() {
+        // The sibling query commands do not need siblings, so `collect_siblings =
+        // false` keeps the extra list empty regardless of what the partition holds.
+        let storage = cbh_storage::MemoryStorage::new();
+        futures::executor::block_on(storage.put(
+            "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/c0/clean.json",
+            b"{}",
+        ))
+        .unwrap();
+
+        let listing = futures::executor::block_on(list_candidates(
+            &storage,
+            "folo",
+            &query("callgrind", "x86_64-unknown-linux-gnu", "m1"),
+            false,
+            &cbh_diag::RecordingReporter::new(),
+        ))
+        .unwrap();
+        assert!(listing.siblings.is_empty());
     }
 }

--- a/packages/cbh_analyze/src/load.rs
+++ b/packages/cbh_analyze/src/load.rs
@@ -254,15 +254,21 @@ pub(crate) async fn list_candidates<S: Storage>(
         // comparable axes — the only base-side evidence that could explain a lagging
         // comparison base by machine-key rotation. `--machine-key all` selects every
         // key, so this stays empty and classification falls back to loaded series.
-        if let Some(query) = &sibling_query
-            && !matches_selection
-            && parsed.file == "clean.json"
-            && query.matches(&parsed.set)
-        {
+        let retained_as_sibling = sibling_query.as_ref().is_some_and(|query| {
+            !matches_selection && parsed.file == "clean.json" && query.matches(&parsed.set)
+        });
+        if retained_as_sibling {
             siblings.push((key.clone(), parsed.clone()));
         }
         if matches_selection {
             selected.push((key, parsed));
+        } else if retained_as_sibling {
+            reporter.note_with(|| {
+                format!(
+                    "retaining {key} as a machine-relaxed sibling: discriminant {}",
+                    parsed.set
+                )
+            });
         } else {
             reporter.note_with(|| {
                 format!(
@@ -650,14 +656,20 @@ mod tests {
         storage: &cbh_storage::MemoryStorage,
         facets: &DiscriminantSetQuery,
     ) -> CandidateListing {
-        futures::executor::block_on(list_candidates(
-            storage,
-            "folo",
-            facets,
-            true,
-            &cbh_diag::RecordingReporter::new(),
-        ))
-        .unwrap()
+        list_reported(storage, facets).0
+    }
+
+    /// Lists candidates and siblings, returning the recording reporter so a test can
+    /// inspect the per-key diagnostics.
+    fn list_reported(
+        storage: &cbh_storage::MemoryStorage,
+        facets: &DiscriminantSetQuery,
+    ) -> (CandidateListing, cbh_diag::RecordingReporter) {
+        let reporter = cbh_diag::RecordingReporter::new();
+        let listing =
+            futures::executor::block_on(list_candidates(storage, "folo", facets, true, &reporter))
+                .unwrap();
+        (listing, reporter)
     }
 
     #[test]
@@ -680,6 +692,51 @@ mod tests {
         assert_eq!(listing.selected.first().unwrap().1.set.machine_key, "m1");
         assert_eq!(listing.siblings.len(), 1, "m2 is a sibling");
         assert_eq!(listing.siblings.first().unwrap().1.set.machine_key, "m2");
+    }
+
+    #[test]
+    fn a_retained_sibling_is_not_diagnosed_as_skipped() {
+        // A machine-relaxed sibling is kept for lag classification, so its verbose note
+        // must say it was retained, never that it was skipped for not matching the
+        // facets. A genuinely non-matching key (a dirty run) still reads as skipped.
+        let storage = cbh_storage::MemoryStorage::new();
+        let put = |key: &str| {
+            futures::executor::block_on(storage.put(key, b"{}")).unwrap();
+        };
+        let selected = "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json";
+        let sibling = "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m2/c0/clean.json";
+        let skipped = "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m3/c0/dirty-5.json";
+        put(selected);
+        put(sibling);
+        put(skipped);
+
+        let (listing, reporter) = list_reported(
+            &storage,
+            &query("callgrind", "x86_64-unknown-linux-gnu", "m1"),
+        );
+        assert_eq!(listing.selected.len(), 1);
+        assert_eq!(listing.siblings.len(), 1);
+
+        assert!(
+            reporter.contains(&format!("retaining {sibling} as a machine-relaxed sibling")),
+            "the sibling is reported as retained: {:?}",
+            reporter.notes()
+        );
+        assert!(
+            !reporter.contains(&format!("skipping {sibling}")),
+            "the retained sibling is never reported as skipped: {:?}",
+            reporter.notes()
+        );
+        assert!(
+            reporter.contains(&format!("skipping {skipped}")),
+            "a genuinely non-matching key is still reported as skipped: {:?}",
+            reporter.notes()
+        );
+        assert!(
+            !reporter.contains(&format!("retaining {skipped}")),
+            "a non-sibling is never reported as retained: {:?}",
+            reporter.notes()
+        );
     }
 
     #[test]

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -291,7 +291,7 @@ where
         &dataset.sibling_observations,
         reporter,
     )
-    .await?;
+    .await;
     reporter.timing(
         "comparison-base lag classification (branch mode)",
         lag_started.elapsed(),

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -28,6 +28,7 @@ use cbh_storage::{Storage, StorageFacade, resolve_storage};
 use jiff::Timestamp;
 use tick::Clock;
 
+use super::comparison_base::classify_comparison_base_lags;
 use super::dataset::{empty_history_hint, select_dataset};
 use super::facets::AutoFacets;
 use super::history::dirty_base_exception_warning;
@@ -277,6 +278,25 @@ where
         .count();
     let notable = !findings.is_empty();
 
+    // Disclose when a branch finding's comparison base lags the merge-base — the
+    // recent base commits carry data only under a rotated machine key, or none at
+    // all. Classified per set from the detector's actual comparison point, drawing on
+    // the already loaded series first and only then a lazy sibling fetch.
+    let lag_started = Instant::now();
+    let comparison_base_lags = classify_comparison_base_lags(
+        storage,
+        &findings,
+        &series,
+        dataset.merge_base_index,
+        &dataset.sibling_observations,
+        reporter,
+    )
+    .await?;
+    reporter.timing(
+        "comparison-base lag classification (branch mode)",
+        lag_started.elapsed(),
+    );
+
     // Break the report down by comparable set so each partition reads on its own.
     let mut sets: Vec<DiscriminantSet> = series.iter().map(|one| one.set.clone()).collect();
     sets.sort();
@@ -291,6 +311,7 @@ where
                 .iter()
                 .filter(|finding| &finding.set == set)
                 .collect(),
+            comparison_base_lags: comparison_base_lags.get(set).cloned().unwrap_or_default(),
         })
         .collect();
 
@@ -528,7 +549,46 @@ mod tests {
         git
     }
 
-    /// A linear master history `c0 - c1 - c2 - c3 - c4 - c5`, HEAD at the tip.
+    /// A five-commit master history `c0..c4` with a feature branch off the tip `c4`:
+    ///
+    /// ```text
+    /// master:  c0 - c1 - c2 - c3 - c4
+    ///                               \
+    /// feature:                       f1 - f2   (HEAD)
+    /// ```
+    ///
+    /// Lets the PR runner's machine key carry base data only up to `c3` (one commit
+    /// behind the `c4` merge-base) while a sibling machine key holds `c4`, so a
+    /// surviving branch finding's comparison base lags by one commit.
+    fn feature_off_c4_git() -> FakeGitHistory {
+        let mut git = FakeGitHistory::new();
+        git.commit("c0", None)
+            .commit("c1", Some("c0"))
+            .commit("c2", Some("c1"))
+            .commit("c3", Some("c2"))
+            .commit("c4", Some("c3"))
+            .commit("f1", Some("c4"))
+            .commit("f2", Some("f1"))
+            .branch("master", "c4")
+            .branch("feature", "f2")
+            .head("feature")
+            .mark_default("master");
+        git
+    }
+
+    /// Seeds the PR runner's (`m1`) base and feature runs for [`feature_off_c4_git`]:
+    /// a flat base line at `c0..c3` (the `c4` tip is missing for `m1`) and a raised
+    /// feature regime `f1`, `f2`, and a dirty `f2` snapshot, large enough to flag.
+    fn seed_lagging_branch(storage: &MemoryStorage) {
+        store(storage, &clean_key("c0"), &ir_set(0, "c0", 100.0));
+        store(storage, &clean_key("c1"), &ir_set(1, "c1", 100.0));
+        store(storage, &clean_key("c2"), &ir_set(2, "c2", 100.0));
+        store(storage, &clean_key("c3"), &ir_set(3, "c3", 100.0));
+        store(storage, &clean_key("f1"), &ir_set(4, "f1", 130.0));
+        store(storage, &clean_key("f2"), &ir_set(5, "f2", 130.0));
+        store(storage, &dirty_key("f2", 6), &ir_set(6, "f2", 130.0));
+    }
+
     ///
     /// Long enough to host a sustained level shift with at least two points on
     /// each side, which the change-point detector requires before it flags.
@@ -1200,6 +1260,93 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         assert_eq!(parsed["runs"], 7, "the dirty f2 snapshot is admitted");
         assert_eq!(regressions, 1, "the admitted dirty f2 completes the step");
+    }
+
+    #[test]
+    fn a_lagging_comparison_base_with_a_sibling_run_warns_of_a_mismatch() {
+        // The PR runner's key (m1) carries base data only through c3, one commit
+        // behind the c4 merge-base, while a sibling key (m2) holds the same benchmark
+        // and metric at c4. The finding's comparison base therefore lags by one commit
+        // because of machine-key rotation, and every surface must disclose it.
+        let storage = MemoryStorage::new();
+        seed_lagging_branch(&storage);
+        store(
+            &storage,
+            &clean_key_in("callgrind", "x86_64-unknown-linux-gnu", "m2", "c4"),
+            &ir_set(7, "c4", 100.0),
+        );
+        let git = feature_off_c4_git();
+
+        let (text, regressions) = analyze(&git, &storage, "folo", &options());
+        assert_eq!(regressions, 1);
+        assert!(
+            text.contains(
+                "Warning: comparison base is 1 commit behind base (discriminant set mismatch)"
+            ),
+            "{text}"
+        );
+
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let lags = &parsed["sets"][0]["comparison_base_lags"];
+        assert_eq!(lags[0]["commits_behind"], 1, "{report}");
+        assert_eq!(lags[0]["reason"], "discriminant_set_mismatch", "{report}");
+    }
+
+    #[test]
+    fn a_lagging_comparison_base_without_a_sibling_warns_of_missing_data() {
+        // Same one-commit lag, but no sibling key holds newer base data at all, so the
+        // reason is ordinary missing base data rather than machine-key rotation.
+        let storage = MemoryStorage::new();
+        seed_lagging_branch(&storage);
+        let git = feature_off_c4_git();
+
+        let (text, regressions) = analyze(&git, &storage, "folo", &options());
+        assert_eq!(regressions, 1);
+        assert!(
+            text.contains(
+                "Warning: comparison base is 1 commit behind base \
+                 (no base data at more recent commits)"
+            ),
+            "{text}"
+        );
+
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let lags = &parsed["sets"][0]["comparison_base_lags"];
+        assert_eq!(lags[0]["reason"], "no_recent_base_data", "{report}");
+    }
+
+    #[test]
+    fn a_comparison_base_reaching_the_merge_base_warns_of_nothing() {
+        // When m1 also carries the c4 merge-base tip, the comparison base reaches it
+        // and no comparison-base warning is emitted on any surface.
+        let storage = MemoryStorage::new();
+        seed_lagging_branch(&storage);
+        store(&storage, &clean_key("c4"), &ir_set(7, "c4", 100.0));
+        let git = feature_off_c4_git();
+
+        let (text, _) = analyze(&git, &storage, "folo", &options());
+        assert!(!text.contains("comparison base is"), "{text}");
+
+        let (report, _, _) = analyze_json(&git, &storage, "folo", &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert!(
+            parsed["sets"][0]["comparison_base_lags"].is_null(),
+            "an unaffected set omits the field entirely: {report}"
+        );
+    }
+
+    #[test]
+    fn history_mode_never_warns_of_a_lagging_comparison_base() {
+        // History mode has no single comparison base, so the warning never applies
+        // even when older commits carry data under a different machine key.
+        let storage = MemoryStorage::new();
+        seed_linear_step(&storage);
+        let git = linear6_git();
+
+        let (text, _) = analyze(&git, &storage, "folo", &options());
+        assert!(!text.contains("comparison base is"), "{text}");
     }
 
     #[test]

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -293,7 +293,7 @@ where
     )
     .await;
     reporter.timing(
-        "comparison-base lag classification (branch mode)",
+        "comparison-base lag classification (classify_comparison_base_lags)",
         lag_started.elapsed(),
     );
 

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -294,6 +294,13 @@ pub struct Finding {
     /// Markdown reports can draw a chart; it is not part of the machine-readable JSON
     /// contract.
     pub series: Vec<SeriesValue>,
+    /// First-parent topological index of the newest base-side point this finding was
+    /// actually compared against — the series' *comparison base*. Set only in branch
+    /// mode (`None` in history mode, where there is no single comparison base). Internal
+    /// cross-crate analysis metadata that lets the analysis measure how far the
+    /// comparison base sits behind the merge-base; it is not part of the JSON finding
+    /// contract.
+    pub comparison_base_index: Option<usize>,
 }
 
 impl Finding {
@@ -637,6 +644,7 @@ fn evaluate_change_point(
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
+            comparison_base_index: None,
         },
         source_index: 0,
         bh_p: effective_p,
@@ -713,6 +721,7 @@ fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> O
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
+            comparison_base_index: None,
         },
         source_index: 0,
         bh_p: trend.p_value,
@@ -877,6 +886,7 @@ fn compare_samples(
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
+            comparison_base_index: None,
         },
         source_index: 0,
         bh_p: effective_p,
@@ -903,14 +913,20 @@ fn evaluate_branch(
     let base_window = recent(&base, config.compare_window);
     let latest_points = latest_commit_points(&branch);
     let commit = branch.last().and_then(|&point| owned_commit(point));
-    compare_samples(
+    // The newest base-side point actually fed to the comparison is this series' comparison
+    // base. Record its first-parent position so the analysis can measure how far it sits
+    // behind the merge-base.
+    let comparison_base_index = base_window.last().map(|point| point.topo_index);
+    let mut candidate = compare_samples(
         series,
         &base_window,
         &latest_points,
         config,
         config.branch_practical_relative,
         commit,
-    )
+    )?;
+    candidate.finding.comparison_base_index = comparison_base_index;
+    Some(candidate)
 }
 
 /// The post-blessing window of `series` as a standalone series for detection.
@@ -1055,6 +1071,7 @@ fn evaluate_resolved_spike(
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
+            comparison_base_index: None,
         },
         source_index: 0,
         bh_p: effective_p,
@@ -1394,6 +1411,7 @@ mod tests {
                 blessed_at: None,
                 blessed_commit_time: None,
                 series: Vec::new(),
+                comparison_base_index: None,
             },
             source_index: 0,
             bh_p: 0.0,
@@ -2258,6 +2276,46 @@ mod tests {
         let finding = only(branch_changes(&[series], Some(2)));
         assert_eq!(finding.direction, Direction::Regression);
         assert_eq!(finding.latest, 130.0);
+    }
+
+    #[test]
+    fn branch_finding_stamps_the_newest_base_window_index() {
+        // Base-side runs at topo 0..2, branch-side at 3..5, merge-base at 2. The
+        // comparison base is the newest base-side point actually compared against.
+        let series = placed_series(&[
+            (0, 100.0, false),
+            (1, 100.0, false),
+            (2, 100.0, false),
+            (3, 130.0, false),
+            (4, 130.0, false),
+            (5, 130.0, false),
+        ]);
+        let finding = only(branch_changes(&[series], Some(2)));
+        assert_eq!(finding.comparison_base_index, Some(2));
+    }
+
+    #[test]
+    fn branch_comparison_base_index_lags_when_recent_base_data_is_missing() {
+        // The merge-base is topo 5, but this series has no base-side runs at topo 3..5;
+        // its newest base point is topo 2, so its comparison base lags the merge-base.
+        let series = placed_series(&[
+            (0, 100.0, false),
+            (1, 100.0, false),
+            (2, 100.0, false),
+            (6, 130.0, false),
+            (7, 130.0, false),
+            (8, 130.0, false),
+        ]);
+        let finding = only(branch_changes(&[series], Some(5)));
+        assert_eq!(finding.comparison_base_index, Some(2));
+    }
+
+    #[test]
+    fn history_finding_has_no_comparison_base_index() {
+        // History mode has no single comparison base, so the field stays `None`.
+        let series = series_of(&[100.0, 100.0, 100.0, 130.0, 130.0, 130.0]);
+        let finding = only(changes(std::slice::from_ref(&series)));
+        assert_eq!(finding.comparison_base_index, None);
     }
 
     // -- Blessing (re-baselining) and recovered spikes ------------------------

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -9,6 +9,7 @@
 //! ranked findings, and a per-set breakdown follows so each comparable partition
 //! reads as its own section.
 
+use std::collections::HashSet;
 use std::num::NonZero;
 
 use cbh_detect::{Direction, Finding, FindingMethod, SeriesValue, short_commit};
@@ -75,6 +76,44 @@ pub struct SetSummary<'a> {
     pub series: usize,
     /// The set's findings, in the same global ranking as the top level.
     pub findings: Vec<&'a Finding>,
+    /// How far this set's comparison base(s) sit behind the merge-base, with the
+    /// reason for each distinct lag. Branch mode only; empty when every finding's
+    /// comparison base reaches the merge-base (the usual whole-suite case) and in
+    /// history mode. Partial runs can leave different findings comparing against
+    /// different points, so this is a deduplicated, deterministically ordered list
+    /// rather than a single value.
+    pub comparison_base_lags: Vec<ComparisonBaseLag>,
+}
+
+/// How far a discriminant set's comparison base sits behind the merge-base, and why.
+///
+/// In branch mode each finding is compared against the recent base-side points of its
+/// own discriminant set. On rotating CI machine pools the newest base commits may carry
+/// data only under a different machine key, so the branch runner's machine key has usable
+/// base data only several commits earlier — the comparison silently reaches back in
+/// history. This records that lag for one set so the report can disclose it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ComparisonBaseLag {
+    /// First-parent distance from the comparison base to the merge-base. Always at
+    /// least one: a comparison base that reaches the merge-base is not a lag and is
+    /// never recorded.
+    pub commits_behind: NonZero<usize>,
+    /// Why the comparison base lags.
+    pub reason: ComparisonBaseLagReason,
+}
+
+/// Why a discriminant set's comparison base lags the merge-base.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComparisonBaseLagReason {
+    /// A newer base-side run for the same benchmark and metric exists, but under a
+    /// different machine key — machine-pool rotation, not missing measurements. The
+    /// comparison base could not use it because counts are not comparable across
+    /// machine keys.
+    DiscriminantSetMismatch,
+    /// No base-side run for the affected series exists at any more recent commit; the
+    /// comparison base is simply the newest data available for this partition.
+    NoRecentBaseData,
 }
 
 /// The inputs a report is rendered from.
@@ -151,6 +190,11 @@ struct JsonSet<'a> {
     regressions: usize,
     /// Flagged improvements in this set.
     improvements: usize,
+    /// How far this set's comparison base(s) lag the merge-base, with the reason for
+    /// each distinct lag (branch mode only). Omitted when the comparison base reaches
+    /// the merge-base — the usual case — and in history mode.
+    #[serde(skip_serializing_if = "<[ComparisonBaseLag]>::is_empty")]
+    comparison_base_lags: &'a [ComparisonBaseLag],
 }
 
 /// The JSON shape of one finding: the machine-readable form of a text-report
@@ -304,6 +348,18 @@ fn push_warning(lines: &mut Vec<String>, warning: Option<&str>) {
     }
 }
 
+/// Formats one comparison-base lag as its exact report warning line, with the
+/// singular/plural agreement the text and Markdown reports share.
+fn comparison_base_lag_warning(lag: &ComparisonBaseLag) -> String {
+    let count = lag.commits_behind.get();
+    let commits = if count == 1 { "commit" } else { "commits" };
+    let reason = match lag.reason {
+        ComparisonBaseLagReason::DiscriminantSetMismatch => "discriminant set mismatch",
+        ComparisonBaseLagReason::NoRecentBaseData => "no base data at more recent commits",
+    };
+    format!("Warning: comparison base is {count} {commits} behind base ({reason})")
+}
+
 /// A one-line label for a set, naming its `engine / triple / machine` partition.
 fn set_label(set: &DiscriminantSet) -> String {
     set.to_string()
@@ -405,6 +461,9 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
         lines.push(set_label(summary.set));
         lines.push(set_counts_line(summary, input.report_improvements));
         lines.push(format!("  filter: {}", set_filter_flags(summary.set)));
+        for lag in &summary.comparison_base_lags {
+            lines.push(format!("  {}", comparison_base_lag_warning(lag)));
+        }
         for finding in &summary.findings {
             push_finding_block(&mut lines, finding, scope);
         }
@@ -812,6 +871,10 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
             ));
         }
         lines.push(format!("- Filter: `{}`", set_filter_flags(summary.set)));
+        for lag in &summary.comparison_base_lags {
+            lines.push(String::new());
+            lines.push(format!("> {}", comparison_base_lag_warning(lag)));
+        }
         for finding in &summary.findings {
             push_finding_markdown(&mut lines, finding, "###", scope);
         }
@@ -883,8 +946,24 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -
 
     // Both modes draw a per-finding chart, matching the full reports; the scope differs
     // (history walks the whole series, branch charts the baseline and recent tail).
+    //
+    // Comparison-base warnings are per-set metadata, but the summary flattens the set
+    // grouping, so surface each affected set's warnings once — immediately before that
+    // set's first retained finding.
     let scope = chart_scope(input.mode);
+    let mut warned_sets: HashSet<&DiscriminantSet> = HashSet::new();
     for finding in input.findings.iter().take(limit.get()) {
+        if warned_sets.insert(&finding.set)
+            && let Some(summary) = input
+                .sets
+                .iter()
+                .find(|summary| *summary.set == finding.set)
+        {
+            for lag in &summary.comparison_base_lags {
+                lines.push(String::new());
+                lines.push(format!("> {}", comparison_base_lag_warning(lag)));
+            }
+        }
         push_finding_markdown(&mut lines, finding, "##", scope);
         push_set_filter_footer(&mut lines, &finding.set);
     }
@@ -966,6 +1045,7 @@ fn render_json(input: &ReportInput<'_>) -> String {
             series: summary.series,
             regressions: count_direction(&summary.findings, Direction::Regression),
             improvements: count_direction(&summary.findings, Direction::Improvement),
+            comparison_base_lags: &summary.comparison_base_lags,
         })
         .collect();
 
@@ -1118,6 +1198,7 @@ mod tests {
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
+            comparison_base_index: None,
         }
     }
 
@@ -1133,6 +1214,7 @@ mod tests {
             runs: findings.len().saturating_add(3),
             series: findings.len().max(1),
             findings: findings.iter().collect(),
+            comparison_base_lags: Vec::new(),
         });
         ReportInput {
             project,
@@ -1481,6 +1563,7 @@ mod tests {
             runs: 7,
             series: 5,
             findings: findings.iter().collect(),
+            comparison_base_lags: Vec::new(),
         }];
         let input = ReportInput {
             project: "folo",
@@ -2377,12 +2460,14 @@ mod tests {
                 runs: 6,
                 series: 1,
                 findings: vec![&findings[0]],
+                comparison_base_lags: Vec::new(),
             },
             SetSummary {
                 set: &set_b,
                 runs: 4,
                 series: 1,
                 findings: Vec::new(),
+                comparison_base_lags: Vec::new(),
             },
         ];
         let input = ReportInput {
@@ -2421,12 +2506,14 @@ mod tests {
                 runs: 6,
                 series: 1,
                 findings: vec![&findings[0]],
+                comparison_base_lags: Vec::new(),
             },
             SetSummary {
                 set: &set_b,
                 runs: 4,
                 series: 1,
                 findings: Vec::new(),
+                comparison_base_lags: Vec::new(),
             },
         ];
         let input = ReportInput {
@@ -2452,6 +2539,148 @@ mod tests {
             !report.contains("aarch64-apple-darwin"),
             "the empty set is skipped: {report}"
         );
+    }
+
+    /// Builds a comparison-base lag from a plain count and reason.
+    fn lag(commits_behind: usize, reason: ComparisonBaseLagReason) -> ComparisonBaseLag {
+        ComparisonBaseLag {
+            commits_behind: NonZero::new(commits_behind).expect("test count is non-zero"),
+            reason,
+        }
+    }
+
+    /// A single-set branch-mode report whose set carries `lags`, for the
+    /// comparison-base warning-surface tests.
+    fn input_with_lags<'a>(
+        set: &'a DiscriminantSet,
+        findings: &'a [Finding],
+        lags: Vec<ComparisonBaseLag>,
+        summaries: &'a mut Vec<SetSummary<'a>>,
+    ) -> ReportInput<'a> {
+        summaries.push(SetSummary {
+            set,
+            runs: findings.len().saturating_add(3),
+            series: findings.len().max(1),
+            findings: findings.iter().collect(),
+            comparison_base_lags: lags,
+        });
+        ReportInput {
+            project: "folo",
+            tip_commit: "1234567890abcdef1234",
+            tip_dirty: false,
+            mode: "branch",
+            notable: !findings.is_empty(),
+            runs: findings.len().saturating_add(3),
+            series: findings.len().max(1),
+            commit_span: None,
+            report_improvements: false,
+            findings,
+            sets: summaries,
+            hint: None,
+            warning: None,
+            ghosts_excluded: 0,
+        }
+    }
+
+    #[test]
+    fn every_format_reports_a_discriminant_set_mismatch_warning() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let input = input_with_lags(
+            &set,
+            &findings,
+            vec![lag(5, ComparisonBaseLagReason::DiscriminantSetMismatch)],
+            &mut summaries,
+        );
+        let expected =
+            "Warning: comparison base is 5 commits behind base (discriminant set mismatch)";
+        for report in [
+            render(&input, ReportFormat::Text, false),
+            render(&input, ReportFormat::Markdown, false),
+            render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT),
+        ] {
+            assert!(report.contains(expected), "{report}");
+        }
+    }
+
+    #[test]
+    fn missing_base_data_warning_uses_a_singular_count() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let input = input_with_lags(
+            &set,
+            &findings,
+            vec![lag(1, ComparisonBaseLagReason::NoRecentBaseData)],
+            &mut summaries,
+        );
+        assert!(
+            render(&input, ReportFormat::Text, false).contains(
+                "Warning: comparison base is 1 commit behind base \
+                 (no base data at more recent commits)"
+            ),
+            "singular count and generic reason"
+        );
+    }
+
+    #[test]
+    fn json_report_carries_comparison_base_lags_in_order() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let input = input_with_lags(
+            &set,
+            &findings,
+            vec![
+                lag(5, ComparisonBaseLagReason::DiscriminantSetMismatch),
+                lag(2, ComparisonBaseLagReason::NoRecentBaseData),
+            ],
+            &mut summaries,
+        );
+        let json = render(&input, ReportFormat::Json, false);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let lags = &parsed["sets"][0]["comparison_base_lags"];
+        assert_eq!(lags[0]["commits_behind"], 5);
+        assert_eq!(lags[0]["reason"], "discriminant_set_mismatch");
+        assert_eq!(lags[1]["commits_behind"], 2);
+        assert_eq!(lags[1]["reason"], "no_recent_base_data");
+    }
+
+    #[test]
+    fn json_report_omits_comparison_base_lags_when_absent() {
+        let set = discriminant_set();
+        let findings = vec![regression()];
+        let mut summaries = Vec::new();
+        let input = single_set_input("folo", &set, &findings, &mut summaries);
+        let json = render(&input, ReportFormat::Json, false);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            parsed["sets"][0].get("comparison_base_lags").is_none(),
+            "unaffected sets carry no comparison_base_lags: {json}"
+        );
+    }
+
+    #[test]
+    fn summary_emits_a_set_warning_once_before_its_findings() {
+        // Two findings from the same set: the set's warning must surface exactly once,
+        // even though the summary flattens the per-set grouping.
+        let set = discriminant_set();
+        let findings = vec![
+            named_regression("alpha", 0.50),
+            named_regression("beta", 0.40),
+        ];
+        let mut summaries = Vec::new();
+        let input = input_with_lags(
+            &set,
+            &findings,
+            vec![lag(3, ComparisonBaseLagReason::DiscriminantSetMismatch)],
+            &mut summaries,
+        );
+        let summary = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
+        let warning =
+            "Warning: comparison base is 3 commits behind base (discriminant set mismatch)";
+        assert_eq!(summary.matches(warning).count(), 1, "{summary}");
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## Why

On rotating CI machine pools (for example GitHub public runners), different machines run different benchmark jobs. Because `cargo-bench-history` never compares counts across machine keys, a PR built on one machine may have usable base data only under that key — and the newest base commits may have run on a *different* machine. When that happens, branch-mode analysis silently compares the PR tip against base data several commits behind the merge-base. That is unavoidable, but it can produce surprising results (e.g. a PR effectively compared against a state 5 commits ago) with nothing to signal it. This change surfaces that gap instead of hiding it.

## What

Branch-mode findings now carry a per-discriminant-set warning when their comparison base lags the merge-base, e.g.:

```
Warning: comparison base is 5 commits behind base (discriminant set mismatch)
Warning: comparison base is 5 commits behind base (no base data at more recent commits)
```

Two distinct reasons are reported:
- **discriminant set mismatch** — a newer base-side run for the same benchmark and metric exists, but under a different machine key (pool rotation).
- **no base data at more recent commits** — no newer base-side run for that series exists at all.

The warning is advisory metadata: it never changes which findings are reported or the exit code.

## Approach

- **Detector (`cbh_detect`)** stamps each branch finding with `comparison_base_index` — the first-parent position of the newest base-side point actually fed to the comparison (`base_window.last()`), so the lag is measured from the real comparison point rather than raw run occupancy.
- **Analyzer (`cbh_analyze`)** classifies the lag reason per set. The single project key listing is partitioned into the selected candidates plus machine-relaxed sibling clean runs (same engine and triple, any machine key), which pass the same on-history/base-side/`--since` admission. Evidence is drawn from already-loaded series first (the whole story under `--machine-key all`, no fetch), and only then from a lazy, deduplicated fetch of the sibling objects that could fall in a lagging finding's gap — parsed to confirm the benchmark and metric are actually present, not just that a key exists.
- **Renderer (`cbh_render`)** surfaces per-set warnings across all report surfaces: text, full Markdown, the condensed Markdown summary (once per affected set), and an optional `comparison_base_lags` array on each JSON set (omitted when empty).

Warnings are deduplicated and deterministically ordered per set (largest gap first, then mismatch before generic), so partial runs that leave different findings at different comparison bases still render stably; the normal whole-suite case yields exactly one warning line per affected set.

## Notes for reviewers

- The lag is deliberately measured from the detector's actual comparison point, not run-level occupancy: a partial run can be newer than the point a given series was compared against, so occupancy would overstate coverage.
- No new list round-trip is added — siblings come out of the existing partition listing, and foreign payloads are fetched only when a loaded-series answer is missing. A run with no surviving lag, an all-ghost set, or history mode fetches nothing.
- Docs updated: design (`docs/DESIGN.md` §8.8, `docs/analyze.md`) and the user book (`analyze` command page and the analysis concept page).

Validated with `validate-local`, `validate-linux`, and `book-build-one` (zero warnings; mutation testing clean on the new code across both platforms).