### PR TITLE
cargo-bench-history: cut 0.2.1 to realign the version group and restore prebuilt binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-bench-history"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bench-history-faker"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "folo_utils",
  "mimalloc",
@@ -546,7 +546,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbh_analyze"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "anyspawn",
  "cbh_command",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_cli"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "cbh_command",
  "cbh_model",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_codec"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "alloc_tracker",
  "cbh_model",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_command"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "cbh_model",
  "mutants",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_config"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "cbh_command",
  "mutants",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_detect"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "anyspawn",
  "cbh_model",
@@ -634,14 +634,14 @@ dependencies = [
 
 [[package]]
 name = "cbh_diag"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "mutants",
 ]
 
 [[package]]
 name = "cbh_engines"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_git"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "cbh_model",
  "futures",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_model"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "jiff",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_probe"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "cbh_git",
  "cbh_model",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_render"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "cbh_detect",
  "cbh_model",
@@ -710,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "cbh_stats"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "mutants",
 ]
 
 [[package]]
 name = "cbh_storage"
-version = "0.0.10"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,20 +22,20 @@ azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
 cargo-freeze-deps = { version = "0.1.5", path = "packages/cargo-freeze-deps", default-features = false }
-cbh_analyze = { version = "=0.0.10", path = "packages/cbh_analyze", default-features = false }
-cbh_cli = { version = "=0.0.10", path = "packages/cbh_cli", default-features = false }
-cbh_codec = { version = "=0.0.10", path = "packages/cbh_codec", default-features = false }
-cbh_command = { version = "=0.0.10", path = "packages/cbh_command", default-features = false }
-cbh_config = { version = "=0.0.10", path = "packages/cbh_config", default-features = false }
-cbh_detect = { version = "=0.0.10", path = "packages/cbh_detect", default-features = false }
-cbh_diag = { version = "=0.0.10", path = "packages/cbh_diag", default-features = false }
-cbh_engines = { version = "=0.0.10", path = "packages/cbh_engines", default-features = false }
-cbh_git = { version = "=0.0.10", path = "packages/cbh_git", default-features = false }
-cbh_model = { version = "=0.0.10", path = "packages/cbh_model", default-features = false }
-cbh_probe = { version = "=0.0.10", path = "packages/cbh_probe", default-features = false }
-cbh_render = { version = "=0.0.10", path = "packages/cbh_render", default-features = false }
-cbh_stats = { version = "=0.0.10", path = "packages/cbh_stats", default-features = false }
-cbh_storage = { version = "=0.0.10", path = "packages/cbh_storage", default-features = false }
+cbh_analyze = { version = "=0.2.1", path = "packages/cbh_analyze", default-features = false }
+cbh_cli = { version = "=0.2.1", path = "packages/cbh_cli", default-features = false }
+cbh_codec = { version = "=0.2.1", path = "packages/cbh_codec", default-features = false }
+cbh_command = { version = "=0.2.1", path = "packages/cbh_command", default-features = false }
+cbh_config = { version = "=0.2.1", path = "packages/cbh_config", default-features = false }
+cbh_detect = { version = "=0.2.1", path = "packages/cbh_detect", default-features = false }
+cbh_diag = { version = "=0.2.1", path = "packages/cbh_diag", default-features = false }
+cbh_engines = { version = "=0.2.1", path = "packages/cbh_engines", default-features = false }
+cbh_git = { version = "=0.2.1", path = "packages/cbh_git", default-features = false }
+cbh_model = { version = "=0.2.1", path = "packages/cbh_model", default-features = false }
+cbh_probe = { version = "=0.2.1", path = "packages/cbh_probe", default-features = false }
+cbh_render = { version = "=0.2.1", path = "packages/cbh_render", default-features = false }
+cbh_stats = { version = "=0.2.1", path = "packages/cbh_stats", default-features = false }
+cbh_storage = { version = "=0.2.1", path = "packages/cbh_storage", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
 colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }

--- a/packages/cargo-bench-history-faker/Cargo.toml
+++ b/packages/cargo-bench-history-faker/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cargo-bench-history-faker"
 description = "Unsupported synthetic benchmark-output generator for validating cargo-bench-history end to end; no stable API or CLI"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-bench-history"
 description = "A Cargo tool that maintains a long-lived history of benchmark results and analyzes it for trends"
 publish = true
-version = "0.2.0"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_analyze/Cargo.toml
+++ b/packages/cbh_analyze/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_analyze"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_cli/Cargo.toml
+++ b/packages/cbh_cli/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_cli"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_codec/Cargo.toml
+++ b/packages/cbh_codec/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_codec"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_command/Cargo.toml
+++ b/packages/cbh_command/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_command"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_config/Cargo.toml
+++ b/packages/cbh_config/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_config"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_detect/Cargo.toml
+++ b/packages/cbh_detect/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_detect"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_diag/Cargo.toml
+++ b/packages/cbh_diag/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_diag"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_engines/Cargo.toml
+++ b/packages/cbh_engines/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_engines"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_git/Cargo.toml
+++ b/packages/cbh_git/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_git"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_model/Cargo.toml
+++ b/packages/cbh_model/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_model"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_probe/Cargo.toml
+++ b/packages/cbh_probe/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_probe"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_render/Cargo.toml
+++ b/packages/cbh_render/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_render"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_stats/Cargo.toml
+++ b/packages/cbh_stats/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_stats"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_storage/Cargo.toml
+++ b/packages/cbh_storage/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_storage"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.0.10"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The `cargo-bench-history` family is meant to publish in lockstep: the CLI, the faker, and the 14 `cbh_*` implementation crates all share one version. The 0.2.0 release broke that invariant — the CLI manifest went to `0.2.0` while the other 15 crates stayed at `0.0.10` — and it shipped without prebuilt binaries, so `cargo binstall cargo-bench-history` has no archives to fetch.

## Change

Realign the whole group to a single clean version, `0.2.1`:

- All 16 group manifests (`cargo-bench-history`, `cargo-bench-history-faker`, and every `cbh_*`) set to `0.2.1`.
- The 14 exact `=` pins for the `cbh_*` crates in the root `Cargo.toml` `[workspace.dependencies]` moved from `=0.0.10` to `=0.2.1`.
- `Cargo.lock` synced so the 16 member entries match (no other churn).

This is a pure renumber — there are no source changes between the `cargo-bench-history-v0.2.0` tag and `main` for any crate in the group. Its sole purpose is to cut a consistent release that the binary-build matrix can attach prebuilt binaries to.

On merge, the release `publish` job verifies the checked-in lockfile, then `release-plz release` publishes all 16 crates at `0.2.1`, tags them, and builds the binaries. The existing `0.2.0` release is left untouched and falls back to source builds.