### PR TITLE
ci: tolerate a coverage scope with no coverage data

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -107,11 +107,14 @@ rendering toolchain.
 
 Coverage is a side effect of the ordinary test run, not a separate re-execution. A single
 commit therefore produces several coverage uploads — one per platform, plus a conditional
-upload from the Azure-backend job. Codecov is configured to hold all notifications until a
-final gate job signals that every expected upload for the commit has landed, so the reported
-figure is computed from the complete set rather than flapping as partial uploads arrive. The
-gate keys off "every expected upload succeeded or was legitimately skipped", never off a
-hardcoded upload count, because the Azure upload is conditional.
+upload from the Azure-backend job. A platform upload is itself conditional on a report
+existing: a delta-scoped run can measure only packages that carry no instrumented code, which
+yields nothing to report, nothing to upload and nothing to notify about. Codecov is configured
+to hold all notifications until a final gate job signals that every expected upload for the
+commit has landed, so the reported figure is computed from the complete set rather than
+flapping as partial uploads arrive. The gate keys off "every expected upload succeeded or was
+legitimately skipped", never off a hardcoded upload count, because the Azure upload is
+conditional; when no coverage landed at all, it releases nothing.
 
 ## Azure backend testing
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -187,6 +187,14 @@ jobs:
   test-x64:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
+    # Whether a coverage report was produced at all. A delta-scoped run can measure only packages
+    # that carry no instrumented code, which leaves nothing to upload and nothing for the coverage
+    # notification gate to release. The matrix legs measure the same scope and write this output in
+    # completion order, so the last one to finish decides. Were platform-gated code ever to make
+    # them disagree, the worst case is a commit whose coverage status goes unreleased - never one
+    # released off an incomplete set of uploads.
+    outputs:
+      coverage_report: ${{ steps.coverage.outputs.report }}
     strategy:
       fail-fast: false
       matrix:
@@ -202,11 +210,21 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Run tests with coverage on ${{ matrix.platform }}
+        id: coverage
+        shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
           just package="${{ needs.delta.outputs.packages }}" coverage-measure
           just coverage-report-ci
 
+          $report = if (Test-Path lcov.info) { 'true' } else { 'false' }
+          "report=$report" | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
       - name: Upload coverage to Codecov
+        if: steps.coverage.outputs.report == 'true'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -867,7 +885,8 @@ jobs:
   # ran and failed, an expected upload is missing and the build is already red - so we do
   # NOT release a status off an incomplete set, which would post the very "coverage
   # decreased" result this gate exists to prevent. A `skip_all` run uploads no coverage at
-  # all, so `test-x64` is skipped and this job does not run.
+  # all, so `test-x64` is skipped and this job does not run - and so does a run whose scope
+  # holds no instrumented code, where `test-x64` succeeds but produces no report to upload.
   #
   # Like the upload jobs, this runs for fork PRs too: the token is empty there and the
   # action falls back to tokenless notification (this is a public repository), so
@@ -877,6 +896,7 @@ jobs:
     if: >-
       !cancelled()
       && needs.test-x64.result == 'success'
+      && needs.test-x64.outputs.coverage_report == 'true'
       && (needs.test-azurite.result == 'success' || needs.test-azurite.result == 'skipped')
     runs-on: ubuntu-latest
 

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -39,9 +39,20 @@ coverage-package := if package == "" { "" } else { "-p " + replace(package, " ",
 coverage-report:
     cargo +{{ env_var('RUST_NIGHTLY') }} llvm-cov report {{ coverage-package }} --open
 
+# Writes the lcov report the CI coverage upload consumes. A measured scope that contains no
+# instrumented code at all yields no report file instead of an error - see
+# scripts/build/Coverage.psm1 (Pester-tested via `just test-scripts`), which owns that decision,
+# leaving this recipe a thin import + call.
 [group('quality')]
+[script]
 coverage-report-ci:
-    cargo +{{ env_var('RUST_NIGHTLY') }} llvm-cov report --lcov --output-path lcov.info
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module "{{ justfile_directory() }}/scripts/build/Coverage.psm1" -Force
+
+    Export-CoverageReport -Toolchain "{{ env_var('RUST_NIGHTLY') }}" -OutputPath "lcov.info" | Out-Null
 
 [group('quality')]
 [no-cd]

--- a/scripts/build/Coverage.Tests.ps1
+++ b/scripts/build/Coverage.Tests.ps1
@@ -1,0 +1,74 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for Coverage.psm1. Test-CoverageDataMissing carries the decision that keeps a
+# delta-scoped CI run green when it measures a package with no instrumented code, while still
+# failing on a real reporting error - including one whose output also mentions an object without
+# coverage mappings - so it is exercised directly here. Export-CoverageReport drives real cargo,
+# so it is covered by the recipe running in CI rather than unit-tested here.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'Coverage.psm1') -Force
+}
+
+Describe 'Test-CoverageDataMissing' {
+    It 'recognizes the llvm-cov complaint about an object without coverage mappings' {
+        # The blank line mirrors the real output, where the captured stream mixes stdout and
+        # stderr - an empty element must not trip parameter binding.
+        $output = @(
+            "error: failed to generate report: process didn't exit successfully",
+            '',
+            "error: failed to load coverage: 'target/llvm-cov-target/debug/deps/x-1.exe': no coverage data found",
+            'error: could not load coverage information'
+        )
+        Test-CoverageDataMissing -Output $output | Should -BeTrue
+    }
+
+    It 'does not recognize an unrelated reporting failure' {
+        $output = @(
+            'error: failed to generate report: process exited with code 1',
+            'error: invalid instrumentation profile data (file header is corrupt)'
+        )
+        Test-CoverageDataMissing -Output $output | Should -BeFalse
+    }
+
+    It 'does not recognize a failure that also names an object without coverage mappings' {
+        $output = @(
+            "error: failed to generate report: process didn't exit successfully",
+            '',
+            "error: failed to load coverage: 'target/llvm-cov-target/debug/deps/x-1.exe': no coverage data found",
+            "error: failed to load coverage: 'target/llvm-cov-target/y.profdata': invalid instrumentation profile data",
+            'error: could not load coverage information'
+        )
+        Test-CoverageDataMissing -Output $output | Should -BeFalse
+    }
+
+    It 'inspects every line of a single multi-line record' {
+        # cargo reports a failed llvm-cov invocation as one record quoting the command it ran and
+        # the whole captured stderr, so the classification cannot assume one line per element.
+        $output = @(
+            @(
+                "error: failed to generate report: process didn't exit successfully: ``llvm-cov export`` (exit code: 1)",
+                '--- stderr',
+                "error: failed to load coverage: 'deps/x-1.exe': no coverage data found",
+                'error: could not load coverage information'
+            ) -join "`n"
+        )
+        Test-CoverageDataMissing -Output $output | Should -BeTrue
+    }
+
+    It 'does not recognize a mixed failure delivered as a single multi-line record' {
+        $output = @(
+            @(
+                "error: failed to generate report: process didn't exit successfully: ``llvm-cov export`` (exit code: 1)",
+                '--- stderr',
+                "error: failed to load coverage: 'deps/x-1.exe': no coverage data found",
+                'error: invalid instrumentation profile data (file header is corrupt)'
+            ) -join "`n"
+        )
+        Test-CoverageDataMissing -Output $output | Should -BeFalse
+    }
+
+    It 'does not recognize an empty output (strict-mode safe)' {
+        Test-CoverageDataMissing -Output @() | Should -BeFalse
+    }
+}

--- a/scripts/build/Coverage.psm1
+++ b/scripts/build/Coverage.psm1
@@ -1,0 +1,96 @@
+#requires -Version 7
+
+# Coverage report generation for the CI coverage upload (`just coverage-report-ci`).
+#
+# `cargo llvm-cov report` treats a measured scope in which no object carries coverage mappings as
+# a hard error and refuses to export a report at all. A delta-scoped CI run can select exactly
+# such a scope - a package that is a pure container for benchmarks, or a deprecated package
+# reduced to a documentation shell - where "no coverage" is the correct outcome rather than a
+# failure. The decision of whether a failed report run means "nothing to measure" is pure and
+# Pester-tested here (Test-CoverageDataMissing); Export-CoverageReport drives the real cargo
+# invocation and is covered by CI running the recipe.
+
+Set-StrictMode -Version Latest
+
+function Test-CoverageDataMissing {
+    # Decides whether the output of a failed `cargo llvm-cov report` run indicates that the
+    # measured scope simply contains no instrumented code, as opposed to a genuine reporting
+    # failure (unreadable profile data, a broken toolchain, bad arguments). llvm-cov reports the
+    # former as "no coverage data found" for the object file it was asked to export. Every other
+    # diagnostic disqualifies the run, so a failure that names both an object without coverage
+    # mappings and a real problem stays a failure rather than being waved through.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $Output
+    )
+
+    $missingData = $false
+
+    # Each captured element can itself span several lines: cargo reports a failed llvm-cov
+    # invocation as one record that quotes the command and the whole captured stderr.
+    foreach ($chunk in $Output) {
+        foreach ($line in $chunk -split "`r?`n") {
+            $diagnostic = $line.Trim()
+            if ($diagnostic -notlike 'error:*') { continue }
+
+            if ($diagnostic -like '*no coverage data found*') {
+                $missingData = $true
+                continue
+            }
+
+            # These two frame the failure without naming a cause of their own. Any other
+            # diagnostic describes a different problem, which must not be mistaken for an
+            # empty scope.
+            if ($diagnostic -like 'error: failed to generate report:*') { continue }
+            if ($diagnostic -like 'error: could not load coverage information*') { continue }
+
+            return $false
+        }
+    }
+
+    return $missingData
+}
+
+function Export-CoverageReport {
+    # Writes the lcov coverage report the CI upload consumes and returns whether it was written:
+    # $true when a report exists at $OutputPath, $false when the measured scope contained no
+    # instrumented code and there was nothing to report. Any other failure throws.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string] $Toolchain,
+        [Parameter(Mandatory)][string] $OutputPath
+    )
+
+    # Disable the native-error preference locally so a non-zero exit does not terminate here
+    # before we can classify it; we inspect the exit code and output ourselves. 2>&1 merges
+    # stderr (where llvm-cov prints its diagnostics) into the captured output.
+    $PSNativeCommandUseErrorActionPreference = $false
+    $output = @(cargo "+$Toolchain" llvm-cov report --lcov --output-path $OutputPath 2>&1 |
+        ForEach-Object { [string] $_ })
+    $exitCode = $LASTEXITCODE
+
+    foreach ($line in $output) {
+        Write-Host $line
+    }
+
+    if ($exitCode -eq 0) {
+        return $true
+    }
+
+    if (Test-CoverageDataMissing -Output $output) {
+        # A report left behind by an earlier run over a different scope would otherwise make the
+        # caller believe this scope produced coverage.
+        if (Test-Path -LiteralPath $OutputPath) {
+            Remove-Item -LiteralPath $OutputPath -Force
+        }
+
+        Write-Host 'The measured scope contains no instrumented code - nothing to report.'
+        return $false
+    }
+
+    throw "cargo llvm-cov report failed with exit code $exitCode."
+}
+
+Export-ModuleMember -Function Test-CoverageDataMissing, Export-CoverageReport


### PR DESCRIPTION
[Copilot speaking]

`just coverage-report-ci` runs `cargo llvm-cov report`, which refuses to export a report - and exits non-zero - when no object in the measured scope carries coverage mappings. A delta-scoped validation run can select exactly such a scope: a package that is a pure container for benchmarks, or a package reduced to a deprecation notice. "No coverage" is the correct outcome there, but it currently turns the x64 test job red.

The CI report step now recognizes that specific outcome and produces no report instead of failing, while every other reporting failure - unreadable profile data, a broken toolchain, bad arguments, or a mixed failure that merely also mentions an object without coverage mappings - still fails as before.

A run that produced no report uploads nothing to Codecov and does not release the gated coverage notification, so an absent report cannot turn into a coverage status computed from an empty set. The Azure-backend upload is unaffected: its scope is fixed and always instrumented.
