### PR TITLE
Render lagged history and data-less commits as chart gaps

### DIFF
--- a/packages/cargo-bench-history/book/src/commands/analyze.md
+++ b/packages/cargo-bench-history/book/src/commands/analyze.md
@@ -48,10 +48,13 @@ See [Analysis](../concepts/analysis.md) for what each mode detects.
 ## Output
 
 Each finding names the benchmark and metric, quantifies the move and confidence, attributes
-it to a commit, and draws a compact chart. History mode charts the full selected series.
-Branch mode charts the comparison baseline followed by the recent observations ending at
-the tip, keeping the one commit being judged visible; intermediate branch points provide
-visual context but do not change the tip-only judgment.
+it to a commit, and draws a compact, topology-accurate chart — one column per first-parent
+commit, so a commit with no measurement is a gap rather than being collapsed away. History
+mode charts the full selected series, keeping a trailing gap up to the analyzed tip when a
+benchmark has not been measured on the most recent commits. Branch mode charts the comparison
+baseline followed by the recent per-commit tail ending at the tip, keeping the one commit
+being judged visible and drawing any comparison-base lag as the empty columns before the tip;
+intermediate branch points do not change the tip-only judgment.
 
 Text goes to stdout by default. File toggles compose, so a single pass can emit text,
 Markdown, and JSON at once; requesting no output at all is an error. A derived, condensed

--- a/packages/cargo-bench-history/book/src/commands/examine.md
+++ b/packages/cargo-bench-history/book/src/commands/examine.md
@@ -23,6 +23,8 @@ benchmark identity and the metric, so pasting them back in is natural.
 `examine` is a drill-down sibling of [`list runs`](list.md): both are read-only previews over
 `analyze`'s exact data-set selection that never analyze. It runs **no detection and no
 re-baselining** — it has no findings, modes, or blessings — and repeats the pivot once per
-matching discriminant set. The text and Markdown renderings lead each set with a small
-line chart of the selected series; the JSON form
-carries the ordered points at full precision with each commit's full title.
+matching discriminant set. The text and Markdown renderings lead each set with the same
+compact, topology-accurate line chart `analyze` draws — one column per first-parent commit,
+so a data-less commit is a gap and a series that stops short of the analyzed tip shows a
+trailing gap. The tabular rows and the JSON form carry only the **real observations** at full
+precision with each commit's full title; the gaps live in the chart alone.

--- a/packages/cargo-bench-history/book/src/concepts/analysis.md
+++ b/packages/cargo-bench-history/book/src/concepts/analysis.md
@@ -96,10 +96,16 @@ keys off a top-level "notable" flag and reads each finding's direction, magnitud
 attribution. Separately, `analyze` can render a condensed Markdown **summary** — a lossy
 excerpt for a size-limited downstream consumer.
 
-Human-readable findings include a compact chart. History mode shows the full selected
-series, including pre-blessing context; branch mode shows the comparison baseline and a
-bounded recent tail ending at the tip, so the commit being judged remains visible without
-compressing months of history into the same chart.
+Human-readable findings include a compact, **topology-accurate** chart: one column per
+first-parent commit from the first observation onward, so a commit with no measurement
+renders as a gap (a broken line) rather than being collapsed away. Leading gaps are trimmed
+and interior gaps kept, and a trailing gap up to the analyzed tip is the visual form of the
+"no newer data" disclosure — a benchmark not measured on the most recent commits. History
+mode shows the full selected series, including pre-blessing context; branch mode shows the
+comparison baseline and a bounded recent tail ending at the tip, dropping the interior branch
+commits and drawing the [comparison-base lag](#comparison-base-lag) as the empty columns
+between the newest base observation and the tip, so the commit being judged remains visible
+without compressing months of history into the same chart.
 
 There is **no severity classification**: a finding's magnitude is conveyed by its
 relative-change percent, and which findings warrant action is left to human or agent judgment.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -639,18 +639,20 @@ gives; when runs enter but none carry the named `(benchmark, metric)` pair, a di
 pointing at the unmatched benchmark id or metric name.
 
 `examine` runs **no detection and no re-baselining** — it has no findings, modes, or
-blessings. It shows every selected point exactly as the chart would plot it (a commit
-carrying both a clean run and dirty snapshots contributes a row each, ordered
-clean-before-dirty and flagged, so a value's provenance is unambiguous), which is why the
-analysis-only flags (improvements, inactive findings) are not part of its surface. The
-three output renderings compose from one pass as everywhere else: the per-commit table on
-stdout by default, the same table in Markdown, and a machine-readable JSON form that carries,
-per discriminant set, the ordered points with full-precision values and each commit's full
-title — the 50-character title truncation is a readability convenience of the text and
-Markdown tables, not of the data. The text and Markdown renderings **lead each set with the
-same small line chart `analyze` draws**, reusing its renderer, so a maintainer sees the shape
-of the series before reading the points it pivots; the line is drawn **uncolored**, and it is
-drawn only when a set has at least two points. The JSON form
+blessings. It lists every selected **observation** (a commit carrying both a clean run and
+dirty snapshots contributes a row each, ordered clean-before-dirty and flagged, so a value's
+provenance is unambiguous), which is why the analysis-only flags (improvements, inactive
+findings) are not part of its surface. The three output renderings compose from one pass as
+everywhere else: the per-commit table on stdout by default, the same table in Markdown, and a
+machine-readable JSON form that carries, per discriminant set, the ordered points with
+full-precision values and each commit's full title — the 50-character title truncation is a
+readability convenience of the text and Markdown tables, not of the data. The text and
+Markdown renderings **lead each set with the same small line chart `analyze` draws**, reusing
+its renderer, so a maintainer sees the shape of the series before reading the points it
+pivots; the chart is **topology-accurate** — one column per first-parent commit, so a
+data-less commit between observations (or a trailing run of them up to the analyzed tip)
+renders as a gap that the tabular points, which list only real observations, do not carry.
+The line is drawn **uncolored**, and only when a set has at least two points. The JSON form
 carries no chart (a charting concern the human reports draw from internally, not data a
 consumer reconstructs).
 
@@ -882,14 +884,35 @@ Every history-mode finding therefore carries an active flag distinguishing the t
   construction. A re-baselined finding records the blessing's commit and time for
   provenance.
 
-The history-mode chart plots the whole series, so the long-range trend the finding is about
-stays visible alongside the earlier context kept for continuity. Branch mode charts
-differently: it
-judges only the **tip commit**, so it plots the detector's comparison baseline followed by
-the recent tail of the series ending at the tip rather than the whole history. Charting
-the full, possibly months-long series would resample it down to the fixed chart width and
-shrink the one commit that matters to an indistinct edge column; the bounded comparison
-chart keeps both the base level and the tip legible and unaliased.
+Charts are **topology-accurate**: a commit's column position reflects its place in
+first-parent history, not its ordinal among the observations. A finding stores only its
+real observations (each tagged with its commit's first-parent index); the renderer
+materializes one column per commit from the first observation onward and draws a
+data-less commit as a **gap** (a broken line), so five missing commits read as five empty
+columns rather than collapsing into one. Leading gaps are trimmed — the line always opens
+on the first observation — while interior gaps are kept. A **trailing gap** from the last
+observation up to the analyzed tip is kept too: it is the visual form of the "no newer
+data" disclosure, showing at a glance that the benchmark has not been measured on the most
+recent commits.
+
+The history-mode chart plots the whole series this way, so the long-range trend the finding
+is about stays visible alongside the earlier context kept for continuity. Branch mode charts
+differently: it judges only the **tip commit**, so it plots the detector's comparison
+baseline followed by the recent per-commit tail ending at the tip rather than the whole
+history, dropping the interior branch commits and representing the tip by a single column at
+its judged latest value. The gap between the newest base observation and that tip column is
+exactly the comparison-base lag (§8.8), drawn as empty interior columns. Charting the full,
+possibly months-long series would shrink the one commit that matters to an indistinct edge
+column; the bounded comparison chart keeps both the base level and the tip legible and
+unaliased.
+
+Both charts bin their columns to at most the fixed chart width **before** plotting: the
+underlying plotter resamples a series to its width with linear interpolation *before*
+computing the axis extrema, and that interpolation is NaN-poisoning, so handing it a long
+gapped series would blend an isolated observation trapped between gaps into a gap and drop
+it — and its axis extreme — entirely. Binning first places every observation in a column by
+integer position (never interpolated away) and leaves empty columns as gaps, so no
+observation and neither axis extreme is ever lost.
 
 ### 8.7 Report formats
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -911,8 +911,10 @@ underlying plotter resamples a series to its width with linear interpolation *be
 computing the axis extrema, and that interpolation is NaN-poisoning, so handing it a long
 gapped series would blend an isolated observation trapped between gaps into a gap and drop
 it — and its axis extreme — entirely. Binning first places every observation in a column by
-integer position (never interpolated away) and leaves empty columns as gaps, so no
-observation and neither axis extreme is ever lost.
+integer position (never interpolated away) and leaves empty columns as gaps, so an isolated
+observation is never dropped and every gap survives. Once the span outgrows the chart width
+several observations can share a column and are averaged, which blurs that dense region and
+can attenuate an extreme falling inside it — the one detail binning gives up.
 
 ### 8.7 Report formats
 

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1768,3 +1768,169 @@ async fn analyze_excludes_ghost_benchmarks() {
         "the ghost benchmark must not appear: {report}"
     );
 }
+
+/// The rendered chart's rows: every axis row carries a `┤` or `┼` tick and the
+/// chart is always drawn uncolored, so filtering on those glyphs isolates the plot
+/// from the surrounding (possibly colored) report prose.
+fn chart_lines(report: &str) -> Vec<&str> {
+    report
+        .lines()
+        .filter(|line| line.contains('┤') || line.contains('┼'))
+        .collect()
+}
+
+/// The chart's rendered width in characters — the widest of its rows. Two charts
+/// spanning the same number of topology columns share this width even when one
+/// carries a trailing gap, so a width match proves the fill reached the tip column.
+fn chart_width(report: &str) -> usize {
+    chart_lines(report)
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0)
+}
+
+/// A feature branch whose comparison base lags the merge-base — the newest base
+/// data sits one commit behind the branch point — both warns in prose and still
+/// draws the branch chart. That trailing lag is the visual form of the warning: the
+/// chart spans the base history and the tip with the gap columns in between.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_branch_comparison_base_lag_warns_and_charts_the_gap() {
+    let workspace = Workspace::repo(&storage_only_config());
+    // Base data reaches only c3; the c4 merge-base carries none, so the branch's
+    // comparison base ends one commit behind the branch point.
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.seed_callgrind("c2", 100.0);
+    workspace.commit_dated("2024-01-03", "c3");
+    workspace.seed_callgrind("c3", 100.0);
+    // c4 is the merge-base and is intentionally left unseeded.
+    workspace.commit_dated("2024-01-04", "c4");
+    workspace.checkout_new_branch("feature");
+    workspace.commit_dated("2024-01-05", "f1");
+    workspace.seed_callgrind("f1", 130.0);
+    workspace.commit_dated("2024-01-06", "f2");
+    workspace.seed_callgrind("f2", 130.0);
+    workspace.commit_dated("2024-01-07", "f3");
+    workspace.seed_callgrind("f3", 130.0);
+
+    let RunOutcome::Analyzed {
+        regressions,
+        report,
+        ..
+    } = workspace.drive(&["analyze"]).await.unwrap()
+    else {
+        panic!("expected an analyzed outcome");
+    };
+    assert_eq!(
+        regressions, 1,
+        "the branch tip regresses against the base: {report}"
+    );
+    assert!(
+        report.contains(
+            "Warning: comparison base is 1 commit behind base \
+             (no base data at more recent commits)"
+        ),
+        "the one-commit comparison-base lag is disclosed: {report}"
+    );
+    assert!(
+        !chart_lines(&report).is_empty(),
+        "the branch finding draws a chart: {report}"
+    );
+}
+
+/// In history mode a benchmark whose latest observation for one metric lags the
+/// analyzed tip renders a trailing gap: the chart still spans every commit through
+/// the tip, with a blank column where the tip carries no datum for that metric. A
+/// sibling metric keeps the benchmark present at the tip, so the lagging metric's
+/// series is retained rather than dropped as a ghost.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn analyze_history_no_newer_data_renders_a_trailing_gap() {
+    // Two identical seven-commit histories. `conditional_branches` steps up at c4
+    // (a sustained regression); `instruction_count` stays flat and never flags. Only
+    // the tip commit c7 differs: the full run records both metrics there while the
+    // lagging run records instruction_count alone, so the benchmark stays present at
+    // the tip (not a ghost) yet its conditional_branches series ends at c6.
+    let steps = [
+        ("2024-01-01", "c1", 100.0),
+        ("2024-01-02", "c2", 100.0),
+        ("2024-01-03", "c3", 100.0),
+        ("2024-01-04", "c4", 130.0),
+        ("2024-01-05", "c5", 130.0),
+        ("2024-01-06", "c6", 130.0),
+    ];
+
+    let full = Workspace::repo(&storage_only_config());
+    let lag = Workspace::repo(&storage_only_config());
+    for workspace in [&full, &lag] {
+        for (date, label, cb) in steps {
+            workspace.commit_dated(date, label);
+            workspace.seed_metrics(
+                label,
+                vec![
+                    Metric::new(MetricKind::InstructionCount, 500.0),
+                    Metric::new(MetricKind::ConditionalBranches, cb),
+                ],
+            );
+        }
+    }
+    // The shared tip commit c7: the full run records both metrics; the lagging run
+    // records only the sibling, leaving conditional_branches one commit behind.
+    full.commit_dated("2024-01-07", "c7");
+    full.seed_metrics(
+        "c7",
+        vec![
+            Metric::new(MetricKind::InstructionCount, 500.0),
+            Metric::new(MetricKind::ConditionalBranches, 130.0),
+        ],
+    );
+    lag.commit_dated("2024-01-07", "c7");
+    lag.seed_metrics("c7", vec![Metric::new(MetricKind::InstructionCount, 500.0)]);
+
+    let RunOutcome::Analyzed {
+        regressions: full_regressions,
+        report: full_report,
+        ..
+    } = full.drive(&["analyze"]).await.unwrap()
+    else {
+        panic!("expected an analyzed outcome");
+    };
+    let RunOutcome::Analyzed {
+        regressions: lag_regressions,
+        report: lag_report,
+        ..
+    } = lag.drive(&["analyze"]).await.unwrap()
+    else {
+        panic!("expected an analyzed outcome");
+    };
+
+    assert_eq!(
+        full_regressions, 1,
+        "the full history flags the conditional_branches step: {full_report}"
+    );
+    assert_eq!(
+        lag_regressions, 1,
+        "the lagging history flags the same step even though the tip lacks the metric: {lag_report}"
+    );
+
+    // The lagging series ends at c6 but its chart is filled with a trailing gap column
+    // up to the analyzed tip c7, so it spans exactly as many columns — and renders
+    // exactly as wide — as the full history's chart. Without that trailing fill the
+    // lagging chart would stop one column short of the tip and be one character
+    // narrower. (`rasciigraph` draws a trailing gap and a continued flat plateau
+    // identically — both a blank final column — so the rendered width, not the glyph
+    // content, is what proves the fill reached the tip.)
+    assert!(
+        chart_width(&full_report) > 0,
+        "the full history draws a chart: {full_report}"
+    );
+    assert_eq!(
+        chart_width(&lag_report),
+        chart_width(&full_report),
+        "the trailing 'no newer data' gap extends the lagging chart to the tip\n\
+         FULL:\n{full_report}\nLAG:\n{lag_report}"
+    );
+}

--- a/packages/cbh_analyze/src/comparison_base.rs
+++ b/packages/cbh_analyze/src/comparison_base.rs
@@ -353,6 +353,7 @@ mod tests {
             blessed_commit_time: None,
             series: Vec::new(),
             comparison_base_index,
+            chart_base_ref: None,
         }
     }
 

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -57,6 +57,10 @@ pub(crate) struct SelectedDataSet {
     /// The full commit ID of the analyzed tip commit (the resolved `--context`/HEAD),
     /// carried into the report so it names the exact commit the findings describe.
     pub(crate) tip_commit: String,
+    /// First-parent topological index of the analyzed tip commit. History-mode chart
+    /// building uses it as the trailing-fill target so a series that stops short of the
+    /// tip renders the data-less commits after its last observation as a gap.
+    pub(crate) tip_index: usize,
     /// Whether the working tree carried uncommitted changes when the analysis ran;
     /// the report annotates the tip `+ uncommitted changes` when set.
     pub(crate) tip_dirty: bool,
@@ -444,6 +448,14 @@ where
         );
     }
 
+    // The analyzed tip's first-parent index (in practice `order.len() - 1`). History
+    // mode charts use it as the trailing-fill target so a series that stops short of
+    // the tip renders the data-less commits after its last observation as a gap.
+    let tip_index = order
+        .get(&tip_commit)
+        .copied()
+        .unwrap_or_else(|| order.len().saturating_sub(1));
+
     Ok(SelectedDataSet {
         series,
         run_index,
@@ -458,6 +470,7 @@ where
         facets,
         commit_subjects,
         tip_commit,
+        tip_index,
         tip_dirty,
         mode,
         merge_base_index,

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -37,8 +37,9 @@ use serde::Serialize;
 use tick::Clock;
 
 use super::{
-    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, chart, dirty_base_exception_warning,
-    empty_history_hint, format_value, resolve_auto_facets, resolve_now, select_dataset,
+    AutoFacets, ReportFormat, Selection, Series, SeriesFilter, chart_series,
+    dirty_base_exception_warning, empty_history_hint, format_value, resolve_auto_facets,
+    resolve_now, select_dataset,
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 
@@ -164,6 +165,7 @@ where
         metric_kind,
         &dataset.series,
         &dataset.commit_subjects,
+        dataset.tip_index,
     );
 
     // When the pivot is empty, explain why: either no run entered the selection at
@@ -224,6 +226,10 @@ struct DataPoint {
     dirty: bool,
     /// The commit's full title (subject), empty when topology reported none.
     title: String,
+    /// First-parent topological index of the commit. Chart-only: it places each point
+    /// in its own per-commit column and materializes the data-less commits between
+    /// observations as gaps. The point table and JSON never read it.
+    topo_index: usize,
 }
 
 /// One discriminant set's slice of the pivot.
@@ -248,16 +254,25 @@ struct Pivot {
     unit: &'static str,
     /// The per-set slices, one entry per discriminant set carrying the series.
     sets: Vec<SetPivot>,
+    /// Trailing-fill target for each set's chart: the analyzed tip's first-parent
+    /// index, so a series that stops short of the tip renders the data-less commits
+    /// after its last observation as a gap. Chart-only.
+    base_ref: Option<usize>,
 }
 
 /// Narrows the reconstructed series to the one `(benchmark, metric)` pair, once per
 /// discriminant set, and turns each into its ordered data points.
+///
+/// `tip_index` is the analyzed tip's first-parent index, carried onto the pivot as the
+/// chart's trailing-fill target so a series that stops short of the tip renders a
+/// trailing gap (see [`chart_of_points`]).
 fn build_pivot(
     project_id: &str,
     benchmark: &str,
     metric_kind: MetricKind,
     series: &[Series],
     commit_subjects: &HashMap<String, String>,
+    tip_index: usize,
 ) -> Pivot {
     let mut sets: Vec<SetPivot> = series
         .iter()
@@ -275,6 +290,7 @@ fn build_pivot(
                         value: point.value,
                         dirty: point.dirty,
                         title,
+                        topo_index: point.topo_index,
                     }
                 })
                 .collect();
@@ -294,6 +310,7 @@ fn build_pivot(
         metric: metric_kind.as_str(),
         unit: metric_kind.as_unit(),
         sets,
+        base_ref: Some(tip_index),
     }
 }
 
@@ -321,11 +338,17 @@ fn short_commit_id(commit_id: &str) -> &str {
     commit_id.get(..12).unwrap_or(commit_id)
 }
 
-/// The line chart of a set's ordered values, drawn before its data points (the same
-/// chart `analyze` renders for a finding). `None` when there are too few points to plot.
-fn chart_of_points(points: &[DataPoint]) -> Option<String> {
-    let values: Vec<f64> = points.iter().map(|point| point.value).collect();
-    chart(&values)
+/// The line chart of a set's observations, drawn before its data points (the same
+/// chart `analyze` renders for a finding). Each observation sits in its own per-commit
+/// column, with the data-less commits between observations — and, when `base_ref`
+/// extends past the last observation, the trailing commits up to the analyzed tip —
+/// rendered as gaps. `None` when there are too few points to plot.
+fn chart_of_points(points: &[DataPoint], base_ref: Option<usize>) -> Option<String> {
+    let pairs: Vec<(usize, f64)> = points
+        .iter()
+        .map(|point| (point.topo_index, point.value))
+        .collect();
+    chart_series(&pairs, base_ref)
 }
 
 /// Renders the pivot in the requested format, appending the diagnostic hint and
@@ -358,7 +381,7 @@ fn render_pivot_text(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
             // Lead the set with the same small line chart `analyze` draws, so a
             // maintainer sees the shape of the series before reading the points it
             // pivots.
-            if let Some(chart) = chart_of_points(&set.points) {
+            if let Some(chart) = chart_of_points(&set.points, pivot.base_ref) {
                 lines.push(chart);
                 lines.push(String::new());
             }
@@ -405,7 +428,7 @@ fn render_pivot_markdown(pivot: &Pivot, hint: Option<&str>, warning: Option<&str
             lines.push(format!("## {}", set.set));
             // The same series chart the text pivot draws, fenced as a `text`
             // block so it survives Markdown rendering (mirrors `analyze`).
-            if let Some(chart) = chart_of_points(&set.points) {
+            if let Some(chart) = chart_of_points(&set.points, pivot.base_ref) {
                 lines.push(String::new());
                 lines.push("```text".to_owned());
                 lines.push(chart);
@@ -976,6 +999,182 @@ mod tests {
         assert!(
             !report.contains('┤') && !report.contains('┼'),
             "no chart for a single point: {report}"
+        );
+    }
+
+    /// A `DataPoint` at the given topology and value, with the other fields fixed —
+    /// enough to drive [`chart_of_points`] and [`cbh_render::topology_columns`].
+    fn data_point(topo: usize, value: f64) -> DataPoint {
+        DataPoint {
+            commit: format!("c{topo}"),
+            short_commit: format!("c{topo}"),
+            value,
+            dirty: false,
+            title: String::new(),
+            topo_index: topo,
+        }
+    }
+
+    #[test]
+    fn chart_of_points_materializes_a_data_less_interior_commit_as_one_gap() {
+        // c0, c1, then c3 have data; the interior c2 (topo 2) does not. The tip is
+        // c3 (topo 3), so there is no trailing gap — exactly one interior gap column.
+        let gapped = [
+            data_point(0, 100.0),
+            data_point(1, 130.0),
+            data_point(3, 128.0),
+        ];
+        let pairs: Vec<(usize, f64)> = gapped.iter().map(|p| (p.topo_index, p.value)).collect();
+        // The span (3) is below the chart width, so the column count is exact and
+        // independent of the 48-wide cap: one column per commit c0..=c3.
+        let columns = cbh_render::topology_columns(&pairs, Some(3), 48);
+        assert_eq!(columns.len(), 4, "one column per commit c0..=c3");
+        assert_eq!(
+            columns.iter().filter(|value| value.is_nan()).count(),
+            1,
+            "exactly the data-less c2 is a gap"
+        );
+        assert!(columns[2].is_nan(), "the gap sits at c2's column");
+        assert!(
+            columns[0].is_finite() && columns[1].is_finite() && columns[3].is_finite(),
+            "the three real observations survive"
+        );
+
+        // The rendered chart differs from the same three values placed contiguously,
+        // proving topology (not observation order) drives the column layout.
+        let contiguous = [
+            data_point(0, 100.0),
+            data_point(1, 130.0),
+            data_point(2, 128.0),
+        ];
+        let with_gap = chart_of_points(&gapped, Some(3)).expect("the gapped series draws");
+        let without_gap =
+            chart_of_points(&contiguous, Some(2)).expect("the contiguous series draws");
+        assert_ne!(
+            with_gap, without_gap,
+            "the interior gap changes the chart raster"
+        );
+    }
+
+    #[test]
+    fn chart_of_points_materializes_the_no_newer_data_tail_as_a_trailing_gap() {
+        // Data stops at c2 while the analyzed tip is c3 (topo 3): the last commit has
+        // no observation, so the chart shows a single trailing gap column.
+        let points = [
+            data_point(0, 100.0),
+            data_point(1, 130.0),
+            data_point(2, 128.0),
+        ];
+        let pairs: Vec<(usize, f64)> = points.iter().map(|p| (p.topo_index, p.value)).collect();
+        let columns = cbh_render::topology_columns(&pairs, Some(3), 48);
+        assert_eq!(columns.len(), 4, "the tip commit c3 gets its own column");
+        assert_eq!(
+            columns.iter().filter(|value| value.is_nan()).count(),
+            1,
+            "exactly the analyzed tip is a trailing gap"
+        );
+        assert!(
+            columns[3].is_nan(),
+            "the trailing gap sits at the tip column"
+        );
+        assert!(
+            chart_of_points(&points, Some(3)).is_some(),
+            "the tail draws"
+        );
+    }
+
+    #[test]
+    fn a_data_less_interior_commit_still_lists_only_real_observations() {
+        // Store c0, c1, c3 — skipping the interior c2 — on the linear history whose
+        // tip is c3. The chart materializes c2 as a gap, but the point table and JSON
+        // list only the three real observations.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        store(
+            &storage,
+            &clean_key("c3"),
+            &single_metric_run(3, "c3", 128.0),
+        );
+        let git = linear_git();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(points.len(), 3, "only the real observations: {report}");
+        let commits: Vec<&str> = points
+            .iter()
+            .map(|point| point["commit"].as_str().unwrap())
+            .collect();
+        assert_eq!(commits, ["c0", "c1", "c3"], "no phantom c2 row: {report}");
+        assert!(
+            points[0].get("topo_index").is_none(),
+            "the JSON point carries no topology index: {report}"
+        );
+
+        let text = examine(&storage, &git, &options());
+        assert!(
+            text.contains('┤') || text.contains('┼'),
+            "the chart is drawn across the gap: {text}"
+        );
+        assert!(text.contains("c3"), "the c3 row is present: {text}");
+        assert!(
+            !text.contains("| c2 |") && !text.contains("  c2  "),
+            "the data-less c2 never becomes a row: {text}"
+        );
+    }
+
+    #[test]
+    fn a_contiguous_history_charts_without_a_gap() {
+        // Every commit c0..=c3 has data and c3 is the tip, so the densified chart
+        // holds one finite column per commit with no `NaN`.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        store(
+            &storage,
+            &clean_key("c2"),
+            &single_metric_run(2, "c2", 128.0),
+        );
+        store(
+            &storage,
+            &clean_key("c3"),
+            &single_metric_run(3, "c3", 126.0),
+        );
+        let git = linear_git();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(
+            points.len(),
+            4,
+            "every commit is a real observation: {report}"
+        );
+
+        // The densified columns the chart draws hold no gap.
+        let pairs = [(0_usize, 100.0), (1, 130.0), (2, 128.0), (3, 126.0)];
+        let columns = cbh_render::topology_columns(&pairs, Some(3), 48);
+        assert_eq!(columns.len(), 4);
+        assert!(
+            columns.iter().all(|value| value.is_finite()),
+            "a contiguous history has no gap columns"
         );
     }
 

--- a/packages/cbh_analyze/src/lib.rs
+++ b/packages/cbh_analyze/src/lib.rs
@@ -51,7 +51,7 @@ mod window;
 
 pub use bless::{bless, unbless};
 pub(crate) use cbh_detect::{Series, SeriesFilter, apply_blessings};
-pub(crate) use cbh_render::{ReportFormat, chart, format_value};
+pub(crate) use cbh_render::{ReportFormat, chart_series, format_value};
 pub(crate) use dataset::{empty_history_hint, select_dataset};
 pub use error::AnalyzeError;
 pub use examine::execute as examine;

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -260,6 +260,7 @@ where
         mode: dataset.mode,
         config: AnalysisConfig::default(),
         merge_base_index: dataset.merge_base_index,
+        tip_index: dataset.tip_index,
         include_improvements: options.include_improvements,
         include_inactive: options.include_inactive,
     };

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -183,6 +183,11 @@ pub struct AnalysisContext {
     /// history from the branch. `None` means no split is known (every point is
     /// treated as branch-side). Consulted only in [`AnalysisMode::Branch`].
     pub merge_base_index: Option<usize>,
+    /// First-parent topological index of the analyzed tip commit (the resolved
+    /// `--context`/HEAD). History-mode chart building uses it as the trailing-fill
+    /// target so a series that stops short of the tip renders the data-less commits
+    /// after its last observation as a gap. Consulted only in [`AnalysisMode::History`].
+    pub tip_index: usize,
     /// Whether improvements are reported. History mode defaults to regressions only
     /// (scheduled drift watch); branch mode always reports both.
     pub include_improvements: bool,
@@ -244,6 +249,10 @@ pub struct SeriesValue {
     pub value: f64,
     /// Whether the point is a dirty (uncommitted-tree) snapshot.
     pub dirty: bool,
+    /// First-parent topological index of the commit the point was measured against.
+    /// Charting places each point in its own per-commit column and materializes gaps
+    /// for the data-less commits between points; it is not part of the JSON contract.
+    pub topo_index: usize,
 }
 
 /// One flagged change: where it is, what moved, by how much, and how sure we are.
@@ -297,6 +306,13 @@ pub struct Finding {
     /// comparison base sits behind the merge-base; it is not part of the JSON finding
     /// contract.
     pub comparison_base_index: Option<usize>,
+    /// Trailing-fill target for the chart: the first-parent index the charted series
+    /// extends to when its last observation stops short of it. `Some(tip_index)` in
+    /// history mode, so the data-less commits between the last observation and the
+    /// analyzed tip render as a gap; `None` in branch mode, where the tip is the
+    /// always-present last column. Chart-only — like [`Finding::series`] it is not part
+    /// of the JSON finding contract.
+    pub chart_base_ref: Option<usize>,
 }
 
 impl Finding {
@@ -335,18 +351,80 @@ fn count_to_f64(count: usize) -> f64 {
     count as f64
 }
 
-/// The full series, oldest-first, as compact [`SeriesValue`] points for the JSON
-/// output (charting and provenance).
-fn series_values(series: &Series) -> Vec<SeriesValue> {
-    series
-        .points
-        .iter()
-        .map(|point| SeriesValue {
-            commit: owned_commit(point),
-            value: point.value,
-            dirty: point.dirty,
-        })
-        .collect()
+/// One source point as a compact [`SeriesValue`] chart point, carrying its
+/// `topo_index` so the renderer can place it in its own per-commit column.
+fn series_value_of(point: &SeriesPoint) -> SeriesValue {
+    SeriesValue {
+        commit: owned_commit(point),
+        value: point.value,
+        dirty: point.dirty,
+        topo_index: point.topo_index,
+    }
+}
+
+/// Builds a surviving finding's compact chart series and its trailing-fill target,
+/// dispatching on the analysis mode.
+///
+/// The series stays compact — one [`SeriesValue`] per real observation, never a
+/// materialized gap — and every point carries its `topo_index`, so the renderer can
+/// place each in its own per-commit column and draw the data-less commits between (and
+/// after) observations as gaps. This is presentation-only: detection reads
+/// `Series.points`, never this series.
+///
+/// History mode maps every source point 1:1 and returns `Some(context.tip_index)` as
+/// the trailing-fill target, so a series that stops short of the analyzed tip renders
+/// the intervening commits as the "no newer data" gap. Branch mode collapses the series
+/// (see [`branch_chart_series`]).
+fn build_chart_series(
+    source: &Series,
+    finding: &Finding,
+    context: &AnalysisContext,
+) -> (Vec<SeriesValue>, Option<usize>) {
+    match context.mode {
+        AnalysisMode::History => (
+            source.points.iter().map(series_value_of).collect(),
+            Some(context.tip_index),
+        ),
+        AnalysisMode::Branch => branch_chart_series(source, finding, context),
+    }
+}
+
+/// The branch-collapsed chart series and its (absent) trailing-fill target.
+///
+/// Branch mode judges the branch's tip commit alone, so the chart keeps the base-side
+/// points at their real `topo_index`, drops every interior branch commit, and
+/// represents the tip by a single point carrying the finding's judged `latest` value at
+/// `merge_base_index + 1`. The trailing-fill target is `None` — the tip is the
+/// always-present last column. The gap between the last base point (at the comparison
+/// base) and the tip therefore spans exactly `merge_base - comparison_base` (==
+/// `commits_behind`) columns.
+///
+/// A real branch finding always carries a known merge-base and comparison base; the
+/// fallback to a plain whole-series chart is defensive (never a panic) for a finding
+/// that somehow lacks either.
+fn branch_chart_series(
+    source: &Series,
+    finding: &Finding,
+    context: &AnalysisContext,
+) -> (Vec<SeriesValue>, Option<usize>) {
+    debug_assert!(
+        context.merge_base_index.is_some() && finding.comparison_base_index.is_some(),
+        "a branch finding always carries a known merge-base and comparison base",
+    );
+    let (Some(merge_base_index), Some(_)) =
+        (context.merge_base_index, finding.comparison_base_index)
+    else {
+        return (source.points.iter().map(series_value_of).collect(), None);
+    };
+    let (base, branch) = split_at_merge_base(&source.points, Some(merge_base_index));
+    let mut series: Vec<SeriesValue> = base.iter().copied().map(series_value_of).collect();
+    series.push(SeriesValue {
+        commit: finding.commit.clone(),
+        value: finding.latest,
+        dirty: branch.last().is_some_and(|point| point.dirty),
+        topo_index: merge_base_index.saturating_add(1),
+    });
+    (series, None)
 }
 
 /// The commit of a point as an owned `String`, for the JSON output.
@@ -640,6 +718,7 @@ fn evaluate_change_point(
             blessed_commit_time: None,
             series: Vec::new(),
             comparison_base_index: None,
+            chart_base_ref: None,
         },
         source_index: 0,
         bh_p: effective_p,
@@ -716,6 +795,7 @@ fn evaluate_drift(series: &Series, values: &[f64], config: &AnalysisConfig) -> O
             blessed_commit_time: None,
             series: Vec::new(),
             comparison_base_index: None,
+            chart_base_ref: None,
         },
         source_index: 0,
         bh_p: trend.p_value,
@@ -880,6 +960,7 @@ fn compare_samples(
             blessed_commit_time: None,
             series: Vec::new(),
             comparison_base_index: None,
+            chart_base_ref: None,
         },
         source_index: 0,
         bh_p: effective_p,
@@ -1063,6 +1144,7 @@ fn evaluate_resolved_spike(
             blessed_commit_time: None,
             series: Vec::new(),
             comparison_base_index: None,
+            chart_base_ref: None,
         },
         source_index: 0,
         bh_p: effective_p,
@@ -1157,7 +1239,9 @@ fn finalize_findings(
             let source = series
                 .get(source_index)
                 .expect("the source index was assigned from this series slice");
-            finding.series = series_values(source);
+            let (chart_series, chart_base_ref) = build_chart_series(source, &finding, context);
+            finding.series = chart_series;
+            finding.chart_base_ref = chart_base_ref;
             Some(finding)
         })
         .collect();
@@ -1402,12 +1486,25 @@ mod tests {
                 blessed_commit_time: None,
                 series: Vec::new(),
                 comparison_base_index: None,
+                chart_base_ref: None,
             },
             source_index: 0,
             bh_p: 0.0,
             split,
             line,
         }
+    }
+
+    /// The largest `topo_index` across every point of `series`, the realistic tip
+    /// index for a history-mode [`AnalysisContext`] over this test fixture. Zero when
+    /// there are no points.
+    fn max_topo_index(series: &[Series]) -> usize {
+        series
+            .iter()
+            .flat_map(|one| one.points.iter())
+            .map(|point| point.topo_index)
+            .max()
+            .unwrap_or(0)
     }
 
     /// Runs the history-mode detector with default config, reporting both
@@ -1419,6 +1516,7 @@ mod tests {
                 mode: AnalysisMode::History,
                 config: AnalysisConfig::default(),
                 merge_base_index: None,
+                tip_index: max_topo_index(series),
                 include_improvements: true,
                 include_inactive: false,
             },
@@ -1459,6 +1557,7 @@ mod tests {
             mode: AnalysisMode::History,
             config: AnalysisConfig::default(),
             merge_base_index: None,
+            tip_index: max_topo_index(&series),
             include_improvements: true,
             include_inactive: false,
         };
@@ -2130,6 +2229,7 @@ mod tests {
                 mode: AnalysisMode::Branch,
                 config: AnalysisConfig::default(),
                 merge_base_index,
+                tip_index: max_topo_index(series),
                 include_improvements: false,
                 include_inactive: false,
             },
@@ -2308,6 +2408,152 @@ mod tests {
         assert_eq!(finding.comparison_base_index, None);
     }
 
+    // -- Compact chart series (topology-accurate rendering input) -------------
+
+    /// The `(topo_index, value)` pairs of a finding's compact chart series.
+    fn chart_pairs(finding: &Finding) -> Vec<(usize, f64)> {
+        finding
+            .series
+            .iter()
+            .map(|point| (point.topo_index, point.value))
+            .collect()
+    }
+
+    #[test]
+    fn history_chart_series_maps_every_observation_and_targets_the_tip() {
+        // History mode keeps the series compact and 1:1 — every observation becomes one
+        // chart point carrying its real topo index — and stamps the analyzed tip as the
+        // trailing-fill target so a lagging series can render its "no newer data" gap.
+        let series = series_of(&[100.0, 100.0, 100.0, 130.0, 130.0, 130.0]);
+        let finding = only(changes(std::slice::from_ref(&series)));
+        assert_eq!(
+            chart_pairs(&finding),
+            vec![
+                (0, 100.0),
+                (1, 100.0),
+                (2, 100.0),
+                (3, 130.0),
+                (4, 130.0),
+                (5, 130.0),
+            ],
+        );
+        // `changes` analyses up to the last observation, so the tip index is 5.
+        assert_eq!(finding.chart_base_ref, Some(5));
+        // Detection is unaffected by carrying the topology through.
+        assert_eq!(finding.direction, Direction::Regression);
+        assert_eq!(finding.latest, 130.0);
+    }
+
+    #[test]
+    fn history_chart_series_preserves_interior_topology_gaps() {
+        // Data-less commits between observations survive as a jump in topo index, which
+        // the renderer turns into gap columns. Observations sit at topo 0..=2 and 6..=8,
+        // with topos 3..=5 carrying no data.
+        let series = placed_series(&[
+            (0, 100.0, false),
+            (1, 100.0, false),
+            (2, 100.0, false),
+            (6, 130.0, false),
+            (7, 130.0, false),
+            (8, 130.0, false),
+        ]);
+        let finding = only(changes(std::slice::from_ref(&series)));
+        assert_eq!(finding.direction, Direction::Regression);
+        assert_eq!(
+            chart_pairs(&finding)
+                .iter()
+                .map(|&(topo, _)| topo)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 6, 7, 8],
+            "the topo gap at 3..=5 is preserved for the renderer to draw",
+        );
+    }
+
+    #[test]
+    fn history_chart_base_ref_is_the_analyzed_tip_beyond_the_last_observation() {
+        // When analysis reaches commits newer than the last observation, the
+        // trailing-fill target is that tip, so the chart shows the lag as a trailing gap
+        // — the visual form of the "lagged history" warning.
+        let series = series_of(&[100.0, 100.0, 100.0, 130.0, 130.0, 130.0]);
+        let context = AnalysisContext {
+            mode: AnalysisMode::History,
+            config: AnalysisConfig::default(),
+            merge_base_index: None,
+            tip_index: 20,
+            include_improvements: true,
+            include_inactive: false,
+        };
+        let finding = only(find_changes(std::slice::from_ref(&series), &context));
+        assert_eq!(finding.chart_base_ref, Some(20));
+    }
+
+    #[test]
+    fn branch_chart_series_collapses_interior_commits_onto_the_tip() {
+        // Branch mode drops every interior branch commit and represents the branch by a
+        // single tip column at merge_base + 1 carrying the judged latest. Here the base
+        // is topo 0..=2 and the merge-base is topo 2, so the tip lands at topo 3.
+        let series = placed_series(&[
+            (0, 100.0, false),
+            (1, 100.0, false),
+            (2, 100.0, false),
+            (3, 130.0, false),
+            (4, 130.0, false),
+            (5, 130.0, false),
+        ]);
+        let finding = only(branch_changes(&[series], Some(2)));
+        assert_eq!(
+            finding.chart_base_ref, None,
+            "the tip is the always-present last column, so no trailing fill"
+        );
+        assert_eq!(
+            chart_pairs(&finding),
+            vec![(0, 100.0), (1, 100.0), (2, 100.0), (3, 130.0)],
+        );
+        let tip = finding.series.last().expect("the tip column is present");
+        assert_eq!(tip.topo_index, 3, "the tip is remapped to merge_base + 1");
+        assert_eq!(
+            tip.value, finding.latest,
+            "the tip column carries the judged latest, not a raw observation"
+        );
+    }
+
+    #[test]
+    fn branch_chart_series_is_unchanged_by_extra_interior_branch_commits() {
+        // Interior branch commits contribute zero columns, so a branch that detoured
+        // (improved, then regressed) collapses to the same compact chart series as one
+        // that went straight to the tip value — the base and tip state being equal.
+        let straight = placed_series(&[
+            (0, 100.0, false),
+            (1, 100.0, false),
+            (2, 100.0, false),
+            (3, 130.0, false),
+            (4, 130.0, false),
+            (5, 130.0, false),
+        ]);
+        let detour = placed_series(&[
+            (0, 100.0, false),
+            (1, 100.0, false),
+            (2, 100.0, false),
+            (3, 80.0, false),
+            (4, 80.0, false),
+            (5, 80.0, false),
+            (6, 130.0, false),
+            (7, 130.0, false),
+            (8, 130.0, false),
+        ]);
+        let straight_finding = only(branch_changes(&[straight], Some(2)));
+        let detour_finding = only(branch_changes(&[detour], Some(2)));
+        assert_eq!(
+            chart_pairs(&straight_finding),
+            chart_pairs(&detour_finding),
+            "interior branch commits must not change the collapsed chart series"
+        );
+        assert_eq!(
+            chart_pairs(&straight_finding),
+            vec![(0, 100.0), (1, 100.0), (2, 100.0), (3, 130.0)],
+        );
+    }
+
     // -- Blessing (re-baselining) and recovered spikes ------------------------
 
     /// Runs the history-mode detector reporting both directions *and* inactive
@@ -2319,6 +2565,7 @@ mod tests {
                 mode: AnalysisMode::History,
                 config: AnalysisConfig::default(),
                 merge_base_index: None,
+                tip_index: max_topo_index(series),
                 include_improvements: true,
                 include_inactive: true,
             },
@@ -2661,6 +2908,7 @@ mod tests {
             mode: AnalysisMode::History,
             config: AnalysisConfig::default(),
             merge_base_index: None,
+            tip_index: 0,
             include_improvements,
             include_inactive: false,
         };
@@ -2676,6 +2924,7 @@ mod tests {
             mode,
             config: AnalysisConfig::default(),
             merge_base_index: None,
+            tip_index: 0,
             include_improvements,
             include_inactive: false,
         };

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -93,6 +93,9 @@ impl Mode {
     /// so the context matches the mode's intended reporting semantics: branch (which
     /// reports both directions) opts in, history opts out. Branch mode ignores the
     /// flag today, but pinning it consistently keeps the context correct if that changes.
+    ///
+    /// `tip_index` feeds only the chart's trailing gap, which these detection-outcome
+    /// cases never inspect, so it is pinned to zero.
     fn context(self, merge_base_index: Option<usize>) -> AnalysisContext {
         let mode = match self {
             Self::History => AnalysisMode::History,
@@ -102,6 +105,7 @@ impl Mode {
             mode,
             config: AnalysisConfig::default(),
             merge_base_index,
+            tip_index: 0,
             include_improvements: self.reports_improvements(),
             include_inactive: false,
         }

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::num::NonZero;
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
-use cbh_detect::{AnalysisMode, Direction, Finding, FindingMethod, SeriesValue, short_commit};
+use cbh_detect::{AnalysisMode, Direction, Finding, FindingMethod, short_commit};
 use cbh_model::{BenchmarkId, DiscriminantSet};
 use colored::Colorize;
 use rasciigraph::{Config, plot};
@@ -642,27 +642,31 @@ fn branch_chart_values(finding: &Finding) -> Vec<f64> {
     // data-less commit between the newest base point and the tip is a visible gap.
     let window = BRANCH_CHART_MAX_POINTS.saturating_sub(1);
     let start_topo = tip_topo.saturating_sub(window.saturating_sub(1));
-    values.extend((start_topo..=tip_topo).map(|topo| mean_at_topo(&finding.series, topo)));
-    values
-}
-
-/// The mean of the finding-series values recorded at first-parent index `topo`.
-///
-/// Returns [`f64::NAN`] when the commit carries no observation (a gap column).
-fn mean_at_topo(series: &[SeriesValue], topo: usize) -> f64 {
-    let mut sum = 0.0;
-    let mut count = 0_usize;
-    for point in series {
-        if point.topo_index == topo {
-            sum += point.value;
-            count = count.saturating_add(1);
+    // The series is ordered by `topo_index`, so the window is a contiguous suffix. Fold
+    // each in-window commit's observations into its own column in a single pass, rather
+    // than re-scanning the whole (in branch mode still-full) base history once per column.
+    let column_count = tip_topo.saturating_sub(start_topo).saturating_add(1);
+    let mut bins = vec![(0.0_f64, 0_usize); column_count];
+    let first = finding
+        .series
+        .partition_point(|point| point.topo_index < start_topo);
+    for point in finding.series.get(first..).unwrap_or_default() {
+        // Every point from `first` onward has `start_topo <= topo_index <= tip_topo`, so
+        // the offset stays within `0..column_count`; `get_mut` guards it regardless.
+        let col = point.topo_index.saturating_sub(start_topo);
+        if let Some((sum, count)) = bins.get_mut(col) {
+            *sum += point.value;
+            *count = count.saturating_add(1);
         }
     }
-    if count == 0 {
-        f64::NAN
-    } else {
-        sum / count_as_f64(count)
-    }
+    values.extend(bins.into_iter().map(|(sum, count)| {
+        if count == 0 {
+            f64::NAN
+        } else {
+            sum / count_as_f64(count)
+        }
+    }));
+    values
 }
 
 /// Bins real `(topo_index, value)` observations into at most `max_width` chart columns.

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::num::NonZero;
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
-use cbh_detect::{AnalysisMode, Direction, Finding, FindingMethod, short_commit};
+use cbh_detect::{AnalysisMode, Direction, Finding, FindingMethod, SeriesValue, short_commit};
 use cbh_model::{BenchmarkId, DiscriminantSet};
 use colored::Colorize;
 use rasciigraph::{Config, plot};
@@ -621,58 +621,192 @@ fn chart_scope(mode: AnalysisMode) -> ChartScope {
     }
 }
 
-/// Builds the bounded values for a branch finding's comparison chart.
+/// Builds the bounded, topology-accurate columns for a branch finding's comparison
+/// chart.
 ///
-/// The first value is the detector's actual comparison baseline. The remaining values
-/// are the recent observed suffix ending at the tip, guaranteeing that both sides of
-/// the reported change remain visible even when a long-lived branch contributes more
-/// points than the chart cap. The tip is the one data point branch mode acts on, and it
-/// must never be dropped or aliased away, however long the underlying history is.
+/// The first column is the detector's actual comparison baseline. The rest are the
+/// recent per-commit tail ending at the tip: one column for each first-parent commit
+/// from `start_topo` up to the tip's `topo_index`, carrying the mean of the
+/// observations at that commit or a gap ([`f64::NAN`]) where the commit has none. The
+/// tip commit's column carries the finding's judged latest value and is never a gap, so
+/// both sides of the reported change stay visible — and the gap between the newest base
+/// point and the tip (the comparison-base lag) is drawn as those empty interior
+/// columns — however long the underlying history is. The window spans at most
+/// [`BRANCH_CHART_MAX_POINTS`] columns.
 fn branch_chart_values(finding: &Finding) -> Vec<f64> {
-    let observed_limit = BRANCH_CHART_MAX_POINTS.saturating_sub(1);
-    let start = finding.series.len().saturating_sub(observed_limit);
-    let observed = finding
-        .series
-        .get(start..)
-        .expect("saturating subtraction keeps the start within the series");
-    let mut values = Vec::with_capacity(observed.len().saturating_add(1));
-    values.push(finding.baseline);
-    values.extend(observed.iter().map(|point| point.value));
+    let mut values = vec![finding.baseline];
+    let Some(tip_topo) = finding.series.last().map(|point| point.topo_index) else {
+        return values;
+    };
+    // One column per first-parent commit in the recent window ending at the tip, so a
+    // data-less commit between the newest base point and the tip is a visible gap.
+    let window = BRANCH_CHART_MAX_POINTS.saturating_sub(1);
+    let start_topo = tip_topo.saturating_sub(window.saturating_sub(1));
+    values.extend((start_topo..=tip_topo).map(|topo| mean_at_topo(&finding.series, topo)));
     values
+}
+
+/// The mean of the finding-series values recorded at first-parent index `topo`.
+///
+/// Returns [`f64::NAN`] when the commit carries no observation (a gap column).
+fn mean_at_topo(series: &[SeriesValue], topo: usize) -> f64 {
+    let mut sum = 0.0;
+    let mut count = 0_usize;
+    for point in series {
+        if point.topo_index == topo {
+            sum += point.value;
+            count = count.saturating_add(1);
+        }
+    }
+    if count == 0 {
+        f64::NAN
+    } else {
+        sum / count_as_f64(count)
+    }
+}
+
+/// Bins real `(topo_index, value)` observations into at most `max_width` chart columns.
+///
+/// A gap ([`f64::NAN`]) is materialized for every commit — or, once the span exceeds
+/// `max_width`, every bin — that carries no observation.
+///
+/// `points` are ascending by `topo_index` (equal indices allowed, e.g. a commit's clean
+/// and dirty snapshots) and hold only real observations. `base_ref` is the trailing-fill
+/// target: when it sits past the last point the columns extend to it, so the data-less
+/// commits after the last observation render as a gap (the "no newer data" tail); `None`,
+/// or a value at or before the last point, adds no trailing gap. The leftmost column
+/// always holds the first observation, so there is never a leading gap. `max_width` must
+/// be at least 1; wide-chart callers pass [`CHART_WIDTH`].
+///
+/// While the span fits (`span + 1 <= max_width`) each commit maps to its own column, so
+/// the topology is exact and a data-less commit is a single `NaN` column. Beyond that
+/// the span is downsampled: every real point still lands in some column (placed by
+/// integer index, never interpolated away, so neither an observation nor an axis extreme
+/// is lost), empty columns stay `NaN`, and a column that catches several observations
+/// averages them (a slight, documented blur of a dense region). Binning to `max_width`
+/// before the series reaches [`chart`] is essential: `rasciigraph` interpolates to its
+/// width *before* computing the axis min/max and its linear interpolation is
+/// NaN-poisoning, so a longer series would blend an isolated observation surrounded by
+/// `NaN` into `NaN` and drop it (and its value) entirely.
+#[must_use]
+pub fn topology_columns(
+    points: &[(usize, f64)],
+    base_ref: Option<usize>,
+    max_width: usize,
+) -> Vec<f64> {
+    assert!(max_width >= 1, "a chart needs at least one column");
+    let Some(&(first, _)) = points.first() else {
+        return Vec::new();
+    };
+    let last = points.last().map_or(first, |&(topo, _)| topo);
+    let end = base_ref.map_or(last, |target| target.max(last));
+    let span = end.saturating_sub(first);
+    let width = span.saturating_add(1).min(max_width);
+    let mut bins = vec![(0.0_f64, 0_usize); width];
+    for &(topo, value) in points {
+        // `topo` lies in `[first, last] ⊆ [first, end]`, so `topo - first ∈ [0, span]` and
+        // the column index stays within `0..width`; when `span == 0` every point maps to
+        // the single column 0. The saturating operations only guard against overflow that
+        // real histories never reach; the true product is at most `span * (width - 1)`.
+        let offset = topo
+            .saturating_sub(first)
+            .saturating_mul(width.saturating_sub(1));
+        let col = offset.checked_div(span).unwrap_or(0);
+        if let Some((sum, count)) = bins.get_mut(col) {
+            *sum += value;
+            *count = count.saturating_add(1);
+        }
+    }
+    bins.into_iter()
+        .map(|(sum, count)| {
+            if count == 0 {
+                f64::NAN
+            } else {
+                sum / count_as_f64(count)
+            }
+        })
+        .collect()
+}
+
+/// Renders a compact line chart of real `(topo_index, value)` observations.
+///
+/// The observations are binned into topology-accurate columns (see [`topology_columns`])
+/// before plotting. `None` when fewer than two columns carry a real value.
+///
+/// Both wide-chart callers — a history finding's whole-series chart and `examine`'s
+/// per-commit chart — go through here, so a sparse or lagging series always renders its
+/// interior and trailing gaps.
+#[must_use]
+pub fn chart_series(points: &[(usize, f64)], base_ref: Option<usize>) -> Option<String> {
+    chart(&topology_columns(points, base_ref, CHART_WIDTH as usize))
+}
+
+/// Casts a small bin count to `f64` for averaging. Bin counts are bounded by the
+/// observation count, far below 2^53, so the conversion is exact.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "bin counts are far below 2^53, so the cast is exact"
+)]
+fn count_as_f64(count: usize) -> f64 {
+    count as f64
 }
 
 /// Renders a finding's metric chart for the given [`ChartScope`], or `None` when the
 /// scoped series has too few points to plot.
 ///
-/// [`ChartScope::FullHistory`] charts the whole series; [`ChartScope::BranchComparison`]
+/// [`ChartScope::FullHistory`] charts the whole series topology (one column per
+/// first-parent commit from the first observation onward, with gaps for data-less
+/// commits and a trailing gap up to the analysis tip); [`ChartScope::BranchComparison`]
 /// charts [`branch_chart_values`], so the comparison baseline and tip commit stay legible
 /// rather than becoming aliased edge columns.
 fn scoped_chart(finding: &Finding, scope: ChartScope) -> Option<String> {
-    let values: Vec<f64> = match scope {
-        ChartScope::FullHistory => finding.series.iter().map(|point| point.value).collect(),
+    match scope {
+        ChartScope::FullHistory => {
+            let points: Vec<(usize, f64)> = finding
+                .series
+                .iter()
+                .map(|point| (point.topo_index, point.value))
+                .collect();
+            chart_series(&points, finding.chart_base_ref)
+        }
         // Chart the comparison baseline and recent tail ending at the tip. This is
         // business-critical: the tip commit is the sole data point branch mode judges,
         // so it must remain visible and unaliased regardless of how much history
         // precedes it.
-        ChartScope::BranchComparison => branch_chart_values(finding),
-    };
-    chart(&values)
+        ChartScope::BranchComparison => chart(&branch_chart_values(finding)),
+    }
 }
 
-/// Renders a compact line chart of `values` over commits at the report's fixed chart
-/// dimensions. Returns `None` when there are fewer than two points (nothing to plot).
+/// Renders a compact line chart of `values` over commits at the report's chart height.
+///
+/// A non-finite (`NaN`) value renders as a gap in the line. Returns `None` when fewer
+/// than two values are finite (nothing to plot a line between).
+///
+/// The chart is drawn one column per supplied value, up to [`CHART_WIDTH`]; callers bin
+/// to at most that many columns first (see [`topology_columns`]), so the chart spans at
+/// most 48 columns. The width deliberately tracks the value count rather than always
+/// stretching to 48: `rasciigraph` resamples every series to `config.width` with linear
+/// interpolation *before* computing the axis extrema, and that interpolation is
+/// NaN-poisoning — stretching a gapped series blends an isolated observation trapped
+/// between two gaps into `NaN` and drops it (and its value) from both the line and the
+/// axis. Matching the width to the value count makes that resample an identity, so every
+/// real observation and both axis extrema survive and each gap stays exactly as wide as
+/// the run of data-less commits it represents.
 ///
 /// The line is always drawn uncolored: the report is most often read as Markdown, where
 /// ANSI styling would only add noise, so the chart carries plain characters that render
 /// anywhere.
 #[must_use]
 pub fn chart(values: &[f64]) -> Option<String> {
-    if values.len() < 2 {
+    if values.iter().filter(|value| value.is_finite()).count() < 2 {
         return None;
     }
+    let width = u32::try_from(values.len())
+        .unwrap_or(CHART_WIDTH)
+        .min(CHART_WIDTH);
     let config = Config::default()
         .with_height(CHART_HEIGHT)
-        .with_width(CHART_WIDTH);
+        .with_width(width);
     Some(
         plot(values.to_vec(), config)
             .trim_end_matches('\n')
@@ -1060,6 +1194,7 @@ mod tests {
             blessed_commit_time: None,
             series: Vec::new(),
             comparison_base_index: None,
+            chart_base_ref: None,
         }
     }
 
@@ -1870,21 +2005,25 @@ mod tests {
                 commit: Some("c0".to_owned()),
                 value: 100.0,
                 dirty: false,
+                topo_index: 0,
             },
             SeriesValue {
                 commit: Some("c1".to_owned()),
                 value: 100.0,
                 dirty: false,
+                topo_index: 1,
             },
             SeriesValue {
                 commit: Some("c2".to_owned()),
                 value: 130.0,
                 dirty: false,
+                topo_index: 2,
             },
             SeriesValue {
                 commit: Some("c3".to_owned()),
                 value: 130.0,
                 dirty: false,
+                topo_index: 3,
             },
         ];
         finding
@@ -1895,29 +2034,33 @@ mod tests {
     /// it can be told apart by a plain substring search.
     const CHART_ONLY_MARKER: f64 = 1000.0;
 
-    /// Builds a regression finding with a long series: a distinctive early spike, a long
-    /// flat baseline, and an elevated tip.
+    /// Builds a regression finding with a long, sparse topology: a lone ancient spike at
+    /// `topo_index` 0, then a wide data-less gap, then a recent 30-commit cluster ending
+    /// at the tip (`topo_index` 199).
     ///
-    /// The early spike ([`CHART_ONLY_MARKER`]) sits far outside the branch chart's
-    /// bounded comparison and dwarfs the tip, so it dominates a whole-series chart's
-    /// y-axis but is absent from a branch chart's — the discriminator the scope tests
-    /// key off. The tip (index `len - 1`) is the one point branch mode judges; it must
-    /// always survive into the chart.
+    /// The ancient spike ([`CHART_ONLY_MARKER`]) sits far outside the branch chart's
+    /// bounded recent window and dwarfs the tip, so it dominates a whole-series chart's
+    /// y-axis but is absent from a branch chart's — the discriminator the scope tests key
+    /// off. Because it is isolated at `topo_index` 0 it keeps its own leftmost column
+    /// (never averaged away), so the whole-series chart still shows it. The tip is the one
+    /// point branch mode judges; it must always survive into the chart.
     fn regression_with_long_series() -> Finding {
-        let len = 200;
-        let tip = 130.0;
+        let tip_topo = 199;
+        let cluster_start = 170;
         let baseline = 100.0;
-        let mut series: Vec<SeriesValue> = (0..len)
-            .map(|index| SeriesValue {
-                commit: Some(format!("c{index}")),
-                value: baseline,
-                dirty: false,
-            })
-            .collect();
-        // A towering early point, older than the bounded branch chart would reach.
-        series[0].value = CHART_ONLY_MARKER;
-        // The tip: the last commit analyzed, the single point branch mode acts on.
-        series[len - 1].value = tip;
+        let tip = 130.0;
+        let mut series = vec![SeriesValue {
+            commit: Some("c0".to_owned()),
+            value: CHART_ONLY_MARKER,
+            dirty: false,
+            topo_index: 0,
+        }];
+        series.extend((cluster_start..=tip_topo).map(|topo| SeriesValue {
+            commit: Some(format!("c{topo}")),
+            value: if topo == tip_topo { tip } else { baseline },
+            dirty: false,
+            topo_index: topo,
+        }));
         Finding {
             series,
             ..regression()
@@ -2082,6 +2225,281 @@ mod tests {
                 .all(|value| value.to_bits() != CHART_ONLY_MARKER.to_bits()),
             "ancient observations must fall outside the bounded chart"
         );
+    }
+
+    /// A regression finding carrying an explicit compact chart series, for exercising the
+    /// column-building helpers directly.
+    fn finding_with_series(baseline: f64, latest: f64, points: &[(usize, f64)]) -> Finding {
+        let mut finding = regression();
+        finding.baseline = baseline;
+        finding.latest = latest;
+        finding.series = points
+            .iter()
+            .map(|&(topo, value)| SeriesValue {
+                commit: Some(format!("c{topo}")),
+                value,
+                dirty: false,
+                topo_index: topo,
+            })
+            .collect();
+        finding
+    }
+
+    /// The count of gap (`NaN`) columns in a column slice.
+    fn gap_count(columns: &[f64]) -> usize {
+        columns.iter().filter(|value| value.is_nan()).count()
+    }
+
+    #[test]
+    fn topology_columns_empty_series_yields_no_columns() {
+        assert!(topology_columns(&[], None, CHART_WIDTH as usize).is_empty());
+        assert!(topology_columns(&[], Some(9), CHART_WIDTH as usize).is_empty());
+    }
+
+    #[test]
+    fn topology_columns_single_point_is_one_solid_column() {
+        // One observation, no base ref: a single finite column, no leading or trailing
+        // gap. (A lone column can't be charted, but the binning is still exact.)
+        let columns = topology_columns(&[(5, 42.0)], None, CHART_WIDTH as usize);
+        assert_eq!(columns.len(), 1);
+        assert_eq!(columns[0].to_bits(), 42.0_f64.to_bits());
+    }
+
+    #[test]
+    fn topology_columns_trims_the_leading_gap() {
+        // The first observation is at topo 5, not 0: the leftmost column still holds it,
+        // so the older empty commits never become leading gap columns.
+        let columns = topology_columns(&[(5, 10.0), (7, 20.0)], None, CHART_WIDTH as usize);
+        assert_eq!(columns.len(), 3, "topos 5..=7 span three columns");
+        assert_eq!(columns[0].to_bits(), 10.0_f64.to_bits(), "no leading gap");
+        assert!(
+            columns[1].is_nan(),
+            "the data-less topo 6 is the one interior gap"
+        );
+        assert_eq!(columns[2].to_bits(), 20.0_f64.to_bits());
+        assert_eq!(gap_count(&columns), 1);
+    }
+
+    #[test]
+    fn topology_columns_keeps_every_interior_gap() {
+        // Five data-less commits between two observations become exactly five gap
+        // columns — the topology is reproduced commit for commit.
+        let columns = topology_columns(&[(0, 10.0), (6, 20.0)], None, CHART_WIDTH as usize);
+        assert_eq!(columns.len(), 7);
+        assert_eq!(columns[0].to_bits(), 10.0_f64.to_bits());
+        assert_eq!(columns[6].to_bits(), 20.0_f64.to_bits());
+        assert_eq!(gap_count(&columns), 5, "five data-less commits, five gaps");
+        assert!(columns[1..6].iter().all(|value| value.is_nan()));
+    }
+
+    #[test]
+    fn topology_columns_keeps_the_trailing_gap_up_to_the_base_ref() {
+        // The base ref (the analyzed tip) sits three commits past the last observation,
+        // so those three data-less commits render as a trailing gap — the visual form of
+        // the "no newer data" lag.
+        let columns = topology_columns(&[(0, 10.0), (2, 20.0)], Some(5), CHART_WIDTH as usize);
+        assert_eq!(columns.len(), 6, "topos 0..=5 span six columns");
+        assert_eq!(columns[0].to_bits(), 10.0_f64.to_bits());
+        assert_eq!(columns[2].to_bits(), 20.0_f64.to_bits());
+        assert!(
+            columns[3..6].iter().all(|value| value.is_nan()),
+            "trailing lag gap"
+        );
+        assert!(
+            columns[1].is_nan(),
+            "the data-less topo 1 is an interior gap"
+        );
+        assert_eq!(
+            gap_count(&columns),
+            4,
+            "one interior (topo 1) plus three trailing (topos 3..=5)"
+        );
+    }
+
+    #[test]
+    fn topology_columns_base_ref_at_or_before_last_adds_no_trailing_gap() {
+        // A base ref that does not exceed the last observation leaves no trailing gap:
+        // there is no newer commit to wait for.
+        let at_last = topology_columns(&[(0, 10.0), (4, 20.0)], Some(4), CHART_WIDTH as usize);
+        assert_eq!(at_last.len(), 5);
+        assert_eq!(
+            at_last[4].to_bits(),
+            20.0_f64.to_bits(),
+            "last column is the observation"
+        );
+        let before_last = topology_columns(&[(0, 10.0), (4, 20.0)], Some(2), CHART_WIDTH as usize);
+        assert!(
+            before_last
+                .iter()
+                .zip(&at_last)
+                .all(|(left, right)| left.to_bits() == right.to_bits()),
+            "a base ref before the last point is inert: {before_last:?} vs {at_last:?}"
+        );
+    }
+
+    #[test]
+    fn topology_columns_averages_observations_that_share_a_commit() {
+        // A commit's clean and dirty snapshots share a topo index, so they land in one
+        // column and average — the column is the commit's mean, not two columns.
+        let columns = topology_columns(
+            &[(0, 10.0), (0, 20.0), (2, 30.0)],
+            None,
+            CHART_WIDTH as usize,
+        );
+        assert_eq!(columns.len(), 3);
+        assert_eq!(
+            columns[0].to_bits(),
+            15.0_f64.to_bits(),
+            "the shared commit's mean"
+        );
+        assert!(columns[1].is_nan());
+        assert_eq!(columns[2].to_bits(), 30.0_f64.to_bits());
+    }
+
+    #[test]
+    fn topology_columns_downsamples_without_losing_isolated_observations_or_extrema() {
+        // REGRESSION GUARD. `rasciigraph::plot` interpolates to its width *before*
+        // computing the axis min/max, and that interpolation is NaN-poisoning: handed a
+        // topology span wider than the chart, an isolated observation trapped between
+        // gaps blends into NaN and vanishes — taking its value out of the axis extrema.
+        // Binning to CHART_WIDTH first (here a 100-commit span into 48 columns) must place
+        // every real observation in its own column so neither the observations nor the
+        // axis extrema can be lost.
+        let points = [(0, 1000.0), (49, 1.0), (99, 500.0)];
+        let columns = topology_columns(&points, None, CHART_WIDTH as usize);
+        assert_eq!(
+            columns.len(),
+            CHART_WIDTH as usize,
+            "the span is capped at the width"
+        );
+        assert_eq!(
+            columns[0].to_bits(),
+            1000.0_f64.to_bits(),
+            "the max survives, in column 0"
+        );
+        assert_eq!(
+            columns[23].to_bits(),
+            1.0_f64.to_bits(),
+            "the isolated min survives"
+        );
+        assert_eq!(
+            columns[47].to_bits(),
+            500.0_f64.to_bits(),
+            "the last observation survives"
+        );
+        assert_eq!(
+            columns.iter().filter(|value| value.is_finite()).count(),
+            3,
+            "each of the three observations keeps its own column — none dropped or merged"
+        );
+        // And the extrema survive all the way into the rendered axis.
+        let chart = chart_series(&points, None).expect("three finite columns plot");
+        assert!(chart.contains("1000"), "the max heads the y-axis: {chart}");
+        assert!(chart.contains("┼") || chart.contains("┤"), "{chart}");
+    }
+
+    #[test]
+    fn chart_series_of_a_lone_observation_with_a_lag_draws_nothing() {
+        // One real observation plus a trailing lag is a single finite value among NaNs —
+        // too few to plot a line, so no chart.
+        assert!(chart_series(&[(0, 5.0)], Some(10)).is_none());
+    }
+
+    #[test]
+    fn chart_gates_on_the_finite_count_not_the_length() {
+        // The gate counts *finite* values: a lone real value padded with gap columns must
+        // not plot (pins the `< 2` finite test against a length-based slip).
+        assert!(
+            chart(&[1.0, f64::NAN]).is_none(),
+            "one finite value is too few"
+        );
+        assert!(chart(&[f64::NAN, f64::NAN]).is_none(), "no finite values");
+        assert!(
+            chart(&[1.0, f64::NAN, 2.0]).is_some(),
+            "two finite values plot"
+        );
+    }
+
+    #[test]
+    fn chart_renders_a_gap_without_disturbing_the_axis() {
+        // A NaN column is a gap, not a data point: it must not poison the axis extrema,
+        // and an isolated interior extreme surrounded by gaps must still head the axis.
+        let gapped = chart(&[10.0, f64::NAN, 30.0]).expect("two finite values plot");
+        assert!(
+            gapped.contains("30"),
+            "the max still labels the axis top: {gapped}"
+        );
+        assert!(
+            gapped.contains("10"),
+            "the min still labels the axis bottom: {gapped}"
+        );
+        let spike =
+            chart(&[10.0, f64::NAN, 1000.0, f64::NAN, 20.0]).expect("three finite values plot");
+        assert!(
+            spike.contains("1000"),
+            "an isolated interior spike survives, un-poisoned: {spike}"
+        );
+    }
+
+    #[test]
+    fn branch_chart_values_open_with_baseline_close_with_latest_and_gap_the_lag() {
+        // The compact branch series is a single base observation at topo 0 and the tip at
+        // topo 3; topos 1 and 2 are the commits the branch's base is behind by. The chart
+        // must open with the comparison baseline, close with the tip's judged latest, and
+        // render those two lagging commits as exactly two gap columns.
+        let finding = finding_with_series(100.0, 130.0, &[(0, 100.0), (3, 130.0)]);
+        let values = branch_chart_values(&finding);
+        assert_eq!(values.len(), 5, "baseline column + topos 0..=3");
+        assert_eq!(
+            values[0].to_bits(),
+            100.0_f64.to_bits(),
+            "opens with the baseline"
+        );
+        assert_eq!(
+            values[1].to_bits(),
+            100.0_f64.to_bits(),
+            "the base observation at topo 0"
+        );
+        assert!(values[2].is_nan(), "the first lagging commit is a gap");
+        assert!(values[3].is_nan(), "the second lagging commit is a gap");
+        assert_eq!(
+            values[4].to_bits(),
+            130.0_f64.to_bits(),
+            "closes with the tip's latest"
+        );
+        assert_eq!(gap_count(&values), 2, "exactly commits_behind gap columns");
+    }
+
+    #[test]
+    fn branch_chart_values_average_a_commits_shared_observations() {
+        // A base commit contributes both a clean and a dirty snapshot at the same topo
+        // index, so the branch chart's column for that commit is their mean, not their sum
+        // or product. topo 0 holds 100 and 120 (mean 110); the tip at topo 2 is the judged
+        // latest, with topo 1 the single lagging commit.
+        let finding = finding_with_series(100.0, 130.0, &[(0, 100.0), (0, 120.0), (2, 130.0)]);
+        let values = branch_chart_values(&finding);
+        assert_eq!(values.len(), 4, "baseline column + topos 0..=2");
+        assert_eq!(
+            values[1].to_bits(),
+            110.0_f64.to_bits(),
+            "the shared commit's column is the mean of its two observations"
+        );
+        assert!(values[2].is_nan(), "the lagging commit is a gap");
+        assert_eq!(
+            values[3].to_bits(),
+            130.0_f64.to_bits(),
+            "closes with the tip's latest"
+        );
+    }
+
+    #[test]
+    fn branch_chart_values_of_an_empty_series_is_just_the_baseline() {
+        // A finding with no charted observations still yields its baseline column (and so
+        // never plots, having one finite value).
+        let finding = finding_with_series(100.0, 130.0, &[]);
+        let values = branch_chart_values(&finding);
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].to_bits(), 100.0_f64.to_bits());
     }
 
     #[test]

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -685,13 +685,14 @@ fn branch_chart_values(finding: &Finding) -> Vec<f64> {
 /// While the span fits (`span + 1 <= max_width`) each commit maps to its own column, so
 /// the topology is exact and a data-less commit is a single `NaN` column. Beyond that
 /// the span is downsampled: every real point still lands in some column (placed by
-/// integer index, never interpolated away, so neither an observation nor an axis extreme
-/// is lost), empty columns stay `NaN`, and a column that catches several observations
-/// averages them (a slight, documented blur of a dense region). Binning to `max_width`
-/// before the series reaches [`chart`] is essential: `rasciigraph` interpolates to its
-/// width *before* computing the axis min/max and its linear interpolation is
-/// NaN-poisoning, so a longer series would blend an isolated observation surrounded by
-/// `NaN` into `NaN` and drop it (and its value) entirely.
+/// integer index, never interpolated away), so an isolated observation is never dropped
+/// and empty columns stay `NaN`. A column that catches several observations averages
+/// them, which blurs a dense region and can attenuate an extreme that shares a bin — the
+/// one detail binning gives up. Binning to `max_width` before the series reaches [`chart`]
+/// is essential: `rasciigraph` interpolates to its width *before* computing the axis
+/// min/max and its linear interpolation is NaN-poisoning, so a longer series would blend
+/// an isolated observation surrounded by `NaN` into `NaN` and drop it (and its value)
+/// entirely.
 #[must_use]
 pub fn topology_columns(
     points: &[(usize, f64)],
@@ -2367,8 +2368,8 @@ mod tests {
         // topology span wider than the chart, an isolated observation trapped between
         // gaps blends into NaN and vanishes — taking its value out of the axis extrema.
         // Binning to CHART_WIDTH first (here a 100-commit span into 48 columns) must place
-        // every real observation in its own column so neither the observations nor the
-        // axis extrema can be lost.
+        // each isolated observation in its own column so neither those observations nor the
+        // axis extrema they define can be lost.
         let points = [(0, 1000.0), (49, 1.0), (99, 500.0)];
         let columns = topology_columns(&points, None, CHART_WIDTH as usize);
         assert_eq!(


### PR DESCRIPTION
[Copilot speaking]

## What & why

The `analyze` and `examine` ASCII charts are now **topology-accurate**: one column per first-parent commit from the first observation onward, with a **gap** where a commit carries no data. This makes the existing "lagged history / no newer data" warning visible in the chart itself.

- **Leading gaps trimmed**, **interior gaps kept** (five data-less commits render as five blank columns), and the **trailing gap** from the last observation up to the analyzed tip is the visual form of the lag warning.
- **Branch mode** drops interior branch commits and charts the base history plus a single tip column, with exactly `commits_behind` gap columns between the newest base observation and the tip.

## How

Findings and `examine` points stay **compact** — real observations plus their `topo_index` and a per-finding `chart_base_ref`. A shared `cbh_render` helper (`topology_columns`) densifies and bins them into ≤48 NaN-gapped columns at draw time, so stored data stays bounded by the observation count. Detection is untouched — this is presentation-only.

### `chart()` width change (worth a look in review)

`chart()` now sizes its width to the column count (≤48) instead of stretching to a fixed 48. This is forced by `rasciigraph`, which resamples every series to `config.width` **before** computing the axis extrema, and whose linear interpolation is NaN-poisoning: stretching a gapped series would blend an isolated observation trapped between gaps into `NaN` and drop it from both the line and the axis. Binning to the width first and matching the width to the value count keeps every observation and both extrema, and each gap stays exactly as wide as the run of data-less commits it represents. A regression test (`topology_columns_downsamples_without_losing_isolated_observations_or_extrema`) guards this. Side effect: short non-gapped charts now render at their true width rather than stretched to 48.

### ASCII limitation

A trailing gap immediately after a **flat plateau** is visually identical to a continued plateau (both a blank final column). Non-flat series show the line stopping short, so the lag is visible; the flat case is inherent to ASCII. The history integration test asserts chart *width* rather than glyph content for this reason.

## Tests

- `cbh_render` pure tests: exact interior/leading/trailing/equal-topo gap counts, the downsample-preserves-extrema regression, the finite-count `chart()` gate, and branch-chart baseline/tip/gap/averaging.
- `cbh_detect` pure Miri-safe tests: history and branch `build_chart_series`, interior-branch-commit drop, tip at `merge_base + 1`.
- Integration tests in `cargo-bench-history`: a branch comparison-base lag that warns and charts the gap, and a history "no newer data" trailing gap.
- `examine` tests: interior and trailing gaps in the chart while the point table and JSON list only real observations (no `topo_index`, no phantom rows, no `NaN`).

## Validation

`clippy` (dev + release), `test`, `test-docs`, `docs`, `docs-default-features`, `default-features-check`, `machete`, `check`/`build` release, `miri`, and `format-check` all pass with zero warnings for `cbh_detect`, `cbh_render`, `cbh_analyze`, and `cargo-bench-history`. Mutation testing scoped to the new logic caught every viable mutant.

## Docs

`docs/DESIGN.md` and the book pages (`concepts/analysis.md`, `commands/analyze.md`, `commands/examine.md`) describe the topology-accurate charts, the lag gaps, and the intentional difference between `analyze`'s branch-collapse chart and `examine`'s full-timeline chart.