### PR TITLE
CI: confine valgrind to the jobs that measure with it

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -44,14 +44,20 @@ runs:
 
     - name: Refresh APT package index (Linux)
       # cache-apt-pkgs-action never refreshes the index (its `refresh` input is documented as
-      # obsolete), so on a cache miss it resolves package versions from the image's baked-in
-      # index. Ubuntu withdraws superseded packages from the archive when it publishes a
-      # security update, so a stale index resolves a version that no longer exists and the
-      # download 404s. Only the valgrind path is exposed to this: build-essential and cmake are
-      # already at the image's newest version and need no download, whereas valgrind's
-      # libc6-dbg is not preinstalled and must be fetched. Gating the refresh on the same input
-      # therefore keeps its cost off every other Linux job.
-      if: runner.os == 'Linux' && inputs.install-valgrind == 'true'
+      # obsolete), so on a cache miss it resolves package versions from the index baked into
+      # the runner image at image build time. Ubuntu withdraws superseded packages from the
+      # archive when it publishes an update, so an index that predates one resolves a version
+      # that no longer exists and the download 404s.
+      #
+      # This applies to every package requested below, not only valgrind, so the refresh is
+      # unconditional on Linux. build-essential and cmake are NOT preinstalled: the Ubuntu
+      # image README lists neither in its apt package inventory, and the CMake it does ship is
+      # an upstream build under /usr/local, unrelated to the archive's `cmake` package that
+      # this step installs together with cmake-data, libjsoncpp25 and librhash0. Scoping the
+      # cache key to the image version (see below) also means every image roll forces exactly
+      # that fresh resolve on every Linux job, so gating the refresh on the valgrind opt-in
+      # would leave the other jobs one archive update away from the same 404.
+      if: runner.os == 'Linux'
       shell: bash
       # Acquire::Retries covers a transient mirror blip in place, matching the workspace stance
       # that a single infrastructure fault must not drop a whole job (see workflows/design.md).
@@ -83,7 +89,7 @@ runs:
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
         packages: ${{ inputs.install-valgrind == 'true' && 'build-essential cmake valgrind' || 'build-essential cmake' }}
-        version: "1-${{ steps.image.outputs.version }}"
+        version: 1-${{ steps.image.outputs.version }}
         execute_install_scripts: true
 
     - name: Install PowerShell (Linux ARM64)

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -10,32 +10,80 @@ inputs:
       in CI (only the on-demand `just bench-history-stress-azure` uses it), so it has no input.
     required: false
     default: "false"
+  install-valgrind:
+    description: >-
+      Whether the Linux APT install should also include valgrind. Off by default because only
+      the jobs that actually execute Callgrind benchmarks need it, and valgrind drags in
+      libc6-dbg - a package pinned by an EXACT version relation to the image's libc6. Any Ubuntu
+      glibc security update therefore invalidates the previously installed debug symbols, and
+      installing valgrind everywhere would let that routine update take down clippy, docs, miri
+      and mutants across the whole repository. Jobs that run Callgrind opt back in by setting
+      this to "true".
+    required: false
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Resolve runner image version (Linux)
+      # Feeds the runner image version into the APT cache key below. GitHub-hosted runners set
+      # ImageVersion (e.g. 20260810.271) on every job, but a composite action's `with:` block
+      # cannot be relied on to resolve the `env` context, whereas the `steps` context always
+      # resolves - so the value is exported as a step output instead. Fail loudly when it is
+      # absent rather than emitting an empty string, because an empty key component would
+      # silently restore the image-independent cache this step exists to eliminate.
+      id: image
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        if [ -z "$ImageVersion" ]; then
+          echo "ImageVersion is not set; the APT cache cannot be scoped to the runner image." >&2
+          exit 1
+        fi
+        echo "version=$ImageVersion" >> "$GITHUB_OUTPUT"
+
+    - name: Refresh APT package index (Linux)
+      # cache-apt-pkgs-action never refreshes the index (its `refresh` input is documented as
+      # obsolete), so on a cache miss it resolves package versions from the image's baked-in
+      # index. Ubuntu withdraws superseded packages from the archive when it publishes a
+      # security update, so a stale index resolves a version that no longer exists and the
+      # download 404s. Only the valgrind path is exposed to this: build-essential and cmake are
+      # already at the image's newest version and need no download, whereas valgrind's
+      # libc6-dbg is not preinstalled and must be fetched. Gating the refresh on the same input
+      # therefore keeps its cost off every other Linux job.
+      if: runner.os == 'Linux' && inputs.install-valgrind == 'true'
+      shell: bash
+      # Acquire::Retries covers a transient mirror blip in place, matching the workspace stance
+      # that a single infrastructure fault must not drop a whole job (see workflows/design.md).
+      run: sudo apt-get update -o Acquire::Retries=3
+
     - name: Install APT packages (Linux)
       # The GitHub-hosted Ubuntu images already ship git, git-lfs, gcc, make, curl,
       # libssl-dev, pkg-config and PowerShell (apt reports them "already the newest"), so
-      # only build-essential, cmake and valgrind - plus their dependencies - are genuinely
-      # installed here. Package downloads are not the bottleneck (~1s for tens of MB on the
-      # Azure mirrors); the cost is the `apt-get update` index refresh and the dpkg
-      # unpack/configure. cache-apt-pkgs-action restores the already-configured files from
-      # an actions/cache entry and skips apt entirely on a hit, cutting this step from ~15s
-      # (amd64) / ~26s (arm64) to a few seconds. The action is in upstream maintenance mode,
-      # so `@v1` only rolls forward to backward-compatible fixes within its major line -
-      # there is no breaking v2 to chase.
+      # only build-essential, cmake and - where a job opts in - valgrind, plus their
+      # dependencies, are genuinely installed here. Package downloads are not the bottleneck
+      # (~1s for tens of MB on the Azure mirrors); the cost is the `apt-get update` index
+      # refresh and the dpkg unpack/configure. cache-apt-pkgs-action restores the
+      # already-configured files from an actions/cache entry and skips apt entirely on a hit,
+      # cutting this step from ~15s (amd64) / ~26s (arm64) to a few seconds. The action is in
+      # upstream maintenance mode, so `@v1` only rolls forward to backward-compatible fixes
+      # within its major line - there is no breaking v2 to chase.
       #
       # execute_install_scripts runs each package's postinst (e.g. ldconfig) on restore so
-      # valgrind's shared-library dependencies resolve. No PR-validation job runs valgrind
-      # (only the nightly bench-history workflow does), so the Verify step below actually
-      # executes valgrind to prove the restored fileset is functional before a regression
-      # could reach that workflow.
+      # valgrind's shared-library dependencies resolve.
+      #
+      # The action's own cache key hashes only the requested package names and the arch, so it
+      # cannot see that valgrind's libc6-dbg carries detached glibc debug symbols that are only
+      # valid against the exact libc6 build present on the image. A cache hit after a glibc
+      # update would then restore stale symbols and valgrind would abort at startup. Scoping
+      # the key to the runner image version makes the cache roll forward with the image
+      # automatically; the leading literal is a manual bust knob, bumped to discard every
+      # existing entry deliberately.
       if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: build-essential cmake valgrind
-        version: "1"
+        packages: ${{ inputs.install-valgrind == 'true' && 'build-essential cmake valgrind' || 'build-essential cmake' }}
+        version: "1-${{ steps.image.outputs.version }}"
         execute_install_scripts: true
 
     - name: Install PowerShell (Linux ARM64)
@@ -174,6 +222,8 @@ runs:
     
     - name: Verify environment setup
       shell: bash
+      env:
+        INSTALL_VALGRIND: ${{ inputs.install-valgrind }}
       run: |
         echo "Verifying installed tools..."
         just --version
@@ -181,12 +231,15 @@ runs:
         rustc --version
         pwsh --version
         if [ "$RUNNER_OS" = "Linux" ]; then
-          # Prove the APT packages restored from the cache are functional. valgrind is the
-          # one that matters: no PR-validation job runs it (only the nightly bench-history
-          # workflow does), and a fileset-only cache restore could leave its shared
-          # libraries unregistered - so actually run it against a trivial program rather
-          # than only printing a version.
+          # Prove the APT packages restored from the cache are functional. valgrind is the one
+          # that matters: a fileset-only cache restore could leave its shared libraries
+          # unregistered, or leave detached glibc debug symbols that no longer match the
+          # image's libc6 - so actually run it against a trivial program rather than only
+          # printing a version, failing here rather than hours later inside a benchmark run.
+          # Checked only where a job opted in, since valgrind is not installed otherwise.
           cmake --version
-          valgrind --quiet --error-exitcode=1 /bin/true
+          if [ "$INSTALL_VALGRIND" = "true" ]; then
+            valgrind --quiet --error-exitcode=1 /bin/true
+          fi
         fi
         echo "Environment setup complete"

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -18,7 +18,11 @@ inputs:
       glibc security update therefore invalidates the previously installed debug symbols, and
       installing valgrind everywhere would let that routine update take down clippy, docs, miri
       and mutants across the whole repository. Jobs that run Callgrind opt back in by setting
-      this to "true".
+      this to "true". A job declares the requirement, not the platform: only Linux-gated steps
+      read this input, so a multi-OS job sets it unconditionally and its Windows and macOS legs
+      ignore it. Repeating a `runner.os` condition at the call sites would duplicate a decision
+      this action already owns, and would suppress the request on any platform that later grows
+      a valgrind install path of its own.
     required: false
     default: "false"
 

--- a/.github/workflows/bench-history-backfill.yml
+++ b/.github/workflows/bench-history-backfill.yml
@@ -89,7 +89,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup environment
+        # Backfill runs the Callgrind measurement engine, which drives Valgrind.
         uses: ./.github/actions/setup-environment
+        with:
+          install-valgrind: "true"
 
       # cargo-bench-history self-federates with GitHub OIDC: given the managed identity's client id
       # and tenant - plus the ACTIONS_ID_TOKEN_* values GitHub injects because of id-token: write -

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -107,7 +107,10 @@ jobs:
           fetch-depth: ${{ inputs.recollect_commit_id && '0' || '1' }}
 
       - name: Setup environment
+        # Collection runs the Callgrind measurement engine, which drives Valgrind.
         uses: ./.github/actions/setup-environment
+        with:
+          install-valgrind: "true"
 
       # cargo-bench-history self-federates with GitHub OIDC: given the managed identity's
       # client id and tenant - plus the ACTIONS_ID_TOKEN_* values GitHub injects because

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -25,4 +25,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup environment
+        # Warms every cache the real jobs restore, so it must request the same APT package set
+        # as the widest consumer - otherwise the Valgrind-installing jobs always take a miss.
         uses: ./.github/actions/setup-environment
+        with:
+          install-valgrind: "true"

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -416,7 +416,9 @@ exact glibc build on the runner image. Installing it in every job would put ever
 in the repository at the mercy of routine Ubuntu security updates, so the opt-in confines
 that exposure to the jobs that cannot work without it. For the same reason the APT package
 cache is scoped to the runner image version, so it rolls forward with the image instead of
-serving debug symbols that no longer match.
+serving debug symbols that no longer match — and because that scoping makes every image roll
+resolve packages afresh, the APT index is refreshed on every Linux job rather than trusted as
+the image left it.
 
 ## Transient-fault handling
 

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -408,6 +408,16 @@ the mostly-cached setup time it would save. Toolchain versions are defined once 
 `constants.env` and `rust-toolchain.toml` and reach the workflows through the `just`
 commands they call, so no version is ever duplicated into a workflow file.
 
+The one deliberate deviation from "one identical environment everywhere" is Valgrind. It is
+installed only where a job actually executes Callgrind measurements — the benchmark
+collection jobs, the test jobs that smoke-run every bench target, and the cache warmup that
+primes their caches — because Valgrind pulls in glibc debug symbols that are pinned to the
+exact glibc build on the runner image. Installing it in every job would put every Ubuntu job
+in the repository at the mercy of routine Ubuntu security updates, so the opt-in confines
+that exposure to the jobs that cannot work without it. For the same reason the APT package
+cache is scoped to the runner image version, so it rolls forward with the image instead of
+serving debug symbols that no longer match.
+
 ## Transient-fault handling
 
 CI touches unreliable infrastructure — package mirrors, the GitHub API, runner disks — where a

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -237,7 +237,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup environment
+        # Collection runs the Callgrind measurement engine, which drives Valgrind.
         uses: ./.github/actions/setup-environment
+        with:
+          install-valgrind: "true"
 
       # Reused unchanged from bench-history.yml: export the prod identity's client id and tenant
       # under the standard names cargo-bench-history reads, then let the tool mint OIDC assertions on

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -207,7 +207,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup environment
+        # The benchmark smoke check below runs every bench target once, and on Linux the
+        # `*_cg` targets are real Gungraun harnesses that execute under Valgrind.
         uses: ./.github/actions/setup-environment
+        with:
+          install-valgrind: "true"
 
       - name: Run tests with coverage on ${{ matrix.platform }}
         id: coverage
@@ -335,7 +339,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup environment
+        # The benchmark smoke check below runs every bench target once, and on Linux the
+        # `*_cg` targets are real Gungraun harnesses that execute under Valgrind.
         uses: ./.github/actions/setup-environment
+        with:
+          install-valgrind: "true"
 
       - name: Run tests on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" test


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Every Ubuntu job in this repository fails in the shared `setup-environment` composite action, before any code compiles. `main` is red and so is every open pull request.

Ubuntu published glibc `2.39-0ubuntu8.8` and withdrew `2.39-0ubuntu8.7` from the archive. `valgrind` depends on `libc6-dbg`, which carries detached glibc debug symbols and is locked to `libc6` by an **exact** version relation (`libc6 (= 2.39-0ubuntu8.8)`). Those symbols are therefore only valid against the precise glibc build present on the runner image.

The composite installed valgrind on every Linux job and then actually executed it as a verification step, so one Ubuntu security update took the whole repository down through two paths:

| Architecture | APT cache | What happens | Symptom |
| --- | --- | --- | --- |
| x86_64 | hit | Cache restores `libc6-dbg=2.39-0ubuntu8.7` onto an image whose `libc6` is now `8.8` | valgrind aborts at startup: `A must-be-redirected function whose name matches the pattern: strlen ... was not found` |
| aarch64 | miss | Install resolves against the image's stale APT index, which still lists the withdrawn `8.7` | `404 Not Found` fetching `libc6-dbg_2.39-0ubuntu8.7_arm64.deb`; valgrind never installs, then `valgrind: command not found` |

The same cache key restoring the same `libc6-dbg` passed on runner image `ubuntu24/20260720.247` and fails on `ubuntu24/20260810.271`; nothing in the repository changed between them.

Without a structural fix this recurs at an unpredictable moment on every future glibc update: the third-party APT cache action keys only on the requested package names and the architecture, so it cannot see the image's `libc6`, and it never refreshes the APT index.

## Change

Valgrind is now opt-in. `setup-environment` gained an off-by-default `install-valgrind` input; when it is off, valgrind is neither installed nor exercised by the verification step. `build-essential` and `cmake` remain unconditional. The jobs that actually execute Valgrind opt back in: benchmark collection in `bench-history`, `bench-history-backfill` and `pr-bench-history`; the `test-x64` and `test-arm` jobs in `validation`, whose bench smoke check runs the `*_cg` Gungraun harnesses under Valgrind on Linux; and `cache-warmup`, so those jobs are not guaranteed a cache miss. Clippy, docs, Miri, mutation testing, the book and release jobs no longer depend on Valgrind at all.

The APT package cache is scoped to the runner image version, so it rolls forward with the image instead of restoring debug symbols that no longer match the live glibc. This is what closes the cache-hit path, where an index refresh alone cannot help because the action skips installation entirely on a hit. The image version reaches the cache key through a step output rather than the `env` context, so it can never silently degrade to an empty string.

The APT index is refreshed on every Linux job before the install, which closes the cache-miss path by preventing resolution of a version that has since been withdrawn from the archive. It applies to the whole requested package set rather than just valgrind: `build-essential` and `cmake` are not part of the runner image's apt inventory either (the CMake the image ships is an upstream build under `/usr/local`, not the archive's `cmake` package), so scoping the cache to the image version makes every image roll resolve them afresh too.

```
before                                  after
------                                  -----
every Linux job                         bench collection + bench smoke
  -> installs valgrind                    -> installs valgrind
  -> runs valgrind in verify              -> runs valgrind in verify
  -> image-independent apt cache          -> apt cache keyed by image version
  -> stale apt index                      -> apt index refreshed

                                        every other Linux job
                                          -> build-essential + cmake only
                                          -> apt cache keyed by image version
                                          -> apt index refreshed
```
