### PR TITLE
Force 64-byte function alignment for wall-clock benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,3 +368,14 @@ inherits = "test"
 # Speed up the build.
 debug = "none"
 incremental = false
+
+# Best-case benchmarking profile used by `just bench-best`. `cargo bench` defaults to the built-in
+# `bench` profile (which mirrors `release`: opt-level 3, no LTO, 16 codegen units); this inherits
+# the same `release` base and turns on whole-program optimization - fat LTO across a single codegen
+# unit - to squeeze out the fastest code the standard pipeline produces. It is deliberately NOT
+# used for the tracked `just bench` history: those numbers must stay comparable over time, and the
+# stability recipes instead force function alignment. See justfiles/just_testing.just.
+[profile.bench-best]
+inherits = "release"
+lto = "fat"
+codegen-units = 1

--- a/constants.env
+++ b/constants.env
@@ -77,3 +77,18 @@ AZURE_SUBSCRIPTION_ID=a94944a5-949a-4cc0-82bf-bf1dc763b137
 # only the tenant and subscription are shared, so the prod data store never depends on
 # test infrastructure. Non-secret, like the identifiers above.
 AZURE_PROD_CLIENT_ID=33e1aa70-9fab-4d89-9c41-96c696389145
+
+# Extra RUSTFLAGS applied by the WALL-CLOCK benchmark recipes (`just bench` and the
+# `gh-collect-*bench-history` collection recipes) to keep timings stable across relinks. Forcing
+# 64-byte function alignment pins every function entry to a 64-byte boundary, so a hot loop keeps
+# a fixed position relative to the L1 instruction-cache lines regardless of how the linker orders
+# functions in the binary. Without it, an unrelated dependency bump can reorder functions and
+# shift a byte-identical hot loop from sitting inside one 64-byte cache line to straddling two,
+# which surfaces as a phantom wall-clock regression with no source change. `-align-all-functions`
+# takes a log2 exponent, so `=6` means 2^6 = 64 bytes. It pads only BETWEEN functions (never
+# inside a loop, unlike `-align-all-nofallthru-blocks`), so the padding is never executed and
+# Callgrind instruction counts and allocation counts stay unchanged - only wall-clock series are
+# affected. This is a benchmark-build concern, so it lives in the recipes; `just bench-cg`
+# (Callgrind, layout-invariant) deliberately omits it, and cargo-bench-history does not impose it
+# on its users (see the tool's "Measurement stability" user-guide page).
+BENCH_STABILITY_RUSTFLAGS=-Cllvm-args=-align-all-functions=6

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -59,11 +59,11 @@ gh-collect-bench-history:
     # stable against link-layout shifts (see constants.env). The tool spawns `cargo bench` as a
     # child process that inherits this RUSTFLAGS. Function-alignment padding sits between functions
     # and is never executed, so any Callgrind instruction counts or allocation counts gathered in
-    # the same collection are unaffected. Keep any other RUSTFLAGS the runner set, but drop a
-    # pre-existing -align-all-functions token first so the stability value always wins - never
-    # duplicated, never silently skipped in favour of a stray runner value.
-    $kept_rustflags = @(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') })
-    $env:RUSTFLAGS = (@($kept_rustflags) + $env:BENCH_STABILITY_RUSTFLAGS) -join " "
+    # the same collection are unaffected. Treat any RUSTFLAGS the runner set as opaque: remove only
+    # a pre-existing -align-all-functions token, then append the stability value so the 64-byte
+    # setting always wins - never duplicated, never silently skipped in favour of a stray value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     # RECOLLECT_COMMIT_ID is empty on a push / plain dispatch (normal append) and a commit SHA when
     # repairing one historical point (overwrite). The mode-selection logic - and the untrusted-input
@@ -102,11 +102,11 @@ gh-collect-pr-bench-history packages:
     # Build the benchmarks with 64-byte function alignment so the collected wall-clock series are
     # stable against link-layout shifts (see constants.env); the tool spawns `cargo bench` as a
     # child that inherits this RUSTFLAGS, and the padding is never executed so instruction and
-    # allocation counts are unaffected. Keep any other RUSTFLAGS the runner set, but drop a
-    # pre-existing -align-all-functions token first so the stability value always wins - never
-    # duplicated, never silently skipped in favour of a stray runner value.
-    $kept_rustflags = @(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') })
-    $env:RUSTFLAGS = (@($kept_rustflags) + $env:BENCH_STABILITY_RUSTFLAGS) -join " "
+    # allocation counts are unaffected. Treat any RUSTFLAGS the runner set as opaque: remove only a
+    # pre-existing -align-all-functions token, then append the stability value so the 64-byte
+    # setting always wins - never duplicated, never silently skipped in favour of a stray value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     # The delta job passes the impacted packages space-separated (the same shape validation.yml's
     # `just package="..."` gating uses); split them into the array the module scopes on.

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -60,9 +60,10 @@ gh-collect-bench-history:
     # child process that inherits this RUSTFLAGS. Function-alignment padding sits between functions
     # and is never executed, so any Callgrind instruction counts or allocation counts gathered in
     # the same collection are unaffected. Treat any RUSTFLAGS the runner set as opaque: remove only
-    # a pre-existing -align-all-functions token, then append the stability value so the 64-byte
-    # setting always wins - never duplicated, never silently skipped in favour of a stray value.
-    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    # a pre-existing -align-all-functions token (in any -C/--codegen spelling), then append the
+    # stability value so the 64-byte setting always wins - never duplicated, never silently skipped
+    # in favour of a stray value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
     $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     # RECOLLECT_COMMIT_ID is empty on a push / plain dispatch (normal append) and a commit SHA when
@@ -103,9 +104,10 @@ gh-collect-pr-bench-history packages:
     # stable against link-layout shifts (see constants.env); the tool spawns `cargo bench` as a
     # child that inherits this RUSTFLAGS, and the padding is never executed so instruction and
     # allocation counts are unaffected. Treat any RUSTFLAGS the runner set as opaque: remove only a
-    # pre-existing -align-all-functions token, then append the stability value so the 64-byte
-    # setting always wins - never duplicated, never silently skipped in favour of a stray value.
-    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    # pre-existing -align-all-functions token (in any -C/--codegen spelling), then append the
+    # stability value so the 64-byte setting always wins - never duplicated, never silently skipped
+    # in favour of a stray value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
     $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     # The delta job passes the impacted packages space-separated (the same shape validation.yml's

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -59,11 +59,11 @@ gh-collect-bench-history:
     # stable against link-layout shifts (see constants.env). The tool spawns `cargo bench` as a
     # child process that inherits this RUSTFLAGS. Function-alignment padding sits between functions
     # and is never executed, so any Callgrind instruction counts or allocation counts gathered in
-    # the same collection are unaffected. Preserve any existing RUSTFLAGS and add the flag once.
-    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
-    if ($existing_rustflags -notlike "*align-all-functions*") {
-        $env:RUSTFLAGS = ($existing_rustflags, $env:BENCH_STABILITY_RUSTFLAGS | Where-Object { $_ }) -join " "
-    }
+    # the same collection are unaffected. Keep any other RUSTFLAGS the runner set, but drop a
+    # pre-existing -align-all-functions token first so the stability value always wins - never
+    # duplicated, never silently skipped in favour of a stray runner value.
+    $kept_rustflags = @(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') })
+    $env:RUSTFLAGS = (@($kept_rustflags) + $env:BENCH_STABILITY_RUSTFLAGS) -join " "
 
     # RECOLLECT_COMMIT_ID is empty on a push / plain dispatch (normal append) and a commit SHA when
     # repairing one historical point (overwrite). The mode-selection logic - and the untrusted-input
@@ -102,11 +102,11 @@ gh-collect-pr-bench-history packages:
     # Build the benchmarks with 64-byte function alignment so the collected wall-clock series are
     # stable against link-layout shifts (see constants.env); the tool spawns `cargo bench` as a
     # child that inherits this RUSTFLAGS, and the padding is never executed so instruction and
-    # allocation counts are unaffected. Preserve any existing RUSTFLAGS and add the flag once.
-    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
-    if ($existing_rustflags -notlike "*align-all-functions*") {
-        $env:RUSTFLAGS = ($existing_rustflags, $env:BENCH_STABILITY_RUSTFLAGS | Where-Object { $_ }) -join " "
-    }
+    # allocation counts are unaffected. Keep any other RUSTFLAGS the runner set, but drop a
+    # pre-existing -align-all-functions token first so the stability value always wins - never
+    # duplicated, never silently skipped in favour of a stray runner value.
+    $kept_rustflags = @(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') })
+    $env:RUSTFLAGS = (@($kept_rustflags) + $env:BENCH_STABILITY_RUSTFLAGS) -join " "
 
     # The delta job passes the impacted packages space-separated (the same shape validation.yml's
     # `just package="..."` gating uses); split them into the array the module scopes on.

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -55,6 +55,16 @@ gh-collect-bench-history:
 
     Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
 
+    # Build the benchmarks with 64-byte function alignment so the collected wall-clock series are
+    # stable against link-layout shifts (see constants.env). The tool spawns `cargo bench` as a
+    # child process that inherits this RUSTFLAGS. Function-alignment padding sits between functions
+    # and is never executed, so any Callgrind instruction counts or allocation counts gathered in
+    # the same collection are unaffected. Preserve any existing RUSTFLAGS and add the flag once.
+    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
+    if ($existing_rustflags -notlike "*align-all-functions*") {
+        $env:RUSTFLAGS = ($existing_rustflags, $env:BENCH_STABILITY_RUSTFLAGS | Where-Object { $_ }) -join " "
+    }
+
     # RECOLLECT_COMMIT_ID is empty on a push / plain dispatch (normal append) and a commit SHA when
     # repairing one historical point (overwrite). The mode-selection logic - and the untrusted-input
     # validation - lives in the module so it is Pester-tested (BenchHistoryCollect.Tests.ps1); this
@@ -88,6 +98,15 @@ gh-collect-pr-bench-history packages:
     $PSNativeCommandUseErrorActionPreference = $true
 
     Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
+
+    # Build the benchmarks with 64-byte function alignment so the collected wall-clock series are
+    # stable against link-layout shifts (see constants.env); the tool spawns `cargo bench` as a
+    # child that inherits this RUSTFLAGS, and the padding is never executed so instruction and
+    # allocation counts are unaffected. Preserve any existing RUSTFLAGS and add the flag once.
+    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
+    if ($existing_rustflags -notlike "*align-all-functions*") {
+        $env:RUSTFLAGS = ($existing_rustflags, $env:BENCH_STABILITY_RUSTFLAGS | Where-Object { $_ }) -join " "
+    }
 
     # The delta job passes the impacted packages space-separated (the same shape validation.yml's
     # `just package="..."` gating uses); split them into the array the module scopes on.

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -63,7 +63,7 @@ gh-collect-bench-history:
     # a pre-existing -align-all-functions token (in any -C/--codegen spelling), then append the
     # stability value so the 64-byte setting always wins - never duplicated, never silently skipped
     # in favour of a stray value.
-    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s*|--codegen(?:\s+|=))llvm-args=-align-all-functions=\d+', '').Trim()
     $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     # RECOLLECT_COMMIT_ID is empty on a push / plain dispatch (normal append) and a commit SHA when
@@ -107,7 +107,7 @@ gh-collect-pr-bench-history packages:
     # pre-existing -align-all-functions token (in any -C/--codegen spelling), then append the
     # stability value so the 64-byte setting always wins - never duplicated, never silently skipped
     # in favour of a stray value.
-    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s*|--codegen(?:\s+|=))llvm-args=-align-all-functions=\d+', '').Trim()
     $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     # The delta job passes the impacted packages space-separated (the same shape validation.yml's

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -18,9 +18,10 @@ bench TARGET="":
     # phantom wall-clock regression (see constants.env and the cargo-bench-history "Measurement
     # stability" guide). $env:BENCH_STABILITY_RUSTFLAGS comes from constants.env via dotenv. Treat
     # any RUSTFLAGS the caller set as an opaque string: remove only a pre-existing
-    # -align-all-functions token, then append the stability value so the 64-byte setting always
-    # wins - never duplicated, never silently skipped in favour of a stray caller value.
-    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    # -align-all-functions token (in any -C/--codegen spelling), then append the stability value so
+    # the 64-byte setting always wins - never duplicated, never silently skipped in favour of a
+    # stray caller value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
     $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     cargo bench {{ target_package }} --all-features $target_selector --locked
@@ -49,8 +50,8 @@ bench-best TARGET="":
     # Best-case means NO forced alignment, so remove any -align-all-functions token that may have
     # been inherited from the environment (e.g. an exported BENCH_STABILITY_RUSTFLAGS); otherwise
     # this would silently run aligned and stop being a true best case. Treat RUSTFLAGS as opaque
-    # and strip only that token.
-    $env:RUSTFLAGS = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    # and strip only that token (in any -C/--codegen spelling).
+    $env:RUSTFLAGS = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
 
     # Build under the `bench-best` profile (root Cargo.toml): the `release` base plus fat LTO and a
     # single codegen unit - the most aggressively optimized build the standard pipeline produces.
@@ -59,7 +60,7 @@ bench-best TARGET="":
     # compiler can still emit suboptimal code (closing that gap would need PGO), but it does remove
     # the explicit pessimizations we accept elsewhere in the name of measurement stability.
 
-    cargo bench {{ target_package }} --all-features $target_selector --locked
+    cargo bench {{ target_package }} --profile bench-best --all-features $target_selector --locked
 
 # Run Callgrind-based instruction-count benchmarks. Requires Linux (Valgrind)
 # and the `gungraun-runner` binary on PATH; both are installed by

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -21,7 +21,7 @@ bench TARGET="":
     # -align-all-functions token (in any -C/--codegen spelling), then append the stability value so
     # the 64-byte setting always wins - never duplicated, never silently skipped in favour of a
     # stray caller value.
-    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s*|--codegen(?:\s+|=))llvm-args=-align-all-functions=\d+', '').Trim()
     $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     cargo bench {{ target_package }} --all-features $target_selector --locked
@@ -51,7 +51,7 @@ bench-best TARGET="":
     # been inherited from the environment (e.g. an exported BENCH_STABILITY_RUSTFLAGS); otherwise
     # this would silently run aligned and stop being a true best case. Treat RUSTFLAGS as opaque
     # and strip only that token (in any -C/--codegen spelling).
-    $env:RUSTFLAGS = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s?|--codegen[ =])llvm-args=-align-all-functions=\d+', '').Trim()
+    $env:RUSTFLAGS = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s*|--codegen(?:\s+|=))llvm-args=-align-all-functions=\d+', '').Trim()
 
     # Build under the `bench-best` profile (root Cargo.toml): the `release` base plus fat LTO and a
     # single codegen unit - the most aggressively optimized build the standard pipeline produces.

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -16,12 +16,12 @@ bench TARGET="":
     # instruction-cache lines across relinks; without it an unrelated dependency bump can reorder
     # functions and shift a byte-identical loop across a cache-line boundary, showing up as a
     # phantom wall-clock regression (see constants.env and the cargo-bench-history "Measurement
-    # stability" guide). $env:BENCH_STABILITY_RUSTFLAGS comes from constants.env via dotenv. Keep
-    # any other RUSTFLAGS the caller set, but drop a pre-existing -align-all-functions token first
-    # so the stability value always wins - and is never duplicated or silently skipped in favour of
-    # a stray caller value.
-    $kept_rustflags = @(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') })
-    $env:RUSTFLAGS = (@($kept_rustflags) + $env:BENCH_STABILITY_RUSTFLAGS) -join " "
+    # stability" guide). $env:BENCH_STABILITY_RUSTFLAGS comes from constants.env via dotenv. Treat
+    # any RUSTFLAGS the caller set as an opaque string: remove only a pre-existing
+    # -align-all-functions token, then append the stability value so the 64-byte setting always
+    # wins - never duplicated, never silently skipped in favour of a stray caller value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
+    $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
 
     cargo bench {{ target_package }} --all-features $target_selector --locked
 
@@ -44,10 +44,11 @@ bench-best TARGET="":
         $target_selector += "{{ TARGET }}"
     }
 
-    # Best-case means NO forced alignment, so strip any -align-all-functions token that may have
+    # Best-case means NO forced alignment, so remove any -align-all-functions token that may have
     # been inherited from the environment (e.g. an exported BENCH_STABILITY_RUSTFLAGS); otherwise
-    # this would silently run aligned and stop being a true best case.
-    $env:RUSTFLAGS = (@(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') }) -join " ")
+    # this would silently run aligned and stop being a true best case. Treat RUSTFLAGS as opaque
+    # and strip only that token.
+    $env:RUSTFLAGS = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
 
     # Override the `bench` profile (which inherits `release`: no LTO, 16 codegen units) for this
     # invocation only, via cargo's per-profile environment overrides. Fat LTO plus a single

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -52,15 +52,12 @@ bench-best TARGET="":
     # and strip only that token.
     $env:RUSTFLAGS = ("$env:RUSTFLAGS" -replace '(^|\s)-Cllvm-args=-align-all-functions=\d+', '').Trim()
 
-    # Override the `bench` profile (which inherits `release`: no LTO, 16 codegen units) for this
-    # invocation only, via cargo's per-profile environment overrides. Fat LTO plus a single
-    # codegen unit gives the most aggressively optimized build the standard pipeline produces. No
-    # alignment flag is set, so this path is free to reach layouts `just bench` pins away from -
+    # Build under the `bench-best` profile (root Cargo.toml): the `release` base plus fat LTO and a
+    # single codegen unit - the most aggressively optimized build the standard pipeline produces.
+    # No alignment flag is set, so this path is free to reach layouts `just bench` pins away from -
     # that is the point: best case, not stable case. Note this is not a guaranteed optimum: the
     # compiler can still emit suboptimal code (closing that gap would need PGO), but it does remove
     # the explicit pessimizations we accept elsewhere in the name of measurement stability.
-    $env:CARGO_PROFILE_BENCH_LTO = "fat"
-    $env:CARGO_PROFILE_BENCH_CODEGEN_UNITS = "1"
 
     cargo bench {{ target_package }} --all-features $target_selector --locked
 

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -12,17 +12,16 @@ bench TARGET="":
         $target_selector += "{{ TARGET }}"
     }
 
-    # Build the benchmarks with 64-byte function alignment so hot loops keep a fixed position
-    # relative to the L1 instruction-cache lines across relinks; without it an unrelated
-    # dependency bump can reorder functions and shift a byte-identical loop across a cache-line
-    # boundary, showing up as a phantom wall-clock regression (see constants.env and the
-    # cargo-bench-history "Measurement stability" guide). $env:BENCH_STABILITY_RUSTFLAGS comes
-    # from constants.env via dotenv. Preserve any RUSTFLAGS the caller already set - chain, don't
-    # clobber - and add the flag only once.
-    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
-    if ($existing_rustflags -notlike "*align-all-functions*") {
-        $env:RUSTFLAGS = ($existing_rustflags, $env:BENCH_STABILITY_RUSTFLAGS | Where-Object { $_ }) -join " "
-    }
+    # Force 64-byte function alignment so hot loops keep a fixed position relative to the L1
+    # instruction-cache lines across relinks; without it an unrelated dependency bump can reorder
+    # functions and shift a byte-identical loop across a cache-line boundary, showing up as a
+    # phantom wall-clock regression (see constants.env and the cargo-bench-history "Measurement
+    # stability" guide). $env:BENCH_STABILITY_RUSTFLAGS comes from constants.env via dotenv. Keep
+    # any other RUSTFLAGS the caller set, but drop a pre-existing -align-all-functions token first
+    # so the stability value always wins - and is never duplicated or silently skipped in favour of
+    # a stray caller value.
+    $kept_rustflags = @(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') })
+    $env:RUSTFLAGS = (@($kept_rustflags) + $env:BENCH_STABILITY_RUSTFLAGS) -join " "
 
     cargo bench {{ target_package }} --all-features $target_selector --locked
 
@@ -44,6 +43,11 @@ bench-best TARGET="":
         $target_selector += "--bench"
         $target_selector += "{{ TARGET }}"
     }
+
+    # Best-case means NO forced alignment, so strip any -align-all-functions token that may have
+    # been inherited from the environment (e.g. an exported BENCH_STABILITY_RUSTFLAGS); otherwise
+    # this would silently run aligned and stop being a true best case.
+    $env:RUSTFLAGS = (@(("$env:RUSTFLAGS" -split '\s+') | Where-Object { $_ -and ($_ -notlike '-Cllvm-args=-align-all-functions=*') }) -join " ")
 
     # Override the `bench` profile (which inherits `release`: no LTO, 16 codegen units) for this
     # invocation only, via cargo's per-profile environment overrides. Fat LTO plus a single

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -27,7 +27,9 @@ bench TARGET="":
 
 # Run the wall-clock benchmarks tuned for the best achievable numbers rather than for stability
 # across history: whole-program optimization (fat LTO, a single codegen unit) and NO alignment
-# padding. Use this to answer "how fast can this actually go" on the current machine. The results
+# padding. Use this to see how fast the standard pipeline gets this code on the current machine -
+# it drops the stability pessimizations `just bench` accepts, though it is not a guaranteed
+# optimum (the compiler can still be suboptimal; PGO would be needed to go further). The results
 # are deliberately NOT comparable with the `just bench` timeline that cargo-bench-history collects
 # - the build profile differs - so never feed a `bench-best` run into the history store.
 [group('testing')]
@@ -52,9 +54,11 @@ bench-best TARGET="":
 
     # Override the `bench` profile (which inherits `release`: no LTO, 16 codegen units) for this
     # invocation only, via cargo's per-profile environment overrides. Fat LTO plus a single
-    # codegen unit gives the most aggressively optimized build. No alignment flag is set, so this
-    # path is free to reach layouts `just bench` pins away from - that is the point: best case,
-    # not stable case.
+    # codegen unit gives the most aggressively optimized build the standard pipeline produces. No
+    # alignment flag is set, so this path is free to reach layouts `just bench` pins away from -
+    # that is the point: best case, not stable case. Note this is not a guaranteed optimum: the
+    # compiler can still emit suboptimal code (closing that gap would need PGO), but it does remove
+    # the explicit pessimizations we accept elsewhere in the name of measurement stability.
     $env:CARGO_PROFILE_BENCH_LTO = "fat"
     $env:CARGO_PROFILE_BENCH_CODEGEN_UNITS = "1"
 

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -12,6 +12,47 @@ bench TARGET="":
         $target_selector += "{{ TARGET }}"
     }
 
+    # Build the benchmarks with 64-byte function alignment so hot loops keep a fixed position
+    # relative to the L1 instruction-cache lines across relinks; without it an unrelated
+    # dependency bump can reorder functions and shift a byte-identical loop across a cache-line
+    # boundary, showing up as a phantom wall-clock regression (see constants.env and the
+    # cargo-bench-history "Measurement stability" guide). $env:BENCH_STABILITY_RUSTFLAGS comes
+    # from constants.env via dotenv. Preserve any RUSTFLAGS the caller already set - chain, don't
+    # clobber - and add the flag only once.
+    $existing_rustflags = if ($env:RUSTFLAGS) { $env:RUSTFLAGS } else { "" }
+    if ($existing_rustflags -notlike "*align-all-functions*") {
+        $env:RUSTFLAGS = ($existing_rustflags, $env:BENCH_STABILITY_RUSTFLAGS | Where-Object { $_ }) -join " "
+    }
+
+    cargo bench {{ target_package }} --all-features $target_selector --locked
+
+# Run the wall-clock benchmarks tuned for the best achievable numbers rather than for stability
+# across history: whole-program optimization (fat LTO, a single codegen unit) and NO alignment
+# padding. Use this to answer "how fast can this actually go" on the current machine. The results
+# are deliberately NOT comparable with the `just bench` timeline that cargo-bench-history collects
+# - the build profile differs - so never feed a `bench-best` run into the history store.
+[group('testing')]
+[script]
+bench-best TARGET="":
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    $target_selector = @()
+
+    if ("{{ TARGET }}" -ne "") {
+        $target_selector += "--bench"
+        $target_selector += "{{ TARGET }}"
+    }
+
+    # Override the `bench` profile (which inherits `release`: no LTO, 16 codegen units) for this
+    # invocation only, via cargo's per-profile environment overrides. Fat LTO plus a single
+    # codegen unit gives the most aggressively optimized build. No alignment flag is set, so this
+    # path is free to reach layouts `just bench` pins away from - that is the point: best case,
+    # not stable case.
+    $env:CARGO_PROFILE_BENCH_LTO = "fat"
+    $env:CARGO_PROFILE_BENCH_CODEGEN_UNITS = "1"
+
     cargo bench {{ target_package }} --all-features $target_selector --locked
 
 # Run Callgrind-based instruction-count benchmarks. Requires Linux (Valgrind)
@@ -19,6 +60,11 @@ bench TARGET="":
 # `just install-tools`. Discovers any bench file whose name ends with `_cg`
 # (short for Callgrind) under `packages/<pkg>/benches/`. Callers on Windows
 # must invoke this through WSL themselves.
+#
+# Unlike `just bench`, this recipe deliberately does NOT force function alignment
+# ($env:BENCH_STABILITY_RUSTFLAGS): Callgrind counts executed instructions, which are already
+# independent of where functions land in memory, so alignment buys no stability here and only
+# perturbs the build. The alignment flag exists purely to stabilize wall-clock timings.
 [group('testing')]
 [script]
 bench-cg TARGET="":

--- a/packages/cargo-bench-history/book/src/SUMMARY.md
+++ b/packages/cargo-bench-history/book/src/SUMMARY.md
@@ -23,4 +23,5 @@
 
 - [Benchmark engines](concepts/engines.md)
 - [Comparability and partitioning](concepts/comparability.md)
+- [Measurement stability](concepts/stability.md)
 - [Analysis](concepts/analysis.md)

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -81,9 +81,9 @@ Two consequences worth planning for:
 - **Introducing it is a one-time step.** Because the build flag is not part of a result's
   identity, aligned and unaligned runs share a series, so turning alignment on shifts wall-clock
   numbers once, at the commit that introduces it. Land that change on its own commit and
-  [`bless`](../commands/bless.md) the affected series at it — `bless --all --context <commit>`
-  accepts the whole workspace in one step — so history-mode analysis reads the step as an accepted
-  baseline change rather than a regression.
+  [`bless`](../commands/bless.md) the affected series at it — `cargo bench-history bless --all
+  --context <commit>` accepts the whole workspace in one step — so history-mode analysis reads the
+  step as an accepted baseline change rather than a regression.
 - **Pull-request comparisons re-baseline on their own.** Blessing re-baselines history-mode
   analysis only; a pull request is judged directly against the recent base-branch points, which
   blessing does not adjust. Until enough aligned points accumulate on the base branch, a pull

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -81,9 +81,9 @@ Two consequences worth planning for:
 - **Introducing it is a one-time step.** Because the build flag is not part of a result's
   identity, aligned and unaligned runs share a series, so turning alignment on shifts wall-clock
   numbers once, at the commit that introduces it. Land that change on its own commit and
-  [`bless`](../commands/bless.md) the affected series at it — `cargo bench-history bless --all
-  --context <commit>` accepts the whole workspace in one step — so history-mode analysis reads the
-  step as an accepted baseline change rather than a regression.
+  [`bless`](../commands/bless.md) the affected series at it —
+  `cargo bench-history bless --all --context <commit>` accepts the whole workspace in one step — so
+  history-mode analysis reads the step as an accepted baseline change rather than a regression.
 - **Pull-request comparisons re-baseline on their own.** Blessing re-baselines history-mode
   analysis only; a pull request is judged directly against the recent base-branch points, which
   blessing does not adjust. Until enough aligned points accumulate on the base branch, a pull

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -44,12 +44,16 @@ cache line. `=5` (32 bytes) is cheaper but only *partly* pins the layout: a func
 start at either the `0` or `32` offset within a line, so a loop long enough to cross the midpoint
 can still straddle. Only 64-byte alignment makes each loop's placement fully deterministic.
 
-Align **functions only** — and this is a *complete* fix for relink-driven instability, not a
-partial one. Once every function starts on a cache-line boundary, a loop's offset from the nearest
-boundary equals its offset *within its own function*. Relinking only ever moves whole functions
-around; it never rewrites a function's internal byte layout. So that intra-function offset — and
-therefore the loop's position relative to the cache lines — is fixed for a given source and can no
-longer shift when an unrelated dependency reorders the binary.
+Align **functions only** — for code the LLVM backend emits under deterministic codegen (which is
+what a Rust benchmark and its dependencies compile to), this is a *complete* fix for relink-driven
+instability, not a partial one. Once every function starts on a cache-line boundary, a loop's
+offset from the nearest boundary equals its offset *within its own function*. Relinking only ever
+moves whole functions around; it never rewrites a function's internal byte layout. So that
+intra-function offset — and therefore the loop's position relative to the cache lines — is fixed
+for a given source and can no longer shift when an unrelated dependency reorders the binary. (The
+flag aligns only LLVM-emitted functions; machine code from a C dependency, hand-written assembly
+or a prebuilt static library is unaffected, and would need its own alignment if it hosted the hot
+loop.)
 
 Do **not** additionally pass `-align-all-nofallthru-blocks`. It aligns basic blocks *inside*
 functions, which buys no extra relink stability — intra-function layout is already deterministic
@@ -75,7 +79,14 @@ Two consequences worth planning for:
   executed instructions, which do not depend on where functions land, so alignment neither helps
   nor should be applied there. Allocation-tracking metrics are likewise layout-invariant.
 - **Introducing it is a one-time step.** Because the build flag is not part of a result's
-  identity, aligned and unaligned runs share a series. Turning alignment on shifts wall-clock
-  numbers once, at the commit that introduces it. Land that change on its own and
-  [`bless`](../commands/bless.md) the affected series at that commit so the step is not reported
-  as a regression.
+  identity, aligned and unaligned runs share a series, so turning alignment on shifts wall-clock
+  numbers once, at the commit that introduces it. Land that change on its own commit and
+  [`bless`](../commands/bless.md) the affected series at it — `bless --all --context <commit>`
+  accepts the whole workspace in one step — so history-mode analysis reads the step as an accepted
+  baseline change rather than a regression.
+- **Pull-request comparisons re-baseline on their own.** Blessing re-baselines history-mode
+  analysis only; a pull request is judged directly against the recent base-branch points, which
+  blessing does not adjust. Until enough aligned points accumulate on the base branch, a pull
+  request that touches an affected wall-clock benchmark can show a one-time-shift-sized move in its
+  performance comment. Those findings are advisory rather than merge gates and clear themselves
+  once the aligned baseline fills in.

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -1,0 +1,64 @@
+# Measurement stability
+
+`cargo-bench-history` compares a benchmark against its own past. That comparison is only
+meaningful if a run's number moves when — and only when — the thing being measured actually
+changes. Wall-clock benchmarks have a notorious source of movement that has nothing to do with
+your code: **instruction-cache layout**.
+
+## The phantom regression
+
+A CPU fetches instructions in fixed-size lines (64 bytes on x86-64). A hot loop that fits
+entirely inside one line is fetched cheaply; the same loop straddling two lines costs an extra
+fetch on every iteration. Where a loop lands is decided by the linker, which orders functions in
+the final binary. That order can shift for reasons entirely outside the benchmarked crate — most
+commonly an unrelated dependency version bump that adds or removes code ahead of your function.
+
+The result is a step in the timeline with **no source change**: a byte-identical hot loop that
+used to sit inside one cache line now straddles two, and the benchmark reports a regression that
+no diff explains. It persists until the layout shifts again, so it looks like a real, lasting
+change. This is a property of the machine, not of the tool: the same relink would perturb any
+wall-clock measurement.
+
+## Pinning the layout
+
+You can make layout a deterministic function of your source by forcing every function to start on
+a cache-line boundary. Then a hot loop's position relative to the cache lines depends only on its
+own offset within its function — which your source fixes — and never on what the linker placed
+before it.
+
+With the LLVM backend (stable Rust), set this through `RUSTFLAGS` when building benchmarks:
+
+```text
+RUSTFLAGS = -Cllvm-args=-align-all-functions=6
+```
+
+The value is a **log2 exponent**, so `=6` aligns every function to `2^6 = 64` bytes — one full
+cache line. `=5` (32 bytes) is cheaper but only *partly* pins the layout: a function can still
+start at either the `0` or `32` offset within a line, so a loop long enough to cross the midpoint
+can still straddle. Only 64-byte alignment makes each loop's placement fully deterministic.
+
+Align **functions only**. Do not add `-align-all-nofallthru-blocks`: that pads *inside* loops,
+injecting NOPs into the measured path, which can make small hot loops dramatically slower rather
+than more stable.
+
+The cost is a modest `.text` size increase (padding between functions) and, for a benchmark that
+was previously lucky enough to sit inside a line, a one-time shift to its aligned position. After
+that, the series stays put.
+
+## `cargo-bench-history` does not impose this
+
+The tool measures whatever your benchmarks produce; it does not inject `RUSTFLAGS` or dictate a
+build profile. Stability of the *inputs* is the responsibility of whoever builds and runs the
+benchmarks. Apply the flag in your own benchmark build path — a `just` recipe, a CI step, a
+`cargo bench` wrapper — so that every run the tool collects is built the same way.
+
+Two consequences worth planning for:
+
+- **Only wall-clock engines need it.** Instruction-count engines (for example Callgrind) count
+  executed instructions, which do not depend on where functions land, so alignment neither helps
+  nor should be applied there. Allocation-tracking metrics are likewise layout-invariant.
+- **Introducing it is a one-time step.** Because the build flag is not part of a result's
+  identity, aligned and unaligned runs share a series. Turning alignment on shifts wall-clock
+  numbers once, at the commit that introduces it. Land that change on its own and
+  [`bless`](../commands/bless.md) the affected series at that commit so the step is not reported
+  as a regression.

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -44,9 +44,19 @@ cache line. `=5` (32 bytes) is cheaper but only *partly* pins the layout: a func
 start at either the `0` or `32` offset within a line, so a loop long enough to cross the midpoint
 can still straddle. Only 64-byte alignment makes each loop's placement fully deterministic.
 
-Align **functions only**. Do not add `-align-all-nofallthru-blocks`: that pads *inside* loops,
-injecting NOPs into the measured path, which can make small hot loops dramatically slower rather
-than more stable.
+Align **functions only** — and this is a *complete* fix for relink-driven instability, not a
+partial one. Once every function starts on a cache-line boundary, a loop's offset from the nearest
+boundary equals its offset *within its own function*. Relinking only ever moves whole functions
+around; it never rewrites a function's internal byte layout. So that intra-function offset — and
+therefore the loop's position relative to the cache lines — is fixed for a given source and can no
+longer shift when an unrelated dependency reorders the binary.
+
+Do **not** additionally pass `-align-all-nofallthru-blocks`. It aligns basic blocks *inside*
+functions, which buys no extra relink stability — intra-function layout is already deterministic
+under fixed codegen — while injecting NOPs into the measured path that can make small hot loops
+dramatically slower. A loop that straddles a line purely because of its offset within its own
+function does so deterministically for a given source: that is a fixed performance cost, not a
+phantom regression, so it is a performance question rather than a stability one.
 
 The cost is a modest `.text` size increase (padding between functions) and, for a benchmark that
 was previously lucky enough to sit inside a line, a one-time shift to its aligned position. After

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -26,10 +26,17 @@ a cache-line boundary. Then a hot loop's position relative to the cache lines de
 own offset within its function — which your source fixes — and never on what the linker placed
 before it.
 
-With the LLVM backend (stable Rust), set this through `RUSTFLAGS` when building benchmarks:
+With the LLVM backend (stable Rust), set the flag through the `RUSTFLAGS` environment variable
+when building benchmarks — for example:
 
-```text
-RUSTFLAGS = -Cllvm-args=-align-all-functions=6
+```sh
+# bash / zsh
+RUSTFLAGS="-Cllvm-args=-align-all-functions=6" cargo bench
+```
+
+```powershell
+# PowerShell
+$env:RUSTFLAGS = "-Cllvm-args=-align-all-functions=6"; cargo bench
 ```
 
 The value is a **log2 exponent**, so `=6` aligns every function to `2^6 = 64` bytes — one full


### PR DESCRIPTION
[Copilot speaking]

## Summary

Wall-clock benchmarks in this repo suffer *phantom* regressions: an unrelated dependency version bump reorders functions in the final binary, which shifts a byte-identical hot loop from sitting inside a single 64-byte L1 instruction-cache line to straddling two, adding an I-cache fetch per iteration. The result is a lasting step in the timeline with no source change. This was diagnosed on the `nm_performance/observation/*` benchmarks (a ~19 → ~24 ns jump at a "harmless" release commit) and confirmed both locally and with VTune (instruction-cache misses).

This PR pins the layout so a hot loop's position relative to the cache lines is a deterministic function of the source, immune to relink order.

## What changed

- **`constants.env`** — new shared `BENCH_STABILITY_RUSTFLAGS=-Cllvm-args=-align-all-functions=6`. The value is a log2 exponent, so `=6` aligns every function entry to 64 bytes (one cache line).
- **`just bench`** and the CI collection recipes **`gh-collect-bench-history`** / **`gh-collect-pr-bench-history`** — chain the flag into `RUSTFLAGS` (preserving any existing value, added once). The collection tool spawns `cargo bench` as a child that inherits it.
- **`just bench-cg`** stays deliberately unaligned — Callgrind counts executed instructions, which are layout-invariant, so alignment buys no stability there. A comment records why.
- **New `just bench-best`** — no alignment, fat LTO and a single codegen unit, for best-case numbers. Its results are deliberately *not* comparable with the `just bench` history (different build profile) and must never be fed into the store.
- **User guide** — new "Measurement stability" concept page for cargo-bench-history, framed as recommended practice for whoever runs benchmarks, **not** something the tool imposes.

## Why 64-byte, functions-only

Empirically verified across three builds (unaligned / 32-byte / 64-byte):

- **64-byte (`=6`)** makes every source function start `mod 64 == 0`, so all affected loops are single-line by construction and stable across every relink. Recovers the regressed cases ~20-23%, with no collateral regressions. `.text` grows ~7.4%.
- **32-byte (`=5`)** leaves a `{0,32}` freedom, so a 27-byte loop can still straddle (safe only by chance), and it caused ~11% collateral slowdown on a control case. Insufficient.
- **Functions only** — `-align-all-nofallthru-blocks` was rejected: it pads *inside* loops, injecting NOPs on the measured path and making tiny hot loops dramatically slower.

Instruction-count (Callgrind) and allocation metrics are unaffected because function-alignment padding sits between functions and is never executed.

## One-time history step

The build flag is not part of a result's identity, so aligned and unaligned runs share a series. Turning alignment on shifts every wall-clock series once, at the commit that introduces it (some series faster where alignment recovers a straddling loop, some marginally slower from inter-function padding).

**Operator step at merge.** Bless the introduction commit so history-mode analysis reads the step as an accepted baseline rather than a regression:

```
cargo-bench-history bless --all --context <merge-commit>
```

Do this before the *second* post-merge `main` collection runs `analyze`; otherwise that run files a one-off "Benchmark regressions detected" issue, which does not auto-close, so you would close it by hand after blessing.

**Branch/PR comparisons self-heal.** Blessing re-baselines history-mode analysis only. A pull request is judged directly against the recent base-branch points, which blessing does not touch, so for the first several post-merge `main` collections a PR touching an affected wall-clock benchmark may show a one-time-shift-sized move in its performance comment. Those findings are advisory (never merge gates) and clear themselves once the aligned baseline fills in.

## Validation

- Justfiles parse; the dotenv value (which contains `=`) reaches the recipe environment intact.
- `just bench cbh_model` runs clean end-to-end with alignment active.
- `bench-best`'s fat-LTO / single-codegen-unit overrides compile.
- The cargo-bench-history mdBook builds with the new page and TOC entry.

