### PR TITLE
Upgrade dependencies, CI actions and pinned tooling to latest majors

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -142,7 +142,7 @@ runs:
       # compiled cargo-tool binaries in ~/.cargo/bin, rustup toolchains are prebuilt,
       # relocatable artifacts that do not link against image-specific dylibs, so the runner
       # ImageVersion is deliberately left out of the key.
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.rustup/toolchains
@@ -197,7 +197,7 @@ runs:
       # automatically. Like rustup toolchains these are prebuilt, relocatable binaries that do not
       # link against image-specific dylibs, so the runner ImageVersion is deliberately left out of
       # the key.
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.cargo/bin/actionlint*

--- a/.github/workflows/bench-history-backfill.yml
+++ b/.github/workflows/bench-history-backfill.yml
@@ -84,7 +84,7 @@ jobs:
         # Full history: the tool benchmarks each historical commit in a throwaway `git worktree`,
         # and the range selection walks `main`'s first-parent history by date. Neither works on the
         # default shallow clone.
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -302,9 +302,10 @@ jobs:
       # Attach the full Markdown and JSON reports to the run as a single artifact, so the
       # rolling issue can carry only the condensed summary (staying under GitHub's
       # 65,536-character issue-body limit) while a reader can still download the complete
-      # reports. upload-artifact always produces a zip, so both files share one
-      # artifact and one download URL; that URL stays valid while the run and artifact
-      # exist. Uploaded only when notable, matching the rolling issue.
+      # reports. The upload keeps `archive` at its default, so it always produces a
+      # zip: both files share one artifact and one download URL; that URL stays valid
+      # while the run and artifact exist. Uploaded only when notable, matching the
+      # rolling issue.
       - name: Upload full benchmark reports
         id: full_reports
         if: steps.notable.outputs.value == 'true'

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # A normal push/dispatch only benchmarks the tip, so a shallow clone is enough. A
         # recollect (recollect_commit_id set) must instead re-measure a historical commit, whose
         # objects and first-parent ancestry the `backfill` worktree needs present locally - so
@@ -161,7 +161,7 @@ jobs:
       # leg's key together (one file per platform). if-no-files-found: error catches a broken
       # key-write step loudly rather than silently dropping a key from the analysis.
       - name: Upload runner machine key
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bench-history-machine-key-${{ matrix.platform }}
           path: ${{ runner.temp }}/machine-key.txt
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Full history: analyze walks first-parent commits to map stored runs to
         # committer timestamps; a shallow clone would hide most commits and skew it.
         with:
@@ -247,7 +247,7 @@ jobs:
       # restored-but-slightly-stale mirror is always correct - a deliberate
       # --overwrite/prune bumps the cloud marker that wipes it on the next read.
       - name: Restore benchmark-history read-through cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.scratch.outputs.dir }}/cache
           key: bench-history-cache-${{ github.run_id }}
@@ -270,7 +270,7 @@ jobs:
       # artifact to the current attempt and 404s ("workflow run not found") on any older-attempt
       # artifact, leaving `analyze` impossible to green without re-running the whole matrix.
       - name: Download collected machine keys
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: bench-history-machine-key-*
           path: ${{ steps.scratch.outputs.dir }}/machine-keys
@@ -302,13 +302,13 @@ jobs:
       # Attach the full Markdown and JSON reports to the run as a single artifact, so the
       # rolling issue can carry only the condensed summary (staying under GitHub's
       # 65,536-character issue-body limit) while a reader can still download the complete
-      # reports. upload-artifact@v4 always produces a zip, so both files share one
+      # reports. upload-artifact always produces a zip, so both files share one
       # artifact and one download URL; that URL stays valid while the run and artifact
       # exist. Uploaded only when notable, matching the rolling issue.
       - name: Upload full benchmark reports
         id: full_reports
         if: steps.notable.outputs.value == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bench-history-full-report
           path: |
@@ -401,7 +401,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Compose the failure-alert body (interpolating the failed run's URL) into the runner temp
       # dir, then file it with the same Publish-RollingIssue seam the regression path uses - one
@@ -472,7 +472,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # The alert job files exactly one rolling issue carrying $FAILURE_ISSUE_TITLE and the
       # ci-failure label; find any still-open instance and close it with an audit trail linking the

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -44,7 +44,7 @@ jobs:
       books: ${{ steps.books.outputs.books }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Discover books
         id: books
@@ -70,7 +70,7 @@ jobs:
         book: ${{ fromJSON(needs.discover.outputs.books) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -97,7 +97,7 @@ jobs:
           just book-build-one ${{ matrix.book }} target/book-site
 
       - name: Upload book artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: book-${{ matrix.book }}
           path: target/book-site
@@ -120,10 +120,10 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download book artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: book-*
           path: public
@@ -141,10 +141,10 @@ jobs:
           Write-Host "Wrote landing page to $path"
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: public
 
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         # Warms every cache the real jobs restore, so it must request the same APT package set

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Setup environment
       uses: ./.github/actions/setup-environment

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Full history so cargo-delta can diff against origin/main in a throwaway worktree (the
         # merge ref the pull_request event checks out is fine for the diff; only collect/analyze
         # need the real head SHA for branch-mode topology).
@@ -140,7 +140,7 @@ jobs:
       - name: Checkout repository
         # Default shallow checkout is enough: the commits-behind count is computed server-side by the
         # compare API, so no local history is walked here - only the module needs to be on disk.
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Signal the new run on the rolling PR comment
         shell: pwsh
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Check out the REAL PR head commit with FULL history, NOT the default pull_request merge ref
         # (refs/pull/N/merge): that merge commit's first parent is `main`, which would corrupt
         # branch-mode topology. A full clone is required (not shallow) because cargo-bench-history
@@ -280,7 +280,7 @@ jobs:
       # leg's key together (one file per platform). if-no-files-found: error catches a broken
       # key-write step loudly rather than silently dropping a key from the analysis.
       - name: Upload runner machine key
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-bench-history-machine-key-${{ matrix.platform }}
           path: ${{ runner.temp }}/machine-key.txt
@@ -318,7 +318,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Same real-head-SHA + full-history checkout as collect: branch mode walks the head's
         # first-parent ancestry and needs origin/main (from fetch-depth 0) for the merge-base.
         with:
@@ -360,7 +360,7 @@ jobs:
       # store keeps a slightly-stale mirror harmless. The path MUST match the `--cache` directory the
       # gh-analyze-pr-bench-history recipe passes (`<scratch>/cache`).
       - name: Restore benchmark-history read-through cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ steps.scratch.outputs.dir }}/cache
           key: bench-history-cache-pr-${{ github.run_id }}
@@ -382,7 +382,7 @@ jobs:
       # artifact to the current attempt and 404s ("workflow run not found") on any older-attempt
       # artifact, leaving `analyze` impossible to green without re-running the whole matrix.
       - name: Download collected machine keys
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pr-bench-history-machine-key-*
           path: ${{ steps.scratch.outputs.dir }}/machine-keys
@@ -423,7 +423,7 @@ jobs:
       - name: Upload full benchmark reports
         id: full_reports
         if: steps.notable.outputs.value == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-bench-history-full-report
           path: |
@@ -503,7 +503,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Remove stale rolling comment if present
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Full history so release-plz can resolve tags/commits; default persist-credentials
         # (true) leaves the token in git config so release-plz can push the release tags.
         with:
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout released tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Build the exact released code, not the branch tip.
         with:
           ref: refs/tags/${{ matrix.tag }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         # The benchmark smoke check below runs every bench target once, and on Linux the
@@ -261,7 +261,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -308,7 +308,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -336,7 +336,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         # The benchmark smoke check below runs every bench target once, and on Linux the
@@ -377,7 +377,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -405,7 +405,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -428,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -451,7 +451,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -474,7 +474,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -495,7 +495,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -516,7 +516,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -536,7 +536,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -562,7 +562,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -585,7 +585,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -607,7 +607,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -629,7 +629,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -650,7 +650,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -690,7 +690,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -751,7 +751,7 @@ jobs:
       && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     # `id-token: write` lets the job mint a short-lived GitHub OIDC token (a signed
-    # JWT proving "this run is repo folo-rs/folo on ref X"). `azure/login@v2` hands
+    # JWT proving "this run is repo folo-rs/folo on ref X"). `azure/login@v3` hands
     # that token to Azure, which matches it against the managed identity's federated
     # credentials (see infra/azure-bench-history-test/main.bicep) and issues an access
     # token - so CI authenticates with no stored secret. The default GITHUB_TOKEN
@@ -764,7 +764,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -778,7 +778,7 @@ jobs:
         run: grep -E '^(AZURE_TEST_CLIENT_ID|AZURE_TENANT_ID|AZURE_SUBSCRIPTION_ID|BENCH_HISTORY_TEST_AZURE_ACCOUNT)=' constants.env >> "$GITHUB_ENV"
 
       - name: Sign in to Azure (OIDC workload identity federation)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.AZURE_TEST_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
@@ -830,7 +830,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -849,7 +849,7 @@ jobs:
       # The tool self-mints regardless of this login; it exists only so the test
       # harness's `az`-based container cleanup has a session to use.
       - name: Sign in to Azure (for harness container cleanup only)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.AZURE_TEST_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
@@ -910,7 +910,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Release Codecov coverage notifications
         uses: codecov/codecov-action@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anyspawn"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d511cca973cf38c589392c55831cebe1e5b3d81c07e77e55595e3b91d15cc8"
+checksum = "394d31a3ddd26884b4080469dbda9b7b8df45641764f1f23206ddeb177b18a09"
 dependencies = [
  "futures-channel",
  "thread_aware",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -190,13 +190,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -369,6 +369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "benchmarks"
 version = "0.0.1-never"
 dependencies = [
@@ -442,7 +448,7 @@ dependencies = [
  "azure_core",
  "azure_identity",
  "azure_storage_blob",
- "base64",
+ "base64 0.23.1",
  "cargo-bench-history-faker",
  "cbh_analyze",
  "cbh_cli",
@@ -717,7 +723,7 @@ dependencies = [
  "azure_core",
  "azure_identity",
  "azure_storage_blob",
- "base64",
+ "base64 0.23.1",
  "cbh_codec",
  "cbh_config",
  "cbh_diag",
@@ -737,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -755,9 +761,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -808,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -818,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -830,14 +836,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -863,12 +869,11 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -897,15 +902,6 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "const-random"
@@ -1024,12 +1020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
-
-[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,13 +1116,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1155,9 +1145,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "either-or-both"
@@ -1187,11 +1177,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1266,15 +1255,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -1378,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1393,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1403,15 +1392,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1420,38 +1409,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1520,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gungraun"
@@ -1630,9 +1619,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1650,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1675,18 +1664,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1724,7 +1713,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1743,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1757,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1770,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1784,16 +1773,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1804,15 +1794,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1872,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1908,11 +1898,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1921,11 +1912,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1992,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2009,9 +2010,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2054,7 +2055,7 @@ version = "1.0.17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2065,9 +2066,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2350,9 +2351,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2378,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "ohno"
-version = "0.3.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b16aa0c03511614585d73caca74e966be50f8f0d518b0a92232b91acb588ff"
+checksum = "4665329d9a246af05b488837c3736801fedbec2ef3a1b1484fde1bc47550cf63"
 dependencies = [
  "ohno_macros",
  "typeid",
@@ -2388,13 +2389,13 @@ dependencies = [
 
 [[package]]
 name = "ohno_macros"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d3f2b0704d4d6b2602e4ce48f78d8443b9050a8977e386c41e0ab5c90fb203"
+checksum = "565bae93429e274bfbb568535b43dd6458538908014e44faec44dddfafcb5fd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2563,9 +2564,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plurality"
@@ -2579,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2594,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2644,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2654,21 +2655,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2762,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2914,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2979,7 +2980,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3064,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3090,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3127,9 +3128,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3160,9 +3161,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "3.8.5"
+version = "3.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f733aa28b85255811ad1358d559fe9a182e39327cf5470140ed9d444de86e6d5"
+checksum = "f8af0b99483d1c3e59471d4f0cb58b244169436a8979c889a91a3f697075ea01"
 dependencies = [
  "saa",
  "sdd",
@@ -3235,9 +3236,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3245,29 +3246,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3287,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3298,13 +3299,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3464,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -3508,29 +3509,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_aware"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8e2e87580ff3c5422b991735ee62fd6100a7aada3f7ad9a21ecc9fb12edcae"
+checksum = "9e1d62dcaf3eec4b3d50494a244af37d0e169c37075ccfe02144ad98e86c6901"
 dependencies = [
  "thread_aware_macros",
 ]
@@ -3576,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "tick"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5b1614b34b2b4edcde4b95ad409647e398d9cece3998f58d23645de0e4f1d6"
+checksum = "cac1a2e273c0e12c23b85ed62b9e7ae46342ed73a4082f95ed28cdbd807b1fce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3588,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3608,9 +3609,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3627,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3662,9 +3663,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3678,13 +3679,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3699,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3712,9 +3713,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3749,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -3881,9 +3882,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
 dependencies = [
  "glob",
  "serde",
@@ -3912,7 +3913,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "quick-xml",
@@ -3928,7 +3929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "dyn-clone",
  "futures",
@@ -4097,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4110,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4120,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4130,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4143,9 +4144,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4165,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4185,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4335,15 +4336,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4441,9 +4433,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "yoke"
@@ -4470,18 +4462,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4517,9 +4509,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4528,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4539,13 +4531,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.93.1"
 [workspace.dependencies]
 all_the_time = { version = "0.6.1", path = "packages/all_the_time", default-features = false }
 alloc_tracker = { version = "0.7.0", path = "packages/alloc_tracker", default-features = false }
-anyspawn = { version = "0.6.0", default-features = false }
+anyspawn = { version = "0.7.0", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
 awaiter_set = { version = "0.1.10", path = "packages/awaiter_set", default-features = false }
@@ -20,7 +20,7 @@ axum = { version = "0.8.0", default-features = false }
 azure_core = { version = "1.0.0", default-features = false }
 azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
-base64 = { version = "0.22.1", default-features = false, features = ["std"] }
+base64 = { version = "0.23.1", default-features = false, features = ["std"] }
 cargo-freeze-deps = { version = "0.1.4", path = "packages/cargo-freeze-deps", default-features = false }
 cbh_analyze = { version = "=0.0.9", path = "packages/cbh_analyze", default-features = false }
 cbh_cli = { version = "=0.0.9", path = "packages/cbh_cli", default-features = false }
@@ -37,7 +37,7 @@ cbh_render = { version = "=0.0.9", path = "packages/cbh_render", default-feature
 cbh_stats = { version = "=0.0.9", path = "packages/cbh_stats", default-features = false }
 cbh_storage = { version = "=0.0.9", path = "packages/cbh_storage", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
-colored = { version = "2.2.0", default-features = false }
+colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }
 cpulist = { version = "1.1.5", path = "packages/cpulist", default-features = false }
 criterion = { version = "0.8.2", default-features = false }
@@ -95,7 +95,7 @@ nm_otel_impl = { version = "=0.4.15", path = "packages/nm_otel_impl", default-fe
 nonempty = { version = "0.12.0", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
-ohno = { version = "0.3.0", default-features = false }
+ohno = { version = "0.4.0", default-features = false }
 oneshot = { version = "0.2.1", default-features = false, features = [
     "std",
     "async",
@@ -118,16 +118,16 @@ semver = { version = "1.0.28", default-features = false, features = ["std"] }
 seq-macro = { version = "0.3.0", default-features = false }
 serde = { version = "1.0.228", default-features = false, features = ["std"] }
 serde_json = { version = "1.0.150", default-features = false, features = ["std"] }
-serial_test = { version = "3.2.0", default-features = false }
+serial_test = { version = "4.0.1", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
 simple-mermaid = { version = "0.2.0", default-features = false }
 smallvec = { version = "1.15.0", default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
-syn = { version = "2.0.117", default-features = false }
+syn = { version = "3.0.3", default-features = false }
 tempfile = { version = "3.20.0", default-features = false }
-thread_aware = { version = "0.8.0", default-features = false }
+thread_aware = { version = "0.9.0", default-features = false }
 threadpool = { version = "1.8.1", default-features = false }
-tick = { version = "0.4.0", default-features = false }
+tick = { version = "0.5.0", default-features = false }
 tokio = { version = "1.49.0", default-features = false }
 toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.12", default-features = false }

--- a/constants.env
+++ b/constants.env
@@ -20,25 +20,32 @@ CARGO_AUDIT_VERSION=0.22.2
 CARGO_CAREFUL_VERSION=0.4.10
 CARGO_DELTA_VERSION=0.3.1
 CARGO_ENSURE_NO_DEFAULT_FEATURES_VERSION=1.1.0
-CARGO_FREEZE_DEPS_VERSION=0.1.2
+CARGO_FREEZE_DEPS_VERSION=0.1.4
 CARGO_HACK_VERSION=0.6.45
 CARGO_LLVM_COV_VERSION=0.8.7
 CARGO_MACHETE_VERSION=0.9.2
 CARGO_MUTANTS_VERSION=27.1.0
-CARGO_NEXTEST_VERSION=0.9.140
-CARGO_SEMVER_CHECKS_VERSION=0.48.0
+CARGO_NEXTEST_VERSION=0.9.143
+CARGO_SEMVER_CHECKS_VERSION=0.50.0
 CARGO_SORT_VERSION=2.1.4
 CARGO_SORT_DERIVES_VERSION=0.13.0
 CARGO_UDEPS_VERSION=0.1.61
-RELEASE_PLZ_VERSION=0.3.159
+RELEASE_PLZ_VERSION=0.3.160
 
 # mdbook (and the mermaid preprocessor) builds the user-guide book(s) published to GitHub
 # Pages; see justfiles/just_book.just and .github/workflows/book.yml. These are NOT installed by
 # `just install-tools` - only the book recipes and the book workflow need them, so they are
 # installed on demand via `just book-install`. Pinned like the cargo tools above so local and CI
 # builds render identically; bump deliberately.
+#
+# mdbook is deliberately held at the version mdbook-mermaid was built against rather than tracking
+# the latest release. mdbook compares its own version against the one each preprocessor was
+# compiled with and warns on any mismatch, and `book-install` passes `--locked`, so mdbook-mermaid
+# resolves the `mdbook-preprocessor` version from its own lockfile. Pairing a newer mdbook with it
+# builds and renders correctly but prints a version-skew warning on every book build. Raise this
+# pin only together with an mdbook-mermaid release built against the same mdbook version.
 BOOK_MDBOOK_VERSION=0.5.0
-BOOK_MDBOOK_MERMAID_VERSION=0.17.0
+BOOK_MDBOOK_MERMAID_VERSION=0.17.1
 
 # PowerShell Gallery module (not a cargo tool) installed by `just install-tools`, pinned to an
 # exact version so `just validate-scripts` gates on a reproducible rule set - a newer PSScriptAnalyzer

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -133,7 +133,7 @@ publish:
     id-token: write   # crates.io Trusted Publishing (OIDC)
   timeout-minutes: 180   # generous: covers up to 3 retry attempts (see below)
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
         # persist-credentials stays at its default (true): release-plz pushes the
@@ -233,7 +233,7 @@ build-binaries:
   permissions:
     contents: write   # upload assets to the release
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: refs/tags/${{ matrix.tag }}   # build the exact released code
     - uses: ./.github/actions/setup-environment

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -33,12 +33,9 @@ cbh_git = { workspace = true }
 cbh_model = { workspace = true }
 cbh_probe = { workspace = true }
 cbh_storage = { workspace = true }
-futures = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 mimalloc = { workspace = true }
-nonempty = { workspace = true }
 ohno = { workspace = true, features = ["app-err"] }
-serde_json = { workspace = true }
 tick = { workspace = true, features = ["tokio"] }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 
@@ -66,7 +63,9 @@ cbh_git = { path = "../cbh_git", features = ["private-test-util"] }
 cbh_storage = { path = "../cbh_storage", features = ["private-test-util"] }
 futures = { workspace = true, features = ["executor"] }
 mutants = { workspace = true }
+nonempty = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "rustls"] }
+serde_json = { workspace = true }
 serial_test = { workspace = true }
 static_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/packages/cbh_storage/Cargo.toml
+++ b/packages/cbh_storage/Cargo.toml
@@ -27,7 +27,6 @@ async-trait = { workspace = true }
 azure_core = { workspace = true }
 azure_identity = { workspace = true, features = ["default"] }
 azure_storage_blob = { workspace = true, features = ["default"] }
-base64 = { workspace = true }
 cbh_codec = { workspace = true }
 cbh_config = { workspace = true }
 cbh_diag = { workspace = true }
@@ -40,6 +39,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 
 [dev-dependencies]
+base64 = { workspace = true }
 cbh_diag = { path = "../cbh_diag", features = ["private-test-util"] }
 futures = { workspace = true, features = ["executor"] }
 mutants = { workspace = true }

--- a/packages/region_cached/Cargo.toml
+++ b/packages/region_cached/Cargo.toml
@@ -21,7 +21,6 @@ arc-swap = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 linked = { workspace = true }
 many_cpus = { workspace = true }
-new_zealand = { workspace = true }
 rsevents = { workspace = true }
 scopeguard = { workspace = true }
 simple-mermaid = { workspace = true }
@@ -31,6 +30,7 @@ axum = { workspace = true, features = ["http1", "tokio"] }
 criterion = { workspace = true }
 many_cpus = { path = "../many_cpus", features = ["test-util"] }
 mutants = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 par_bench = { path = "../par_bench", features = ["criterion"] }
 static_assertions = { workspace = true }
 testing = { path = "../testing" }

--- a/packages/region_local/Cargo.toml
+++ b/packages/region_local/Cargo.toml
@@ -21,7 +21,6 @@ arc-swap = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 linked = { workspace = true }
 many_cpus = { workspace = true }
-new_zealand = { workspace = true }
 rsevents = { workspace = true }
 scopeguard = { workspace = true }
 simple-mermaid = { workspace = true }
@@ -31,6 +30,7 @@ axum = { workspace = true, features = ["http1", "tokio"] }
 criterion = { workspace = true }
 many_cpus = { path = "../many_cpus", features = ["test-util"] }
 mutants = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 par_bench = { path = "../par_bench", features = ["criterion"] }
 static_assertions = { workspace = true }
 testing = { path = "../testing" }

--- a/scripts/install-azcopy.ps1
+++ b/scripts/install-azcopy.ps1
@@ -55,17 +55,17 @@ Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
 
 # The pinned azcopy release. Keep $AzCopyVersion and the per-platform digests in
 # $AzCopyBuilds in sync - both come from one GitHub release of azure-storage-azcopy.
-$script:AzCopyVersion = '10.32.4'
+$script:AzCopyVersion = '10.32.7'
 
 # One entry per supported OS/architecture: the release asset name, the archive format
 # it ships as, the binary inside it, and the asset's published lowercase SHA-256.
 $script:AzCopyBuilds = @{
-    'windows-amd64' = @{ Asset = "azcopy_windows_amd64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy.exe'; Sha256 = 'f3a91ff981095077540254e1681de07eddb3c7179475c542612464cbdaa30275' }
-    'windows-arm64' = @{ Asset = "azcopy_windows_arm64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy.exe'; Sha256 = 'c48447f0a65ece9f78d7bcbc75c4fe431aa5dff0b9a3e08d747ecc7c7855e9bc' }
-    'linux-amd64'   = @{ Asset = "azcopy_linux_amd64_$($script:AzCopyVersion).tar.gz"; Kind = 'tar.gz'; Binary = 'azcopy'; Sha256 = '8f859a0dbbc117660c249fb3569694fc8a0f33b68701f5b2b92ccc001ee50784' }
-    'linux-arm64'   = @{ Asset = "azcopy_linux_arm64_$($script:AzCopyVersion).tar.gz"; Kind = 'tar.gz'; Binary = 'azcopy'; Sha256 = 'c614777841277ab2c53eecc9ecca5704fd697375c2ffaf4a407058891f00f673' }
-    'mac-amd64'     = @{ Asset = "azcopy_darwin_amd64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy'; Sha256 = 'b4325d4d20a830270a2b00890aa15e238728778774fc1b3539bf2ddfc8093a66' }
-    'mac-arm64'     = @{ Asset = "azcopy_darwin_arm64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy'; Sha256 = '7563ceaa5f0cf2fa822df142c1a1a62e7236183d36eb87cc159c8b09f85afe0f' }
+    'windows-amd64' = @{ Asset = "azcopy_windows_amd64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy.exe'; Sha256 = '7a7e572ea75445acf856cba53e8985374e46ecd3db6324042fc1911c5e27e30a' }
+    'windows-arm64' = @{ Asset = "azcopy_windows_arm64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy.exe'; Sha256 = 'e8961b448460e3ae5e2e6ceacf8f0fa3a92704eb3b9faae9fa1cf91813b3d55e' }
+    'linux-amd64'   = @{ Asset = "azcopy_linux_amd64_$($script:AzCopyVersion).tar.gz"; Kind = 'tar.gz'; Binary = 'azcopy'; Sha256 = '771dabec5bd8034223010d6f5186956203649e1013ed1d9e6b533fc09ed4a9ee' }
+    'linux-arm64'   = @{ Asset = "azcopy_linux_arm64_$($script:AzCopyVersion).tar.gz"; Kind = 'tar.gz'; Binary = 'azcopy'; Sha256 = '71072ff9609123e0f3ff70215303c15ab3e52ae4ad9d2ea5022db19f48204782' }
+    'mac-amd64'     = @{ Asset = "azcopy_darwin_amd64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy'; Sha256 = '233069680b3c3a1d7d67d58750c4d3eaf85b97cf4d68b9bc9dabddf502c4ccda' }
+    'mac-arm64'     = @{ Asset = "azcopy_darwin_arm64_$($script:AzCopyVersion).zip"; Kind = 'zip'; Binary = 'azcopy'; Sha256 = '9ff234c4e0eed47d74b112320a0774326da213feee603caa93da35f9d09b7d1c' }
 }
 
 function Get-PlatformKey {


### PR DESCRIPTION
[Copilot speaking]

Nothing in the workspace was tracking upstream majors, so several dependencies, every CI action and most of the pinned developer tools had drifted a full major version or more behind. This brings all three surfaces up to their latest releases and absorbs the breaking changes that come with them.

## Cargo dependencies

Eight crates move to their latest major (or 0.x) series: `anyspawn` 0.6 to 0.7, `base64` 0.22 to 0.23, `colored` 2 to 3, `ohno` 0.3 to 0.4, `serial_test` 3 to 4, `syn` 2 to 3, `thread_aware` 0.8 to 0.9 and `tick` 0.4 to 0.5. `Cargo.lock` is regenerated to the latest compatible versions throughout, as `docs/dependencies.md` asks for.

No Rust source needed changing. Each changelog was checked against actual usage, and the changes that could have reached us do not: `syn` 3's renamed syntax-tree nodes, `ohno` 0.4's now-crate-private constructors and stricter `#[display]` templates, `base64` 0.23's `InvalidLength` reclassification, `serial_test` 4's new `file_locks` gate on `file_serial`/`file_parallel`, and `thread_aware` 0.9's new default-on `std` feature all sit outside the API surface this workspace touches.

## GitHub Actions

`checkout` to v7, `cache` and `cache/restore` to v6, `upload-artifact` to v7, `download-artifact` to v8, `upload-pages-artifact` to v5, `deploy-pages` to v5, and `azure/login` to v3. These are largely Node 24 and ESM migrations that leave the input schemas we depend on intact, and every runner is GitHub-hosted so the new runner floor is met.

The three behavioral changes worth naming all miss us:

- `checkout` v7 blocks fork-PR checkout by default, but no workflow triggers on `pull_request_target` or `workflow_run`.
- `download-artifact` v5 changed the output path for single artifacts fetched by ID; every download here selects by `pattern:`.
- `upload-pages-artifact` v4 began excluding dotfiles, but the Pages artifact is assembled from `upload-artifact` output that already excludes hidden files.

`download-artifact` v8 also makes a digest mismatch fail instead of warn. That is deliberately left at the new secure default.

## Pinned tooling

`cargo-freeze-deps`, `cargo-nextest`, `cargo-semver-checks`, `release-plz` and `mdbook-mermaid` move to current releases, along with the pinned `azcopy` build and its six per-platform SHA-256 digests.

`cargo-semver-checks` crosses two 0.x boundaries: semver violations and tool errors now exit under distinct codes rather than a shared `1`, and rustdoc JSON v56 support is dropped. The `verify-semver-checks` canary treats any non-zero exit as "the tool is broken", which stays correct under the new codes, and it confirms the tool still parses what the pinned nightly emits.

`mdbook` is deliberately held back. mdbook compares its own version against the one each preprocessor was built with, and `book-install` passes `--locked`, so pairing a newer mdbook with `mdbook-mermaid` renders correctly but warns on every book build. `constants.env` now records that constraint so the pin is not raised in isolation.

## A latent misdeclaration this surfaced

`cbh_storage` declared `base64` as a regular dependency although only its test module uses it. It had been invisible to `cargo udeps` because it resolved to the same version as a transitive Azure SDK dependency; moving to 0.23 broke that coincidence and the check started failing.

The same masking hid the same mistake elsewhere, so the whole class is fixed rather than just the one instance that happened to break: `futures`, `nonempty` and `serde_json` in `cargo-bench-history` (test-only), and `new_zealand` in `region_cached` and `region_local` (bench-only). This narrows the production dependency metadata these published crates ship.

## Validation

Full local validation on Windows and Linux: 3422 tests, 2943 under Miri, clippy at `-D warnings`, doctests, docs, udeps, release builds, plus actionlint, binstall and PSScriptAnalyzer with its 402 Pester tests. `check-frozen` confirms the declared minimum versions still compile on the MSRV toolchain. Mutation testing across all affected packages ran 1587 mutants with none uncaught. Each updated tool was exercised through the recipe that actually uses it.