### PR TITLE
docs: clarify design and implementation ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,15 +31,15 @@ directly:
 * **Check for a package-local `AGENTS.md`** before doing nontrivial work in a
   specific crate (e.g. `packages/events_once/AGENTS.md`). Package-local
   guidance refines and sometimes overrides the workspace-wide rules.
-* **`AGENTS.md` files are agent instructions, not design docs.** A package-local
-  `AGENTS.md` holds only actionable guidance for working in that package —
-  conventions to follow, gotchas, invariants to preserve, how to run and test.
-  It must **not** duplicate design documentation (that lives in the
-  `docs/design.md`-style files), restate implementation detail, or keep a
-  decision/change history. If a fact explains *what* the code is or *why* it is
-  shaped that way, it belongs in a design doc; if it is trivia that does not
-  change how an agent works, leave it out. Point at the design doc instead of
-  repeating it.
+* **`AGENTS.md` files are agent instructions, not design or implementation
+  docs.** A package-local `AGENTS.md` holds only actionable guidance for working
+  in that package — conventions to follow, gotchas, invariants to preserve, how
+  to run and test. It must **not** duplicate design or implementation
+  documentation or keep a decision/change history. User-visible behavior and its
+  tenets belong in the owning package's `docs/design.md`; internal architecture,
+  ownership boundaries, and implementation tenets belong in the package's
+  `docs/implementation.md`. If a fact is trivia that does not change how an agent
+  works, leave it out. Point at the appropriate document instead of repeating it.
 
 ## Chapters
 
@@ -77,14 +77,23 @@ builder method, or variable.
 
 ### [docs/design.md](docs/design.md)
 
-Where design documentation lives (inline `//` comments, package-level
-`docs/design.md`, per-component files), what it should contain (high-level
-patterns, tenets, and relationships — *what* and *why*, never *how*), and what to
-keep out of it (implementation detail, listings/catalogues, changelogs, decision
-logs).
+Which packages own design documentation, where it lives (package-level
+`docs/design.md` and optional component files), what it should contain
+(user-visible behavior and design tenets), and what to keep out of it
+(implementation detail, listings/catalogues, changelogs, decision logs).
 
-**Open this when**: writing or maintaining design documentation, and keeping it up
-to date with every commit.
+**Open this when**: writing or maintaining design documentation; changing
+user-visible behavior or its design tenets.
+
+### [docs/implementation.md](docs/implementation.md)
+
+The implementation-guide requirement for every package, including private
+implementation crates; how owning packages link their component guides into one
+architecture; and what belongs in implementation documentation rather than
+behavioral design documentation.
+
+**Open this when**: writing or maintaining implementation documentation; changing
+internal architecture, package ownership boundaries, or implementation tenets.
 
 ### [docs/file-organization.md](docs/file-organization.md)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,31 +1,36 @@
 # Design documentation
 
-How design intent is captured across the workspace: where it lives, what it should
-contain, and how to keep it current.
+How user-visible behavior and its design tenets are captured across the workspace:
+which package owns them, where they live, and how to keep them current.
 
 ## Where design documentation lives
 
-* Record design elements, key decisions, and architectural choices as inline `//`
-  comments (not `///` API-documentation comments) in the files to which they apply.
-* Give each package a package-level `package-name/docs/design.md`. All major
-  refactoring or redesign work must be accompanied by design documentation, kept up
-  to date as the design changes.
-* When a package has multiple significant sub-components, give each its own
-  `package-name/docs/componentN.md`, referenced from that package's `design.md`.
+* Give each package that owns an independent user-visible behavior contract a
+  package-level `docs/design.md`. This includes applications and independently
+  consumable libraries.
+* A private implementation crate that only implements an owning application and has
+  no independent behavior contract does not need a separate design document. Its
+  behavioral design belongs in the owning application's design document. Behavioral
+  component documents, when useful, live under the owning application's `docs/` and
+  are linked from its `design.md`.
+* When an owning package has multiple significant behavioral components, give each
+  its own document under `docs/`, referenced from that package's `design.md`.
+* Keep the owning design documentation current whenever user-visible behavior or its
+  design tenets change.
 
 ## What a design document contains
 
-Keep it a design document, not an implementation record: describe patterns, tenets,
-and relationships — *what* exists and *why*, never *how* it is coded.
+Keep it a behavioral design document, not an implementation record: describe the
+user-visible behavior, its design tenets, and the relationships between behavioral
+concepts — *what* users can rely on and *why*.
 
-* Stay high-level. Do not name private types, methods, fields, or flags, and do not
-  transcribe control flow, data structures, or wire-protocol mechanics. Illustrate
-  with examples rather than catalogues or listings of types and functions.
-* Spell out implementation detail only for a genuinely exceptional corner case that
-  cannot be understood otherwise. When in doubt, cut detail — the code and its tests
-  are the record of *how*.
+* Keep internal architecture, ownership boundaries, and non-user-visible tenets in
+  the package's [implementation guide](implementation.md).
+* Do not name private types, methods, fields, or flags, and do not transcribe control
+  flow or data structures. Illustrate behavior with examples rather than catalogues
+  or listings of types and functions.
 * Describe the desired end state as the final achieved state. Do not write
-  "in progress" language, changelogs, or historical notes. Open questions are fine.
+  "in progress" language, changelogs, or historical notes.
 * Do not maintain a running or numbered decision log. Recording the alternatives
   that were considered and why they were not chosen is fine when it explains the
   design; a chronological ledger of changes is not.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,0 +1,36 @@
+# Implementation documentation
+
+How internal architecture is captured across the workspace: where implementation
+guides live, how package boundaries are connected, and what they should contain.
+
+## Where implementation documentation lives
+
+* Give every package a package-level `docs/implementation.md`, including
+  applications, independently consumable libraries, and private implementation
+  crates.
+* When an application is implemented by private crates, its implementation guide
+  links the package guides and explains how their ownership boundaries form one
+  coherent application architecture.
+* When a package has multiple significant implementation components, give each its
+  own document under `docs/`, referenced from that package's `implementation.md`.
+* Keep implementation documentation current whenever internal architecture,
+  ownership boundaries, or implementation tenets change.
+
+## What an implementation guide contains
+
+Describe internal architecture, ownership boundaries, and non-user-visible
+implementation tenets — the structure that keeps the package coherent and why that
+structure exists.
+
+* Keep user-visible behavior and its design tenets in the owning package's
+  [design document](design.md). A private implementation crate with no independent
+  behavior contract refers to its owning package's design documentation instead of
+  restating that behavior.
+* Stay high-level. Do not catalogue private types, methods, fields, or flags, and do
+  not transcribe control flow or data structures. Use links to component guides when
+  an area needs more detail.
+* Describe the desired end state as the final achieved state. Do not write
+  "in progress" language, changelogs, or historical notes.
+* Do not maintain a running or numbered decision log. Recording alternatives and
+  their trade-offs is useful when it explains the architecture; a chronological
+  ledger of changes is not.


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Audit feedback from PR #425 exposed ambiguity in the workspace documentation rules: requiring a design document from every package misstates ownership for private implementation crates, while implementation-guide ownership was not discoverable from the repository instructions.

## Result

Packages with independent user-visible behavior contracts now own behavioral design documentation. Private implementation crates place behavioral design with their owning application instead of creating independent design contracts. Every package owns implementation documentation for its internal architecture and boundaries, and owning applications connect private package guides into one coherent architecture. Both document types describe the target state and keep behavioral design separate from internal implementation.
