### PR TITLE
Remove chart graph coloring from cargo-bench-history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,9 +2769,6 @@ name = "rasciigraph"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d4b4f6be8decb01c72dc816cd58d0a9896a3c78f0ca9ba53aafea55cc9844b"
-dependencies = [
- "colored",
-]
 
 [[package]]
 name = "redox_syscall"

--- a/packages/cargo-bench-history/book/src/commands/examine.md
+++ b/packages/cargo-bench-history/book/src/commands/examine.md
@@ -24,5 +24,5 @@ benchmark identity and the metric, so pasting them back in is natural.
 `analyze`'s exact data-set selection that never analyze. It runs **no detection and no
 re-baselining** — it has no findings, modes, or blessings — and repeats the pivot once per
 matching discriminant set. The text and Markdown renderings lead each set with a small
-neutral line chart of the selected series (`examine` makes no judgment); the JSON form
+line chart of the selected series; the JSON form
 carries the ordered points at full precision with each commit's full title.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -649,9 +649,8 @@ per discriminant set, the ordered points with full-precision values and each com
 title — the 50-character title truncation is a readability convenience of the text and
 Markdown tables, not of the data. The text and Markdown renderings **lead each set with the
 same small line chart `analyze` draws**, reusing its renderer, so a maintainer sees the shape
-of the series before reading the points it pivots; because `examine` makes no
-regression/improvement judgment the line is **neutral (uncolored)** rather than
-direction-colored, and it is drawn only when a set has at least two points. The JSON form
+of the series before reading the points it pivots; the line is drawn **uncoloured**, and it is
+drawn only when a set has at least two points. The JSON form
 carries no chart (a charting concern the human reports draw from internally, not data a
 consumer reconstructs).
 
@@ -883,9 +882,9 @@ Every history-mode finding therefore carries an active flag and an active-from b
   construction. A re-baselined finding records the blessing's commit and time for
   provenance.
 
-The history-mode chart greys the pre-active prefix and draws the active window in the
-finding's direction colour, so the live period a finding is about is visually separated
-from the inactive context kept only for continuity. Branch mode charts differently: it
+The history-mode chart plots the whole series, so the long-range trend the finding is about
+stays visible alongside the earlier context kept for continuity. Branch mode charts
+differently: it
 judges only the **tip commit**, so it plots the detector's comparison baseline followed by
 the recent tail of the series ending at the tip rather than the whole history. Charting
 the full, possibly months-long series would resample it down to the fixed chart width and
@@ -902,8 +901,8 @@ commit. Text goes to stdout as one paragraph per finding — the benchmark id on
 line as a chapter title, then a direction-coloured headline pairing the relative-change
 percent with the metric and its confidence, a dimmed detail line, and a small line chart
 of the series — the whole series in history mode, only the bounded baseline-and-tail
-comparison in branch mode — with colour enabled only
-when stdout is a terminal and not disabled by environment. The text and Markdown reports
+comparison in branch mode — the chart itself always uncoloured, with headline colour
+enabled only when stdout is a terminal and not disabled by environment. The text and Markdown reports
 group findings under a per-set header, which also states the **facet-filter flags** that
 reproduce exactly that partition, so a reader who spots a change can drill into it without
 reconstructing the query by hand. Markdown is that data with

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -867,7 +867,7 @@ via the base-tip dirty exception.
 
 History mode distinguishes a change that is **still in effect** from one that has **already
 been addressed**, so a long history does not keep re-flagging events a reviewer has handled.
-Every history-mode finding therefore carries an active flag and an active-from boundary.
+Every history-mode finding therefore carries an active flag distinguishing the two.
 
 * **Resolved spikes** — when a level rose and later returned to its prior baseline, the
   current state matches the baseline and there is nothing to act on. Such a finding is

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -649,7 +649,7 @@ per discriminant set, the ordered points with full-precision values and each com
 title — the 50-character title truncation is a readability convenience of the text and
 Markdown tables, not of the data. The text and Markdown renderings **lead each set with the
 same small line chart `analyze` draws**, reusing its renderer, so a maintainer sees the shape
-of the series before reading the points it pivots; the line is drawn **uncoloured**, and it is
+of the series before reading the points it pivots; the line is drawn **uncolored**, and it is
 drawn only when a set has at least two points. The JSON form
 carries no chart (a charting concern the human reports draw from internally, not data a
 consumer reconstructs).
@@ -898,10 +898,10 @@ layout is canonical. Each report names the **analyzed tip commit** — the commi
 of history the findings describe — annotated `+ uncommitted changes` when the working tree
 was dirty, so a reader (or the auto-filed regression issue) can tie the report to an exact
 commit. Text goes to stdout as one paragraph per finding — the benchmark id on its own
-line as a chapter title, then a direction-coloured headline pairing the relative-change
+line as a chapter title, then a direction-colored headline pairing the relative-change
 percent with the metric and its confidence, a dimmed detail line, and a small line chart
 of the series — the whole series in history mode, only the bounded baseline-and-tail
-comparison in branch mode — the chart itself always uncoloured, with headline colour
+comparison in branch mode — the chart itself always uncolored, with headline color
 enabled only when stdout is a terminal and not disabled by environment. The text and Markdown reports
 group findings under a per-set header, which also states the **facet-filter flags** that
 reproduce exactly that partition, so a reader who spots a change can drill into it without

--- a/packages/cbh_analyze/src/comparison_base.rs
+++ b/packages/cbh_analyze/src/comparison_base.rs
@@ -349,7 +349,6 @@ mod tests {
             commit: Some("f2".to_owned()),
             flipped_at: None,
             active: true,
-            active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -15,8 +15,7 @@
 //! exactly as the chart would plot it (a commit's clean run and its dirty snapshots
 //! each contribute a flagged row, clean before dirty). The text and Markdown
 //! renderings lead each set with the same small line chart `analyze` draws (reusing
-//! its renderer), neutral/uncolored since `examine` makes no regression/improvement
-//! judgment. Like `analyze` it needs a resolvable repository — first-parent topology
+//! its renderer). Like `analyze` it needs a resolvable repository — first-parent topology
 //! to order the points and each commit's title to label them — and repeats the pivot
 //! once per matching discriminant set.
 
@@ -38,7 +37,7 @@ use serde::Serialize;
 use tick::Clock;
 
 use super::{
-    AutoFacets, ChartColor, ReportFormat, Selection, Series, SeriesFilter, chart,
+    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, chart,
     dirty_base_exception_warning, empty_history_hint, format_value, resolve_auto_facets,
     resolve_now, select_dataset,
 };
@@ -323,12 +322,11 @@ fn short_commit_id(commit_id: &str) -> &str {
     commit_id.get(..12).unwrap_or(commit_id)
 }
 
-/// The neutral line chart of a set's ordered values, drawn before its data points
-/// (the same chart `analyze` renders for a finding, but uncolored because `examine`
-/// makes no judgment). `None` when there are too few points to plot.
+/// The line chart of a set's ordered values, drawn before its data points (the same
+/// chart `analyze` renders for a finding). `None` when there are too few points to plot.
 fn chart_of_points(points: &[DataPoint]) -> Option<String> {
     let values: Vec<f64> = points.iter().map(|point| point.value).collect();
-    chart(&values, ChartColor::Neutral, 0)
+    chart(&values)
 }
 
 /// Renders the pivot in the requested format, appending the diagnostic hint and
@@ -360,8 +358,7 @@ fn render_pivot_text(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
             lines.push(set.set.to_string());
             // Lead the set with the same small line chart `analyze` draws, so a
             // maintainer sees the shape of the series before reading the points it
-            // pivots. Neutral (uncolored) because `examine` makes no regression /
-            // improvement judgment.
+            // pivots.
             if let Some(chart) = chart_of_points(&set.points) {
                 lines.push(chart);
                 lines.push(String::new());
@@ -407,7 +404,7 @@ fn render_pivot_markdown(pivot: &Pivot, hint: Option<&str>, warning: Option<&str
         for set in &pivot.sets {
             lines.push(String::new());
             lines.push(format!("## {}", set.set));
-            // The same neutral series chart the text pivot draws, fenced as a `text`
+            // The same series chart the text pivot draws, fenced as a `text`
             // block so it survives Markdown rendering (mirrors `analyze`).
             if let Some(chart) = chart_of_points(&set.points) {
                 lines.push(String::new());
@@ -900,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn text_draws_a_neutral_chart_before_the_points() {
+    fn text_draws_a_chart_before_the_points() {
         let storage = MemoryStorage::new();
         store(
             &storage,
@@ -920,7 +917,7 @@ mod tests {
         let git = linear_git();
 
         let report = examine(&storage, &git, &options());
-        // The rasciigraph axis marker proves the neutral chart was drawn.
+        // The rasciigraph axis marker proves the chart was drawn.
         let axis = report
             .find('┤')
             .or_else(|| report.find('┼'))
@@ -933,7 +930,7 @@ mod tests {
             axis < first_point,
             "the chart precedes the points: {report}"
         );
-        // A neutral chart carries no color (no ANSI escapes).
+        // The chart carries no color (no ANSI escapes).
         assert!(!report.contains('\u{1b}'), "no ANSI escape: {report:?}");
     }
 

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -37,9 +37,8 @@ use serde::Serialize;
 use tick::Clock;
 
 use super::{
-    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, chart,
-    dirty_base_exception_warning, empty_history_hint, format_value, resolve_auto_facets,
-    resolve_now, select_dataset,
+    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, chart, dirty_base_exception_warning,
+    empty_history_hint, format_value, resolve_auto_facets, resolve_now, select_dataset,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -51,7 +51,7 @@ mod window;
 
 pub use bless::{bless, unbless};
 pub(crate) use cbh_detect::{Series, SeriesFilter, apply_blessings};
-pub(crate) use cbh_render::{ChartColor, ReportFormat, chart, format_value};
+pub(crate) use cbh_render::{ReportFormat, chart, format_value};
 pub(crate) use dataset::{empty_history_hint, select_dataset};
 pub use error::AnalyzeError;
 pub use examine::execute as examine;

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -282,10 +282,6 @@ pub struct Finding {
     /// since recovered (history mode only — branch always looks at the latest
     /// state, so its findings are always active).
     pub active: bool,
-    /// Index into `series` at which the active (post-blessing) window begins; points
-    /// before it are pre-blessing history, retained for charting but excluded from
-    /// detection. `0` when the series is unblessed.
-    pub active_from: usize,
     /// Abbreviated commit of the blessing that re-baselined this series, if any.
     pub blessed_at: Option<String>,
     /// Effective (committer) time of the blessed commit, RFC 3339, if blessed.
@@ -640,7 +636,6 @@ fn evaluate_change_point(
             commit,
             flipped_at: None,
             active: true,
-            active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
@@ -717,7 +712,6 @@ fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> O
             commit,
             flipped_at: None,
             active: true,
-            active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
@@ -882,7 +876,6 @@ fn compare_samples(
             commit,
             flipped_at: None,
             active: true,
-            active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
@@ -954,14 +947,13 @@ fn active_view(series: &Series) -> Series {
     }
 }
 
-/// Records a history-mode finding's re-baseline provenance, so the chart can grey
-/// the pre-blessing prefix and the report can name the blessing.
+/// Records a history-mode finding's re-baseline provenance, so the report can name
+/// the blessing.
 ///
 /// The finding's charting points ([`Finding::series`]) are filled in later, when
 /// the candidate survives filtering (see [`find_changes_spawned`]); a dropped candidate
 /// never builds them.
 fn stamp_history(finding: &mut Finding, series: &Series) {
-    finding.active_from = series.active_start;
     if let Some(blessing) = &series.blessing {
         finding.blessed_at = Some(short_commit(&blessing.commit));
         finding.blessed_commit_time = blessing.commit_time.map(|time| time.to_string());
@@ -1067,7 +1059,6 @@ fn evaluate_resolved_spike(
             commit: points.get(rise).and_then(owned_commit),
             flipped_at: points.get(recovery).and_then(owned_commit),
             active: false,
-            active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),
@@ -1407,7 +1398,6 @@ mod tests {
                 commit: None,
                 flipped_at: None,
                 active: true,
-                active_from: 0,
                 blessed_at: None,
                 blessed_commit_time: None,
                 series: Vec::new(),
@@ -2374,18 +2364,12 @@ mod tests {
         assert_eq!(finding.latest, 160.0);
         // The full nine-point series is restored for charting...
         assert_eq!(finding.series.len(), 9);
-        // ...and the active window plus blessing provenance are recorded.
-        assert_eq!(finding.active_from, 3);
+        // ...and the blessing provenance is recorded.
         assert_eq!(finding.blessed_at.as_deref(), Some("abcdef012345"));
         assert_eq!(
             finding.blessed_commit_time.as_deref(),
             Some("1970-01-01T00:00:03Z")
         );
-        // An unblessed finding has a zero active window.
-        let unblessed = only(changes(&[series_of(&[
-            10.0, 10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 20.0,
-        ])]));
-        assert_eq!(unblessed.active_from, 0);
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -65,7 +65,7 @@ pub struct SeriesPoint {
 /// In history analysis a series with a matching blessing is *re-baselined* to the
 /// blessed commit — the detector treats the blessed level as the new baseline and
 /// only sees points from that commit onward, while the pre-blessing points are
-/// retained for charting (drawn greyed). See the *Re-baselining* analysis
+/// retained for charting. See the *Re-baselining* analysis
 /// section of `DESIGN.md`.
 #[derive(Clone, Debug)]
 pub struct Blessing {
@@ -98,7 +98,7 @@ pub struct Series {
     /// Index into `points` where the active (post-blessing) window begins; `0`
     /// when the series is unblessed (every point is active). History-mode
     /// detection considers only `points[active_start..]`, while charts draw the
-    /// whole series with the pre-`active_start` prefix greyed.
+    /// whole series.
     pub active_start: usize,
     /// The blessing that re-baselined this series, if any (the report anchor).
     pub blessing: Option<Blessing>,

--- a/packages/cbh_detect/src/detect/series.rs
+++ b/packages/cbh_detect/src/detect/series.rs
@@ -97,8 +97,8 @@ pub struct Series {
     pub points: Vec<SeriesPoint>,
     /// Index into `points` where the active (post-blessing) window begins; `0`
     /// when the series is unblessed (every point is active). History-mode
-    /// detection considers only `points[active_start..]`, while charts draw the
-    /// whole series.
+    /// detection considers only `points[active_start..]`; the full `points` are
+    /// retained for reporting.
     pub active_start: usize,
     /// The blessing that re-baselined this series, if any (the report anchor).
     pub blessing: Option<Blessing>,

--- a/packages/cbh_render/Cargo.toml
+++ b/packages/cbh_render/Cargo.toml
@@ -20,7 +20,7 @@ doc = false
 cbh_detect = { workspace = true }
 cbh_model = { workspace = true }
 colored = { workspace = true }
-rasciigraph = { workspace = true, features = ["color"] }
+rasciigraph = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -658,7 +658,11 @@ pub fn chart(values: &[f64]) -> Option<String> {
     let config = Config::default()
         .with_height(CHART_HEIGHT)
         .with_width(CHART_WIDTH);
-    Some(plot(values.to_vec(), config).trim_end_matches('\n').to_owned())
+    Some(
+        plot(values.to_vec(), config)
+            .trim_end_matches('\n')
+            .to_owned(),
+    )
 }
 
 fn render_markdown(input: &ReportInput<'_>) -> String {

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -306,7 +306,8 @@ struct JsonReport<'a> {
 
 /// Renders `input` in the requested `format`.
 ///
-/// `color` enables ANSI styling of the headline percentage in the text format. The
+/// `color` enables ANSI styling of the text format — the direction-colored headline
+/// percentage, the bold benchmark id, and the dimmed detail and blessing lines. The
 /// caller decides it from the output terminal so tests and pipes stay plain; charts
 /// are always uncolored, and `markdown` and `json` ignore it.
 #[must_use]

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -1034,7 +1034,6 @@ mod tests {
             commit: Some("deadbee".to_owned()),
             flipped_at: None,
             active: true,
-            active_from: 0,
             blessed_at: None,
             blessed_commit_time: None,
             series: Vec::new(),

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -12,10 +12,10 @@
 use std::collections::HashSet;
 use std::num::NonZero;
 
-use cbh_detect::{Direction, Finding, FindingMethod, SeriesValue, short_commit};
+use cbh_detect::{Direction, Finding, FindingMethod, short_commit};
 use cbh_model::{BenchmarkId, DiscriminantSet};
-use colored::{Color, Colorize};
-use rasciigraph::{Config, plot, plot_colored, plot_many_colored};
+use colored::Colorize;
+use rasciigraph::{Config, plot};
 use serde::Serialize;
 
 /// Height, in rows, of a finding chart.
@@ -306,9 +306,9 @@ struct JsonReport<'a> {
 
 /// Renders `input` in the requested `format`.
 ///
-/// `color` enables ANSI styling in the text format (the headline percentage and
-/// the per-finding chart). The caller decides it from the output terminal so tests
-/// and pipes stay plain; `markdown` and `json` ignore it.
+/// `color` enables ANSI styling of the headline percentage in the text format. The
+/// caller decides it from the output terminal so tests and pipes stay plain; charts
+/// are always uncolored, and `markdown` and `json` ignore it.
 #[must_use]
 pub fn render(input: &ReportInput<'_>, format: ReportFormat, color: bool) -> String {
     match format {
@@ -415,9 +415,9 @@ impl Drop for ColorOverride {
 }
 
 fn render_text(input: &ReportInput<'_>, color: bool) -> String {
-    // Force `colored` and `rasciigraph` to honor this explicit decision rather than
-    // their own ambient terminal auto-detection, so tests and pipes are deterministic
-    // regardless of how the process is run. The guard restores auto-detection on return.
+    // Force `colored` to honor this explicit decision rather than its own ambient
+    // terminal auto-detection, so tests and pipes are deterministic regardless of how
+    // the process is run. The guard restores auto-detection on return.
     let _color = ColorOverride::force(color);
 
     let regressions = count_top(input.findings, Direction::Regression);
@@ -579,99 +579,18 @@ fn blessing_text(finding: &Finding) -> Option<String> {
     Some(format!("blessed at {blessed_at}{date}"))
 }
 
-/// Whether the active window spans the whole series, so no greyed prefix is drawn.
-///
-/// An `active_from` of zero means every point is active; one at or past the end
-/// means there is nothing to grey out. Either way the chart is a single series.
-fn covers_whole_series(active_from: usize, len: usize) -> bool {
-    active_from == 0 || active_from >= len
-}
-
-/// Masks `values` to the greyed pre-blessing prefix: points strictly after
-/// `active_from` become `NaN` (a gap), while the boundary point is kept so the
-/// grey and active lines join.
-fn grey_prefix(values: &[f64], active_from: usize) -> Vec<f64> {
-    values
-        .iter()
-        .enumerate()
-        .map(|(index, &value)| {
-            if index <= active_from {
-                value
-            } else {
-                f64::NAN
-            }
-        })
-        .collect()
-}
-
-/// Masks `values` to the active window: points strictly before `active_from`
-/// become `NaN` (a gap), while the boundary point is kept so the grey and active
-/// lines join.
-fn active_window(values: &[f64], active_from: usize) -> Vec<f64> {
-    values
-        .iter()
-        .enumerate()
-        .map(|(index, &value)| {
-            if index >= active_from {
-                value
-            } else {
-                f64::NAN
-            }
-        })
-        .collect()
-}
-
-/// The line color of a rendered metric chart.
-///
-/// `analyze` colors a finding's chart by the direction of the detected change;
-/// `examine` makes no such judgment and draws a neutral line, so the color
-/// vocabulary lives here in the rendering crate rather than being borrowed from the
-/// detector's [`Direction`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ChartColor {
-    /// A regression — the line is drawn in red.
-    Regression,
-    /// An improvement — the line is drawn in green.
-    Improvement,
-    /// No judgment — the line is drawn uncolored, in the terminal's default color.
-    Neutral,
-}
-
-impl ChartColor {
-    /// The `rasciigraph` line color, or `None` for a neutral (uncolored) line.
-    fn line_color(self) -> Option<Color> {
-        match self {
-            Self::Regression => Some(Color::Red),
-            Self::Improvement => Some(Color::Green),
-            Self::Neutral => None,
-        }
-    }
-}
-
-impl From<Direction> for ChartColor {
-    fn from(direction: Direction) -> Self {
-        match direction {
-            Direction::Regression => Self::Regression,
-            Direction::Improvement => Self::Improvement,
-        }
-    }
-}
-
 /// How a finding's metric chart is scoped for the analysis mode it was produced in.
 ///
 /// The two modes ask different questions of the same stored history, so they chart
 /// different slices of a finding's series.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ChartScope {
-    /// History mode: plot the whole series, greying the pre-blessing prefix per the
-    /// finding's `active_from`, so the long-range trend and any re-baseline boundary
-    /// both show.
+    /// History mode: plot the whole series, so the long-range trend shows.
     FullHistory,
     /// Branch mode: plot the comparison baseline followed by the most recent points
     /// ending at the tip commit. Branch mode judges the branch by that one commit, so
     /// the bounded chart keeps it legible instead of aliasing it into a single edge
-    /// column (see [`BRANCH_CHART_MAX_POINTS`]). A branch series is never blessed, so
-    /// its active window always starts at `0`.
+    /// column (see [`BRANCH_CHART_MAX_POINTS`]).
     BranchComparison,
 }
 
@@ -707,117 +626,42 @@ fn branch_chart_values(finding: &Finding) -> Vec<f64> {
     values
 }
 
-/// Renders a compact line chart of a finding's series values over commits, colored
-/// by direction. Returns `None` when there are too few points to plot.
-///
-/// When `active_from` falls in the series interior, the pre-blessing prefix is drawn
-/// greyed (the level that was re-baselined away) and the active window in the
-/// direction color, so the chart shows the full history while making clear which part
-/// the detector judged.
-fn chart_of(series: &[SeriesValue], direction: Direction, active_from: usize) -> Option<String> {
-    let values: Vec<f64> = series.iter().map(|point| point.value).collect();
-    chart(&values, direction.into(), active_from)
-}
-
 /// Renders a finding's metric chart for the given [`ChartScope`], or `None` when the
 /// scoped series has too few points to plot.
 ///
-/// [`ChartScope::FullHistory`] charts the whole series honoring the finding's
-/// `active_from`; [`ChartScope::BranchComparison`] charts [`branch_chart_values`] with
-/// the active window pinned to `0` (a branch series is never blessed), so the
-/// comparison baseline and tip commit stay legible rather than becoming aliased edge
-/// columns.
+/// [`ChartScope::FullHistory`] charts the whole series; [`ChartScope::BranchComparison`]
+/// charts [`branch_chart_values`], so the comparison baseline and tip commit stay legible
+/// rather than becoming aliased edge columns.
 fn scoped_chart(finding: &Finding, scope: ChartScope) -> Option<String> {
-    match scope {
-        ChartScope::FullHistory => {
-            chart_of(&finding.series, finding.direction, finding.active_from)
-        }
+    let values: Vec<f64> = match scope {
+        ChartScope::FullHistory => finding.series.iter().map(|point| point.value).collect(),
         // Chart the comparison baseline and recent tail ending at the tip. This is
         // business-critical: the tip commit is the sole data point branch mode judges,
         // so it must remain visible and unaliased regardless of how much history
         // precedes it.
-        ChartScope::BranchComparison => {
-            chart(&branch_chart_values(finding), finding.direction.into(), 0)
-        }
-    }
-}
-
-/// The plotting strategy [`chart`] selects for a series, deciding how the line is
-/// colored before any characters are drawn.
-///
-/// Separating the decision from the drawing keeps it observable without going through
-/// `colored`'s process-global override (which the plotting functions consult), so the
-/// color/overlay choice can be asserted deterministically.
-#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
-enum ChartPlan {
-    /// A single uncolored line — a neutral chart that makes no judgment.
-    Plain,
-    /// A single line drawn in one color: the whole series is active, so there is no
-    /// pre-blessing prefix to distinguish.
-    Solid(Color),
-    /// A greyed pre-blessing prefix overlaid with the color-drawn active window, so an
-    /// interior blessing boundary shows which part of the history the detector judged.
-    Split(Color),
-}
-
-/// Chooses how a `len`-point series colored per `color` with active window `active_from`
-/// is plotted. Only meaningful once the series has enough points to plot (see [`chart`]).
-fn chart_plan(color: ChartColor, len: usize, active_from: usize) -> ChartPlan {
-    match color.line_color() {
-        Some(line_color) if !covers_whole_series(active_from, len) => ChartPlan::Split(line_color),
-        Some(line_color) => ChartPlan::Solid(line_color),
-        None => ChartPlan::Plain,
-    }
+        ChartScope::BranchComparison => branch_chart_values(finding),
+    };
+    chart(&values)
 }
 
 /// Renders a compact line chart of `values` over commits at the report's fixed chart
-/// dimensions, colored per `color`. Returns `None` when there are fewer than two
-/// points (nothing to plot).
+/// dimensions. Returns `None` when there are fewer than two points (nothing to plot).
 ///
-/// When `color` names a direction and `active_from` falls in the series interior
-/// (`0 < active_from < values.len()`), the pre-blessing prefix is drawn greyed and
-/// the active window in the line color, so the chart shows the full history while
-/// making clear which part the detector judged. An `active_from` of `0` (everything
-/// active) or at/past the end (nothing active) draws the whole series as a single
-/// colored line. A [`ChartColor::Neutral`] chart makes no judgment, so it always draws
-/// the whole series as a single uncolored line regardless of `active_from`; callers
-/// with no blessing pass `0`.
+/// The line is always drawn uncolored: the report is most often read as Markdown, where
+/// ANSI styling would only add noise, so the chart carries plain characters that render
+/// anywhere.
 #[must_use]
-pub fn chart(values: &[f64], color: ChartColor, active_from: usize) -> Option<String> {
+pub fn chart(values: &[f64]) -> Option<String> {
     if values.len() < 2 {
         return None;
     }
     let config = Config::default()
         .with_height(CHART_HEIGHT)
         .with_width(CHART_WIDTH);
-    let rendered = match chart_plan(color, values.len(), active_from) {
-        // A judged chart with an interior active window overlays two series: the
-        // greyed pre-blessing prefix and the direction-colored active window. They
-        // share the boundary point so the line reads as continuous; `NaN` renders as
-        // a gap elsewhere.
-        ChartPlan::Split(line_color) => {
-            let grey = grey_prefix(values, active_from);
-            let active = active_window(values, active_from);
-            let config = config.with_series_colors(vec![Color::BrightBlack, line_color]);
-            plot_many_colored(vec![grey, active], config).to_string()
-        }
-        ChartPlan::Solid(line_color) => {
-            plot_colored(values.to_vec(), config.with_series_colors(vec![line_color])).to_string()
-        }
-        // A neutral chart carries no color, so it plots uncolored and never depends
-        // on `colored`'s process-global override.
-        ChartPlan::Plain => plot(values.to_vec(), config),
-    };
-    Some(rendered.trim_end_matches('\n').to_owned())
+    Some(plot(values.to_vec(), config).trim_end_matches('\n').to_owned())
 }
 
 fn render_markdown(input: &ReportInput<'_>) -> String {
-    // Charts embed ANSI color when `colored` is active; force it off while rendering
-    // so the fenced code blocks carry plain characters that render in any Markdown
-    // viewer. The guard restores ambient auto-detection on return so this override
-    // never leaks into later output in the same process.
-    let _color = ColorOverride::force(false);
-
     let regressions = count_top(input.findings, Direction::Regression);
 
     let mut lines = vec![
@@ -896,11 +740,6 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
 /// report for the rest.
 #[must_use]
 pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -> String {
-    // Charts embed ANSI color when `colored` is active; force it off so the fenced
-    // blocks carry plain characters, matching `render_markdown`. The guard restores
-    // ambient auto-detection on return.
-    let _color = ColorOverride::force(false);
-
     let regressions = count_top(input.findings, Direction::Regression);
 
     let mut lines = vec![
@@ -1162,6 +1001,7 @@ fn format_percent(relative_delta: f64) -> String {
 mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
+    use cbh_detect::SeriesValue;
     use cbh_model::MetricKind;
     use nonempty::nonempty;
 
@@ -2237,193 +2077,23 @@ mod tests {
     }
 
     #[test]
-    fn chart_of_needs_at_least_two_points() {
-        // Deterministic, Miri-safe color state for the rasciigraph plot.
-        let _color = ColorOverride::force(false);
-        let point = |value: f64| SeriesValue {
-            commit: None,
-            value,
-            dirty: false,
-        };
-        // A single point cannot be plotted.
-        assert!(chart_of(&[point(1.0)], Direction::Regression, 0).is_none());
-        // Exactly two points is the minimum that plots (a `< 2` -> `<= 2` slip
-        // would reject it).
-        assert!(chart_of(&[point(1.0), point(2.0)], Direction::Regression, 0).is_some());
+    fn chart_needs_at_least_two_points() {
+        // A single point cannot be plotted; two is the minimum (a `< 2` -> `<= 2`
+        // slip would reject the two-point case).
+        assert!(chart(&[1.0]).is_none());
+        assert!(chart(&[1.0, 2.0]).is_some());
     }
 
     #[test]
-    fn chart_of_plots_improvements_and_overlays_a_partial_active_window() {
-        // Deterministic, Miri-safe color state for the rasciigraph plot.
-        let _color = ColorOverride::force(false);
-        let point = |value: f64| SeriesValue {
-            commit: None,
-            value,
-            dirty: false,
-        };
-        let series = [point(1.0), point(2.0), point(3.0)];
-        // An improvement plots through the green color arm and the whole-series path.
-        assert!(chart_of(&series, Direction::Improvement, 0).is_some());
-        // A partial active window (active_from in the interior) overlays the greyed
-        // pre-blessing prefix and the active tail as two series.
-        assert!(chart_of(&series, Direction::Improvement, 1).is_some());
-    }
-
-    #[test]
-    fn chart_neutral_plots_uncolored_without_ansi() {
-        // A neutral chart carries no color, so it must not depend on `colored`'s
-        // override at all. Force it on to prove the neutral path never emits ANSI.
+    fn chart_plots_uncolored_without_ansi() {
+        // Charts are always uncolored, whatever `colored`'s process-global override
+        // says. Force it on to prove a drawn chart never embeds an ANSI escape.
         let _color = ColorOverride::force(true);
-        let chart = chart(&[1.0, 2.0, 3.0], ChartColor::Neutral, 0).expect("two-plus points plot");
-        // The rasciigraph axis marker proves a chart was drawn, and no escape byte
-        // proves the neutral line stayed uncolored.
+        let chart = chart(&[1.0, 2.0, 3.0]).expect("two-plus points plot");
+        // The rasciigraph axis marker proves a chart was drawn; no escape byte proves
+        // the line stayed uncolored.
         assert!(chart.contains('┤') || chart.contains('┼'), "{chart}");
         assert!(!chart.contains('\u{1b}'), "no ANSI escape: {chart:?}");
-    }
-
-    #[test]
-    fn chart_needs_at_least_two_points() {
-        let _color = ColorOverride::force(false);
-        // A single point cannot be plotted, in any color.
-        assert!(chart(&[1.0], ChartColor::Neutral, 0).is_none());
-        assert!(chart(&[1.0], ChartColor::Regression, 0).is_none());
-        // Two points is the minimum that plots.
-        assert!(chart(&[1.0, 2.0], ChartColor::Neutral, 0).is_some());
-    }
-
-    #[test]
-    fn chart_neutral_ignores_the_active_window() {
-        // A neutral chart makes no judgment, so an interior `active_from` still draws
-        // the whole series as one uncolored line rather than the greyed overlay.
-        let _color = ColorOverride::force(false);
-        let whole = chart(&[1.0, 2.0, 3.0], ChartColor::Neutral, 0).expect("plots");
-        let with_window = chart(&[1.0, 2.0, 3.0], ChartColor::Neutral, 1).expect("plots");
-        assert_eq!(
-            whole, with_window,
-            "neutral ignores active_from: {with_window:?}"
-        );
-    }
-
-    #[test]
-    fn chart_plan_draws_one_solid_line_when_the_whole_series_is_active() {
-        // Both boundaries `covers_whole_series` recognizes collapse to a single
-        // color-drawn line: nothing to grey at the start (`active_from == 0`) and
-        // nothing active at the end (`active_from >= len`). `Solid` (not `Split`)
-        // proves no greyed pre-blessing overlay is drawn.
-        assert_eq!(
-            chart_plan(ChartColor::Regression, 4, 0),
-            ChartPlan::Solid(Color::Red)
-        );
-        assert_eq!(
-            chart_plan(ChartColor::Regression, 4, 4),
-            ChartPlan::Solid(Color::Red)
-        );
-    }
-
-    #[test]
-    fn chart_plan_splits_an_interior_active_window() {
-        // An interior blessing boundary overlays the greyed pre-blessing prefix on the
-        // color-drawn active window, mapping each direction to its own line color.
-        assert_eq!(
-            chart_plan(ChartColor::Regression, 4, 2),
-            ChartPlan::Split(Color::Red)
-        );
-        assert_eq!(
-            chart_plan(ChartColor::Improvement, 4, 2),
-            ChartPlan::Split(Color::Green)
-        );
-    }
-
-    #[test]
-    fn chart_plan_is_plain_and_windowless_for_a_neutral_chart() {
-        // A neutral chart is always a single uncolored line, whatever the active window.
-        assert_eq!(chart_plan(ChartColor::Neutral, 4, 0), ChartPlan::Plain);
-        assert_eq!(chart_plan(ChartColor::Neutral, 4, 2), ChartPlan::Plain);
-    }
-
-    #[test]
-    fn chart_color_maps_each_direction() {
-        assert_eq!(
-            ChartColor::from(Direction::Regression),
-            ChartColor::Regression
-        );
-        assert_eq!(
-            ChartColor::from(Direction::Improvement),
-            ChartColor::Improvement
-        );
-    }
-
-    #[test]
-    fn covers_whole_series_only_at_the_boundaries() {
-        // `active_from == 0` (everything active) and `active_from >= len` (nothing
-        // to grey) both render a single series; anything in between splits.
-        assert!(covers_whole_series(0, 4), "zero covers the whole series");
-        assert!(covers_whole_series(4, 4), "the end covers the whole series");
-        assert!(
-            covers_whole_series(5, 4),
-            "past the end covers the whole series"
-        );
-        assert!(
-            !covers_whole_series(2, 4),
-            "a mid split does not cover the whole series"
-        );
-        assert!(
-            !covers_whole_series(1, 4),
-            "a near-start split does not cover the whole series"
-        );
-    }
-
-    /// Compares two `f64` slices treating `NaN` as equal to `NaN`, so masked
-    /// (gap) positions can be asserted exactly.
-    fn masks_equal(actual: &[f64], expected: &[f64]) -> bool {
-        actual.len() == expected.len()
-            && actual
-                .iter()
-                .zip(expected)
-                .all(|(a, b)| (a.is_nan() && b.is_nan()) || (a - b).abs() < f64::EPSILON)
-    }
-
-    #[test]
-    fn grey_prefix_keeps_up_to_the_boundary_and_gaps_the_rest() {
-        let values = [0.0, 10.0, 20.0, 30.0];
-        // Points after the boundary become gaps; the boundary itself is kept so
-        // the grey line meets the active line.
-        assert!(
-            masks_equal(&grey_prefix(&values, 2), &[0.0, 10.0, 20.0, f64::NAN]),
-            "{:?}",
-            grey_prefix(&values, 2)
-        );
-        assert!(
-            masks_equal(
-                &grey_prefix(&values, 0),
-                &[0.0, f64::NAN, f64::NAN, f64::NAN]
-            ),
-            "{:?}",
-            grey_prefix(&values, 0)
-        );
-    }
-
-    #[test]
-    fn active_window_gaps_before_the_boundary_and_keeps_the_rest() {
-        let values = [0.0, 10.0, 20.0, 30.0];
-        // Points before the boundary become gaps; from the boundary on they are
-        // kept (the boundary is shared with the grey prefix).
-        assert!(
-            masks_equal(
-                &active_window(&values, 2),
-                &[f64::NAN, f64::NAN, 20.0, 30.0]
-            ),
-            "{:?}",
-            active_window(&values, 2)
-        );
-        assert!(
-            masks_equal(
-                &active_window(&values, 3),
-                &[f64::NAN, f64::NAN, f64::NAN, 30.0]
-            ),
-            "{:?}",
-            active_window(&values, 3)
-        );
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## What

Removes the direction-based coloring of the output graphs (sparkline charts) in `cargo-bench-history`. Charts are now always drawn as plain, uncolored sparklines.

## Why

The chart coloring was jankily hacked on: it relied on `rasciigraph`'s `color` feature plus an overlay trick (`plot_many_colored` drawing a greyed pre-blessing prefix behind the active window). The reports are most often consumed as Markdown, where ANSI chart coloring is invisible anyway, so the machinery added complexity for output almost nobody sees.

## Changes

- **`cbh_render`**: dropped the `rasciigraph` `color` feature; removed the whole chart-coloring subsystem (`ChartColor`, `ChartPlan`, `chart_of`, and the grey-prefix / active-window overlay helpers, `plot_colored`/`plot_many_colored`). `chart` is simplified to `chart(values: &[f64]) -> Option<String>` using plain `rasciigraph::plot`. Dead `ColorOverride` guards removed from the Markdown paths.
- **Kept**: the terminal text headline coloring (red/green percentages, bold, dimmed) in `render_text` — that is idiomatic `colored` usage and not part of "the graphs".
- **`cbh_detect`**: removed the now-orphaned `Finding::active_from` field. It existed only to drive the greyed pre-blessing chart prefix; it was written at bless time but read nowhere in production code and is not part of the JSON contract. `Series::active_start` is retained (detection still runs on the post-blessing active window).
- **`cbh_analyze`**: updated for the new `chart` signature and dropped the `ChartColor` re-export.
- **Docs**: `DESIGN.md`, the mdBook `examine.md`, and stale in-code comments updated to drop greying/direction-color references.

## Validation

`cargo clippy --all-targets` and `cargo test` pass for `cbh_detect` (140), `cbh_render` (54), and `cbh_analyze` (211). The shell crate builds with all targets, including integration tests (which only assert axis-marker presence/order, still produced by plain `plot`).