### PR TITLE
release: gate publishing on a consistent checked-in lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
+      - name: Verify checked-in lockfile is consistent
+        shell: pwsh
+        # Fail the release BEFORE any crate is published or tag is created if the committed
+        # Cargo.lock disagrees with the manifests. The workspace shares one lockfile, so a single
+        # stale entry (e.g. a manifest bumped without its lock entry) would otherwise sail through
+        # publish and then fail every `build-binaries` job under `--locked`. Verify-only: it reads
+        # the checked-in lockfile and aborts, it never regenerates it. See docs/release-automation.md.
+        run: just verify-lockfile
+
       - name: Compose CI release-plz config (enable git releases for binary crates)
         shell: pwsh
         # git_release_enable stays false in the committed release-plz.toml; this writes a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,11 @@ full design.
     * `just prepare-release` also warns if a crate has never been published — such a
       crate's first release must be done manually (see "First publish" below).
     * Verify pending changes manually and adjust as necessary.
+    * If you hand-edit any version number, run `cargo update --workspace` (or `cargo build`) so
+      the checked-in `Cargo.lock` matches, then `just verify-lockfile` to confirm. The workspace
+      shares one lockfile, so a version bumped without its lock entry updated breaks every
+      `--locked` build — the release `publish` job runs the same `verify-lockfile` gate and
+      aborts before publishing or tagging if the lock is stale.
     * Commit as "chore: prepare for release" when satisfied with the changes.
     * `git push`
 1. On push to `main`, `release.yml` publishes the bumped crates to crates.io (via

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -139,6 +139,9 @@ publish:
         # persist-credentials stays at its default (true): release-plz pushes the
         # release tags via git, which uses the checkout-persisted token.
     - uses: ./.github/actions/setup-environment
+    - name: Verify the checked-in lockfile is consistent
+      shell: pwsh
+      run: just verify-lockfile   # aborts before publish/tag if Cargo.lock is stale
     - name: Compose the CI release-plz config
       shell: pwsh
       run: just gh-compose-release-config "$env:RUNNER_TEMP/release-plz.ci.toml"
@@ -147,6 +150,20 @@ publish:
       env:
         GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # forge API (tags + GitHub releases)
 ```
+
+Before it publishes or tags anything, `publish` runs a **lockfile-consistency gate**
+(`just verify-lockfile`). The whole workspace shares a single `Cargo.lock`, so one entry
+that disagrees with its manifest — the classic case being a version bumped in a
+`Cargo.toml` without the matching lock entry updated — makes *every* `--locked` build fail.
+Nothing else stops such a commit from being tagged: `release-plz` publishes and tags on push
+to `main` before the ordinary `--locked` validation on that push can block it, so the broken
+lock would only surface downstream as a total `build-binaries` wipeout. The gate runs
+`cargo metadata --locked`, which resolves the graph against the committed lockfile and exits
+non-zero if the lock would need to change, turning that latent failure into an early, actionable
+abort — no crate is published and no tag is created. It is **verify-only**: it reads the
+checked-in lockfile and never regenerates it (workflows build the committed lockfile verbatim).
+The same recipe is runnable locally (`just verify-lockfile`) to catch a stale lock after a manual
+version edit, before pushing.
 
 Each step is a thin `pwsh` call into a `just` recipe; the publishing logic — deriving
 the binary crates, injecting `git_release_enable`, and the retry loop — lives in

--- a/justfiles/just_release.just
+++ b/justfiles/just_release.just
@@ -56,6 +56,46 @@ verify-semver-checks:
         exit 1
     }
 
+# Verifies the checked-in Cargo.lock is consistent with the workspace manifests, WITHOUT
+# modifying it. `cargo metadata --locked` resolves the dependency graph against the committed
+# lockfile and exits non-zero if the lock would need to change - the classic trigger being a
+# manifest version bumped without its Cargo.lock entry updated to match. The whole workspace
+# shares one lockfile, so a single stale entry breaks every `--locked` build, which means a
+# release tagged with an inconsistent lock fails all `build-binaries` jobs at once (they check
+# out the tag and build `--locked`). The release `publish` job runs this gate before anything is
+# published or tagged, turning that latent, workspace-wide failure into an early, actionable
+# abort; run it locally after a manual version edit to catch the problem before pushing. It only
+# reads the lockfile - the fix for a stale lock is to regenerate it locally and commit it, never
+# to regenerate it inside a workflow.
+[group('release')]
+[script]
+verify-lockfile:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+
+    Write-Verbose "Verifying that the checked-in Cargo.lock is consistent with the workspace manifests" -Verbose
+
+    try {
+        # Full-graph resolve (no --no-deps) so --locked actually validates the lockfile; the JSON
+        # on stdout is discarded, only the exit status matters. Any error message from cargo (e.g.
+        # "cannot update the lock file ... because --locked was passed") surfaces above.
+        cargo metadata --locked --format-version 1 1> $null
+    }
+    catch {
+        Write-Host ""
+        Write-Host "ERROR: the checked-in Cargo.lock is out of date with the workspace manifests (see the error above)." -ForegroundColor Red
+        Write-Host ""
+        Write-Host "A manifest version was almost certainly changed (e.g. a manual version bump) without updating" -ForegroundColor Red
+        Write-Host "the matching Cargo.lock entry. Because the whole workspace shares one lockfile, this makes every" -ForegroundColor Red
+        Write-Host "'--locked' build fail, including all release binary builds." -ForegroundColor Red
+        Write-Host ""
+        Write-Host "Fix: run 'cargo update --workspace' (or 'cargo build') locally to sync Cargo.lock, commit the" -ForegroundColor Red
+        Write-Host "result, and re-push. Never regenerate the lockfile inside a workflow - workflows must build the" -ForegroundColor Red
+        Write-Host "checked-in lockfile verbatim." -ForegroundColor Red
+        exit 1
+    }
+
 # Warns about publishable crates that crates.io has never seen. Trusted Publishing cannot
 # perform a crate's first-ever publish (it can only be configured on a crate that already
 # exists), so a brand-new crate's first release must be done by hand (cargo publish), after


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The `build-binaries` jobs in the Release workflow failed for every binary crate at a release (e.g. `cargo-bench-history-v0.2.0`) with:

```
error: cannot update the lock file ... because --locked was passed to prevent this
```

The workspace shares a single root `Cargo.lock`. At that release, `packages/cargo-bench-history/Cargo.toml` was bumped to `0.2.0` while its `Cargo.lock` entry stayed at `0.0.10`. Because the lockfile is shared, one stale entry invalidates `cargo build --locked` for the **entire** workspace, so all `build-binaries` matrix jobs failed — even though `publish` had already succeeded and tagged the release.

Nothing stopped the inconsistent commit from being tagged: `release-plz` publishes and tags on push to `main` *before* ordinary `--locked` validation on that push can block it. The broken lock therefore only surfaced downstream, after the (immutable) tag already existed.

## Change

Add a fail-closed **lockfile-consistency gate** to the release `publish` job, running before anything is published or tagged:

```
                 push to main
                      │
              ┌───────▼────────┐
              │  publish job   │
              │  checkout+setup│
              │  verify-lockfile ──► stale lock? abort (no publish, no tag)
              │  compose config│
              │  release-plz   │  ← only runs if the lock is consistent
              └───────┬────────┘
                      ▼
              plan/build binaries (still strictly --locked)
```

- New `just verify-lockfile` recipe runs `cargo metadata --locked`, which resolves the graph against the committed lockfile and exits non-zero if the lock would need to change. It is **verify-only** — it reads the checked-in lockfile and never regenerates it. Workflows continue to build the committed lockfile verbatim.
- The recipe is also runnable locally to catch a stale lock after a manual version edit, before pushing.
- `build-binaries` is unchanged and stays strictly `--locked`.
- Design and maintainer docs updated (`docs/release-automation.md`, `RELEASING.md`).

The gate prevents *recurrence*. Recovering prebuilt binaries for the already-tagged `cargo-bench-history-v0.2.0` (whose committed lock is broken at that immutable tag) is a separate maintainer decision.