### PR TITLE
Relax bless/prune guards and remove capture-time unblessing

### DIFF
--- a/packages/cargo-bench-history/book/src/commands/bless.md
+++ b/packages/cargo-bench-history/book/src/commands/bless.md
@@ -7,7 +7,7 @@ the same accepted step forever. Blessing re-baselines the series from the blesse
 forward.
 
 ```console
-# Accept a change on one or more benchmarks (matched by id prefix) at a base-branch commit.
+# Accept a change on one or more benchmarks (matched by id prefix) at a commit.
 cargo bench-history bless --local=./bench-history <benchmark-prefix>...
 
 # Remove the blessings recorded at the context commit.
@@ -20,17 +20,25 @@ cargo bench-history unbless --local=./bench-history <benchmark-prefix>...
   it is deliberately per-benchmark — accepting the benchmark that caused trouble must not
   silently accept every other benchmark that may be trending badly. `--all` (mutually
   exclusive with prefixes) accepts every benchmark recorded at the commit.
-- Both commands operate on a context ref (default `HEAD`), so any base-branch commit can be
+- Both commands operate on a context ref (default `HEAD`), so any commit that resolves can be
   (un)blessed, not just the checked-out one.
-- A blessing is recorded only when the context commit is **on the base branch** and a clean
-  run already exists there; both are hard errors otherwise. A dirty working tree is allowed
-  (the blessing targets the committed run) but warns.
+- Blessing prefers — but does not require — the base branch and an existing clean run at the
+  commit. Blessing **off the base branch warns**: it takes effect only once the commit joins
+  the base branch's first-parent history (for example after a fast-forward), so a fast-forward
+  merge workflow can bless a commit already on a feature branch. Blessing a commit with **no
+  recorded run also warns** (double-check the commit id) and synthesizes the target discriminant
+  sets from the resolved facets — all four engines when `--engine` is omitted, under the resolved
+  target triple and machine key — so a change can be accepted *before* its data is captured.
+  A no-data blessing needs a concrete target triple and machine key, so one whose triple or
+  machine-key facet is unconstrained (`all`) is an error. An unresolvable context ref, an
+  undeterminable base branch, or no prefixes without `--all` remain hard errors.
+- A dirty working tree is allowed (the blessing targets the committed run) but warns.
 
 ## Lifecycle
 
-A blessing is an append-only sidecar alongside the commit's clean run, so narrowing one means
-unbless-then-re-bless the subset to keep, and overwriting a commit's clean run drops its stale
-sidecars. `unbless` deletes only the blessings recorded at the context commit; blessings at
+A blessing is an append-only sidecar in each targeted set's commit directory (which need not
+yet hold a run), so narrowing one means unbless-then-re-bless the subset to keep. Capturing or
+overwriting a run never removes a blessing. `unbless` deletes only the blessings recorded at the context commit; blessings at
 later commits stay in effect. Blessings are honored **only in history mode** — branch mode
 judges the latest state against the base, which is treated as fully blessed by construction.
 

--- a/packages/cargo-bench-history/book/src/commands/prune.md
+++ b/packages/cargo-bench-history/book/src/commands/prune.md
@@ -9,15 +9,19 @@ rather than reporting on them.
 # Preview deletion of dirty snapshots without deleting anything.
 cargo bench-history prune --local=./bench-history --dry-run --dirty
 
-# Delete clean runs (and their blessings) from the selected feature-branch commits.
+# Delete clean runs from the selected feature-branch commits.
 cargo bench-history prune --local=./bench-history --clean
+
+# Also delete the blessing sidecars in the selected range.
+cargo bench-history prune --local=./bench-history --clean --include-blessings
 ```
 
-## Deletion scope is required
+## An action is required
 
-A deletion scope is required: `--clean` removes clean runs and their blessings, `--dirty`
-removes only dirty snapshots, and `--all` removes both. A bare `prune` is therefore an
-error that names the three choices.
+An action is required: `--clean` removes clean runs, `--dirty` removes only dirty snapshots,
+and `--all` removes both. `--include-blessings` additionally deletes blessing sidecars and may
+be given on its own to remove only blessings. A bare `prune` is therefore an error that names
+these choices.
 
 ## What prune preserves
 
@@ -26,6 +30,7 @@ branch's own commits, preserving shared base-branch history. If the context is i
 base branch, deletion is refused unless you explicitly confirm it with `--prune-base`; that
 guard protects the mainline data every feature analysis compares against.
 
-A blessing is removed only when the clean run it annotates is removed in the same pass, so
-blessings follow their clean run and are never time-filtered directly. A dry run builds the
-identical plan but skips the deletes.
+Pruning runs never removes a blessing; only `--include-blessings` (or [`unbless`](bless.md))
+does. With `--include-blessings`, every blessing in the selected range is deleted — including
+an orphan on a commit that has no recorded run. A dry run builds the identical plan but skips
+the deletes.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -187,6 +187,10 @@ engine is partitioned by machine key, so a bare query scopes every engine unifor
 the machine-key facet. A facet that matches several sets yields one report per set —
 parallel data sets analyzed individually.
 
+Facet identity is **case-insensitive**: engine names and every key segment are normalized to
+lowercase, so `Callgrind`, `callgrind`, and `CALLGRIND` name the same engine, and a triple or
+machine key differing only in case resolves to one set rather than silently splitting into two.
+
 The commands divide into **create** and **query** roles. `collect` and `backfill` record
 new data into exactly one machine's reality, so they auto-detect every facet and accept
 only a machine-key override (for a stable CI-pool key); they reject engine or triple
@@ -569,18 +573,19 @@ bad run, or drop the ephemeral uncommitted-tree snapshots that evaluation runs l
 behind. It reuses `analyze`'s selection pipeline (keeping the three commands in lockstep)
 and then removes the selected objects rather than reporting on them.
 
-A deletion **scope is required** — clean runs (and the blessings riding on them), dirty
-snapshots only, or both — so a bare `prune` is an error that names the three. Pruning never
-touches base-branch history: it walks the selected commits from the context back to the
-merge-base with the base and deletes only the context branch's own commits, preserving the
-shared base. Deleting the base branch's own data set (context resolves onto the base) wipes
-the mainline every feature analysis compares against, so it is refused unless a confirming
-flag is passed. The one intentional divergence from `analyze` / `list` is that the base
-tip's dirty snapshots are admitted **unconditionally**, so a dirty prune can reclaim
-ephemeral base-branch snapshots regardless of the current tree state. A blessing is removed
-only when the clean run it annotates is removed in the same pass, so blessings follow their
-clean run and are never time-filtered directly. A dry-run builds the identical plan but
-skips the deletes.
+A deletion **action is required** — remove clean runs, dirty snapshots, or both, and/or
+delete blessing sidecars with `--include-blessings` — so a bare `prune` is an error that
+names them. Pruning never touches base-branch history: it walks the selected commits from
+the context back to the merge-base with the base and deletes only the context branch's own
+commits, preserving the shared base. Deleting the base branch's own data set (context
+resolves onto the base) wipes the mainline every feature analysis compares against, so it is
+refused unless a confirming flag is passed. The one intentional divergence from `analyze` /
+`list` is that the base tip's dirty snapshots are admitted **unconditionally**, so a dirty
+prune can reclaim ephemeral base-branch snapshots regardless of the current tree state.
+Pruning runs never removes a blessing; `--include-blessings` deletes every blessing sidecar
+in the selected range — including an orphan on a commit with no recorded run — and may be
+given on its own to remove only blessings. A blessing is otherwise removed only by `unbless`.
+A dry-run builds the identical plan but skips the deletes.
 
 ### 7.7 `bless` / `unbless`
 
@@ -593,17 +598,24 @@ accepted step forever. Blessing re-baselines the series from the blessed commit 
 it is deliberately per-benchmark — accepting the benchmark that caused trouble must not
 silently accept every other benchmark that may be trending badly unnoticed. An all-switch
 (mutually exclusive with prefixes) accepts every benchmark recorded at the commit. Both
-commands operate on a context ref (default `HEAD`), so any base-branch commit can be
-(un)blessed, not just the checked-out one. A blessing is recorded only when the context
-commit is **on the base branch** and a clean run already exists there; both are hard errors
-otherwise, with no force escape hatch, because a feature-branch blessing would vanish or
-duplicate once the branch is squash-merged and blessing a commit with no data point is
-meaningless. A dirty working tree is allowed (the blessing targets the committed run) but
-warns.
+commands operate on a context ref (default `HEAD`), so any commit that resolves can be
+(un)blessed, not just the checked-out one. Blessing prefers — but does not require — the
+base branch and an existing clean run at the commit. Blessing off the base branch **warns**:
+the blessing only takes effect once the commit joins the base branch's first-parent history
+(for example after a fast-forward), so a fast-forward merge workflow can legitimately bless a
+commit already on a feature branch. Blessing a commit with **no recorded run** also warns
+(the commit id is worth double-checking) and synthesizes the target discriminant sets from
+the resolved facets — all four engines when `--engine` is omitted, under the resolved target
+triple and machine key — so an intentional change can be accepted *before* its data is
+captured; whichever engine's data lands there later is then accepted. This synthesis needs a
+concrete target triple and machine key, so a no-data blessing whose triple or machine-key
+facet is unconstrained (`all`) is a hard error. The remaining hard errors are an unresolvable
+context ref, an undeterminable base branch, and no prefixes without `--all`. A dirty working
+tree is allowed (the blessing targets the committed run) but warns.
 
-A blessing is an **append-only sidecar** alongside the commit's clean run, so narrowing one
-means unbless-then-re-bless the subset to keep, and overwriting a commit's clean run drops
-its stale sidecars. `unbless` deletes only the blessings recorded at the context commit;
+A blessing is an **append-only sidecar** in each targeted set's commit directory (which need
+not yet hold a run), so narrowing one means unbless-then-re-bless the subset to keep.
+Capturing or overwriting a run never removes a blessing. `unbless` deletes only the blessings recorded at the context commit;
 blessings at later commits stay in effect, so the timeline may remain blessed past the
 unblessed commit. `list blessings` audits them — the sidecars at the current commit by
 default, or the most recent blessing of every benchmark across the analysis window.

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -862,15 +862,6 @@ where
                 .reporter
                 .note_with(|| format!("{engine}: stored {object_key}"));
 
-            // Replacing a clean run discards the data point its blessings accepted, so
-            // any blessing sidecars on this commit no longer describe a stored level.
-            // Remove them on overwrite so a stale blessing cannot silently re-baseline
-            // the new run.
-            if params.overwrite && !dirty {
-                invalidate_blessings(storage, &key, store.project_id, commit, store.reporter)
-                    .await?;
-            }
-
             Ok(EngineSummary {
                 stored: true,
                 count,
@@ -923,33 +914,6 @@ async fn store_result<S: Storage>(
         }
         Err(error) => Err(error.into()),
     }
-}
-
-/// Deletes every blessing sidecar recorded at `commit` in the partition `key`.
-///
-/// Called when an overwrite replaces a clean run: the blessings accepted the level
-/// of the run being replaced, so they are removed rather than left to re-baseline
-/// the new (possibly different) level.
-async fn invalidate_blessings<S: Storage>(
-    storage: &S,
-    key: &DiscriminantSet,
-    project: &str,
-    commit: &str,
-    reporter: &dyn Reporter,
-) -> Result<(), RunError> {
-    let prefix = key.commit_prefix(project, commit);
-    let keys = storage.list(&prefix).await?;
-    for object_key in keys {
-        let is_bless = object_key
-            .rsplit('/')
-            .next()
-            .is_some_and(|name| name.starts_with("bless-"));
-        if is_bless {
-            storage.delete(&object_key).await?;
-            reporter.note_with(|| format!("removed stale blessing {object_key}"));
-        }
-    }
-    Ok(())
 }
 
 /// Parses harvested engine output into result records, naming the offending
@@ -1998,7 +1962,7 @@ mod tests {
     }
 
     #[test]
-    fn overwriting_a_clean_run_removes_stale_blessing_sidecars() {
+    fn overwriting_a_clean_run_keeps_blessing_sidecars() {
         let storage = MemoryStorage::new();
         // A first clean run establishes the commit directory.
         drive(
@@ -2024,8 +1988,10 @@ mod tests {
         block_on(storage.put(&bless_key, record.to_json().unwrap().as_bytes())).unwrap();
         assert!(storage.keys().iter().any(|key| key == &bless_key));
 
-        // Overwriting the clean run discards the accepted data point, so its
-        // blessing sidecar is removed.
+        // Capturing a run never removes a blessing — even an overwrite that replaces
+        // the clean run leaves the sidecar in place. A blessing is removed only by the
+        // `unbless` command, so a pre-emptive blessing (applied before the data lands)
+        // survives the capture that gives it something to baseline.
         let overwrite = CollectOptions {
             overwrite: true,
             ..CollectOptions::default()
@@ -2041,8 +2007,8 @@ mod tests {
 
         let keys = storage.keys();
         assert!(
-            !keys.iter().any(|key| key == &bless_key),
-            "the stale blessing should be gone: {keys:?}"
+            keys.iter().any(|key| key == &bless_key),
+            "the blessing survives the capture: {keys:?}"
         );
         assert!(
             keys.iter().any(|key| key.ends_with("/clean.json")),
@@ -2075,9 +2041,9 @@ mod tests {
     #[test]
     fn overwriting_a_dirty_snapshot_keeps_blessing_sidecars() {
         let storage = MemoryStorage::new();
-        // Blessings accept the clean run's data point, so a blessing sidecar on the
-        // commit must survive when only a dirty snapshot of that commit is rewritten;
-        // invalidation is reserved for a clean overwrite that discards the point.
+        // Capturing never removes a blessing, so a blessing sidecar on the commit
+        // survives when a dirty snapshot of that commit is rewritten, just as it does
+        // for a clean run. Blessings are removed only by the `unbless` command.
         let machine = probe_machine_key();
         let commit_dir = format!(
             "v1/folo/objects/callgrind/x86_64-pc-windows-msvc/{machine}/\

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -135,9 +135,12 @@
 //! ## `prune`
 //!
 //! Deletes a chosen portion of the stored data, using the same selection pipeline
-//! as `analyze`/`list`. A scope is required: `--dirty` removes ephemeral
-//! uncommitted-tree snapshots, `--clean` removes clean runs and their blessing
-//! sidecars, and `--all` removes both. Pruning preserves base-branch history — only
+//! as `analyze`/`list`. An action is required: `--dirty` removes ephemeral
+//! uncommitted-tree snapshots, `--clean` removes clean runs, and `--all` removes
+//! both. `--include-blessings` additionally deletes blessing sidecars in the
+//! selected range — including orphans on commits with no recorded run — and may be
+//! given on its own; pruning runs otherwise never removes a blessing. Pruning
+//! preserves base-branch history — only
 //! the context branch's own commits (those after the merge-base with `--base`) are
 //! removed. When the context resolves onto the base branch itself, the whole
 //! selection *is* base-branch history, so the deletion is refused unless
@@ -168,8 +171,12 @@
 //! `bless all_the_time/read_cell`), or `--all` to accept every benchmark recorded
 //! at the commit. A blessing re-baselines the benchmark's history from the blessed
 //! commit forward, so the accepted step is no longer reported while earlier points
-//! stay on the chart for context. Blessing is base-branch-only and requires an
-//! existing recorded run at the blessed commit. By default `bless`/`unbless` act on
+//! stay on the chart for context. Blessing prefers the base branch and an existing
+//! recorded run at the blessed commit, but neither is required: blessing off the base
+//! branch warns (the blessing only takes effect once the commit joins the base's
+//! first-parent history), and blessing a commit with no recorded run warns and
+//! synthesizes the target discriminant sets from the resolved facets, so a change can
+//! be accepted *before* its data is captured. By default `bless`/`unbless` act on
 //! `HEAD`; `--context <ref>` blesses or unblesses another commit instead. `unbless`
 //! removes the blessings recorded at that commit — note that any blessings defined
 //! at *later* commits remain in force, so the timeline may stay blessed past the

--- a/packages/cargo-bench-history/src/outcome.rs
+++ b/packages/cargo-bench-history/src/outcome.rs
@@ -117,8 +117,10 @@ pub enum RunError {
         /// Human-readable description, including any partial backfill summary.
         message: String,
     },
-    /// A blessing precondition failed (a dirty working tree, a commit not on the
-    /// base branch, no stored result at the current commit, or no prefixes given).
+    /// A blessing precondition failed: no benchmark prefixes given (and no `--all`),
+    /// an unresolvable context ref, an undeterminable base branch, or — when the
+    /// commit has no stored run — an unconstrained target triple or machine key that
+    /// leaves no discriminant set to synthesize a sidecar for.
     Bless {
         /// Human-readable description of the precondition failure.
         message: String,

--- a/packages/cargo-bench-history/tests/cbh_integration/bless.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/bless.rs
@@ -135,11 +135,12 @@ async fn unbless_restores_a_previously_blessed_regression() {
     );
 }
 
-/// Blessing is base-branch-only: attempting it from a feature branch is a hard
-/// error with no escape hatch, and records nothing.
+/// Blessing off the base branch is allowed but warns: the sidecar is still written,
+/// with an explanatory note that it only takes effect once the commit joins the base
+/// branch's first-parent history (for example after a fast-forward).
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn bless_on_a_feature_branch_is_rejected() {
+async fn bless_on_a_feature_branch_warns_but_succeeds() {
     let workspace = Workspace::clean_repo(&storage_only_config());
     workspace.commit_dated("2024-01-01", "c1");
     workspace.seed_callgrind("c1", 100.0);
@@ -147,19 +148,111 @@ async fn bless_on_a_feature_branch_is_rejected() {
     workspace.commit_dated("2024-01-02", "f1");
     workspace.seed_callgrind("f1", 130.0);
 
-    let error = workspace
-        .drive(&["bless", "nm/nm::observe"])
-        .await
-        .unwrap_err();
-    let RunError::Bless { message } = error else {
-        panic!("expected a bless error, got {error:?}");
+    let RunOutcome::Completed { message } =
+        workspace.drive(&["bless", "nm/nm::observe"]).await.unwrap()
+    else {
+        panic!("expected a completed outcome");
     };
     assert!(message.contains("not on the base branch"), "{message}");
-    // Only the two seeded clean runs exist; no blessing sidecar was written.
-    let objects = workspace.stored_objects();
-    assert!(
-        objects.iter().all(|(key, _)| key.ends_with("clean.json")),
-        "no blessing sidecar should be written: {objects:?}"
+    assert!(message.contains("first-parent history"), "{message}");
+    assert!(message.contains("Blessed"), "{message}");
+
+    // The blessing sidecar is still recorded at the off-base commit (the clean run
+    // present at f1 anchors it), so `list blessings` at HEAD finds it.
+    let listing = workspace.drive_json(&["list", "blessings"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&listing).unwrap();
+    let blessings = parsed["blessings"].as_array().unwrap();
+    assert_eq!(
+        blessings.len(),
+        1,
+        "the off-base blessing is still recorded: {listing}"
+    );
+}
+
+/// The off-base check follows *first-parent* history, not mere ancestry. A commit
+/// merged in as a second parent is reachable from the base branch, yet it is not on
+/// the base branch's official (first-parent) line, so `analyze` would ignore a
+/// blessing there. Blessing such a commit must therefore warn, even though a plain
+/// ancestry check would consider it "on the base branch."
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn bless_on_a_merged_in_side_commit_warns_off_first_parent() {
+    let workspace = Workspace::repo(&storage_only_config());
+    // master:  root - c1 - M - c3   (M merges the side branch in)
+    //                  \   /
+    //  side:            sf1
+    workspace.commit("c1");
+    workspace.checkout_new_branch("side");
+    workspace.commit("sf1");
+    workspace.checkout("master");
+    workspace.merge("side", "M");
+    workspace.commit("c3");
+
+    // A clean run anchors the blessing at the second-parent commit sf1.
+    workspace.seed_callgrind("sf1", 100.0);
+
+    // Bless with HEAD on sf1: reachable from master (via M's second parent) but off
+    // master's first-parent line.
+    workspace.checkout("side");
+    let RunOutcome::Completed { message } =
+        workspace.drive(&["bless", "nm/nm::observe"]).await.unwrap()
+    else {
+        panic!("expected a completed outcome");
+    };
+    assert!(message.contains("not on the base branch"), "{message}");
+    assert!(message.contains("first-parent history"), "{message}");
+    assert!(message.contains("Blessed"), "{message}");
+
+    // The sidecar is still written at sf1.
+    let listing = workspace.drive_json(&["list", "blessings"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&listing).unwrap();
+    assert_eq!(
+        parsed["blessings"].as_array().unwrap().len(),
+        1,
+        "the off-first-parent blessing is still recorded: {listing}"
+    );
+}
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn bless_before_capture_applies_once_the_data_lands() {
+    let workspace = Workspace::clean_repo(&storage_only_config());
+    // Build the full commit history first, capturing no data yet.
+    for (date, label) in [
+        ("2024-01-01", "c1"),
+        ("2024-01-02", "c2"),
+        ("2024-01-03", "c3"),
+        ("2024-01-04", "c4"),
+        ("2024-01-05", "c5"),
+        ("2024-01-06", "c6"),
+    ] {
+        workspace.commit_dated(date, label);
+    }
+
+    // Pre-emptively accept the tip before any run exists there. With no data to
+    // anchor to, the target sets are synthesized from the resolved facets (every
+    // engine on this host).
+    let RunOutcome::Completed { message } = workspace.drive(&["bless", "--all"]).await.unwrap()
+    else {
+        panic!("expected a completed outcome");
+    };
+    assert!(message.contains("no stored result"), "{message}");
+    assert!(message.contains("Blessed"), "{message}");
+
+    // Now capture the rising Callgrind history over those same commits.
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.seed_callgrind("c2", 100.0);
+    workspace.seed_callgrind("c3", 100.0);
+    workspace.seed_callgrind("c4", 130.0);
+    workspace.seed_callgrind("c5", 130.0);
+    workspace.seed_callgrind("c6", 130.0);
+
+    // The pre-emptive blessing occupies the exact Callgrind set the run landed in,
+    // so the regression is suppressed with no re-bless.
+    let report = workspace.drive_json(&["analyze"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(
+        parsed["regressions"], 0,
+        "a pre-emptive blessing must apply once the data lands: {report}"
     );
 }
 

--- a/packages/cargo-bench-history/tests/cbh_integration/prune.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/prune.rs
@@ -298,8 +298,8 @@ async fn prune_dirty_since_only_removes_runs_on_or_after_the_cutoff() {
     );
 }
 
-/// The `--all` scope deletes clean *and* dirty runs (and their blessing sidecars)
-/// for the narrowed selection. A `<commit>` argument selecting one feature commit removes its
+/// The `--all` scope deletes clean *and* dirty runs for the narrowed selection. A
+/// `<commit>` argument selecting one feature commit removes its
 /// clean and dirty runs while leaving the base-branch run intact.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
@@ -326,8 +326,9 @@ async fn prune_all_removes_clean_and_dirty_for_a_commit() {
     assert_eq!(parsed["totals"]["runs"], 1, "{message}");
 }
 
-/// `prune` requires a scope: invoking it without `--clean`, `--dirty`, or `--all`
-/// is rejected at parse time, protecting against an accidental wipe with no intent.
+/// `prune` requires an action: invoking it without `--clean`, `--dirty`, `--all`,
+/// or `--include-blessings` is rejected at parse time, protecting against an
+/// accidental wipe with no intent.
 #[test]
 fn prune_requires_a_scope() {
     let error = Cli::from_args(&["cargo-bench-history"], &["prune"]).unwrap_err();
@@ -374,7 +375,7 @@ async fn prune_all_removes_only_the_feature_side() {
     );
 }
 
-/// `--clean` deletes clean runs (and their blessings) while leaving dirty snapshots
+/// `--clean` deletes clean runs while leaving dirty snapshots
 /// in place — the inverse of `--dirty`.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
@@ -404,11 +405,12 @@ async fn prune_clean_scope_removes_clean_and_keeps_dirty() {
     assert_eq!(parsed["totals"]["runs"], 1, "dirty f1 survived: {message}");
 }
 
-/// A blessing sidecar follows its clean run: deleting a commit's clean run with the
-/// default scope also removes the blessing recorded there.
+/// Pruning a run never removes a blessing; only `--include-blessings` (or `unbless`)
+/// does. The default `--all` prune deletes the clean run but leaves the blessing,
+/// which `--include-blessings` then removes.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn prune_removes_a_blessing_with_its_clean_run() {
+async fn include_blessings_is_required_to_prune_a_blessing() {
     let workspace = Workspace::clean_repo(&storage_only_config());
     workspace.seed_rising_callgrind_history();
     let head = workspace.head();
@@ -424,13 +426,30 @@ async fn prune_removes_a_blessing_with_its_clean_run() {
         "{message}"
     );
 
-    // Pruning HEAD's clean run also deletes the blessing that rode on it. The
-    // checkout is the base branch tip, so the base-branch guard must be confirmed.
+    // The default `--all` prune removes HEAD's clean run but leaves the blessing.
+    // The checkout is the base branch tip, so the base-branch guard must be confirmed.
     let message = workspace
         .drive_json(&["prune", &head, "--all", "--prune-base"])
         .await;
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert_eq!(parsed["totals"]["runs"], 1, "the clean HEAD run: {message}");
+    assert_eq!(parsed["totals"]["blessings"], 0, "{message}");
+
+    // The blessing survives the run prune.
+    let message = workspace.drive_json(&["list", "blessings"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(
+        parsed["blessings"].as_array().unwrap().len(),
+        1,
+        "the blessing outlived its clean run: {message}"
+    );
+
+    // `--include-blessings` removes the now-orphan blessing.
+    let message = workspace
+        .drive_json(&["prune", &head, "--include-blessings", "--prune-base"])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(parsed["totals"]["runs"], 0, "no runs left: {message}");
     assert_eq!(parsed["totals"]["blessings"], 1, "{message}");
 
     // The blessing is gone.
@@ -438,7 +457,41 @@ async fn prune_removes_a_blessing_with_its_clean_run() {
     let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
     assert!(
         parsed["blessings"].as_array().unwrap().is_empty(),
-        "the blessing was removed with its clean run: {message}"
+        "the blessing was removed by --include-blessings: {message}"
+    );
+}
+
+/// `--all` and `--include-blessings` are additive and combine in a single
+/// invocation: the run and its blessing are both removed in one pass.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn all_and_include_blessings_combine_in_one_invocation() {
+    let workspace = Workspace::clean_repo(&storage_only_config());
+    workspace.seed_rising_callgrind_history();
+    let head = workspace.head();
+
+    workspace.drive(&["bless", "nm/nm::observe"]).await.unwrap();
+
+    // A single pass with both flags removes the clean HEAD run and its blessing.
+    let message = workspace
+        .drive_json(&[
+            "prune",
+            &head,
+            "--all",
+            "--include-blessings",
+            "--prune-base",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert_eq!(parsed["totals"]["runs"], 1, "the clean HEAD run: {message}");
+    assert_eq!(parsed["totals"]["blessings"], 1, "the blessing: {message}");
+
+    // Both are gone.
+    let message = workspace.drive_json(&["list", "blessings"]).await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    assert!(
+        parsed["blessings"].as_array().unwrap().is_empty(),
+        "the blessing was removed alongside its run: {message}"
     );
 }
 

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -2,21 +2,34 @@
 //! benchmark's level on the base branch, so history analysis stops re-flagging an
 //! intentional change.
 //!
-//! `bless` writes an append-only `BlessingRecord`
-//! sidecar into every facet-selected discriminant set that has a stored result at
-//! the context commit (`HEAD` by default, or `--context <ref>`). It is
-//! base-branch-only with no escape hatch: a context commit that is not on the base
-//! branch, or the absence of a stored result there, are hard errors, because a
-//! blessing on anything else would not survive a history analysis (see the
-//! `bless` / `unbless` command in `DESIGN.md`). When blessing `HEAD`, a dirty
-//! working tree is allowed — the blessing
-//! applies to the committed `clean.json` recorded at `HEAD`, which the local edits
-//! do not change — but it emits a warning. `unbless` deletes every blessing
-//! recorded at the context commit in the selected sets; sidecars are immutable, so
-//! narrowing a blessing means unblessing and re-blessing the subset to keep.
-//! Blessings issued at later commits are unaffected, so the timeline can stay
-//! blessed past the context commit.
+//! `bless` writes an append-only `BlessingRecord` sidecar for the context commit
+//! (`HEAD` by default, or `--context <ref>`). Any commit that *resolves* can be
+//! blessed; the hard errors are an unresolvable ref, no benchmark prefixes (and no
+//! `--all`), an undeterminable base branch, and — only when the commit has no stored
+//! run — an unconstrained target triple or machine key (nothing to synthesize a set
+//! from). Two conditions warn and proceed rather than refuse, so the command never
+//! refuses without cause:
+//!
+//! * **Off the base branch** — a blessing only takes effect once the commit joins
+//!   the base branch's first-parent history (for example after a fast-forward), so
+//!   this warns and proceeds rather than refusing.
+//! * **No stored result at the commit** — a blessing may be recorded *before* data
+//!   is captured. With a run present, the sidecar lands in every facet-selected set
+//!   that has a stored result there. With no run present, the target sets are
+//!   synthesized from the resolved facets (all four engines when `--engine` is
+//!   omitted, under the resolved target triple and machine key), so whichever
+//!   engine's data is captured later at that commit is accepted. This warns,
+//!   because a typo'd commit id is the likelier cause.
+//!
+//! When blessing `HEAD`, a dirty working tree is allowed — the blessing applies to
+//! the committed `clean.json` recorded at `HEAD`, which the local edits do not
+//! change — but it emits a warning. `unbless` deletes every blessing recorded at
+//! the context commit in the selected sets; sidecars are immutable, so narrowing a
+//! blessing means unblessing and re-blessing the subset to keep. Blessings issued
+//! at later commits are unaffected, so the timeline can stay blessed past the
+//! context commit.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use cbh_command::{BlessOptions, UnblessOptions};
@@ -24,9 +37,10 @@ use cbh_config::{
     Config, load_config, resolve_config_path, resolve_local_path, resolve_project_id, resolve_repo,
     storage_env,
 };
+use cbh_detect::{DiscriminantSetQuery, FacetFilter};
 use cbh_diag::{Reporter, ReporterExt, StderrReporter, count_noun};
 use cbh_git::{GitHistory, SystemGitHistory};
-use cbh_model::{BlessingRecord, StorageKey};
+use cbh_model::{BlessingRecord, DiscriminantSet, Engine, MachineKey, StorageKey, TargetTriple};
 use cbh_storage::{Storage, build_storage, finish_with_flush};
 use jiff::Timestamp;
 use tick::Clock;
@@ -179,9 +193,11 @@ where
     let head = resolve_commit(git, context).await?;
     let short = short_commit_id(&head);
 
-    // Blessing is base-branch-only: a feature-branch blessing would silently
-    // vanish (or duplicate) once the branch is squash-merged, so it is refused
-    // outright with no `--force` escape hatch.
+    // The base branch must still be *determinable* (an undeterminable base, or a bad
+    // explicit `--base`, is a real configuration problem worth surfacing). Its only
+    // remaining job here is to check membership and, when the commit is not on it,
+    // warn — blessing off the base branch is allowed but only takes effect once the
+    // commit joins the base's first-parent history.
     let base = resolve_base(git, config, options.base.as_deref())
         .await?
         .ok_or_else(|| AnalyzeError::Bless {
@@ -194,8 +210,6 @@ where
     // The always-on effective-selection announcement: one line, printed regardless
     // of `--verbose`, naming the resolved (possibly auto-detected) partition, base
     // branch, and context commit, so a plain run never hides a value it defaulted.
-    // Emitted before the base-branch guard so even that refusal states what was
-    // selected.
     announce_selection(
         reporter,
         &selection_announcement(
@@ -212,21 +226,29 @@ where
         ),
     );
 
+    // Warnings are surfaced in the returned message (like the dirty-tree warning),
+    // in a stable order: off-base, then no-data, then dirty.
+    let mut warnings: Vec<String> = Vec::new();
+
+    // `analyze` orders a series by the base branch's first-parent history and admits
+    // a blessing only when its commit lies on that mainline, so the membership test
+    // here mirrors it exactly: the context commit must appear in the base ref's
+    // first-parent ancestry. An ordinary (non-first-parent) ancestor — a commit
+    // merged in as a side parent — is *not* on the mainline `analyze` walks, so it
+    // must warn just like an unrelated commit.
     let on_base = git
-        .merge_base(&head, &base.commit)
+        .first_parent(&base.commit)
         .await
         .map_err(AnalyzeError::Io)?
-        .as_deref()
-        == Some(head.as_str());
+        .iter()
+        .any(|commit| commit.commit_id == head);
     if !on_base {
-        return Err(AnalyzeError::Bless {
-            message: format!(
-                "the context commit {short} is not on the base branch {}; blessings are only \
-                 allowed on the base branch, since a feature-branch blessing would not survive \
-                 a squash merge",
-                short_commit_id(&base.commit)
-            ),
-        });
+        warnings.push(format!(
+            "Warning: the context commit {short} is not on the base branch {}; the blessing takes \
+             effect only once this commit is part of the base branch's first-parent history (for \
+             example after a fast-forward), and analyze ignores it until then.",
+            short_commit_id(&base.commit)
+        ));
     }
 
     // A blessing accepts the *committed* level recorded at the context commit
@@ -237,36 +259,67 @@ where
     let working_tree_dirty =
         options.context.is_none() && git.is_dirty().await.map_err(AnalyzeError::Io)?;
 
+    let issued_unix = now.as_second();
     let candidates = facet_filtered_candidates(storage, project_id, &facets, reporter).await?;
     let clean_at_head: Vec<StorageKey> = candidates
         .into_iter()
         .filter(|(_, parsed)| parsed.commit == head && parsed.is_clean())
         .map(|(_, parsed)| parsed)
         .collect();
-    if clean_at_head.is_empty() {
-        return Err(AnalyzeError::Bless {
-            message: format!(
-                "no stored result at the context commit {short}; record a run there before \
-                 blessing (a blessing accepts an existing data point)"
-            ),
-        });
-    }
 
-    let issued_unix = now.as_second();
+    // Each target is a `(discriminant set, sidecar key)` pair. With a run present the
+    // sidecars land beside the stored results at the commit; with no run present they
+    // are synthesized from the resolved facets so a pre-emptive blessing still has a
+    // concrete home for whichever engine's data is captured there later.
+    let targets: Vec<(DiscriminantSet, String)> = if clean_at_head.is_empty() {
+        warnings.push(format!(
+            "Warning: no stored result at the context commit {short}; blessing anyway — \
+             double-check the commit id. The blessing takes effect once a run is captured at this \
+             commit in a matching discriminant set."
+        ));
+        let sets = synthesize_target_sets(&facets);
+        if sets.is_empty() {
+            return Err(AnalyzeError::Bless {
+                message: format!(
+                    "no stored result at the context commit {short} and the target-triple or \
+                     machine-key facet is unconstrained, so no discriminant set can be targeted; \
+                     pass --target-triple and --machine-key (or record a run at the commit first)"
+                ),
+            });
+        }
+        sets.into_iter()
+            .map(|set| {
+                let key = set.bless_key(project_id, &head, issued_unix);
+                (set, key)
+            })
+            .collect()
+    } else {
+        clean_at_head
+            .iter()
+            .map(|parsed| (parsed.set.clone(), parsed.bless_key(issued_unix)))
+            .collect()
+    };
+
     let mut sets = 0_usize;
-    for parsed in &clean_at_head {
+    for (set, bless_key) in &targets {
         let record =
             BlessingRecord::new(head.clone(), now, prefixes.clone(), tool_version.to_owned());
         let json = record
             .to_json()
             .expect("a freshly built blessing always serializes to JSON");
-        let bless_key = parsed.bless_key(issued_unix);
         storage
-            .put_overwrite(&bless_key, json.as_bytes())
+            .put_overwrite(bless_key, json.as_bytes())
             .await
             .map_err(AnalyzeError::Storage)?;
-        reporter.note_with(|| format!("blessed set {} at {bless_key}", parsed.set));
+        reporter.note_with(|| format!("blessed set {set} at {bless_key}"));
         sets = sets.saturating_add(1);
+    }
+
+    if working_tree_dirty {
+        warnings.push(format!(
+            "Warning: uncommitted changes present. Blessing was applied to the existing commit at \
+             HEAD ({short})."
+        ));
     }
 
     let scope = if options.all {
@@ -274,16 +327,13 @@ where
     } else {
         count_noun(prefixes.len(), "prefix filter")
     };
+    let warnings_prefix = if warnings.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", warnings.join("\n"))
+    };
     let message = format!(
-        "{}Blessed {scope} across {} at commit {short}.",
-        if working_tree_dirty {
-            format!(
-                "Warning: uncommitted changes present. Blessing was applied to the existing \
-                 commit at HEAD ({short}).\n"
-            )
-        } else {
-            String::new()
-        },
+        "{warnings_prefix}Blessed {scope} across {} at commit {short}.",
         count_noun(sets, "discriminant set"),
     );
     Ok(message)
@@ -371,6 +421,61 @@ async fn resolve_commit<G: GitHistory>(git: &G, reference: &str) -> Result<Strin
 /// The first twelve characters of a commit ID (all of it when shorter), for messages.
 fn short_commit_id(commit_id: &str) -> &str {
     commit_id.get(..12).unwrap_or(commit_id)
+}
+
+/// Concrete discriminant sets to record a pre-emptive blessing in when the context
+/// commit has no stored run to anchor to.
+///
+/// Analysis matches a blessing to a series by an *exact* [`DiscriminantSet`], so a
+/// pre-emptive blessing must already occupy the set a future run will land in. The
+/// targets are the cartesian product of the resolved facets' concrete values: an
+/// omitted `--engine` expands to every [`Engine`] (there is no host default), so
+/// whichever engine's data is captured later is accepted, while the target triple and
+/// machine key default to the current host. The product is empty only when the triple
+/// or machine-key facet is unconstrained (`all`) and so cannot be enumerated.
+///
+/// Repeated facet values (for example `--engine callgrind --engine callgrind`) or
+/// values that sanitize to the same segment collapse to one set, so the caller writes
+/// each sidecar key once and reports an honest count.
+fn synthesize_target_sets(facets: &DiscriminantSetQuery) -> Vec<DiscriminantSet> {
+    let engines: Vec<Engine> = match &facets.engine {
+        FacetFilter::All => Engine::ALL.to_vec(),
+        FacetFilter::Auto(value) => Engine::from_name(value).into_iter().collect(),
+        FacetFilter::Explicit(values) => values
+            .iter()
+            .filter_map(|value| Engine::from_name(value))
+            .collect(),
+    };
+    let triples = concrete_facet_values(&facets.target_triple);
+    let machines = concrete_facet_values(&facets.machine_key);
+
+    let mut sets = Vec::new();
+    let mut seen = HashSet::new();
+    for engine in &engines {
+        for triple in &triples {
+            for machine in &machines {
+                let set = DiscriminantSet::new(
+                    *engine,
+                    &TargetTriple::from(triple.as_str()),
+                    &MachineKey::from(machine.as_str()),
+                );
+                if seen.insert(set.clone()) {
+                    sets.push(set);
+                }
+            }
+        }
+    }
+    sets
+}
+
+/// The concrete values a non-engine facet resolves to, or empty when it is
+/// unconstrained (`all`) and so cannot be enumerated.
+fn concrete_facet_values(filter: &FacetFilter) -> Vec<String> {
+    match filter {
+        FacetFilter::All => Vec::new(),
+        FacetFilter::Auto(value) => vec![value.clone()],
+        FacetFilter::Explicit(values) => values.iter().cloned().collect(),
+    }
 }
 
 #[cfg(test)]
@@ -521,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn bless_off_the_base_branch_is_an_error() {
+    fn bless_off_the_base_branch_warns_but_succeeds() {
         let storage = MemoryStorage::new();
         block_on(storage.put(&clean_key("f1"), clean_run_json("f1", 1000).as_bytes())).unwrap();
         // A feature commit on top of master: HEAD is not on the base branch.
@@ -535,14 +640,51 @@ mod tests {
             .head("feature")
             .mark_default("master");
 
-        let error = drive_bless(&storage, &git, &bless_options(&["all_the_time"])).unwrap_err();
-        assert!(matches!(error, AnalyzeError::Bless { .. }), "{error:?}");
-        assert!(error.to_string().contains("base branch"), "{error}");
+        let message = drive_bless(&storage, &git, &bless_options(&["all_the_time"])).unwrap();
+        // Off-base is a warning now, not a refusal, and the warning is explanatory
+        // about when the blessing takes effect.
+        assert!(message.contains("not on the base branch"), "{message}");
+        assert!(message.contains("first-parent history"), "{message}");
+        assert!(message.contains("Blessed"), "{message}");
         // The message names both the current commit and the base ref via
         // `short_commit_id`, so both must appear verbatim.
-        assert!(error.to_string().contains("f1"), "names HEAD: {error}");
-        assert!(error.to_string().contains("c2"), "names base: {error}");
-        assert!(stored_blessings(&storage).is_empty(), "nothing written");
+        assert!(message.contains("f1"), "names HEAD: {message}");
+        assert!(message.contains("c2"), "names base: {message}");
+
+        // The clean run present at f1 is still blessed in its own set.
+        let blessings = stored_blessings(&storage);
+        assert_eq!(blessings.len(), 1, "one sidecar written: {blessings:?}");
+        assert!(
+            blessings[0].contains("/f1/bless-"),
+            "sidecar in the f1 commit dir: {}",
+            blessings[0]
+        );
+    }
+
+    #[test]
+    fn bless_a_prefix_matching_no_benchmark_still_writes_a_sidecar() {
+        let storage = MemoryStorage::new();
+        block_on(storage.put(&clean_key("c2"), clean_run_json("c2", 1000).as_bytes())).unwrap();
+
+        // The clean run only carries `all_the_time/read_cell`; this prefix matches no
+        // benchmark in it. Prefixes are recorded verbatim, never validated against the
+        // run, so the blessing still succeeds and stores the unmatched prefix.
+        let message = drive_bless(
+            &storage,
+            &master_git(),
+            &bless_options(&["all_the_time/nonexistent"]),
+        )
+        .unwrap();
+        assert!(message.contains("Blessed"), "{message}");
+
+        let blessings = stored_blessings(&storage);
+        assert_eq!(blessings.len(), 1, "one sidecar written: {blessings:?}");
+        let bytes = block_on(storage.get(&blessings[0])).unwrap();
+        let record = BlessingRecord::from_json(&String::from_utf8(bytes).unwrap()).unwrap();
+        assert_eq!(
+            record.prefixes,
+            vec![BenchmarkIdPrefix::new("all_the_time/nonexistent").unwrap()]
+        );
     }
 
     #[test]
@@ -656,14 +798,123 @@ mod tests {
     }
 
     #[test]
-    fn bless_without_a_run_at_head_is_an_error() {
+    fn bless_without_a_run_at_the_commit_warns_and_synthesizes_all_engine_sets() {
         let storage = MemoryStorage::new();
         // A clean run exists, but on an earlier commit, not HEAD.
         block_on(storage.put(&clean_key("c1"), clean_run_json("c1", 1000).as_bytes())).unwrap();
-        let error =
-            drive_bless(&storage, &master_git(), &bless_options(&["all_the_time"])).unwrap_err();
-        assert!(matches!(error, AnalyzeError::Bless { .. }), "{error:?}");
-        assert!(error.to_string().contains("no stored result"), "{error}");
+
+        let message =
+            drive_bless(&storage, &master_git(), &bless_options(&["all_the_time"])).unwrap();
+        // No data at the commit is a warning now, not a refusal.
+        assert!(message.contains("no stored result"), "{message}");
+        assert!(message.contains("Blessed"), "{message}");
+
+        // With no run to anchor to, one sidecar is synthesized per engine under the
+        // auto-detected triple and machine key.
+        let blessings = stored_blessings(&storage);
+        assert_eq!(blessings.len(), 4, "one sidecar per engine: {blessings:?}");
+        assert!(
+            blessings.iter().all(|key| key.contains("/c2/bless-")),
+            "all at the c2 commit dir: {blessings:?}"
+        );
+        // The callgrind sidecar sits exactly where a future callgrind run at c2 would,
+        // so the blessing will actually apply once that data lands.
+        let callgrind = DiscriminantSet::new(
+            Engine::Callgrind,
+            &TargetTriple::from("x86_64-unknown-linux-gnu"),
+            &MachineKey::from("m1"),
+        )
+        .bless_key("folo", "c2", 1_700_000_000);
+        assert!(
+            blessings.contains(&callgrind),
+            "{blessings:?} lacks {callgrind}"
+        );
+    }
+
+    #[test]
+    fn bless_all_on_an_empty_project_synthesizes_all_engine_sets() {
+        let storage = MemoryStorage::new();
+        // No runs recorded anywhere: `bless --all` still succeeds pre-emptively.
+        let options = BlessOptions {
+            all: true,
+            ..BlessOptions::default()
+        };
+
+        let message = drive_bless(&storage, &master_git(), &options).unwrap();
+        assert!(message.contains("no stored result"), "{message}");
+        assert!(message.contains("all benchmarks"), "{message}");
+
+        let blessings = stored_blessings(&storage);
+        assert_eq!(blessings.len(), 4, "one sidecar per engine: {blessings:?}");
+        // Each carries an empty prefix list (accepting every benchmark).
+        for key in &blessings {
+            let bytes = block_on(storage.get(key)).unwrap();
+            let record = BlessingRecord::from_json(&String::from_utf8(bytes).unwrap()).unwrap();
+            assert!(record.prefixes.is_empty(), "{key} should accept all");
+        }
+    }
+
+    #[test]
+    fn bless_without_data_and_explicit_engine_targets_only_that_engine() {
+        let storage = MemoryStorage::new();
+        let options = BlessOptions {
+            engine: vec!["callgrind".to_owned()],
+            ..bless_options(&["all_the_time"])
+        };
+
+        let message = drive_bless(&storage, &master_git(), &options).unwrap();
+        assert!(message.contains("no stored result"), "{message}");
+
+        // An explicit engine narrows synthesis to just that engine.
+        let blessings = stored_blessings(&storage);
+        assert_eq!(blessings.len(), 1, "one callgrind sidecar: {blessings:?}");
+        assert!(
+            blessings[0].contains("/callgrind/x86_64-unknown-linux-gnu/m1/c2/bless-"),
+            "{}",
+            blessings[0]
+        );
+    }
+
+    #[test]
+    fn bless_without_data_dedupes_repeated_engine_facets() {
+        let storage = MemoryStorage::new();
+        // A repeated `--engine` value must not write the same sidecar key twice or
+        // over-report the discriminant-set count.
+        let options = BlessOptions {
+            engine: vec!["callgrind".to_owned(), "callgrind".to_owned()],
+            ..bless_options(&["all_the_time"])
+        };
+
+        let message = drive_bless(&storage, &master_git(), &options).unwrap();
+        assert!(message.contains("no stored result"), "{message}");
+        assert!(
+            message.contains("across 1 discriminant set "),
+            "the repeated engine collapses to one set: {message}"
+        );
+
+        let blessings = stored_blessings(&storage);
+        assert_eq!(blessings.len(), 1, "one callgrind sidecar: {blessings:?}");
+    }
+
+    #[test]
+    fn bless_without_data_and_unconstrained_machine_is_an_error() {
+        let storage = MemoryStorage::new();
+        // No data at the commit and the machine-key facet is `all`, so no concrete
+        // discriminant set can be synthesized to anchor the blessing.
+        let options = BlessOptions {
+            machine_key: vec!["all".to_owned()],
+            ..bless_options(&["all_the_time"])
+        };
+
+        let error = drive_bless(&storage, &master_git(), &options).unwrap_err();
+        match error {
+            AnalyzeError::Bless { message } => {
+                assert!(message.contains("no stored result"), "{message}");
+                assert!(message.contains("machine-key"), "{message}");
+            }
+            other => panic!("expected a bless error, got {other:?}"),
+        }
+        assert!(stored_blessings(&storage).is_empty(), "nothing written");
     }
 
     #[test]

--- a/packages/cbh_analyze/src/bless.rs
+++ b/packages/cbh_analyze/src/bless.rs
@@ -918,6 +918,27 @@ mod tests {
     }
 
     #[test]
+    fn synthesize_expands_an_auto_engine_and_explicit_facets() {
+        // An auto-detected engine resolves to that single engine, while explicit
+        // multi-value facets expand across each concrete value.
+        let facets = DiscriminantSetQuery {
+            engine: FacetFilter::Auto("callgrind".to_owned()),
+            target_triple: FacetFilter::Explicit(nonempty![
+                "x86_64-unknown-linux-gnu".to_owned(),
+                "aarch64-apple-darwin".to_owned(),
+            ]),
+            machine_key: FacetFilter::Auto("m1".to_owned()),
+        };
+        let sets = synthesize_target_sets(&facets);
+        // One engine × two triples × one machine = two sets.
+        assert_eq!(sets.len(), 2, "{sets:?}");
+        assert!(
+            sets.iter().all(|set| set.engine == Engine::Callgrind),
+            "the auto engine is callgrind: {sets:?}"
+        );
+    }
+
+    #[test]
     fn unbless_removes_every_blessing_at_head() {
         let storage = MemoryStorage::new();
         block_on(storage.put(&clean_key("c2"), clean_run_json("c2", 1000).as_bytes())).unwrap();

--- a/packages/cbh_analyze/src/error.rs
+++ b/packages/cbh_analyze/src/error.rs
@@ -26,8 +26,10 @@ pub enum AnalyzeError {
         /// Human-readable description of the analysis failure.
         message: String,
     },
-    /// A blessing precondition failed (a dirty working tree, a commit not on the
-    /// base branch, no stored result at the current commit, or no prefixes given).
+    /// A blessing precondition failed: no benchmark prefixes given (and no `--all`),
+    /// an unresolvable context ref, an undeterminable base branch, or — when the
+    /// commit has no stored run — an unconstrained target triple or machine key that
+    /// leaves no discriminant set to synthesize a sidecar for.
     Bless {
         /// Human-readable description of the precondition failure.
         message: String,

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -1636,6 +1636,33 @@ mod tests {
     }
 
     #[test]
+    fn include_blessings_respects_the_since_cutoff() {
+        let storage = MemoryStorage::new();
+        // Orphan blessings on dated feature commits: f1 (100s) predates the 180s
+        // cutoff and is kept; f3 (300s) is on or after it and removed.
+        store_bless(&storage, &bless_key("f1", 10));
+        store_bless(&storage, &bless_key("f3", 30));
+        let git = dated_feature_git();
+
+        let opts = PruneOptions {
+            include_blessings: true,
+            since: Some("1970-01-01T00:03:00Z".to_owned()), // 180s
+            ..PruneOptions::default()
+        };
+        prune(&storage, &git, &opts);
+
+        let remaining = keys(&storage);
+        assert!(
+            remaining.contains(&bless_key("f1", 10)),
+            "f1's blessing (committed at 100s) predates --since and is kept"
+        );
+        assert!(
+            !remaining.contains(&bless_key("f3", 30)),
+            "f3's blessing (committed at 300s) is on or after --since and removed"
+        );
+    }
+
+    #[test]
     fn commit_filter_restricts_removal_to_the_named_commit() {
         let storage = MemoryStorage::new();
         store(&storage, &dirty_key("f1", 200), &set("f1"));

--- a/packages/cbh_analyze/src/prune.rs
+++ b/packages/cbh_analyze/src/prune.rs
@@ -1,5 +1,5 @@
-//! The `prune` command: delete stored runs (and their blessing sidecars) from the
-//! data set a matching `analyze`/`list` pass resolves.
+//! The `prune` command: delete stored runs — and, on request, blessing sidecars —
+//! from the data set a matching `analyze`/`list` pass resolves.
 //!
 //! `prune` accepts the same data-set-selection options as `analyze`/`list` and
 //! resolves the identical commit topology via [`resolve_history`](super::resolve_history),
@@ -7,9 +7,12 @@
 //! ([`DirtyTipPolicy::Always`](super::DirtyTipPolicy)) — a deletion tool sees every
 //! stored run as a candidate, regardless of the present working-tree state.
 //!
-//! The caller must say which kinds of run to delete: `--clean` removes clean runs
-//! (plus the blessing sidecars on every commit whose clean run it removes),
-//! `--dirty` removes dirty (uncommitted-tree) snapshots, and `--all` removes both.
+//! The caller must say what to delete: `--clean` removes clean runs, `--dirty`
+//! removes dirty (uncommitted-tree) snapshots, and `--all` removes both. Pruning
+//! runs never removes a blessing; `--include-blessings` additionally deletes every
+//! blessing sidecar in the selected range — including on a commit with no recorded
+//! run (an orphan left by a pre-emptive blessing) — and may be given on its own to
+//! remove only blessings. A blessing is otherwise removed only by `unbless`.
 //!
 //! `prune` cleans only the *context branch's own* commits — those after the
 //! merge-base with the base ref — so base-branch history is preserved by default.
@@ -18,7 +21,7 @@
 //! is required to confirm it. `--dry-run` previews what would be removed without
 //! deleting anything.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use cbh_command::PruneOptions;
@@ -42,32 +45,39 @@ use super::{
 };
 use crate::{AnalyzeError, RenderedReports, ReportRequest};
 
-/// Which objects a prune pass deletes.
+/// Which runs a prune pass deletes.
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum Scope {
-    /// Delete clean and dirty runs (plus the blessings on removed clean commits).
+    /// Delete clean and dirty runs.
     All,
     /// Delete only dirty (uncommitted-tree) snapshots.
     Dirty,
-    /// Delete only clean runs (plus their blessing sidecars).
+    /// Delete only clean runs.
     Clean,
 }
 
 impl Scope {
-    /// Resolves the deletion scope from the `--clean`/`--dirty`/`--all` switches.
-    /// The CLI requires exactly one of them; setting both `clean` and `dirty`
-    /// (what `--all` expands to) deletes everything.
-    fn from_options(options: &PruneOptions) -> Result<Self, AnalyzeError> {
-        match (options.clean, options.dirty) {
-            (true, true) => Ok(Self::All),
-            (false, true) => Ok(Self::Dirty),
-            (true, false) => Ok(Self::Clean),
-            (false, false) => Err(AnalyzeError::Analyze {
-                message: "specify which runs to delete: --clean (clean runs and their \
-                          blessings), --dirty (dirty snapshots), or --all (both)"
+    /// Resolves the run-deletion scope from the `--clean`/`--dirty`/`--all`
+    /// switches, or `None` when none is set (only blessings are being removed).
+    ///
+    /// At least one action must be requested: a run scope, or `--include-blessings`
+    /// on its own. `--all` expands to both `clean` and `dirty`.
+    fn from_options(options: &PruneOptions) -> Result<Option<Self>, AnalyzeError> {
+        let scope = match (options.clean, options.dirty) {
+            (true, true) => Some(Self::All),
+            (false, true) => Some(Self::Dirty),
+            (true, false) => Some(Self::Clean),
+            (false, false) => None,
+        };
+        if scope.is_none() && !options.include_blessings {
+            return Err(AnalyzeError::Analyze {
+                message: "specify what to delete: --clean (clean runs), --dirty (dirty \
+                          snapshots), --all (both), and/or --include-blessings (blessing \
+                          sidecars)"
                     .to_owned(),
-            }),
+            });
         }
+        Ok(scope)
     }
 
     /// Whether this scope deletes clean runs (and thus durable history).
@@ -232,125 +242,117 @@ where
         });
     }
 
-    // Separate blessing sidecars from runs: a blessing is removed only when the
-    // commit's clean run is removed (it references that run), so it is selected in
-    // a second pass keyed off the clean removals.
+    // Runs and blessing sidecars are pruned independently: `--clean`/`--dirty`/`--all`
+    // select runs, while `--include-blessings` selects blessing sidecars. Partition
+    // the candidates so each pass considers only its own object kind.
     let (runs, blessings): (Vec<_>, Vec<_>) = candidates
         .into_iter()
         .partition(|(_, parsed)| !parsed.is_bless());
 
     let mut items: Vec<RemovalItem> = Vec::new();
-    // Commits whose clean run is removed, so their blessing sidecars go too.
-    let mut clean_removed: HashSet<(DiscriminantSet, String)> = HashSet::new();
 
-    for (key, parsed) in runs {
-        let Some(&index) = order.get(&parsed.commit) else {
-            reporter.note_with(|| {
-                format!(
-                    "skipping {key}: commit {} is not on {target_ref}'s history",
-                    parsed.commit
-                )
-            });
-            continue;
-        };
-        // Preserve base-branch history: unless this is a base-branch prune, only
-        // the commits after the merge-base (the context branch's own commits) are
-        // eligible for removal.
-        if !commit_is_eligible(index, merge_base_index, tip_is_merge_base) {
-            reporter.note_with(|| {
-                format!(
-                    "skipping {key}: commit {} is on the base branch (preserved; prune from \
-                     the base branch with --prune-base to remove it)",
-                    parsed.commit
-                )
-            });
-            continue;
-        }
-        if !commit_matches(&parsed.commit, &options.commit) {
-            reporter.note_with(|| {
-                format!(
-                    "skipping {key}: commit {} does not match the requested <commit> arguments",
-                    parsed.commit
-                )
-            });
-            continue;
-        }
-
-        let kind = if parsed.is_dirty() {
-            RunKind::Dirty
-        } else {
-            RunKind::Clean
-        };
-
-        match kind {
-            RunKind::Dirty => {
-                if !scope.touches_dirty() {
-                    reporter
-                        .note_with(|| format!("skipping {key}: --clean removes only clean runs"));
-                    continue;
-                }
-                // `--dirty` reproduces `clean`: a dirty snapshot is removed only on
-                // a commit whose dirty runs the matching analyze/list would admit.
-                // The broader scopes delete dirty runs wherever they sit.
-                if scope == Scope::Dirty
-                    && !admit_dirty
-                        .get(parsed.commit.as_str())
-                        .copied()
-                        .unwrap_or(false)
-                {
-                    reporter.note_with(|| {
-                        format!(
-                            "skipping {key}: dirty snapshot on a base-side commit ({} admits \
-                             only clean runs)",
-                            parsed.commit
-                        )
-                    });
-                    continue;
-                }
-            }
-            RunKind::Clean => {
-                if !scope.touches_clean() {
-                    reporter
-                        .note_with(|| format!("skipping {key}: --dirty removes only dirty runs"));
-                    continue;
-                }
-            }
-            RunKind::Bless => unreachable!("blessings were partitioned out"),
-        }
-
-        // The `--since` cutoff is a per-commit property — git's committer date —
-        // which topology already resolved with the rest of the history, so deciding
-        // it needs no object fetch.
-        if before_since_cutoff(commit_times.get(&parsed.commit).copied(), since) {
-            reporter
-                .note_with(|| format!("skipping {key}: its commit predates the --since cutoff"));
-            continue;
-        }
-
-        if kind == RunKind::Clean {
-            clean_removed.insert((parsed.set.clone(), parsed.commit.clone()));
-        }
-        reporter.note_with(|| format!("selected {key} for removal"));
-        items.push(RemovalItem {
-            index,
-            set: parsed.set,
-            commit: parsed.commit,
-            key,
-            kind,
-        });
-    }
-
-    // Second pass: a blessing sidecar is removed exactly when its commit's clean
-    // run is removed (the clean run's blessing has nothing left to baseline once
-    // the run is gone).
-    if scope.touches_clean() {
-        for (key, parsed) in blessings {
-            let Some(&index) = order.get(&parsed.commit) else {
+    if let Some(scope) = scope {
+        for (key, parsed) in runs {
+            let Some(index) = selected_index(
+                &key,
+                &parsed.commit,
+                &order,
+                merge_base_index,
+                tip_is_merge_base,
+                &options.commit,
+                &target_ref,
+                reporter,
+            ) else {
                 continue;
             };
-            if !clean_removed.contains(&(parsed.set.clone(), parsed.commit.clone())) {
-                reporter
-                    .note_with(|| format!("skipping {key}: its clean run is not being removed"));
+
+            let kind = if parsed.is_dirty() {
+                RunKind::Dirty
+            } else {
+                RunKind::Clean
+            };
+
+            match kind {
+                RunKind::Dirty => {
+                    if !scope.touches_dirty() {
+                        reporter.note_with(|| {
+                            format!("skipping {key}: --clean removes only clean runs")
+                        });
+                        continue;
+                    }
+                    // `--dirty` reproduces `clean`: a dirty snapshot is removed only on
+                    // a commit whose dirty runs the matching analyze/list would admit.
+                    // The broader scopes delete dirty runs wherever they sit.
+                    if scope == Scope::Dirty
+                        && !admit_dirty
+                            .get(parsed.commit.as_str())
+                            .copied()
+                            .unwrap_or(false)
+                    {
+                        reporter.note_with(|| {
+                            format!(
+                                "skipping {key}: dirty snapshot on a base-side commit ({} admits \
+                                 only clean runs)",
+                                parsed.commit
+                            )
+                        });
+                        continue;
+                    }
+                }
+                RunKind::Clean => {
+                    if !scope.touches_clean() {
+                        reporter.note_with(|| {
+                            format!("skipping {key}: --dirty removes only dirty runs")
+                        });
+                        continue;
+                    }
+                }
+                RunKind::Bless => unreachable!("blessings were partitioned out"),
+            }
+
+            // The `--since` cutoff is a per-commit property — git's committer date —
+            // which topology already resolved with the rest of the history, so deciding
+            // it needs no object fetch.
+            if before_since_cutoff(commit_times.get(&parsed.commit).copied(), since) {
+                reporter.note_with(|| {
+                    format!("skipping {key}: its commit predates the --since cutoff")
+                });
+                continue;
+            }
+
+            reporter.note_with(|| format!("selected {key} for removal"));
+            items.push(RemovalItem {
+                index,
+                set: parsed.set,
+                commit: parsed.commit,
+                key,
+                kind,
+            });
+        }
+    }
+
+    // Blessing sidecars are removed only with `--include-blessings`, and then every
+    // one in the selected range goes — including on a commit with no recorded run (an
+    // orphan left by a pre-emptive blessing) — because a blessing stands on its own
+    // rather than referencing a stored run.
+    if options.include_blessings {
+        for (key, parsed) in blessings {
+            let Some(index) = selected_index(
+                &key,
+                &parsed.commit,
+                &order,
+                merge_base_index,
+                tip_is_merge_base,
+                &options.commit,
+                &target_ref,
+                reporter,
+            ) else {
+                continue;
+            };
+            if before_since_cutoff(commit_times.get(&parsed.commit).copied(), since) {
+                reporter.note_with(|| {
+                    format!("skipping {key}: its commit predates the --since cutoff")
+                });
                 continue;
             }
             reporter.note_with(|| format!("selected {key} for removal (blessing sidecar)"));
@@ -412,6 +414,55 @@ fn commit_matches(commit: &str, filters: &[String]) -> bool {
     filters
         .iter()
         .any(|filter| commit.starts_with(&filter.to_ascii_lowercase()))
+}
+
+/// The first-parent index of `commit` when it is in the selected range: on the
+/// target's history, eligible for removal (not preserved base-branch history), and
+/// matching the `<commit>` selection. Returns `None`, after noting why, when the
+/// commit is out of range. `key` names the object being considered, for the note.
+///
+/// Both prune passes (runs and blessing sidecars) share these commit-level gates;
+/// each pass then applies its own remaining checks (run-kind and `--since`).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "shared gate over resolved topology"
+)]
+fn selected_index(
+    key: &str,
+    commit: &str,
+    order: &HashMap<String, usize>,
+    merge_base_index: Option<usize>,
+    tip_is_merge_base: bool,
+    commit_filters: &[String],
+    target_ref: &str,
+    reporter: &dyn Reporter,
+) -> Option<usize> {
+    let Some(&index) = order.get(commit) else {
+        reporter.note_with(|| {
+            format!("skipping {key}: commit {commit} is not on {target_ref}'s history")
+        });
+        return None;
+    };
+    // Preserve base-branch history: unless this is a base-branch prune, only the
+    // commits after the merge-base (the context branch's own commits) are eligible.
+    if !commit_is_eligible(index, merge_base_index, tip_is_merge_base) {
+        reporter.note_with(|| {
+            format!(
+                "skipping {key}: commit {commit} is on the base branch (preserved; prune from \
+                 the base branch with --prune-base to remove it)"
+            )
+        });
+        return None;
+    }
+    if !commit_matches(commit, commit_filters) {
+        reporter.note_with(|| {
+            format!(
+                "skipping {key}: commit {commit} does not match the requested <commit> arguments"
+            )
+        });
+        return None;
+    }
+    Some(index)
 }
 
 /// Which kind of object a removal item names.
@@ -1100,7 +1151,7 @@ mod tests {
     }
 
     #[test]
-    fn all_scope_removes_clean_dirty_and_blessings_for_a_commit() {
+    fn all_scope_with_include_blessings_removes_clean_dirty_and_blessings_for_a_commit() {
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("f1"), &set("f1"));
         store(&storage, &dirty_key("f1", 200), &set("f1"));
@@ -1113,6 +1164,7 @@ mod tests {
         let opts = PruneOptions {
             clean: true,
             dirty: true,
+            include_blessings: true,
             commit: vec!["f1".to_owned()],
             ..PruneOptions::default()
         };
@@ -1139,7 +1191,40 @@ mod tests {
     }
 
     #[test]
-    fn clean_scope_removes_clean_and_blessings_but_keeps_dirty() {
+    fn pruning_runs_keeps_blessings_without_include_blessings() {
+        let storage = MemoryStorage::new();
+        store(&storage, &clean_key("f1"), &set("f1"));
+        store(&storage, &dirty_key("f1", 200), &set("f1"));
+        store_bless(&storage, &bless_key("f1", 50));
+        let git = feature_git();
+
+        // `--all` removes both runs but leaves the blessing: capturing or pruning a
+        // run never removes a blessing, only `unbless` (or `--include-blessings`) does.
+        let opts = PruneOptions {
+            clean: true,
+            dirty: true,
+            commit: vec!["f1".to_owned()],
+            ..PruneOptions::default()
+        };
+        let report = prune_json(&storage, &git, &opts);
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["totals"]["runs"], 2, "clean + dirty: {report}");
+        assert_eq!(parsed["totals"]["blessings"], 0, "{report}");
+
+        let remaining = keys(&storage);
+        assert!(!remaining.contains(&clean_key("f1")), "f1 clean removed");
+        assert!(
+            !remaining.contains(&dirty_key("f1", 200)),
+            "f1 dirty removed"
+        );
+        assert!(
+            remaining.contains(&bless_key("f1", 50)),
+            "the blessing survives a run prune"
+        );
+    }
+
+    #[test]
+    fn include_blessings_with_clean_scope_removes_clean_and_blessings_but_keeps_dirty() {
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("f1"), &set("f1"));
         store(&storage, &dirty_key("f1", 200), &set("f1"));
@@ -1148,6 +1233,7 @@ mod tests {
 
         let opts = PruneOptions {
             clean: true,
+            include_blessings: true,
             commit: vec!["f1".to_owned()],
             ..PruneOptions::default()
         };
@@ -1157,7 +1243,7 @@ mod tests {
         assert!(!remaining.contains(&clean_key("f1")), "clean removed");
         assert!(
             !remaining.contains(&bless_key("f1", 50)),
-            "blessing removed with its clean run"
+            "blessing removed by --include-blessings"
         );
         assert!(
             remaining.contains(&dirty_key("f1", 200)),
@@ -1166,17 +1252,91 @@ mod tests {
     }
 
     #[test]
-    fn prune_leaves_a_blessing_whose_commit_is_off_history() {
+    fn include_blessings_removes_an_orphan_blessing_with_no_run() {
+        let storage = MemoryStorage::new();
+        // A pre-emptive blessing on an in-range commit that has no recorded run.
+        store_bless(&storage, &bless_key("f1", 50));
+        let git = feature_git();
+
+        // `--include-blessings` alone (no run scope) removes the orphan blessing.
+        let opts = PruneOptions {
+            include_blessings: true,
+            commit: vec!["f1".to_owned()],
+            ..PruneOptions::default()
+        };
+        let report = prune_json(&storage, &git, &opts);
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["totals"]["runs"], 0, "no runs removed: {report}");
+        assert_eq!(parsed["totals"]["blessings"], 1, "{report}");
+        assert!(
+            !keys(&storage).contains(&bless_key("f1", 50)),
+            "orphan blessing removed"
+        );
+    }
+
+    #[test]
+    fn include_blessings_alone_leaves_runs_untouched() {
+        let storage = MemoryStorage::new();
+        store(&storage, &clean_key("f1"), &set("f1"));
+        store_bless(&storage, &bless_key("f1", 50));
+        let git = feature_git();
+
+        let opts = PruneOptions {
+            include_blessings: true,
+            commit: vec!["f1".to_owned()],
+            ..PruneOptions::default()
+        };
+        prune(&storage, &git, &opts);
+
+        let remaining = keys(&storage);
+        assert!(
+            remaining.contains(&clean_key("f1")),
+            "the clean run is untouched"
+        );
+        assert!(
+            !remaining.contains(&bless_key("f1", 50)),
+            "the blessing is removed"
+        );
+    }
+
+    #[test]
+    fn prune_without_any_action_is_an_error() {
+        let storage = MemoryStorage::new();
+        store(&storage, &clean_key("f1"), &set("f1"));
+        let git = feature_git();
+
+        let error = block_on(prune_with(
+            &git,
+            &storage,
+            "folo",
+            &config(),
+            &PruneOptions::default(),
+            &auto(),
+            now(),
+            &RecordingReporter::new(),
+        ))
+        .unwrap_err();
+        match error {
+            AnalyzeError::Analyze { message } => {
+                assert!(message.contains("--include-blessings"), "{message}");
+            }
+            other => panic!("expected an Analyze error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn include_blessings_leaves_a_blessing_whose_commit_is_off_history() {
         let storage = MemoryStorage::new();
         store(&storage, &clean_key("f1"), &set("f1"));
         // A blessing sidecar on a commit that is not on the analyzed history; the
-        // clean-touching second pass skips it instead of removing it.
+        // blessing pass skips it because the range only covers commits on history.
         store_bless(&storage, &bless_key("z9", 70));
         let git = feature_git();
 
         let opts = PruneOptions {
             clean: true,
             dirty: true,
+            include_blessings: true,
             commit: vec!["f1".to_owned()],
             ..PruneOptions::default()
         };

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -745,18 +745,27 @@ impl ExamineCommand {
     }
 }
 
-/// Delete stored runs (and their blessing sidecars) from the data set a matching
-/// `analyze`/`list` would resolve.
+/// Delete stored runs from the data set a matching `analyze`/`list` would resolve.
 ///
-/// You must say which kinds of run to delete with `--clean`, `--dirty`, or
-/// `--all`. Pruning walks the selected commits from `--context` back to `--base`;
-/// deleting the base branch's own data set requires the `--prune-base` guard.
+/// You must say what to delete with `--clean`, `--dirty`, `--all`, or
+/// `--include-blessings`. Pruning runs never removes a blessing on its own;
+/// `--include-blessings` additionally deletes blessing sidecars in the selected
+/// range (including on commits with no recorded run) and may be given alone.
+/// Pruning walks the selected commits from `--context` back to `--base`; deleting
+/// the base branch's own data set requires the `--prune-base` guard.
 #[derive(Args, Debug)]
-#[command(group(
-    ArgGroup::new("prune-kind")
-        .args(["clean", "dirty", "all"])
-        .required(true)
-))]
+#[command(
+    group(
+        ArgGroup::new("prune-action")
+            .args(["clean", "dirty", "all", "include_blessings"])
+            .required(true)
+            .multiple(true)
+    ),
+    group(
+        ArgGroup::new("prune-run-kind")
+            .args(["clean", "dirty", "all"])
+    )
+)]
 struct PruneCommand {
     /// Restrict removal to these commits (a full or short commit ID, prefix-matched);
     /// repeatable (default: every one of the selected commits).
@@ -787,7 +796,7 @@ struct PruneCommand {
     #[command(flatten)]
     commit_selection: PruneCommitArgs,
 
-    /// Remove only clean runs and their blessing sidecars.
+    /// Remove only clean runs.
     #[arg(long, help_heading = HEADING_FILTER)]
     clean: bool,
 
@@ -795,10 +804,14 @@ struct PruneCommand {
     #[arg(long, help_heading = HEADING_FILTER)]
     dirty: bool,
 
-    /// Remove both clean runs (with their blessing sidecars) and dirty snapshots
-    /// (the same as `--clean --dirty`).
+    /// Remove both clean and dirty runs (the same as `--clean --dirty`).
     #[arg(long, help_heading = HEADING_FILTER)]
     all: bool,
+
+    /// Also remove blessing sidecars in the selected range, including on commits
+    /// with no recorded run. May be given alone to remove only blessings.
+    #[arg(long, help_heading = HEADING_FILTER)]
+    include_blessings: bool,
 }
 
 /// Commit selection for `prune`: the range of commits whose data is removed.
@@ -840,6 +853,7 @@ impl PruneCommand {
             machine_key: self.facets.machine_key,
             clean,
             dirty,
+            include_blessings: self.include_blessings,
             prune_base: self.prune_base,
             dry_run: self.dry_run,
             no_text: self.output.no_text,
@@ -2034,6 +2048,43 @@ mod tests {
         assert!(options.clean, "--all enables clean removal");
         assert!(options.dirty, "--all enables dirty removal");
         assert!(!options.dry_run);
+    }
+
+    #[test]
+    fn prune_include_blessings_combines_with_a_run_scope() {
+        // `--include-blessings` is additive: it must be usable alongside a run scope
+        // to prune runs and their blessings in one pass.
+        let Command::Prune(options) = parse(&["prune", "--all", "--include-blessings"]) else {
+            panic!("expected prune command");
+        };
+        assert!(options.clean, "--all enables clean removal");
+        assert!(options.dirty, "--all enables dirty removal");
+        assert!(options.include_blessings, "--include-blessings is set");
+    }
+
+    #[test]
+    fn prune_include_blessings_alone_is_accepted() {
+        let Command::Prune(options) = parse(&["prune", "--include-blessings"]) else {
+            panic!("expected prune command");
+        };
+        assert!(!options.clean);
+        assert!(!options.dirty);
+        assert!(options.include_blessings);
+    }
+
+    #[test]
+    fn prune_rejects_combining_clean_and_dirty() {
+        // `--clean`, `--dirty`, and `--all` remain mutually exclusive alternatives;
+        // `--all` is the way to remove both run kinds.
+        let error =
+            Cli::from_args(&["cargo-bench-history"], &["prune", "--clean", "--dirty"]).unwrap_err();
+        assert!(
+            error.output.contains("cannot be used with")
+                || error.output.contains("conflict")
+                || error.output.contains("cannot be used"),
+            "combining --clean and --dirty should be rejected: {}",
+            error.output
+        );
     }
 
     #[test]

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -447,12 +447,13 @@ pub struct ExamineOptions {
 /// Options for the `prune` command.
 ///
 /// The data-set-selection options mirror [`AnalyzeOptions`]/[`ListOptions`] so a
-/// `analyze`/`list` invocation would resolve. The caller must say which kinds of
-/// run to delete: `clean` removes clean runs (plus the blessing sidecars on every
-/// commit whose clean run is removed), `dirty` removes dirty (uncommitted-tree)
-/// snapshots, and setting both removes everything. Pruning the base branch's own
-/// data set (when `context` resolves to the same commit as `base`) requires
-/// `prune_base` as a safety guard.
+/// `analyze`/`list` invocation would resolve. The caller must say what to delete:
+/// `clean` removes clean runs, `dirty` removes dirty (uncommitted-tree) snapshots,
+/// and setting both removes every run. Pruning runs never removes a blessing;
+/// `include_blessings` additionally removes blessing sidecars in the selected
+/// range (including on commits with no recorded run) and may be given on its own.
+/// Pruning the base branch's own data set (when `context` resolves to the same
+/// commit as `base`) requires `prune_base` as a safety guard.
 #[doc(hidden)]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PruneOptions {
@@ -488,10 +489,14 @@ pub struct PruneOptions {
     /// auto-detects the current machine's fingerprint; `all` matches every
     /// machine.
     pub machine_key: Vec<String>,
-    /// Remove clean runs (and their blessing sidecars).
+    /// Remove clean runs.
     pub clean: bool,
     /// Remove dirty (uncommitted-tree) snapshots.
     pub dirty: bool,
+    /// Also remove blessing sidecars in the selected range, including on commits
+    /// with no recorded run. Off by default, so pruning runs never removes a
+    /// blessing (only the `unbless` command does).
+    pub include_blessings: bool,
     /// Confirm pruning the base branch's own data set (when `context` resolves to
     /// the same commit as `base`).
     pub prune_base: bool,

--- a/packages/cbh_model/src/bless.rs
+++ b/packages/cbh_model/src/bless.rs
@@ -2,8 +2,9 @@
 //! the base branch, so history analysis stops re-flagging an intentional change.
 //!
 //! A blessing is an append-only sidecar (`bless-<issued_unix>.json`, described by
-//! the `bless` / `unbless` command in `DESIGN.md`) stored in the same commit
-//! directory as the run it accepts. It names one
+//! the `bless` / `unbless` command in `DESIGN.md`) stored in the commit directory of
+//! each targeted discriminant set, which need not yet hold a run — a change can be
+//! blessed before its data is captured. It names one
 //! or more benchmark-id prefixes; a series whose qualified id starts with any of
 //! them is re-baselined to the blessed commit, so the accepted step stops being
 //! reported as a regression while its pre-blessing history is still retained for

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -59,10 +59,10 @@ impl Engine {
         }
     }
 
-    /// Parses an [`Engine`] from its stable lowercase identifier.
+    /// Parses an [`Engine`] from its stable identifier, case-insensitively.
     #[must_use]
     pub fn from_name(name: &str) -> Option<Self> {
-        match name {
+        match name.to_ascii_lowercase().as_str() {
             "criterion" => Some(Self::Criterion),
             "callgrind" => Some(Self::Callgrind),
             "alloc_tracker" => Some(Self::AllocTracker),
@@ -369,20 +369,26 @@ pub fn parse_key(key: &str) -> Option<StorageKey> {
     })
 }
 
-/// Replaces every character that is not safe in a single path segment with `_`,
-/// mapping an otherwise-empty or all-dots result to `_`.
+/// Canonicalizes a single path segment: lowercases ASCII letters, replaces every
+/// character that is not safe with `_`, and maps an otherwise-empty or all-dots
+/// result to `_`.
 ///
 /// "Safe" is the conservative set `[A-Za-z0-9._-]`, which is valid both as a
 /// filesystem path component (for local storage) and as an Azure blob name part.
 /// Mangling rather than rejecting means the tool never refuses a run merely
 /// because its project, triple, or machine key contains an awkward character.
+///
+/// Letters are folded to lower case so a segment's identity is case-insensitive:
+/// a discriminant set, project, or commit differing only in letter case resolves
+/// to the same storage key, and so blessing, pruning, and analysis never split on
+/// case alone.
 #[must_use]
 pub fn sanitize_segment(raw: &str) -> String {
     let mangled: String = raw
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
-                c
+                c.to_ascii_lowercase()
             } else {
                 '_'
             }
@@ -527,12 +533,27 @@ mod tests {
     }
 
     #[test]
+    fn engine_from_name_is_case_insensitive() {
+        assert_eq!(Engine::from_name("Callgrind"), Some(Engine::Callgrind));
+        assert_eq!(Engine::from_name("ALL_THE_TIME"), Some(Engine::AllTheTime));
+    }
+
+    #[test]
     fn sanitize_segment_keeps_safe_characters() {
         assert_eq!(
             sanitize_segment("x86_64-unknown-linux-gnu"),
             "x86_64-unknown-linux-gnu"
         );
         assert_eq!(sanitize_segment("my.project-1"), "my.project-1");
+    }
+
+    #[test]
+    fn sanitize_segment_folds_case() {
+        assert_eq!(sanitize_segment("Team-App"), "team-app");
+        assert_eq!(
+            sanitize_segment("X86_64-PC-Windows-MSVC"),
+            "x86_64-pc-windows-msvc"
+        );
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

Makes `bless` permissive about *where* and *when* a blessing may be recorded, stops capture from silently discarding blessings, splits blessing removal out of `prune`, and folds away all discriminant-key case sensitivity.

## Changes

- **bless — off-base and no-data are warnings, not errors.** Blessing an off-base commit or a commit with no stored result now warns and proceeds instead of refusing. The target set is synthesized from the resolved facets (all engines when `--engine` is unset), so a blessing can be recorded *before* its data is captured. The off-base check is first-parent precise: only commits absent from the base branch's first-parent history warn (so a fast-forwarded commit already on the branch does not).
- **collect — capture never unblesses.** Storing a new clean run (overwrite or not) no longer removes a blessing. Only `unbless` deletes blessings.
- **prune — blessing removal is opt-in.** Pruning runs no longer touches blessings. A new `--include-blessings` flag additionally deletes blessing sidecars in the selected range, including orphans on commits with no recorded run, and may be given alone. `--clean`, `--dirty`, and `--all` stay mutually exclusive; `--include-blessings` is additive and combines with any of them.
- **comparability — case-insensitive identity.** Discriminant identity is case-insensitive end to end: key segments are lowercased at the single sanitize chokepoint and engine names fold case on parse.

## Docs & tests

- DESIGN.md, the mdBook `prune`/`bless` pages, and `lib.rs` are updated to the new behavior.
- Unit and integration coverage added for each case, including the additive `prune --all --include-blessings` combination (parser + a single-invocation end-to-end test) and a real-git first-parent precision test for the off-base warning.

## Validation

All green locally: clippy `-D warnings` (cbh_cli, cargo-bench-history), nightly rustfmt, cbh_cli lib (72), cbh_analyze lib (220), full `cbh_integration` (140), rustdoc.