### PR TITLE
Add nightly bench-history backfill to densify per-machine-key series

### DIFF
--- a/.github/workflows/bench-history-backfill.yml
+++ b/.github/workflows/bench-history-backfill.yml
@@ -1,0 +1,123 @@
+name: Benchmark history backfill
+
+# Nightly gap-filling for the benchmark history the push-triggered workflow (bench-history.yml)
+# collects. GitHub's hosted runner pool is heterogeneous, so consecutive pushes to `main` are
+# measured by different hardware and every per-machine-key series is sparse: a commit measured under
+# one machine key is simply missing from every other machine key's series. Each night this job
+# measures the recent commits that whichever machine key it draws is missing, appending them to that
+# key's series; analysis is left to the next push run, which surveys whatever landed here.
+#
+# Best-effort by design. Each leg fills roughly one gap per platform per night (the benchmark suite
+# at `--best-of 3` takes most of a job), and which series gets densified depends on the hardware the
+# runner happens to have, so this is opportunistic densification of recent history rather than a
+# guarantee for any particular series. See the gh-backfill-bench-history recipe for the range
+# selection and the flags.
+on:
+  schedule:
+    # 02:00 UTC, deliberately off the cache-warmup workflow's midnight slot so the two multi-hour
+    # nightly jobs do not compete for the same runner-concurrency budget.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      # Optional escape hatch: the SHA to use as the range END instead of the computed one (the
+      # newest commit at least 24 hours old). A commit that fails slowly is re-selected every night
+      # and can eat a whole run before anything is stored, so this lets an operator step over it by
+      # aiming the window at an older commit. Leave empty for a normal run.
+      to_commit:
+        description: "Commit SHA to backfill up to (leave empty for the newest commit at least 24 hours old)"
+        required: false
+        type: string
+        default: ""
+
+# One backfill at a time, repository-wide: a fixed group name is what serializes every run of this
+# workflow against every other, since a leg spends hours rebuilding a historical checkout per commit
+# and a second concurrent run would race the first for the same gaps rather than add to them.
+# Queueing rather than cancelling is what makes a manual dispatch wait for the scheduled run instead
+# of racing it. The SHA-keyed shape bench-history.yml uses would be wrong on both counts here: it
+# serializes nothing across runs, and a scheduled run's github.sha is the current tip, so this job
+# would land in the same group as that tip's own collect run and whichever started later would kill
+# the other.
+concurrency:
+  group: bench-history-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    # Skip everywhere the OIDC sign-in cannot work: forks (only this repository's identity can
+    # federate into Azure) and any ref other than main (the federated credential is scoped to
+    # refs/heads/main). A scheduled run is always on refs/heads/main, so this only ever gates a
+    # manual dispatch from a feature branch, which skips cleanly instead of failing red.
+    if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+
+    strategy:
+      # One platform's benchmarks failing must not abandon the other's gap-filling; each platform
+      # stores into its own partition independently.
+      fail-fast: false
+      matrix:
+        # x86_64 Linux and Windows only, matching the platforms the push workflow collects on -
+        # backfilling a platform whose series does not exist would measure nothing comparable.
+        platform: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    # 360 minutes is GitHub's hard per-job ceiling, and this job is designed to simply work until it
+    # hits it: there is no per-run commit budget, the tool just keeps filling gaps until the axe
+    # falls. Results are stored per commit as that commit completes, so a kill keeps everything
+    # already stored and affects only the commit in flight.
+    timeout-minutes: 360
+    # A timeout is therefore the EXPECTED end of a healthy run, not a failure, so the job must not
+    # mark the workflow red - hence continue-on-error. The accepted cost is that a genuine failure
+    # (auth, storage, a tool defect) is also invisible here; such breakage surfaces within hours in
+    # the push workflow, which does alert.
+    continue-on-error: true
+
+    # `id-token: write` lets cargo-bench-history mint short-lived GitHub OIDC tokens (each a signed
+    # JWT proving "this run is repo folo-rs/folo on ref refs/heads/main"), which it exchanges
+    # directly with Entra against the prod managed identity's `main`-branch federated credential - so
+    # CI authenticates with no stored secret, and a multi-hour run stays authenticated past the ~1h
+    # access-token lifetime. `contents: read` is the minimum the checkout needs.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        # Full history: the tool benchmarks each historical commit in a throwaway `git worktree`,
+        # and the range selection walks `main`'s first-parent history by date. Neither works on the
+        # default shallow clone.
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      # cargo-bench-history self-federates with GitHub OIDC: given the managed identity's client id
+      # and tenant - plus the ACTIONS_ID_TOKEN_* values GitHub injects because of id-token: write -
+      # it mints a fresh OIDC assertion each time Entra needs a new access token, so a long run never
+      # re-submits an expired assertion. Export those two identifiers from constants.env under the
+      # standard names the tool reads (AZURE_PROD_CLIENT_ID is the prod identity's client id). The
+      # data store account name is NOT needed here: it is baked into the committed
+      # .cargo/bench_history.toml.
+      - name: Configure Azure federation identity from constants.env
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          # constants.env holds the two non-secret identifiers the benchmark-history jobs federate
+          # with; the module re-exports them under the standard AZURE_* names the tool reads, failing
+          # loudly if either is missing. Shared with bench-history.yml so the two cannot drift. See
+          # scripts/bench-history/AzureFederation.psm1.
+          Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
+          Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
+
+      # The recipe resolves the commit range, measures only the commits this runner's own machine
+      # partition is missing, and appends them under the runner's real hardware fingerprint (no fixed
+      # machine key). BACKFILL_TO_COMMIT is empty on a scheduled run; it is passed through the
+      # environment so an untrusted dispatch input is never spliced into a shell command line here.
+      - name: Backfill benchmark history
+        shell: pwsh
+        env:
+          BACKFILL_TO_COMMIT: ${{ inputs.to_commit }}
+        run: just gh-backfill-bench-history

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -131,12 +131,12 @@ jobs:
           Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
       # Every engine — Callgrind and the allocation/time counters included — is partitioned by each
-      # runner's OWN real hardware fingerprint (see the
-      # gh-collect-bench-history recipe) so a heterogeneous runner pool splits into one clean series
-      # per SKU rather than one jittery mixed series. RECOLLECT_COMMIT_ID (empty on a push/plain
-      # dispatch) switches the recipe from appending the pushed commit to re-measuring and OVERWRITING
-      # one historical commit; it is passed through the environment so an untrusted dispatch input is
-      # never spliced into a shell command line here.
+      # runner's OWN real hardware fingerprint (see the gh-collect-bench-history recipe) so a
+      # heterogeneous runner pool splits into one clean series per hardware type rather than one
+      # jittery mixed series. RECOLLECT_COMMIT_ID (empty on a push/plain dispatch) switches the
+      # recipe from appending the pushed commit to re-measuring and OVERWRITING one historical
+      # commit; it is passed through the environment so an untrusted dispatch input is never
+      # spliced into a shell command line here.
       - name: Collect benchmark history
         env:
           RECOLLECT_COMMIT_ID: ${{ inputs.recollect_commit_id }}

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -74,7 +74,12 @@ workflow's concurrency group so cancel-in-progress reclaims the stale run. Both 
 workflow and the PR benchmark-history workflow pair with such a close companion. The exception
 is history collection on `main`, which is keyed on the commit **SHA**: each commit is a distinct
 measurement, so distinct commits must run in parallel and only a redundant re-trigger of the
-*same* commit is deduplicated. Schedule-driven workflows carry no concurrency block at all.
+*same* commit is deduplicated. A schedule-driven workflow carries a concurrency block only when
+a duplicate run would be expensive: the nightly history backfill groups on itself with
+cancellation **off**, so a manual dispatch queues behind the scheduled run rather than
+duplicating hours of benchmarking. Keeping it out of collection's SHA-keyed group matters for
+the same reason — a scheduled run's SHA is the current tip, so a shared group would let the
+nightly and that tip's own collection cancel each other.
 
 ## Thin steps
 
@@ -145,6 +150,7 @@ Two managed identities exist, each registered with exactly the subjects its even
 | Event | OIDC subject | Identity | Consumer |
 | --- | --- | --- | --- |
 | push to `main` | `…:ref:refs/heads/main` | prod | `bench-history.yml` |
+| schedule on `main` | `…:ref:refs/heads/main` | prod | `bench-history-backfill.yml` |
 | pull request | `…:pull_request` | prod | `pr-bench-history.yml` |
 | push to `main` | `…:ref:refs/heads/main` | test | `test-azure` backend tests |
 | pull request | `…:pull_request` | test | `test-azure` backend tests |
@@ -166,13 +172,21 @@ intermediate commits. It writes to a dedicated production storage account under 
 production managed identity, kept entirely separate from the throwaway account the test jobs
 use, so the long-lived data store never depends on test infrastructure. Collection is
 append-only and idempotent, which is what makes a re-run safe and lets a read-through cache
-of the bulk history persist between runs. Collection stamps the wall-clock (per-machine)
-engines with a fixed `github` machine key instead of the auto-detected hardware fingerprint,
-and analysis reads only that key: the GitHub-hosted runner pool may hold differently-specced
-machines, so fingerprinting would fork the series on every SKU change and let unrelated
-machines pollute the data set, whereas one fixed key keeps a single series (accepting the
-pool's jitter) that a deliberate blessing absorbs across a genuine hardware migration.
-To blunt that jitter rather than merely accept it, collection runs the whole suite several
+of the bulk history persist between runs.
+
+Collection stamps every engine's results with the runner's **own auto-detected hardware
+fingerprint**, with no fixed key override. The GitHub-hosted pool is heterogeneous, so a
+single shared key would blend genuinely different machines into one jittery series;
+fingerprinting instead splits the pool into one clean series per hardware type. Because
+collection is a matrix and analysis is a single job that cannot re-derive those keys from its
+own hardware, each collect leg writes its fingerprint out as an artifact and the analysis job
+threads exactly the keys collected this run into its selection — scoping the analysis to the
+machines that actually measured this commit, without assuming anything about other data in
+the shared store. The cost of that split is sparseness: consecutive commits land on whatever
+hardware the pool handed out, so each per-key series sees only a fraction of `main`'s commits.
+The nightly backfill below exists to densify them.
+
+To blunt the residual within-machine jitter, collection runs the whole suite several
 times per commit and keeps, per metric, the minimum sample: runner interference is one-sided
 (a contended host only ever makes a benchmark slower) and the repeats are spaced apart in
 time, so the minimum is the reading least perturbed by transient noise. This trades a
@@ -190,8 +204,9 @@ commit and *overwrites* its stored point instead of appending the pushed tip. Th
 resolves is that the collection tool lives in the same repository as the benchmarks, so a naive
 "check out that commit and re-run" would also run the tool as it shipped at that commit. Instead
 the re-collection benchmarks the code *at* the target commit in a throwaway worktree while
-running the current tool, so only the measured code — never the collection logic — comes from
-the past. The overwrite bumps the cache-invalidation marker so downstream analysis refreshes,
+running the current tool, so the measured code and the compiler that builds it come from that
+commit while the collection logic does not. The overwrite bumps the cache-invalidation marker
+so downstream analysis refreshes,
 and it deliberately discards any blessings recorded at that commit, since a fresh measurement
 invalidates a level that was previously accepted. Analysis is unaffected by the input and always
 surveys the current `main` tip.
@@ -210,6 +225,56 @@ regressions never fail the run. Because a GitHub issue body is size-capped and a
 analysis can exceed it, the issue carries a **condensed summary** (the top findings) and
 links to the **full Markdown and JSON reports**, which the job uploads as a run artifact — so
 the issue always fits while the complete data stays one click away.
+
+### Nightly history backfill
+
+A scheduled companion workflow densifies the per-machine-key series the push workflow leaves
+sparse. At 02:00 UTC — clear of the cache warmup's midnight slot — it runs the collection tool's
+`backfill` in its default skip-existing mode over a window of recent `main` commits, on the same
+two platforms, so whichever machine key its runner draws that night receives the newest commits
+that key is missing. It is purely a producer: it performs no analysis and raises no alert.
+Analysis stays with the push workflow, which surveys a densified series the next time one of its
+runners draws that same machine key.
+
+The window is computed per run rather than fixed. Its newest end is the newest first-parent
+commit at least 24 hours old, which keeps the nightly from racing a push-collect that may still
+be measuring a recent commit (collection runs for hours). Its oldest end is 14 days
+back: history older than that has no comparison value against the current tip, since detection
+reads only a short window of recent points, and the same bound caps how far back the
+measurement-configuration caveat below can plant an odd-looking point.
+
+Being killed by the clock is the expected outcome, not a failure. One commit costs as much as a
+push-collect and more — the backfill worktree's build directory sits outside the shared
+dependency cache, so it always builds cold — so a night fills roughly one gap per platform
+against the six-hour hosted-runner ceiling. The job therefore carries the maximum
+`timeout-minutes` *together with* `continue-on-error`, which is what turns the kill into an
+unremarkable end rather than a red scheduled workflow, and it ignores per-commit errors so one
+unbuildable commit does not end the walk. Because backfill works newest-first, whatever the run
+managed to finish is the most comparison-relevant part of the range. A kill landing in the
+seconds a commit spends writing its per-engine results leaves that commit stored for only some
+engines, and later runs count it as filled; repairing it takes a `backfill --overwrite` over
+that commit. The accepted cost is that a
+genuinely broken nightly — bad credentials, a tool bug, every commit failing — is equally green
+and silent; this is an opportunistic job, and such breakage still surfaces within hours in the
+push workflow, which does alert.
+
+It carries its own concurrency group instead of joining history collection's. A scheduled run's
+SHA *is* the current tip, so sharing that SHA-keyed, cancel-in-progress group would put the
+nightly and the tip commit's own collection into one group where whichever started later kills
+the other — hours of benchmarking discarded in either direction. The backfill's own group merely
+stops a manual dispatch from duplicating a scheduled run, queueing it instead. The dispatch
+exists as an escape hatch: it can override the computed newest endpoint to step over a commit
+that fails slowly and would otherwise be re-selected every night.
+
+Two fidelity caveats ride along, both worth recognising before an unexplained step in a series
+is read as a real regression. A backfilled commit is built with the toolchain that commit pins,
+but its `RUSTFLAGS` and benchmark scope come from the current checkout — they are caller intent
+that a general-purpose tool cannot recover from a historical worktree — so a commit older than
+the newest change to either is measured slightly differently from its pushed neighbours; the
+14-day window is what bounds this. Separately, the hosted runner images roll weekly and the
+hardware fingerprint does not capture the image version, so a gap filled tonight may be measured
+on a newer image than the neighbour it sits between — an exposure the pushed series already
+carries, and strictly better than leaving the gap empty.
 
 ### PR benchmark history
 
@@ -299,12 +364,14 @@ safe even when slightly stale.
 
 ## Failure alerting
 
-The history, release, and validation workflows all open a GitHub issue on failure, but with
+The push-triggered history collection, release, and validation workflows all open a GitHub
+issue on failure, but with
 deliberately different lifecycles matched to what failed. A benchmark-history failure is
 a recurring condition on a rolling target, so it opens a *deduplicated* tracking issue
 (keyed on a fixed title) that a companion job closes automatically once the workflow is
 green again — exactly one open issue per persistent failure, cleared without manual
-intervention. A release failure is a discrete event tied to one publish attempt, so it
+intervention. The nightly backfill is deliberately outside this scheme and files nothing (see
+Nightly history backfill). A release failure is a discrete event tied to one publish attempt, so it
 opens a *per-run* issue (identified by the failing run) that stays open until a human
 investigates; each failed release is tracked individually rather than folded into a
 rolling issue. A push-to-`main` Validation failure follows the same per-run shape as the
@@ -385,4 +452,7 @@ explicit cap is sized as the job's own work budget *plus* that ~90-minute cold-s
 allowance; sizing a cap to the warm-cache setup time alone would make a cache miss spuriously
 fail the job. Jobs whose work is comfortably bounded carry no explicit cap and rely on
 GitHub's default ceiling, which already clears a cold setup with room to spare. Explicit caps
-exist only to stop a genuinely stuck run, never to bound the expected duration.
+exist only to stop a genuinely stuck run, never to bound the expected duration. The nightly
+history backfill is the deliberate exception: its work is unbounded by nature (it keeps filling
+gaps until it runs out of range), so it takes the ceiling as its run budget and pairs the cap
+with `continue-on-error` so being cut off is an ordinary end rather than a failure.

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -255,8 +255,8 @@ jobs:
 
       # Collect only the delta-affected packages (space-separated from the delta job), keyed by the
       # PR head commit and stamped with THIS runner's real hardware fingerprint (no fixed key) so the
-      # wall-clock series lives on the same per-SKU partitions as main's baseline. `--skip-existing`
-      # makes a re-run of the same head SHA a no-op append.
+      # wall-clock series lives on the same per-machine-key partitions as main's baseline.
+      # `--skip-existing` makes a re-run of the same head SHA a no-op append.
       - name: Collect PR benchmark history
         shell: pwsh
         env:

--- a/TODO.md
+++ b/TODO.md
@@ -23,3 +23,18 @@ later:
    or better than the stable-helper baseline. The stdlib version uses an
    LLVM intrinsic and should be at least as effective as the
    `#[cold] #[inline(never)] fn` workaround.
+
+## Reorder bench-history object-key segments to `triple/machine/engine`
+
+`cargo-bench-history` keys stored objects as
+`v1/<project>/objects/<engine>/<target_triple>/<machine>/<commit>/…`
+(`packages/cbh_model/src/comparability.rs`), putting the engine outermost.
+
+Target triple and machine key identify completely independent data sets, so
+they belong outermost, with the engines nested inside one machine's data. Under
+the current order "everything this machine key recorded" is not a single
+prefix, so a partition-scoped scan — such as `backfill`'s skip-existing
+pre-check — needs one listing per engine instead of one listing overall.
+
+Reordering rewrites every stored key, so it is not worth a storage-schema break
+on its own. Do it as part of the next change that breaks the schema anyway.

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -118,7 +118,7 @@ jobs:
 crates.io **Trusted Publishing (OIDC)** is the credential model: the job carries
 `id-token: write` and no `CARGO_REGISTRY_TOKEN` exists anywhere. `release-plz`
 performs the crates.io OIDC token exchange itself, so no long-lived crates.io
-token is stored. This matches the repo's OIDC-first posture (the nightly
+token is stored. This matches the repo's OIDC-first posture (the
 `bench-history` workflow already federates into Azure the same way). The GitHub
 side (tags + releases) uses the ambient `secrets.GITHUB_TOKEN` with
 `contents: write`.
@@ -253,8 +253,9 @@ build-binaries:
 
 #### Target matrix
 
-Native runners, one per target, no cross-compilation — the same runner set as the
-nightly `bench-history` matrix plus macOS. This table is the single `triple → runner`
+Native runners, one per target, no cross-compilation — the `bench-history` matrix's two
+x86_64 runners plus the ARM and macOS targets binaries are published for. This table is the
+single `triple → runner`
 source that `plan-binaries` joins each missing `(crate, target)` pair against to set
 its `os`:
 

--- a/infra/azure-bench-history-prod/README.md
+++ b/infra/azure-bench-history-prod/README.md
@@ -1,7 +1,8 @@
 # Azure infrastructure for the benchmark-history data store
 
 This directory provisions the Azure storage account that holds the **real,
-long-lived benchmark history** collected by the `bench-history` GitHub workflow
+long-lived benchmark history** collected by the `bench-history` GitHub workflow and its
+nightly backfill companion
 (and by local `cargo run -p cargo-bench-history -- collect` invocations). It is the production data store,
 as opposed to the throwaway test account in
 [`infra/azure-bench-history-test/`](../azure-bench-history-test/).
@@ -17,8 +18,9 @@ the environment can be deleted and re-created with one command.
   disabled** (Entra ID only, so there is no account key to leak). Container and blob
   soft-delete are disabled, matching the test account.
 - A **dedicated user-assigned managed identity** (`id-folo-bench-history-prod`) with
-  **GitHub OIDC federated credentials** for `main` and for same-repo **pull requests**. Both
-  the bench-history workflow (on `main`) and the PR benchmark-history workflow federate into
+  **GitHub OIDC federated credentials** for `main` and for same-repo **pull requests**. The
+  bench-history workflow and its nightly backfill companion (both running on `main`) and the
+  PR benchmark-history workflow federate into
   it with no stored secret: `cargo-bench-history` mints a fresh GitHub OIDC token on
   demand and exchanges it with Entra for each access token (so a multi-hour run stays
   authenticated). The pull-request credential (subject `…:pull_request`) is what lets the PR

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -8,7 +8,7 @@
 # Collects the whole workspace's benchmark history (excluding the slow, special-purpose
 # `benchmarks` package) into the prod Azure store, keyed by the current commit. The machine
 # partition for every engine is the runner's OWN auto-detected hardware fingerprint,
-# NOT a fixed key: the GitHub-hosted runner pool is heterogeneous, and pinning every SKU onto one
+# NOT a fixed key: the GitHub-hosted runner pool is heterogeneous, and pinning every runner onto one
 # shared series just mixes incomparable machines and jitters daily. Letting each runner stamp
 # its real fingerprint splits the data into one clean series per hardware type; the analyze job is
 # fed the exact fingerprints collected this run (see gh-analyze-bench-history) so it surveys only
@@ -20,7 +20,7 @@
 # enough apart in time that a transient slowdown is unlikely to hit every one. This roughly
 # triples the wall-clock benchmark portion of the collect job (see bench-history.yml's
 # `timeout-minutes`). `--verbose` makes the collect log spell out the resolved machine key and the
-# fingerprint components behind it, so a key change (a runner-pool SKU shift) is debuggable from the
+# fingerprint components behind it, so a key change (a runner hardware shift) is debuggable from the
 # log alone. `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
 # already-stored object is skipped, not overwritten), so a re-triggered run of an
 # already-collected commit never bumps the cache-invalidation marker the `analyze` job's
@@ -85,8 +85,8 @@ gh-collect-bench-history:
 # branch-unique head commit, i.e. exactly the packages collected here (see
 # gh-analyze-pr-bench-history and .github/workflows/design.md). Everything else is identical to the
 # push-to-main collect: each runner stamps its OWN real hardware fingerprint (no fixed key), so PR
-# wall-clock series live on the same per-SKU partitions as main's baseline, `--best-of 3` sheds
-# one-sided runner jitter, `--verbose` logs the resolved key and its components, and
+# wall-clock series live on the same per-machine-key partitions as main's baseline, `--best-of 3`
+# sheds one-sided runner jitter, `--verbose` logs the resolved key and its components, and
 # `--skip-existing` makes a re-run of the same head SHA a no-op append. There is no recollect mode on
 # PRs (that repairs main's permanent history); the scope decision lives in
 # scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this is

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -31,18 +31,20 @@
 # `collect` job wires it from the optional `recollect_commit_id` workflow_dispatch input), this
 # recipe instead re-measures that ONE historical commit and OVERWRITES its stored point, rather
 # than appending the pushed commit. It does so with `backfill <id> <id> --overwrite`, which
-# benchmarks the code AT that commit inside a throwaway git worktree (never the primary checkout)
-# while running THIS (HEAD) build of the tool - so a data point corrupted by a bad benchmark day
-# (transient spikes, a degraded runner) is replaced by a clean re-run under the CURRENT collection
-# logic, never the tool version that happened to ship at that commit. `--overwrite` bumps the
-# cloud cache-invalidation marker so the `analyze` job's read-through cache refreshes; note it also
-# drops any blessings recorded at that commit, which must be re-applied if the re-measured level is
-# still an intentional step change. The value should be a real commit on `main`'s first-parent
-# history: the module validates only the SHA *format*, and `backfill` then requires the id to
-# *resolve* to a commit in the clone (failing loudly otherwise) - but neither checks main
-# ancestry, so a resolvable off-main commit is not rejected; it would just overwrite/store a
-# point the `analyze` job (which surveys only `main`) never surfaces. The mode selection and the
-# untrusted-input validation live in
+# benchmarks the code AT that commit inside a throwaway git worktree (never the primary checkout),
+# built with the toolchain that commit pins, while running THIS (HEAD) build of the tool - so a data
+# point corrupted by a bad benchmark day (transient spikes, a degraded runner) is replaced by a clean
+# re-run under the CURRENT collection logic, never the tool version that happened to ship at that
+# commit. Note the RUSTFLAGS below come from HEAD's constants.env rather than that commit's, so a
+# recollect of a commit older than the newest change to them measures it slightly differently from
+# how it was originally collected. `--overwrite` bumps the cloud cache-invalidation marker so the
+# `analyze` job's read-through cache refreshes; note it also drops any blessings recorded at that
+# commit, which must be re-applied if the re-measured level is still an intentional step change.
+# The value should be a real commit on `main`'s first-parent history: the module validates only the
+# SHA *format*, and `backfill` then requires the id to *resolve* to a commit in the clone (failing
+# loudly otherwise) - but neither checks main ancestry, so a resolvable off-main commit is not
+# rejected; it would just overwrite/store a point the `analyze` job (which surveys only `main`)
+# never surfaces. The mode selection and the untrusted-input validation live in
 # scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this
 # recipe is a thin import + call; the value is read from the environment, never spliced into the
 # script body.
@@ -119,6 +121,71 @@ gh-collect-pr-bench-history packages:
 
     Write-Verbose "Collecting PR benchmark history scoped to the packages impacted by this PR: $($packageList -join ', ')." -Verbose
     $toolArgs = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package $packageList -Verbose
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
+
+# Fills gaps in the benchmark history of the machine partition THIS runner happens to belong to
+# (.github/workflows/bench-history-backfill.yml, nightly). The GitHub-hosted runner pool is
+# heterogeneous, so consecutive pushes to `main` are measured by different hardware and every
+# per-machine-key series ends up sparse: a commit measured under one machine key is simply missing
+# from every other machine key's series. This recipe walks a rolling window of recent `main` history
+# and measures the commits this runner's own partition lacks, relying on the tool's default
+# skip-existing behaviour so a commit already recorded for this partition costs nothing. Which
+# partition gets densified is whatever the nightly runner draws - this is opportunistic
+# densification of recent history, not a guarantee for any particular series.
+#
+# The window comes from Get-BenchHistoryBackfillCommand (scripts/bench-history/BenchHistoryCollect.psm1,
+# Pester-tested via `just test-scripts`), so this recipe is a thin import + call: its range end is the
+# newest first-parent commit at least 24 hours old - old enough that the push-triggered collection of
+# it has long since finished, so the two never race for the same commit - and its range start the
+# oldest first-parent commit reachable from that end and newer than 14 days, since older points have
+# no comparison value against current tips. An EMPTY argument vector means no commit is eligible yet
+# (every commit is still inside the quarantine), which is a successful no-op rather than a failure.
+# The scope, `--best-of 3` and `--verbose` are the same ones gh-collect-bench-history uses - a point
+# measured with a narrower scope or a lower best-of would not be comparable to its pushed neighbours,
+# and would still count as recorded and never be revisited. `--ignore-errors` walks past a commit
+# that fails to build instead of abandoning the rest of the window; there is no `--overwrite` (an
+# existing point is exactly what should be skipped) and no `--machine-key` (each runner stamps its
+# own real hardware fingerprint).
+#
+# Each commit is built with the toolchain it pins, but the RUSTFLAGS below come from HEAD's
+# constants.env, so a commit older than the newest change to them is measured slightly differently
+# from how its pushed neighbours were. The 14-day window is what bounds that exposure.
+#
+# BACKFILL_TO_COMMIT (empty on the scheduled run) overrides the computed range end, which is how an
+# operator steps over a commit that fails slowly and would otherwise be re-selected every night. It
+# is read from the environment, never spliced into the script body, and the module validates its SHA
+# format before it becomes a range endpoint.
+#
+# There is no analyze step here: analysis runs on the next push, which surveys whatever this run
+# appended.
+[group('automation')]
+[script]
+gh-backfill-bench-history:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module ./scripts/bench-history/BenchHistoryCollect.psm1 -Force
+
+    # Build the benchmarks with 64-byte function alignment so the collected wall-clock series are
+    # stable against link-layout shifts (see constants.env); the tool spawns `cargo bench` as a child
+    # that inherits this RUSTFLAGS, and the padding is never executed so instruction and allocation
+    # counts are unaffected. Treat any RUSTFLAGS the runner set as opaque: remove only a pre-existing
+    # -align-all-functions token (in any -C/--codegen spelling), then append the stability value so
+    # the 64-byte setting always wins - never duplicated, never silently skipped in favour of a stray
+    # value.
+    $kept_rustflags = ("$env:RUSTFLAGS" -replace '(^|\s)(-C\s*|--codegen(?:\s+|=))llvm-args=-align-all-functions=\d+', '').Trim()
+    $env:RUSTFLAGS = (@($kept_rustflags, $env:BENCH_STABILITY_RUSTFLAGS) | Where-Object { $_ }) -join " "
+
+    # The window resolution - including the nothing-eligible case and the untrusted-input validation -
+    # lives in the module so it is Pester-tested (BenchHistoryCollect.Tests.ps1); this step runs
+    # whatever subcommand + flags it returns.
+    $toolArgs = @(Get-BenchHistoryBackfillCommand -ToCommitId $env:BACKFILL_TO_COMMIT -Verbose)
+    if ($toolArgs.Count -eq 0) {
+        Write-Verbose "No commit is old enough to backfill yet, so there is nothing to measure this run." -Verbose
+        return
+    }
+
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- @toolArgs
 
 # Writes THIS runner's real hardware machine key (the fingerprint the collect step just stamped its

--- a/packages/cargo-bench-history/book/src/commands/backfill.md
+++ b/packages/cargo-bench-history/book/src/commands/backfill.md
@@ -1,17 +1,24 @@
 # backfill
 
 `backfill` reconstructs history by checking out each commit in a range and running
-[`collect`](collect.md) for it — bootstrapping an existing repository's timeline, and also a
+[`collect`](collect.md) for it — bootstrapping an existing repository's timeline, filling the
+gaps a mixed pool of benchmark machines leaves in any one machine's series, and also a
 convenient path for ad-hoc evaluation over a span of commits.
 
 ```console
 cargo bench-history backfill --local=./bench-history <from-commit> <to-commit>
 ```
 
-The range endpoints are inclusive positional subjects. Commits are enumerated oldest-first
-along the first-parent mainline; the tool first verifies both endpoints resolve and that the
-start is a first-parent ancestor of the end, then derives the range purely from the end's
+The range endpoints are inclusive positional subjects: `<from-commit>` is the oldest commit of
+the span and `<to-commit>` the newest. The tool first verifies both endpoints resolve and that
+the start is a first-parent ancestor of the end, then derives the range purely from the end's
 history — so backfilling does not depend on the current checkout or branch.
+
+Commits are **processed newest-first**. A long backfill is routinely cut short — you stop it,
+or a CI job hits its time limit — and the recent end of the history is the part an analysis of
+the current tip actually reads, so an interrupted run has already spent its time where it
+counts. The one visible consequence: without `--ignore-errors`, the run stops at the *newest*
+failing commit.
 
 ## Isolation and resumability
 
@@ -25,6 +32,34 @@ before their benches run, making backfill resumable and cheap to re-issue;
 `--overwrite` regenerates them. A build or bench failure stops by default;
 `--ignore-errors` instead continues and includes every failed commit in the end-of-run
 summary. Infrastructure failures always abort.
+
+That skip check looks only at the **storage partition this run writes to** — the target triple
+and machine key this run stores under, `--machine-key` override included — so a commit measured
+on other hardware, or for another target, never counts as already done here. Across engines it
+takes the union: a commit that has a clean result for only some engines still counts as recorded
+and is skipped, because nothing requires a run to produce every engine (off Linux, Callgrind
+produces nothing at all). Use `--overwrite` to re-measure such a commit — for example after
+adding a new bench, or after a run was killed partway through storing one commit's per-engine
+results.
+
+## Toolchain and measurement configuration
+
+Each commit is built with **the toolchain its own checkout selects**: the worktree is a
+historical checkout, so the toolchain selection your shell exported into `cargo bench-history`
+is dropped for the per-commit run and the toolchain is resolved from the checkout itself — the
+`rust-toolchain.toml` at that commit when it has one, your local default otherwise. The stored
+`rustc` version names the compiler that actually built the benchmarks either way.
+
+The rest of the measurement configuration is *not* reconstructed from the commit and cannot be.
+`RUSTFLAGS` and the benchmark scope flags are your intent as the caller — passing them through
+to `cargo bench` is [`collect`](collect.md)'s contract, and a general-purpose tool has no way to
+read a specific project's build configuration out of a historical worktree. So a commit older
+than the newest change to either is measured slightly differently from a point that was
+collected at the time that commit was pushed, and the difference can look like a step in the
+series that no code change explains. Keep backfilled ranges recent to bound this, and treat an
+unexplained step at the boundary of a backfilled span with suspicion.
+
+## Noise reduction
 
 `--best-of N` carries through to each commit's `collect`, applying the same min-of-N noise
 reduction uniformly across the range.

--- a/packages/cargo-bench-history/book/src/concepts/stability.md
+++ b/packages/cargo-bench-history/book/src/concepts/stability.md
@@ -73,7 +73,7 @@ build profile. Stability of the *inputs* is the responsibility of whoever builds
 benchmarks. Apply the flag in your own benchmark build path — a `just` recipe, a CI step, a
 `cargo bench` wrapper — so that every run the tool collects is built the same way.
 
-Two consequences worth planning for:
+Consequences worth planning for:
 
 - **Only wall-clock engines need it.** Instruction-count engines (for example Callgrind) count
   executed instructions, which do not depend on where functions land, so alignment neither helps
@@ -90,3 +90,8 @@ Two consequences worth planning for:
   request that touches an affected wall-clock benchmark can show a one-time-shift-sized move in its
   performance comment. Those findings are advisory rather than merge gates and clear themselves
   once the aligned baseline fills in.
+- **Backfilling across the change mixes the two configurations.** `RUSTFLAGS` reaches
+  [`backfill`](../commands/backfill.md) from the invocation, not from the commit being measured,
+  so backfilling commits that predate the alignment change measures them *with* alignment while
+  their originally-collected neighbours lack it. Keep backfilled ranges recent enough to stay
+  inside one configuration, or expect an extra step where the two meet.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -221,18 +221,15 @@ partitioned by it.
 There is no machine-independent partition: every engine — Callgrind instruction counts and
 `alloc_tracker` allocations included — is keyed by the host fingerprint, because those
 figures vary with the microarchitecture in practice. The string `synthetic` carries no
-special meaning; it is an ordinary machine-key value like any other. Historical data that
-earlier tool versions stored under a literal `synthetic` placeholder is not migrated: those
-series restart under the runner's real fingerprint at the changeover, and the old objects
-stay reachable only via an explicit `--machine-key synthetic` (or `--machine-key all`).
+special meaning; it is an ordinary machine-key value like any other, reachable only through
+an explicit `--machine-key synthetic` (or `--machine-key all`).
 
 The individual factors behind the fingerprint (the version tag, processor and memory-region
 counts, processor models, and the per-processor speed histogram) are surfaced for debugging:
 `collect` and the query commands emit them to standard error under `--verbose`, and the
 standalone `machine-key` command prints the key to standard output (with `--verbose` adding
-the factors to standard error). The
-latter exists so CI can capture the real per-runner key and thread it into a later `analyze`
-selection, now that runs are keyed by the auto-detected fingerprint rather than a fixed pin.
+the factors to standard error). The latter exists so CI can capture the real per-runner key
+and thread it into a later `analyze` selection.
 The same factors and resulting fingerprint are also recorded on every stored run as
 write-only provenance (see §5).
 
@@ -530,21 +527,60 @@ never mistaken for an empty project.
 ### 7.4 `backfill`
 
 `backfill` reconstructs history by checking out each commit in a range and running
-`collect` for it — bootstrapping an existing repository's timeline, and also the convenient
-path for ad-hoc evaluation over a span of commits. The range endpoints are inclusive
-positional subjects. Commits are enumerated oldest-first along the first-parent mainline;
-the tool first verifies both endpoints resolve and that the start is a first-parent
-ancestor of the end, then derives the range purely from the end's history — so backfilling
-does not depend on the current checkout or branch.
+`collect` for it — bootstrapping an existing repository's timeline, filling the gaps a
+heterogeneous machine pool leaves in a per-machine series, and also the convenient path for
+ad-hoc evaluation over a span of commits. The range endpoints are inclusive positional
+subjects naming the oldest and newest commit of a first-parent mainline span; the tool first
+verifies both endpoints resolve and that the start is a first-parent ancestor of the end,
+then derives the range purely from the end's history — so backfilling does not depend on the
+current checkout or branch.
+
+Within that range commits are processed **newest-first**. A long backfill is routinely cut
+short — by an operator losing patience or by a CI job ceiling — and the recent end of the
+history is what a comparison against the current tip actually reads, so an interrupted run
+has already spent its time on the points that matter most. The visible consequence is that
+stopping at the first failure stops at the *newest* failing commit.
 
 All work happens inside a dedicated **git worktree** under the temp directory rather than
 in the primary checkout, so a dirty primary tree neither blocks backfill nor affects what
 is measured (each point benchmarks a specific commit, never the working tree), and an
 interruption leaves the user exactly where they were. Between commits the worktree is reset
-clean while preserving the ignored build directory for incremental speed. By default,
-commits that already have a stored result are listed once up front and **skipped before
-their benches run**, making backfill resumable and cheap to re-issue; overwrite regenerates
-them. A build or bench failure stops by default (or, with a flag, is recorded and skipped
+clean while preserving the ignored build directory for incremental speed.
+
+Because that worktree is a **historical checkout, its own toolchain selection governs its
+build**: the toolchain selection the launcher exported into the tool's environment is
+dropped for the per-commit bench run, so the toolchain is resolved from the checkout itself —
+the pin at that commit when it has one, the local default otherwise — and the recorded `rustc`
+provenance (§5) names the compiler that actually ran. `collect` keeps the inherited selection
+instead — its checkout *is* the current workspace, where a deliberate toolchain choice by the
+caller must be honoured.
+
+The rest of the measurement configuration is **not** reconstructed and cannot be: the
+caller's `RUSTFLAGS` and the benchmark scope are caller intent, arriving from the
+invocation rather than from the commit, and passing them through is `collect`'s contract
+(§7.1) — a general-purpose tool has no way to read a specific project's build configuration
+out of a historical worktree. A commit older than the newest change to either is therefore
+measured slightly differently from a point collected when it was pushed, which can surface
+as a step in the series that no code change explains. This is a limitation to bound by
+keeping backfilled ranges recent, not a defect with a fix.
+
+By default, commits that already have a stored result are listed once up front and
+**skipped before their benches run**, making backfill resumable and cheap to re-issue;
+overwrite regenerates them. That pre-check reads only the **partition this run would write
+to** — the target triple and machine key this run stores under, honouring a `--machine-key`
+override (§3) — because a different triple or machine key is an independent data set and
+must never count as coverage of this one. The partition is resolved **once**, from the
+newest checkout in the range, so the pre-check matches every write as long as all the
+toolchains in the range resolve to the same host triple; that condition is the price of
+letting each worktree govern its own toolchain, the same decision that gives backfilled
+points their compiler fidelity. Across engines the pre-check unions rather than intersects:
+nothing requires a run to produce every engine (off Linux, Callgrind produces nothing at
+all), so a commit with a clean result for only some engines is still skipped, and overwrite
+is the way to revisit it. Engine results are stored one at a time, so a run killed inside
+that window leaves a partially stored commit that later runs consider complete —
+overwriting that one commit is the repair.
+
+A build or bench failure stops by default (or, with a flag, is recorded and skipped
 with an end-of-run summary), while infrastructure failures always abort since continuing
 cannot produce correct data. `--best-of N` carries through to each commit's `collect`, so a
 backfill can apply the same min-of-N noise reduction (§7.1) uniformly across the range.

--- a/packages/cargo-bench-history/src/commands/backfill.rs
+++ b/packages/cargo-bench-history/src/commands/backfill.rs
@@ -1,12 +1,21 @@
 //! The `backfill` command: replay `collect` across a range of historical commits.
 //!
 //! Backfilling bootstraps a history for a repository that adopted the tool late,
-//! and supports ad-hoc "what did this look like N commits ago" investigations. It
-//! checks out each commit of a range in a dedicated git **worktree** (never the
-//! primary checkout) and runs the configured engines there exactly as the `collect`
-//! command does. A backfilled run carries no commit timestamp of its own; its
-//! position on the timeline is where its commit sits in git history, resolved live
-//! at analyze time (see the `backfill` command in `DESIGN.md`).
+//! fills gaps left by a heterogeneous CI machine pool, and supports ad-hoc "what
+//! did this look like N commits ago" investigations. It checks out each commit of
+//! a range in a dedicated git **worktree** (never the primary checkout) and runs
+//! the configured engines there exactly as the `collect` command does, except that
+//! the worktree's own `rust-toolchain.toml` governs the build rather than the
+//! toolchain this tool was launched with. A backfilled run carries no commit
+//! timestamp of its own; its position on the timeline is where its commit sits in
+//! git history, resolved live at analyze time (see the `backfill` command in
+//! `DESIGN.md`).
+//!
+//! The range is walked **newest commit first**. The newest gaps are the ones
+//! current comparisons draw on, so a run that is cut short (a CI job timeout) has
+//! spent its time on the most valuable commits. The endpoints are independent of
+//! that walk: `--from` names the oldest commit of the range and `--to` the newest,
+//! both inclusive.
 //!
 //! Like `collect`, the orchestration is generic over small ports so the loop logic is
 //! exercised with in-memory fakes (Miri-safe): a [`BackfillGit`] port for the git
@@ -16,12 +25,13 @@
 //! worktree-rooted probe, engine runner, and output source.
 //!
 //! Before any commit is benchmarked, the commits that already have a stored
-//! (clean) result are listed once from storage. In the default skip-existing mode
-//! a commit already present is skipped outright, so its (expensive) benchmark
-//! execution never runs; this makes a backfill resumable and cheap to re-run. A
-//! commit with a clean result for only some engines is still skipped — use
-//! `--overwrite` to re-benchmark every commit (for example after adding a new
-//! bench), which replaces results in place rather than colliding with them.
+//! (clean) result **in the partition this run would write to** are listed once from
+//! storage. In the default skip-existing mode a commit already present is skipped
+//! outright, so its (expensive) benchmark execution never runs; this makes a
+//! backfill resumable and cheap to re-run. A commit with a clean result for only
+//! some engines is still skipped — use `--overwrite` to re-benchmark every commit
+//! (for example after adding a new bench), which replaces results in place rather
+//! than colliding with them.
 
 use std::collections::HashSet;
 use std::future::Future;
@@ -34,14 +44,18 @@ use cbh_config::{
     load_config, resolve_config_path, resolve_local_path, resolve_project_id, resolve_repo,
     storage_env,
 };
-use cbh_diag::{StderrReporter, count_noun};
+use cbh_diag::{Reporter, ReporterExt, StderrReporter, count_noun};
 use cbh_engines::FsBenchOutputSource;
 use cbh_git::{GitHistory, SystemGitHistory, TokioBenchRunner, capture};
 use cbh_probe::SystemProbe;
-use cbh_storage::{Storage, build_storage, project_objects_prefix};
+use cbh_storage::{Storage, build_storage};
 use tick::Clock;
 
-use super::collect::{CollectDeps, CollectSummary, default_bench_command, run_engines};
+use super::collect::{
+    CollectDeps, CollectSummary, Partition, default_bench_command, partition_selection_summary,
+    probe_partition, run_engines,
+};
+use crate::model::{Engine, StorageKey, parse_key};
 use crate::{BackfillOptions, CollectOptions, RunError, RunOutcome, finish_with_flush};
 
 /// Read access to a repository's commit topology plus the worktree lifecycle a
@@ -68,10 +82,23 @@ trait BackfillGit {
 
 /// Runs and stores the configured engines for one already-checked-out commit.
 trait CommitRunner {
-    /// The set of commits (by full commit ID) that already have a stored clean result
-    /// anywhere under this project's partitions. A commit in this set has already
-    /// been backfilled, so the default skip-existing mode skips it without
-    /// benchmarking. Probed once per backfill.
+    /// The set of commits (by full commit ID) that already have a stored clean
+    /// result **in the partition this backfill writes to** — this host's target
+    /// triple and machine key (or the `--machine-key` override), across every
+    /// engine. A commit in that set has already been backfilled here, so the
+    /// default skip-existing mode skips it without benchmarking. Probed once per
+    /// backfill.
+    ///
+    /// Other target triples and machine keys are independent data sets: a commit
+    /// measured on another platform or another machine pool leaves this
+    /// partition's gap open, so it must not count as recorded. Engines, by
+    /// contrast, are unioned — no rule says which engines a run produces (Callgrind
+    /// records nothing off Linux), so requiring all of them would never skip
+    /// anything.
+    ///
+    /// Implementations announce the partition they scanned. A backfill that a job
+    /// timeout ends never reaches the summary, so the pre-check has to state its
+    /// own inputs to leave any trace of what the run decided to measure.
     fn recorded_commits(&self) -> impl Future<Output = Result<HashSet<String>, RunError>>;
 
     /// Runs the engines in `worktree` and reports the outcome. Recoverable
@@ -127,22 +154,24 @@ pub(crate) async fn execute(
     let bench_command = bench_command.unwrap_or_else(default_bench_command);
 
     let git = SystemBackfillGit::new(base);
+    let worktree = worktree_path();
+    let reporter = StderrReporter::new(options.verbose);
     let runner = SystemCommitRunner {
         project_id: &project_id,
         storage: &storage,
         tool_version: env!("CARGO_PKG_VERSION"),
         options,
         bench_command: &bench_command,
+        worktree: &worktree,
+        reporter: &reporter,
     };
-    let worktree = worktree_path();
 
-    let result = execute_backfill(options, &git, &runner, &worktree).await;
+    let result = execute_backfill(options, &git, &runner, &worktree, &reporter).await;
     // Flush the cache-invalidation marker once for the whole range: where a
     // `backfill --overwrite` replaces an already-stored object it arms the shared
     // backend, and a single coalesced bump invalidates other machines' caches.
     // Filling a gap with a brand-new object is additive and never arms it, so an
     // append-only backfill is a cheap no-op.
-    let reporter = StderrReporter::new(options.verbose);
     let flush = storage
         .flush_pending_invalidation(&project_id, &reporter)
         .await;
@@ -160,20 +189,24 @@ async fn execute_backfill<G, C>(
     git: &G,
     runner: &C,
     worktree: &Path,
+    reporter: &dyn Reporter,
 ) -> Result<RunOutcome, RunError>
 where
     G: BackfillGit,
     C: CommitRunner,
 {
     let commits = plan_commits(options, git).await?;
+    // Seeding the worktree at the first commit that will be processed saves it one
+    // checkout; `run_commits` resets the worktree for every commit it runs anyway,
+    // so this is an optimization rather than a precondition.
     let first = commits
         .first()
-        .expect("the planned range always contains at least the --from commit");
+        .expect("the planned range is inclusive of both endpoints, so it is never empty");
 
     git.add_worktree(worktree, first)
         .await
         .map_err(RunError::Io)?;
-    let result = run_commits(options, git, runner, worktree, &commits).await;
+    let result = run_commits(options, git, runner, worktree, &commits, reporter).await;
     let teardown = git.remove_worktree(worktree).await;
 
     let report = result?;
@@ -187,11 +220,16 @@ where
     }
 }
 
-/// Validates the request and resolves the oldest-first, inclusive commit range.
+/// Validates the request and resolves the inclusive commit range, **newest commit
+/// first**.
 ///
 /// Requires both endpoints to resolve and requires `--from` to be a first-parent
 /// ancestor of `--to`. The range is derived purely from `--to`'s first-parent
 /// history, so backfilling does not depend on the current checkout.
+///
+/// `--from` names the oldest commit of the range and `--to` the newest; the
+/// returned order is the reverse, so a run cut short has filled the most recent
+/// gaps.
 async fn plan_commits<G: BackfillGit>(
     options: &BackfillOptions,
     git: &G,
@@ -210,7 +248,11 @@ async fn plan_commits<G: BackfillGit>(
             ),
         })?;
 
-    Ok(ancestry.split_off(start))
+    // The ancestry arrives oldest-first, which is what locating `--from` above
+    // needs; the reversal therefore happens only once that endpoint has been found.
+    let mut range = ancestry.split_off(start);
+    range.reverse();
+    Ok(range)
 }
 
 /// Resolves `reference` to a commit ID, mapping an absent ref to a clear error.
@@ -229,14 +271,24 @@ async fn resolve_required<G: BackfillGit>(
 
 /// Runs each commit of the range in the worktree, aggregating a [`BackfillReport`].
 ///
-/// A per-commit build/bench failure stops the loop unless `--ignore-errors` is
-/// set; an infrastructure error always aborts (propagated as `Err`).
+/// `commits` arrives newest-first, so the most recent gaps are filled before a run
+/// is cut short. A per-commit build/bench failure stops the loop unless
+/// `--ignore-errors` is set — which, in this order, means the run stops at the
+/// *newest* failing commit and leaves the older ones untouched; an infrastructure
+/// error always aborts (propagated as `Err`).
+///
+/// What the skip pre-check decided is announced before the loop rather than left
+/// to [`BackfillReport::render`]: a run that is cut short by a job timeout — the
+/// designed steady state of a nightly backfill — never reaches the summary, and
+/// the pre-check is precisely the step whose misbehaviour would show up as a run
+/// that quietly measures nothing.
 async fn run_commits<G, C>(
     options: &BackfillOptions,
     git: &G,
     runner: &C,
     worktree: &Path,
     commits: &[String],
+    reporter: &dyn Reporter,
 ) -> Result<BackfillReport, RunError>
 where
     G: BackfillGit,
@@ -251,8 +303,26 @@ where
     } else {
         runner.recorded_commits().await?
     };
+    // Only the overlap with this range matters: the listings cover the partition's
+    // whole history, which reaches beyond `--from`..`--to`.
+    let already_recorded = commits
+        .iter()
+        .filter(|commit| recorded.contains(*commit))
+        .count();
+    reporter.announce(&scan_outcome_summary(
+        commits.len(),
+        already_recorded,
+        options.overwrite,
+    ));
+
     for commit in commits {
         if recorded.contains(commit) {
+            reporter.note_with(|| {
+                format!(
+                    "skipping {}: a clean result for it is already stored in this partition",
+                    short(commit)
+                )
+            });
             report.skipped_existing.push(commit.clone());
             continue;
         }
@@ -271,6 +341,31 @@ where
         }
     }
     Ok(report)
+}
+
+/// Builds the always-on line stating what the skip pre-check decided for a range
+/// of `total` commits, `already_recorded` of which the pre-check found stored in
+/// this partition.
+///
+/// It names the rule that produced the split and the flag that changes it, so a
+/// run whose measured count is surprising can be diagnosed from this one line —
+/// which, in a run that a job timeout ends before the summary, is the only record
+/// of the decision.
+///
+/// A pure formatter so the wording is unit-tested without a store.
+fn scan_outcome_summary(total: usize, already_recorded: usize, overwrite: bool) -> String {
+    let range = format!("backfilling {}, newest first", count_noun(total, "commit"));
+    if overwrite {
+        return format!(
+            "{range}: --overwrite disables the skip pre-check, so every commit is \
+             re-measured and its stored result replaced"
+        );
+    }
+    let to_measure = total.saturating_sub(already_recorded);
+    format!(
+        "{range}: {already_recorded} already recorded in this partition and skipped \
+         without benchmarking (pass --overwrite to re-measure them), {to_measure} to measure"
+    )
 }
 
 /// The per-commit outcomes a backfill accumulated, rendered into a summary.
@@ -370,14 +465,60 @@ fn map_collect_result(result: Result<CollectSummary, RunError>) -> Result<Commit
     }
 }
 
-/// The commit (full commit ID) recorded by a stored clean object, or `None` when the key
-/// is not a clean object.
+/// The commits that already have a stored clean result in `partition`.
 ///
-/// A clean key is `…/<commit>/clean.json`, so the commit is the path segment
-/// immediately before the `clean.json` filename. Dirty snapshots and any other
-/// keys are ignored.
-fn commit_of_clean_key(key: &str) -> Option<&str> {
-    key.strip_suffix("/clean.json")?.rsplit('/').next()
+/// Scans one narrow listing per engine — the engine is the outermost discriminant
+/// segment, so a machine's partitions do not form a single prefix — and unions the
+/// results, because no rule says which engines a run must produce (Callgrind
+/// records nothing off Linux, so an intersection would never be satisfied there).
+///
+/// A listing matches a plain string prefix, so every key it returns is re-parsed
+/// rather than sliced by hand: only a key that decomposes into a clean object of
+/// this partition contributes its commit. Dirty snapshots and blessing sidecars are
+/// not backfilled results and are ignored.
+async fn recorded_commits_in<S: Storage>(
+    storage: &S,
+    project_id: &str,
+    partition: &Partition,
+    reporter: &dyn Reporter,
+) -> Result<HashSet<String>, RunError> {
+    let mut recorded = HashSet::new();
+    for engine in Engine::ALL {
+        let prefix = partition
+            .discriminant_set(engine)
+            .partition_prefix(project_id);
+        let keys = storage.list(&prefix).await?;
+        let before = recorded.len();
+        let clean_commits: Vec<String> = keys
+            .iter()
+            .filter_map(|key| parse_key(key))
+            .filter(StorageKey::is_clean)
+            .map(|parsed| parsed.commit)
+            .collect();
+        let clean = clean_commits.len();
+        recorded.extend(clean_commits);
+        reporter.note_with(|| {
+            format!(
+                "listed {prefix}: {} objects, {clean} of them clean results, \
+                 adding {} commit(s) not already contributed by another engine",
+                keys.len(),
+                recorded.len().saturating_sub(before)
+            )
+        });
+    }
+    reporter.note_with(|| {
+        format!(
+            "{} commit(s) are recorded in this partition across all engines. The engines \
+             are unioned rather than intersected because no rule says which engines a run \
+             produces (Callgrind records nothing off Linux, so an intersection would never \
+             be satisfied there). Only clean results count: a dirty snapshot measures an \
+             uncommitted working tree and a blessing is an annotation, so neither fills a \
+             gap. No other target triple or machine key is listed, because those are \
+             independent data sets whose results say nothing about this one",
+            recorded.len()
+        )
+    });
+    Ok(recorded)
 }
 
 /// The real [`BackfillGit`], shelling out to `git` in a fixed repository.
@@ -496,32 +637,48 @@ struct SystemCommitRunner<'a, S> {
     options: &'a BackfillOptions,
     /// The benchmark command (`cargo bench` in production) run in each worktree.
     bench_command: &'a [String],
+    /// The worktree every commit is checked out into. The pre-check probes it for
+    /// the partition, so it reads the same partition each commit then writes to.
+    worktree: &'a Path,
+    /// Diagnostic sink for the pre-check, and for each per-commit `collect`.
+    reporter: &'a dyn Reporter,
 }
 
 impl<S: Storage> CommitRunner for SystemCommitRunner<'_, S> {
+    #[cfg_attr(test, mutants::skip)] // Probes the real host; the scan is tested separately.
     async fn recorded_commits(&self) -> Result<HashSet<String>, RunError> {
-        // Every stored object lives under the project's objects subtree, so one list
-        // of that prefix yields the full history; the clean objects' commit segments
-        // are the commits already backfilled. A dirty snapshot does not count as a
-        // backfilled commit, so only clean objects contribute.
-        let prefix = project_objects_prefix(self.project_id);
-        let keys = self.storage.list(&prefix).await?;
-        Ok(keys
-            .iter()
-            .filter_map(|key| commit_of_clean_key(key))
-            .map(ToOwned::to_owned)
-            .collect())
+        // The partition comes from the same helper (and the same worktree probe)
+        // the store path uses, so the commits treated as already recorded are
+        // exactly the ones that would collide were they benchmarked again — the
+        // `--machine-key` override included.
+        let probe = SystemProbe::in_worktree(self.worktree);
+        let env = |name: &str| std::env::var(name).ok();
+        let partition = probe_partition(&probe, &env, self.options.machine_key.as_deref()).await?;
+
+        // Always-on, because a nightly backfill is designed to end in a job
+        // timeout and never reaches the summary: this line is what tells a reader
+        // which partition the run considered, and therefore what it measured.
+        self.reporter.announce(&partition_selection_summary(
+            "scanning for already-backfilled commits",
+            partition.target_triple.as_str(),
+            "toolchain host of the newest checkout in the range",
+            partition.machine_key.as_str(),
+            self.options.machine_key.is_some(),
+        ));
+        recorded_commits_in(self.storage, self.project_id, &partition, self.reporter).await
     }
 
     #[cfg_attr(test, mutants::skip)] // Wires real adapters; the result mapping is tested via `map_collect_result`.
     async fn run(&self, worktree: &Path, _commit: &str) -> Result<CommitOutcome, RunError> {
-        let probe = SystemProbe::in_dir(worktree);
-        let runner = TokioBenchRunner::in_dir(worktree);
+        // A historical checkout is built and described by the toolchain it pins
+        // itself, not by the one that happened to build this tool, so the stored
+        // provenance names the compiler that produced the numbers.
+        let probe = SystemProbe::in_worktree(worktree);
+        let runner = TokioBenchRunner::in_worktree(worktree);
         let target_root = worktree.join("target");
         let output = FsBenchOutputSource::new(target_root.clone());
         let clock = Clock::new_tokio();
         let env = |name: &str| std::env::var(name).ok();
-        let reporter = StderrReporter::new(self.options.verbose);
 
         // A backfilled run is always clean (the worktree is a pristine checkout)
         // and takes its timeline position from the commit's committer date.
@@ -554,7 +711,7 @@ impl<S: Storage> CommitRunner for SystemCommitRunner<'_, S> {
             tool_version: self.tool_version,
             target_root: &target_root,
             bench_command: self.bench_command,
-            reporter: &reporter,
+            reporter: self.reporter,
         };
 
         map_collect_result(run_engines(&collect_options, &deps).await)
@@ -568,12 +725,14 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::future::{Future, ready};
 
+    use cbh_diag::RecordingReporter;
     use cbh_git::FakeGitHistory;
     use cbh_storage::MemoryStorage;
     use futures::executor::block_on;
 
     use super::*;
     use crate::StorageError;
+    use crate::model::{MachineKey, TargetTriple};
 
     /// A canned per-commit result the fake [`CommitRunner`] returns.
     #[derive(Clone)]
@@ -720,13 +879,32 @@ mod tests {
         PathBuf::from("/tmp/cargo-bench-history-worktree-test")
     }
 
+    /// Drives [`run_commits`] over `commits`, discarding the diagnostics the
+    /// separate reporting tests assert on.
+    fn drive_commits<G: BackfillGit, C: CommitRunner>(
+        options: &BackfillOptions,
+        git: &G,
+        runner: &C,
+        commits: &[String],
+    ) -> Result<BackfillReport, RunError> {
+        let reporter = RecordingReporter::new();
+        block_on(run_commits(
+            options,
+            git,
+            runner,
+            &worktree(),
+            commits,
+            &reporter,
+        ))
+    }
+
     #[test]
-    fn plan_enumerates_inclusive_first_parent_range_oldest_first() {
+    fn plan_enumerates_inclusive_first_parent_range_newest_first() {
         let git = FakeBackfillGit::new(fixture());
         let commits = block_on(plan_commits(&options("c1", "f2"), &git)).unwrap();
         assert!(
-            commits.iter().eq(["c1", "f1", "f2"].iter()),
-            "inclusive of both endpoints, oldest first: {commits:?}"
+            commits.iter().eq(["f2", "f1", "c1"].iter()),
+            "inclusive of both endpoints, newest first: {commits:?}"
         );
     }
 
@@ -765,7 +943,7 @@ mod tests {
         let git = FakeBackfillGit::new(fixture());
         let commits = block_on(plan_commits(&options("c0", "c3"), &git)).unwrap();
         assert!(
-            commits.iter().eq(["c0", "c1", "c2", "c3"].iter()),
+            commits.iter().eq(["c3", "c2", "c1", "c0"].iter()),
             "the range is derived from --to, independent of the checkout: {commits:?}"
         );
     }
@@ -785,14 +963,7 @@ mod tests {
             "f2".to_owned(),
         ];
 
-        let report = block_on(run_commits(
-            &options("c0", "f2"),
-            &git,
-            &runner,
-            &worktree(),
-            &commits,
-        ))
-        .unwrap();
+        let report = drive_commits(&options("c0", "f2"), &git, &runner, &commits).unwrap();
 
         assert!(
             report
@@ -825,14 +996,7 @@ mod tests {
         let runner = FakeCommitRunner::new().with("c1", FakeResult::BenchFailed("boom".to_owned()));
         let commits = vec!["c0".to_owned(), "c1".to_owned(), "f1".to_owned()];
 
-        let report = block_on(run_commits(
-            &options("c0", "f1"),
-            &git,
-            &runner,
-            &worktree(),
-            &commits,
-        ))
-        .unwrap();
+        let report = drive_commits(&options("c0", "f1"), &git, &runner, &commits).unwrap();
 
         assert!(
             report
@@ -859,7 +1023,7 @@ mod tests {
         let mut opts = options("c0", "f1");
         opts.ignore_errors = true;
 
-        let report = block_on(run_commits(&opts, &git, &runner, &worktree(), &commits)).unwrap();
+        let report = drive_commits(&opts, &git, &runner, &commits).unwrap();
 
         assert!(
             report
@@ -885,40 +1049,49 @@ mod tests {
         let mut opts = options("c0", "f1");
         opts.ignore_errors = true;
 
-        let error = block_on(run_commits(&opts, &git, &runner, &worktree(), &commits)).unwrap_err();
+        let error = drive_commits(&opts, &git, &runner, &commits).unwrap_err();
         assert!(matches!(error, RunError::Io(_)), "{error:?}");
         // The loop stopped at the failing commit; f1 was never reached.
         assert!(runner.ran.borrow().iter().eq(["c0", "c1"].iter()));
     }
 
-    /// Builds a real [`SystemCommitRunner`] over an in-memory store for testing the
-    /// storage-backed `recorded_commits` query.
-    fn system_runner<'a>(
-        storage: &'a MemoryStorage,
-        options: &'a BackfillOptions,
-    ) -> SystemCommitRunner<'a, MemoryStorage> {
-        SystemCommitRunner {
-            project_id: "proj",
-            storage,
-            tool_version: "0.0.0-test",
-            options,
-            bench_command: &[],
+    /// The project the storage-scan tests write and read under.
+    const PROJECT: &str = "proj";
+
+    /// The target triple the storage-scan tests treat as this host's.
+    const TRIPLE: &str = "x86_64-unknown-linux-gnu";
+
+    /// The machine key the storage-scan tests treat as this host's. It is a strict
+    /// prefix of `ci-pool` so the sibling-key cases are meaningful.
+    const MACHINE: &str = "ci";
+
+    /// The partition a backfill would write to on a host with `machine_key`.
+    fn partition(machine_key: &str) -> Partition {
+        Partition {
+            target_triple: TargetTriple::from(TRIPLE),
+            machine_key: MachineKey::from(machine_key),
         }
     }
 
-    #[test]
-    fn commit_of_clean_key_extracts_the_commit_only_for_clean_objects() {
-        assert_eq!(
-            commit_of_clean_key("v1/proj/objects/callgrind/triple/m1/abc123/clean.json"),
-            Some("abc123")
-        );
-        // A dirty snapshot is not a backfilled commit.
-        assert_eq!(
-            commit_of_clean_key("v1/proj/objects/criterion/triple/mk/abc123/dirty-42.json"),
-            None
-        );
-        // An unrelated key contributes nothing.
-        assert_eq!(commit_of_clean_key("v1/proj/index.json"), None);
+    /// Stores an empty object under `key`, standing in for a recorded result.
+    fn store(storage: &MemoryStorage, key: &str) {
+        block_on(storage.put(key, b"{}")).unwrap();
+    }
+
+    /// The commits `recorded_commits_in` finds for `machine_key`, sorted.
+    fn recorded(storage: &MemoryStorage, machine_key: &str) -> Vec<String> {
+        let reporter = RecordingReporter::new();
+        let mut commits: Vec<_> = block_on(recorded_commits_in(
+            storage,
+            PROJECT,
+            &partition(machine_key),
+            &reporter,
+        ))
+        .unwrap()
+        .into_iter()
+        .collect();
+        commits.sort();
+        commits
     }
 
     #[test]
@@ -927,14 +1100,7 @@ mod tests {
         let runner = FakeCommitRunner::new().complete("c1");
         let commits = vec!["c0".to_owned(), "c1".to_owned(), "f1".to_owned()];
 
-        let report = block_on(run_commits(
-            &options("c0", "f1"),
-            &git,
-            &runner,
-            &worktree(),
-            &commits,
-        ))
-        .unwrap();
+        let report = drive_commits(&options("c0", "f1"), &git, &runner, &commits).unwrap();
 
         // c1 was recognized as already recorded and reported as skipped-existing.
         assert!(report.skipped_existing.iter().eq(std::iter::once(&"c1")));
@@ -966,7 +1132,7 @@ mod tests {
         let mut opts = options("c0", "f1");
         opts.overwrite = true;
 
-        let report = block_on(run_commits(&opts, &git, &runner, &worktree(), &commits)).unwrap();
+        let report = drive_commits(&opts, &git, &runner, &commits).unwrap();
 
         // With --overwrite the pre-check is bypassed: every commit, including the
         // already-recorded c1, is reset and run.
@@ -983,51 +1149,175 @@ mod tests {
     }
 
     #[test]
-    fn recorded_commits_collects_every_clean_commit_across_partitions() {
+    fn run_commits_announces_what_the_skip_pre_check_decided() {
+        // A nightly backfill is designed to be killed by a job timeout and never
+        // reaches the summary, so the split between skipped and to-be-measured
+        // commits has to be stated up front or the run leaves no record of it.
+        let git = FakeBackfillGit::new(fixture());
+        let runner = FakeCommitRunner::new().complete("c1");
+        let commits = vec!["c0".to_owned(), "c1".to_owned(), "f1".to_owned()];
+        let reporter = RecordingReporter::new();
+
+        _ = block_on(run_commits(
+            &options("c0", "f1"),
+            &git,
+            &runner,
+            &worktree(),
+            &commits,
+            &reporter,
+        ))
+        .unwrap();
+
+        let announcements = reporter.announcements();
+        assert!(
+            announcements.iter().any(|line| line.contains("3 commits")
+                && line.contains("1 already recorded")
+                && line.contains("2 to measure")),
+            "{announcements:?}"
+        );
+        // Progress is visible per commit under --verbose, so a run cut short still
+        // shows how far the skipping got.
+        assert!(reporter.contains("skipping c1"), "{:?}", reporter.notes());
+    }
+
+    #[test]
+    fn scan_outcome_summary_states_the_split_and_the_rule_behind_it() {
+        let partial = scan_outcome_summary(10, 4, false);
+        assert!(
+            partial.contains("backfilling 10 commits, newest first"),
+            "{partial}"
+        );
+        assert!(partial.contains("4 already recorded"), "{partial}");
+        assert!(partial.contains("6 to measure"), "{partial}");
+        // The flag that changes the decision is named, so a surprising count is
+        // actionable from this line alone.
+        assert!(partial.contains("--overwrite"), "{partial}");
+
+        // A range with nothing left to do still says so rather than staying silent.
+        let complete = scan_outcome_summary(10, 10, false);
+        assert!(complete.contains("0 to measure"), "{complete}");
+
+        // With --overwrite the pre-check never ran, so no count is invented for it.
+        let overwriting = scan_outcome_summary(10, 0, true);
+        assert!(
+            overwriting.contains("--overwrite disables the skip pre-check"),
+            "{overwriting}"
+        );
+        assert!(!overwriting.contains("to measure"), "{overwriting}");
+    }
+
+    #[test]
+    fn recorded_commits_explains_each_listing_and_the_union_rule() {
+        // The verbose trail must let a reader reconstruct why a commit counted:
+        // which prefixes were listed, what each contributed, and which objects were
+        // deliberately not counted.
         let storage = MemoryStorage::new();
-        let opts = BackfillOptions::default();
-        let runner = system_runner(&storage, &opts);
+        store(
+            &storage,
+            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/ci/c0/clean.json",
+        );
+        let reporter = RecordingReporter::new();
 
-        // Two engines record c0 (under different partitions); c1 has only a dirty
-        // snapshot; a different project's clean run must not leak in.
-        block_on(storage.put(
-            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/m1/c0/clean.json",
-            b"{}",
-        ))
-        .unwrap();
-        block_on(storage.put(
-            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/mk/c0/clean.json",
-            b"{}",
-        ))
-        .unwrap();
-        block_on(storage.put(
-            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/mk/c1/dirty-7.json",
-            b"{}",
-        ))
-        .unwrap();
-        block_on(storage.put(
-            "v1/other/objects/callgrind/x86_64-unknown-linux-gnu/m1/c9/clean.json",
-            b"{}",
+        _ = block_on(recorded_commits_in(
+            &storage,
+            PROJECT,
+            &partition(MACHINE),
+            &reporter,
         ))
         .unwrap();
 
-        let recorded = block_on(runner.recorded_commits()).unwrap();
+        let notes = reporter.notes();
+        assert!(
+            notes.iter().any(|note| {
+                note.contains("v1/proj/objects/criterion/x86_64-unknown-linux-gnu/ci/")
+                    && note.contains("1 of them clean")
+            }),
+            "{notes:?}"
+        );
+        assert!(
+            reporter.contains("unioned rather than intersected"),
+            "{notes:?}"
+        );
+        assert!(reporter.contains("independent data sets"), "{notes:?}");
+    }
 
-        // Only c0 has a clean result under this project: a dirty-only commit and
-        // another project's commit are excluded.
-        let mut commits: Vec<_> = recorded.into_iter().collect();
-        commits.sort();
-        assert_eq!(commits, vec!["c0".to_owned()]);
+    #[test]
+    fn recorded_commits_counts_any_engine_of_the_partition() {
+        let storage = MemoryStorage::new();
+        // No rule says which engines a run produces, so a clean result from any one
+        // of them means the partition's gap for that commit is filled.
+        store(
+            &storage,
+            "v1/proj/objects/callgrind/x86_64-unknown-linux-gnu/ci/c0/clean.json",
+        );
+        store(
+            &storage,
+            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/ci/c1/clean.json",
+        );
+
+        assert_eq!(recorded(&storage, MACHINE), ["c0", "c1"]);
+    }
+
+    #[test]
+    fn recorded_commits_ignores_a_sibling_machine_key() {
+        let storage = MemoryStorage::new();
+        // `ci-pool` is a different machine and thus a different data set, even
+        // though its key starts with this host's `ci`.
+        store(
+            &storage,
+            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/ci-pool/c0/clean.json",
+        );
+
+        assert!(recorded(&storage, MACHINE).is_empty());
+        // The same object is exactly what the sibling machine itself would skip.
+        assert_eq!(recorded(&storage, "ci-pool"), ["c0"]);
+    }
+
+    #[test]
+    fn recorded_commits_ignores_another_target_triple() {
+        let storage = MemoryStorage::new();
+        // Numbers from another platform say nothing about this one.
+        store(
+            &storage,
+            "v1/proj/objects/criterion/aarch64-apple-darwin/ci/c0/clean.json",
+        );
+
+        assert!(recorded(&storage, MACHINE).is_empty());
+    }
+
+    #[test]
+    fn recorded_commits_ignores_another_project() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            "v1/other/objects/criterion/x86_64-unknown-linux-gnu/ci/c0/clean.json",
+        );
+
+        assert!(recorded(&storage, MACHINE).is_empty());
+    }
+
+    #[test]
+    fn recorded_commits_ignores_objects_that_are_not_clean_results() {
+        let storage = MemoryStorage::new();
+        // A dirty snapshot is a working-tree measurement and a blessing sidecar is
+        // an annotation; neither fills a backfill gap.
+        store(
+            &storage,
+            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/ci/c0/dirty-7.json",
+        );
+        store(
+            &storage,
+            "v1/proj/objects/criterion/x86_64-unknown-linux-gnu/ci/c1/bless-7.json",
+        );
+
+        assert!(recorded(&storage, MACHINE).is_empty());
     }
 
     #[test]
     fn recorded_commits_is_empty_when_nothing_is_stored() {
         let storage = MemoryStorage::new();
-        let opts = BackfillOptions::default();
-        let runner = system_runner(&storage, &opts);
 
-        let recorded = block_on(runner.recorded_commits()).unwrap();
-        assert!(recorded.is_empty());
+        assert!(recorded(&storage, MACHINE).is_empty());
     }
 
     #[test]
@@ -1103,6 +1393,7 @@ mod tests {
             &git,
             &runner,
             &worktree(),
+            &RecordingReporter::new(),
         ))
         .unwrap();
 
@@ -1110,12 +1401,13 @@ mod tests {
             panic!("expected a completed outcome");
         };
         assert!(message.contains("4 stored"), "{message}");
-        // The worktree was created once at the first commit and then removed.
+        // The worktree was created once, at the newest commit — the first one the
+        // newest-first walk processes — and then removed.
         assert!(
             git.added
                 .borrow()
                 .iter()
-                .eq(std::iter::once(&(worktree(), "c0".to_owned())))
+                .eq(std::iter::once(&(worktree(), "f2".to_owned())))
         );
         assert!(git.removed.borrow().iter().eq(std::iter::once(&worktree())));
     }
@@ -1129,6 +1421,7 @@ mod tests {
             &git,
             &runner,
             &worktree(),
+            &RecordingReporter::new(),
         ))
         .unwrap_err();
 
@@ -1149,6 +1442,7 @@ mod tests {
             &git,
             &runner,
             &worktree(),
+            &RecordingReporter::new(),
         ))
         .unwrap_err();
 

--- a/packages/cargo-bench-history/src/commands/collect.rs
+++ b/packages/cargo-bench-history/src/commands/collect.rs
@@ -253,6 +253,73 @@ where
     })
 }
 
+/// The storage partition a run's results are keyed under, less the engine.
+///
+/// A stored object's discriminant set is `engine / target_triple / machine_key`.
+/// The engine varies across the engines of a single run, while the other two are
+/// fixed by the host and the `--machine-key` override — so they are derived once,
+/// here. This is the one place that derivation lives, so `backfill`'s pre-check
+/// and the store path share it rather than reimplementing it.
+///
+/// The target triple is whatever `rustc -vV` reports in the checkout being
+/// probed, and a worktree governs its own toolchain — so `backfill`, which
+/// derives the partition once from the newest checkout in its range, holds that
+/// partition for the whole range only as long as every toolchain in the range
+/// resolves to the same host triple. Pinning a bare channel does; a
+/// fully-qualified pin carrying its own host triple (`1.75.0-x86_64-unknown-linux-musl`)
+/// does not, and a range that crosses such a change scans one partition while
+/// writing another.
+///
+/// The components are held exactly as probed;
+/// [`discriminant_set`](Self::discriminant_set) is what sanitizes them into path
+/// segments, so the effective-partition announcement still reports what the host
+/// reported.
+pub(crate) struct Partition {
+    /// Effective target triple: the toolchain host, or an `import` override.
+    pub(crate) target_triple: TargetTriple,
+    /// Effective machine key: an explicit `--machine-key` or the auto-detected
+    /// hardware fingerprint.
+    pub(crate) machine_key: MachineKey,
+}
+
+impl Partition {
+    /// The discriminant set this partition forms together with `engine`.
+    pub(crate) fn discriminant_set(&self, engine: Engine) -> DiscriminantSet {
+        DiscriminantSet::new(engine, &self.target_triple, &self.machine_key)
+    }
+}
+
+/// Derives the storage partition from an already-probed host context.
+///
+/// `machine_key_override` is the `--machine-key` value, which wins over the
+/// hardware fingerprint; `None` uses the fingerprint.
+pub(crate) fn partition_of(
+    shared: &SharedContext,
+    machine_key_override: Option<&str>,
+) -> Partition {
+    Partition {
+        target_triple: shared.target_triple.clone(),
+        machine_key: MachineKey::from(resolve_machine_key(machine_key_override, &shared.hardware)),
+    }
+}
+
+/// Probes the host and derives the storage partition a run there would write to.
+///
+/// The read-side counterpart of the store path: `backfill` calls this against the
+/// worktree probe before any commit is benchmarked, so the commits it treats as
+/// already recorded are exactly the ones present in the partition it would write.
+pub(crate) async fn probe_partition<P>(
+    probe: &P,
+    env: &dyn Fn(&str) -> Option<String>,
+    machine_key_override: Option<&str>,
+) -> Result<Partition, RunError>
+where
+    P: EnvironmentProbe,
+{
+    let shared = probe_context(probe, env).await?;
+    Ok(partition_of(&shared, machine_key_override))
+}
+
 /// The injected collaborators the store back half operates against, shared by
 /// `collect` and `import`.
 ///
@@ -498,12 +565,12 @@ where
     // uses — an explicit `--machine-key` or the auto-detected fingerprint). It
     // mirrors the query commands' effective-selection summary so the partition a
     // run writes and an `analyze` reads is stated the same way.
-    let effective_machine_key = resolve_machine_key(params.machine_key, &shared.hardware);
+    let partition = partition_of(shared, params.machine_key);
     store.reporter.announce(&partition_selection_summary(
         operation,
         shared.target_triple.as_str(),
         triple_note,
-        &effective_machine_key,
+        partition.machine_key.as_str(),
         params.machine_key.is_some(),
     ));
     // Under --verbose, spell out the individual hardware factors behind the
@@ -529,8 +596,16 @@ where
         })?;
         note_best_of_selections(store.reporter, engine, runs, &combined.selections);
 
-        let summary =
-            store_engine(store, shared, params, engine, combined.results, run_start).await?;
+        let summary = store_engine(
+            store,
+            shared,
+            params,
+            &partition,
+            engine,
+            combined.results,
+            run_start,
+        )
+        .await?;
         if summary.stored {
             stored = stored.saturating_add(1);
         }
@@ -559,7 +634,7 @@ where
 ///
 /// A pure formatter so the wording is unit-tested without a probe; the effective
 /// values are resolved by the caller.
-fn partition_selection_summary(
+pub(crate) fn partition_selection_summary(
     operation: &str,
     target_triple: &str,
     triple_note: &str,
@@ -730,13 +805,15 @@ where
 /// Stores one engine's reduced result set (unless suppressed).
 ///
 /// The back half of collecting an engine: given the records to persist (already
-/// reduced across the `--best-of` runs), it builds the run context and storage
-/// key and writes the object. `run_start` is the first run's start, which stamps
-/// the observation time and any dirty-snapshot second.
+/// reduced across the `--best-of` runs) and the [`Partition`] the run writes to,
+/// it builds the run context and storage key and writes the object. `run_start` is
+/// the first run's start, which stamps the observation time and any dirty-snapshot
+/// second.
 async fn store_engine<S>(
     store: &FinalizeDeps<'_, S>,
     shared: &SharedContext,
     params: &StoreParams<'_>,
+    partition: &Partition,
     engine: Engine,
     records: Vec<BenchmarkResult>,
     run_start: SystemTime,
@@ -799,10 +876,10 @@ where
     let run = Run::new(context, records);
 
     // Every engine partitions its history by a machine key so only equivalent
-    // machines share a series. An explicit `--machine-key` overrides the computed
-    // hardware fingerprint.
-    let machine_key = MachineKey::from(resolve_machine_key(params.machine_key, &shared.hardware));
-    let key = DiscriminantSet::new(engine, target_triple, &machine_key);
+    // machines share a series; the run's partition supplies that key (an explicit
+    // `--machine-key` or the computed hardware fingerprint) for every engine.
+    let machine_key = &partition.machine_key;
+    let key = partition.discriminant_set(engine);
     // History is organized by commit, so the full commit ID names the directory
     // (`analyze` resolves which commits to read from git topology). A clean run is
     // keyed solely by its commit and so is deterministic; a dirty snapshot adds its
@@ -1837,6 +1914,52 @@ mod tests {
             set.context.toolchain.target_triple,
             "x86_64-pc-windows-msvc"
         );
+    }
+
+    #[test]
+    fn probed_partition_is_the_partition_that_is_written_to() {
+        // The backfill pre-check asks `probe_partition` which partition a run here
+        // would occupy and then scans exactly that. If the two ever diverged, a
+        // backfill would scan one partition and write to another, so every commit
+        // would look unrecorded and be benchmarked again. Both the auto-detected
+        // fingerprint and an explicit `--machine-key` must line up.
+        for machine_key in [None, Some("ci-pool-a".to_owned())] {
+            let options = CollectOptions {
+                machine_key: machine_key.clone(),
+                ..CollectOptions::default()
+            };
+            let storage = MemoryStorage::new();
+
+            drive(
+                &options,
+                &FakeRunner::succeeding(),
+                &FakeProbe::new(),
+                &FakeOutput::with_two_callgrind_summaries(),
+                &storage,
+            )
+            .unwrap();
+
+            let env = |_name: &str| None::<String>;
+            let partition = block_on(probe_partition(
+                &FakeProbe::new(),
+                &env,
+                options.machine_key.as_deref(),
+            ))
+            .unwrap();
+            let prefix = partition
+                .discriminant_set(Engine::Callgrind)
+                .partition_prefix("folo");
+
+            let keys = storage.keys();
+            assert!(
+                keys.iter().all(|key| key.starts_with(&prefix)),
+                "machine key {machine_key:?} scanned {prefix} but wrote {keys:?}"
+            );
+            assert!(
+                !keys.is_empty(),
+                "machine key {machine_key:?} stored nothing"
+            );
+        }
     }
 
     #[test]

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -96,12 +96,16 @@
 //! history for a repository that adopted the tool late. Each commit is checked out
 //! in a dedicated git **worktree** (the primary checkout is never touched, so a
 //! dirty working tree is fine) and benched there, taking its timeline position
-//! from where the commit sits in git history. The range `<from> <to>` only needs to form a
-//! first-parent chain; it does not have to lie on the current branch. Commits that
-//! already have a stored result are skipped
-//! (so backfill is resumable and cheap to re-run); `--overwrite` re-benches the
-//! whole range. A commit that fails to build or bench stops the run unless
-//! `--ignore-errors` continues past it.
+//! from where the commit sits in git history. The range `<from> <to>` only needs
+//! to form a first-parent chain; it does not have to lie on the current branch.
+//! The range is processed newest commit first, so a run cut short has filled the
+//! most recent — and most comparison-relevant — gaps. Each commit is built by the
+//! toolchain its own checkout selects, so a `rust-toolchain.toml` in history
+//! governs its own build and a `cargo +nightly run … backfill` does not impose
+//! `nightly` on it. Commits that already have a stored result for this host's
+//! target triple and machine key are skipped (so backfill is resumable and cheap
+//! to re-run); `--overwrite` re-benches the whole range. A commit that fails to
+//! build or bench stops the run unless `--ignore-errors` continues past it.
 //!
 //! ## `analyze`
 //!

--- a/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/backfill.rs
@@ -116,8 +116,9 @@ async fn backfill_spans_a_merge_commit_along_first_parent() {
     }
 }
 
-/// A commit that fails to benchmark stops the backfill by default: earlier commits
-/// are stored, but the loop halts at the failure and reports a non-zero exit.
+/// A commit that fails to benchmark stops the backfill by default: the newer
+/// commits are stored, but the loop halts at the failure and reports a non-zero
+/// exit.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn backfill_stops_on_a_failing_commit_by_default() {
@@ -138,10 +139,11 @@ async fn backfill_stops_on_a_failing_commit_by_default() {
     };
     assert!(message.contains("stopped at"), "{message}");
 
-    // Only the first (healthy) commit was stored before the stop; c3 never ran.
+    // The walk is newest-first, so only c3 (healthy) was stored before the stop at
+    // c2; c1 never ran.
     let objects = workspace.stored_objects();
     assert_eq!(objects.len(), 1, "{objects:?}");
-    assert!(objects[0].0.contains(&c1), "{:?}", objects[0].0);
+    assert!(objects[0].0.contains(&c3), "{:?}", objects[0].0);
 }
 
 /// `backfill --help` is an early exit whose usage text documents the range

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -865,6 +865,9 @@ impl PruneCommand {
 }
 
 /// Replay `collect` across a range of historical commits.
+///
+/// The range is walked newest commit first, so a run that is cut short has filled
+/// the most recent — and most comparison-relevant — gaps.
 #[derive(Args, Debug)]
 struct BackfillCommand {
     /// Oldest commit of the range to backfill, inclusive; a commit ID, tag, or ref such
@@ -922,7 +925,8 @@ struct BackfillCommand {
     #[arg(long, help_heading = HEADING_ENV)]
     overwrite: bool,
 
-    /// Continue past commits whose build or benchmark fails instead of stopping.
+    /// Continue past commits whose build or benchmark fails instead of stopping at
+    /// the newest failing one.
     #[arg(long, help_heading = HEADING_ENV)]
     ignore_errors: bool,
 

--- a/packages/cbh_git/src/lib.rs
+++ b/packages/cbh_git/src/lib.rs
@@ -33,4 +33,6 @@ pub use git::parse_git_info;
 #[cfg_attr(docsrs, doc(cfg(feature = "private-test-util")))]
 pub use git_history::FakeGitHistory;
 pub use git_history::{FirstParentCommit, GitHistory, SystemGitHistory};
-pub use process::{BenchRunner, CommandOutput, EngineStatus, TokioBenchRunner, capture};
+pub use process::{
+    BenchRunner, CommandOutput, EngineStatus, TokioBenchRunner, capture, capture_in_worktree,
+};

--- a/packages/cbh_git/src/process.rs
+++ b/packages/cbh_git/src/process.rs
@@ -6,7 +6,7 @@
 
 use std::future::Future;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 
 /// Launches the benchmark command (`cargo bench`) with injected environment
@@ -57,21 +57,71 @@ pub struct CommandOutput {
 /// The real [`BenchRunner`], backed by `tokio::process`.
 ///
 /// By default the engine command runs in the process working directory.
-/// `in_dir` runs it in a specific directory (a checked-out worktree) without
-/// mutating the process current directory.
+/// [`in_dir`](Self::in_dir) runs it in a specific directory that is still this
+/// tool's own workspace; [`in_worktree`](Self::in_worktree) runs it in a
+/// historical checkout, which additionally governs its own toolchain.
 #[derive(Clone, Debug, Default)]
 pub struct TokioBenchRunner {
     /// Working directory for the engine command; the process CWD when absent.
     dir: Option<PathBuf>,
+    /// Whether the launcher's toolchain selection is removed from the child
+    /// environment. It is kept for the tool's own workspace, where the caller
+    /// picked that toolchain deliberately (`cargo +nightly run`), and removed for
+    /// a historical checkout, which must be built by the toolchain it pins itself.
+    detach_from_launcher_toolchain: bool,
 }
 
 impl TokioBenchRunner {
     /// Runs the engine command in `dir` instead of the process CWD.
+    ///
+    /// `dir` is treated as this tool's own workspace, so the toolchain the tool
+    /// was launched with also builds the benchmarks.
     #[must_use]
     pub fn in_dir(dir: impl Into<PathBuf>) -> Self {
         Self {
             dir: Some(dir.into()),
+            detach_from_launcher_toolchain: false,
         }
+    }
+
+    /// Runs the engine command in `dir`, a **historical checkout** rather than
+    /// this tool's own workspace.
+    ///
+    /// Behaves like [`in_dir`](Self::in_dir) but additionally detaches the child
+    /// from the launcher's toolchain selection (see
+    /// [`detach_from_launcher_toolchain`]), so the benchmarks of a past commit are
+    /// built by the toolchain that commit pins rather than by whichever toolchain
+    /// happened to build this tool.
+    #[must_use]
+    pub fn in_worktree(dir: impl Into<PathBuf>) -> Self {
+        Self {
+            dir: Some(dir.into()),
+            detach_from_launcher_toolchain: true,
+        }
+    }
+
+    /// Builds the configured engine command without launching it.
+    ///
+    /// Split from [`run_benches`](BenchRunner::run_benches) so the working
+    /// directory and environment this runner imposes are asserted without spawning
+    /// a process.
+    fn command(&self, argv: &[String], env: &[(String, String)]) -> tokio::process::Command {
+        let mut command = engine_command(argv);
+
+        if let Some(dir) = self.dir.as_deref() {
+            command.current_dir(dir);
+        }
+        if self.detach_from_launcher_toolchain {
+            detach_from_launcher_toolchain(&mut command);
+        }
+
+        // Applied last so an explicitly injected value always wins over the
+        // detachment above.
+        for (name, value) in env {
+            command.env(name, value);
+        }
+
+        command
     }
 }
 
@@ -81,17 +131,30 @@ impl BenchRunner for TokioBenchRunner {
         argv: &[String],
         env: &[(String, String)],
     ) -> io::Result<EngineStatus> {
-        let mut command = engine_command(argv);
+        Ok(EngineStatus::from_exit(
+            self.command(argv, env).status().await?,
+        ))
+    }
+}
 
-        if let Some(dir) = self.dir.as_deref() {
-            command.current_dir(dir);
-        }
+/// The environment variables through which a rustup-proxied launcher imposes its
+/// own toolchain on everything it spawns.
+///
+/// `cargo run` exports both: `RUSTUP_TOOLCHAIN` names the toolchain that built
+/// this tool and **overrides** any `rust-toolchain.toml` in the directory a child
+/// `cargo`/`rustc` runs in, and `CARGO` is the absolute path to that toolchain's
+/// `cargo` binary.
+const LAUNCHER_TOOLCHAIN_VARS: [&str; 2] = ["RUSTUP_TOOLCHAIN", "CARGO"];
 
-        for (name, value) in env {
-            command.env(name, value);
-        }
-
-        Ok(EngineStatus::from_exit(command.status().await?))
+/// Removes the launcher's toolchain selection from `command`'s environment, so the
+/// rustup proxy resolves the toolchain from the directory the command runs in.
+///
+/// Nothing else is stripped: `CARGO_HOME`/`RUSTUP_HOME` still locate the rustup
+/// installation (which auto-installs a pinned toolchain it does not have yet), and
+/// `RUSTFLAGS` is caller intent that the tool passes through by contract.
+fn detach_from_launcher_toolchain(command: &mut tokio::process::Command) {
+    for name in LAUNCHER_TOOLCHAIN_VARS {
+        command.env_remove(name);
     }
 }
 
@@ -101,11 +164,36 @@ impl BenchRunner for TokioBenchRunner {
 ///
 /// Returns an error if the process cannot be spawned or awaited.
 pub async fn capture(program: &str, args: &[&str]) -> io::Result<CommandOutput> {
-    let output = tokio::process::Command::new(program)
-        .args(args)
-        .stdin(Stdio::null())
-        .output()
-        .await?;
+    let mut command = tokio::process::Command::new(program);
+    command.args(args);
+    capture_output(command).await
+}
+
+/// Runs `program` with `args` **inside a historical checkout** at `dir`,
+/// capturing its standard output.
+///
+/// Mirrors [`TokioBenchRunner::in_worktree`] for helper commands: the command runs
+/// in `dir` and is detached from the launcher's toolchain selection (see
+/// [`detach_from_launcher_toolchain`]), so a `rustc` queried this way describes the
+/// same compiler that builds that checkout's benchmarks.
+///
+/// # Errors
+///
+/// Returns an error if the process cannot be spawned or awaited.
+pub async fn capture_in_worktree(
+    program: &str,
+    args: &[&str],
+    dir: &Path,
+) -> io::Result<CommandOutput> {
+    let mut command = tokio::process::Command::new(program);
+    command.args(args).current_dir(dir);
+    detach_from_launcher_toolchain(&mut command);
+    capture_output(command).await
+}
+
+/// Awaits `command` to completion, capturing its standard output.
+async fn capture_output(mut command: tokio::process::Command) -> io::Result<CommandOutput> {
+    let output = command.stdin(Stdio::null()).output().await?;
 
     Ok(CommandOutput {
         status: output.status,
@@ -130,9 +218,24 @@ fn engine_command(argv: &[String]) -> tokio::process::Command {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::collections::HashMap;
+    use std::ffi::OsString;
     use std::path::PathBuf;
 
-    use super::{TokioBenchRunner, engine_command};
+    use super::{LAUNCHER_TOOLCHAIN_VARS, TokioBenchRunner, engine_command};
+
+    /// The environment overrides a runner applies to its child, keyed by variable
+    /// name. A `None` value is a removal, which is how the launcher's toolchain
+    /// selection is kept out of a historical checkout's build.
+    fn env_overrides(runner: &TokioBenchRunner) -> HashMap<OsString, Option<OsString>> {
+        let argv = vec!["cargo".to_owned(), "bench".to_owned()];
+        runner
+            .command(&argv, &[])
+            .as_std()
+            .get_envs()
+            .map(|(name, value)| (name.to_owned(), value.map(ToOwned::to_owned)))
+            .collect()
+    }
 
     #[test]
     fn in_dir_sets_the_working_directory() {
@@ -141,6 +244,66 @@ mod tests {
         let runner = TokioBenchRunner::in_dir("some/worktree");
         assert_eq!(runner.dir, Some(PathBuf::from("some/worktree")));
         assert_eq!(TokioBenchRunner::default().dir, None);
+    }
+
+    #[test]
+    fn in_worktree_runs_in_the_directory_like_in_dir() {
+        let runner = TokioBenchRunner::in_worktree("some/worktree");
+        assert_eq!(runner.dir, Some(PathBuf::from("some/worktree")));
+    }
+
+    #[test]
+    // The Windows environment map compares keys with `CompareStringOrdinal`, a
+    // foreign function Miri cannot call; the same assertion runs under Linux Miri.
+    #[cfg_attr(all(miri, windows), ignore)]
+    fn in_worktree_detaches_the_child_from_the_launcher_toolchain() {
+        // A historical checkout must be built by the toolchain it pins, so the
+        // selection `cargo run` exported into this process is removed from the
+        // child (a removal surfaces as a `None` value).
+        let overrides = env_overrides(&TokioBenchRunner::in_worktree("some/worktree"));
+
+        for name in LAUNCHER_TOOLCHAIN_VARS {
+            assert_eq!(
+                overrides.get(&OsString::from(name)),
+                Some(&None),
+                "{name} must be removed for a historical checkout: {overrides:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn in_dir_keeps_the_launcher_toolchain() {
+        // The tool's own workspace builds with the toolchain the caller selected
+        // (for example via `cargo +nightly run`), so nothing is removed.
+        let overrides = env_overrides(&TokioBenchRunner::in_dir("some/workspace"));
+        assert!(overrides.is_empty(), "{overrides:?}");
+
+        let overrides = env_overrides(&TokioBenchRunner::default());
+        assert!(overrides.is_empty(), "{overrides:?}");
+    }
+
+    #[test]
+    // The Windows environment map compares keys with `CompareStringOrdinal`, a
+    // foreign function Miri cannot call; the same assertion runs under Linux Miri.
+    #[cfg_attr(all(miri, windows), ignore)]
+    fn injected_environment_wins_over_the_detachment() {
+        // The injected engine environment is applied last, so a caller that sets
+        // one of these variables explicitly still gets its value through.
+        let runner = TokioBenchRunner::in_worktree("some/worktree");
+        let argv = vec!["cargo".to_owned(), "bench".to_owned()];
+        let env = vec![("CARGO".to_owned(), "/custom/cargo".to_owned())];
+        let command = runner.command(&argv, &env);
+        let overrides: HashMap<OsString, Option<OsString>> = command
+            .as_std()
+            .get_envs()
+            .map(|(name, value)| (name.to_owned(), value.map(ToOwned::to_owned)))
+            .collect();
+
+        assert_eq!(
+            overrides.get(&OsString::from("CARGO")),
+            Some(&Some(OsString::from("/custom/cargo"))),
+            "{overrides:?}"
+        );
     }
 
     #[test]

--- a/packages/cbh_model/src/comparability.rs
+++ b/packages/cbh_model/src/comparability.rs
@@ -132,11 +132,16 @@ impl DiscriminantSet {
     /// The storage prefix that all runs in this series share, within `project`.
     ///
     /// Layout:
-    /// `{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{target_triple}/{machine}`.
+    /// `{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{target_triple}/{machine}/`.
     /// The fixed `objects` segment separates the data subtree from a project's
     /// metadata siblings (e.g. the cache-invalidation marker); below this prefix the
     /// history is organized by commit (see [`clean_key`] and [`dirty_key`]) so
     /// `analyze` can resolve a series from git topology.
+    ///
+    /// The trailing separator is part of the contract: storage listings match on a
+    /// plain string prefix, so without it a listing of this partition would also
+    /// return a sibling partition whose machine key merely *starts with* this one
+    /// (`ci` picking up `ci-pool`), silently mixing two independent data sets.
     ///
     /// [`clean_key`]: Self::clean_key
     /// [`dirty_key`]: Self::dirty_key
@@ -146,62 +151,75 @@ impl DiscriminantSet {
         let engine = self.engine.as_str();
         let triple = &self.target_triple;
         let machine_key = &self.machine_key;
-        format!("{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{triple}/{machine_key}")
+        format!("{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{triple}/{machine_key}/")
     }
 
     /// The object key for the canonical (clean working tree) result at `commit`.
     ///
-    /// Layout: `{prefix}/{commit}/clean.json`. A clean run is keyed solely by its
-    /// commit, so it is deterministic: a second clean run of the same commit maps
-    /// to the same key and collides, which the write-once storage detects so `run`
-    /// can refuse the duplicate unless an overwrite is explicitly requested.
+    /// Layout: `{prefix}{commit}/clean.json`, where `{prefix}` is
+    /// [`partition_prefix`] and already ends in a separator. A clean run is keyed
+    /// solely by its commit, so it is deterministic: a second clean run of the same
+    /// commit maps to the same key and collides, which the write-once storage
+    /// detects so `run` can refuse the duplicate unless an overwrite is explicitly
+    /// requested.
     ///
     /// `commit` is sanitized so the directory name always forms a single segment.
+    ///
+    /// [`partition_prefix`]: Self::partition_prefix
     #[must_use]
     pub fn clean_key(&self, project: &str, commit: &str) -> String {
         let prefix = self.partition_prefix(project);
         let commit = sanitize_segment(commit);
-        format!("{prefix}/{commit}/clean.json")
+        format!("{prefix}{commit}/clean.json")
     }
 
     /// The object key for a dirty (uncommitted-changes) snapshot at `commit`,
     /// observed at `observation_unix`.
     ///
-    /// Layout: `{prefix}/{commit}/dirty-{observation_unix}.json`. Because a dirty
+    /// Layout: `{prefix}{commit}/dirty-{observation_unix}.json`, where `{prefix}`
+    /// is [`partition_prefix`] and already ends in a separator. Because a dirty
     /// snapshot does not correspond to committed code, it is distinguished by its
     /// observation time rather than by the commit alone, so multiple dirty
     /// snapshots on the same base commit coexist; only two snapshots sharing an
     /// observation second collide.
     ///
     /// `commit` is sanitized so the directory name always forms a single segment.
+    ///
+    /// [`partition_prefix`]: Self::partition_prefix
     #[must_use]
     pub fn dirty_key(&self, project: &str, commit: &str, observation_unix: i64) -> String {
         let prefix = self.partition_prefix(project);
         let commit = sanitize_segment(commit);
-        format!("{prefix}/{commit}/dirty-{observation_unix}.json")
+        format!("{prefix}{commit}/dirty-{observation_unix}.json")
     }
 
     /// The blessing sidecar key for this set's commit directory, issued at
     /// `issued_unix`.
     ///
-    /// Layout: `{prefix}/{commit}/bless-{issued_unix}.json`. `commit` is sanitized
+    /// Layout: `{prefix}{commit}/bless-{issued_unix}.json`, where `{prefix}` is
+    /// [`partition_prefix`] and already ends in a separator. `commit` is sanitized
     /// so the directory name always forms a single segment.
+    ///
+    /// [`partition_prefix`]: Self::partition_prefix
     #[must_use]
     pub fn bless_key(&self, project: &str, commit: &str, issued_unix: i64) -> String {
         let prefix = self.partition_prefix(project);
         let commit = sanitize_segment(commit);
-        format!("{prefix}/{commit}/bless-{issued_unix}.json")
+        format!("{prefix}{commit}/bless-{issued_unix}.json")
     }
 
     /// The storage prefix shared by every object recorded at `commit` in this
-    /// partition (`{prefix}/{commit}/`), used to enumerate a commit directory.
+    /// partition (`{prefix}{commit}/`, where `{prefix}` is [`partition_prefix`] and
+    /// already ends in a separator), used to enumerate a commit directory.
     ///
     /// `commit` is sanitized so the directory name always forms a single segment.
+    ///
+    /// [`partition_prefix`]: Self::partition_prefix
     #[must_use]
     pub fn commit_prefix(&self, project: &str, commit: &str) -> String {
         let prefix = self.partition_prefix(project);
         let commit = sanitize_segment(commit);
-        format!("{prefix}/{commit}/")
+        format!("{prefix}{commit}/")
     }
 }
 
@@ -416,7 +434,7 @@ mod tests {
         );
         assert_eq!(
             set.partition_prefix("folo"),
-            "v1/folo/objects/alloc_tracker/x86_64-pc-windows-msvc/abc123"
+            "v1/folo/objects/alloc_tracker/x86_64-pc-windows-msvc/abc123/"
         );
     }
 
@@ -431,7 +449,7 @@ mod tests {
         );
         assert_eq!(
             set.partition_prefix("folo"),
-            "v1/folo/objects/all_the_time/x86_64-pc-windows-msvc/abc123"
+            "v1/folo/objects/all_the_time/x86_64-pc-windows-msvc/abc123/"
         );
     }
 
@@ -444,7 +462,31 @@ mod tests {
         );
         assert_eq!(
             set.partition_prefix("folo"),
-            "v1/folo/objects/criterion/x86_64-pc-windows-msvc/abc123"
+            "v1/folo/objects/criterion/x86_64-pc-windows-msvc/abc123/"
+        );
+    }
+
+    #[test]
+    fn partition_prefix_does_not_match_a_sibling_machine_key() {
+        // Storage listings match on a plain string prefix, so a partition prefix
+        // that stopped at the machine key would also return every sibling key that
+        // merely starts with it. The trailing separator keeps the two independent
+        // data sets apart.
+        let triple = TargetTriple::from("x86_64-pc-windows-msvc");
+        let ci = DiscriminantSet::new(Engine::Criterion, &triple, &MachineKey::from("ci"));
+        let pool = DiscriminantSet::new(Engine::Criterion, &triple, &MachineKey::from("ci-pool"));
+
+        assert!(
+            !pool
+                .clean_key("folo", "abc123")
+                .starts_with(&ci.partition_prefix("folo")),
+            "{} must not fall under {}",
+            pool.clean_key("folo", "abc123"),
+            ci.partition_prefix("folo")
+        );
+        assert!(
+            ci.clean_key("folo", "abc123")
+                .starts_with(&ci.partition_prefix("folo"))
         );
     }
 
@@ -581,10 +623,13 @@ mod tests {
         );
         assert_eq!(
             set.partition_prefix("team/app"),
-            "v1/team_app/objects/criterion/weird_triple/machine_one"
+            "v1/team_app/objects/criterion/weird_triple/machine_one/"
         );
-        // The partition prefix has exactly the six canonical segments.
-        assert_eq!(set.partition_prefix("team/app").split('/').count(), 6);
+        // The partition prefix has exactly the six canonical segments and ends in
+        // the separator that keeps a listing inside this partition.
+        let prefix = set.partition_prefix("team/app");
+        assert!(prefix.ends_with('/'), "{prefix}");
+        assert_eq!(prefix.trim_end_matches('/').split('/').count(), 6);
     }
 
     #[test]

--- a/packages/cbh_model/src/constants.rs
+++ b/packages/cbh_model/src/constants.rs
@@ -4,7 +4,7 @@
 /// Version segment that prefixes every storage object key.
 ///
 /// It is the first segment of a partition prefix
-/// (`{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{triple}/{machine}`)
+/// (`{STORAGE_VERSION}/{project}/{OBJECTS_SEGMENT}/{engine}/{triple}/{machine}/`)
 /// and the value that `parse_key` requires before it
 /// accepts a key, so the writer and reader share a single source of truth for the
 /// layout version.

--- a/packages/cbh_probe/src/probe.rs
+++ b/packages/cbh_probe/src/probe.rs
@@ -2,12 +2,17 @@
 //!
 //! The real adapter shells out to `git` and `rustc`; an in-memory fake (in
 //! `#[cfg(test)]`) returns canned facts so orchestration is testable.
+//!
+//! A probe is bound to a directory and to how much of that directory it adopts:
+//! the tool's own workspace keeps the launching toolchain, while a historical
+//! checkout is described by the toolchain it pins itself, so the recorded
+//! provenance names the compiler that actually built the measured benchmarks.
 
 use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use cbh_git::{capture, parse_git_info};
+use cbh_git::{capture, capture_in_worktree, parse_git_info};
 use cbh_model::GitInfo;
 
 use crate::host::{RustcInfo, parse_rustc_verbose};
@@ -38,21 +43,75 @@ pub trait EnvironmentProbe {
 
 /// The real [`EnvironmentProbe`], backed by `git` and `rustc`.
 ///
-/// By default `git` is queried in the process working directory. `in_dir`
-/// targets a specific repository directory (via `git -C <dir>`) so a run can
-/// probe a checked-out worktree without mutating the process current directory.
+/// By default both are queried in the process working directory.
+/// [`in_dir`](Self::in_dir) redirects `git` to a specific repository directory
+/// (via `git -C <dir>`) without mutating the process current directory;
+/// [`in_worktree`](Self::in_worktree) additionally describes the toolchain of that
+/// directory rather than of this tool.
 #[derive(Clone, Debug, Default)]
 pub struct SystemProbe {
-    /// Repository directory passed to `git -C`; the process CWD when absent.
-    repo: Option<PathBuf>,
+    /// Which directory the probe describes, and how far that redirection reaches.
+    scope: ProbeScope,
+}
+
+/// Which directory a [`SystemProbe`] describes, and how far the redirection
+/// reaches into the toolchain query.
+///
+/// `git` always follows the directory, while `rustc` follows it only for a
+/// historical checkout: the toolchain recorded on a run must be the one that
+/// actually compiled its benchmarks, and only a historical checkout builds with a
+/// toolchain other than the launcher's.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+enum ProbeScope {
+    /// The process working directory.
+    #[default]
+    Process,
+    /// A repository directory that is this tool's own workspace: `git` is
+    /// redirected there while `rustc` still describes the toolchain this tool was
+    /// launched with, which is also the one that builds the benchmarks there.
+    Repo(PathBuf),
+    /// A historical checkout: `git` is redirected there and `rustc` runs there
+    /// detached from the launcher's toolchain selection, so the recorded toolchain
+    /// is the one that checkout's own `rust-toolchain.toml` pins — the same one
+    /// that builds its benchmarks.
+    Worktree(PathBuf),
+}
+
+impl ProbeScope {
+    /// The repository directory `git` is redirected to; `None` for the process CWD.
+    fn repo(&self) -> Option<&Path> {
+        match self {
+            Self::Process => None,
+            Self::Repo(dir) | Self::Worktree(dir) => Some(dir),
+        }
+    }
 }
 
 impl SystemProbe {
     /// Probes `git` in `repo` (via `git -C <repo>`) instead of the process CWD.
+    ///
+    /// `repo` is treated as this tool's own workspace, so the toolchain facts stay
+    /// those of the launching toolchain — the one that builds benchmarks there.
     #[must_use]
     pub fn in_dir(repo: impl Into<PathBuf>) -> Self {
         Self {
-            repo: Some(repo.into()),
+            scope: ProbeScope::Repo(repo.into()),
+        }
+    }
+
+    /// Probes `repo` as a **historical checkout** rather than this tool's own
+    /// workspace.
+    ///
+    /// Behaves like [`in_dir`](Self::in_dir) for `git`, and additionally runs
+    /// `rustc` there detached from the launcher's toolchain selection, so the
+    /// reported toolchain is the one that checkout pins and therefore the one that
+    /// compiles its benchmarks. Recording the launcher's toolchain instead would
+    /// make the stored provenance disagree with the compiler that produced the
+    /// numbers.
+    #[must_use]
+    pub fn in_worktree(repo: impl Into<PathBuf>) -> Self {
+        Self {
+            scope: ProbeScope::Worktree(repo.into()),
         }
     }
 
@@ -60,8 +119,8 @@ impl SystemProbe {
     #[cfg_attr(test, mutants::skip)] // Shells out to `git`; environment IO with no pure logic to assert.
     async fn git_field(&self, args: &[&str]) -> String {
         let repo = self
-            .repo
-            .as_deref()
+            .scope
+            .repo()
             .map(Path::to_string_lossy)
             .map(std::borrow::Cow::into_owned);
         let mut full: Vec<&str> = Vec::new();
@@ -89,7 +148,10 @@ impl EnvironmentProbe for SystemProbe {
 
     #[cfg_attr(test, mutants::skip)] // Shells out to `rustc`; the parsing it delegates to is tested.
     async fn toolchain(&self) -> io::Result<RustcInfo> {
-        let output = capture("rustc", &["-vV"]).await.ok();
+        let output = match &self.scope {
+            ProbeScope::Worktree(dir) => capture_in_worktree("rustc", &["-vV"], dir).await.ok(),
+            ProbeScope::Process | ProbeScope::Repo(_) => capture("rustc", &["-vV"]).await.ok(),
+        };
         let rustc_output = output
             .as_ref()
             .filter(|output| output.status.success())
@@ -135,9 +197,11 @@ fn host_triple_for(arch: &str, os: &str) -> String {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::env::consts;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
-    use super::{SystemProbe, fallback_host_triple, host_triple_for, resolve_toolchain};
+    use super::{
+        ProbeScope, SystemProbe, fallback_host_triple, host_triple_for, resolve_toolchain,
+    };
 
     #[test]
     fn in_dir_targets_the_repository_directory() {
@@ -145,8 +209,34 @@ mod tests {
         // `-C <repo>`; the default probe leaves it absent (git runs in the
         // process CWD), so the two must differ.
         let probe = SystemProbe::in_dir("some/repo");
-        assert_eq!(probe.repo, Some(PathBuf::from("some/repo")));
-        assert_eq!(SystemProbe::default().repo, None);
+        assert_eq!(probe.scope, ProbeScope::Repo(PathBuf::from("some/repo")));
+        assert_eq!(SystemProbe::default().scope, ProbeScope::Process);
+    }
+
+    #[test]
+    fn in_worktree_targets_the_checkout_as_a_historical_one() {
+        // A historical checkout redirects git exactly like `in_dir`, but is a
+        // distinct scope so the toolchain query follows it too.
+        let probe = SystemProbe::in_worktree("some/worktree");
+        assert_eq!(
+            probe.scope,
+            ProbeScope::Worktree(PathBuf::from("some/worktree"))
+        );
+        assert_eq!(probe.scope.repo(), Some(Path::new("some/worktree")));
+        assert_ne!(probe.scope, SystemProbe::in_dir("some/worktree").scope);
+    }
+
+    #[test]
+    fn only_the_process_scope_leaves_git_in_the_process_directory() {
+        assert_eq!(ProbeScope::Process.repo(), None);
+        assert_eq!(
+            ProbeScope::Repo(PathBuf::from("a")).repo(),
+            Some(Path::new("a"))
+        );
+        assert_eq!(
+            ProbeScope::Worktree(PathBuf::from("b")).repo(),
+            Some(Path::new("b"))
+        );
     }
 
     #[test]

--- a/packages/cbh_storage/src/keys.rs
+++ b/packages/cbh_storage/src/keys.rs
@@ -63,10 +63,10 @@ pub(crate) fn cache_epoch_key(project: &str) -> String {
 /// The listing prefix that covers every **data** object of `project`:
 /// `{STORAGE_VERSION}/<project>/{OBJECTS_SEGMENT}/`.
 ///
-/// Data loaders (`analyze`/`list`/`prune`, `backfill`'s recorded-commit scan) list
-/// under this prefix so they enumerate only benchmark objects, never a per-project
-/// metadata sibling such as the [`cache_epoch_key`] marker. The read-through cache
-/// also wipes exactly this subtree when invalidating one project's mirror.
+/// Data loaders (`analyze`/`list`/`prune`) list under this prefix so they
+/// enumerate only benchmark objects, never a per-project metadata sibling such as
+/// the [`cache_epoch_key`] marker. The read-through cache also wipes exactly this
+/// subtree when invalidating one project's mirror.
 #[must_use]
 pub fn project_objects_prefix(project: &str) -> String {
     format!(

--- a/scripts/bench-history/BenchHistoryCollect.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryCollect.Tests.ps1
@@ -3,6 +3,13 @@
 # Pester suite for BenchHistoryCollect.psm1. Proves the mode selection the bench-history `collect`
 # step depends on - append vs. overwrite, and the untrusted-input validation - without a workflow
 # run: each case asserts the exact argument vector the step would hand the tool.
+#
+# The nightly backfill's rolling date window is proven the same way: `git` is isolated behind the
+# module's Invoke-GitCapture seam and mocked here in the module's scope, so the window resolution
+# (including the quiet-fortnight fallback and the nothing-eligible exit) is exercised against
+# canned `rev-list` output rather than a real repository, whose history would change under the
+# suite. The scope-identity case is what keeps a backfilled point measured exactly like a pushed
+# one.
 
 BeforeAll {
     Import-Module (Join-Path $PSScriptRoot 'BenchHistoryCollect.psm1') -Force
@@ -15,6 +22,13 @@ BeforeAll {
         '--best-of', '3',
         '--verbose'
     )
+
+    # The canned `git rev-list` output the mocked window queries return: the range end is the newest
+    # first-parent commit outside the quarantine and the range start the oldest one inside the
+    # 14-day horizon, with one more commit between them. Full 40-character object ids, as git prints
+    # them.
+    $script:WindowEnd = 'a' * 40
+    $script:WindowStart = 'c' * 40
 }
 
 Describe 'Get-BenchHistoryCollectCommand' {
@@ -121,6 +135,172 @@ Describe 'Get-BenchHistoryCollectCommand' {
         It 'treats an all-blank package list as no scope (whole workspace)' {
             $result = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package @('', '  ')
             $result | Should -Be (@('collect') + $script:Scope + @('--skip-existing'))
+        }
+    }
+}
+
+Describe 'Get-BenchHistoryBackfillCommand' {
+    Context 'the rolling date window (mocked git rev-list)' {
+        BeforeEach {
+            # The `-1` query resolves the range end (the newest first-parent commit outside the
+            # quarantine); the other query lists the first-parent commits within the horizon of it,
+            # newest first, so its LAST line is the range start.
+            Mock git -ModuleName BenchHistoryCollect {
+                $global:LASTEXITCODE = 0
+                if ($args -contains '-1') {
+                    'a' * 40
+                } else {
+                    @(('a' * 40), ('b' * 40), ('c' * 40))
+                }
+            }
+        }
+
+        It 'backfills the whole window with skip-existing and walks past failing commits' {
+            $result = Get-BenchHistoryBackfillCommand
+            $result | Should -Be (@('backfill', $script:WindowStart, $script:WindowEnd) +
+                $script:Scope + @('--ignore-errors'))
+        }
+
+        It 'never overwrites an already-stored point' {
+            $result = Get-BenchHistoryBackfillCommand
+            $result | Should -Not -Contain '--overwrite'
+        }
+
+        It 'never pins a machine key, so each runner fills its own partition' {
+            $result = Get-BenchHistoryBackfillCommand
+            $result | Should -Not -Contain '--machine-key'
+        }
+
+        It 'measures with exactly the scope the push-to-main collect uses' {
+            # A partially-scoped or lower-best-of commit would still count as recorded and never be
+            # revisited, so the two builders must emit an identical scope slice. Both are compared
+            # between their leading positionals and their distinct trailing flag.
+            $collect = Get-BenchHistoryCollectCommand -RecollectCommitId ''
+            $backfill = Get-BenchHistoryBackfillCommand
+            $collectScope = $collect[1..($collect.Count - 2)]
+            $backfillScope = $backfill[3..($backfill.Count - 2)]
+            $backfillScope | Should -Be $collectScope
+        }
+
+        It 'quarantines the range end from the push-triggered collection' {
+            Get-BenchHistoryBackfillCommand | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 1 -Exactly -ParameterFilter {
+                ($args -contains '-1') -and ($args -contains '--before=24 hours ago') -and
+                ($args -contains 'HEAD')
+            }
+        }
+
+        It 'resolves the range start from the range end rather than from HEAD' {
+            # `backfill` hard-errors unless the range start is a first-parent ancestor of the range
+            # end, which resolving from the end is what guarantees.
+            Get-BenchHistoryBackfillCommand | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 1 -Exactly -ParameterFilter {
+                ($args -contains '--since=14 days ago') -and ($args -contains ('a' * 40)) -and
+                ($args -notcontains 'HEAD')
+            }
+        }
+
+        It 'restricts every history query to the first-parent line' {
+            Get-BenchHistoryBackfillCommand | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 2 -Exactly -ParameterFilter {
+                $args -contains '--first-parent'
+            }
+        }
+    }
+
+    Context 'a quiet fortnight (the range end predates the horizon)' {
+        BeforeEach {
+            Mock git -ModuleName BenchHistoryCollect {
+                $global:LASTEXITCODE = 0
+                if ($args -contains '-1') { 'a' * 40 } else { @() }
+            }
+        }
+
+        It 'collapses the window onto the single eligible commit' {
+            $result = Get-BenchHistoryBackfillCommand
+            $result | Should -Be (@('backfill', $script:WindowEnd, $script:WindowEnd) +
+                $script:Scope + @('--ignore-errors'))
+        }
+    }
+
+    Context 'nothing eligible yet (every commit is inside the quarantine)' {
+        BeforeEach {
+            Mock git -ModuleName BenchHistoryCollect {
+                $global:LASTEXITCODE = 0
+                @()
+            }
+        }
+
+        It 'emits no command at all' {
+            @(Get-BenchHistoryBackfillCommand).Count | Should -Be 0
+        }
+
+        It 'does not query the window once the range end came back empty' {
+            Get-BenchHistoryBackfillCommand | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 1 -Exactly
+        }
+    }
+
+    Context 'an operator-supplied range end' {
+        BeforeEach {
+            Mock git -ModuleName BenchHistoryCollect {
+                $global:LASTEXITCODE = 0
+                @(('d' * 40), ('e' * 40))
+            }
+        }
+
+        It 'uses the given commit as the range end' {
+            $result = Get-BenchHistoryBackfillCommand -ToCommitId 'abc1234'
+            $result | Should -Be (@('backfill', ('e' * 40), 'abc1234') + $script:Scope +
+                @('--ignore-errors'))
+        }
+
+        It 'bypasses the quarantine computation' {
+            Get-BenchHistoryBackfillCommand -ToCommitId 'abc1234' | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 0 -Exactly -ParameterFilter {
+                $args -contains '-1'
+            }
+        }
+
+        It 'still bounds the range start by the horizon' {
+            Get-BenchHistoryBackfillCommand -ToCommitId 'abc1234' | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 1 -Exactly -ParameterFilter {
+                ($args -contains '--since=14 days ago') -and ($args -contains 'abc1234')
+            }
+        }
+
+        It 'trims surrounding whitespace before use' {
+            $result = Get-BenchHistoryBackfillCommand -ToCommitId '  abc1234  '
+            $result[2] | Should -Be 'abc1234'
+        }
+
+        It 'treats an empty id as no override' {
+            Get-BenchHistoryBackfillCommand -ToCommitId '' | Out-Null
+            Should -Invoke git -ModuleName BenchHistoryCollect -Times 1 -Exactly -ParameterFilter {
+                $args -contains '-1'
+            }
+        }
+
+        It 'rejects a ref expression such as HEAD~1' {
+            { Get-BenchHistoryBackfillCommand -ToCommitId 'HEAD~1' } | Should -Throw '*hex commit SHA*'
+        }
+
+        It 'rejects an id carrying shell metacharacters' {
+            { Get-BenchHistoryBackfillCommand -ToCommitId 'abc1234; rm -rf /' } |
+                Should -Throw '*hex commit SHA*'
+        }
+    }
+
+    Context 'a failing git query' {
+        BeforeEach {
+            Mock git -ModuleName BenchHistoryCollect {
+                $global:LASTEXITCODE = 1
+                'fatal: bad revision'
+            }
+        }
+
+        It 'fails loudly instead of backfilling an unresolved range' {
+            { Get-BenchHistoryBackfillCommand } | Should -Throw '*failed (exit 1)*'
         }
     }
 }

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -1,8 +1,10 @@
 #requires -Version 7
 
-# Argument selection for the benchmark-history `collect` step, shared by the push-to-main workflow
-# (.github/workflows/bench-history.yml, via the gh-collect-bench-history recipe) and the per-PR
-# workflow (.github/workflows/pr-bench-history.yml, via gh-collect-pr-bench-history).
+# Argument selection for the benchmark-history collection steps: the push-to-main workflow
+# (.github/workflows/bench-history.yml, via the gh-collect-bench-history recipe), the per-PR
+# workflow (.github/workflows/pr-bench-history.yml, via gh-collect-pr-bench-history) and the nightly
+# gap-filling workflow (.github/workflows/bench-history-backfill.yml, via
+# gh-backfill-bench-history).
 #
 # The step has two modes and the choice between them is real logic - a branch, input validation and
 # error handling - so it lives here behind a seam the Pester suite (BenchHistoryCollect.Tests.ps1)
@@ -13,15 +15,25 @@
 # Normal mode (no recollect id): append the pushed commit with `collect --skip-existing`, so a
 # re-triggered run of an already-collected commit is a no-op rather than a rewrite. Recollect mode
 # (a commit id set): re-measure just that one historical commit and OVERWRITE its stored point with
-# `backfill <id> <id> --overwrite`, which benchmarks the code AT that commit in a throwaway worktree
-# while running THIS (HEAD) build of the tool - repairing a point corrupted by a bad benchmark day
-# without adopting the tool version that shipped at that commit.
+# `backfill <id> <id> --overwrite`, which benchmarks the code AT that commit in a throwaway worktree,
+# built with the toolchain that commit pins, while running THIS (HEAD) build of the tool - repairing
+# a point corrupted by a bad benchmark day without adopting the tool version that shipped at that
+# commit.
 #
 # Collection scope is orthogonal to the mode: with no explicit package list the whole workspace is
 # benched except the special-purpose `benchmarks` crate (the push-to-main default); the PR workflow
 # instead passes the delta-affected packages so it benches only what the PR impacts.
 # Select-BenchmarkablePackage is the shared helper that drops `benchmarks` from a delta-affected set
 # before both the scope decision and the "is there anything to bench at all" gate.
+#
+# The nightly backfill (Get-BenchHistoryBackfillCommand) fills gaps in the series belonging to
+# whichever machine key the nightly runner draws: the GitHub-hosted runner pool is heterogeneous, so
+# consecutive pushed commits land on different hardware and every per-key series is sparse. It walks
+# a rolling date window - from the newest first-parent commit at least 24 hours old back to the
+# oldest first-parent commit newer than 14 days - and relies on the tool's default skip-existing
+# behaviour to measure only the commits this runner's partition is missing. Its scope flags come
+# from the same helper the collect builders use, because a backfilled point must be measured exactly
+# like a pushed one to be comparable to it.
 
 Set-StrictMode -Version Latest
 
@@ -31,6 +43,27 @@ Set-StrictMode -Version Latest
 # must drop this name from that set before collecting (and before deciding whether anything is left
 # to bench at all). Defined once so the exclusion cannot drift between the two paths.
 $script:ExcludedPackage = 'benchmarks'
+
+# The shape of a plausible commit SHA: hex, 7-40 characters. Every commit id this module accepts
+# from a workflow_dispatch input is matched against it, so a typo fails loudly before an expensive
+# benchmark run and an untrusted value can carry no shell metacharacters. It is also what the git
+# queries' output is checked against, so a garbled `rev-list` result can never be spliced into a
+# tool invocation as a range endpoint.
+$script:CommitIdPattern = '^[0-9a-fA-F]{7,40}$'
+
+# The nightly backfill's rolling date window, as git approxidate expressions.
+#
+# The quarantine keeps the newest candidate commit at arm's length from the push-triggered
+# collection: a collect job takes hours and can be queued for more, so anything younger risks the
+# nightly re-measuring a commit whose own collect run is still in flight and burning a whole run to
+# discover a duplicate at the store step.
+#
+# The horizon bounds how far back the window reaches. Regression detection only ever compares
+# against a handful of recent points, so older gaps buy nothing, and the bound also caps how far
+# back a point measured with HEAD's benchmark configuration (RUSTFLAGS, collection scope) can be
+# planted among neighbours measured with their own.
+$script:BackfillQuarantine = '24 hours ago'
+$script:BackfillHorizon = '14 days ago'
 
 function Select-BenchmarkablePackage {
     # Filters a delta-affected package list down to the ones the benchmark-history workflow actually
@@ -50,20 +83,63 @@ function Select-BenchmarkablePackage {
     return @($Package | Where-Object { $_ -cne $script:ExcludedPackage })
 }
 
+function Get-BenchHistoryScopeArgument {
+    # Builds the scope + noise-reduction flags EVERY benchmark-history run shares, so a `collect` and
+    # a `backfill` can never measure the same commit differently. `collect` and `backfill` flatten the
+    # same clap arg groups, so this array applies verbatim to either subcommand.
+    #
+    # $Package selects the collection scope. When empty (the push-to-main and nightly-backfill
+    # default), the whole workspace is benched except the excluded `benchmarks` crate (`--workspace
+    # --exclude benchmarks`). When non-empty (the PR workflow, which passes the delta-affected
+    # packages), the run is scoped to exactly those packages (`--package <name>` each); the caller is
+    # expected to have already dropped `benchmarks` via Select-BenchmarkablePackage.
+    #
+    # No `--machine-key` override: each runner stamps its results with its OWN real hardware
+    # fingerprint, so a heterogeneous GitHub runner pool splits into one clean wall-clock series per
+    # hardware type instead of one jittery series mixing incomparable machines. `--best-of 3` keeps
+    # each metric's minimum across three runs to shed one-sided runner jitter - a point taken at a
+    # lower best-of would sit systematically higher than its neighbours and manufacture a step change
+    # in the series. `--verbose` makes the log spell out the resolved machine key and the fingerprint
+    # components behind it, so a key change is debuggable from the log alone.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]] $Package
+    )
+
+    $packages = @($Package | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($packages.Count -gt 0) {
+        # Explicit package scoping (PR workflow): one `--package <name>` per impacted crate.
+        $selection = @()
+        foreach ($name in $packages) { $selection += @('--package', $name) }
+        Write-Verbose ("Scoping collection to the delta-affected packages: " +
+            ($packages -join ', ') + '.')
+    } else {
+        $selection = @('--workspace', '--exclude', $script:ExcludedPackage)
+        Write-Verbose ("No explicit package scope: benching the whole workspace except the " +
+            "'$script:ExcludedPackage' crate.")
+    }
+
+    return $selection + @(
+        '--best-of', '3',
+        '--verbose'
+    )
+}
+
 function Get-BenchHistoryCollectCommand {
     # Builds the argument vector passed to the tool after `--` (a `collect ...` or `backfill ...`
     # invocation), choosing the mode from $RecollectCommitId. Returns a string[]; throws when a
     # non-empty id is not a plausible commit SHA. Emits an explanatory verbose note describing which
     # mode was chosen and why, for the workflow log.
     #
-    # $Package selects the collection scope. When empty (the push-to-main default), the whole
-    # workspace is benched except the excluded `benchmarks` crate (`--workspace --exclude
-    # benchmarks`). When non-empty (the PR workflow, which passes the delta-affected packages), the
-    # run is scoped to exactly those packages (`--package <name>` each); the caller is expected to
-    # have already dropped `benchmarks` via Select-BenchmarkablePackage. An empty scope is not an
-    # error here: the PR workflow structurally never reaches collection with an empty benchmarkable
-    # set (its `delta` job gates that case out to the cleanup path), so the only caller that passes
-    # no packages is the push-to-main path, which wants exactly the whole-workspace default.
+    # $Package selects the collection scope and is handed to Get-BenchHistoryScopeArgument. An empty
+    # scope is not an error here: the PR workflow structurally never reaches collection with an empty
+    # benchmarkable set (its `delta` job gates that case out to the cleanup path), so the only caller
+    # that passes no packages is the push-to-main path, which wants exactly the whole-workspace
+    # default.
     [CmdletBinding()]
     [OutputType([string[]])]
     param(
@@ -78,31 +154,7 @@ function Get-BenchHistoryCollectCommand {
         [string[]] $Package
     )
 
-    # Scope + noise-reduction flags shared by both modes: `collect` and `backfill` flatten the same
-    # clap arg groups, so this array applies verbatim to either subcommand. No `--machine-key`
-    # override: each runner stamps its results with its OWN real hardware fingerprint, so a
-    # heterogeneous GitHub runner pool splits into one clean wall-clock series per hardware type
-    # instead of one jittery series mixing incomparable machines. `--best-of 3` keeps each metric's
-    # minimum across three runs to shed one-sided runner jitter; `--verbose` makes the collect log
-    # spell out the resolved machine key and the fingerprint components behind it, so a key change is
-    # debuggable from the log alone.
-    $packages = @($Package | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-    if ($packages.Count -gt 0) {
-        # Explicit package scoping (PR workflow): one `--package <name>` per impacted crate.
-        $selection = @()
-        foreach ($name in $packages) { $selection += @('--package', $name) }
-        Write-Verbose ("Scoping collection to the delta-affected packages: " +
-            ($packages -join ', ') + '.')
-    } else {
-        $selection = @('--workspace', '--exclude', $script:ExcludedPackage)
-        Write-Verbose ("No explicit package scope: benching the whole workspace except the " +
-            "'$script:ExcludedPackage' crate.")
-    }
-
-    $scope = $selection + @(
-        '--best-of', '3',
-        '--verbose'
-    )
+    $scope = Get-BenchHistoryScopeArgument -Package $Package
 
     $recollect = if ($null -eq $RecollectCommitId) { '' } else { $RecollectCommitId.Trim() }
 
@@ -115,7 +167,7 @@ function Get-BenchHistoryCollectCommand {
     # A commit SHA only - hex, 7-40 chars. Rejecting anything else fails a typo'd dispatch loudly
     # (before an expensive benchmark run) and, because the value is an untrusted dispatch input,
     # also guarantees it can carry no shell metacharacters.
-    if ($recollect -notmatch '^[0-9a-fA-F]{7,40}$') {
+    if ($recollect -notmatch $script:CommitIdPattern) {
         throw ("Recollect commit id must be a 7-40 character hex commit SHA, got '$recollect'. " +
             "This validates the format only; that the id resolves to a real commit is enforced " +
             "later by the backfill step (which fails if the ref cannot be resolved), while whether " +
@@ -124,10 +176,156 @@ function Get-BenchHistoryCollectCommand {
     }
 
     Write-Verbose ("Recollect commit ${recollect}: re-measuring that single commit in a throwaway " +
-        'worktree and overwriting its stored point with `backfill --overwrite`, using this HEAD ' +
-        'build of the tool so only the benchmark code - not the collection logic - comes from that ' +
-        'commit.')
+        'worktree and overwriting its stored point with `backfill --overwrite`. The benchmark code ' +
+        'and the toolchain that builds it come from that commit; the collection logic, the ' +
+        'RUSTFLAGS and the scope flags come from this checkout.')
     return @('backfill', $recollect, $recollect) + $scope + @('--overwrite')
 }
 
-Export-ModuleMember -Function Get-BenchHistoryCollectCommand, Select-BenchmarkablePackage
+function Invoke-GitCapture {
+    # Runs `git` with the given arguments and returns its stdout as a string[] of trimmed, non-blank
+    # lines. Inspecting the exit code here - rather than letting a non-zero `git` abort the pipeline -
+    # is what lets the failure message name the exact query that failed, and is why the native-error
+    # toggle is off. This is the single seam the Pester suite mocks (via `Mock git`), so the window
+    # resolution below is exercised without a real repository.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $PSNativeCommandUseErrorActionPreference = $false
+    $output = @(git @Arguments)
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "git $($Arguments -join ' ') failed (exit ${exitCode}): $($output -join ' ')"
+    }
+
+    return @($output |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object { $_.Trim() })
+}
+
+function Get-BenchHistoryBackfillWindow {
+    # Resolves the rolling date window the nightly backfill walks, as an object carrying `From` and
+    # `To` commit ids. Returns $null when nothing is eligible, which the caller reports and treats as
+    # a successful no-op run.
+    #
+    # `To` is the newest first-parent commit at least $script:BackfillQuarantine old, or $ToCommitId
+    # when the operator supplied one (the workflow_dispatch escape hatch for stepping over a commit
+    # that fails slowly and would otherwise be re-selected every night). `From` is the oldest
+    # first-parent commit reachable from `To` that is newer than $script:BackfillHorizon - a horizon
+    # measured from NOW, not from `To`, so an override reaching further back than the horizon
+    # collapses the window onto that single commit.
+    #
+    # `From` is resolved FROM `To`, never from HEAD: `backfill` hard-checks that its range start is a
+    # first-parent ancestor of its range end and errors out otherwise, and resolving from `To` makes
+    # that true by construction. Every query passes `--first-parent` for the same reason - default
+    # history simplification can return a commit off the first-parent line, and this repository does
+    # carry merge commits.
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $ToCommitId
+    )
+
+    $override = if ($null -eq $ToCommitId) { '' } else { $ToCommitId.Trim() }
+
+    if ($override -eq '') {
+        $newest = @(Invoke-GitCapture -Arguments @(
+                'rev-list', '-1', '--first-parent', "--before=$script:BackfillQuarantine", 'HEAD'))
+        if ($newest.Count -eq 0) {
+            Write-Verbose ("No first-parent commit predates '$script:BackfillQuarantine', so every " +
+                'commit is still inside the quarantine that keeps this run from racing the ' +
+                'push-triggered collection. There is nothing to backfill this run.')
+            return $null
+        }
+
+        $to = $newest[0]
+        Write-Verbose ("Range end $to is the newest first-parent commit predating " +
+            "'$script:BackfillQuarantine', so the push-triggered collection of it has long since " +
+            'finished and this run cannot race it.')
+    } else {
+        # An untrusted workflow_dispatch input: validate the SHA format before it becomes a range
+        # endpoint, exactly as the recollect id is validated.
+        if ($override -notmatch $script:CommitIdPattern) {
+            throw ("Backfill range end must be a 7-40 character hex commit SHA, got '$override'. " +
+                'This validates the format only; that the id resolves to a real commit is enforced ' +
+                'later by the backfill step, which fails if the ref cannot be resolved.')
+        }
+
+        $to = $override
+        Write-Verbose ("Range end $to comes from the operator-supplied override, so the " +
+            "'$script:BackfillQuarantine' quarantine is bypassed for this run.")
+    }
+
+    $ancestry = @(Invoke-GitCapture -Arguments @(
+            'rev-list', '--first-parent', "--since=$script:BackfillHorizon", $to))
+    if ($ancestry.Count -eq 0) {
+        # `To` itself predates the horizon (a quiet fortnight, or an override reaching further back),
+        # so the window collapses onto it. That is a valid single-commit range, unlike the
+        # non-ancestor range a HEAD-relative resolution would have produced.
+        $from = $to
+        Write-Verbose ("No first-parent commit reachable from $to is newer than " +
+            "'$script:BackfillHorizon', so the window collapses onto that single commit.")
+    } else {
+        $from = $ancestry[-1]
+        $noun = if ($ancestry.Count -eq 1) { 'commit' } else { 'commits' }
+        Write-Verbose ("Range start $from is the oldest of the $($ancestry.Count) first-parent " +
+            "$noun reachable from $to and newer than '$script:BackfillHorizon'; older history " +
+            'has no comparison value against current tips.')
+    }
+
+    foreach ($endpoint in @($from, $to)) {
+        if ($endpoint -notmatch $script:CommitIdPattern) {
+            throw ("git resolved a backfill range endpoint to '$endpoint', which is not a commit " +
+                'SHA. Refusing to hand it to the tool as a range endpoint.')
+        }
+    }
+
+    return [pscustomobject]@{
+        From = $from
+        To   = $to
+    }
+}
+
+function Get-BenchHistoryBackfillCommand {
+    # Builds the argument vector the nightly gap-filling run passes to the tool after `--`. Returns a
+    # string[] holding a `backfill <from> <to> ...` invocation, or an EMPTY array when no commit is
+    # eligible yet (a repository whose whole history is still inside the quarantine) - the caller
+    # then skips the tool and the run is a successful no-op.
+    #
+    # $ToCommitId overrides the computed range end (the workflow_dispatch escape hatch); leave it
+    # empty for the scheduled run. The scope flags come from Get-BenchHistoryScopeArgument, the same
+    # helper the collect builder uses, because a backfilled point is only comparable to its pushed
+    # neighbours if it was measured with the same scope and the same `--best-of`.
+    #
+    # No `--overwrite`: the tool's default skip-existing behaviour is the entire point, since only
+    # the commits this runner's own partition is missing are worth measuring. `--ignore-errors` walks
+    # past a commit that fails to build instead of abandoning the rest of the window.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $ToCommitId
+    )
+
+    $window = Get-BenchHistoryBackfillWindow -ToCommitId $ToCommitId
+    if ($null -eq $window) {
+        return @()
+    }
+
+    Write-Verbose ("Backfilling the first-parent range $($window.From)..$($window.To), measuring " +
+        'only the commits this machine partition is missing and walking past any commit that ' +
+        'fails to build.')
+    return @('backfill', $window.From, $window.To) +
+        (Get-BenchHistoryScopeArgument) +
+        @('--ignore-errors')
+}
+
+Export-ModuleMember -Function Get-BenchHistoryCollectCommand, Get-BenchHistoryBackfillCommand, Select-BenchmarkablePackage


### PR DESCRIPTION
[Copilot speaking]

## Why

The bench-history workflow runs on every push to `main`, but GitHub's hosted runner pool is heterogeneous — consecutive commits get measured by different hardware, so every per-machine-key series ends up sparse and comparison-poor. A fixed self-hosted runner pool would be the proper fix; this is the practical workaround.

A nightly workflow fills gaps in whichever partition its runner draws, **newest commit first** so a run cut short by the job timeout has prioritised the most comparison-relevant history. There is no analysis phase — the next push-triggered run analyzes whatever landed.

## Blocking defect found while planning

`backfill`'s skip pre-check listed the **entire project prefix** and treated a commit as recorded if *any* engine, target triple or machine key had data for it. Target triples and machine keys are completely independent data sets and must never count as coverage of one another — and left as-is the nightly would have been a permanent no-op.

The pre-check is now scoped to the exact partition the run would write to, honouring `--machine-key`, unioned over engines (nothing requires a run to produce every engine — Callgrind stores nothing off Linux, so an intersection would never match there). A shared `Partition` type gives the pre-check and the write path a single derivation; `DiscriminantSet::new` is now reachable from exactly one place. Partition prefixes also gained a trailing separator so a sibling machine key (`ci` vs `ci-pool`) cannot bleed in.

`collect` was audited for the same class of bug and is clean — its collision detection is a write-once `put` on the fully-qualified key.

## Toolchain fidelity

`cargo run` exports `RUSTUP_TOOLCHAIN` and `CARGO`, and the tool passed its environment to the `cargo bench` it spawned in a historical worktree — so a backfilled commit was **not** built with the toolchain its own `rust-toolchain.toml` pins. Verified empirically: a directory pinning 1.91 built with 1.96.1; with the variables cleared, 1.91.1 was selected.

`TokioBenchRunner::in_worktree` now detaches the child from the launcher's toolchain, and `cbh_probe` gained a matching scope so the `rustc -vV` provenance probe runs the same way — otherwise the stored `rustc_version` would name a compiler that did not build the benchmarks. `collect` is deliberately unchanged: its checkout *is* the current workspace, and clearing there would silently override a deliberate `cargo +nightly run`.

## Range selection

- `to` = newest first-parent commit **at least 24 h old**, so the nightly never targets a commit whose own collect run may still be in flight and burns a whole run discovering a duplicate at the store step.
- `from` = oldest first-parent commit within **14 days**, resolved *from `to`* rather than from `HEAD`, which makes the first-parent ancestry the tool hard-checks true by construction.

## Accepted limitations, documented rather than hidden

- **`RUSTFLAGS` and scope flags still come from the current checkout.** They are caller intent, not launcher pollution, and a published general-purpose tool cannot read this repository's `constants.env` out of a worktree. A commit older than the newest change to those values is measured slightly differently from its pushed neighbours; the 14-day window caps the exposure.
- **No failure alerting.** With `--ignore-errors` and `continue-on-error: true`, a permanently broken nightly would exit 0. Mitigated by putting the pre-check's decision on the always-on output channel — the nightly runs without `--verbose`, and its designed steady state is being killed at the 360-minute ceiling before the summary ever prints, so verbose-gated notes would be invisible in exactly the run that matters.
- **Engine results are stored one at a time**, so a kill inside that window leaves a partially stored commit that later runs consider complete; overwriting that one commit is the repair.

Also files a `TODO.md` entry: the key segments should become `triple/machine/engine` whenever the storage schema is next broken — the independent discriminants belong outermost, so "everything this machine key recorded" would be a single prefix instead of one listing per engine. Not worth a schema break on its own.

## Validation

`just test` (3185 passed) · `just clippy` · `just docs` · `just format-check` · `just miri` (Windows + Linux via WSL) · `just test-scripts` (358 passed) · `just validate-scripts` · `just validate-workflows` · `cargo-mutants` on `cargo-bench-history`: **0 missed**.

Two rubber-duck review rounds; findings either fixed or recorded as accepted with rationale. Corrected along the way: a stale claim in `.github/workflows/design.md` that collection stamps a fixed `github` machine key (each runner stamps its own fingerprint and analysis threads the collected keys), and the recollect contract wording, which must now say the toolchain comes from the target commit too.