### PR TITLE
release: reconcile Cargo.lock before the locked binary build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,22 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
+      - name: Reconcile Cargo.lock with the released manifests
+        shell: bash
+        # A release-plz major bump can tag a commit whose committed Cargo.lock lags the bumped
+        # manifests: the manifest goes to the major version (e.g. cargo-bench-history 0.0.9 ->
+        # 0.2.0) while the lockfile entry for that package is only patch-bumped (-> 0.0.10). The
+        # whole workspace shares one Cargo.lock, so that single stale entry makes the `--locked`
+        # build below fail for *every* binary crate ("cannot update the lock file ... because
+        # --locked was passed"). `--workspace` re-syncs only the workspace members' own versions
+        # in the lockfile - registry dependencies already present in the lockfile stay pinned, so
+        # the build stays reproducible - letting a tag whose lockfile release-plz left inconsistent
+        # still build. `--offline` is deliberately omitted: setup-environment warms only the tool
+        # dependencies' index entries, not the whole workspace's, so an offline resolve could miss
+        # a cached index entry; the online resolve fetches index metadata but changes no pinned
+        # dependency version. This is a no-op when the tag's lockfile is already consistent.
+        run: cargo update --workspace
+
       - name: Build, package, checksum and upload
         uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -57,6 +57,15 @@ fail *before* any version or changelog is touched:
 * **never-published warning** (`check-never-published`, a post-step). See
   [Manual publishing](#manual-publishing) below.
 
+After `release-plz update` bumps the manifests and changelogs, `prepare-release`
+runs `cargo update --workspace` to re-sync the shared `Cargo.lock` with the
+bumped manifests. On a *major* bump release-plz can leave a package's lockfile
+entry at a patch bump while its manifest jumped to the major version; because the
+workspace shares one lockfile, that single stale entry breaks every
+`cargo build --locked` on `main` and in the release binary builds. `--workspace`
+touches only the workspace members' own versions and leaves registry
+dependencies pinned, so the committed release carries a consistent lockfile.
+
 ## What ships a binary (derived, never hardcoded)
 
 The set of published binary crates is **derived**, so new tools are covered
@@ -218,6 +227,20 @@ on **every** platform (`tar: none`, `zip: all`) — `.zip` is universally
 extractable, and a single format keeps the `[package.metadata.binstall]` blocks
 free of per-OS overrides.
 
+**Lockfile reconciliation before the `--locked` build.** A `cargo update
+--workspace` step runs between checkout and the build. The build uses
+`locked: true` for reproducibility, but a release-plz *major* bump can tag a
+commit whose committed `Cargo.lock` still records a package at a patch bump
+(e.g. `0.0.10`) while its manifest jumped to the major version (e.g. `0.2.0`).
+Because the workspace shares one `Cargo.lock`, that single stale entry fails the
+`--locked` build of **every** binary crate. `cargo update --workspace` re-syncs
+only the workspace members' own versions in the lockfile — registry dependencies
+already present stay pinned, so reproducibility is preserved — and is a no-op
+when the tag's lockfile is already consistent. `prepare-release` performs the
+same reconciliation (see [Preflights](#preflights-around-release-plz-update)), so
+new releases carry a consistent lockfile; this step tolerates already-created
+tags that predate that fix.
+
 ```yaml
 # Illustrative.
 build-binaries:
@@ -237,6 +260,7 @@ build-binaries:
       with:
         ref: refs/tags/${{ matrix.tag }}   # build the exact released code
     - uses: ./.github/actions/setup-environment
+    - run: cargo update --workspace   # re-sync workspace-member versions a stale tag lockfile may lag
     - uses: taiki-e/upload-rust-binary-action@v1
       with:
         bin: ${{ matrix.name }}

--- a/justfiles/just_release.just
+++ b/justfiles/just_release.just
@@ -12,6 +12,16 @@ prepare-release: verify-semver-checks && check-never-published
     Write-Verbose "Bumping versions and changelogs via 'release-plz update'" -Verbose
     release-plz update
 
+    # release-plz bumps each manifest to its computed next version, but on a *major* bump it can
+    # leave the shared Cargo.lock's entry for that package at a patch bump (e.g. manifest -> 0.2.0
+    # while the lockfile records 0.0.10). The whole workspace shares one Cargo.lock, so that single
+    # stale entry breaks every `cargo build --locked` on main and in the release binary builds.
+    # `cargo update --workspace` re-syncs only the workspace members' own versions in the lockfile;
+    # registry dependencies already present stay pinned, so this reconciles the manifests and the
+    # lockfile without churning third-party versions.
+    Write-Verbose "Reconciling Cargo.lock with the bumped manifests via 'cargo update --workspace'" -Verbose
+    cargo update --workspace
+
 # Preflight for `just prepare-release`: proves that `cargo semver-checks` can actually run on
 # this machine before `release-plz update` starts trusting it. release-plz runs
 # cargo-semver-checks to decide whether a bumped version needs to be a *major* bump, but when the


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The `build-binaries` step of the Release workflow failed for the `cargo-bench-history-v0.2.0` release ([run 31964187326](https://github.com/folo-rs/folo/actions/runs/31964187326/job/95208888821)). `publish` succeeded (0.2.0 is on crates.io), but **every** `build-binaries` matrix job failed — across all crates (`cargo-bench-history`, `cargo-bench-history-faker`, `cargo-detect-package`, `cargo-freeze-deps`) and all targets — with:

```
error: cannot update the lock file /home/runner/work/folo/folo/Cargo.lock because --locked was passed to prevent this
```

## Root cause

`release-plz update` performed a **major** bump for `cargo-bench-history` (breaking change detected by cargo-semver-checks), writing `0.2.0` to its `Cargo.toml`, but the shared `Cargo.lock` entry for that package was only patch-bumped to `0.0.10`. The workspace shares a single `Cargo.lock`, so that one inconsistent entry fails `cargo build --locked` for *every* binary crate in the workspace — hence all matrix legs failed, not just `cargo-bench-history`. The release tag is immutable, so re-running alone could never succeed.

```
Cargo.toml: cargo-bench-history = 0.2.0   -> mismatch: whole-workspace
Cargo.lock: cargo-bench-history = 0.0.10  -> `--locked` resolve fails
                                           -> build-binaries fails for
                                              ALL crates (shared lockfile)
```

## Changes

- **`build-binaries` job**: reconcile the lockfile with `cargo update --workspace` between checkout and the `--locked` build. It re-syncs only workspace-member versions (registry dependencies already in the lockfile stay pinned, preserving reproducibility) and is a no-op when the tag's lockfile is already consistent. This heals already-created tags whose lockfile release-plz left inconsistent.
- **`just prepare-release`**: run the same `cargo update --workspace` after `release-plz update`, so new releases commit a consistent lockfile and `main` never ends up with a broken `--locked` build.
- **`docs/release-automation.md`**: document both reconciliations.

The `cargo update --workspace` behavior was verified locally against a reproduced stale lockfile: it corrected the single stale version and produced a lockfile byte-identical to the correct one.

## Recovery of the stuck release

Once merged to `main`, trigger a bare `workflow_dispatch` on the Release workflow: `plan-binaries` reconciles the still-missing archives and `build-binaries` now heals the tag's lockfile before building, so the `cargo-bench-history-v0.2.0` binaries get built and uploaded.