### PR TITLE
cargo-bench-history: Clarify cbh documentation ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,11 @@ directly:
   ownership boundaries, and implementation tenets belong in the package's
   `docs/implementation.md`. If a fact is trivia that does not change how an agent
   works, leave it out. Point at the appropriate document instead of repeating it.
+  The private `cbh_*` crates are implementation partitions of
+  `cargo-bench-history`: their user-visible behavioral contracts belong in the
+  parent application's design and API documentation, while partition-local
+  documentation covers only implementation ownership and boundaries and links to
+  the parent.
 
 ## Chapters
 


### PR DESCRIPTION
[Copilot speaking]

Private `cbh_*` crates are implementation partitions of `cargo-bench-history`, but the workspace guidance could be read as requiring each partition to own a separate behavioral design document.

This clarifies that user-visible behavioral contracts remain in the parent application's design and API documentation, while partition-local documentation covers only implementation ownership and boundaries and links back to the parent.