### PR TITLE
Fix bench-history analyze 404 on machine-key download after partial re-run

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -178,11 +178,14 @@ jobs:
     timeout-minutes: 150
 
     # id-token to self-federate with Entra (reads the history; see collect's note),
-    # contents for checkout, issues to file the rolling regression issue.
+    # contents for checkout, issues to file the rolling regression issue, and actions:read so the
+    # machine-key download below can enumerate this run's artifacts through the REST run-artifacts
+    # endpoint (see that step's note) rather than the attempt-scoped internal artifact service.
     permissions:
       id-token: write
       contents: read
       issues: write
+      actions: read
 
     steps:
       - name: Checkout repository
@@ -255,11 +258,21 @@ jobs:
       # simply absent and not analyzed. If EVERY leg failed there are no matching artifacts: a pattern
       # download tolerates zero matches (it does not fail), and the recipe treats the empty directory
       # as "nothing to analyze".
+      #
+      # `github-token` (with `run-id`, defaulted to this run) is what routes the download through the
+      # public REST run-artifacts endpoint instead of the attempt-bound internal artifact service.
+      # That endpoint lists a run's artifacts across ALL of its attempts, so after a PARTIAL re-run
+      # (e.g. `gh run rerun --failed` on one flaky collect leg) the surviving leg's artifact - which
+      # stays under the earlier attempt - still resolves. Without the token the action pins each
+      # artifact to the current attempt and 404s ("workflow run not found") on any older-attempt
+      # artifact, leaving `analyze` impossible to green without re-running the whole matrix.
       - name: Download collected machine keys
         uses: actions/download-artifact@v4
         with:
           pattern: bench-history-machine-key-*
           path: ${{ steps.scratch.outputs.dir }}/machine-keys
+          github-token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
 
       # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
       # top-findings Markdown) and notable.txt into the scratch directory. Findings never fail

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -303,12 +303,15 @@ jobs:
     # cold-cache setup-environment on top of the analysis.
     timeout-minutes: 150
 
-    # id-token to self-federate with Entra (reads the history), contents for checkout, and
-    # pull-requests to post/update the rolling comment.
+    # id-token to self-federate with Entra (reads the history), contents for checkout,
+    # pull-requests to post/update the rolling comment, and actions:read so the machine-key
+    # download below can enumerate this run's artifacts through the REST run-artifacts endpoint
+    # (see that step's note) rather than the attempt-scoped internal artifact service.
     permissions:
       id-token: write
       contents: read
       pull-requests: write
+      actions: read
 
     steps:
       - name: Checkout repository
@@ -367,11 +370,21 @@ jobs:
       # the recipe scans recursively. A leg whose collection failed uploaded nothing, so its key is
       # simply absent; if EVERY leg failed the pattern download matches nothing (it does not fail) and
       # the recipe treats the empty directory as "nothing to analyze".
+      #
+      # `github-token` (with `run-id`, defaulted to this run) is what routes the download through the
+      # public REST run-artifacts endpoint instead of the attempt-bound internal artifact service.
+      # That endpoint lists a run's artifacts across ALL of its attempts, so after a PARTIAL re-run
+      # (e.g. `gh run rerun --failed` on one flaky collect leg) the surviving leg's artifact - which
+      # stays under the earlier attempt - still resolves. Without the token the action pins each
+      # artifact to the current attempt and 404s ("workflow run not found") on any older-attempt
+      # artifact, leaving `analyze` impossible to green without re-running the whole matrix.
       - name: Download collected machine keys
         uses: actions/download-artifact@v4
         with:
           pattern: pr-bench-history-machine-key-*
           path: ${{ steps.scratch.outputs.dir }}/machine-keys
+          github-token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
 
       # Renders report.md (full Markdown), report.json (full JSON), summary.md (the condensed
       # top-findings Markdown) and notable.txt into the scratch directory, in BRANCH mode (PR head


### PR DESCRIPTION
[Copilot speaking]

Fixes #423.

## Problem

The `analyze` job in both `bench-history.yml` and `pr-bench-history.yml` downloads each collect leg's machine-key artifact via `actions/download-artifact@v4`. Without a `github-token`, the action resolves artifacts through the attempt-bound internal artifact service. After a **partial re-run** (`gh run rerun --failed`, common when a multi-hour collect leg hits a transient hosted-runner death), the re-run leg's artifact lands under a new run *attempt* while the still-green leg's artifact stays under the earlier attempt. The action then 404s (`Failed to GetSignedArtifactURL: (404) Not Found: workflow run not found`) on the older-attempt artifact. This is deterministic once attempts are mixed, and only a fresh full run (~4h) could clear it — defeating the workflow's deliberate tolerance of a partially-failed collect.

## Fix

Pass `github-token: ${{ github.token }}` and `run-id: ${{ github.run_id }}` to the download step, and grant the `analyze` job `actions: read`. The `github-token` input is the documented switch that routes the download through the public REST run-artifacts endpoint, which lists a run's artifacts across **all** of its attempts, so the surviving leg's older-attempt artifact resolves and `analyze` goes green on retry with no manual action.

Applied to both workflows, which share the hand-off. Everything downstream is unchanged: the upload side, the analyze recipes, the `Get-MachineKeyArgument` module, and the load-bearing zero-match "nothing to analyze" path (a total collect failure still yields an empty dir, not an error).

## Why this approach

Considered alternatives and rejected them:

- **Deriving keys from the store** ("which machine keys have a point at the head commit") — rejected: another source (a manual dev-machine `collect`, `backfill`, another workflow) could record a point at the same commit and be folded into the analysis, breaking the "exactly the keys this run collected" guarantee.
- **`gh run download`** — it has no distinct "no artifacts matched" exit code, so preserving the zero-match path would require version-brittle stderr matching.
- **`actions/cache` transport** — caches are evictable, so a partial re-run after eviction could silently restore only one platform's key without surfacing a collect failure.

Keeping the first-party action and switching only which endpoint it reads is the most surgical fix: it preserves the action's retry/extraction, the `<artifact-name>/machine-key.txt` layout the module scans recursively, the zero-match tolerance, and the deterministic latest-per-name selection (today's de-facto behavior).

## Validation

- `just validate-workflows` (actionlint) — clean.
- Fork PRs remain excluded by the existing same-repo gates in `pr-bench-history.yml`; `actions: read` adds no write capability.

Note: the cross-attempt REST behavior is confirmed by the `download-artifact` action docs, but CI cannot be exercised from the authoring environment — the next real mixed-attempt run is the empirical proof.