### PR TITLE
Make `examine` list every commit in its range

### DIFF
--- a/packages/cargo-bench-history/book/src/commands/examine.md
+++ b/packages/cargo-bench-history/book/src/commands/examine.md
@@ -2,9 +2,9 @@
 
 `examine` answers the question a finding raises: *which commits actually moved this number?*
 Where [`analyze`](analyze.md) reports that a benchmark's metric shifted and draws a small
-chart, `examine` pivots that chart into its data points — one row per recorded observation of
-a single `(benchmark, metric)` series, in git first-parent order, each row pairing the value
-with the short commit id and the start of the commit's title.
+chart, `examine` pivots that chart into a per-commit listing of a single `(benchmark, metric)`
+series — a row for every commit, in git first-parent order, each row pairing the value with
+the short commit id and the start of the commit's title.
 
 ```console
 cargo bench-history examine --local=./bench-history \
@@ -22,9 +22,25 @@ benchmark identity and the metric, so pasting them back in is natural.
 
 `examine` is a drill-down sibling of [`list runs`](list.md): both are read-only previews over
 `analyze`'s exact data-set selection that never analyze. It runs **no detection and no
-re-baselining** — it has no findings, modes, or blessings — and repeats the pivot once per
-matching discriminant set. The text and Markdown renderings lead each set with the same
-compact, topology-accurate line chart `analyze` draws — one column per first-parent commit,
-so a data-less commit is a gap and a series that stops short of the analyzed tip shows a
-trailing gap. The tabular rows and the JSON form carry only the **real observations** at full
-precision with each commit's full title; the gaps live in the chart alone.
+re-baselining** — it has no findings, modes, or blessings — and repeats the listing once per
+matching discriminant set.
+
+The listing covers **every commit in the examined range**. That range starts at the earliest
+commit at which any matching discriminant set carries the series and ends at the analyzed tip
+commit, and it is the same for every set, so two sets' tables cover the same commits in the
+same order and can be read side by side. A commit that carries data contributes one row per
+observation (clean before dirty, each flagged); a commit with no data point for this series
+and selection contributes one row whose value reads `n/a`, still naming the commit and its
+title so you can see which commits are missing data and what they changed. Nothing caps the
+listing — use `--since` to bound the range.
+
+The JSON form carries the same rows in the same order, with full precision and each commit's
+full title (the text and Markdown tables truncate the title to 50 characters). A row for a
+commit with no data point has a null value and no clean/dirty flag.
+
+The text and Markdown renderings lead each set with the same compact, topology-accurate line
+chart history-mode `analyze` draws — one column per first-parent commit over that set's own
+observations, so a data-less commit is a gap and a series that stops short of the analyzed tip
+shows a trailing gap. The chart trims its own leading gap, so a set whose first observation
+comes after the start of the range draws a chart that begins later than its table does: the
+table is the complete commit listing, the chart is the shape of the series.

--- a/packages/cargo-bench-history/book/src/commands/examine.md
+++ b/packages/cargo-bench-history/book/src/commands/examine.md
@@ -25,14 +25,12 @@ benchmark identity and the metric, so pasting them back in is natural.
 re-baselining** — it has no findings, modes, or blessings — and repeats the listing once per
 matching discriminant set.
 
-The listing covers **every commit in the examined range**. That range starts at the earliest
-commit at which any matching discriminant set carries the series and ends at the analyzed tip
-commit, and it is the same for every set, so two sets' tables cover the same commits in the
-same order and can be read side by side. A commit that carries data contributes one row per
-observation (clean before dirty, each flagged); a commit with no data point for this series
-and selection contributes one row whose value reads `n/a`, still naming the commit and its
-title so you can see which commits are missing data and what they changed. Nothing caps the
-listing — use `--since` to bound the range.
+The listing covers **every commit in the examined range**: from the earliest commit at which
+any matching set carries the series through to the analyzed tip. Every set shares that range,
+so their tables cover the same commits and can be read side by side. A commit that carries
+data contributes one row per observation (clean before dirty, each flagged); a commit with no
+data point reads `n/a`, still naming the commit and its title. Nothing caps the listing — use
+`--since` to bound the range.
 
 The JSON form carries the same rows in the same order, with full precision and each commit's
 full title (the text and Markdown tables truncate the title to 50 characters). A row for a
@@ -40,7 +38,6 @@ commit with no data point has a null value and no clean/dirty flag.
 
 The text and Markdown renderings lead each set with the same compact, topology-accurate line
 chart history-mode `analyze` draws — one column per first-parent commit over that set's own
-observations, so a data-less commit is a gap and a series that stops short of the analyzed tip
-shows a trailing gap. The chart trims its own leading gap, so a set whose first observation
-comes after the start of the range draws a chart that begins later than its table does: the
-table is the complete commit listing, the chart is the shape of the series.
+observations, so a data-less commit is a gap. The chart trims its own leading gap, so a
+late-starting set draws a chart that begins after its table does: the table is the complete
+commit listing, the chart is the shape of the series.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -651,38 +651,28 @@ gives; when runs enter but none carry the named `(benchmark, metric)` pair, a di
 pointing at the unmatched benchmark id or metric name.
 
 `examine` runs **no detection and no re-baselining** — it has no findings, modes, or
-blessings — which is why the analysis-only flags (improvements, inactive findings) are not
-part of its surface. What it lists is a **complete commit listing**: every commit in the
-examined range gets a row, and a commit that carries no data point for the examined series
-and selection is marked `n/a`. The range opens at the earliest commit at which *any*
-matching discriminant set carries the series and closes at the analyzed tip, and that
-opening is a **union across the sets**, so every set lists exactly the same commits in the
-same order and two sets can be read side by side, commit for commit. A commit that does
-carry data contributes one row per **observation** instead — a clean run and the dirty
-snapshots at the same commit each get a row, ordered clean-before-dirty and flagged, so a
-value's provenance is unambiguous. Nothing caps the listing; `--since` is the way to bound
-the range, and `--verbose` states the resolved range and why it opens and closes where it
-does.
+blessings, which is why the analysis-only flags (improvements, inactive findings) are not
+part of its surface. It lists **every commit** from the earliest one at which any matching
+set carries the series through to the analyzed tip: a commit carrying data contributes a row
+per **observation** (clean run before dirty snapshots, each flagged, so a value's provenance
+is unambiguous), and a commit carrying none is marked `n/a`. That opening is a union across
+the sets, so every set lists the same commits and two of them can be read side by side.
+Nothing caps the listing; `--since` bounds it, and `--verbose` states the resolved range.
 
 The three output renderings compose from one pass as everywhere else: the per-commit table
 on stdout by default, the same table in Markdown, and a machine-readable JSON form that
-mirrors the table row for row and carries, per discriminant set, the ordered rows with
-full-precision values and each commit's full title — the 50-character title truncation is a
-readability convenience of the text and Markdown tables, not of the data. A commit with no
-data point carries no value and no clean/dirty flag there, so a consumer distinguishes a gap
-from a measurement without parsing a marker. The text and Markdown renderings **lead each
-set with the same whole-series chart history-mode `analyze` draws**, reusing its renderer, so
-a maintainer sees the shape of the series before reading the rows beneath it. The chart is
-deliberately **not** the table: it plots that set's own real observations, one
-topology-accurate column per first-parent commit — so a data-less commit between
-observations, or a trailing run of them up to the analyzed tip, is a visible gap — but it
-trims its own leading gap, so a set whose first observation falls after the shared range
-start opens its chart later than its table. Beyond the fixed chart width it also bins
-several commits into one column (§8.6), so a long range makes the chart an approximation
-while the table stays exact, commit by commit. The table is the complete listing; the
-chart is the shape of the series. The line is drawn **uncolored**, and only when a set has
-at least two observations. The JSON form carries no chart (a charting concern the human
-reports draw from internally, not data a consumer reconstructs).
+mirrors it row for row with full-precision values and each commit's full title — the
+50-character title truncation is a readability convenience of the text and Markdown tables,
+not of the data — carrying a null value and no clean/dirty flag where a commit has no data.
+The text and Markdown renderings **lead each set with the same line chart history-mode
+`analyze` draws**, reusing its renderer, so a maintainer sees the shape of the series before
+reading the rows beneath it. The chart is not the table: it plots that set's real
+observations only and trims its leading gap, so a late-starting set opens its chart after its
+table, and beyond the fixed chart width it bins commits into shared columns (§8.6). The table
+is the complete listing; the chart is the shape of the series. The line is drawn
+**uncolored**, and only when a set has at least two observations. The JSON form carries no
+chart (a charting concern the human reports draw from internally, not data a consumer
+reconstructs).
 
 ### 7.9 `import`
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -624,7 +624,7 @@ default, or the most recent blessing of every benchmark across the analysis wind
 
 `examine` answers the question a finding raises: *which commits actually moved this
 number?* Where `analyze` reports that a benchmark's metric shifted and draws a small chart,
-`examine` **pivots that chart into its data points** — one row per recorded observation of a
+`examine` **pivots that chart into a per-commit listing** — a row for every commit of a
 single `(benchmark, metric)` series, in git first-parent order, each row pairing the value
 with the short commit id and the start of the commit's title. A maintainer reads the values
 down the column, spots where one jumps, and reads across to the title to correlate the move
@@ -634,9 +634,9 @@ It is a **drill-down sibling of `list runs`**: both are read-only previews over 
 exact data-set selection that never analyze, so `examine` reuses that selection pipeline
 unchanged and stays in the same lockstep — a selection parameter added to `analyze` is added
 to `list`, `prune`, and `examine` alike. Like `analyze` it requires a resolvable repository
-(it needs first-parent topology to order the points and each commit's title to label them)
-and repeats the pivot once **per matching discriminant set**, since the same series can exist
-under several triples or machine keys.
+(it needs first-parent topology to enumerate and order the listed commits and each commit's
+title to label them) and repeats the pivot once **per matching discriminant set**, since the
+same series can exist under several triples or machine keys.
 
 Two required options name the series, and they are the one place a command names a
 **metric**: `--benchmark <qualified-id>` selects exactly one benchmark identity and
@@ -651,22 +651,38 @@ gives; when runs enter but none carry the named `(benchmark, metric)` pair, a di
 pointing at the unmatched benchmark id or metric name.
 
 `examine` runs **no detection and no re-baselining** — it has no findings, modes, or
-blessings. It lists every selected **observation** (a commit carrying both a clean run and
-dirty snapshots contributes a row each, ordered clean-before-dirty and flagged, so a value's
-provenance is unambiguous), which is why the analysis-only flags (improvements, inactive
-findings) are not part of its surface. The three output renderings compose from one pass as
-everywhere else: the per-commit table on stdout by default, the same table in Markdown, and a
-machine-readable JSON form that carries, per discriminant set, the ordered points with
+blessings — which is why the analysis-only flags (improvements, inactive findings) are not
+part of its surface. What it lists is a **complete commit listing**: every commit in the
+examined range gets a row, and a commit that carries no data point for the examined series
+and selection is marked `n/a`. The range opens at the earliest commit at which *any*
+matching discriminant set carries the series and closes at the analyzed tip, and that
+opening is a **union across the sets**, so every set lists exactly the same commits in the
+same order and two sets can be read side by side, commit for commit. A commit that does
+carry data contributes one row per **observation** instead — a clean run and the dirty
+snapshots at the same commit each get a row, ordered clean-before-dirty and flagged, so a
+value's provenance is unambiguous. Nothing caps the listing; `--since` is the way to bound
+the range, and `--verbose` states the resolved range and why it opens and closes where it
+does.
+
+The three output renderings compose from one pass as everywhere else: the per-commit table
+on stdout by default, the same table in Markdown, and a machine-readable JSON form that
+mirrors the table row for row and carries, per discriminant set, the ordered rows with
 full-precision values and each commit's full title — the 50-character title truncation is a
-readability convenience of the text and Markdown tables, not of the data. The text and
-Markdown renderings **lead each set with the same small line chart `analyze` draws**, reusing
-its renderer, so a maintainer sees the shape of the series before reading the points it
-pivots; the chart is **topology-accurate** — one column per first-parent commit, so a
-data-less commit between observations (or a trailing run of them up to the analyzed tip)
-renders as a gap that the tabular points, which list only real observations, do not carry.
-The line is drawn **uncolored**, and only when a set has at least two points. The JSON form
-carries no chart (a charting concern the human reports draw from internally, not data a
-consumer reconstructs).
+readability convenience of the text and Markdown tables, not of the data. A commit with no
+data point carries no value and no clean/dirty flag there, so a consumer distinguishes a gap
+from a measurement without parsing a marker. The text and Markdown renderings **lead each
+set with the same whole-series chart history-mode `analyze` draws**, reusing its renderer, so
+a maintainer sees the shape of the series before reading the rows beneath it. The chart is
+deliberately **not** the table: it plots that set's own real observations, one
+topology-accurate column per first-parent commit — so a data-less commit between
+observations, or a trailing run of them up to the analyzed tip, is a visible gap — but it
+trims its own leading gap, so a set whose first observation falls after the shared range
+start opens its chart later than its table. Beyond the fixed chart width it also bins
+several commits into one column (§8.6), so a long range makes the chart an approximation
+while the table stays exact, commit by commit. The table is the complete listing; the
+chart is the shape of the series. The line is drawn **uncolored**, and only when a set has
+at least two observations. The JSON form carries no chart (a charting concern the human
+reports draw from internally, not data a consumer reconstructs).
 
 ### 7.9 `import`
 

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -150,18 +150,24 @@
 //! ## `examine`
 //!
 //! A drill-down sibling of `list runs` over the same `analyze`/`list` selection: it
-//! pivots the small chart `analyze` draws into its raw data points. Given the two
-//! required options `--benchmark <qualified-id>` and `--metric <name>` — the one
-//! command that names a metric, meant to be pasted from an `analyze` finding — it
-//! prints one row per recorded observation of that series, in git first-parent
-//! order and once per matching discriminant set, pairing the value with the short
-//! commit id and the first 50 characters of the commit's title (JSON keeps the full
-//! title and full-precision value). It requires a repository, runs no detection or
-//! re-baselining, and shows every selected point (clean before dirty, each flagged).
-//! An unknown metric name is rejected. An empty pivot is explained by one of two
-//! hints: when no run enters the selection at all, the same "matched no runs" hint
-//! `analyze` gives; when runs enter but none carry the named `(benchmark, metric)`
-//! pair, a distinct hint pointing at the unmatched benchmark id or metric name.
+//! pivots the small chart `analyze` draws into a per-commit listing of raw data
+//! points. Given the two required options `--benchmark <qualified-id>` and
+//! `--metric <name>` — the one command that names a metric, meant to be pasted from
+//! an `analyze` finding — it lists every commit from the earliest one at which any
+//! matching discriminant set carries that series up to the analyzed tip, oldest
+//! first in git first-parent order and once per set, pairing the value with the
+//! short commit id and the first 50 characters of the commit's title (JSON keeps the
+//! full title and full-precision value). The range is shared by every set, so their
+//! listings cover the same commits in the same order, and a commit with no data point
+//! for the series reads `n/a` (a null value in JSON) while still naming its commit
+//! and title. It requires a repository, runs no detection or re-baselining, and shows
+//! every selected observation (clean before dirty, each flagged, so a commit with
+//! several observations gets a row each); `--verbose` explains where the listed range
+//! opens and closes. An unknown metric name is rejected. An empty pivot is explained
+//! by one of two hints: when no run enters the selection at all, the same "matched no
+//! runs" hint `analyze` gives; when runs enter but none carry the named
+//! `(benchmark, metric)` pair, a distinct hint pointing at the unmatched benchmark id
+//! or metric name.
 //!
 //! ## `bless` / `unbless`
 //!

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -150,20 +150,17 @@
 //! ## `examine`
 //!
 //! A drill-down sibling of `list runs` over the same `analyze`/`list` selection: it
-//! pivots the small chart `analyze` draws into a per-commit listing of raw data
-//! points. Given the two required options `--benchmark <qualified-id>` and
-//! `--metric <name>` — the one command that names a metric, meant to be pasted from
-//! an `analyze` finding — it lists every commit from the earliest one at which any
-//! matching discriminant set carries that series up to the analyzed tip, oldest
-//! first in git first-parent order and once per set, pairing the value with the
-//! short commit id and the first 50 characters of the commit's title (JSON keeps the
-//! full title and full-precision value). The range is shared by every set, so their
-//! listings cover the same commits in the same order, and a commit with no data point
-//! for the series reads `n/a` (a null value in JSON) while still naming its commit
-//! and title. It requires a repository, runs no detection or re-baselining, and shows
-//! every selected observation (clean before dirty, each flagged, so a commit with
-//! several observations contributes one row per observation); `--verbose` explains
-//! where the listed range opens and closes. An unknown metric name is rejected. An
+//! pivots the small chart `analyze` draws into a per-commit listing. Given the two
+//! required options `--benchmark <qualified-id>` and `--metric <name>` — the one
+//! command that names a metric, meant to be pasted from an `analyze` finding — it
+//! lists every commit from the earliest one carrying that series in any matching
+//! discriminant set up to the analyzed tip, in git first-parent order and once per
+//! set, pairing the value with the short commit id and the first 50 characters of the
+//! commit's title (JSON keeps the full title and full-precision value). Every set
+//! shares that range, so their listings cover the same commits; a commit with no data
+//! point reads `n/a` (null in JSON), and one with several observations contributes a
+//! row per observation (clean before dirty, each flagged). It requires a repository
+//! and runs no detection or re-baselining. An unknown metric name is rejected. An
 //! empty pivot is explained by one of two hints: when no run enters the selection at
 //! all, the same "matched no runs" hint `analyze` gives; when runs enter but none
 //! carry the named `(benchmark, metric)` pair, a distinct hint pointing at the

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -162,12 +162,12 @@
 //! for the series reads `n/a` (a null value in JSON) while still naming its commit
 //! and title. It requires a repository, runs no detection or re-baselining, and shows
 //! every selected observation (clean before dirty, each flagged, so a commit with
-//! several observations gets a row each); `--verbose` explains where the listed range
-//! opens and closes. An unknown metric name is rejected. An empty pivot is explained
-//! by one of two hints: when no run enters the selection at all, the same "matched no
-//! runs" hint `analyze` gives; when runs enter but none carry the named
-//! `(benchmark, metric)` pair, a distinct hint pointing at the unmatched benchmark id
-//! or metric name.
+//! several observations contributes one row per observation); `--verbose` explains
+//! where the listed range opens and closes. An unknown metric name is rejected. An
+//! empty pivot is explained by one of two hints: when no run enters the selection at
+//! all, the same "matched no runs" hint `analyze` gives; when runs enter but none
+//! carry the named `(benchmark, metric)` pair, a distinct hint pointing at the
+//! unmatched benchmark id or metric name.
 //!
 //! ## `bless` / `unbless`
 //!

--- a/packages/cargo-bench-history/tests/cbh_integration/examine.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/examine.rs
@@ -1,9 +1,9 @@
 use crate::harness::*;
 
 /// `examine` pivots one `(benchmark, metric)` series into its raw per-commit data
-/// points: one JSON row per recorded observation, oldest first by git topology,
-/// pairing each value with the commit it was measured against and that commit's
-/// title.
+/// points: one JSON row per commit in the listed range, oldest first by git
+/// topology, pairing each value with the commit it was measured against and that
+/// commit's title.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn examine_pivots_a_rising_history_into_points() {
@@ -115,7 +115,7 @@ async fn examine_renders_a_text_pivot_with_titles() {
     assert!(axis < first_point, "a chart leads the points: {message}");
 }
 
-/// `examine` renders a per-set Markdown table with a row per observation.
+/// `examine` renders a per-set Markdown table with a row per listed commit.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn examine_renders_a_markdown_table() {
@@ -415,6 +415,105 @@ async fn examine_dirty_tree_on_the_base_warns() {
         "{message}"
     );
     assert!(parsed["warning"].is_null(), "{message}");
+}
+
+/// A commit inside the listed range that recorded nothing for the series is listed
+/// as `n/a` rather than skipped, so the table represents the same commits the
+/// leading chart draws columns for.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_lists_commits_without_data_as_n_a() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.commit_dated("2024-01-03", "c3");
+    workspace.seed_callgrind("c3", 130.0);
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let points = parsed["sets"][0]["points"].as_array().unwrap();
+    assert_eq!(points.len(), 3, "one row per commit c1..=c3: {message}");
+    assert_eq!(points[0]["value"].as_f64().unwrap(), 100.0, "{message}");
+    assert!(
+        points[1]["value"].is_null(),
+        "c2 recorded nothing: {message}"
+    );
+    assert!(
+        points[1].get("dirty").is_none(),
+        "a data-less entry carries no cleanliness flag: {message}"
+    );
+    assert_eq!(
+        points[1]["title"], "c2",
+        "the data-less row still names its commit: {message}"
+    );
+    assert_eq!(points[2]["value"].as_f64().unwrap(), 130.0, "{message}");
+
+    // The text pivot lists the same three commits, the middle one without a value.
+    let RunOutcome::Completed { message } = workspace
+        .drive(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await
+        .unwrap()
+    else {
+        panic!("expected a completed outcome");
+    };
+    assert!(message.contains("n/a"), "{message}");
+}
+
+/// The listed range spans the merge-base on a feature branch: base-side and
+/// branch-side commits are listed alike, and the ones carrying no data read `n/a`.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn examine_lists_the_range_across_a_merge_base() {
+    let workspace = Workspace::repo(&storage_only_config());
+    workspace.commit_dated("2024-01-01", "c1");
+    workspace.seed_callgrind("c1", 100.0);
+    workspace.commit_dated("2024-01-02", "c2");
+    workspace.checkout_new_branch("feature");
+    workspace.commit_dated("2024-01-03", "f1");
+    workspace.commit_dated("2024-01-04", "f2");
+    workspace.seed_callgrind("f2", 130.0);
+
+    let message = workspace
+        .drive_json(&[
+            "examine",
+            "--benchmark",
+            "nm/nm::observe/pull",
+            "--metric",
+            "instruction_count",
+        ])
+        .await;
+    let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let points = parsed["sets"][0]["points"].as_array().unwrap();
+    let titles: Vec<&str> = points
+        .iter()
+        .map(|point| point["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["c1", "c2", "f1", "f2"],
+        "the range runs from the earliest observation through the branch tip: {message}"
+    );
+    let values: Vec<Option<f64>> = points.iter().map(|point| point["value"].as_f64()).collect();
+    assert_eq!(
+        values,
+        vec![Some(100.0), None, None, Some(130.0)],
+        "{message}"
+    );
 }
 
 /// An unknown `--metric` is rejected up front, before any load, listing the valid

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -54,6 +54,10 @@ pub(crate) struct SelectedDataSet {
     /// each data point with what its commit changed. A commit absent here has an
     /// empty subject; only `examine` reads this.
     pub(crate) commit_subjects: HashMap<String, String>,
+    /// The analyzed commits in first-parent order, oldest first, indexed by
+    /// topological position. It lets `examine` name every commit in a range,
+    /// including the ones that carry no observation; only `examine` reads this.
+    pub(crate) ordered_commits: Vec<String>,
     /// The full commit ID of the analyzed tip commit (the resolved `--context`/HEAD),
     /// carried into the report so it names the exact commit the findings describe.
     pub(crate) tip_commit: String,
@@ -155,6 +159,7 @@ where
         tip_commit,
         tip_dirty,
         order,
+        ordered_commits,
         commit_times,
         commit_subjects,
         admit_dirty,
@@ -469,6 +474,7 @@ where
         target_ref,
         facets,
         commit_subjects,
+        ordered_commits,
         tip_commit,
         tip_index,
         tip_dirty,

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -6,18 +6,22 @@
 //! `AnalyzeOptions` and `ExamineOptions`) resolved via
 //! the shared [`select_dataset`](super::select_dataset) path, so a selection
 //! parameter added to `analyze` applies here unchanged. Where `list` counts the
-//! selected runs, `examine` names one `(benchmark, metric)` series and prints its
-//! points — one row per recorded observation, in git first-parent order, pairing
-//! the value with the short commit id and the start of the commit's title so a
-//! maintainer can correlate a value's move with the commit that caused it.
+//! selected runs, `examine` names one `(benchmark, metric)` series and lists every
+//! commit it spans, in git first-parent order, pairing each value with the short
+//! commit id and the start of the commit's title so a maintainer can correlate a
+//! value's move with the commit that caused it. A commit carrying no selected
+//! observation is listed as `n/a`, so the listing is a complete range of commits
+//! rather than a sparse set of measurements.
 //!
-//! It runs no detection, re-baselining, or blessing: it shows every selected point
-//! exactly as the chart would plot it (a commit's clean run and its dirty snapshots
-//! each contribute a flagged row, clean before dirty). The text and Markdown
-//! renderings lead each set with the same small line chart `analyze` draws (reusing
-//! its renderer). Like `analyze` it needs a resolvable repository — first-parent topology
-//! to order the points and each commit's title to label them — and repeats the pivot
-//! once per matching discriminant set.
+//! It runs no detection, re-baselining, or blessing: it shows every selected
+//! observation with the value and dirty flag exactly as recorded (a commit's clean
+//! run and its dirty snapshots each contribute a flagged row, clean before dirty).
+//! The text and Markdown
+//! renderings lead each set with the whole-series line chart history-mode `analyze`
+//! draws for a finding (reusing its renderer), which plots that set's real
+//! observations only. Like `analyze` it needs a resolvable repository — first-parent
+//! topology to order and name the commits and each commit's title to label them —
+//! and repeats the pivot once per matching discriminant set.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -28,6 +32,7 @@ use cbh_config::{
     Config, cache_env, load_config, resolve_cache_path, resolve_config_path, resolve_local_path,
     resolve_project_id, resolve_repo, storage_env,
 };
+use cbh_detect::SeriesPoint;
 use cbh_diag::{Reporter, ReporterExt, StderrReporter, count_noun};
 use cbh_git::{GitHistory, SystemGitHistory};
 use cbh_model::{BenchmarkIdPrefix, DiscriminantSet, MetricKind};
@@ -47,6 +52,10 @@ use crate::{AnalyzeError, RenderedReports, ReportRequest};
 /// keep. The truncation is a readability convenience of those renderings; the JSON
 /// form carries the full title.
 const TITLE_LIMIT: usize = 50;
+
+/// What the text and Markdown tables show in place of a value for a commit that
+/// carries no data point in this pivot.
+const NO_DATA: &str = "n/a";
 
 /// The real `examine`: load configuration, wire the configured storage and git
 /// history, and orchestrate.
@@ -165,7 +174,14 @@ where
         metric_kind,
         &dataset.series,
         &dataset.commit_subjects,
+        &dataset.ordered_commits,
         dataset.tip_index,
+    );
+    report_listed_range(
+        &pivot,
+        &dataset.ordered_commits,
+        dataset.run_index.total(),
+        reporter,
     );
 
     // When the pivot is empty, explain why: either no run entered the selection at
@@ -215,21 +231,28 @@ fn parse_metric(name: &str) -> Result<MetricKind, AnalyzeError> {
 
 /// One recorded observation of the examined series.
 #[derive(Clone, Debug)]
-struct DataPoint {
-    /// The commit the run was measured against (full commit ID, or a label in tests).
-    commit: String,
-    /// The short commit id shown in the text and Markdown tables.
-    short_commit: String,
+struct Observation {
     /// The measured value.
     value: f64,
     /// Whether the observation came from a dirty (uncommitted-tree) snapshot.
     dirty: bool,
+}
+
+/// One row of the pivot: a commit in the listed range, and the observation it
+/// carries — or none, when no selected run recorded this series against it.
+#[derive(Clone, Debug)]
+struct DataPoint {
+    /// The commit the row names (full commit ID, or a label in tests).
+    commit: String,
     /// The commit's full title (subject), empty when topology reported none.
     title: String,
-    /// First-parent topological index of the commit. Chart-only: it places each point
-    /// in its own per-commit column and materializes the data-less commits between
-    /// observations as gaps. The point table and JSON never read it.
+    /// First-parent topological index of the commit (oldest = 0). It places the
+    /// row's observation in its own per-commit chart column; the tables and JSON
+    /// never render it.
     topo_index: usize,
+    /// The measurement recorded here, or `None` for a commit with no data point in
+    /// this pivot — which the tables show as [`NO_DATA`].
+    observation: Option<Observation>,
 }
 
 /// One discriminant set's slice of the pivot.
@@ -237,7 +260,9 @@ struct DataPoint {
 struct SetPivot {
     /// The comparable partition these points share.
     set: DiscriminantSet,
-    /// The observations, oldest first by git topology (clean before dirty).
+    /// One row per commit in the pivot's range, oldest first by git topology. A
+    /// commit carrying several observations contributes one row each (clean before
+    /// dirty); a commit carrying none contributes a single data-less row.
     points: Vec<DataPoint>,
 }
 
@@ -254,6 +279,9 @@ struct Pivot {
     unit: &'static str,
     /// The per-set slices, one entry per discriminant set carrying the series.
     sets: Vec<SetPivot>,
+    /// The inclusive first-parent index range every set lists, for the verbose
+    /// note. `None` when no set carries the series.
+    range: Option<(usize, usize)>,
     /// Trailing-fill target for each set's chart: the analyzed tip's first-parent
     /// index, so a series that stops short of the tip renders the data-less commits
     /// after its last observation as a gap. Chart-only.
@@ -261,48 +289,42 @@ struct Pivot {
 }
 
 /// Narrows the reconstructed series to the one `(benchmark, metric)` pair, once per
-/// discriminant set, and turns each into its ordered data points.
+/// discriminant set, and lists every commit in the pivot's range against it.
 ///
-/// `tip_index` is the analyzed tip's first-parent index, carried onto the pivot as the
-/// chart's trailing-fill target so a series that stops short of the tip renders a
-/// trailing gap (see [`chart_of_points`]).
+/// `tip_index` is the analyzed tip's first-parent index: it both closes the listed
+/// range and serves as the chart's trailing-fill target, so a series that stops short
+/// of the tip renders a trailing gap in both (see [`chart_of_points`]).
+/// `ordered_commits` names the commit at each first-parent index, so a commit with no
+/// observation can still be listed.
 fn build_pivot(
     project_id: &str,
     benchmark: &str,
     metric_kind: MetricKind,
     series: &[Series],
     commit_subjects: &HashMap<String, String>,
+    ordered_commits: &[String],
     tip_index: usize,
 ) -> Pivot {
-    let mut sets: Vec<SetPivot> = series
+    let mut matching: Vec<&Series> = series
         .iter()
         .filter(|one| one.kind == metric_kind && one.id.qualified() == benchmark)
-        .map(|one| {
-            let points = one
-                .points
-                .iter()
-                .map(|point| {
-                    let commit = point.commit.as_deref().unwrap_or("unknown");
-                    let title = commit_subjects.get(commit).cloned().unwrap_or_default();
-                    DataPoint {
-                        short_commit: short_commit_id(commit).to_owned(),
-                        commit: commit.to_owned(),
-                        value: point.value,
-                        dirty: point.dirty,
-                        title,
-                        topo_index: point.topo_index,
-                    }
-                })
-                .collect();
-            SetPivot {
-                set: one.set.clone(),
-                points,
-            }
-        })
         .collect();
     // Sort the sets deterministically so the same data set always renders in the
     // same order regardless of series-build order.
-    sets.sort_by(|left, right| left.set.cmp(&right.set));
+    matching.sort_by(|left, right| left.set.cmp(&right.set));
+
+    let observations: Vec<&[SeriesPoint]> =
+        matching.iter().map(|one| one.points.as_slice()).collect();
+    let range = pivot_range(&observations, tip_index);
+    let sets = matching
+        .iter()
+        .map(|one| SetPivot {
+            set: one.set.clone(),
+            points: range.map_or_else(Vec::new, |range| {
+                points_in_range(&one.points, range, ordered_commits, commit_subjects)
+            }),
+        })
+        .collect();
 
     Pivot {
         project: project_id.to_owned(),
@@ -310,8 +332,130 @@ fn build_pivot(
         metric: metric_kind.as_str(),
         unit: metric_kind.as_unit(),
         sets,
+        range,
         base_ref: Some(tip_index),
     }
+}
+
+/// The inclusive first-parent index range every set lists: from the earliest
+/// observation of *any* matching set to the analyzed tip.
+///
+/// The start is a union across the sets rather than each set's own first
+/// observation, so every set lists exactly the same commits and their tables can be
+/// read side by side. `None` when no set carries an observation — there is then
+/// nothing to anchor a range to, and nothing to list.
+///
+/// The start is the minimum topological index rather than the leading point's, so
+/// the range covers every observation even if a set ever arrives unsorted.
+///
+/// The tip closes the range unconditionally: it is the last commit of the
+/// first-parent ancestry the topological indices were assigned from, so no
+/// observation can sit past it.
+fn pivot_range(observations: &[&[SeriesPoint]], tip_index: usize) -> Option<(usize, usize)> {
+    let start = observations
+        .iter()
+        .flat_map(|points| points.iter())
+        .map(|point| point.topo_index)
+        .min()?;
+    Some((start, tip_index))
+}
+
+/// Lists every commit in `range` against one set's `observations`, mirroring how the
+/// chart materializes a data-less commit as a gap.
+///
+/// A commit with observations contributes one row each, in the order the series
+/// already holds them (clean before dirty, then object ordinal); a commit with none
+/// contributes a single data-less row. `observations` is ordered by ascending
+/// topological index, so one forward cursor walks it alongside the range.
+fn points_in_range(
+    observations: &[SeriesPoint],
+    range: (usize, usize),
+    ordered_commits: &[String],
+    commit_subjects: &HashMap<String, String>,
+) -> Vec<DataPoint> {
+    let (start, end) = range;
+    // Every commit in the range contributes at least one row, and a commit with
+    // several observations contributes one each.
+    let mut points = Vec::with_capacity(
+        end.saturating_sub(start)
+            .saturating_add(1)
+            .saturating_add(observations.len()),
+    );
+    let mut cursor = observations
+        .iter()
+        .skip_while(|point| point.topo_index < start)
+        .peekable();
+    for topo_index in start..=end {
+        let commit = ordered_commits
+            .get(topo_index)
+            .expect("the range is bounded by the same first-parent ancestry it indexes");
+        let title = commit_subjects.get(commit).cloned().unwrap_or_default();
+        let mut listed = false;
+        while let Some(point) = cursor.next_if(|point| point.topo_index == topo_index) {
+            points.push(DataPoint {
+                commit: commit.clone(),
+                title: title.clone(),
+                topo_index,
+                observation: Some(Observation {
+                    value: point.value,
+                    dirty: point.dirty,
+                }),
+            });
+            listed = true;
+        }
+        if !listed {
+            points.push(DataPoint {
+                commit: commit.clone(),
+                title,
+                topo_index,
+                observation: None,
+            });
+        }
+    }
+    points
+}
+
+/// Explains, under `--verbose`, which commits the listing spans and why it opens
+/// and closes where it does — so a reader can tell an `n/a` row (a commit inside the
+/// range with no data) from a commit the range deliberately never reached.
+fn report_listed_range(
+    pivot: &Pivot,
+    ordered_commits: &[String],
+    entered: usize,
+    reporter: &dyn Reporter,
+) {
+    reporter.note_with(|| {
+        let Some((start, end)) = pivot.range else {
+            if entered == 0 {
+                return "commit listing spans no commits: no run entered the selection at all, \
+                        so there is no observation to anchor a range to"
+                    .to_owned();
+            }
+            return format!(
+                "commit listing spans no commits: {} entered the selection, but none recorded \
+                 benchmark {} with metric {}, so there is no observation to anchor a range to",
+                count_noun(entered, "run"),
+                pivot.benchmark,
+                pivot.metric
+            );
+        };
+        let name = |index: usize| {
+            ordered_commits
+                .get(index)
+                .map_or("<unknown>", |commit| short_commit_id(commit))
+        };
+        format!(
+            "commit listing spans {} from {} to {}: the range opens at the earliest observation \
+             across the {} carrying this series (first-parent index {start}) and closes at the \
+             analyzed tip (index {end}), so every set lists the same commits and their tables \
+             line up; a commit inside the range with no selected observation is listed as \
+             {NO_DATA} rather than omitted, and `--since` is what narrows the range",
+            count_noun(end.saturating_sub(start).saturating_add(1), "commit"),
+            name(start),
+            name(end),
+            count_noun(pivot.sets.len(), "discriminant set"),
+        )
+    });
 }
 
 /// The hint shown when runs entered the selection but none carried the examined
@@ -338,17 +482,50 @@ fn short_commit_id(commit_id: &str) -> &str {
     commit_id.get(..12).unwrap_or(commit_id)
 }
 
+/// The value cell of a row: the formatted measurement, or [`NO_DATA`] for a commit
+/// carrying no data point.
+fn cell_value(point: &DataPoint) -> String {
+    point.observation.as_ref().map_or_else(
+        || NO_DATA.to_owned(),
+        |observation| format_value(observation.value),
+    )
+}
+
+/// Whether a row's observation came from a dirty snapshot. A data-less row is not
+/// dirty: it has no run whose cleanliness could be described.
+fn is_dirty(point: &DataPoint) -> bool {
+    point
+        .observation
+        .as_ref()
+        .is_some_and(|observation| observation.dirty)
+}
+
 /// The line chart of a set's observations, drawn before its data points (the same
-/// chart `analyze` renders for a finding). Each observation sits in its own per-commit
-/// column, with the data-less commits between observations — and, when `base_ref`
-/// extends past the last observation, the trailing commits up to the analyzed tip —
-/// rendered as gaps. `None` when there are too few points to plot.
+/// chart history-mode `analyze` renders for a finding). Each observation sits in its
+/// own per-commit column, with the data-less commits between observations — and,
+/// when `base_ref` extends past the last observation, the trailing commits up to the
+/// analyzed tip — rendered as gaps. `None` when there are too few points to plot.
+///
+/// The chart plots the real observations only, so it trims its own leading gap: a
+/// set whose first observation is later than the listed range's start draws a chart
+/// that begins after its table does.
 fn chart_of_points(points: &[DataPoint], base_ref: Option<usize>) -> Option<String> {
-    let pairs: Vec<(usize, f64)> = points
-        .iter()
-        .map(|point| (point.topo_index, point.value))
-        .collect();
+    let pairs: Vec<(usize, f64)> = observed_pairs(points);
     chart_series(&pairs, base_ref)
+}
+
+/// The `(topological index, value)` pairs of the rows that carry an observation —
+/// the chart's input, which ignores the data-less rows the tables list.
+fn observed_pairs(points: &[DataPoint]) -> Vec<(usize, f64)> {
+    points
+        .iter()
+        .filter_map(|point| {
+            point
+                .observation
+                .as_ref()
+                .map(|observation| (point.topo_index, observation.value))
+        })
+        .collect()
 }
 
 /// Renders the pivot in the requested format, appending the diagnostic hint and
@@ -390,21 +567,17 @@ fn render_pivot_text(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
             let commit_width = set
                 .points
                 .iter()
-                .map(|point| point.short_commit.len())
+                .map(|point| short_commit_id(&point.commit).len())
                 .max()
                 .unwrap_or(0);
-            let values: Vec<String> = set
-                .points
-                .iter()
-                .map(|point| format_value(point.value))
-                .collect();
+            let values: Vec<String> = set.points.iter().map(cell_value).collect();
             let value_width = values.iter().map(String::len).max().unwrap_or(0);
             for (point, value) in set.points.iter().zip(&values) {
                 let title = truncate_title(&point.title);
-                let marker = if point.dirty { "  (dirty)" } else { "" };
+                let marker = if is_dirty(point) { "  (dirty)" } else { "" };
                 lines.push(format!(
                     "  {commit:<commit_width$}  {value:>value_width$}  {title}{marker}",
-                    commit = point.short_commit,
+                    commit = short_commit_id(&point.commit),
                 ));
             }
         }
@@ -438,11 +611,15 @@ fn render_pivot_markdown(pivot: &Pivot, hint: Option<&str>, warning: Option<&str
             lines.push("| Commit | Value | Kind | Title |".to_owned());
             lines.push("| --- | --- | --- | --- |".to_owned());
             for point in &set.points {
-                let kind = if point.dirty { "dirty" } else { "clean" };
+                let kind = match &point.observation {
+                    Some(observation) if observation.dirty => "dirty",
+                    Some(_) => "clean",
+                    None => NO_DATA,
+                };
                 lines.push(format!(
                     "| {} | {} | {} | {} |",
-                    point.short_commit,
-                    format_value(point.value),
+                    short_commit_id(&point.commit),
+                    cell_value(point),
                     kind,
                     escape_cell(&truncate_title(&point.title)),
                 ));
@@ -457,8 +634,12 @@ fn render_pivot_json(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
     #[derive(Serialize)]
     struct JsonPoint<'a> {
         commit: &'a str,
-        value: f64,
-        dirty: bool,
+        /// `null` for a commit that carries no data point in this pivot.
+        value: Option<f64>,
+        /// Absent for a commit that carries no data point: there is no run whose
+        /// cleanliness the flag could describe.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dirty: Option<bool>,
         title: &'a str,
     }
     #[derive(Serialize)]
@@ -493,8 +674,8 @@ fn render_pivot_json(pivot: &Pivot, hint: Option<&str>, warning: Option<&str>) -
                 .iter()
                 .map(|point| JsonPoint {
                     commit: &point.commit,
-                    value: point.value,
-                    dirty: point.dirty,
+                    value: point.observation.as_ref().map(|one| one.value),
+                    dirty: point.observation.as_ref().map(|one| one.dirty),
                     title: &point.title,
                 })
                 .collect(),
@@ -741,6 +922,29 @@ mod tests {
             .expect("the Markdown report was rendered for the requested path")
     }
 
+    /// Drives `examine_with` and returns the diagnostic notes the run emitted, for
+    /// the tests that assert on `--verbose` reasoning rather than on the report.
+    fn examine_notes(
+        storage: &MemoryStorage,
+        git: &FakeGitHistory,
+        options: &ExamineOptions,
+    ) -> Vec<String> {
+        let reporter = RecordingReporter::new();
+        block_on(examine_with(
+            git,
+            storage,
+            "folo",
+            &config(),
+            options,
+            &auto(),
+            Timestamp::from_second(0).unwrap(),
+            &reporter,
+            &spawner(),
+        ))
+        .unwrap();
+        reporter.notes()
+    }
+
     #[test]
     fn pivots_one_series_into_ordered_points() {
         let storage = MemoryStorage::new();
@@ -770,7 +974,7 @@ mod tests {
         let sets = parsed["sets"].as_array().unwrap();
         assert_eq!(sets.len(), 1);
         let points = sets[0]["points"].as_array().unwrap();
-        assert_eq!(points.len(), 3);
+        assert_eq!(points.len(), 4, "every commit c0..=c3 is listed: {report}");
         // Oldest first by topology.
         assert_eq!(points[0]["commit"], "c0");
         assert_eq!(points[0]["value"], 100.0);
@@ -778,6 +982,10 @@ mod tests {
         assert_eq!(points[0]["title"], "Add the pull benchmark");
         assert_eq!(points[2]["commit"], "c2");
         assert_eq!(points[2]["value"], 128.0);
+        // Data stops before the tip, which is listed without a value.
+        assert_eq!(points[3]["commit"], "c3");
+        assert!(points[3]["value"].is_null(), "{report}");
+        assert!(points[3].get("dirty").is_none(), "{report}");
     }
 
     #[test]
@@ -864,6 +1072,21 @@ mod tests {
 
         let text = examine(&storage, &git, &options());
         assert!(text.contains("(dirty)"), "the dirty row is flagged: {text}");
+        assert_eq!(
+            text.matches("(dirty)").count(),
+            1,
+            "only the dirty row is flagged, not the clean one: {text}"
+        );
+
+        let markdown = examine_markdown(&storage, &git, &options());
+        assert!(
+            markdown.contains("| c3 | 100 | clean |"),
+            "the clean run's kind: {markdown}"
+        );
+        assert!(
+            markdown.contains("| c3 | 118 | dirty |"),
+            "the dirty snapshot's kind: {markdown}"
+        );
     }
 
     #[test]
@@ -879,7 +1102,11 @@ mod tests {
         let report = examine_json(&storage, &git, &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let points = parsed["sets"][0]["points"].as_array().unwrap();
-        assert_eq!(points.len(), 1);
+        assert_eq!(
+            points.len(),
+            4,
+            "c0's observation plus the three data-less commits after it: {report}"
+        );
         // The instruction-count value, not the conditional-branches one.
         assert_eq!(points[0]["value"], 100.0);
 
@@ -1002,17 +1229,48 @@ mod tests {
         );
     }
 
-    /// A `DataPoint` at the given topology and value, with the other fields fixed —
-    /// enough to drive [`chart_of_points`] and [`cbh_render::topology_columns`].
+    /// A `DataPoint` carrying an observation at the given topology and value, with
+    /// the other fields fixed — enough to drive [`chart_of_points`] and
+    /// [`cbh_render::topology_columns`].
     fn data_point(topo: usize, value: f64) -> DataPoint {
         DataPoint {
             commit: format!("c{topo}"),
-            short_commit: format!("c{topo}"),
-            value,
-            dirty: false,
             title: String::new(),
             topo_index: topo,
+            observation: Some(Observation {
+                value,
+                dirty: false,
+            }),
         }
+    }
+
+    /// A `DataPoint` for a commit that carries no observation — the `n/a` row.
+    fn gap_point(topo: usize) -> DataPoint {
+        DataPoint {
+            commit: format!("c{topo}"),
+            title: String::new(),
+            topo_index: topo,
+            observation: None,
+        }
+    }
+
+    /// A series observation at the given topology, carrying the fields the pivot
+    /// reads and neutral values for the rest.
+    fn observation(topo: usize, value: f64) -> SeriesPoint {
+        SeriesPoint {
+            topo_index: topo,
+            dirty: false,
+            object_ordinal: 0,
+            commit: None,
+            value,
+            interval_low: None,
+            interval_high: None,
+        }
+    }
+
+    /// The ordered first-parent ancestry the pivot names its commits from.
+    fn ordered_commits(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| (*name).to_owned()).collect()
     }
 
     #[test]
@@ -1022,9 +1280,10 @@ mod tests {
         let gapped = [
             data_point(0, 100.0),
             data_point(1, 130.0),
+            gap_point(2),
             data_point(3, 128.0),
         ];
-        let pairs: Vec<(usize, f64)> = gapped.iter().map(|p| (p.topo_index, p.value)).collect();
+        let pairs = observed_pairs(&gapped);
         // The span (3) is below the chart width, so the column count is exact and
         // independent of the 48-wide cap: one column per commit c0..=c3.
         let columns = cbh_render::topology_columns(&pairs, Some(3), 48);
@@ -1064,8 +1323,9 @@ mod tests {
             data_point(0, 100.0),
             data_point(1, 130.0),
             data_point(2, 128.0),
+            gap_point(3),
         ];
-        let pairs: Vec<(usize, f64)> = points.iter().map(|p| (p.topo_index, p.value)).collect();
+        let pairs = observed_pairs(&points);
         let columns = cbh_render::topology_columns(&pairs, Some(3), 48);
         assert_eq!(columns.len(), 4, "the tip commit c3 gets its own column");
         assert_eq!(
@@ -1084,10 +1344,36 @@ mod tests {
     }
 
     #[test]
-    fn a_data_less_interior_commit_still_lists_only_real_observations() {
+    fn a_late_starting_sets_chart_still_trims_its_leading_gap() {
+        // A set whose table opens with `n/a` rows charts only from its own first
+        // observation: the table lists the shared commit range, while the chart shows
+        // the shape of that set's series. A deliberate divergence.
+        let points = [
+            gap_point(0),
+            gap_point(1),
+            data_point(2, 128.0),
+            data_point(3, 126.0),
+        ];
+        let pairs = observed_pairs(&points);
+        assert_eq!(
+            pairs,
+            [(2, 128.0), (3, 126.0)],
+            "the leading gaps never reach the chart"
+        );
+        let columns = cbh_render::topology_columns(&pairs, Some(3), 48);
+        assert_eq!(
+            columns.len(),
+            2,
+            "the chart opens at the set's first observation, not the range's start"
+        );
+        assert!(columns.iter().all(|value| value.is_finite()));
+    }
+
+    #[test]
+    fn lists_a_data_less_interior_commit_as_n_a() {
         // Store c0, c1, c3 — skipping the interior c2 — on the linear history whose
-        // tip is c3. The chart materializes c2 as a gap, but the point table and JSON
-        // list only the three real observations.
+        // tip is c3. The chart materializes c2 as a gap, and so does the listing: c2
+        // gets a row of its own, without a value but still naming its commit.
         let storage = MemoryStorage::new();
         store(
             &storage,
@@ -1109,12 +1395,23 @@ mod tests {
         let report = examine_json(&storage, &git, &options());
         let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
         let points = parsed["sets"][0]["points"].as_array().unwrap();
-        assert_eq!(points.len(), 3, "only the real observations: {report}");
+        assert_eq!(points.len(), 4, "every commit c0..=c3 is listed: {report}");
         let commits: Vec<&str> = points
             .iter()
             .map(|point| point["commit"].as_str().unwrap())
             .collect();
-        assert_eq!(commits, ["c0", "c1", "c3"], "no phantom c2 row: {report}");
+        assert_eq!(commits, ["c0", "c1", "c2", "c3"], "{report}");
+        // The gap entry carries no value and no cleanliness flag...
+        assert!(points[2]["value"].is_null(), "{report}");
+        assert!(points[2].get("dirty").is_none(), "{report}");
+        // ...but still names what its commit changed.
+        assert_eq!(
+            points[2]["title"], "Refactor the observer to shave allocations off the record path",
+            "{report}"
+        );
+        // An observation entry carries both, and neither shape leaks the topology.
+        assert_eq!(points[0]["value"], 100.0, "{report}");
+        assert_eq!(points[0]["dirty"], false, "{report}");
         assert!(
             points[0].get("topo_index").is_none(),
             "the JSON point carries no topology index: {report}"
@@ -1125,10 +1422,374 @@ mod tests {
             text.contains('┤') || text.contains('┼'),
             "the chart is drawn across the gap: {text}"
         );
-        assert!(text.contains("c3"), "the c3 row is present: {text}");
         assert!(
-            !text.contains("| c2 |") && !text.contains("  c2  "),
-            "the data-less c2 never becomes a row: {text}"
+            text.contains(NO_DATA),
+            "the data-less c2 reads {NO_DATA}: {text}"
+        );
+        assert!(
+            text.contains("Refactor the observer to shave allocations off the"),
+            "the data-less row still carries its commit title: {text}"
+        );
+    }
+
+    #[test]
+    fn lists_the_trailing_commits_up_to_the_tip_as_n_a() {
+        // Data stops at c1 while the analyzed tip is c3: the listing runs to the tip,
+        // so c2 and c3 are both listed without a value.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        let git = linear_git();
+
+        let report = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(points.len(), 4, "the listing runs to the tip: {report}");
+        assert_eq!(points[1]["value"], 130.0, "{report}");
+        assert!(points[2]["value"].is_null(), "{report}");
+        assert!(points[3]["value"].is_null(), "{report}");
+    }
+
+    #[test]
+    fn the_listing_opens_at_the_earliest_observation_of_any_set() {
+        // Callgrind first records at c0, Criterion only at c2. The range is the union
+        // of the two, so both sets list c0..=c3 and Criterion's earlier commits read
+        // `n/a` — keeping the two tables aligned row for row.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            "v1/folo/objects/criterion/x86_64-unknown-linux-gnu/m1/c2/clean.json",
+            &single_metric_run(2, "c2", 200.0),
+        );
+        let git = linear_git();
+
+        let opts = ExamineOptions {
+            engine: vec!["all".to_owned()],
+            ..options()
+        };
+        let report = examine_json(&storage, &git, &opts);
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let sets = parsed["sets"].as_array().unwrap();
+        assert_eq!(sets.len(), 2, "{report}");
+        for set in sets {
+            let commits: Vec<&str> = set["points"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|point| point["commit"].as_str().unwrap())
+                .collect();
+            assert_eq!(
+                commits,
+                ["c0", "c1", "c2", "c3"],
+                "every set lists the same commits: {report}"
+            );
+        }
+        let criterion = sets
+            .iter()
+            .find(|set| set["engine"] == "criterion")
+            .expect("the criterion set is present");
+        let points = criterion["points"].as_array().unwrap();
+        assert!(
+            points[0]["value"].is_null() && points[1]["value"].is_null(),
+            "criterion's listing opens before its own first observation: {report}"
+        );
+        assert_eq!(points[2]["value"], 200.0, "{report}");
+    }
+
+    #[test]
+    fn no_dirty_leaves_the_commit_as_an_n_a_row() {
+        // c0 has a clean run and the tip c3 only a dirty snapshot, admitted by the
+        // base-tip dirty exception. `--no-dirty` drops that snapshot, and the tip
+        // becomes an `n/a` row rather than vanishing from the listing.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        store(
+            &storage,
+            &dirty_key("c3", 400),
+            &single_metric_run(4, "c3", 118.0),
+        );
+        let mut git = linear_git();
+        git.mark_dirty();
+
+        let admitted = examine_json(&storage, &git, &options());
+        let parsed: serde_json::Value = serde_json::from_str(&admitted).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(
+            points[3]["value"], 118.0,
+            "the snapshot is listed: {admitted}"
+        );
+        assert_eq!(points[3]["dirty"], true, "{admitted}");
+
+        let opts = ExamineOptions {
+            no_dirty: true,
+            ..options()
+        };
+        let report = examine_json(&storage, &git, &opts);
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        let points = parsed["sets"][0]["points"].as_array().unwrap();
+        assert_eq!(points.len(), 4, "the tip is still listed: {report}");
+        assert_eq!(points[3]["commit"], "c3", "{report}");
+        assert!(
+            points[3]["value"].is_null(),
+            "its only run was excluded: {report}"
+        );
+    }
+
+    #[test]
+    fn markdown_renders_a_data_less_commit_as_n_a() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = linear_git();
+
+        let report = examine_markdown(&storage, &git, &options());
+        assert!(report.contains("| c0 | 100 | clean |"), "{report}");
+        assert!(report.contains("| c1 | n/a | n/a |"), "{report}");
+    }
+
+    #[test]
+    fn the_text_value_column_stays_aligned_with_an_n_a_row() {
+        // The `n/a` cell takes part in the value-column width, so the values still
+        // read straight down.
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 123_456.0),
+        );
+        let git = linear_git();
+
+        let report = examine(&storage, &git, &options());
+        let value = format_value(123_456.0);
+        let cell_end = |needle: &str| {
+            let line = report
+                .lines()
+                .find(|line| line.contains(needle))
+                .unwrap_or_else(|| panic!("the {needle} row is present: {report}"));
+            line.find(needle)
+                .expect("the needle was just located on this line")
+                + needle.len()
+        };
+        assert_eq!(
+            cell_end(&value),
+            cell_end(NO_DATA),
+            "both value cells end in the same column: {report}"
+        );
+    }
+
+    #[test]
+    fn pivot_range_is_none_when_no_set_carries_an_observation() {
+        let empty: [&[SeriesPoint]; 0] = [];
+        assert_eq!(pivot_range(&empty, 3), None);
+        let no_points: [&[SeriesPoint]; 1] = [&[]];
+        assert_eq!(pivot_range(&no_points, 3), None);
+    }
+
+    #[test]
+    fn pivot_range_opens_at_the_first_observation_and_closes_at_the_tip() {
+        let points = [observation(1, 100.0), observation(2, 130.0)];
+        let sets: [&[SeriesPoint]; 1] = [&points];
+        assert_eq!(pivot_range(&sets, 5), Some((1, 5)));
+    }
+
+    #[test]
+    fn pivot_range_unions_the_earliest_observation_across_sets() {
+        // Whichever order the sets arrive in, the range opens at the earliest
+        // observation of any of them.
+        let early = [observation(1, 100.0)];
+        let late = [observation(4, 200.0)];
+        let forwards: [&[SeriesPoint]; 2] = [&early, &late];
+        let backwards: [&[SeriesPoint]; 2] = [&late, &early];
+        assert_eq!(pivot_range(&forwards, 5), Some((1, 5)));
+        assert_eq!(pivot_range(&backwards, 5), Some((1, 5)));
+    }
+
+    #[test]
+    fn pivot_range_of_a_tip_only_set_is_the_tip_alone() {
+        let points = [observation(3, 100.0)];
+        let sets: [&[SeriesPoint]; 1] = [&points];
+        assert_eq!(pivot_range(&sets, 3), Some((3, 3)));
+    }
+
+    #[test]
+    fn points_in_range_lists_every_commit_and_every_observation() {
+        // c0 carries a clean run and a dirty snapshot, c2 a clean run, and c1 and c3
+        // nothing: five rows across four commits.
+        let observations = [
+            observation(0, 100.0),
+            SeriesPoint {
+                dirty: true,
+                ..observation(0, 110.0)
+            },
+            observation(2, 130.0),
+        ];
+        let commits = ordered_commits(&["c0", "c1", "c2", "c3"]);
+        let mut subjects = HashMap::new();
+        subjects.insert("c1".to_owned(), "Optimize the hot loop".to_owned());
+
+        let points = points_in_range(&observations, (0, 3), &commits, &subjects);
+        let listed: Vec<(&str, Option<f64>)> = points
+            .iter()
+            .map(|point| {
+                (
+                    point.commit.as_str(),
+                    point.observation.as_ref().map(|one| one.value),
+                )
+            })
+            .collect();
+        assert_eq!(
+            listed,
+            [
+                ("c0", Some(100.0)),
+                ("c0", Some(110.0)),
+                ("c1", None),
+                ("c2", Some(130.0)),
+                ("c3", None),
+            ]
+        );
+        assert!(is_dirty(&points[1]), "the snapshot keeps its dirty flag");
+        assert_eq!(
+            points[2].title, "Optimize the hot loop",
+            "a data-less row still carries its commit title"
+        );
+        assert!(
+            points[4].title.is_empty(),
+            "a commit whose subject topology did not report lists an empty title"
+        );
+    }
+
+    #[test]
+    fn points_in_range_lists_only_the_commits_inside_the_range() {
+        // Observations outside the range are not listed, and the range's own bounds
+        // decide which commits appear.
+        let observations = [
+            observation(0, 100.0),
+            observation(1, 130.0),
+            observation(3, 128.0),
+        ];
+        let commits = ordered_commits(&["c0", "c1", "c2", "c3"]);
+        let points = points_in_range(&observations, (1, 2), &commits, &HashMap::new());
+        let listed: Vec<(&str, Option<f64>)> = points
+            .iter()
+            .map(|point| {
+                (
+                    point.commit.as_str(),
+                    point.observation.as_ref().map(|one| one.value),
+                )
+            })
+            .collect();
+        assert_eq!(listed, [("c1", Some(130.0)), ("c2", None)]);
+    }
+
+    #[test]
+    fn the_verbose_note_explains_the_listed_range() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c1"),
+            &single_metric_run(1, "c1", 130.0),
+        );
+        let git = linear_git();
+
+        let notes = examine_notes(&storage, &git, &options());
+        let note = notes
+            .iter()
+            .find(|note| note.starts_with("commit listing spans"))
+            .unwrap_or_else(|| panic!("the range note is emitted: {notes:?}"));
+        assert!(note.contains("3 commits"), "the commit count: {note}");
+        assert!(note.contains("from c1 to c3"), "both endpoints: {note}");
+        assert!(
+            note.contains("earliest observation"),
+            "why the range opens there: {note}"
+        );
+        assert!(
+            note.contains("analyzed tip"),
+            "why the range closes there: {note}"
+        );
+        assert!(
+            note.contains("1 discriminant set"),
+            "how many sets the union spans: {note}"
+        );
+        assert!(
+            note.contains(NO_DATA),
+            "what a data-less commit reads as: {note}"
+        );
+        assert!(
+            note.contains("`--since`"),
+            "which lever narrows the range: {note}"
+        );
+    }
+
+    #[test]
+    fn the_verbose_note_explains_an_unmatched_series() {
+        let storage = MemoryStorage::new();
+        store(
+            &storage,
+            &clean_key("c0"),
+            &single_metric_run(0, "c0", 100.0),
+        );
+        let git = linear_git();
+
+        let opts = ExamineOptions {
+            benchmark: "nm/nm::observe/nonexistent".to_owned(),
+            ..options()
+        };
+        let notes = examine_notes(&storage, &git, &opts);
+        let note = notes
+            .iter()
+            .find(|note| note.starts_with("commit listing spans"))
+            .unwrap_or_else(|| panic!("the range note is emitted: {notes:?}"));
+        assert!(note.contains("no commits"), "nothing is listed: {note}");
+        assert!(
+            note.contains("1 run entered the selection"),
+            "runs did enter the selection: {note}"
+        );
+        assert!(
+            note.contains("nonexistent"),
+            "which series found no observation: {note}"
+        );
+    }
+
+    #[test]
+    fn the_verbose_note_explains_an_empty_selection() {
+        // Nothing was ever recorded, so the range is anchorless for a different
+        // reason than an unmatched series: no run entered the selection at all.
+        let storage = MemoryStorage::new();
+        let git = linear_git();
+
+        let notes = examine_notes(&storage, &git, &options());
+        let note = notes
+            .iter()
+            .find(|note| note.starts_with("commit listing spans"))
+            .unwrap_or_else(|| panic!("the range note is emitted: {notes:?}"));
+        assert!(note.contains("no commits"), "nothing is listed: {note}");
+        assert!(
+            note.contains("no run entered the selection"),
+            "the selection itself is empty: {note}"
+        );
+        assert!(
+            !note.contains("but none recorded"),
+            "an empty selection is not an unmatched series: {note}"
         );
     }
 

--- a/packages/cbh_analyze/src/examine.rs
+++ b/packages/cbh_analyze/src/examine.rs
@@ -261,8 +261,9 @@ struct SetPivot {
     /// The comparable partition these points share.
     set: DiscriminantSet,
     /// One row per commit in the pivot's range, oldest first by git topology. A
-    /// commit carrying several observations contributes one row each (clean before
-    /// dirty); a commit carrying none contributes a single data-less row.
+    /// commit carrying several observations contributes one row per observation
+    /// (clean before dirty); a commit carrying none contributes a single data-less
+    /// row.
     points: Vec<DataPoint>,
 }
 
@@ -363,7 +364,8 @@ fn pivot_range(observations: &[&[SeriesPoint]], tip_index: usize) -> Option<(usi
 /// Lists every commit in `range` against one set's `observations`, mirroring how the
 /// chart materializes a data-less commit as a gap.
 ///
-/// A commit with observations contributes one row each, in the order the series
+/// A commit with observations contributes one row per observation, in the order the
+/// series
 /// already holds them (clean before dirty, then object ordinal); a commit with none
 /// contributes a single data-less row. `observations` is ordered by ascending
 /// topological index, so one forward cursor walks it alongside the range.

--- a/packages/cbh_analyze/src/history.rs
+++ b/packages/cbh_analyze/src/history.rs
@@ -51,6 +51,11 @@ pub(crate) struct ResolvedHistory {
     /// First-parent position of each selected commit, for series ordering. An
     /// object whose commit is absent is outside the analyzed history.
     pub(crate) order: HashMap<String, usize>,
+    /// The selected commits in first-parent order, oldest first — the reverse of
+    /// [`order`](Self::order), so `ordered_commits[order[c]] == c`. It lets a
+    /// consumer name the commit at a topological index, including one that carries
+    /// no data; only `examine` reads it.
+    pub(crate) ordered_commits: Vec<String>,
     /// Committer timestamp of each first-parent commit, for deciding the
     /// `--since` cutoff from topology before any object is fetched. A
     /// commit absent here has an unknown time and is treated as in-window.
@@ -258,6 +263,7 @@ where
         tip_commit: target_commit_id,
         tip_dirty: working_tree_dirty,
         order,
+        ordered_commits: ancestry,
         commit_times,
         commit_subjects,
         admit_dirty,

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -685,10 +685,12 @@ impl ListCommand {
 /// Show the raw per-commit data points of one `(benchmark, metric)` series.
 ///
 /// A drill-down sibling of `list runs`: it resolves exactly the data set a matching
-/// `analyze`/`list` would, then pivots one named series into its data points — one
-/// row per recorded observation, in git first-parent order, pairing the value with
-/// the short commit id and the start of the commit's title. Both `--benchmark` and
-/// `--metric` are required.
+/// `analyze`/`list` would, then pivots one named series into a per-commit listing —
+/// every commit from the earliest one carrying the series in any matching set up to
+/// the analyzed tip, in git first-parent order, pairing the value with the short
+/// commit id and the start of the commit's title. A commit with several observations
+/// gets a row each, clean before dirty; a commit with no data point reads `n/a`. Both
+/// `--benchmark` and `--metric` are required.
 #[derive(Args, Debug)]
 struct ExamineCommand {
     #[command(flatten)]

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -689,8 +689,8 @@ impl ListCommand {
 /// every commit from the earliest one carrying the series in any matching set up to
 /// the analyzed tip, in git first-parent order, pairing the value with the short
 /// commit id and the start of the commit's title. A commit with several observations
-/// gets a row each, clean before dirty; a commit with no data point reads `n/a`. Both
-/// `--benchmark` and `--metric` are required.
+/// contributes one row per observation, clean before dirty; a commit with no data
+/// point reads `n/a`. Both `--benchmark` and `--metric` are required.
 #[derive(Args, Debug)]
 struct ExamineCommand {
     #[command(flatten)]


### PR DESCRIPTION
[Copilot speaking]

`examine` listed only the commits that recorded an observation, so a data-less commit existed in the leading chart (as a gap) but vanished from the table beneath it. The two now agree on which commits exist.

## What changed

The listing spans **every first-parent commit** from the earliest observation of any matching discriminant set through the analyzed tip. A commit carrying no selected observation is listed as `n/a` — a `null` value in JSON, with no cleanliness flag — while still naming its commit and title.

The range opens at a **union across the sets** rather than each set's own first observation, so two sets list the same commits in the same order and their tables can be read side by side.

`--verbose` explains where the range opens and closes, why, and points at `--since` as the lever that narrows it.

## What did not change

The chart. It still plots that set's real observations and trims its own leading gap, so a late-starting set draws a chart that begins after its table does. That asymmetry is deliberate: the table is the complete commit listing, the chart is the shape of the series.

No selection parameter changed, so the `analyze`/`list`/`prune`/`examine` lockstep rule is not engaged.

## Implementation

`ResolvedHistory` now carries the first-parent ancestry it already built (`ordered_commits`) instead of dropping it, threaded through `SelectedDataSet` to `examine`. `pivot_range` computes the union range; `points_in_range` walks it with a single forward cursor over the already-sorted observations, so the cost is O(range + observations).

## Validation

`just validate-local` clean on Windows and under WSL: zero warnings, 520 mutants tested with 0 missed, 34 `examine` unit tests and 18 integration tests passing.