### PR TITLE
Strengthen cargo-bench-history typing: enums and newtypes over primitives

### DIFF
--- a/packages/cargo-bench-history-stress/src/scenario.rs
+++ b/packages/cargo-bench-history-stress/src/scenario.rs
@@ -44,7 +44,9 @@
               behavior is intentional and cannot misbehave for the sizes used here"
 )]
 
-use cbh_model::{BenchmarkId, DiscriminantSet, Engine, Metric, MetricKind};
+use cbh_model::{
+    BenchmarkId, DiscriminantSet, Engine, MachineKey, Metric, MetricKind, TargetTriple,
+};
 use jiff::Timestamp;
 use nonempty::nonempty;
 
@@ -153,7 +155,11 @@ pub(crate) fn discriminant_sets() -> Vec<DiscriminantSet> {
             if engine == Engine::Callgrind && !targets_linux(triple) {
                 continue;
             }
-            sets.push(DiscriminantSet::new(engine, triple, MACHINE_KEY));
+            sets.push(DiscriminantSet::new(
+                engine,
+                &TargetTriple::from(triple),
+                &MachineKey::from(MACHINE_KEY),
+            ));
         }
     }
     sets
@@ -422,7 +428,7 @@ mod tests {
         for set in &sets {
             if set.engine == Engine::Callgrind {
                 assert!(
-                    targets_linux(&set.target_triple),
+                    targets_linux(set.target_triple.as_str()),
                     "callgrind set on non-Linux triple {}",
                     set.target_triple
                 );

--- a/packages/cargo-bench-history-stress/src/scenario.rs
+++ b/packages/cargo-bench-history-stress/src/scenario.rs
@@ -413,14 +413,14 @@ mod tests {
         // Every engine is represented at least once.
         for engine in Engine::ALL {
             assert!(
-                sets.iter().any(|set| set.engine == engine.as_str()),
+                sets.iter().any(|set| set.engine == engine),
                 "missing engine {engine}"
             );
         }
 
         // Callgrind sets are Linux-only.
         for set in &sets {
-            if set.engine == Engine::Callgrind.as_str() {
+            if set.engine == Engine::Callgrind {
                 assert!(
                     targets_linux(&set.target_triple),
                     "callgrind set on non-Linux triple {}",

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -367,7 +367,7 @@ fn i64_from(value: usize) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use cbh_model::{DiscriminantSet, Engine};
+    use cbh_model::{DiscriminantSet, Engine, MachineKey, TargetTriple};
     use jiff::Timestamp;
 
     use super::*;
@@ -397,8 +397,8 @@ mod tests {
         // CleanMain tasks map one-to-one onto the main commits that have a run.
         let sets = vec![DiscriminantSet::new(
             Engine::Callgrind,
-            "x86_64-unknown-linux-gnu",
-            "stress-rig",
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("stress-rig"),
         )];
         let repo = main_only_repo(4);
         let scenario = Scenario {

--- a/packages/cargo-bench-history-stress/src/seed.rs
+++ b/packages/cargo-bench-history-stress/src/seed.rs
@@ -12,8 +12,8 @@ use std::thread;
 
 use cbh_codec as codec;
 use cbh_model::{
-    BenchmarkIdPrefix, BenchmarkResult, BlessingRecord, DiscriminantSet, Engine, EnvironmentInfo,
-    GitInfo, Run, RunContext, ToolchainInfo,
+    BenchmarkIdPrefix, BenchmarkResult, BlessingRecord, DiscriminantSet, EnvironmentInfo, GitInfo,
+    Run, RunContext, ToolchainInfo,
 };
 use jiff::Timestamp;
 
@@ -312,8 +312,7 @@ fn clean_run(
     dirty: bool,
     value: impl Fn(usize) -> f64,
 ) -> Run {
-    let engine = Engine::from_name(&set.engine)
-        .expect("discriminant sets are built from Engine::ALL, so the engine name always resolves");
+    let engine = set.engine;
     let results: Vec<BenchmarkResult> = (0..scenario.benchmarks)
         .map(|b| {
             BenchmarkResult::new(

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -28,8 +28,8 @@ use jiff::Timestamp;
 use tick::Clock;
 
 use crate::model::{
-    BenchmarkResult, DiscriminantSet, Engine, EnvironmentInfo, GitInfo, MachineInfo, Run,
-    RunContext, ToolchainInfo, detect_environment, min_per_metric,
+    BenchmarkResult, DiscriminantSet, Engine, EnvironmentInfo, GitInfo, MachineInfo, MachineKey,
+    Run, RunContext, TargetTriple, ToolchainInfo, detect_environment, min_per_metric,
 };
 use crate::{CollectOptions, LocalStorageSelection, RunError, RunOutcome, finish_with_flush};
 
@@ -226,7 +226,7 @@ pub(crate) struct SharedContext {
     /// Effective target triple the run is keyed under and recorded against — the
     /// host triple `rustc` reports for `collect`, or an `import --target-triple`
     /// override. It feeds both the partition key and `ToolchainInfo.target_triple`.
-    pub(crate) target_triple: String,
+    pub(crate) target_triple: TargetTriple,
     /// Host hardware profile, fingerprinted into the machine key.
     pub(crate) hardware: HardwareProfile,
 }
@@ -246,7 +246,7 @@ where
     let rustc = probe.toolchain().await?;
     Ok(SharedContext {
         git: probe.git().await?,
-        target_triple: rustc.host.clone().unwrap_or_default(),
+        target_triple: TargetTriple::from(rustc.host.clone().unwrap_or_default()),
         rustc,
         env: detect_environment(env),
         hardware: probe.hardware().await,
@@ -501,7 +501,7 @@ where
     let effective_machine_key = resolve_machine_key(params.machine_key, &shared.hardware);
     store.reporter.announce(&partition_selection_summary(
         operation,
-        &shared.target_triple,
+        shared.target_triple.as_str(),
         triple_note,
         &effective_machine_key,
         params.machine_key.is_some(),
@@ -801,7 +801,7 @@ where
     // Every engine partitions its history by a machine key so only equivalent
     // machines share a series. An explicit `--machine-key` overrides the computed
     // hardware fingerprint.
-    let machine_key = resolve_machine_key(params.machine_key, &shared.hardware);
+    let machine_key = MachineKey::from(resolve_machine_key(params.machine_key, &shared.hardware));
     let key = DiscriminantSet::new(engine, target_triple, &machine_key);
     // History is organized by commit, so the full commit ID names the directory
     // (`analyze` resolves which commits to read from git topology). A clean run is

--- a/packages/cargo-bench-history/src/commands/import.rs
+++ b/packages/cargo-bench-history/src/commands/import.rs
@@ -33,7 +33,7 @@ use super::collect::{
     FinalizeDeps, SharedContext, StoreParams, build_message, describe_storage, finalize_and_store,
     harvest_records, probe_context,
 };
-use crate::model::{BenchmarkResult, Engine};
+use crate::model::{BenchmarkResult, Engine, TargetTriple};
 use crate::{ImportOptions, RunError, RunOutcome, finish_with_flush};
 
 /// The real `import`: wire the production adapters and orchestrate.
@@ -238,7 +238,7 @@ where
         reporter.note_with(|| {
             format!("overriding target triple to {triple} (partition key and recorded toolchain)")
         });
-        shared.target_triple = triple.to_owned();
+        shared.target_triple = TargetTriple::from(triple);
     }
 
     if let Some(reference) = options.commit.as_deref() {

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -13,7 +13,7 @@ pub(crate) use cargo_bench_history::{
     default_template, run, run_with_overrides,
 };
 use cbh_codec as codec;
-use cbh_model::{DiscriminantSet, Engine};
+use cbh_model::{DiscriminantSet, Engine, MachineKey, TargetTriple};
 pub(crate) use jiff::Timestamp;
 use nonempty::nonempty;
 pub(crate) use serial_test::serial;
@@ -1385,7 +1385,12 @@ const SEED_PROJECT: &str = "testproj";
 /// code path `run` writes under — so a seed helper cannot drift from the
 /// production storage layout by hand-formatting a key string.
 fn seed_clean_key(engine: Engine, triple: &str, machine: &str, commit: &str) -> String {
-    DiscriminantSet::new(engine, triple, machine).clean_key(SEED_PROJECT, commit)
+    DiscriminantSet::new(
+        engine,
+        &TargetTriple::from(triple),
+        &MachineKey::from(machine),
+    )
+    .clean_key(SEED_PROJECT, commit)
 }
 
 /// Builds a dirty-snapshot storage key through the model's key builder, keyed by
@@ -1397,7 +1402,12 @@ fn seed_dirty_key(
     commit: &str,
     observation_unix: i64,
 ) -> String {
-    DiscriminantSet::new(engine, triple, machine).dirty_key(SEED_PROJECT, commit, observation_unix)
+    DiscriminantSet::new(
+        engine,
+        &TargetTriple::from(triple),
+        &MachineKey::from(machine),
+    )
+    .dirty_key(SEED_PROJECT, commit, observation_unix)
 }
 
 /// Clears `CARGO_TARGET_DIR` from the process environment for its lifetime,

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -240,7 +240,7 @@ where
     let candidates = facet_filtered_candidates(storage, project_id, &facets, reporter).await?;
     let clean_at_head: Vec<StorageKey> = candidates
         .into_iter()
-        .filter(|(_, parsed)| parsed.commit == head && parsed.file == "clean.json")
+        .filter(|(_, parsed)| parsed.commit == head && parsed.is_clean())
         .map(|(_, parsed)| parsed)
         .collect();
     if clean_at_head.is_empty() {

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -397,7 +397,7 @@ mod tests {
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            machine_key: "m1".into(),
         }
     }
 

--- a/packages/cbh_analyze/src/comparison_base.rs
+++ b/packages/cbh_analyze/src/comparison_base.rs
@@ -319,8 +319,8 @@ mod tests {
     fn set(machine: &str) -> DiscriminantSet {
         DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: machine.to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: machine.into(),
         }
     }
 
@@ -783,14 +783,14 @@ mod tests {
         assert!(!is_sibling_set(&set("m1"), &target), "same machine key");
         let other_engine = DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m2".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m2".into(),
         };
         assert!(!is_sibling_set(&other_engine, &target), "different engine");
         let other_triple = DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "aarch64-apple-darwin".to_owned(),
-            machine_key: "m2".to_owned(),
+            target_triple: "aarch64-apple-darwin".into(),
+            machine_key: "m2".into(),
         };
         assert!(!is_sibling_set(&other_triple, &target), "different triple");
     }

--- a/packages/cbh_analyze/src/comparison_base.rs
+++ b/packages/cbh_analyze/src/comparison_base.rs
@@ -305,7 +305,7 @@ mod tests {
     use cbh_detect::{Direction, FindingMethod, SeriesPoint};
     use cbh_diag::RecordingReporter;
     use cbh_model::{
-        BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, Run, RunContext,
+        BenchmarkId, BenchmarkResult, Engine, EnvironmentInfo, GitInfo, Metric, Run, RunContext,
         ToolchainInfo, parse_key,
     };
     use cbh_storage::MemoryStorage;
@@ -318,7 +318,7 @@ mod tests {
     /// The discriminant set for `machine`, sharing every other comparable axis.
     fn set(machine: &str) -> DiscriminantSet {
         DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: machine.to_owned(),
         }
@@ -782,13 +782,13 @@ mod tests {
         assert!(is_sibling_set(&set("m2"), &target), "different machine key");
         assert!(!is_sibling_set(&set("m1"), &target), "same machine key");
         let other_engine = DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m2".to_owned(),
         };
         assert!(!is_sibling_set(&other_engine, &target), "different engine");
         let other_triple = DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "aarch64-apple-darwin".to_owned(),
             machine_key: "m2".to_owned(),
         };

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -463,8 +463,8 @@ fn render_pivot_json(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
         .iter()
         .map(|set| JsonSet {
             engine: set.set.engine.as_str(),
-            target_triple: &set.set.target_triple,
-            machine_key: &set.set.machine_key,
+            target_triple: set.set.target_triple.as_str(),
+            machine_key: set.set.machine_key.as_str(),
             points: set
                 .points
                 .iter()
@@ -537,7 +537,7 @@ mod tests {
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            machine_key: "m1".into(),
         }
     }
 

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -462,7 +462,7 @@ fn render_pivot_json(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
         .sets
         .iter()
         .map(|set| JsonSet {
-            engine: &set.set.engine,
+            engine: set.set.engine.as_str(),
             target_triple: &set.set.target_triple,
             machine_key: &set.set.machine_key,
             points: set

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -237,11 +237,11 @@ where
         .collect();
     let admit_dirty: HashMap<String, bool> = selected
         .iter()
-        .map(|one| (one.commit.clone(), one.admit_dirty))
+        .map(|one| (one.commit.clone(), one.dirty.admits_dirty()))
         .collect();
     let dirty_base_exception: HashMap<String, bool> = selected
         .iter()
-        .map(|one| (one.commit.clone(), one.dirty_base_exception))
+        .map(|one| (one.commit.clone(), one.dirty.is_base_exception()))
         .collect();
 
     // The merge-base's topological position (when it is on the analyzed chain)

--- a/packages/cbh_analyze/src/list.rs
+++ b/packages/cbh_analyze/src/list.rs
@@ -418,8 +418,8 @@ fn render_listing_json(listing: &Listing, hint: Option<&str>, warning: Option<&s
         .iter()
         .map(|set| JsonSet {
             engine: set.set.engine.as_str(),
-            target_triple: &set.set.target_triple,
-            machine_key: &set.set.machine_key,
+            target_triple: set.set.target_triple.as_str(),
+            machine_key: set.set.machine_key.as_str(),
             runs: set.runs,
             series: set.series,
             commits: set
@@ -477,8 +477,8 @@ fn render_discriminants(sets: &[DiscriminantSet], format: ReportFormat) -> Strin
                 .iter()
                 .map(|set| JsonDiscriminant {
                     engine: set.engine.as_str(),
-                    target_triple: &set.target_triple,
-                    machine_key: &set.machine_key,
+                    target_triple: set.target_triple.as_str(),
+                    machine_key: set.machine_key.as_str(),
                 })
                 .collect();
             serde_json::to_string_pretty(&list).expect("discriminant list serializes to JSON")
@@ -856,8 +856,8 @@ fn render_blessings_json(
         .iter()
         .map(|entry| JsonBlessing {
             engine: entry.set.engine.as_str(),
-            target_triple: &entry.set.target_triple,
-            machine_key: &entry.set.machine_key,
+            target_triple: entry.set.target_triple.as_str(),
+            machine_key: entry.set.machine_key.as_str(),
             benchmark: entry.benchmark.as_deref(),
             commit: &entry.commit,
             commit_time: entry.commit_time,
@@ -903,7 +903,7 @@ mod tests {
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            machine_key: "m1".into(),
         }
     }
 
@@ -1012,8 +1012,8 @@ mod tests {
     fn linux_set() -> DiscriminantSet {
         DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         }
     }
 
@@ -1025,8 +1025,8 @@ mod tests {
     fn mac_set() -> DiscriminantSet {
         DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "aarch64-apple-darwin".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "aarch64-apple-darwin".into(),
+            machine_key: "m1".into(),
         }
     }
 

--- a/packages/cbh_analyze/src/list.rs
+++ b/packages/cbh_analyze/src/list.rs
@@ -417,7 +417,7 @@ fn render_listing_json(listing: &Listing, hint: Option<&str>, warning: Option<&s
         .sets
         .iter()
         .map(|set| JsonSet {
-            engine: &set.set.engine,
+            engine: set.set.engine.as_str(),
             target_triple: &set.set.target_triple,
             machine_key: &set.set.machine_key,
             runs: set.runs,
@@ -476,7 +476,7 @@ fn render_discriminants(sets: &[DiscriminantSet], format: ReportFormat) -> Strin
             let list: Vec<JsonDiscriminant<'_>> = sets
                 .iter()
                 .map(|set| JsonDiscriminant {
-                    engine: &set.engine,
+                    engine: set.engine.as_str(),
                     target_triple: &set.target_triple,
                     machine_key: &set.machine_key,
                 })
@@ -855,7 +855,7 @@ fn render_blessings_json(
     let blessings: Vec<JsonBlessing<'_>> = entries
         .iter()
         .map(|entry| JsonBlessing {
-            engine: &entry.set.engine,
+            engine: entry.set.engine.as_str(),
             target_triple: &entry.set.target_triple,
             machine_key: &entry.set.machine_key,
             benchmark: entry.benchmark.as_deref(),
@@ -885,7 +885,7 @@ mod tests {
     use cbh_diag::RecordingReporter;
     use cbh_git::FakeGitHistory;
     use cbh_model::{
-        BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, EnvironmentInfo, GitInfo, Metric,
+        BenchmarkId, BenchmarkIdPrefix, BenchmarkResult, Engine, EnvironmentInfo, GitInfo, Metric,
         MetricKind, Run, RunContext, ToolchainInfo,
     };
     use cbh_storage::{MemoryStorage, Storage};
@@ -1011,7 +1011,7 @@ mod tests {
 
     fn linux_set() -> DiscriminantSet {
         DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         }
@@ -1024,7 +1024,7 @@ mod tests {
     /// A discriminant set distinct from [`linux_set`], for grouping tests.
     fn mac_set() -> DiscriminantSet {
         DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "aarch64-apple-darwin".to_owned(),
             machine_key: "m1".to_owned(),
         }

--- a/packages/cbh_analyze/src/load.rs
+++ b/packages/cbh_analyze/src/load.rs
@@ -499,8 +499,8 @@ mod tests {
     fn run_index_counts_runs_and_reports_emptiness() {
         let set = DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
         let mut index = RunIndex::new();
         assert!(index.is_empty(), "a fresh index admits no runs");
@@ -530,13 +530,13 @@ mod tests {
         // summing the totals and the per-(set, commit) clean/dirty counts.
         let set = DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
         let other_set = DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
 
         // The reference index folds every run in one pass.
@@ -585,13 +585,13 @@ mod tests {
     fn commit_span_spans_the_oldest_and_newest_analyzed_commit() {
         let set = DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
         let other_set = DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
 
         let mut index = RunIndex::new();
@@ -615,8 +615,8 @@ mod tests {
     fn commit_span_collapses_to_a_single_commit() {
         let set = DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
         let mut index = RunIndex::new();
         index.record(&set, 0, "solo", false);

--- a/packages/cbh_analyze/src/load.rs
+++ b/packages/cbh_analyze/src/load.rs
@@ -255,7 +255,7 @@ pub(crate) async fn list_candidates<S: Storage>(
         // comparison base by machine-key rotation. `--machine-key all` selects every
         // key, so this stays empty and classification falls back to loaded series.
         let retained_as_sibling = sibling_query.as_ref().is_some_and(|query| {
-            !matches_selection && parsed.file == "clean.json" && query.matches(&parsed.set)
+            !matches_selection && parsed.is_clean() && query.matches(&parsed.set)
         });
         if retained_as_sibling {
             siblings.push((key.clone(), parsed.clone()));
@@ -491,14 +491,14 @@ fn ordinal_of(rank: usize) -> u32 {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use cbh_model::DiscriminantSet;
+    use cbh_model::{DiscriminantSet, Engine};
 
     use super::*;
 
     #[test]
     fn run_index_counts_runs_and_reports_emptiness() {
         let set = DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };
@@ -529,12 +529,12 @@ mod tests {
         // the per-worker indices must reproduce the single-threaded tally exactly,
         // summing the totals and the per-(set, commit) clean/dirty counts.
         let set = DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };
         let other_set = DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };
@@ -584,12 +584,12 @@ mod tests {
     #[test]
     fn commit_span_spans_the_oldest_and_newest_analyzed_commit() {
         let set = DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };
         let other_set = DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     fn commit_span_collapses_to_a_single_commit() {
         let set = DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };
@@ -765,8 +765,8 @@ mod tests {
             "only the exact clean run under the same engine and triple is a sibling"
         );
         let sibling = &listing.siblings.first().unwrap().1;
-        assert_eq!(sibling.file, "clean.json");
-        assert_eq!(sibling.set.engine, "callgrind");
+        assert!(sibling.is_clean());
+        assert_eq!(sibling.set.engine, Engine::Callgrind);
         assert_eq!(sibling.set.target_triple, "x86_64-unknown-linux-gnu");
     }
 

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -661,7 +661,7 @@ mod tests {
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            machine_key: "m1".into(),
         }
     }
 

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -345,7 +345,7 @@ where
         project: project_id,
         tip_commit: &dataset.tip_commit,
         tip_dirty: dataset.tip_dirty,
-        mode: dataset.mode.as_str(),
+        mode: dataset.mode,
         notable,
         runs: dataset.run_index.total(),
         series: series.len(),

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -675,8 +675,8 @@ fn render_plan_json(plan: &Plan, dry_run: bool) -> String {
         .iter()
         .map(|set| JsonSet {
             engine: set.set.engine.as_str(),
-            target_triple: &set.set.target_triple,
-            machine_key: &set.set.machine_key,
+            target_triple: set.set.target_triple.as_str(),
+            machine_key: set.set.machine_key.as_str(),
             runs: set.runs,
             blessings: set.blessings,
             commits: set
@@ -735,7 +735,7 @@ mod tests {
     fn auto() -> AutoFacets {
         AutoFacets {
             triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            machine_key: "m1".into(),
         }
     }
 
@@ -1583,8 +1583,8 @@ mod tests {
     fn build_plan_counts_runs_and_blessings_separately() {
         let set = DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
         // Two clean runs (c0, c1) plus one blessing on c0: an asymmetric mix so a
         // run/blessing miscount diverges from the truth.

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -674,7 +674,7 @@ fn render_plan_json(plan: &Plan, dry_run: bool) -> String {
         .sets
         .iter()
         .map(|set| JsonSet {
-            engine: &set.set.engine,
+            engine: set.set.engine.as_str(),
             target_triple: &set.set.target_triple,
             machine_key: &set.set.machine_key,
             runs: set.runs,
@@ -717,7 +717,7 @@ mod tests {
     use cbh_diag::RecordingReporter;
     use cbh_git::FakeGitHistory;
     use cbh_model::{
-        BenchmarkId, BenchmarkResult, EnvironmentInfo, GitInfo, Metric, MetricKind, Run,
+        BenchmarkId, BenchmarkResult, Engine, EnvironmentInfo, GitInfo, Metric, MetricKind, Run,
         RunContext, ToolchainInfo,
     };
     use cbh_storage::{MemoryStorage, Storage};
@@ -1582,7 +1582,7 @@ mod tests {
     #[test]
     fn build_plan_counts_runs_and_blessings_separately() {
         let set = DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };

--- a/packages/cbh_detect/src/detect/discriminant.rs
+++ b/packages/cbh_detect/src/detect/discriminant.rs
@@ -76,8 +76,8 @@ impl DiscriminantSetQuery {
     #[must_use]
     pub fn matches(&self, set: &DiscriminantSet) -> bool {
         self.engine.passes(set.engine.as_str())
-            && self.target_triple.passes(&set.target_triple)
-            && self.machine_key.passes(&set.machine_key)
+            && self.target_triple.passes(set.target_triple.as_str())
+            && self.machine_key.passes(set.machine_key.as_str())
     }
 }
 
@@ -92,8 +92,8 @@ mod tests {
     fn set(triple: &str) -> DiscriminantSet {
         DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: triple.to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: triple.into(),
+            machine_key: "m1".into(),
         }
     }
 
@@ -207,8 +207,8 @@ mod tests {
     fn set_obeys_the_auto_detected_machine_key() {
         let machine = DiscriminantSet {
             engine: Engine::Criterion,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         };
         // This machine matches its own auto-detected fingerprint.
         assert!(

--- a/packages/cbh_detect/src/detect/discriminant.rs
+++ b/packages/cbh_detect/src/detect/discriminant.rs
@@ -75,7 +75,7 @@ impl DiscriminantSetQuery {
     /// profile is a different measurement).
     #[must_use]
     pub fn matches(&self, set: &DiscriminantSet) -> bool {
-        self.engine.passes(&set.engine)
+        self.engine.passes(set.engine.as_str())
             && self.target_triple.passes(&set.target_triple)
             && self.machine_key.passes(&set.machine_key)
     }
@@ -84,13 +84,14 @@ impl DiscriminantSetQuery {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use cbh_model::Engine;
     use nonempty::nonempty;
 
     use super::*;
 
     fn set(triple: &str) -> DiscriminantSet {
         DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: triple.to_owned(),
             machine_key: "m1".to_owned(),
         }
@@ -205,7 +206,7 @@ mod tests {
     #[test]
     fn set_obeys_the_auto_detected_machine_key() {
         let machine = DiscriminantSet {
-            engine: "criterion".to_owned(),
+            engine: Engine::Criterion,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         };

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1328,8 +1328,8 @@ mod tests {
         Series {
             set: DiscriminantSet {
                 engine: Engine::Callgrind,
-                target_triple: "t".to_owned(),
-                machine_key: "m1".to_owned(),
+                target_triple: "t".into(),
+                machine_key: "m1".into(),
             },
             id: BenchmarkId::new(nonempty!["group".to_owned(), "case".to_owned()]),
             kind,
@@ -1383,8 +1383,8 @@ mod tests {
             finding: Finding {
                 set: DiscriminantSet {
                     engine: Engine::Callgrind,
-                    target_triple: "t".to_owned(),
-                    machine_key: "m1".to_owned(),
+                    target_triple: "t".into(),
+                    machine_key: "m1".into(),
                 },
                 id: BenchmarkId::new(nonempty!["group".to_owned(), "case".to_owned()]),
                 kind: MetricKind::InstructionCount,
@@ -2111,8 +2111,8 @@ mod tests {
         Series {
             set: DiscriminantSet {
                 engine: Engine::Callgrind,
-                target_triple: "t".to_owned(),
-                machine_key: "m1".to_owned(),
+                target_triple: "t".into(),
+                machine_key: "m1".into(),
             },
             id: BenchmarkId::new(nonempty!["group".to_owned(), "case".to_owned()]),
             kind: MetricKind::InstructionCount,

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1284,7 +1284,7 @@ mod tests {
 
     use std::sync::Arc;
 
-    use cbh_model::{DiscriminantSet, MetricKind};
+    use cbh_model::{DiscriminantSet, Engine, MetricKind};
     use jiff::Timestamp;
     use nonempty::nonempty;
 
@@ -1327,7 +1327,7 @@ mod tests {
             .collect();
         Series {
             set: DiscriminantSet {
-                engine: "callgrind".to_owned(),
+                engine: Engine::Callgrind,
                 target_triple: "t".to_owned(),
                 machine_key: "m1".to_owned(),
             },
@@ -1382,7 +1382,7 @@ mod tests {
         Candidate {
             finding: Finding {
                 set: DiscriminantSet {
-                    engine: "callgrind".to_owned(),
+                    engine: Engine::Callgrind,
                     target_triple: "t".to_owned(),
                     machine_key: "m1".to_owned(),
                 },
@@ -2110,7 +2110,7 @@ mod tests {
             .collect();
         Series {
             set: DiscriminantSet {
-                engine: "callgrind".to_owned(),
+                engine: Engine::Callgrind,
                 target_triple: "t".to_owned(),
                 machine_key: "m1".to_owned(),
             },

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -25,7 +25,7 @@ pub use findings::{
 };
 pub use parallel::{balanced_chunk_sizes, worker_count};
 pub use run_points::{MetricPoint, ResultPoints, RunPoints};
-pub use selection::{SelectedCommit, select_commits};
+pub use selection::{DirtyAdmission, SelectedCommit, select_commits};
 pub use series::{
     Blessing, BlessingPlacement, LoadedObject, Series, SeriesBuilder, SeriesFilter, SeriesPoint,
     apply_blessings, build_series, retain_present_at_context,

--- a/packages/cbh_detect/src/detect/run_points.rs
+++ b/packages/cbh_detect/src/detect/run_points.rs
@@ -192,7 +192,7 @@ mod tests {
             },
             EnvironmentInfo::default(),
             ToolchainInfo {
-                target_triple: "x86_64-unknown-linux-gnu".to_owned(),
+                target_triple: "x86_64-unknown-linux-gnu".into(),
                 rustc_version: Some("1.80.0".to_owned()),
             },
             "9.9.9".to_owned(),

--- a/packages/cbh_detect/src/detect/selection.rs
+++ b/packages/cbh_detect/src/detect/selection.rs
@@ -8,19 +8,46 @@
 //! *target-side* (clean and dirty runs count). The async git calls live in
 //! [`detect`](super); keeping the split here pure keeps it Miri-testable.
 
+/// How a selected commit treats dirty (uncommitted-tree) snapshots.
+///
+/// Replacing a pair of booleans, this makes the base-branch exception's invariant
+/// structural: the exception is a *kind* of admission, so a commit can never
+/// claim the exception while excluding dirty runs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirtyAdmission {
+    /// Dirty snapshots are excluded: a base-side commit, or `--no-dirty`.
+    Excluded,
+    /// Dirty snapshots are admitted for a target-side commit.
+    Admitted,
+    /// Dirty snapshots are admitted *only* by the base-branch dirty-tree exception:
+    /// a base-side tip whose dirty runs are the user's current in-flight work. When
+    /// such a run is actually included, `analyze` warns that it is ephemeral (see
+    /// the `analyze` command in `DESIGN.md`).
+    BaseException,
+}
+
+impl DirtyAdmission {
+    /// Whether dirty snapshots on the commit are admitted at all.
+    #[must_use]
+    pub fn admits_dirty(self) -> bool {
+        matches!(self, Self::Admitted | Self::BaseException)
+    }
+
+    /// Whether admission is granted *only* by the base-branch dirty-tree exception,
+    /// the case that triggers the ephemeral-data warning.
+    #[must_use]
+    pub fn is_base_exception(self) -> bool {
+        matches!(self, Self::BaseException)
+    }
+}
+
 /// One commit selected for analysis, in oldest-first topological position.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SelectedCommit {
     /// The commit ID (the storage commit-directory segment).
     pub commit: String,
-    /// Whether dirty snapshots on this commit are admitted (target-side, or the
-    /// base-side tip under the dirty-working-tree exception).
-    pub admit_dirty: bool,
-    /// Whether `admit_dirty` is granted *only* by the base-branch dirty-tree
-    /// exception (a base-side tip whose dirty runs are the user's current work).
-    /// When such a run is actually included, `analyze` warns that it is
-    /// ephemeral (see the `analyze` command in `DESIGN.md`).
-    pub dirty_base_exception: bool,
+    /// How this commit treats dirty (uncommitted-tree) snapshots.
+    pub dirty: DirtyAdmission,
 }
 
 /// Splits the target's first-parent `ancestry` (oldest-first) at the `merge_base`
@@ -37,7 +64,7 @@ pub struct SelectedCommit {
 /// `dirty_tip_exception` carves out the on-the-base-branch scenario: when the
 /// **tip** commit is base-side (an official view) but the working tree is
 /// currently dirty, its dirty snapshots are the user's in-flight work, so they are
-/// admitted (flagged via [`SelectedCommit::dirty_base_exception`] so the caller can
+/// admitted (flagged via [`DirtyAdmission::BaseException`] so the caller can
 /// warn). Earlier base-side commits are unaffected — only the tip. `allow_dirty`
 /// still gates it, so `--no-dirty` overrides the exception.
 #[must_use]
@@ -55,11 +82,16 @@ pub fn select_commits(
         .map(|(index, commit)| {
             let target_side = split.is_none_or(|boundary| index > boundary);
             let is_tip = tip_index == Some(index);
-            let dirty_base_exception = !target_side && is_tip && allow_dirty && dirty_tip_exception;
+            let dirty = if !target_side && is_tip && allow_dirty && dirty_tip_exception {
+                DirtyAdmission::BaseException
+            } else if target_side && allow_dirty {
+                DirtyAdmission::Admitted
+            } else {
+                DirtyAdmission::Excluded
+            };
             SelectedCommit {
                 commit: commit.clone(),
-                admit_dirty: (target_side && allow_dirty) || dirty_base_exception,
-                dirty_base_exception,
+                dirty,
             }
         })
         .collect()
@@ -77,7 +109,7 @@ mod tests {
     fn admit(selection: &[SelectedCommit]) -> Vec<(&str, bool)> {
         selection
             .iter()
-            .map(|selected| (selected.commit.as_str(), selected.admit_dirty))
+            .map(|selected| (selected.commit.as_str(), selected.dirty.admits_dirty()))
             .collect()
     }
 
@@ -94,7 +126,7 @@ mod tests {
         assert!(
             selection
                 .iter()
-                .all(|selected| !selected.dirty_base_exception)
+                .all(|selected| !selected.dirty.is_base_exception())
         );
     }
 
@@ -114,7 +146,11 @@ mod tests {
     fn no_dirty_suppresses_target_side_admission() {
         let ancestry = commit_ids(&["c0", "c1", "f1", "f2"]);
         let selection = select_commits(&ancestry, Some("c1"), false, false);
-        assert!(selection.iter().all(|selected| !selected.admit_dirty));
+        assert!(
+            selection
+                .iter()
+                .all(|selected| !selected.dirty.admits_dirty())
+        );
     }
 
     #[test]
@@ -130,7 +166,11 @@ mod tests {
         // inclusive (target-side) treatment.
         let ancestry = commit_ids(&["c0", "c1", "c2"]);
         let selection = select_commits(&ancestry, Some("zz"), true, false);
-        assert!(selection.iter().all(|selected| selected.admit_dirty));
+        assert!(
+            selection
+                .iter()
+                .all(|selected| selected.dirty.admits_dirty())
+        );
     }
 
     #[test]
@@ -157,7 +197,7 @@ mod tests {
         );
         let flagged: Vec<&str> = selection
             .iter()
-            .filter(|selected| selected.dirty_base_exception)
+            .filter(|selected| selected.dirty.is_base_exception())
             .map(|selected| selected.commit.as_str())
             .collect();
         assert_eq!(flagged, vec!["c3"], "only the tip carries the exception");
@@ -168,11 +208,15 @@ mod tests {
         // --no-dirty (allow_dirty == false) overrides the dirty-tree exception.
         let ancestry = commit_ids(&["c0", "c1", "c2", "c3"]);
         let selection = select_commits(&ancestry, Some("c3"), false, true);
-        assert!(selection.iter().all(|selected| !selected.admit_dirty));
         assert!(
             selection
                 .iter()
-                .all(|selected| !selected.dirty_base_exception)
+                .all(|selected| !selected.dirty.admits_dirty())
+        );
+        assert!(
+            selection
+                .iter()
+                .all(|selected| !selected.dirty.is_base_exception())
         );
     }
 
@@ -185,7 +229,7 @@ mod tests {
         assert!(
             selection
                 .iter()
-                .all(|selected| !selected.dirty_base_exception),
+                .all(|selected| !selected.dirty.is_base_exception()),
             "a target-side tip is admitted normally, not via the exception"
         );
     }

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -57,7 +57,7 @@
 
 use std::sync::Arc;
 
-use cbh_model::{BenchmarkId, DiscriminantSet, MetricKind};
+use cbh_model::{BenchmarkId, DiscriminantSet, Engine, MetricKind};
 use nonempty::nonempty;
 
 use crate::detect::findings::find_changes;
@@ -295,7 +295,7 @@ fn curated_series(values: &[f64], kind: MetricKind) -> Series {
         .collect();
     Series {
         set: DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "t".to_owned(),
             machine_key: "m1".to_owned(),
         },

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -296,8 +296,8 @@ fn curated_series(values: &[f64], kind: MetricKind) -> Series {
     Series {
         set: DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "t".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "t".into(),
+            machine_key: "m1".into(),
         },
         id: BenchmarkId::new(nonempty!["signal".to_owned(), "case".to_owned()]),
         kind,

--- a/packages/cbh_model/benches/cbh_model.rs
+++ b/packages/cbh_model/benches/cbh_model.rs
@@ -15,7 +15,9 @@
 
 use std::hint::black_box;
 
-use cbh_model::{BenchmarkId, DiscriminantSet, Engine, parse_key, sanitize_segment};
+use cbh_model::{
+    BenchmarkId, DiscriminantSet, Engine, MachineKey, TargetTriple, parse_key, sanitize_segment,
+};
 use criterion::{Criterion, criterion_group, criterion_main};
 use nonempty::nonempty;
 
@@ -45,7 +47,11 @@ fn storage_key(c: &mut Criterion) {
         b.iter(|| black_box(sanitize_segment(black_box("x86_64-unknown-linux-gnu"))));
     });
 
-    let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
+    let set = DiscriminantSet::new(
+        Engine::Callgrind,
+        &TargetTriple::from("x86_64-unknown-linux-gnu"),
+        &MachineKey::from("m1"),
+    );
     group.bench_function("clean_key", |b| {
         b.iter(|| {
             black_box(black_box(&set).clean_key(

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -6,14 +6,21 @@
 //! incomparable — project, engine, target triple, and a machine key — and to
 //! record everything else as metadata so its effect stays visible in the timeline.
 
+use std::cmp::Ordering;
 use std::fmt;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::constants::{OBJECTS_SEGMENT, STORAGE_VERSION};
 
 /// A benchmark engine: the measurement tool whose output a series accumulates.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+///
+/// Serializes to (and deserializes from) its stable lowercase
+/// [identifier](Self::as_str) — `criterion`, `callgrind`, `alloc_tracker`,
+/// `all_the_time` — so a [`DiscriminantSet`] flattened into a JSON report keeps
+/// that exact wire name.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Engine {
     /// Criterion wall-clock benchmarks: noisy, with a confidence interval.
     Criterion,
@@ -64,6 +71,21 @@ impl Engine {
     }
 }
 
+/// Orders engines by their stable [identifier](Self::as_str), so a
+/// [`DiscriminantSet`] sorts identically whether its engine is compared as an
+/// `Engine` or as the serialized string that used to stand in for it.
+impl Ord for Engine {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for Engine {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl fmt::Display for Engine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
@@ -79,8 +101,8 @@ impl fmt::Display for Engine {
 /// back (parsed from a storage key), so the same type drives both sides.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct DiscriminantSet {
-    /// Engine identifier (for example, `callgrind`).
-    pub engine: String,
+    /// The benchmark engine whose output the series accumulates.
+    pub engine: Engine,
     /// Resolved target triple the run was recorded under.
     pub target_triple: String,
     /// Machine key: a stable hardware fingerprint (or an explicit override). Every
@@ -100,7 +122,7 @@ impl DiscriminantSet {
     #[must_use]
     pub fn new(engine: Engine, target_triple: &str, machine_key: &str) -> Self {
         Self {
-            engine: engine.as_str().to_owned(),
+            engine,
             target_triple: sanitize_segment(target_triple),
             machine_key: sanitize_segment(machine_key),
         }
@@ -120,7 +142,7 @@ impl DiscriminantSet {
     #[must_use]
     pub fn partition_prefix(&self, project: &str) -> String {
         let project = sanitize_segment(project);
-        let engine = &self.engine;
+        let engine = self.engine.as_str();
         let triple = &self.target_triple;
         let machine_key = &self.machine_key;
         format!("{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{triple}/{machine_key}")
@@ -192,13 +214,66 @@ impl fmt::Display for DiscriminantSet {
     }
 }
 
+/// Which kind of object a storage key names, decoded from its file segment.
+///
+/// A commit directory holds three kinds of object, distinguished by file name:
+/// the canonical clean run (`clean.json`), zero or more dirty snapshots
+/// (`dirty-<observation_unix>.json`), and zero or more blessing sidecars
+/// (`bless-<issued_unix>.json`). Recovering this typed classification once
+/// (rather than re-testing string prefixes at each use site) keeps the three
+/// cases exhaustive and parses each embedded timestamp a single time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ObjectKind {
+    /// The canonical clean-working-tree run (`clean.json`).
+    Clean,
+    /// A dirty (uncommitted-tree) snapshot, distinguished by its observation second.
+    Dirty {
+        /// The Unix second at which the snapshot was observed, from the file name.
+        observation_unix: i64,
+    },
+    /// A blessing sidecar, distinguished by the second it was issued.
+    Bless {
+        /// The Unix second at which the blessing was issued, from the file name.
+        issued_unix: i64,
+    },
+}
+
+impl ObjectKind {
+    /// Decodes the file segment of a storage key into its object kind, returning
+    /// `None` when the segment is not one of the three recognized object files.
+    fn from_file_segment(file: &str) -> Option<Self> {
+        if file == "clean.json" {
+            return Some(Self::Clean);
+        }
+        if let Some(seconds) = file
+            .strip_prefix("dirty-")
+            .and_then(|rest| rest.strip_suffix(".json"))
+        {
+            return seconds
+                .parse()
+                .ok()
+                .map(|observation_unix| Self::Dirty { observation_unix });
+        }
+        if let Some(seconds) = file
+            .strip_prefix("bless-")
+            .and_then(|rest| rest.strip_suffix(".json"))
+        {
+            return seconds
+                .parse()
+                .ok()
+                .map(|issued_unix| Self::Bless { issued_unix });
+        }
+        None
+    }
+}
+
 /// The components a storage key decomposes into.
 ///
 /// A storage key references one of three kinds of object in a commit directory:
 /// a clean run (`clean.json`), a dirty snapshot (`dirty-<unix>.json`), or a
-/// blessing sidecar (`bless-<unix>.json`). The [`file`](Self::file) segment
-/// distinguishes them; [`is_dirty`](Self::is_dirty) and
-/// [`is_bless`](Self::is_bless) classify it.
+/// blessing sidecar (`bless-<unix>.json`). The [`kind`](Self::kind) field, an
+/// [`ObjectKind`], captures which; [`is_clean`](Self::is_clean),
+/// [`is_dirty`](Self::is_dirty), and [`is_bless`](Self::is_bless) classify it.
 ///
 /// This is the inverse of the key-construction methods above ([`clean_key`],
 /// [`dirty_key`], [`bless_key`]): [`parse_key`] recovers this decomposition from a
@@ -215,21 +290,27 @@ pub struct StorageKey {
     pub set: DiscriminantSet,
     /// The commit directory segment (full commit ID, or `unknown`).
     pub commit: String,
-    /// The file segment (`clean.json`, `dirty-<unix>.json`, or `bless-<unix>.json`).
-    pub file: String,
+    /// Which kind of object the key names, decoded from its file segment.
+    pub kind: ObjectKind,
 }
 
 impl StorageKey {
+    /// Whether the key names a clean (committed-tree) run.
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        matches!(self.kind, ObjectKind::Clean)
+    }
+
     /// Whether the key names a dirty (uncommitted-tree) snapshot.
     #[must_use]
     pub fn is_dirty(&self) -> bool {
-        self.file.starts_with("dirty-")
+        matches!(self.kind, ObjectKind::Dirty { .. })
     }
 
     /// Whether the key names a blessing sidecar rather than a stored run.
     #[must_use]
     pub fn is_bless(&self) -> bool {
-        self.file.starts_with("bless-")
+        matches!(self.kind, ObjectKind::Bless { .. })
     }
 
     /// The blessing sidecar key for this set's commit directory, issued at
@@ -247,8 +328,10 @@ impl StorageKey {
 /// — exactly eight non-empty segments, with the fixed `objects` segment directly
 /// under the project. Any key that does not match that shape exactly (wrong
 /// version, missing `objects` segment, too few or too many segments, or an empty
-/// segment) is ignored (returns `None`) rather than misattributed — so a
-/// per-project metadata sibling such as the cache-invalidation marker is skipped.
+/// segment), names an engine the tool has no adapter for, or whose file segment is
+/// not one of the three recognized object files, is ignored (returns `None`)
+/// rather than misattributed — so a per-project metadata sibling such as the
+/// cache-invalidation marker is skipped.
 #[must_use]
 pub fn parse_key(key: &str) -> Option<StorageKey> {
     let parts: Vec<&str> = key.split('/').collect();
@@ -271,15 +354,17 @@ pub fn parse_key(key: &str) -> Option<StorageKey> {
     if parts.iter().any(|segment| segment.is_empty()) {
         return None;
     }
+    let engine = Engine::from_name(engine)?;
+    let kind = ObjectKind::from_file_segment(file)?;
     Some(StorageKey {
         project: (*project).to_owned(),
         set: DiscriminantSet {
-            engine: (*engine).to_owned(),
+            engine,
             target_triple: (*target_triple).to_owned(),
             machine_key: (*machine_key).to_owned(),
         },
         commit: (*commit).to_owned(),
-        file: (*file).to_owned(),
+        kind,
     })
 }
 
@@ -474,11 +559,11 @@ mod tests {
             parse_key("v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json")
                 .unwrap();
         assert_eq!(parsed.project, "folo");
-        assert_eq!(parsed.set.engine, "callgrind");
+        assert_eq!(parsed.set.engine, Engine::Callgrind);
         assert_eq!(parsed.set.target_triple, "x86_64-unknown-linux-gnu");
         assert_eq!(parsed.set.machine_key, "m1");
         assert_eq!(parsed.commit, "abc123");
-        assert_eq!(parsed.file, "clean.json");
+        assert!(parsed.is_clean());
         assert!(!parsed.is_dirty());
         assert!(!parsed.is_bless());
     }
@@ -490,6 +575,12 @@ mod tests {
         )
         .unwrap();
         assert!(parsed.is_dirty());
+        assert_eq!(
+            parsed.kind,
+            ObjectKind::Dirty {
+                observation_unix: 1_700_000_000
+            }
+        );
         assert_eq!(parsed.set.target_triple, "x86_64-pc-windows-msvc");
         assert_eq!(parsed.set.machine_key, "m1");
     }
@@ -502,6 +593,12 @@ mod tests {
         .unwrap();
         assert!(parsed.is_bless());
         assert!(!parsed.is_dirty());
+        assert_eq!(
+            parsed.kind,
+            ObjectKind::Bless {
+                issued_unix: 1_700_000_000
+            }
+        );
         assert_eq!(parsed.commit, "abc123");
     }
 
@@ -529,5 +626,24 @@ mod tests {
         assert!(parse_key("v1/folo/objects/callgrind/t/m/c/sub/f.json").is_none());
         assert!(parse_key("v1/folo/objects/callgrind/t//c/f.json").is_none());
         assert!(parse_key("v1/folo/objects/callgrind/t/m/c/").is_none());
+        // A structurally valid key naming an engine the tool has no adapter for.
+        assert!(parse_key("v1/folo/objects/dhat/t/m/c/clean.json").is_none());
+        // A structurally valid key whose file segment is not a known object.
+        assert!(parse_key("v1/folo/objects/callgrind/t/m/c/notes.json").is_none());
+    }
+
+    #[test]
+    fn engine_serde_matches_as_str() {
+        // The serialized wire form must equal `as_str`, so a flattened
+        // `DiscriminantSet` keeps the exact engine name in JSON reports.
+        for engine in Engine::ALL {
+            let json = serde_json::to_string(&engine).unwrap();
+            assert_eq!(json, format!("\"{}\"", engine.as_str()));
+            assert_eq!(
+                serde_json::from_str::<Engine>(&json).unwrap(),
+                engine,
+                "engine {engine} must round-trip through its wire form"
+            );
+        }
     }
 }

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -620,6 +620,7 @@ mod tests {
         )
         .unwrap();
         assert!(parsed.is_dirty());
+        assert!(!parsed.is_clean());
         assert_eq!(
             parsed.kind,
             ObjectKind::Dirty {
@@ -638,6 +639,7 @@ mod tests {
         .unwrap();
         assert!(parsed.is_bless());
         assert!(!parsed.is_dirty());
+        assert!(!parsed.is_clean());
         assert_eq!(
             parsed.kind,
             ObjectKind::Bless {
@@ -675,6 +677,34 @@ mod tests {
         assert!(parse_key("v1/folo/objects/dhat/t/m/c/clean.json").is_none());
         // A structurally valid key whose file segment is not a known object.
         assert!(parse_key("v1/folo/objects/callgrind/t/m/c/notes.json").is_none());
+        // Keys that are valid in every respect except one guarded segment, so the
+        // version and `objects` guards are each exercised in isolation (a real
+        // engine and object file would otherwise let a mutated guard slip through).
+        assert!(
+            parse_key("v2/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json")
+                .is_none()
+        );
+        assert!(
+            parse_key("v1/folo/data/callgrind/x86_64-unknown-linux-gnu/m1/abc123/clean.json")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn engine_orders_by_identifier() {
+        // Ordering follows `as_str`, so a `DiscriminantSet` sorts identically
+        // whether its engine is compared as an `Engine` or as its serialized name.
+        let mut by_engine = Engine::ALL.to_vec();
+        by_engine.sort();
+        let ordered_names: Vec<&str> = by_engine.iter().map(|engine| engine.as_str()).collect();
+        let mut by_name = Engine::ALL.map(Engine::as_str).to_vec();
+        by_name.sort_unstable();
+        assert_eq!(ordered_names, by_name);
+        assert!(Engine::Callgrind < Engine::Criterion);
+        assert_eq!(
+            Engine::Callgrind.partial_cmp(&Engine::Criterion),
+            Some(Ordering::Less)
+        );
     }
 
     #[test]

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::constants::{OBJECTS_SEGMENT, STORAGE_VERSION};
+use super::identifiers::{MachineKey, TargetTriple};
 
 /// A benchmark engine: the measurement tool whose output a series accumulates.
 ///
@@ -104,10 +105,10 @@ pub struct DiscriminantSet {
     /// The benchmark engine whose output the series accumulates.
     pub engine: Engine,
     /// Resolved target triple the run was recorded under.
-    pub target_triple: String,
+    pub target_triple: TargetTriple,
     /// Machine key: a stable hardware fingerprint (or an explicit override). Every
     /// engine is machine-keyed.
-    pub machine_key: String,
+    pub machine_key: MachineKey,
 }
 
 impl DiscriminantSet {
@@ -120,11 +121,11 @@ impl DiscriminantSet {
     /// stray `/` (or other surprising input) from silently splitting a storage key
     /// into the wrong number of segments.
     #[must_use]
-    pub fn new(engine: Engine, target_triple: &str, machine_key: &str) -> Self {
+    pub fn new(engine: Engine, target_triple: &TargetTriple, machine_key: &MachineKey) -> Self {
         Self {
             engine,
-            target_triple: sanitize_segment(target_triple),
-            machine_key: sanitize_segment(machine_key),
+            target_triple: TargetTriple::from(sanitize_segment(target_triple.as_str())),
+            machine_key: MachineKey::from(sanitize_segment(machine_key.as_str())),
         }
     }
 
@@ -360,8 +361,8 @@ pub fn parse_key(key: &str) -> Option<StorageKey> {
         project: (*project).to_owned(),
         set: DiscriminantSet {
             engine,
-            target_triple: (*target_triple).to_owned(),
-            machine_key: (*machine_key).to_owned(),
+            target_triple: TargetTriple::from(*target_triple),
+            machine_key: MachineKey::from(*machine_key),
         },
         commit: (*commit).to_owned(),
         kind,
@@ -402,7 +403,11 @@ mod tests {
     fn every_engine_partitions_by_machine_key() {
         // Every engine is machine-keyed: even the low-noise simulated counts differ
         // by microarchitecture, so a machine key always appears in the partition.
-        let set = DiscriminantSet::new(Engine::AllocTracker, "x86_64-pc-windows-msvc", "abc123");
+        let set = DiscriminantSet::new(
+            Engine::AllocTracker,
+            &TargetTriple::from("x86_64-pc-windows-msvc"),
+            &MachineKey::from("abc123"),
+        );
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/alloc_tracker/x86_64-pc-windows-msvc/abc123"
@@ -413,7 +418,11 @@ mod tests {
     fn all_the_time_partitions_by_machine_key() {
         // Processor time depends on the machine, so `all_the_time` carries a
         // machine fingerprint.
-        let set = DiscriminantSet::new(Engine::AllTheTime, "x86_64-pc-windows-msvc", "abc123");
+        let set = DiscriminantSet::new(
+            Engine::AllTheTime,
+            &TargetTriple::from("x86_64-pc-windows-msvc"),
+            &MachineKey::from("abc123"),
+        );
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/all_the_time/x86_64-pc-windows-msvc/abc123"
@@ -422,7 +431,11 @@ mod tests {
 
     #[test]
     fn machine_key_appears_in_partition() {
-        let set = DiscriminantSet::new(Engine::Criterion, "x86_64-pc-windows-msvc", "abc123");
+        let set = DiscriminantSet::new(
+            Engine::Criterion,
+            &TargetTriple::from("x86_64-pc-windows-msvc"),
+            &MachineKey::from("abc123"),
+        );
         assert_eq!(
             set.partition_prefix("folo"),
             "v1/folo/objects/criterion/x86_64-pc-windows-msvc/abc123"
@@ -431,13 +444,21 @@ mod tests {
 
     #[test]
     fn display_formats_engine_triple_and_machine_key() {
-        let set = DiscriminantSet::new(Engine::Criterion, "x86_64-pc-windows-msvc", "abc123");
+        let set = DiscriminantSet::new(
+            Engine::Criterion,
+            &TargetTriple::from("x86_64-pc-windows-msvc"),
+            &MachineKey::from("abc123"),
+        );
         assert_eq!(set.to_string(), "criterion/x86_64-pc-windows-msvc/abc123");
     }
 
     #[test]
     fn clean_key_is_named_by_commit() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "abc123");
+        let set = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("abc123"),
+        );
         assert_eq!(
             set.clean_key("folo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
             "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/abc123/\
@@ -447,7 +468,11 @@ mod tests {
 
     #[test]
     fn dirty_key_is_named_by_commit_and_observation_time() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "abc123");
+        let set = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("abc123"),
+        );
         assert_eq!(
             set.dirty_key(
                 "folo",
@@ -461,7 +486,11 @@ mod tests {
 
     #[test]
     fn bless_key_targets_the_commit_directory() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
+        let set = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("m1"),
+        );
         assert_eq!(
             set.bless_key("folo", "abc123", 1_700_000_000),
             "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/abc123/bless-1700000000.json"
@@ -470,7 +499,11 @@ mod tests {
 
     #[test]
     fn commit_prefix_enumerates_one_commit_directory() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
+        let set = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("m1"),
+        );
         assert_eq!(
             set.commit_prefix("folo", "dead/beef"),
             "v1/folo/objects/callgrind/x86_64-unknown-linux-gnu/m1/dead_beef/"
@@ -520,7 +553,11 @@ mod tests {
 
     #[test]
     fn new_sanitizes_partition_components() {
-        let set = DiscriminantSet::new(Engine::Criterion, "weird/triple", "machine/one");
+        let set = DiscriminantSet::new(
+            Engine::Criterion,
+            &TargetTriple::from("weird/triple"),
+            &MachineKey::from("machine/one"),
+        );
         assert_eq!(
             set.partition_prefix("team/app"),
             "v1/team_app/objects/criterion/weird_triple/machine_one"
@@ -531,7 +568,11 @@ mod tests {
 
     #[test]
     fn clean_key_sanitizes_the_commit() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
+        let set = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("m1"),
+        );
         let object = set.clean_key("folo", "dead/beef");
         assert_eq!(
             object,
@@ -543,7 +584,11 @@ mod tests {
 
     #[test]
     fn dirty_key_sanitizes_the_commit() {
-        let set = DiscriminantSet::new(Engine::Callgrind, "x86_64-unknown-linux-gnu", "m1");
+        let set = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("m1"),
+        );
         let object = set.dirty_key("folo", "dead/beef", 1_700_000_000);
         assert_eq!(
             object,

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -11,6 +11,8 @@
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
+use super::identifiers::TargetTriple;
+
 /// Metadata attached to every stored run.
 ///
 /// A run's timeline position comes from git topology (keyed by the commit ID in
@@ -136,7 +138,7 @@ pub struct ToolchainInfo {
     /// Target triple the benchmark binary ran on. The tool always runs on the
     /// same OS it benchmarks (under WSL, the Linux side), so this is the host
     /// triple `rustc` reports.
-    pub target_triple: String,
+    pub target_triple: TargetTriple,
     /// `rustc` version string, if detected.
     pub rustc_version: Option<String>,
 }

--- a/packages/cbh_model/src/identifiers.rs
+++ b/packages/cbh_model/src/identifiers.rs
@@ -1,14 +1,16 @@
-//! String-newtype identifiers for the two opaque, sanitized storage-key segments
-//! that would otherwise be indistinguishable `String`s: the [`TargetTriple`] a run
-//! was measured on and the [`MachineKey`] its history is partitioned by.
+//! String-newtype identifiers for two opaque text values that would otherwise be
+//! indistinguishable `String`s: the [`TargetTriple`] a run was measured on and the
+//! [`MachineKey`] its history is partitioned by. Each is sanitized when it becomes
+//! a path segment in a storage key, but also appears in raw form elsewhere — most
+//! notably [`TargetTriple`], which holds the value `rustc` reported in a
+//! [`ToolchainInfo`](crate::ToolchainInfo).
 //!
-//! Both are arbitrary text sitting side by side as path segments in a storage key,
-//! so as bare strings they are trivially transposed where they are constructed or
-//! passed together — most visibly in
-//! [`DiscriminantSet::new`](crate::DiscriminantSet::new) and the flattened JSON
-//! reports. Distinct types make that transposition a compile error while
-//! preserving the stored wire format (`#[serde(transparent)]`) and the string
-//! ordering a [`DiscriminantSet`](crate::DiscriminantSet) sorts by.
+//! As storage-key segments the two sit side by side, so as bare strings they are
+//! trivially transposed where they are constructed or passed together — most
+//! visibly in [`DiscriminantSet::new`](crate::DiscriminantSet::new) and the
+//! flattened JSON reports. Distinct types make that transposition a compile error
+//! while preserving the stored wire format (`#[serde(transparent)]`) and the
+//! string ordering a [`DiscriminantSet`](crate::DiscriminantSet) sorts by.
 
 use std::fmt;
 

--- a/packages/cbh_model/src/identifiers.rs
+++ b/packages/cbh_model/src/identifiers.rs
@@ -1,0 +1,85 @@
+//! String-newtype identifiers for the two opaque, sanitized storage-key segments
+//! that would otherwise be indistinguishable `String`s: the [`TargetTriple`] a run
+//! was measured on and the [`MachineKey`] its history is partitioned by.
+//!
+//! Both are arbitrary text sitting side by side as path segments in a storage key,
+//! so as bare strings they are trivially transposed where they are constructed or
+//! passed together — most visibly in
+//! [`DiscriminantSet::new`](crate::DiscriminantSet::new) and the flattened JSON
+//! reports. Distinct types make that transposition a compile error while
+//! preserving the stored wire format (`#[serde(transparent)]`) and the string
+//! ordering a [`DiscriminantSet`](crate::DiscriminantSet) sorts by.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Defines a transparent `String` newtype with the shared accessor, conversion,
+/// display, and string-comparison conveniences the two identifiers need.
+macro_rules! string_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// The identifier as a string slice.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_owned())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+    };
+}
+
+string_newtype! {
+    /// The target triple a run was measured on (for example,
+    /// `x86_64-unknown-linux-gnu`).
+    ///
+    /// A `DiscriminantSet` holds the sanitized, path-segment form; a
+    /// [`ToolchainInfo`](crate::ToolchainInfo) holds the raw value `rustc`
+    /// reported. Both are the same type — the sanitization is a step, not a
+    /// distinct kind of triple.
+    TargetTriple
+}
+
+string_newtype! {
+    /// The machine key a series is partitioned by: a stable hardware fingerprint
+    /// or an explicit `--machine-key` override.
+    ///
+    /// Every engine is machine-keyed, so this segment always participates in a
+    /// storage key alongside the [`TargetTriple`]; the distinct types keep the two
+    /// from being transposed.
+    MachineKey
+}

--- a/packages/cbh_model/src/identifiers.rs
+++ b/packages/cbh_model/src/identifiers.rs
@@ -49,12 +49,6 @@ macro_rules! string_newtype {
             }
         }
 
-        impl PartialEq<str> for $name {
-            fn eq(&self, other: &str) -> bool {
-                self.0 == other
-            }
-        }
-
         impl PartialEq<&str> for $name {
             fn eq(&self, other: &&str) -> bool {
                 self.0 == *other

--- a/packages/cbh_model/src/lib.rs
+++ b/packages/cbh_model/src/lib.rs
@@ -29,6 +29,7 @@ mod bless;
 mod comparability;
 mod constants;
 mod context;
+mod identifiers;
 mod metric;
 mod run;
 
@@ -43,5 +44,6 @@ pub use context::{
     EnvironmentInfo, EnvironmentProvider, GitInfo, MachineInfo, RunContext, ToolchainInfo,
     detect_environment,
 };
+pub use identifiers::{MachineKey, TargetTriple};
 pub use metric::{Metric, MetricKind};
 pub use run::{BenchmarkResult, MetricList, Run, SCHEMA_VERSION};

--- a/packages/cbh_model/src/lib.rs
+++ b/packages/cbh_model/src/lib.rs
@@ -35,7 +35,9 @@ mod run;
 pub use aggregate::{AggregateError, Combined, Selection, min_per_metric};
 pub use benchmark_id::{BenchmarkId, BenchmarkIdPrefix, EmptyBenchmarkIdPrefix};
 pub use bless::{BLESS_SCHEMA_VERSION, BlessingRecord};
-pub use comparability::{DiscriminantSet, Engine, StorageKey, parse_key, sanitize_segment};
+pub use comparability::{
+    DiscriminantSet, Engine, ObjectKind, StorageKey, parse_key, sanitize_segment,
+};
 pub use constants::{OBJECTS_SEGMENT, STORAGE_VERSION};
 pub use context::{
     EnvironmentInfo, EnvironmentProvider, GitInfo, MachineInfo, RunContext, ToolchainInfo,

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -892,8 +892,8 @@ fn render_json(input: &ReportInput<'_>) -> String {
         .iter()
         .map(|summary| JsonSet {
             engine: summary.set.engine.as_str(),
-            target_triple: &summary.set.target_triple,
-            machine_key: &summary.set.machine_key,
+            target_triple: summary.set.target_triple.as_str(),
+            machine_key: summary.set.machine_key.as_str(),
             runs: summary.runs,
             series: summary.series,
             regressions: count_direction(&summary.findings, Direction::Regression),
@@ -1027,8 +1027,8 @@ mod tests {
     fn discriminant_set() -> DiscriminantSet {
         DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "x86_64-unknown-linux-gnu".to_owned(),
-            machine_key: "m1".to_owned(),
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            machine_key: "m1".into(),
         }
     }
 
@@ -1259,8 +1259,8 @@ mod tests {
         let windows = Finding {
             set: DiscriminantSet {
                 engine: Engine::Criterion,
-                target_triple: "x86_64-pc-windows-msvc".to_owned(),
-                machine_key: "m1".to_owned(),
+                target_triple: "x86_64-pc-windows-msvc".into(),
+                machine_key: "m1".into(),
             },
             ..named_regression("shared", 0.40)
         };
@@ -2146,8 +2146,8 @@ mod tests {
     fn darwin_set() -> DiscriminantSet {
         DiscriminantSet {
             engine: Engine::Callgrind,
-            target_triple: "aarch64-apple-darwin".to_owned(),
-            machine_key: "m2".to_owned(),
+            target_triple: "aarch64-apple-darwin".into(),
+            machine_key: "m2".into(),
         }
     }
 

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::num::NonZero;
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
-use cbh_detect::{Direction, Finding, FindingMethod, short_commit};
+use cbh_detect::{AnalysisMode, Direction, Finding, FindingMethod, short_commit};
 use cbh_model::{BenchmarkId, DiscriminantSet};
 use colored::Colorize;
 use rasciigraph::{Config, plot};
@@ -131,8 +131,8 @@ pub struct ReportInput<'a> {
     /// checkout differs from the committed tip. False for a clean tree (the CI
     /// collection case).
     pub tip_dirty: bool,
-    /// The analysis mode the report was produced in (`history`/`branch`).
-    pub mode: &'a str,
+    /// The analysis mode the report was produced in.
+    pub mode: AnalysisMode,
     /// Whether any finding survived — the at-a-glance signal a downstream
     /// automation reads to decide whether the report is worth surfacing.
     pub notable: bool,
@@ -278,8 +278,9 @@ struct JsonReport<'a> {
     tip_commit: &'a str,
     /// Whether the working tree carried uncommitted changes when the analysis ran.
     tip_dirty: bool,
-    /// The analysis mode (`history`/`branch`).
-    mode: &'a str,
+    /// The analysis mode. Serializes to its stable lowercase wire name
+    /// (`history`/`branch`).
+    mode: AnalysisMode,
     /// Whether any finding survived — the downstream automation signal.
     notable: bool,
     /// Total stored runs loaded.
@@ -444,7 +445,11 @@ fn render_text(input: &ReportInput<'_>, color: bool) -> String {
     }
 
     let mut lines = vec![
-        format!("Analyzed project {} ({} mode)", input.project, input.mode),
+        format!(
+            "Analyzed project {} ({} mode)",
+            input.project,
+            input.mode.as_str()
+        ),
         format!("  commit: {}", tip_label(input.tip_commit, input.tip_dirty)),
         format!("  {}", header.join("  ")),
     ];
@@ -604,12 +609,12 @@ enum ChartScope {
     BranchComparison,
 }
 
-/// Chooses the [`ChartScope`] for an analysis `mode` string (`history`/`branch`).
+/// Chooses the [`ChartScope`] for an analysis `mode`.
 ///
-/// Only `branch` uses the bounded comparison; every other value (history, and any
-/// future mode) charts the full series, the information-preserving default.
-fn chart_scope(mode: &str) -> ChartScope {
-    if mode == "branch" {
+/// Only [`AnalysisMode::Branch`] uses the bounded comparison; history charts the
+/// full series, the information-preserving default.
+fn chart_scope(mode: AnalysisMode) -> ChartScope {
+    if mode == AnalysisMode::Branch {
         ChartScope::BranchComparison
     } else {
         ChartScope::FullHistory
@@ -682,7 +687,7 @@ fn render_markdown(input: &ReportInput<'_>) -> String {
         format!("# Benchmark history analysis: {}", input.project),
         String::new(),
         format!("- Commit: {}", tip_label(input.tip_commit, input.tip_dirty)),
-        format!("- Mode: {}", input.mode),
+        format!("- Mode: {}", input.mode.as_str()),
         format!(
             "- Runs analyzed: {}",
             runs_with_span(input.runs, input.commit_span)
@@ -760,7 +765,7 @@ pub fn render_markdown_summary(input: &ReportInput<'_>, limit: NonZero<usize>) -
         format!("# Benchmark history analysis: {}", input.project),
         String::new(),
         format!("- Commit: {}", tip_label(input.tip_commit, input.tip_dirty)),
-        format!("- Mode: {}", input.mode),
+        format!("- Mode: {}", input.mode.as_str()),
         format!(
             "- Runs analyzed: {}",
             runs_with_span(input.runs, input.commit_span)
@@ -1076,7 +1081,7 @@ mod tests {
             project,
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: !findings.is_empty(),
             runs: findings.len().saturating_add(3),
             series: findings.len().max(1),
@@ -1098,7 +1103,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: !findings.is_empty(),
             runs: findings.len().saturating_add(3),
             series: findings.len().max(1),
@@ -1329,7 +1334,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 3,
             series: 1,
@@ -1353,7 +1358,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 0,
             series: 0,
@@ -1425,7 +1430,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: true,
             runs: 99,
             series: 88,
@@ -1620,7 +1625,7 @@ mod tests {
         let findings = vec![regression_with_series()];
         let mut summaries = Vec::new();
         let mut input = single_set_input("folo", &set, &findings, &mut summaries);
-        input.mode = "history";
+        input.mode = AnalysisMode::History;
         let report = render(&input, ReportFormat::Markdown, false);
         // The chart sits inside a fenced `text` block and carries no ANSI escapes.
         assert!(report.contains("```text"), "{report}");
@@ -1634,7 +1639,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 0,
             series: 0,
@@ -1657,7 +1662,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 0,
             series: 0,
@@ -1705,7 +1710,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 1,
             series: 1,
@@ -1731,7 +1736,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 0,
             series: 0,
@@ -1807,7 +1812,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: true,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: false,
             runs: 1,
             series: 1,
@@ -1925,7 +1930,7 @@ mod tests {
         let findings = vec![regression_with_series()];
         let mut summaries = Vec::new();
         let mut input = single_set_input("folo", &set, &findings, &mut summaries);
-        input.mode = "history";
+        input.mode = AnalysisMode::History;
         let text = render(&input, ReportFormat::Text, false);
         // The rasciigraph axis marker proves a chart was drawn under the finding.
         assert!(text.contains('┤') || text.contains('┼'), "{text}");
@@ -1937,7 +1942,7 @@ mod tests {
         let findings = vec![regression_with_series()];
         let mut summaries = Vec::new();
         let mut input = single_set_input("folo", &set, &findings, &mut summaries);
-        input.mode = "branch";
+        input.mode = AnalysisMode::Branch;
         let text = render(&input, ReportFormat::Text, false);
         // Branch mode now charts too (it previously did not); the axis marker proves it.
         assert!(text.contains('┤') || text.contains('┼'), "{text}");
@@ -1957,7 +1962,7 @@ mod tests {
         let findings = vec![regression_with_long_series()];
         let mut summaries = Vec::new();
         let mut input = single_set_input("folo", &set, &findings, &mut summaries);
-        input.mode = "branch";
+        input.mode = AnalysisMode::Branch;
         let text = render(&input, ReportFormat::Text, false);
 
         // A chart is drawn.
@@ -1988,7 +1993,7 @@ mod tests {
         let findings = vec![regression_with_long_series()];
         let mut summaries = Vec::new();
         let mut input = single_set_input("folo", &set, &findings, &mut summaries);
-        input.mode = "history";
+        input.mode = AnalysisMode::History;
         let text = render(&input, ReportFormat::Text, false);
 
         assert!(text.contains('┤') || text.contains('┼'), "{text}");
@@ -2004,7 +2009,7 @@ mod tests {
         let findings = vec![regression_with_series()];
         let mut summaries = Vec::new();
         let mut input = single_set_input("folo", &set, &findings, &mut summaries);
-        input.mode = "branch";
+        input.mode = AnalysisMode::Branch;
         let report = render(&input, ReportFormat::Markdown, false);
         // The branch chart sits inside the same fenced `text` block as a history chart.
         assert!(report.contains("```text"), "{report}");
@@ -2019,7 +2024,7 @@ mod tests {
         // `branch_mode_text_charts_the_bounded_comparison_including_the_tip`.
         let findings = vec![regression_with_long_series()];
         let mut input = flat_input(&findings);
-        input.mode = "branch";
+        input.mode = AnalysisMode::Branch;
         let report = render_markdown_summary(&input, DEFAULT_SUMMARY_LIMIT);
 
         assert!(report.contains("```text"), "{report}");
@@ -2176,7 +2181,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: true,
             runs: 10,
             series: 2,
@@ -2222,7 +2227,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "history",
+            mode: AnalysisMode::History,
             notable: true,
             runs: 10,
             series: 2,
@@ -2270,7 +2275,7 @@ mod tests {
             project: "folo",
             tip_commit: "1234567890abcdef1234",
             tip_dirty: false,
-            mode: "branch",
+            mode: AnalysisMode::Branch,
             notable: !findings.is_empty(),
             runs: findings.len().saturating_add(3),
             series: findings.len().max(1),

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -891,7 +891,7 @@ fn render_json(input: &ReportInput<'_>) -> String {
         .sets
         .iter()
         .map(|summary| JsonSet {
-            engine: &summary.set.engine,
+            engine: summary.set.engine.as_str(),
             target_triple: &summary.set.target_triple,
             machine_key: &summary.set.machine_key,
             runs: summary.runs,
@@ -1019,14 +1019,14 @@ mod tests {
     use std::thread;
 
     use cbh_detect::SeriesValue;
-    use cbh_model::MetricKind;
+    use cbh_model::{Engine, MetricKind};
     use nonempty::nonempty;
 
     use super::*;
 
     fn discriminant_set() -> DiscriminantSet {
         DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "x86_64-unknown-linux-gnu".to_owned(),
             machine_key: "m1".to_owned(),
         }
@@ -1258,7 +1258,7 @@ mod tests {
         let linux = named_regression("shared", 0.50);
         let windows = Finding {
             set: DiscriminantSet {
-                engine: "criterion".to_owned(),
+                engine: Engine::Criterion,
                 target_triple: "x86_64-pc-windows-msvc".to_owned(),
                 machine_key: "m1".to_owned(),
             },
@@ -2145,7 +2145,7 @@ mod tests {
 
     fn darwin_set() -> DiscriminantSet {
         DiscriminantSet {
-            engine: "callgrind".to_owned(),
+            engine: Engine::Callgrind,
             target_triple: "aarch64-apple-darwin".to_owned(),
             machine_key: "m2".to_owned(),
         }


### PR DESCRIPTION
[Copilot speaking]

Reviews `cargo-bench-history` for "primitive obsession" and "stringly-typed" design and expresses valid values through the type system instead of bare strings, unbounded integers, and boolean pairs. Each commit is one self-contained change and validation stayed green throughout.

## Changes

**Type the `DiscriminantSet` engine and `StorageKey` object kind**
- `DiscriminantSet.engine` was a `String` even though an `Engine` enum already existed — the enum was parsed and then thrown away. It now holds `Engine`, and `parse_key` rejects unknown engines instead of silently accepting arbitrary text.
- `StorageKey`'s stringly-typed `file: String` (probed with `== "clean.json"` and string-prefix predicates) becomes an `ObjectKind` enum, so the object variants (clean / dirty / bless, with their embedded timestamps) are matched exhaustively rather than by string sniffing.

**Introduce `TargetTriple` and `MachineKey` newtypes**
- The data model's identifier fields were interchangeable `String`s that were easy to transpose. They now use dedicated `#[serde(transparent)]` newtypes threaded through the model, detect, analyze, render, and collect/import paths.
- The CLI/query-facet layer (repeatable `--target-triple` / `--machine-key` filter tokens, including the `all` keyword) deliberately stays `String`; values are wrapped into newtypes at the data-model boundary.

**Type the render-layer analysis mode as `AnalysisMode`**
- `AnalysisMode` was a proper enum everywhere except the analyze→render boundary, where it was downgraded to `mode: &str` (with `if mode == "branch"` steering the chart scope). `ReportInput`, `JsonReport`, and `chart_scope` now carry `AnalysisMode`. It serializes to the same lowercase names, so the JSON wire format is unchanged.

**Replace `SelectedCommit`'s two-bool dirty state with `DirtyAdmission`**
- `admit_dirty` + `dirty_base_exception` encoded a tri-state across two booleans with a hand-maintained invariant (the exception implies admission), leaving one combination invalid-but-representable. A three-variant `DirtyAdmission` enum (`Excluded` / `Admitted` / `BaseException`) makes the base-branch exception structurally a kind of admission, so the illegal state can no longer be built.

## Not changed
- `PruneOptions { clean, dirty }` stays a pair of raw CLI flags: it is the clap-populated input struct and is resolved into the existing internal `Scope` enum (with validation of the empty case) at first use — the same CLI-boundary-stays-primitive line drawn for the facet filters.

## Compatibility
On-disk key format and JSON wire formats are unchanged; these are internal type refinements.

## Validation
- `cargo clippy --workspace --all-targets`: zero warnings
- `just format-check`: clean
- rustdoc with `-D warnings`: clean
- Tests: cbh_model, cbh_detect, cbh_analyze, cbh_render, cbh_storage, stress, and the 137 shell integration tests all pass (the JSON `mode` assertions confirm the unchanged wire format)