### PR TITLE
Add external-types validation gate

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -124,12 +124,12 @@ runs:
       run: git lfs install
     
     - name: Cache Rust toolchains
-      # Restored BEFORE the toolchain is installed so the pinned stable, the MSRV and the
-      # pinned nightly (whose profile pulls rust-src, llvm-tools-preview and miri) are all
-      # served from cache, turning every `rustup toolchain install` - the install step below
-      # and the ones inside `just install-tools` - into a no-op on a hit. rust-cache below
-      # caches ~/.cargo and ./target but never ~/.rustup, so re-installing these toolchains is
-      # the single largest uncached cost of this composite.
+      # Restored BEFORE the toolchain is installed so the pinned stable, the MSRV, the general
+      # pinned nightly (whose profile pulls rust-src, llvm-tools-preview and miri) and the dedicated
+      # external-types nightly (minimal profile) are all served from cache, turning every
+      # `rustup toolchain install` - the install step below and the ones inside `just install-tools` -
+      # into a no-op on a hit. rust-cache below caches ~/.cargo and ./target but never ~/.rustup, so
+      # re-installing these toolchains is the single largest uncached cost of this composite.
       #
       # It also means every toolchain is already present when Swatinem/rust-cache runs, so its
       # shared `prerequisites` key (which enumerates `rustup toolchain list`) reflects the

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -63,6 +63,30 @@ and Miri passes, `clippy-release`, `careful`) carries a whole-job `github.event_
 Ubuntu-dropping `miri-x64`) selects its platform list with a `fromJSON` conditional matrix
 keyed on the same event. Both reduce to "the full set on push, the pruned set on a PR".
 
+## External type surface
+
+A dedicated job fails validation when a library exposes an external type — one that is
+neither a standard-library type nor defined by the crate itself (a type from another crate,
+first-party or not) — in its public API without that type being listed in the crate's
+allow-list. The intent is to catch *accidental* additions to the external surface (a leaked
+dependency type, a forgotten `pub`), not to prohibit external types outright; an intentional
+exposure is admitted by adding it to the crate's
+`[package.metadata.cargo_check_external_types]`. The user-facing principle and the allow-list
+mechanics live in `docs/external-types.md`.
+
+The check drives nightly rustdoc's unstable JSON output, which pins an exact schema version,
+so it runs on its own pinned nightly (`RUST_NIGHTLY_EXTERNAL_TYPES`) held separate from the
+general nightly and bumped only in lockstep with the tool. Like the other package jobs it is
+delta-scoped, iterating the affected crates one manifest at a time and leaving the tool's
+`--skip-unsupported` flag to pass over crates it cannot document (proc-macro and binary-only).
+Because a public API can differ by platform through cfg-gated items, the surface is verified
+on both a Unix and a Windows target, so a Windows-only or Unix-only leak cannot slip through.
+Two targets suffice because platform-variant public surface here is gated only on
+`cfg(windows)`/`cfg(unix)` (Linux stands in for macOS) or hidden behind a platform abstraction
+layer with an identical public facade, and nothing public is `target_arch`-gated;
+`docs/external-types.md` records the assumption and when the matrix must grow.
+
+
 ## Concurrency
 
 Commit-driven and PR-driven workflows cancel superseded runs, keyed on the ref, so pushing

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -149,6 +149,30 @@ jobs:
       - name: Run default-features-check
         run: just default-features-check
 
+  # Fails when a library's public API exposes an external type that is not on its allow-list, so an
+  # accidental addition to the external surface is caught in review. Modelled on `machete`: a
+  # ubuntu + windows matrix, because the public surface is platform-dependent (cfg-gated items) and
+  # macOS (also cfg(unix)) is redundant with ubuntu here. Delta-scoped like the other package jobs.
+  check-external-types:
+    needs: [delta]
+    if: needs.delta.outputs.skip_all != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Run check-external-types on ${{ matrix.platform }}
+        run: just package="${{ needs.delta.outputs.packages }}" check-external-types
+
   clippy-dev:
     needs: [delta]
     if: needs.delta.outputs.skip_all != 'true'
@@ -937,6 +961,7 @@ jobs:
       - validate-workflows
       - format-check
       - default-features-check
+      - check-external-types
       - clippy-dev
       - test-x64
       - test-docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,20 @@ for intra-doc links to feature-gated items.
 linked item exists only under a non-default feature; the
 `docs-default-features` validation step flags a broken link.
 
+### [docs/external-types.md](docs/external-types.md)
+
+The external-types check: a validation gate (`just check-external-types`, backed
+by `cargo-check-external-types` on a dedicated pinned nightly) that fails when a
+library's public API exposes an external type absent from that crate's
+`[package.metadata.cargo_check_external_types]` allow-list. Covers the
+catch-accidents intent, the glob-the-internal/list-the-external convention,
+canonical partition paths, and the separate `RUST_NIGHTLY_EXTERNAL_TYPES` pin.
+
+**Open this when**: a PR fails the external-types check; intentionally exposing an
+external or cross-crate first-party type in a public API; adding a dependency
+whose types appear in public signatures; adding a new library crate; bumping the
+tool or its nightly pin.
+
 ### [docs/examples.md](docs/examples.md)
 
 Conventions for inline doctest examples and stand-alone `examples/` binaries:

--- a/constants.env
+++ b/constants.env
@@ -7,6 +7,26 @@ RUST_MSRV=1.93.1
 # clean"). Bump this deliberately (and verify the miri component exists for the date).
 RUST_NIGHTLY=nightly-2026-06-19
 
+# Dedicated nightly for the external-types check (`just check-external-types`).
+# cargo-check-external-types drives nightly rustdoc's unstable JSON output and pins the exact
+# `rustdoc-types` schema version that output must match, so it only works on the single nightly it
+# was built against - NOT the RUST_NIGHTLY above. This MUST equal the `channel` in the pinned
+# cargo-check-external-types build's `rust-toolchain.toml`; bump it in lockstep with the tool pin
+# (CARGO_CHECK_EXTERNAL_TYPES_REV below) or the check fails with a rustdoc schema mismatch.
+RUST_NIGHTLY_EXTERNAL_TYPES=nightly-2026-03-20
+
+# cargo-check-external-types is pinned to a git commit rather than a crates.io `@version` (unlike
+# every tool in the version block below) because the latest published release (0.5.0) predates the
+# multi-target/workspace support this repo needs: it invokes `cargo rustdoc` without `--lib`, which
+# errors on any crate that has a library plus examples/benches/binaries (most crates here). The fix
+# lives on the tool's `main` branch. `just install-tools` installs it with
+# `cargo install --git <url> --rev <rev> --locked`, so the commit's own Cargo.lock makes the build
+# reproducible. Switch back to a `CARGO_CHECK_EXTERNAL_TYPES_VERSION` pin in the block below once a
+# published release includes the fix (verify that release's `rust-toolchain.toml` still matches
+# RUST_NIGHTLY_EXTERNAL_TYPES above, and bump it if not).
+CARGO_CHECK_EXTERNAL_TYPES_GIT=https://github.com/awslabs/cargo-check-external-types
+CARGO_CHECK_EXTERNAL_TYPES_REV=705a0941997ebeb3bfb1a7f14070ba342f79d879
+
 # Versions of the Cargo tools installed by `just install-tools`, kept in one place and injected
 # into the recipe as `cargo install <crate>@<version>` (dotenv exposes each `FOO_VERSION` as
 # `$env:FOO_VERSION`). They are pinned to explicit versions rather than left floating because a

--- a/docs/external-types.md
+++ b/docs/external-types.md
@@ -1,0 +1,124 @@
+# External type exposure
+
+This chapter covers the external-types check: a validation gate that fails when a
+library's public API exposes an *external* type that is not on that crate's
+allow-list. It is driven by
+[`cargo-check-external-types`](https://github.com/awslabs/cargo-check-external-types)
+and run by `just check-external-types`.
+
+## What problem it solves
+
+An **external type** is any type in a crate's public API that is neither a
+standard-library type (`std`, `core`, `alloc`) nor defined by the crate itself.
+Exposing one in a public signature couples the crate's API to that other crate:
+a caller must now name the foreign type, and a semver-breaking change in the
+foreign crate becomes a semver-breaking change in ours.
+
+The gate exists to **catch accidents**, not to forbid external types. A leaked
+dependency type (an error type surfacing through `?`, a builder returning a
+foreign struct, a `pub use` that re-exports more than intended) is easy to add
+without noticing and hard to remove later without breaking callers. The check
+fails the build when a crate exposes an external type its allow-list does not
+cover, so a *new* external exposure is a deliberate, reviewed act rather than an
+oversight.
+
+This is an **additive allow policy, not an exact two-way baseline**. Adding an
+uncovered external type fails; removing an exposure does not — it merely leaves a
+now-unreferenced allow-list entry, which the tool reports as a harmless warning.
+Unused entries cannot be rejected automatically because a legitimate
+platform-specific entry is unreferenced on every other platform (see *Platform
+coverage* below). Prune stale entries by hand when you remove an exposure.
+
+Exposing an external type remains perfectly legitimate — the check only asks that
+it be **acknowledged**.
+
+## How a crate declares its allowed types
+
+Each crate lists the external types it intentionally exposes in its `Cargo.toml`:
+
+```toml
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "some_crate::module::SomeType",
+    "another_crate::*",
+]
+```
+
+Entries are `wildmatch` globs, where `*` matches any run of characters (including
+path separators). A type that matches **no** entry fails the check; a type that
+matches **two or more** entries is also an error, so keep globs from overlapping.
+
+When you intentionally add an external type to a public API, add it here in the
+same change. When you remove one, delete its entry so the allow-list does not rot.
+
+### Granularity: glob the internal, list the external
+
+The allow-lists follow one convention so the gate stays sensitive to accidents
+while not nagging about intentional internal layering:
+
+* A crate's **own** implementation or macro partition is allowed with a
+  crate-level glob (`many_cpus_impl::*`, `nm_impl::*`, `cbh_*::*`,
+  `linked_macros::*`). Re-exporting any type from your own partition is by-design
+  layering (see [impl-crate-split.md](impl-crate-split.md)); a glob keeps a routine
+  internal refactor from tripping the gate.
+* Every **other** external type — a third-party ecosystem type, or a public type
+  from a *different* first-party crate — is listed individually. Listing the exact
+  types means that exposing a *new* type from an already-referenced crate still
+  trips the check, which is the accident we want to catch.
+
+### Canonical paths
+
+A type is reported by the crate that **defines** it, not the crate you name to
+reach it. Because a shell crate re-exports its partition's types, a first-party
+type is reported by its partition path: `many_cpus`'s `SystemHardware` appears
+everywhere as `many_cpus_impl::system_hardware::SystemHardware`. Allow-list
+entries must use that canonical path.
+
+## The dedicated nightly toolchain
+
+`cargo-check-external-types` reads nightly rustdoc's unstable JSON output, which
+pins an exact schema version. It therefore works only on the single nightly it was
+built against — **not** the workspace's general `RUST_NIGHTLY`. That nightly is
+pinned separately as `RUST_NIGHTLY_EXTERNAL_TYPES` in `constants.env` and must
+equal the channel in the pinned tool build's `rust-toolchain.toml`. Bump the two
+together; bumping either alone fails the check with a rustdoc schema mismatch.
+
+The tool itself is pinned in `constants.env` as well
+(`CARGO_CHECK_EXTERNAL_TYPES_GIT` / `CARGO_CHECK_EXTERNAL_TYPES_REV`) and installed
+by `just install-tools`. See the comments in `constants.env` for why it is pinned
+to a git commit rather than a crates.io release, and the condition for switching
+back.
+
+## Running the check
+
+```
+just check-external-types                        # every checkable crate
+just package="many_cpus nm" check-external-types # only the named crates
+```
+
+The check runs per crate and lets the tool's `--skip-unsupported` flag pass over
+crates it cannot document (proc-macro and binary-only). It is part of
+`validate-local` and runs in CI as a delta-scoped job.
+
+Warnings about types inside `#[doc(hidden)]` items are expected and do not fail
+the check: rustdoc records those items in a way the tool cannot inspect.
+
+## Platform coverage
+
+A public API can differ by platform through cfg-gated items, so the check runs on
+both a Linux and a Windows target — a Windows-only exposure (for example
+`testing`'s `deranged::RangedU8`, gated on `cfg(windows)`) is only observed on
+Windows, and a Unix-only one only on Linux. An allow-list entry that applies to
+one platform is simply unreferenced on the other, which is why unused entries are
+tolerated rather than rejected.
+
+Two targets suffice for this workspace, not by coincidence but because of how
+platform variation is written here: platform-specific dependencies are gated on
+`cfg(windows)` or `cfg(unix)` (which Linux represents for macOS), the
+platform-specific implementations sit behind a platform abstraction layer whose
+public facade is identical on every target (see [pal.md](pal.md)), and no public
+item is gated on `target_arch`. If that ever stops holding — a dependency or
+public type gated specifically on `cfg(target_os = "macos")`, or an
+architecture-gated public item — extend the check's CI matrix to cover that
+target, because a Linux or Windows run cannot see it.
+

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -151,6 +151,83 @@ machete:
 default-features-check:
     cargo ensure-no-default-features
 
+# Fails when a library exposes an external type (one that is neither std nor defined by the crate
+# itself - a type from another crate, first-party or not) in its public API that is not on that
+# crate's allow-list, so accidental growth of the external surface is caught in review rather than
+# shipped. Removing an exposure is not a failure, so this is an additive allow policy, not an exact
+# two-way baseline. The allow-list lives in each crate's
+# `[package.metadata.cargo_check_external_types]`; see docs/external-types.md for the principle and
+# how to intentionally allow a type. A dedicated nightly toolchain (RUST_NIGHTLY_EXTERNAL_TYPES) is
+# required because the tool consumes an exact, unstable rustdoc JSON schema. The check runs once per
+# package so the delta-scoped CI job can check only the crates a branch changed; the tool skips
+# crates it cannot document (proc-macro and binary-only) via `--skip-unsupported`. The public surface
+# is platform-dependent (cfg-gated items), so this runs on every OS that `validate-local` targets.
+[group('quality')]
+[script]
+check-external-types:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    Import-Module "{{ justfile_directory() }}/scripts/build/ExternalTypes.psm1" -Force
+
+    $filter = "{{ package }}"
+    $manifests = @(Get-ExternalTypesManifest -PackagesRoot "packages" -PackageFilter $filter)
+    if ($manifests.Count -eq 0) {
+        if ([string]::IsNullOrWhiteSpace($filter)) {
+            # An empty filter means "all packages", so resolving nothing implies a broken workspace
+            # rather than a legitimately empty selection.
+            Write-Host "No packages found to check for external types." -ForegroundColor Red
+            exit 1
+        }
+        # A non-empty filter that resolves to nothing is a typo or a stale name, not a clean pass:
+        # cargo-delta only names extant, affected packages, so surface it loudly.
+        Write-Host "No packages matched '$filter'; nothing to check for external types." -ForegroundColor Red
+        exit 1
+    }
+
+    $packageWord = if ($manifests.Count -eq 1) { "package" } else { "packages" }
+    Write-Host "Checking external types in $($manifests.Count) $packageWord (toolchain $env:RUST_NIGHTLY_EXTERNAL_TYPES)"
+    Write-Host ""
+
+    # This check only consumes rustdoc's JSON description of the public type surface; doc lints are
+    # irrelevant to it and are validated separately by the docs job. Capping lints is not cosmetic:
+    # the pinned nightly's rustdoc can ICE while rendering a doc-link warning (it panics inside the
+    # annotate-snippet renderer), which would fail the check for a reason unrelated to external types.
+    # Suppressing the warning avoids that. Deliberately no `--cfg docsrs`: it only toggles doc-cfg
+    # badges, never the type surface, and the baselines were captured without it.
+    $env:RUSTDOCFLAGS = "--cap-lints allow"
+
+    # Inspect each manifest's exit code by hand so one failing crate does not abort the loop: this
+    # aggregates every failure into one report instead of stopping at the first. A nonzero cargo exit
+    # must therefore not throw, so native-command error promotion is disabled for the loop.
+    $PSNativeCommandUseErrorActionPreference = $false
+
+    $failures = @()
+    foreach ($manifest in $manifests) {
+        Write-Host "Checking $manifest..." -ForegroundColor Cyan
+        cargo +$env:RUST_NIGHTLY_EXTERNAL_TYPES check-external-types --skip-unsupported --all-features --manifest-path $manifest
+        if ($LASTEXITCODE -ne 0) {
+            $failures += $manifest
+        }
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Host ""
+        Write-Host "External-types check failed for:" -ForegroundColor Red
+        foreach ($failure in $failures) {
+            Write-Host "  - $failure" -ForegroundColor Red
+        }
+        Write-Host ""
+        Write-Host ("A library exposes an external type that is not on its allow-list. If the exposure " +
+            "is intentional, add the type to that crate's [package.metadata.cargo_check_external_types] " +
+            "allowed_external_types in Cargo.toml. See docs/external-types.md.") -ForegroundColor Yellow
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "External-types check passed." -ForegroundColor Green
+
 [group('quality')]
 [script]
 careful FILTER="":
@@ -198,6 +275,7 @@ validate-local:
     just package="{{ package }}" miri
     just package="{{ package }}" machete
     just package="{{ package }}" default-features-check
+    just package="{{ package }}" check-external-types
     just package="{{ package }}" check release
     just package="{{ package }}" clippy release
     just package="{{ package }}" build release

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -65,13 +65,37 @@ install-tools:
     # lacks the multi-target/workspace support this repo needs; see constants.env
     # (CARGO_CHECK_EXTERNAL_TYPES_GIT / CARGO_CHECK_EXTERNAL_TYPES_REV) for the full rationale and
     # the condition for switching back to a crates.io pin. `--locked` builds against the commit's
-    # own Cargo.lock so the result is reproducible, and cargo replaces an install built from a
-    # different rev (a fast no-op when the rev already matches), so bumping the tool is just editing
-    # the rev in constants.env.
-    cargo install cargo-check-external-types `
-        --git $env:CARGO_CHECK_EXTERNAL_TYPES_GIT `
-        --rev $env:CARGO_CHECK_EXTERNAL_TYPES_REV `
-        --locked
+    # own Cargo.lock so the result is reproducible.
+    #
+    # Unlike the `@version` tools above, a plain reinstall cannot reconcile a git pin: cargo keys
+    # "already installed" on the crate *version*, which does not change between the commits we pin,
+    # so it would keep an older commit after a rev bump. rust-cache compounds this by restoring the
+    # previously compiled binary under a key that excludes the rev. So we read the commit cargo
+    # recorded in .crates2.json and reinstall with --force only when it differs from the pin: a rev
+    # bump always takes effect, while an unchanged pin stays a no-op instead of recompiling the tool
+    # on every CI job. constants.env pins a full 40-character commit SHA, which .crates2.json records
+    # verbatim, so an exact comparison suffices.
+    $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
+    $cratesMetadata = Join-Path $cargoHome ".crates2.json"
+    $installedRev = ""
+    if (Test-Path -LiteralPath $cratesMetadata) {
+        $json = Get-Content -LiteralPath $cratesMetadata -Raw | ConvertFrom-Json
+        if ($json.PSObject.Properties.Name -contains "installs") {
+            $entry = $json.installs.PSObject.Properties.Name |
+                Where-Object { $_ -like "cargo-check-external-types *git+*" } |
+                Select-Object -First 1
+            if ($entry -and $entry -match "#([0-9a-f]{40})\)$") {
+                $installedRev = $Matches[1]
+            }
+        }
+    }
+
+    if ($installedRev -ne $env:CARGO_CHECK_EXTERNAL_TYPES_REV) {
+        cargo install cargo-check-external-types `
+            --git $env:CARGO_CHECK_EXTERNAL_TYPES_GIT `
+            --rev $env:CARGO_CHECK_EXTERNAL_TYPES_REV `
+            --locked --force
+    }
 
     # cargo-mutants transitively depends on `winapi 0.2.8`, which only defines its
     # types for `target_arch = "x86"` / `"x86_64"` and fails to compile on aarch64

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -30,6 +30,12 @@ install-tools:
     Install-RustupToolchain -Channel $env:RUST_NIGHTLY `
         -Component @('miri', 'rustfmt', 'rust-src', 'llvm-tools-preview')
 
+    # Dedicated nightly for `just check-external-types` (see constants.env,
+    # RUST_NIGHTLY_EXTERNAL_TYPES, for why it must be separate from RUST_NIGHTLY). The minimal
+    # profile is enough: the check only drives rustdoc, which ships with the rustc component - it
+    # needs neither miri/rustfmt nor rust-src.
+    Install-RustupToolchain -Channel $env:RUST_NIGHTLY_EXTERNAL_TYPES -InstallProfile minimal
+
     # Every tool is pinned to an explicit version from constants.env (dotenv, configured in the
     # root justfile, exposes each `FOO_VERSION` as `$env:FOO_VERSION`). This is deliberate: a plain
     # `cargo install <crate>` never upgrades an already-installed crate - it prints "already
@@ -52,6 +58,19 @@ install-tools:
         cargo-sort-derives@$env:CARGO_SORT_DERIVES_VERSION `
         cargo-udeps@$env:CARGO_UDEPS_VERSION `
         release-plz@$env:RELEASE_PLZ_VERSION `
+        --locked
+
+    # cargo-check-external-types powers `just check-external-types`. It is installed from a git
+    # commit rather than the pinned `@version` block above because the latest crates.io release
+    # lacks the multi-target/workspace support this repo needs; see constants.env
+    # (CARGO_CHECK_EXTERNAL_TYPES_GIT / CARGO_CHECK_EXTERNAL_TYPES_REV) for the full rationale and
+    # the condition for switching back to a crates.io pin. `--locked` builds against the commit's
+    # own Cargo.lock so the result is reproducible, and cargo replaces an install built from a
+    # different rev (a fast no-op when the rev already matches), so bumping the tool is just editing
+    # the rev in constants.env.
+    cargo install cargo-check-external-types `
+        --git $env:CARGO_CHECK_EXTERNAL_TYPES_GIT `
+        --rev $env:CARGO_CHECK_EXTERNAL_TYPES_REV `
         --locked
 
     # cargo-mutants transitively depends on `winapi 0.2.8`, which only defines its

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -11,6 +11,13 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+# Baseline of external types intentionally exposed in the public API.
+# `cargo-bench-history` is the public shell over its own `cbh_*` implementation
+# partitions, so re-exporting any partition type is by-design layering, not
+# accidental exposure. Ref: docs/external-types.md; docs/impl-crate-split.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["cbh_*::*"]
+
 [package.metadata.binstall]
 # Prebuilt binaries are published by .github/workflows/release.yml (see
 # docs/release-automation.md). release-plz tags releases as `<crate>-v<version>`,

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -14,6 +14,17 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "clap_builder::derive::Args",
+    "clap_builder::derive::CommandFactory",
+    "clap_builder::derive::FromArgMatches",
+    "clap_builder::derive::Parser",
+]
+
 [package.metadata.binstall]
 # Prebuilt binaries are published by .github/workflows/release.yml (see
 # docs/release-automation.md). release-plz tags releases as `<crate>-v<version>`,

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -14,6 +14,17 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "clap_builder::derive::Args",
+    "clap_builder::derive::CommandFactory",
+    "clap_builder::derive::FromArgMatches",
+    "clap_builder::derive::Parser",
+]
+
 [package.metadata.binstall]
 # Prebuilt binaries are published by .github/workflows/release.yml (see
 # docs/release-automation.md). release-plz tags releases as `<crate>-v<version>`,

--- a/packages/cpulist/Cargo.toml
+++ b/packages/cpulist/Cargo.toml
@@ -17,10 +17,7 @@ all-features = true
 # external type here trips the check so accidental exposures are caught.
 # Ref: docs/external-types.md.
 [package.metadata.cargo_check_external_types]
-allowed_external_types = [
-    "ohno::enrichable::Enrichable",
-    "ohno::error_ext::ErrorExt",
-]
+allowed_external_types = ["ohno::enrichable::Enrichable", "ohno::error_ext::ErrorExt"]
 
 [features]
 default = []

--- a/packages/cpulist/Cargo.toml
+++ b/packages/cpulist/Cargo.toml
@@ -13,6 +13,15 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "ohno::enrichable::Enrichable",
+    "ohno::error_ext::ErrorExt",
+]
+
 [features]
 default = []
 

--- a/packages/future_deque/Cargo.toml
+++ b/packages/future_deque/Cargo.toml
@@ -13,6 +13,12 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["futures_core::stream::Stream"]
+
 [features]
 futures-stream = ["dep:futures-core"]
 

--- a/packages/linked/Cargo.toml
+++ b/packages/linked/Cargo.toml
@@ -13,6 +13,13 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API.
+# `linked` re-exports macro-support internals from its companion `linked_macros`
+# crate, so those are by-design layering, not accidental exposure.
+# Ref: docs/external-types.md; docs/impl-crate-split.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["linked_macros::*"]
+
 [features]
 default = []
 

--- a/packages/linked_macros_impl/Cargo.toml
+++ b/packages/linked_macros_impl/Cargo.toml
@@ -13,6 +13,12 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["proc_macro2::TokenStream"]
+
 [lib]
 doc = false
 

--- a/packages/many_cpus/Cargo.toml
+++ b/packages/many_cpus/Cargo.toml
@@ -13,6 +13,13 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API.
+# `many_cpus` is the public shell over its own `many_cpus_impl` partition, so
+# re-exporting any impl type is by-design layering, not accidental exposure.
+# Ref: docs/external-types.md; docs/impl-crate-split.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["many_cpus_impl::*"]
+
 # `testing` is used by the Windows-only `*_obey_job_*` examples (inside
 # `#[cfg(windows)]` modules) but not by anything on Linux, so cargo-udeps
 # reports it as unused there.

--- a/packages/many_cpus_benchmarking/Cargo.toml
+++ b/packages/many_cpus_benchmarking/Cargo.toml
@@ -13,6 +13,12 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["criterion::Criterion"]
+
 [features]
 default = []
 

--- a/packages/nm/Cargo.toml
+++ b/packages/nm/Cargo.toml
@@ -13,6 +13,13 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API.
+# `nm` is the public shell over its own `nm_impl` partition, so re-exporting any
+# impl type is by-design layering, not accidental exposure.
+# Ref: docs/external-types.md; docs/impl-crate-split.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["nm_impl::*"]
+
 [dependencies]
 nm_impl = { workspace = true }
 

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -13,6 +13,13 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API.
+# `nm_otel` is the public shell over its own `nm_otel_impl` partition, so
+# re-exporting any impl type is by-design layering, not accidental exposure.
+# Ref: docs/external-types.md; docs/impl-crate-split.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["nm_otel_impl::*"]
+
 [dependencies]
 nm_otel_impl = { workspace = true }
 

--- a/packages/par_bench/Cargo.toml
+++ b/packages/par_bench/Cargo.toml
@@ -13,6 +13,20 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "all_the_time::report::Report",
+    "all_the_time::session::Session",
+    "alloc_tracker::report::Report",
+    "alloc_tracker::session::Session",
+    "criterion::benchmark_group::BenchmarkGroup",
+    "criterion::measurement::WallTime",
+    "many_cpus_impl::processor_set::ProcessorSet",
+]
+
 [features]
 default = []
 all_the_time = ["dep:all_the_time"]

--- a/packages/region_cached/Cargo.toml
+++ b/packages/region_cached/Cargo.toml
@@ -13,6 +13,16 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "linked::family::Family",
+    "linked::object::Object",
+    "many_cpus_impl::system_hardware::SystemHardware",
+]
+
 [features]
 default = []
 

--- a/packages/region_local/Cargo.toml
+++ b/packages/region_local/Cargo.toml
@@ -13,6 +13,16 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "linked::family::Family",
+    "linked::object::Object",
+    "many_cpus_impl::system_hardware::SystemHardware",
+]
+
 [features]
 default = []
 

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -13,6 +13,12 @@ rust-version.workspace = true
 [lib]
 doc = false
 
+# Baseline of external types intentionally exposed in the public API. Any new
+# external type here trips the check so accidental exposures are caught.
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["deranged::RangedU8"]
+
 [features]
 default = []
 

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -10,14 +10,14 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[lib]
-doc = false
-
 # Baseline of external types intentionally exposed in the public API. Any new
 # external type here trips the check so accidental exposures are caught.
 # Ref: docs/external-types.md.
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["deranged::RangedU8"]
+
+[lib]
+doc = false
 
 [features]
 default = []

--- a/packages/vicinal/Cargo.toml
+++ b/packages/vicinal/Cargo.toml
@@ -13,6 +13,13 @@ rust-version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+# Baseline of external types intentionally exposed in the public API. Cross-crate
+# first-party types are listed individually by their canonical defining crate
+# (many_cpus re-exports `SystemHardware` from its `many_cpus_impl` partition).
+# Ref: docs/external-types.md.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["many_cpus_impl::system_hardware::SystemHardware"]
+
 [features]
 default = []
 

--- a/scripts/build/ExternalTypes.Tests.ps1
+++ b/scripts/build/ExternalTypes.Tests.ps1
@@ -4,8 +4,9 @@
 #
 # Get-ExternalTypesManifest walks the filesystem, so tests build a `packages/<pkg>/Cargo.toml`
 # fixture under TestDrive and assert the filter behaviour: empty filter selects every package,
-# a space-separated filter restricts to named packages, directories without a Cargo.toml are
-# ignored, and a filter naming a non-existent package drops it instead of emitting a bad path.
+# a whitespace-separated filter restricts to named packages (collapsing repeats and arbitrary
+# spacing), directories without a Cargo.toml are ignored, and a filter naming a non-existent
+# package drops it instead of emitting a bad path.
 
 BeforeAll {
     Import-Module (Join-Path $PSScriptRoot 'ExternalTypes.psm1') -Force
@@ -39,6 +40,12 @@ Describe 'Get-ExternalTypesManifest' {
 
     It 'restricts to a space-separated package allow-list, sorted' {
         $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root -PackageFilter 'gamma alpha')
+        $names = $manifests | ForEach-Object { Split-Path (Split-Path $_ -Parent) -Leaf }
+        ($names -join ',') | Should -Be 'alpha,gamma'
+    }
+
+    It 'collapses arbitrary whitespace and de-duplicates repeated names' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root -PackageFilter "gamma`t alpha   gamma")
         $names = $manifests | ForEach-Object { Split-Path (Split-Path $_ -Parent) -Leaf }
         ($names -join ',') | Should -Be 'alpha,gamma'
     }

--- a/scripts/build/ExternalTypes.Tests.ps1
+++ b/scripts/build/ExternalTypes.Tests.ps1
@@ -1,0 +1,63 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Pester suite for ExternalTypes.psm1.
+#
+# Get-ExternalTypesManifest walks the filesystem, so tests build a `packages/<pkg>/Cargo.toml`
+# fixture under TestDrive and assert the filter behaviour: empty filter selects every package,
+# a space-separated filter restricts to named packages, directories without a Cargo.toml are
+# ignored, and a filter naming a non-existent package drops it instead of emitting a bad path.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'ExternalTypes.psm1') -Force
+}
+
+Describe 'Get-ExternalTypesManifest' {
+    BeforeEach {
+        $script:Root = Join-Path $TestDrive 'packages'
+
+        # Three real packages, each with a Cargo.toml.
+        foreach ($name in @('alpha', 'beta', 'gamma')) {
+            $dir = Join-Path $script:Root $name
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            Set-Content -Path (Join-Path $dir 'Cargo.toml') -Value '[package]'
+        }
+
+        # A directory that is not a package (no Cargo.toml) must be ignored.
+        New-Item -ItemType Directory -Path (Join-Path $script:Root 'noise') -Force | Out-Null
+    }
+
+    It 'selects every package with a Cargo.toml when the filter is empty, sorted' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root)
+        $names = $manifests | ForEach-Object { Split-Path (Split-Path $_ -Parent) -Leaf }
+        ($names -join ',') | Should -Be 'alpha,beta,gamma'
+    }
+
+    It 'ignores directories without a Cargo.toml' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root)
+        ($manifests | Where-Object { $_ -like '*noise*' }) | Should -BeNullOrEmpty
+    }
+
+    It 'restricts to a space-separated package allow-list, sorted' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root -PackageFilter 'gamma alpha')
+        $names = $manifests | ForEach-Object { Split-Path (Split-Path $_ -Parent) -Leaf }
+        ($names -join ',') | Should -Be 'alpha,gamma'
+    }
+
+    It 'drops a filtered package whose manifest does not exist' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root -PackageFilter 'alpha does_not_exist')
+        $names = $manifests | ForEach-Object { Split-Path (Split-Path $_ -Parent) -Leaf }
+        ($names -join ',') | Should -Be 'alpha'
+    }
+
+    It 'returns a manifest path that points at the package Cargo.toml' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root -PackageFilter 'beta')
+        $manifests.Count | Should -Be 1
+        (Test-Path -LiteralPath $manifests[0]) | Should -BeTrue
+        (Split-Path $manifests[0] -Leaf) | Should -Be 'Cargo.toml'
+    }
+
+    It 'returns nothing when the filter names only unknown packages' {
+        $manifests = @(Get-ExternalTypesManifest -PackagesRoot $script:Root -PackageFilter 'nope')
+        $manifests | Should -BeNullOrEmpty
+    }
+}

--- a/scripts/build/ExternalTypes.psm1
+++ b/scripts/build/ExternalTypes.psm1
@@ -1,0 +1,50 @@
+#requires -Version 7
+
+# Backs the `check-external-types` recipe: resolves which crate manifests the external-types check
+# should run against.
+#
+# `check-external-types` runs cargo-check-external-types once per selected package so the
+# delta-scoped CI job can check just the crates a branch touches. The one part worth testing in
+# isolation is turning the `{{ package }}` filter into a concrete, deterministic list of Cargo.toml
+# paths: an empty filter means "every package", a non-empty filter is the space-separated allow-list
+# cargo-delta emits, and a name whose manifest no longer exists must be dropped rather than handed to
+# cargo as a bad path. Deciding which crates are actually checkable (library vs. proc-macro vs.
+# binary-only) is deliberately left to the tool's own `--skip-unsupported` flag, so this module never
+# has to reimplement - and drift from - that classification.
+
+Set-StrictMode -Version Latest
+
+function Get-ExternalTypesManifest {
+    # Returns the Cargo.toml manifest paths under $PackagesRoot to check, one per selected package,
+    # sorted for deterministic ordering. An empty $PackageFilter selects every package that has a
+    # Cargo.toml; otherwise it is a space-separated allow-list of package names (e.g. cargo-delta
+    # output). Only packages whose manifest exists are returned, so a stale name is skipped instead
+    # of being passed to cargo as a non-existent path.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string] $PackagesRoot,
+        [string] $PackageFilter = ''
+    )
+
+    $packages = if ([string]::IsNullOrWhiteSpace($PackageFilter)) {
+        Get-ChildItem -LiteralPath $PackagesRoot -Directory |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'Cargo.toml') } |
+            ForEach-Object { $_.Name } |
+            Sort-Object
+    } else {
+        # Support space-separated package lists (e.g. from cargo-delta output).
+        $PackageFilter -split ' ' | Where-Object { $_ -ne '' } | Sort-Object
+    }
+
+    $manifests = [System.Collections.Generic.List[string]]::new()
+    foreach ($package in $packages) {
+        $manifest = Join-Path $PackagesRoot $package 'Cargo.toml'
+        if (Test-Path -LiteralPath $manifest) {
+            $manifests.Add($manifest)
+        }
+    }
+    return $manifests.ToArray()
+}
+
+Export-ModuleMember -Function Get-ExternalTypesManifest

--- a/scripts/build/ExternalTypes.psm1
+++ b/scripts/build/ExternalTypes.psm1
@@ -6,22 +6,22 @@
 # `check-external-types` runs cargo-check-external-types once per selected package so the
 # delta-scoped CI job can check just the crates a branch touches. The one part worth testing in
 # isolation is turning the `{{ package }}` filter into a concrete, deterministic list of Cargo.toml
-# paths: an empty filter means "every package", a non-empty filter is the space-separated allow-list
-# cargo-delta emits, and a name whose manifest no longer exists must be dropped rather than handed to
-# cargo as a bad path. Deciding which crates are actually checkable (library vs. proc-macro vs.
-# binary-only) is deliberately left to the tool's own `--skip-unsupported` flag, so this module never
-# has to reimplement - and drift from - that classification.
+# paths: an empty filter means "every package", a non-empty filter is the whitespace-separated
+# allow-list cargo-delta emits, and a name whose manifest no longer exists must be dropped rather than
+# handed to cargo as a bad path. Deciding which crates are actually checkable (library vs. proc-macro
+# vs. binary-only) is deliberately left to the tool's own `--skip-unsupported` flag, so this module
+# never has to reimplement - and drift from - that classification.
 
 Set-StrictMode -Version Latest
 
 function Get-ExternalTypesManifest {
     # Returns the Cargo.toml manifest paths under $PackagesRoot to check, one per selected package,
     # sorted for deterministic ordering. An empty $PackageFilter selects every package that has a
-    # Cargo.toml; otherwise it is a space-separated allow-list of package names (e.g. cargo-delta
+    # Cargo.toml; otherwise it is a whitespace-separated allow-list of package names (e.g. cargo-delta
     # output). Only packages whose manifest exists are returned, so a stale name is skipped instead
     # of being passed to cargo as a non-existent path.
     [CmdletBinding()]
-    [OutputType([string])]
+    [OutputType([string[]])]
     param(
         [Parameter(Mandatory)][string] $PackagesRoot,
         [string] $PackageFilter = ''
@@ -33,8 +33,9 @@ function Get-ExternalTypesManifest {
             ForEach-Object { $_.Name } |
             Sort-Object
     } else {
-        # Support space-separated package lists (e.g. from cargo-delta output).
-        $PackageFilter -split ' ' | Where-Object { $_ -ne '' } | Sort-Object
+        # Support arbitrary whitespace between names (e.g. from cargo-delta output) and drop
+        # duplicates so a repeated name checks its manifest only once.
+        $PackageFilter -split '\s+' | Where-Object { $_ -ne '' } | Sort-Object -Unique
     }
 
     $manifests = [System.Collections.Generic.List[string]]::new()


### PR DESCRIPTION
[Copilot speaking]

## Motivation

A library can accidentally leak an external type into its public API — an error type surfacing through `?`, a builder returning a foreign struct, a `pub use` that re-exports more than intended. Such a leak couples our API to another crate (callers must name the foreign type, and a semver break there becomes a semver break here) and is easy to add unnoticed but hard to remove later without breaking callers.

This adds a validation gate that fails when a library's set of externally-exposed public types grows without being acknowledged. The goal is to catch *accidents*, not to prohibit external types: an intentional exposure is admitted by listing it in the crate's allow-list.

## What changes

`cargo-check-external-types` now runs as a delta-scoped CI job (Linux + Windows) and via `just check-external-types` (part of `validate-local`). It fails when a crate exposes an external type — one not defined by the crate itself — that is not covered by that crate's `[package.metadata.cargo_check_external_types].allowed_external_types`.

```
public API change ──▶ CI delta ──▶ check-external-types (per crate)
                                    │  pinned nightly + git-pinned tool
                                    │  rustdoc JSON ─▶ compare vs allow-list
                                    ▼
                         unlisted external type?  ── yes ──▶ fail
                                    │
                                    no ──▶ pass
```

Design notes:

- **Dedicated nightly.** The tool consumes an exact, unstable rustdoc JSON schema, so it runs on its own pinned nightly (`RUST_NIGHTLY_EXTERNAL_TYPES`) held separate from the general nightly and bumped only in lockstep with the tool. The tool itself is pinned to a git commit because the published release lacks the multi-target/workspace fix. `just install-tools` installs both.
- **Per-crate baselines.** Each library carries an allow-list capturing its current external surface, so the check passes today and fails on future drift. A shell crate's own implementation partition is allowed with a crate-level glob; cross-crate and third-party types are listed individually, so a *new* exposure from an already-referenced crate still trips the check.
- **Additive allow policy.** Adding an uncovered external type fails; removing an exposure does not (it leaves a harmless unreferenced entry). Unused entries cannot be auto-rejected because a legitimate platform-specific entry is unreferenced on the other platform.
- **Platform coverage.** The public surface can differ by platform, so the check runs on both a Unix and a Windows target. Two targets suffice for this workspace because platform-variant surface is gated only on `cfg(windows)`/`cfg(unix)` (Linux stands in for macOS) or hidden behind a PAL facade with an identical public surface, and nothing public is `target_arch`-gated.

The principle is documented in `docs/external-types.md` and referenced from `AGENTS.md`; the CI job is described in the workflows design.