### PR TITLE
infinity_pool: narrow the successor recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ allocators that keep the memory around for reuse, so the next allocation is simp
 While allocator APIs are still an unstable Rust feature, there are stable-API alternatives.
 Another term for special-purpose allocators is object pools and [`infinity_pool`][infinity_pool]
 offers several of them, from basic `Vec<T>` style pinned object collections to type-agnostic object
-pools that can allocate any type of object, though it is superseded and receives maintenance only.
-While the safe-API variants come with substantial overheads compared to the unsafe-API variants,
-they both can surpass the efficiency of using the global memory allocator under many conditions.
-Your mileage may vary - measure 100 times, cut 10 times. The packages here now reach for
-[`multitude`][multitude] when many objects share a lifetime and for [`plurality`][plurality] when
-objects are individually rented and returned.
+pools that can allocate any type of object, though it receives maintenance only. While the safe-API
+variants come with substantial overheads compared to the unsafe-API variants, they both can surpass
+the efficiency of using the global memory allocator under many conditions. Your mileage may vary -
+measure 100 times, cut 10 times. To pool values of a single named type, the packages here now reach
+for [`plurality`][plurality], and where many objects share a lifetime and can be reclaimed together
+they use the [`multitude`][multitude] arena instead of a pool.
 
 A surprising source of memory allocations in high-performance code can be signaling. We are used
 to thinking of oneshot channels as cheap and efficient things and while this is true, they are

--- a/packages/infinity_pool/README.md
+++ b/packages/infinity_pool/README.md
@@ -4,7 +4,11 @@ Object pools with trait object support and multiple access models. Provides fast
 
 ## Maintenance status
 
-This package is superseded and receives maintenance only. Prefer [`multitude`](https://crates.io/crates/multitude) for the opaque and blind pooling scenarios and [`plurality`](https://crates.io/crates/plurality) for the pinned pooling scenario.
+This package receives maintenance only.
+
+For the pinned pooling scenario, prefer [`plurality`](https://crates.io/crates/plurality), whose `Pool<T>` is an equivalent of `PinnedPool`. It pools a single named type, so it is not an alternative to `OpaquePool` or `BlindPool`.
+
+Where all the objects can be reclaimed together, an arena allocator such as [`multitude`](https://crates.io/crates/multitude) can take the place of a type-agnostic pool, trading per-object slot reuse for cheaper allocation.
 
 ## Pool types
 

--- a/packages/infinity_pool/src/lib.rs
+++ b/packages/infinity_pool/src/lib.rs
@@ -8,8 +8,15 @@
 //!
 //! # Maintenance status
 //!
-//! This package is superseded and receives maintenance only. Prefer [`multitude`] for the
-//! opaque and blind pooling scenarios and [`plurality`] for the pinned pooling scenario.
+//! This package receives maintenance only.
+//!
+//! For the pinned pooling scenario, prefer [`plurality`], whose `Pool<T>` is an equivalent
+//! of [`PinnedPool`]. It pools a single named type, so it is not an alternative to
+//! [`OpaquePool`] or [`BlindPool`].
+//!
+//! Where all the objects can be reclaimed together, an arena allocator such as [`multitude`]
+//! can take the place of a type-agnostic pool, trading per-object slot reuse for cheaper
+//! allocation.
 //!
 //! # Motivating scenario
 //!


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The documentation recently started describing `infinity_pool` as superseded, directing readers to `multitude` for "the opaque and blind pooling scenarios" and `plurality` for "the pinned pooling scenario". That overstates what those crates cover. `plurality` pools values of a single named type, so it stands in for `PinnedPool` and nothing else; neither crate offers a type-erased or heterogeneous pool, so `OpaquePool` and `BlindPool` have no counterpart. Where a blind pool was replaced by a `multitude::Arena`, per-object slot reuse was given up in exchange for arena allocation, which is a different memory model rather than a substitution.

## What changes

The root README, the package README and the crate-level rustdoc now say the same, narrower thing:

- `infinity_pool` receives maintenance only. The "superseded" claim is gone.
- `plurality` is recommended for the pinned pooling scenario, with an explicit statement that it pools a single named type and is therefore not an alternative to `OpaquePool` or `BlindPool`.
- `multitude` is presented as an arena for workloads where all objects can be reclaimed together, explicitly trading per-object slot reuse for cheaper allocation, rather than as a pool replacement.