### PR TITLE
future_deque: skip mutations of release_ref that hang blocking tests

### DIFF
--- a/packages/future_deque/src/waker_meta.rs
+++ b/packages/future_deque/src/waker_meta.rs
@@ -108,6 +108,12 @@ pub(crate) fn check_activated(meta: MetaPtr) -> bool {
 /// Decrements the refcount and returns the metadata to the pool if this was the
 /// last reference. Called when a Slot releases its reference (future completes or
 /// deque is dropped) and when the last waker clone is dropped.
+// Mutating the `previous == 1` guard (to `!=` or `true`) frees the pooled slot while other
+// references remain, so a live slot is reused for a new WakerMeta while stale wakers still
+// point at it. The resulting corrupted waker state leaves block_on-based tests polling or
+// parking forever, so the test binary never exits within the mutation testing timeout.
+// Non-blocking tests catch these mutations, but cannot prevent the blocking tests from hanging.
+#[cfg_attr(test, mutants::skip)]
 pub(crate) fn release_ref(meta: MetaPtr) {
     // SAFETY: The metadata is valid (refcount > 0 guarantees it has not been removed).
     let previous = unsafe { &*meta.0 }.ref_count.fetch_sub(1, Ordering::AcqRel);


### PR DESCRIPTION
[Copilot speaking]

Fixes #448

## Why

Mutation testing reported `TIMEOUT` for `replace == with != in release_ref` in `packages/future_deque/src/waker_meta.rs`. A timeout (rather than a clean `CAUGHT`) is worth understanding: a leak alone would not hang, so something else is going on.

## What is happening

The `previous == 1` guard in `release_ref` detects the *last* reference drop, the only point at which the pooled `WakerMeta` slot should be returned. Inverting it (`!=`, and likewise the `true` mutation) frees the slot whenever *other* references still remain and never frees on the true last drop. The pool then hands that still-referenced slot back out for a new `WakerMeta` while stale wakers keep pointing at the old address. The resulting corrupted waker/activation state leaves `block_on`-based tests polling or parking forever, so the test binary never exits within the mutation timeout.

The non-blocking unit tests in this module do catch the mutation, but they cannot stop the blocking tests in the same binary from hanging, so the run is scored as `TIMEOUT` instead of `CAUGHT`.

## Change

Apply `#[cfg_attr(test, mutants::skip)]` to `release_ref` with a justification comment. This matches the convention already established in this package for the same class of hang: `check_activated` in the same file, and `poll` / `pop_front` / `is_empty` in `future_deque_core.rs`.

No production behavior changes; this only affects mutation-test configuration.