### PR TITLE
Make mutants-careful keep parallel mutation jobs, serialize only tests

### DIFF
--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -27,15 +27,11 @@ mutants SHARD="" CAREFUL='false':
     $mutantArgs = @(Get-MutantsExcludeArgument -IsWindowsPlatform $IsWindows -IsLinuxPlatform $IsLinux)
 
     $mutantArgs += "--jobs"
-    if ($careful) {
-        # In careful mode, only one mutation is tested at a time. Combined with
-        # `RUST_TEST_THREADS=1` set below, this ensures that exactly one test runs at any
-        # given moment across the entire mutation testing run.
-        $mutantArgs += "1"
-    } else {
-        # Experimentally determined heuristics.
-        $mutantArgs += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
-    }
+    # Experimentally determined heuristics. Careful mode deliberately keeps this same
+    # mutation-job parallelism; it only serializes the tests within each job (via
+    # `RUST_TEST_THREADS=1` set below), so latent per-test timeouts are not masked by
+    # concurrent tests.
+    $mutantArgs += [int]([Math]::Floor([Environment]::ProcessorCount / 6)) + 1
 
     # Optional sharding lets CI split mutation testing across multiple parallel runners. We accept
     # the same 1-based "N/M" format as `miri-harder` (so `1/8 .. 8/8` for 8 shards); the module
@@ -94,10 +90,11 @@ mutants SHARD="" CAREFUL='false':
     }
 
     if ($careful) {
-        # Force libtest to run a single test at a time within each `cargo test` invocation.
-        # Combined with `--jobs 1` above, this ensures that exactly one test runs at any
-        # given moment, which helps diagnose tests that are sensitive to concurrent
-        # execution or otherwise interact in unexpected ways.
+        # Disable libtest's intra-suite parallelism so each mutation job runs its tests
+        # one at a time. Mutation jobs still run concurrently (the `--jobs` heuristic
+        # above is unchanged); only test concurrency within a job is removed. Serial
+        # tests surface latent per-test timeouts that concurrent execution can otherwise
+        # hide - which is the entire point of the `mutants-careful` recipe.
         $env:RUST_TEST_THREADS = "1"
     }
 
@@ -114,6 +111,6 @@ mutants SHARD="" CAREFUL='false':
     Invoke-Expression "cargo mutants {{ target_package }} --baseline=skip --timeout=60 --no-shuffle --caught --unviable $expanded_args"
     exit $LASTEXITCODE
 
-# Run mutation tests with no parallelism: one mutation at a time, one test at a time within each mutation. Slow but useful for investigating flaky or concurrency-sensitive tests.
+# Run mutation tests like `mutants` (mutation jobs still run in parallel) but with test concurrency disabled, so only one test runs at a time within each mutation job. Slower, but surfaces per-test timeouts that concurrent test execution can hide.
 [group('quality')]
 mutants-careful: (mutants "" "true")

--- a/justfiles/just_quality_mutants.just
+++ b/justfiles/just_quality_mutants.just
@@ -94,7 +94,7 @@ mutants SHARD="" CAREFUL='false':
         # one at a time. Mutation jobs still run concurrently (the `--jobs` heuristic
         # above is unchanged); only test concurrency within a job is removed. Serial
         # tests surface latent per-test timeouts that concurrent execution can otherwise
-        # hide - which is the entire point of the `mutants-careful` recipe.
+        # hide, which is the entire point of the `mutants-careful` recipe.
         $env:RUST_TEST_THREADS = "1"
     }
 


### PR DESCRIPTION
[Copilot speaking]

## Why

Mutation runs can hide latent per-test timeouts. When many tests run concurrently within a mutant, a genuinely slow or hanging test can be masked by other tests completing first, so a timeout that should surface never does. We want a mode that shakes those out.

## What changed

`just mutants-careful` now runs the same way as `just mutants` with one difference: test concurrency is disabled. Mutation jobs still run in parallel (the `--jobs` heuristic is unchanged); only the tests *within* each mutation job are serialized via `RUST_TEST_THREADS=1`, so exactly one test runs at a time per job. Running tests serially forces each one to complete on its own, surfacing per-test timeouts that concurrent execution can otherwise hide.

Previously `mutants-careful` also forced `--jobs 1`, fully serializing the entire run. That made it much slower than necessary for this purpose and threw away the parallelism across mutants, which is orthogonal to the test-concurrency question.

This is a comment-heavy change in `justfiles/just_quality_mutants.just`; the recipe description and inline rationale were updated to match. No Rust code is affected.