### PR TITLE
Release cargo-detect-package 1.0.27 and cargo-freeze-deps 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-detect-package"
-version = "1.0.26"
+version = "1.0.27"
 dependencies = [
  "clap",
  "mimalloc",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-freeze-deps"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ azure_core = { version = "1.0.0", default-features = false }
 azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
-cargo-freeze-deps = { version = "0.1.5", path = "packages/cargo-freeze-deps", default-features = false }
+cargo-freeze-deps = { version = "0.1.6", path = "packages/cargo-freeze-deps", default-features = false }
 cbh_analyze = { version = "=0.2.1", path = "packages/cbh_analyze", default-features = false }
 cbh_cli = { version = "=0.2.1", path = "packages/cbh_cli", default-features = false }
 cbh_codec = { version = "=0.2.1", path = "packages/cbh_codec", default-features = false }

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-detect-package"
 description = "A Cargo tool to detect the package that a file belongs to, passing the package name to a subcommand"
 publish = true
-version = "1.0.26"
+version = "1.0.27"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-freeze-deps"
 description = "A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file to their literal values"
 publish = true
-version = "0.1.5"
+version = "0.1.6"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The `build-binaries` step of the Release workflow keeps failing for two straggler binary crates, `cargo-detect-package` and `cargo-freeze-deps`. Their most recent release tags — `cargo-detect-package-v1.0.26` and `cargo-freeze-deps-v0.1.5` — were cut during the broken-lockfile window, before the verify-lockfile gate and the `cargo-bench-history` 0.2.1 realignment landed on main. At those tags the workspace `Cargo.lock` is internally inconsistent (a stale `cargo-bench-history` entry), so `cargo build --locked` fails for every binary crate built from them, including these two unrelated ones.

Because the tags are immutable, the fix already on main cannot repair them. Worse, the self-healing `plan-binaries` job keys off each crate's *current* manifest version, so it re-attempts those exact poisoned tags on every release and fails forever.

## Change

Cut fresh patch releases so the current manifest versions move off the poisoned tags:

- `cargo-detect-package`: 1.0.26 → 1.0.27
- `cargo-freeze-deps`: 0.1.5 → 0.1.6 (and the matching workspace-dependency line in the root manifest)
- `Cargo.lock` synced to match (only these two entries change)

On merge, `release-plz` publishes the new versions and tags them from good-lock main, so `build-binaries` succeeds and `plan-binaries` stops retrying the poisoned `v1.0.26` / `v0.1.5` tags. The old tags remain available as source-build/binstall fallbacks, the same treatment already applied to `cargo-bench-history-v0.2.0`.

No source or behavioral changes; version bumps only.