### PR TITLE
events_once: fix use-after-free in LocalEvent completion paths

### DIFF
--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -27,9 +27,9 @@ use crate::{
 /// # Reentrancy
 ///
 /// Completing or cancelling an event runs the awaiting task's waker, either waking it or dropping
-/// it. Such a callback may freely operate on the endpoints of the event it belongs to: it may drop
-/// an endpoint, poll the receiver to completion or consume its value, and it may release the event
-/// storage by dropping the last endpoint.
+/// it. Such a callback may operate on the endpoints of the event it belongs to: it may poll the
+/// receiver to completion, and it may drop an endpoint - including the last one, which releases
+/// the event storage.
 pub struct LocalEvent<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: Cell<u8>,
@@ -655,14 +655,14 @@ impl<T: 'static> fmt::Debug for LocalEvent<T> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::RefCell;
-    use std::mem;
     use std::panic::{RefUnwindSafe, UnwindSafe};
     use std::pin::Pin;
     use std::rc::Rc;
-    use std::task::{self, Poll, RawWaker, RawWakerVTable};
+    use std::sync::Arc;
+    use std::task::{self, Poll};
 
     use static_assertions::{assert_impl_all, assert_not_impl_any};
-    use testing::{ReentrantWakerData, with_watchdog};
+    use testing::{ReentrantWakerData, drop_waker, with_watchdog};
 
     use super::*;
     use crate::IntoValueError;
@@ -1427,26 +1427,12 @@ mod tests {
     // deallocation is caught if the ordering regresses.
     #[test]
     fn boxed_receiver_cancel_with_sender_dropping_waker_preserves_storage() {
-        // Owns the sender behind a refcounted waker. When the last waker
-        // reference is dropped, `Drop` drops the sender, reentrantly entering
-        // `sender_dropped_without_set` while `final_poll` is on the stack.
-        struct DropSenderOnWakerDrop {
-            sender: RefCell<Option<BoxedLocalSender<i32>>>,
-        }
-
-        impl Drop for DropSenderOnWakerDrop {
-            fn drop(&mut self) {
-                drop(self.sender.borrow_mut().take());
-            }
-        }
-
         let (sender, receiver) = LocalEvent::<i32>::boxed();
         let mut receiver = Box::pin(receiver);
 
-        let data = Rc::new(DropSenderOnWakerDrop {
-            sender: RefCell::new(Some(sender)),
-        });
-        let waker = rc_drop_waker(data);
+        let (data, sender_dropped) = DropEndpointOnWakerDrop::new(sender);
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(data) };
 
         // First poll transitions BOUND -> AWAITING and stores a clone of the
         // waker inside the event.
@@ -1456,11 +1442,14 @@ mod tests {
         // Drop our local waker so only the event's stored clone remains; the
         // sender is still owned behind that clone.
         drop(waker);
+        assert!(!sender_dropped.get());
 
         // Dropping the receiver cancels the wait: `final_poll` drops the stored
         // waker, whose destructor drops the sender. The event storage must
         // survive until `final_poll` returns.
         drop(receiver);
+
+        assert!(sender_dropped.get(), "{REENTRANCY_REQUIRED}");
     }
 
     // Regression test for the reentrancy hazard in `set`. The wake callback
@@ -1471,44 +1460,32 @@ mod tests {
     // protected-pointer deallocation is caught if the shape regresses.
     #[test]
     fn boxed_send_with_reentrant_receiver_drop_releases_storage() {
-        // Owns the receiver behind a refcounted waker. When the last waker
-        // reference is dropped, `Drop` drops the receiver, which observes the
-        // SET state and releases the event storage.
-        struct DropReceiverOnWakerDrop {
-            receiver: RefCell<Option<Pin<Box<BoxedLocalReceiver<i32>>>>>,
-        }
-
-        impl Drop for DropReceiverOnWakerDrop {
-            fn drop(&mut self) {
-                drop(self.receiver.borrow_mut().take());
-            }
-        }
-
         let (sender, receiver) = LocalEvent::<i32>::boxed();
 
-        let data = Rc::new(DropReceiverOnWakerDrop {
-            receiver: RefCell::new(Some(Box::pin(receiver))),
-        });
-        let waker = rc_drop_waker(Rc::clone(&data));
+        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
         // First poll transitions BOUND -> AWAITING and stores a clone of the
         // waker inside the event.
         {
-            let mut receiver = data.receiver.borrow_mut();
-            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut endpoint = data.endpoint.borrow_mut();
+            let receiver = endpoint.as_mut().expect("receiver still held");
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
         }
 
         // Leave the event's stored clone as the only reference, so waking it
-        // runs the reentrant drop. Without this the test would silently pass
-        // even if the hazard were present.
+        // runs the reentrant drop.
         drop(waker);
         drop(data);
+        assert!(!receiver_dropped.get());
 
         // `set` stores the value, transitions AWAITING -> SET and wakes, which
         // drops the receiver, which consumes the value and frees the event.
         sender.send(42);
+
+        assert!(receiver_dropped.get(), "{REENTRANCY_REQUIRED}");
     }
 
     // Regression test for the reentrancy hazard in `sender_dropped_without_set`.
@@ -1516,79 +1493,63 @@ mod tests {
     // observes DISCONNECTED instead of SET.
     #[test]
     fn boxed_sender_drop_with_reentrant_receiver_drop_releases_storage() {
-        struct DropReceiverOnWakerDrop {
-            receiver: RefCell<Option<Pin<Box<BoxedLocalReceiver<i32>>>>>,
-        }
-
-        impl Drop for DropReceiverOnWakerDrop {
-            fn drop(&mut self) {
-                drop(self.receiver.borrow_mut().take());
-            }
-        }
-
         let (sender, receiver) = LocalEvent::<i32>::boxed();
 
-        let data = Rc::new(DropReceiverOnWakerDrop {
-            receiver: RefCell::new(Some(Box::pin(receiver))),
-        });
-        let waker = rc_drop_waker(Rc::clone(&data));
+        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
         {
-            let mut receiver = data.receiver.borrow_mut();
-            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut endpoint = data.endpoint.borrow_mut();
+            let receiver = endpoint.as_mut().expect("receiver still held");
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
         }
 
         drop(waker);
         drop(data);
+        assert!(!receiver_dropped.get());
 
         // `sender_dropped_without_set` transitions AWAITING -> DISCONNECTED and
         // wakes, which drops the receiver, which frees the event.
         drop(sender);
+
+        assert!(receiver_dropped.get(), "{REENTRANCY_REQUIRED}");
     }
 
-    /// Creates a waker that holds one reference to `data` and whose `wake()` and destructor
-    /// both merely release that reference. Any reentrant behavior under test therefore belongs
-    /// in the `Drop` implementation of `T`, which runs once the last reference is released.
-    ///
-    /// This is a Miri-compatible alternative to [`ReentrantWakerData`], so tests built on it can
-    /// exercise the aliasing rules that only Miri enforces.
-    fn rc_drop_waker<T: 'static>(data: Rc<T>) -> Waker {
-        unsafe { Waker::from_raw(RcDropWaker::<T>::raw_waker(data)) }
+    /// Owns an event endpoint on behalf of a waker, dropping that endpoint once the last waker
+    /// reference goes away. When the event under test releases its stored waker while completing
+    /// or cancelling, the endpoint drop therefore happens reentrantly, from inside the operation
+    /// being tested.
+    struct DropEndpointOnWakerDrop<T> {
+        endpoint: RefCell<Option<T>>,
+        dropped: Rc<Cell<bool>>,
     }
 
-    /// Carries the [`RawWakerVTable`] for [`rc_drop_waker`], one instance per payload type.
-    struct RcDropWaker<T>(PhantomData<T>);
+    impl<T> DropEndpointOnWakerDrop<T> {
+        /// Returns the payload together with a flag that records whether the endpoint has been
+        /// dropped, letting a test prove that the reentrancy it targets actually occurred.
+        fn new(endpoint: T) -> (Arc<Self>, Rc<Cell<bool>>) {
+            let dropped = Rc::new(Cell::new(false));
 
-    impl<T: 'static> RcDropWaker<T> {
-        const VTABLE: RawWakerVTable = RawWakerVTable::new(
-            Self::clone_raw,
-            Self::wake_raw,
-            Self::wake_by_ref_raw,
-            Self::drop_raw,
-        );
+            let data = Arc::new(Self {
+                endpoint: RefCell::new(Some(endpoint)),
+                dropped: Rc::clone(&dropped),
+            });
 
-        fn raw_waker(data: Rc<T>) -> RawWaker {
-            RawWaker::new(Rc::into_raw(data).cast(), &Self::VTABLE)
-        }
-
-        unsafe fn clone_raw(data: *const ()) -> RawWaker {
-            let rc = unsafe { Rc::from_raw(data.cast::<T>()) };
-            let clone = Rc::clone(&rc);
-            // Keep the original reference alive; we only wanted to bump the count.
-            mem::forget(rc);
-            Self::raw_waker(clone)
-        }
-
-        unsafe fn wake_raw(data: *const ()) {
-            unsafe { Self::drop_raw(data) }
-        }
-
-        unsafe fn wake_by_ref_raw(_data: *const ()) {}
-
-        unsafe fn drop_raw(data: *const ()) {
-            drop(unsafe { Rc::from_raw(data.cast::<T>()) });
+            (data, dropped)
         }
     }
+
+    impl<T> Drop for DropEndpointOnWakerDrop<T> {
+        fn drop(&mut self) {
+            drop(self.endpoint.borrow_mut().take());
+            self.dropped.set(true);
+        }
+    }
+
+    /// Explains a failure to reach the reentrant drop that a regression test exists to exercise.
+    /// Without it the test would pass no matter how the code under test behaved.
+    const REENTRANCY_REQUIRED: &str =
+        "the event must have held a waker clone whose drop reentered the operation under test";
 }

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -662,7 +662,7 @@ mod tests {
     use std::task::{self, Poll};
 
     use static_assertions::{assert_impl_all, assert_not_impl_any};
-    use testing::{ReentrantWakerData, drop_waker, with_watchdog};
+    use testing::{DropOnWakerRelease, ReentrantWakerData, drop_waker, with_watchdog};
 
     use super::*;
     use crate::IntoValueError;
@@ -1416,6 +1416,59 @@ mod tests {
         });
     }
 
+    // Parity counterpart of the `set` case above. A waker fired by the sender
+    // drop that synchronously polls the receiver must likewise observe a
+    // terminal state, here DISCONNECTED.
+    #[test]
+    #[cfg_attr(miri, ignore)] // Custom raw waker is not Miri-compatible.
+    fn boxed_sender_drop_with_reentrant_waker_observes_disconnected() {
+        type ObservedResult = Poll<Result<i32, Disconnected>>;
+
+        with_watchdog(|| {
+            let (sender, receiver) = LocalEvent::<i32>::boxed();
+            let receiver_holder: Rc<RefCell<Option<Pin<Box<_>>>>> =
+                Rc::new(RefCell::new(Some(Box::pin(receiver))));
+            let receiver_for_waker = Rc::clone(&receiver_holder);
+
+            let reentrant_observed: Rc<RefCell<Option<ObservedResult>>> =
+                Rc::new(RefCell::new(None));
+            let observed_for_waker = Rc::clone(&reentrant_observed);
+
+            let waker_data = ReentrantWakerData::new(move || {
+                let mut holder = receiver_for_waker.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let noop = Waker::noop();
+                let mut cx = task::Context::from_waker(noop);
+                let result = receiver.as_mut().poll(&mut cx);
+                *observed_for_waker.borrow_mut() = Some(result);
+            });
+            // SAFETY: `waker_data` outlives the waker and the test is single-threaded.
+            let waker = unsafe { waker_data.waker() };
+
+            // First poll transitions BOUND -> AWAITING and stores the
+            // reentrant waker.
+            {
+                let mut holder = receiver_holder.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let mut cx = task::Context::from_waker(&waker);
+                assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+            }
+
+            // Dropping the sender transitions AWAITING -> DISCONNECTED and then
+            // invokes the waker, which must observe the terminal state.
+            drop(sender);
+
+            assert!(waker_data.was_woken());
+            let observed = reentrant_observed.borrow_mut().take();
+            assert!(
+                matches!(observed, Some(Poll::Ready(Err(Disconnected)))),
+                "reentrant poll should observe DISCONNECTED",
+            );
+
+            drop(receiver_holder.borrow_mut().take());
+        });
+    }
+
     // Regression test for the cancellation reentrancy hazard in `final_poll`.
     // A stored waker whose destructor reentrantly drops the sender must not
     // cause the event storage to be deallocated while `final_poll` is still
@@ -1430,7 +1483,7 @@ mod tests {
         let (sender, receiver) = LocalEvent::<i32>::boxed();
         let mut receiver = Box::pin(receiver);
 
-        let (data, sender_dropped) = DropEndpointOnWakerDrop::new(sender);
+        let (data, sender_dropped) = DropOnWakerRelease::new(sender);
         // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
         let waker = unsafe { drop_waker(data) };
 
@@ -1462,18 +1515,16 @@ mod tests {
     fn boxed_send_with_reentrant_receiver_drop_releases_storage() {
         let (sender, receiver) = LocalEvent::<i32>::boxed();
 
-        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        let (data, receiver_dropped) = DropOnWakerRelease::new(Box::pin(receiver));
         // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
         let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
         // First poll transitions BOUND -> AWAITING and stores a clone of the
         // waker inside the event.
-        {
-            let mut endpoint = data.endpoint.borrow_mut();
-            let receiver = endpoint.as_mut().expect("receiver still held");
+        data.with_value(|receiver| {
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
-        }
+        });
 
         // Leave the event's stored clone as the only reference, so waking it
         // runs the reentrant drop.
@@ -1495,16 +1546,14 @@ mod tests {
     fn boxed_sender_drop_with_reentrant_receiver_drop_releases_storage() {
         let (sender, receiver) = LocalEvent::<i32>::boxed();
 
-        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        let (data, receiver_dropped) = DropOnWakerRelease::new(Box::pin(receiver));
         // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
         let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
-        {
-            let mut endpoint = data.endpoint.borrow_mut();
-            let receiver = endpoint.as_mut().expect("receiver still held");
+        data.with_value(|receiver| {
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
-        }
+        });
 
         drop(waker);
         drop(data);
@@ -1515,37 +1564,6 @@ mod tests {
         drop(sender);
 
         assert!(receiver_dropped.get(), "{REENTRANCY_REQUIRED}");
-    }
-
-    /// Owns an event endpoint on behalf of a waker, dropping that endpoint once the last waker
-    /// reference goes away. When the event under test releases its stored waker while completing
-    /// or cancelling, the endpoint drop therefore happens reentrantly, from inside the operation
-    /// being tested.
-    struct DropEndpointOnWakerDrop<T> {
-        endpoint: RefCell<Option<T>>,
-        dropped: Rc<Cell<bool>>,
-    }
-
-    impl<T> DropEndpointOnWakerDrop<T> {
-        /// Returns the payload together with a flag that records whether the endpoint has been
-        /// dropped, letting a test prove that the reentrancy it targets actually occurred.
-        fn new(endpoint: T) -> (Arc<Self>, Rc<Cell<bool>>) {
-            let dropped = Rc::new(Cell::new(false));
-
-            let data = Arc::new(Self {
-                endpoint: RefCell::new(Some(endpoint)),
-                dropped: Rc::clone(&dropped),
-            });
-
-            (data, dropped)
-        }
-    }
-
-    impl<T> Drop for DropEndpointOnWakerDrop<T> {
-        fn drop(&mut self) {
-            drop(self.endpoint.borrow_mut().take());
-            self.dropped.set(true);
-        }
     }
 
     /// Explains a failure to reach the reentrant drop that a regression test exists to exercise.

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -23,6 +23,18 @@ use crate::{
 };
 
 /// Coordinates delivery of a `T` at most once from a sender to a receiver on the same thread.
+///
+/// # Reentrancy
+///
+/// Completing an event runs a user-supplied callback (`Waker::wake()` or the waker's destructor)
+/// that is free to release the event storage before it returns. Any method that runs such a
+/// callback therefore reaches the event through an `&UnsafeCell<Self>` argument instead of
+/// `&self`: a `&self` argument stays strongly protected by the aliasing model for the whole call,
+/// which makes deallocating the event from inside the callback undefined behavior, whereas
+/// references derived from an `UnsafeCell` are exempt from that protection and may dangle once
+/// the callback returns. Such methods therefore do not touch the event after the callback runs.
+///
+/// See `docs/callback-safety.md` in the repository root for the workspace-wide convention.
 pub struct LocalEvent<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: Cell<u8>,
@@ -75,11 +87,11 @@ impl<T: 'static> LocalEvent<T> {
     /// This is for internal use only and is wrapped by public methods that also
     /// wire up the sender and receiver after doing the initialization. An event
     /// without a sender and receiver is invalid.
-    pub(crate) fn new_in_inner(place: &mut MaybeUninit<Self>) -> NonNull<Self> {
+    pub(crate) fn new_in_inner(place: &mut UnsafeCell<MaybeUninit<Self>>) {
         // We can skip initializing the MaybeUninit fields because they start uninitialized
         // by design and the UnsafeCell wrapper is transparent, only affecting accesses and
         // not the contents.
-        let base_ptr = place.as_mut_ptr();
+        let base_ptr = place.get_mut().as_mut_ptr();
 
         // SAFETY: We are making a pointer to a known field at a compiler-guaranteed offset.
         let state_ptr = unsafe { base_ptr.byte_add(offset_of!(Self, state)) }.cast::<Cell<u8>>();
@@ -100,9 +112,6 @@ impl<T: 'static> LocalEvent<T> {
                 backtrace_ptr.write(RefCell::new(None));
             }
         }
-
-        // SAFETY: This came from a reference so guaranteed non-null.
-        unsafe { NonNull::new_unchecked(base_ptr) }
     }
 
     #[must_use]
@@ -152,13 +161,18 @@ impl<T: 'static> LocalEvent<T> {
 
     #[must_use]
     pub(crate) unsafe fn placed_core(
-        place: Pin<&mut MaybeUninit<Self>>,
+        place: Pin<&mut UnsafeCell<MaybeUninit<Self>>>,
     ) -> (
         LocalSenderCore<PtrLocalRef<T>, T>,
         LocalReceiverCore<PtrLocalRef<T>, T>,
     ) {
         // SAFETY: Nothing is getting moved, we just temporarily unwrap the Pin wrapper.
-        let event = Self::new_in_inner(unsafe { place.get_unchecked_mut() });
+        let place_mut = unsafe { place.get_unchecked_mut() };
+
+        Self::new_in_inner(place_mut);
+
+        // We cast away the MaybeUninit wrapper because it is now initialized.
+        let event = NonNull::from_mut(place_mut).cast::<UnsafeCell<Self>>();
 
         (
             LocalSenderCore::new(PtrLocalRef::new(event)),
@@ -236,8 +250,13 @@ impl<T: 'static> LocalEvent<T> {
     /// occupies. Snapshots taken earlier remain valid because they are shared owners of the
     /// backtrace.
     #[cfg(debug_assertions)]
-    pub(crate) fn clear_awaiter_backtrace(&self) {
-        let mut backtrace = self.backtrace.borrow_mut();
+    pub(crate) fn clear_awaiter_backtrace(event_cell: &UnsafeCell<Self>) {
+        // SAFETY: The cell's pointer is always valid and points to an initialized event because
+        // the caller is still an endpoint of it. We only ever create shared references to the
+        // event through this cell, so no exclusive reference can alias this one.
+        let event = unsafe { &*event_cell.get() };
+
+        let mut backtrace = event.backtrace.borrow_mut();
 
         *backtrace = None;
     }
@@ -245,9 +264,17 @@ impl<T: 'static> LocalEvent<T> {
     /// Sets the value of the event and notifies the awaiter, if there is one.
     ///
     /// Returns `Err` if the receiver has already disconnected and we must clean up the event now.
+    ///
+    /// Reaches the event through an [`UnsafeCell`] because the wake callback may reentrantly
+    /// release the event storage; see the type-level reentrancy documentation.
     #[inline]
-    pub(crate) fn set(&self, result: T) -> Result<(), Disconnected> {
-        let value_cell = self.value.get();
+    pub(crate) fn set(event_cell: &UnsafeCell<Self>, result: T) -> Result<(), Disconnected> {
+        // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
+        // The event lives until both sender and receiver are dropped or inert, so we know it must
+        // still exist because something was able to call this method.
+        let event = unsafe { &*event_cell.get() };
+
+        let value_cell = event.value.get();
 
         // We can start by setting the value - this has to happen no matter what.
         // Everything else we do here is just to get the awaiter to come pick it up.
@@ -272,7 +299,7 @@ impl<T: 'static> LocalEvent<T> {
         // one. In the DISCONNECTED branch the SET we just stored is a
         // don't-care because the event is about to be deallocated, and no
         // external observer can witness the transient state.
-        let previous_state = self.state.replace(EVENT_SET);
+        let previous_state = event.state.replace(EVENT_SET);
 
         match previous_state {
             EVENT_BOUND => {
@@ -296,7 +323,7 @@ impl<T: 'static> LocalEvent<T> {
                     // short-lived references in this type, which cannot exist at the moment
                     // because the type is single-threaded and does not let any references
                     // escape.
-                    let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
+                    let awaiter_cell_maybe = unsafe { event.awaiter.get().as_mut() };
                     // SAFETY: UnsafeCell pointer is never null.
                     let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
 
@@ -306,7 +333,9 @@ impl<T: 'static> LocalEvent<T> {
                     unsafe { awaiter_cell.assume_init_read() }
                 };
 
-                // Come and get it.
+                // Come and get it. The event is in a terminal state, so the woken receiver may
+                // reentrantly complete and release the event storage. We touch nothing in the
+                // event after this point.
                 waker.wake();
 
                 // The receiver is still connected, so it will clean up.
@@ -319,7 +348,7 @@ impl<T: 'static> LocalEvent<T> {
                 // SAFETY: The only other potential references to the field are other short-lived
                 // references in this type, which cannot exist at the moment because
                 // the type is single-threaded and does not let any references escape.
-                let value_cell_maybe = unsafe { self.value.get().as_mut() };
+                let value_cell_maybe = unsafe { event.value.get().as_mut() };
                 // SAFETY: UnsafeCell pointer is never null.
                 let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
 
@@ -438,13 +467,23 @@ impl<T: 'static> LocalEvent<T> {
     /// Marks the event as having been disconnected early from the sender side.
     ///
     /// Returns `Err` if the receiver has already disconnected and we must clean up the event now.
+    ///
+    /// Reaches the event through an [`UnsafeCell`] because the wake callback may reentrantly
+    /// release the event storage; see the type-level reentrancy documentation.
     #[inline]
-    pub(crate) fn sender_dropped_without_set(&self) -> Result<(), Disconnected> {
-        let previous_state = self.state.get();
+    pub(crate) fn sender_dropped_without_set(
+        event_cell: &UnsafeCell<Self>,
+    ) -> Result<(), Disconnected> {
+        // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
+        // The event lives until both sender and receiver are dropped or inert, so we know it must
+        // still exist because something was able to call this method.
+        let event = unsafe { &*event_cell.get() };
+
+        let previous_state = event.state.get();
 
         // We can immediately set this because this is a single-threaded event, so there cannot
         // be any race condition causing us issues with the receiver seeing this too early.
-        self.state.set(EVENT_DISCONNECTED);
+        event.state.set(EVENT_DISCONNECTED);
 
         match previous_state {
             EVENT_BOUND => {
@@ -459,7 +498,7 @@ impl<T: 'static> LocalEvent<T> {
                 // SAFETY: The only other potential references to the field are other short-lived
                 // references in this type, which cannot exist at the moment because
                 // the type is single-threaded and does not let any references escape.
-                let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
+                let awaiter_cell_maybe = unsafe { event.awaiter.get().as_mut() };
                 // SAFETY: UnsafeCell pointer is never null.
                 let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
 
@@ -467,7 +506,9 @@ impl<T: 'static> LocalEvent<T> {
                 // SAFETY: We were in EVENT_AWAITING which guarantees there is a waker in there.
                 let waker = unsafe { awaiter_cell.assume_init_read() };
 
-                // Come and get it.
+                // Come and get it. The event is in a terminal state, so the woken receiver may
+                // reentrantly complete and release the event storage. We touch nothing in the
+                // event after this point.
                 waker.wake();
 
                 // The receiver is the last endpoint remaining, so it will clean up.
@@ -499,25 +540,33 @@ impl<T: 'static> LocalEvent<T> {
     /// Returns `Ok(Some(value))` if the sender sender has already sent a value.
     /// Returns `Err` if the sender has already disconnected without sending a value.
     /// In both of these cases, the receiver must clean up the event now.
+    ///
+    /// Reaches the event through an [`UnsafeCell`] because the waker destructor may reentrantly
+    /// release the event storage; see the type-level reentrancy documentation.
     #[inline]
-    pub(crate) fn final_poll(&self) -> Result<Option<T>, Disconnected> {
+    pub(crate) fn final_poll(event_cell: &UnsafeCell<Self>) -> Result<Option<T>, Disconnected> {
+        // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
+        // The event lives until both sender and receiver are dropped or inert, so we know it must
+        // still exist because something was able to call this method.
+        let event = unsafe { &*event_cell.get() };
+
         // If we are still awaiting, the receiver (the caller) owns the stored waker and must
         // destroy it before disconnecting. We revert to EVENT_BOUND *before* dropping the waker
         // so that a reentrant sender drop triggered by the waker's destructor observes a live,
-        // non-terminal event and defers cleanup, rather than deallocating the storage out from
-        // under this still-executing call (which holds a strongly-protected `&self`). Only once
-        // the waker is gone do we read the resulting state and transition to EVENT_DISCONNECTED.
+        // non-terminal event and defers cleanup, rather than deallocating the storage we are
+        // about to read from again. Only once the waker is gone do we read the resulting state
+        // and transition to EVENT_DISCONNECTED.
         //
         // This mirrors the sync `Event::final_poll`, which reverts AWAITING -> BOUND before
         // destroying the awaiter, and follows docs/callback-safety.md ("No callbacks under
         // borrows of shared state"; symmetric handoff vs. cleanup ordering).
-        if self.state.get() == EVENT_AWAITING {
-            self.state.set(EVENT_BOUND);
+        if event.state.get() == EVENT_AWAITING {
+            event.state.set(EVENT_BOUND);
 
             // SAFETY: The only other potential references to the field are other short-lived
             // references in this type, which cannot exist at the moment because
             // the type is single-threaded and does not let any references escape.
-            let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
+            let awaiter_cell_maybe = unsafe { event.awaiter.get().as_mut() };
             // SAFETY: UnsafeCell pointer is never null.
             let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
 
@@ -532,11 +581,11 @@ impl<T: 'static> LocalEvent<T> {
         // have advanced us from EVENT_BOUND to EVENT_DISCONNECTED. In this single-threaded
         // design the reentrant sender is the only actor that could have changed the state while
         // we were dropping the waker.
-        let previous_state = self.state.get();
+        let previous_state = event.state.get();
 
         // We can immediately set this because this is a single-threaded event, so there cannot
         // be any race condition causing us issues with the receiver seeing this too early.
-        self.state.set(EVENT_DISCONNECTED);
+        event.state.set(EVENT_DISCONNECTED);
 
         match previous_state {
             EVENT_BOUND => {
@@ -551,7 +600,7 @@ impl<T: 'static> LocalEvent<T> {
                 // SAFETY: The only other potential references to the field are other short-lived
                 // references in this type, which cannot exist at the moment because
                 // the type is single-threaded and does not let any references escape.
-                let value_cell_maybe = unsafe { self.value.get().as_mut() };
+                let value_cell_maybe = unsafe { event.value.get().as_mut() };
                 // SAFETY: UnsafeCell pointer is never null.
                 let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
 
@@ -600,7 +649,11 @@ impl<T: 'static> fmt::Debug for LocalEvent<T> {
 }
 
 #[cfg(test)]
-#[expect(clippy::undocumented_unsafe_blocks, reason = "test code, be concise")]
+#[allow(
+    clippy::undocumented_unsafe_blocks,
+    clippy::multiple_unsafe_ops_per_block,
+    reason = "test code, be concise"
+)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::RefCell;
@@ -1206,7 +1259,8 @@ mod tests {
         let mut place = Box::pin(EmbeddedLocalEvent::<i32>::new());
         let _endpoints = unsafe { LocalEvent::<i32>::placed(place.as_mut()) };
 
-        let backtrace = unsafe { place.inner.assume_init_ref() }.awaiter_backtrace();
+        let backtrace =
+            unsafe { place.inner.get().as_ref().unwrap().assume_init_ref() }.awaiter_backtrace();
 
         assert!(backtrace.is_none());
     }
@@ -1221,7 +1275,8 @@ mod tests {
         let mut receiver = Box::pin(receiver);
         _ = receiver.as_mut().poll(&mut cx);
 
-        let backtrace = unsafe { place.inner.assume_init_ref() }.awaiter_backtrace();
+        let backtrace =
+            unsafe { place.inner.get().as_ref().unwrap().assume_init_ref() }.awaiter_backtrace();
 
         assert!(backtrace.is_some());
     }
@@ -1238,7 +1293,8 @@ mod tests {
 
         drop(sender);
 
-        let backtrace = unsafe { place.inner.assume_init_ref() }.awaiter_backtrace();
+        let backtrace =
+            unsafe { place.inner.get().as_ref().unwrap().assume_init_ref() }.awaiter_backtrace();
 
         assert!(backtrace.is_some());
     }
@@ -1255,7 +1311,8 @@ mod tests {
 
         drop(receiver);
 
-        let backtrace = unsafe { place.inner.assume_init_ref() }.awaiter_backtrace();
+        let backtrace =
+            unsafe { place.inner.get().as_ref().unwrap().assume_init_ref() }.awaiter_backtrace();
 
         assert!(backtrace.is_some());
     }
@@ -1271,7 +1328,7 @@ mod tests {
             let mut receiver = Box::pin(receiver);
             _ = receiver.as_mut().poll(&mut cx);
 
-            unsafe { place.inner.assume_init_ref() }
+            unsafe { place.inner.get().as_ref().unwrap().assume_init_ref() }
                 .awaiter_backtrace()
                 .expect("the event has been awaited")
         };
@@ -1295,7 +1352,7 @@ mod tests {
 
         // The event has been released but its storage is still ours to inspect. Releasing an
         // event releases its backtrace, because the storage may be reused without dropping it.
-        let event = unsafe { place.inner.assume_init_ref() };
+        let event = unsafe { place.inner.get().as_ref().unwrap().assume_init_ref() };
 
         assert!(event.awaiter_backtrace().is_none());
     }
@@ -1376,39 +1433,22 @@ mod tests {
         // reference is dropped, `Drop` drops the sender, reentrantly entering
         // `sender_dropped_without_set` while `final_poll` is on the stack.
         struct DropSenderOnWakerDrop {
-            sender: Option<BoxedLocalSender<i32>>,
+            sender: RefCell<Option<BoxedLocalSender<i32>>>,
         }
 
         impl Drop for DropSenderOnWakerDrop {
             fn drop(&mut self) {
-                drop(self.sender.take());
+                drop(self.sender.borrow_mut().take());
             }
         }
-
-        unsafe fn clone_raw(data: *const ()) -> RawWaker {
-            let rc = unsafe { Rc::from_raw(data.cast::<DropSenderOnWakerDrop>()) };
-            let clone = Rc::clone(&rc);
-            // Keep the original reference alive; we only wanted to bump the count.
-            mem::forget(rc);
-            RawWaker::new(Rc::into_raw(clone).cast(), &VTABLE)
-        }
-        unsafe fn wake_raw(data: *const ()) {
-            unsafe { drop_raw(data) }
-        }
-        unsafe fn wake_by_ref_raw(_data: *const ()) {}
-        unsafe fn drop_raw(data: *const ()) {
-            unsafe { drop(Rc::from_raw(data.cast::<DropSenderOnWakerDrop>())) }
-        }
-        static VTABLE: RawWakerVTable =
-            RawWakerVTable::new(clone_raw, wake_raw, wake_by_ref_raw, drop_raw);
 
         let (sender, receiver) = LocalEvent::<i32>::boxed();
         let mut receiver = Box::pin(receiver);
 
         let data = Rc::new(DropSenderOnWakerDrop {
-            sender: Some(sender),
+            sender: RefCell::new(Some(sender)),
         });
-        let waker = unsafe { Waker::from_raw(RawWaker::new(Rc::into_raw(data).cast(), &VTABLE)) };
+        let waker = rc_drop_waker(data);
 
         // First poll transitions BOUND -> AWAITING and stores a clone of the
         // waker inside the event.
@@ -1423,5 +1463,134 @@ mod tests {
         // waker, whose destructor drops the sender. The event storage must
         // survive until `final_poll` returns.
         drop(receiver);
+    }
+
+    // Regression test for the reentrancy hazard in `set`. The wake callback
+    // fired by the sender is free to drop the receiver, which completes the
+    // event and releases its storage while `set` is still on the stack. `set`
+    // must therefore reach the event through an `UnsafeCell` and must not touch
+    // it after waking. Ref: docs/callback-safety.md. Runs under Miri so the
+    // protected-pointer deallocation is caught if the shape regresses.
+    #[test]
+    fn boxed_send_with_reentrant_receiver_drop_releases_storage() {
+        // Owns the receiver behind a refcounted waker. When the last waker
+        // reference is dropped, `Drop` drops the receiver, which observes the
+        // SET state and releases the event storage.
+        struct DropReceiverOnWakerDrop {
+            receiver: RefCell<Option<Pin<Box<BoxedLocalReceiver<i32>>>>>,
+        }
+
+        impl Drop for DropReceiverOnWakerDrop {
+            fn drop(&mut self) {
+                drop(self.receiver.borrow_mut().take());
+            }
+        }
+
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+
+        let data = Rc::new(DropReceiverOnWakerDrop {
+            receiver: RefCell::new(Some(Box::pin(receiver))),
+        });
+        let waker = rc_drop_waker(Rc::clone(&data));
+
+        // First poll transitions BOUND -> AWAITING and stores a clone of the
+        // waker inside the event.
+        {
+            let mut receiver = data.receiver.borrow_mut();
+            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut cx = task::Context::from_waker(&waker);
+            assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+        }
+
+        // Leave the event's stored clone as the only reference, so waking it
+        // runs the reentrant drop. Without this the test would silently pass
+        // even if the hazard were present.
+        drop(waker);
+        drop(data);
+
+        // `set` stores the value, transitions AWAITING -> SET and wakes, which
+        // drops the receiver, which consumes the value and frees the event.
+        sender.send(42);
+    }
+
+    // Regression test for the reentrancy hazard in `sender_dropped_without_set`.
+    // Identical in shape to the `set` case above, except that the receiver
+    // observes DISCONNECTED instead of SET.
+    #[test]
+    fn boxed_sender_drop_with_reentrant_receiver_drop_releases_storage() {
+        struct DropReceiverOnWakerDrop {
+            receiver: RefCell<Option<Pin<Box<BoxedLocalReceiver<i32>>>>>,
+        }
+
+        impl Drop for DropReceiverOnWakerDrop {
+            fn drop(&mut self) {
+                drop(self.receiver.borrow_mut().take());
+            }
+        }
+
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+
+        let data = Rc::new(DropReceiverOnWakerDrop {
+            receiver: RefCell::new(Some(Box::pin(receiver))),
+        });
+        let waker = rc_drop_waker(Rc::clone(&data));
+
+        {
+            let mut receiver = data.receiver.borrow_mut();
+            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut cx = task::Context::from_waker(&waker);
+            assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+        }
+
+        drop(waker);
+        drop(data);
+
+        // `sender_dropped_without_set` transitions AWAITING -> DISCONNECTED and
+        // wakes, which drops the receiver, which frees the event.
+        drop(sender);
+    }
+
+    /// Creates a waker that holds one reference to `data` and whose `wake()` and destructor
+    /// both merely release that reference. Any reentrant behavior under test therefore belongs
+    /// in the `Drop` implementation of `T`, which runs once the last reference is released.
+    ///
+    /// This is a Miri-compatible alternative to [`ReentrantWakerData`], so tests built on it can
+    /// exercise the aliasing rules that only Miri enforces.
+    fn rc_drop_waker<T: 'static>(data: Rc<T>) -> Waker {
+        unsafe { Waker::from_raw(RcDropWaker::<T>::raw_waker(data)) }
+    }
+
+    /// Carries the [`RawWakerVTable`] for [`rc_drop_waker`], one instance per payload type.
+    struct RcDropWaker<T>(PhantomData<T>);
+
+    impl<T: 'static> RcDropWaker<T> {
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(
+            Self::clone_raw,
+            Self::wake_raw,
+            Self::wake_by_ref_raw,
+            Self::drop_raw,
+        );
+
+        fn raw_waker(data: Rc<T>) -> RawWaker {
+            RawWaker::new(Rc::into_raw(data).cast(), &Self::VTABLE)
+        }
+
+        unsafe fn clone_raw(data: *const ()) -> RawWaker {
+            let rc = unsafe { Rc::from_raw(data.cast::<T>()) };
+            let clone = Rc::clone(&rc);
+            // Keep the original reference alive; we only wanted to bump the count.
+            mem::forget(rc);
+            Self::raw_waker(clone)
+        }
+
+        unsafe fn wake_raw(data: *const ()) {
+            unsafe { Self::drop_raw(data) }
+        }
+
+        unsafe fn wake_by_ref_raw(_data: *const ()) {}
+
+        unsafe fn drop_raw(data: *const ()) {
+            drop(unsafe { Rc::from_raw(data.cast::<T>()) });
+        }
     }
 }

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -26,15 +26,10 @@ use crate::{
 ///
 /// # Reentrancy
 ///
-/// Completing an event runs a user-supplied callback (`Waker::wake()` or the waker's destructor)
-/// that is free to release the event storage before it returns. Any method that runs such a
-/// callback therefore reaches the event through an `&UnsafeCell<Self>` argument instead of
-/// `&self`: a `&self` argument stays strongly protected by the aliasing model for the whole call,
-/// which makes deallocating the event from inside the callback undefined behavior, whereas
-/// references derived from an `UnsafeCell` are exempt from that protection and may dangle once
-/// the callback returns. Such methods therefore do not touch the event after the callback runs.
-///
-/// See `docs/callback-safety.md` in the repository root for the workspace-wide convention.
+/// Completing or cancelling an event runs the awaiting task's waker, either waking it or dropping
+/// it. Such a callback may freely operate on the endpoints of the event it belongs to: it may drop
+/// an endpoint, poll the receiver to completion or consume its value, and it may release the event
+/// storage by dropping the last endpoint.
 pub struct LocalEvent<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: Cell<u8>,
@@ -265,8 +260,12 @@ impl<T: 'static> LocalEvent<T> {
     ///
     /// Returns `Err` if the receiver has already disconnected and we must clean up the event now.
     ///
-    /// Reaches the event through an [`UnsafeCell`] because the wake callback may reentrantly
-    /// release the event storage; see the type-level reentrancy documentation.
+    /// The event arrives as an `&UnsafeCell<Self>` rather than as `&self` because the wake
+    /// callback performed here is free to release the event storage. A `&self` argument stays
+    /// strongly protected by the aliasing model for the whole call, which makes such a release
+    /// undefined behavior, whereas references derived from an `UnsafeCell` carry no protector and
+    /// may dangle. The event is therefore not touched after the callback runs.
+    /// Ref: docs/callback-safety.md.
     #[inline]
     pub(crate) fn set(event_cell: &UnsafeCell<Self>, result: T) -> Result<(), Disconnected> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
@@ -468,8 +467,7 @@ impl<T: 'static> LocalEvent<T> {
     ///
     /// Returns `Err` if the receiver has already disconnected and we must clean up the event now.
     ///
-    /// Reaches the event through an [`UnsafeCell`] because the wake callback may reentrantly
-    /// release the event storage; see the type-level reentrancy documentation.
+    /// See [`set()`][Self::set] for why the event arrives as an `&UnsafeCell<Self>`.
     #[inline]
     pub(crate) fn sender_dropped_without_set(
         event_cell: &UnsafeCell<Self>,
@@ -541,8 +539,8 @@ impl<T: 'static> LocalEvent<T> {
     /// Returns `Err` if the sender has already disconnected without sending a value.
     /// In both of these cases, the receiver must clean up the event now.
     ///
-    /// Reaches the event through an [`UnsafeCell`] because the waker destructor may reentrantly
-    /// release the event storage; see the type-level reentrancy documentation.
+    /// See [`set()`][Self::set] for why the event arrives as an `&UnsafeCell<Self>`; here it is
+    /// the waker's destructor rather than `wake()` that may release the event storage.
     #[inline]
     pub(crate) fn final_poll(event_cell: &UnsafeCell<Self>) -> Result<Option<T>, Disconnected> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.

--- a/packages/events_once/src/core/local_embedded.rs
+++ b/packages/events_once/src/core/local_embedded.rs
@@ -1,4 +1,5 @@
 use std::any::type_name;
+use std::cell::UnsafeCell;
 use std::fmt;
 use std::mem::MaybeUninit;
 use std::panic::RefUnwindSafe;
@@ -43,7 +44,7 @@ use crate::LocalEvent;
 ///
 /// [1]: crate::LocalEvent::placed
 pub struct EmbeddedLocalEvent<T> {
-    pub(crate) inner: MaybeUninit<LocalEvent<T>>,
+    pub(crate) inner: UnsafeCell<MaybeUninit<LocalEvent<T>>>,
 }
 
 // MaybeUninit<LocalEvent<T>> inherits LocalEvent's !RefUnwindSafe
@@ -56,7 +57,7 @@ impl<T: 'static> EmbeddedLocalEvent<T> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            inner: MaybeUninit::uninit(),
+            inner: UnsafeCell::new(MaybeUninit::uninit()),
         }
     }
 }

--- a/packages/events_once/src/core/local_endpoints_nice.rs
+++ b/packages/events_once/src/core/local_endpoints_nice.rs
@@ -2,6 +2,7 @@
 //! the outer generic type parameter, leaving only the inner T of the payload.
 
 use std::any::type_name;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::task::Poll;
 use std::{fmt, task};
@@ -17,6 +18,12 @@ use crate::{
 pub struct BoxedLocalSender<T: 'static> {
     inner: LocalSenderCore<BoxedLocalRef<T>, T>,
 }
+
+// Senders are one-shot and consumed on use. The UnsafeCell around the
+// underlying event is guarded by a state machine that prevents observing
+// inconsistent state during unwind.
+impl<T: 'static> UnwindSafe for BoxedLocalSender<T> {}
+impl<T: 'static> RefUnwindSafe for BoxedLocalSender<T> {}
 
 impl<T: 'static> BoxedLocalSender<T> {
     pub(crate) fn new(inner: LocalSenderCore<BoxedLocalRef<T>, T>) -> Self {
@@ -50,6 +57,12 @@ impl<T: 'static> fmt::Debug for BoxedLocalSender<T> {
 pub struct BoxedLocalReceiver<T: 'static> {
     inner: LocalReceiverCore<BoxedLocalRef<T>, T>,
 }
+
+// Receivers are one-shot. The UnsafeCell around the underlying event is
+// guarded by a state machine that prevents observing inconsistent state
+// during unwind.
+impl<T: 'static> UnwindSafe for BoxedLocalReceiver<T> {}
+impl<T: 'static> RefUnwindSafe for BoxedLocalReceiver<T> {}
 
 impl<T: 'static> BoxedLocalReceiver<T> {
     pub(crate) fn new(inner: LocalReceiverCore<BoxedLocalRef<T>, T>) -> Self {
@@ -140,6 +153,10 @@ pub struct RawLocalSender<T: 'static> {
     inner: LocalSenderCore<PtrLocalRef<T>, T>,
 }
 
+// See BoxedLocalSender for justification.
+impl<T: 'static> UnwindSafe for RawLocalSender<T> {}
+impl<T: 'static> RefUnwindSafe for RawLocalSender<T> {}
+
 impl<T: 'static> RawLocalSender<T> {
     pub(crate) fn new(inner: LocalSenderCore<PtrLocalRef<T>, T>) -> Self {
         Self { inner }
@@ -173,6 +190,10 @@ impl<T: 'static> fmt::Debug for RawLocalSender<T> {
 pub struct RawLocalReceiver<T: 'static> {
     inner: LocalReceiverCore<PtrLocalRef<T>, T>,
 }
+
+// See BoxedLocalReceiver for justification.
+impl<T: 'static> UnwindSafe for RawLocalReceiver<T> {}
+impl<T: 'static> RefUnwindSafe for RawLocalReceiver<T> {}
 
 impl<T: 'static> RawLocalReceiver<T> {
     pub(crate) fn new(inner: LocalReceiverCore<PtrLocalRef<T>, T>) -> Self {

--- a/packages/events_once/src/core/local_receiver.rs
+++ b/packages/events_once/src/core/local_receiver.rs
@@ -8,7 +8,7 @@ use std::task::{self, Poll};
 
 use crate::{
     Disconnected, EVENT_AWAITING, EVENT_BOUND, EVENT_DISCONNECTED, EVENT_SET, IntoValueError,
-    LocalRef,
+    LocalEvent, LocalRef,
 };
 
 /// Receives a single value from the sender connected to the same event.
@@ -48,7 +48,12 @@ where
             panic!("receiver queried after completion");
         };
 
-        event_ref.is_set()
+        // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
+        // The event lives until both sender and receiver are dropped or inert, so we know it must
+        // still exist because something was able to call this method with `Some(event_ref)`.
+        let event = unsafe { &*event_ref.get() };
+
+        event.is_set()
     }
 
     /// Consumes the receiver and transforms it into the received value, if the value is available.
@@ -67,7 +72,13 @@ where
             .expect("receiver polled after completion: Future trait contract violated");
 
         // Check the current state directly to decide what to do
-        let current_state = event_ref.state.get();
+        //
+        // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
+        // The event lives until both sender and receiver are dropped or inert, so we know it must
+        // still exist because something was able to call this method with `Some(event_ref)`.
+        let event = unsafe { &*event_ref.get() };
+
+        let current_state = event.state.get();
 
         match current_state {
             EVENT_BOUND | EVENT_AWAITING => {
@@ -79,7 +90,7 @@ where
                 let mut this = ManuallyDrop::new(self);
                 let event_ref = this.event_ref.take().unwrap();
 
-                match event_ref.final_poll() {
+                match LocalEvent::final_poll(&event_ref) {
                     Ok(Some(value)) => {
                         event_ref.release_event();
                         Ok(value)
@@ -120,7 +131,15 @@ where
             .as_ref()
             .expect("receiver polled after completion: Future trait contract violated");
 
-        let inner_poll_result = event_ref.poll(cx.waker());
+        let inner_poll_result = {
+            // SAFETY: We only ever create shared references to the event, so no aliasing
+            // conflicts. The event lives until both sender and receiver are dropped or inert, so
+            // we know it must still exist because something was able to call this method with
+            // `Some(event_ref)`.
+            let event = unsafe { &*event_ref.get() };
+
+            event.poll(cx.waker())
+        };
 
         // If the poll returns `Some`, we need to clean up the event.
         if inner_poll_result.is_some() {
@@ -148,7 +167,7 @@ where
     #[inline]
     fn drop(&mut self) {
         if let Some(event_ref) = self.event_ref.take() {
-            match event_ref.final_poll() {
+            match LocalEvent::final_poll(&event_ref) {
                 Ok(None) => {
                     // Nothing for us to do - the sender was still connected and had not
                     // sent any value, so it will perform the cleanup on its own.

--- a/packages/events_once/src/core/local_refs.rs
+++ b/packages/events_once/src/core/local_refs.rs
@@ -1,5 +1,6 @@
 use std::alloc::{Layout, alloc, dealloc};
 use std::any::type_name;
+use std::cell::UnsafeCell;
 use std::fmt;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
@@ -8,7 +9,9 @@ use std::ptr::NonNull;
 use crate::LocalEvent;
 
 /// Enables a sender or receiver to reference the event that connects them.
-pub(crate) trait LocalRef<T>: Deref<Target = LocalEvent<T>> + fmt::Debug {
+pub(crate) trait LocalRef<T>:
+    Deref<Target = UnsafeCell<LocalEvent<T>>> + fmt::Debug
+{
     /// Releases the event, asserting that the last endpoint has been dropped
     /// and nothing will access the event after this call.
     fn release_event(&self);
@@ -16,12 +19,12 @@ pub(crate) trait LocalRef<T>: Deref<Target = LocalEvent<T>> + fmt::Debug {
 
 /// References an event stored anywhere, via raw pointer.
 pub(crate) struct PtrLocalRef<T> {
-    event: NonNull<LocalEvent<T>>,
+    event: NonNull<UnsafeCell<LocalEvent<T>>>,
 }
 
 impl<T: 'static> PtrLocalRef<T> {
     #[must_use]
-    pub(crate) fn new(event: NonNull<LocalEvent<T>>) -> Self {
+    pub(crate) fn new(event: NonNull<UnsafeCell<LocalEvent<T>>>) -> Self {
         Self { event }
     }
 }
@@ -32,12 +35,12 @@ impl<T: 'static> LocalRef<T> for PtrLocalRef<T> {
         // The storage is owned by whoever placed the event there and is reused without dropping
         // the event, so we clear its diagnostic state before we let go of it.
         #[cfg(debug_assertions)]
-        self.clear_awaiter_backtrace();
+        LocalEvent::clear_awaiter_backtrace(self);
     }
 }
 
 impl<T: 'static> Deref for PtrLocalRef<T> {
-    type Target = LocalEvent<T>;
+    type Target = UnsafeCell<LocalEvent<T>>;
 
     fn deref(&self) -> &Self::Target {
         // SAFETY: The creator of the reference is responsible for ensuring the event outlives it.
@@ -56,7 +59,7 @@ impl<T: 'static> fmt::Debug for PtrLocalRef<T> {
 
 /// References an event stored on the heap.
 pub(crate) struct BoxedLocalRef<T> {
-    event: NonNull<LocalEvent<T>>,
+    event: NonNull<UnsafeCell<LocalEvent<T>>>,
 }
 
 impl<T: 'static> BoxedLocalRef<T> {
@@ -69,7 +72,11 @@ impl<T: 'static> BoxedLocalRef<T> {
 
         // SAFETY: MaybeUninit is a transparent wrapper, so the layout matches.
         // This is the only reference, so we have exclusive access rights.
-        let event_as_maybe_uninit = unsafe { event.cast::<MaybeUninit<LocalEvent<T>>>().as_mut() };
+        let event_as_maybe_uninit = unsafe {
+            event
+                .cast::<UnsafeCell<MaybeUninit<LocalEvent<T>>>>()
+                .as_mut()
+        };
 
         LocalEvent::new_in_inner(event_as_maybe_uninit);
 
@@ -88,7 +95,7 @@ impl<T: 'static> LocalRef<T> for BoxedLocalRef<T> {
 
         // Releasing the memory does not drop the event, so we clear its diagnostic state first.
         #[cfg(debug_assertions)]
-        self.clear_awaiter_backtrace();
+        LocalEvent::clear_awaiter_backtrace(self);
 
         // SAFETY: Still the same type - all is well. We rely on the event state machine
         // to ensure that there is no double-release happening.
@@ -99,7 +106,7 @@ impl<T: 'static> LocalRef<T> for BoxedLocalRef<T> {
 }
 
 impl<T: 'static> Deref for BoxedLocalRef<T> {
-    type Target = LocalEvent<T>;
+    type Target = UnsafeCell<LocalEvent<T>>;
 
     fn deref(&self) -> &Self::Target {
         // SAFETY: Storage is automatically managed - as long as either sender/receiver

--- a/packages/events_once/src/core/local_sender.rs
+++ b/packages/events_once/src/core/local_sender.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::{fmt, ptr};
 
-use crate::{Disconnected, LocalRef};
+use crate::{Disconnected, LocalEvent, LocalRef};
 
 /// Delivers a single value to the receiver connected to the same event.
 pub(crate) struct LocalSenderCore<E, T>
@@ -38,7 +38,7 @@ where
         // The drop logic is different before/after set(), so we switch to manual drop here.
         let mut this = ManuallyDrop::new(self);
 
-        if this.event_ref.set(value) == Err(Disconnected) {
+        if LocalEvent::set(&this.event_ref, value) == Err(Disconnected) {
             // The other endpoint has disconnected, so we need to clean up the event.
             this.event_ref.release_event();
         }
@@ -58,7 +58,7 @@ where
 {
     #[inline]
     fn drop(&mut self) {
-        if self.event_ref.sender_dropped_without_set() == Err(Disconnected) {
+        if LocalEvent::sender_dropped_without_set(&self.event_ref) == Err(Disconnected) {
             // The other endpoint has disconnected, so we need to clean up the event.
             self.event_ref.release_event();
         }

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -981,7 +981,7 @@ impl<T: Send + 'static> fmt::Debug for Event<T> {
 )]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::cell::{Cell, RefCell};
+    use std::cell::RefCell;
     use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe, catch_unwind, resume_unwind};
     use std::rc::Rc;
     use std::sync::Barrier;
@@ -990,7 +990,7 @@ mod tests {
 
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
-    use testing::{ReentrantWakerData, drop_waker, with_watchdog};
+    use testing::{DropOnWakerRelease, ReentrantWakerData, drop_waker, with_watchdog};
 
     use super::*;
     use crate::IntoValueError;
@@ -2203,25 +2203,101 @@ mod tests {
         });
     }
 
+    // Parity counterpart of the disconnect case above. A waker fired by `send` that
+    // synchronously polls the receiver must likewise observe a terminal state, here SET, and read
+    // out the value.
+    #[test]
+    #[cfg_attr(miri, ignore)] // Custom raw waker is not Miri-compatible.
+    fn boxed_send_with_reentrant_waker_observes_set() {
+        type ObservedResult = Poll<Result<i32, Disconnected>>;
+
+        with_watchdog(|| {
+            let (sender, receiver) = Event::<i32>::boxed();
+            let receiver_holder: Rc<RefCell<Option<Pin<Box<_>>>>> =
+                Rc::new(RefCell::new(Some(Box::pin(receiver))));
+            let receiver_for_waker = Rc::clone(&receiver_holder);
+
+            let reentrant_observed: Rc<RefCell<Option<ObservedResult>>> =
+                Rc::new(RefCell::new(None));
+            let observed_for_waker = Rc::clone(&reentrant_observed);
+
+            let waker_data = ReentrantWakerData::new(move || {
+                let mut holder = receiver_for_waker.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let noop = Waker::noop();
+                let mut cx = task::Context::from_waker(noop);
+                let result = receiver.as_mut().poll(&mut cx);
+                *observed_for_waker.borrow_mut() = Some(result);
+            });
+            // SAFETY: `waker_data` outlives the waker and the test is single-threaded.
+            let waker = unsafe { waker_data.waker() };
+
+            // First poll transitions BOUND -> AWAITING and stores the reentrant waker.
+            {
+                let mut holder = receiver_holder.borrow_mut();
+                let receiver = holder.as_mut().expect("receiver still held");
+                let mut cx = task::Context::from_waker(&waker);
+                assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+            }
+
+            // `set` reaches a terminal state and then invokes the waker, which must observe SET
+            // and consume the value reentrantly.
+            sender.send(42);
+
+            assert!(waker_data.was_woken());
+            let observed = reentrant_observed.borrow_mut().take();
+            assert!(
+                matches!(observed, Some(Poll::Ready(Ok(42)))),
+                "reentrant poll should observe SET and read the value",
+            );
+
+            // The receiver was consumed reentrantly; drop the shell that still owns it.
+            drop(receiver_holder.borrow_mut().take());
+        });
+    }
+
     // Parity counterparts of the `LocalEvent` reentrancy regression tests in `core/local.rs`.
     // A wake callback fired while completing or cancelling an event is free to drop the receiver,
     // which releases the event storage while the operation is still on the stack. Ref:
     // docs/callback-safety.md. These run under Miri, which is what detects a regression here.
     #[test]
+    fn boxed_receiver_cancel_with_sender_dropping_waker_preserves_storage() {
+        let (sender, receiver) = Event::<i32>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        let (data, sender_dropped) = DropOnWakerRelease::new(sender);
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(data) };
+
+        // First poll transitions BOUND -> AWAITING and stores a clone of the waker in the event.
+        let mut cx = task::Context::from_waker(&waker);
+        assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+        // Drop our local waker so only the event's stored clone remains; the sender is still
+        // owned behind that clone.
+        drop(waker);
+        assert!(!sender_dropped.get());
+
+        // Dropping the receiver cancels the wait: `final_poll` drops the stored waker, whose
+        // destructor drops the sender. The event storage must survive until `final_poll` returns.
+        drop(receiver);
+
+        assert!(sender_dropped.get(), "{REENTRANCY_REQUIRED}");
+    }
+
+    #[test]
     fn boxed_send_with_reentrant_receiver_drop_releases_storage() {
         let (sender, receiver) = Event::<i32>::boxed();
 
-        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        let (data, receiver_dropped) = DropOnWakerRelease::new(Box::pin(receiver));
         // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
         let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
         // First poll transitions BOUND -> AWAITING and stores a clone of the waker in the event.
-        {
-            let mut endpoint = data.endpoint.borrow_mut();
-            let receiver = endpoint.as_mut().expect("receiver still held");
+        data.with_value(|receiver| {
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
-        }
+        });
 
         // Leave the event's stored clone as the only reference, so waking it runs the reentrant
         // drop.
@@ -2240,16 +2316,14 @@ mod tests {
     fn boxed_sender_drop_with_reentrant_receiver_drop_releases_storage() {
         let (sender, receiver) = Event::<i32>::boxed();
 
-        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        let (data, receiver_dropped) = DropOnWakerRelease::new(Box::pin(receiver));
         // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
         let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
-        {
-            let mut endpoint = data.endpoint.borrow_mut();
-            let receiver = endpoint.as_mut().expect("receiver still held");
+        data.with_value(|receiver| {
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
-        }
+        });
 
         drop(waker);
         drop(data);
@@ -2260,37 +2334,6 @@ mod tests {
         drop(sender);
 
         assert!(receiver_dropped.get(), "{REENTRANCY_REQUIRED}");
-    }
-
-    /// Owns an event endpoint on behalf of a waker, dropping that endpoint once the last waker
-    /// reference goes away. When the event under test releases its stored waker while completing
-    /// or cancelling, the endpoint drop therefore happens reentrantly, from inside the operation
-    /// being tested.
-    struct DropEndpointOnWakerDrop<T> {
-        endpoint: RefCell<Option<T>>,
-        dropped: Rc<Cell<bool>>,
-    }
-
-    impl<T> DropEndpointOnWakerDrop<T> {
-        /// Returns the payload together with a flag that records whether the endpoint has been
-        /// dropped, letting a test prove that the reentrancy it targets actually occurred.
-        fn new(endpoint: T) -> (Arc<Self>, Rc<Cell<bool>>) {
-            let dropped = Rc::new(Cell::new(false));
-
-            let data = Arc::new(Self {
-                endpoint: RefCell::new(Some(endpoint)),
-                dropped: Rc::clone(&dropped),
-            });
-
-            (data, dropped)
-        }
-    }
-
-    impl<T> Drop for DropEndpointOnWakerDrop<T> {
-        fn drop(&mut self) {
-            drop(self.endpoint.borrow_mut().take());
-            self.dropped.set(true);
-        }
     }
 
     /// Explains a failure to reach the reentrant drop that a regression test exists to exercise.

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -55,6 +55,13 @@ thread_local! {
 }
 
 /// Coordinates delivery of a `T` at most once from a sender to a receiver on any thread.
+///
+/// # Reentrancy
+///
+/// Completing or cancelling an event runs the awaiting task's waker, either waking it or dropping
+/// it. Such a callback may freely operate on the endpoints of the event it belongs to: it may drop
+/// an endpoint, poll the receiver to completion or consume its value, and it may release the event
+/// storage by dropping the last endpoint.
 pub struct Event<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: AtomicU8,
@@ -975,18 +982,19 @@ impl<T: Send + 'static> fmt::Debug for Event<T> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::RefCell;
+    use std::marker::PhantomData;
     use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe, catch_unwind, resume_unwind};
     use std::rc::Rc;
     use std::sync::Barrier;
-    use std::task::Poll;
-    use std::{task, thread};
+    use std::task::{Poll, RawWaker, RawWakerVTable};
+    use std::{mem, task, thread};
 
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
     use testing::{ReentrantWakerData, with_watchdog};
 
     use super::*;
-    use crate::IntoValueError;
+    use crate::{IntoValueError, NEVER_POISONED};
 
     assert_impl_all!(Event<u32>: Send, Sync, UnwindSafe, RefUnwindSafe);
 
@@ -2194,5 +2202,126 @@ mod tests {
             // Drop the receiver to release its half of the event.
             drop(receiver_holder.borrow_mut().take());
         });
+    }
+
+    // Parity counterparts of the `LocalEvent` reentrancy regression tests in `core/local.rs`.
+    // A wake callback fired while completing or cancelling an event is free to drop the receiver,
+    // which releases the event storage while the operation is still on the stack. Ref:
+    // docs/callback-safety.md. These run under Miri, which is what detects a regression here.
+    #[test]
+    fn boxed_send_with_reentrant_receiver_drop_releases_storage() {
+        // Owns the receiver behind a refcounted waker. When the last waker reference is dropped,
+        // `Drop` drops the receiver, which observes the SET state and releases the event storage.
+        struct DropReceiverOnWakerDrop {
+            receiver: Mutex<Option<Pin<Box<BoxedReceiver<i32>>>>>,
+        }
+
+        impl Drop for DropReceiverOnWakerDrop {
+            fn drop(&mut self) {
+                drop(self.receiver.lock().expect(NEVER_POISONED).take());
+            }
+        }
+
+        let (sender, receiver) = Event::<i32>::boxed();
+
+        let data = Arc::new(DropReceiverOnWakerDrop {
+            receiver: Mutex::new(Some(Box::pin(receiver))),
+        });
+        let waker = arc_drop_waker(Arc::clone(&data));
+
+        // First poll transitions BOUND -> AWAITING and stores a clone of the waker in the event.
+        {
+            let mut receiver = data.receiver.lock().expect(NEVER_POISONED);
+            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut cx = task::Context::from_waker(&waker);
+            assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+        }
+
+        // Leave the event's stored clone as the only reference, so waking it runs the reentrant
+        // drop. Without this the test would silently pass even if the hazard were present.
+        drop(waker);
+        drop(data);
+
+        // `set` stores the value, reaches a terminal state and wakes, which drops the receiver,
+        // which consumes the value and frees the event.
+        sender.send(42);
+    }
+
+    #[test]
+    fn boxed_sender_drop_with_reentrant_receiver_drop_releases_storage() {
+        struct DropReceiverOnWakerDrop {
+            receiver: Mutex<Option<Pin<Box<BoxedReceiver<i32>>>>>,
+        }
+
+        impl Drop for DropReceiverOnWakerDrop {
+            fn drop(&mut self) {
+                drop(self.receiver.lock().expect(NEVER_POISONED).take());
+            }
+        }
+
+        let (sender, receiver) = Event::<i32>::boxed();
+
+        let data = Arc::new(DropReceiverOnWakerDrop {
+            receiver: Mutex::new(Some(Box::pin(receiver))),
+        });
+        let waker = arc_drop_waker(Arc::clone(&data));
+
+        {
+            let mut receiver = data.receiver.lock().expect(NEVER_POISONED);
+            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut cx = task::Context::from_waker(&waker);
+            assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+        }
+
+        drop(waker);
+        drop(data);
+
+        // `sender_dropped_without_set` reaches DISCONNECTED and wakes, which drops the receiver,
+        // which frees the event.
+        drop(sender);
+    }
+
+    /// Creates a waker that holds one reference to `data` and whose `wake()` and destructor both
+    /// merely release that reference. Any reentrant behavior under test therefore belongs in the
+    /// `Drop` implementation of `T`, which runs once the last reference is released.
+    ///
+    /// This is a Miri-compatible alternative to [`ReentrantWakerData`], so tests built on it can
+    /// exercise the aliasing rules that only Miri enforces.
+    fn arc_drop_waker<T: Send + Sync + 'static>(data: Arc<T>) -> Waker {
+        unsafe { Waker::from_raw(ArcDropWaker::<T>::raw_waker(data)) }
+    }
+
+    /// Carries the [`RawWakerVTable`] for [`arc_drop_waker`], one instance per payload type.
+    struct ArcDropWaker<T>(PhantomData<T>);
+
+    impl<T: Send + Sync + 'static> ArcDropWaker<T> {
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(
+            Self::clone_raw,
+            Self::wake_raw,
+            Self::wake_by_ref_raw,
+            Self::drop_raw,
+        );
+
+        fn raw_waker(data: Arc<T>) -> RawWaker {
+            RawWaker::new(Arc::into_raw(data).cast(), &Self::VTABLE)
+        }
+
+        unsafe fn clone_raw(data: *const ()) -> RawWaker {
+            let arc = unsafe { Arc::from_raw(data.cast::<T>()) };
+            let clone = Arc::clone(&arc);
+            // Keep the original reference alive; we only wanted to bump the count.
+            mem::forget(arc);
+            Self::raw_waker(clone)
+        }
+
+        unsafe fn wake_raw(data: *const ()) {
+            unsafe { Self::drop_raw(data) }
+        }
+
+        unsafe fn wake_by_ref_raw(_data: *const ()) {}
+
+        unsafe fn drop_raw(data: *const ()) {
+            drop(unsafe { Arc::from_raw(data.cast::<T>()) });
+        }
     }
 }

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -59,9 +59,9 @@ thread_local! {
 /// # Reentrancy
 ///
 /// Completing or cancelling an event runs the awaiting task's waker, either waking it or dropping
-/// it. Such a callback may freely operate on the endpoints of the event it belongs to: it may drop
-/// an endpoint, poll the receiver to completion or consume its value, and it may release the event
-/// storage by dropping the last endpoint.
+/// it. Such a callback may operate on the endpoints of the event it belongs to: it may poll the
+/// receiver to completion, and it may drop an endpoint - including the last one, which releases
+/// the event storage.
 pub struct Event<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: AtomicU8,
@@ -981,20 +981,19 @@ impl<T: Send + 'static> fmt::Debug for Event<T> {
 )]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::cell::RefCell;
-    use std::marker::PhantomData;
+    use std::cell::{Cell, RefCell};
     use std::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe, catch_unwind, resume_unwind};
     use std::rc::Rc;
     use std::sync::Barrier;
-    use std::task::{Poll, RawWaker, RawWakerVTable};
-    use std::{mem, task, thread};
+    use std::task::Poll;
+    use std::{task, thread};
 
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
-    use testing::{ReentrantWakerData, with_watchdog};
+    use testing::{ReentrantWakerData, drop_waker, with_watchdog};
 
     use super::*;
-    use crate::{IntoValueError, NEVER_POISONED};
+    use crate::IntoValueError;
 
     assert_impl_all!(Event<u32>: Send, Sync, UnwindSafe, RefUnwindSafe);
 
@@ -2210,118 +2209,92 @@ mod tests {
     // docs/callback-safety.md. These run under Miri, which is what detects a regression here.
     #[test]
     fn boxed_send_with_reentrant_receiver_drop_releases_storage() {
-        // Owns the receiver behind a refcounted waker. When the last waker reference is dropped,
-        // `Drop` drops the receiver, which observes the SET state and releases the event storage.
-        struct DropReceiverOnWakerDrop {
-            receiver: Mutex<Option<Pin<Box<BoxedReceiver<i32>>>>>,
-        }
-
-        impl Drop for DropReceiverOnWakerDrop {
-            fn drop(&mut self) {
-                drop(self.receiver.lock().expect(NEVER_POISONED).take());
-            }
-        }
-
         let (sender, receiver) = Event::<i32>::boxed();
 
-        let data = Arc::new(DropReceiverOnWakerDrop {
-            receiver: Mutex::new(Some(Box::pin(receiver))),
-        });
-        let waker = arc_drop_waker(Arc::clone(&data));
+        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
         // First poll transitions BOUND -> AWAITING and stores a clone of the waker in the event.
         {
-            let mut receiver = data.receiver.lock().expect(NEVER_POISONED);
-            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut endpoint = data.endpoint.borrow_mut();
+            let receiver = endpoint.as_mut().expect("receiver still held");
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
         }
 
         // Leave the event's stored clone as the only reference, so waking it runs the reentrant
-        // drop. Without this the test would silently pass even if the hazard were present.
+        // drop.
         drop(waker);
         drop(data);
+        assert!(!receiver_dropped.get());
 
         // `set` stores the value, reaches a terminal state and wakes, which drops the receiver,
         // which consumes the value and frees the event.
         sender.send(42);
+
+        assert!(receiver_dropped.get(), "{REENTRANCY_REQUIRED}");
     }
 
     #[test]
     fn boxed_sender_drop_with_reentrant_receiver_drop_releases_storage() {
-        struct DropReceiverOnWakerDrop {
-            receiver: Mutex<Option<Pin<Box<BoxedReceiver<i32>>>>>,
-        }
-
-        impl Drop for DropReceiverOnWakerDrop {
-            fn drop(&mut self) {
-                drop(self.receiver.lock().expect(NEVER_POISONED).take());
-            }
-        }
-
         let (sender, receiver) = Event::<i32>::boxed();
 
-        let data = Arc::new(DropReceiverOnWakerDrop {
-            receiver: Mutex::new(Some(Box::pin(receiver))),
-        });
-        let waker = arc_drop_waker(Arc::clone(&data));
+        let (data, receiver_dropped) = DropEndpointOnWakerDrop::new(Box::pin(receiver));
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(Arc::clone(&data)) };
 
         {
-            let mut receiver = data.receiver.lock().expect(NEVER_POISONED);
-            let receiver = receiver.as_mut().expect("receiver still held");
+            let mut endpoint = data.endpoint.borrow_mut();
+            let receiver = endpoint.as_mut().expect("receiver still held");
             let mut cx = task::Context::from_waker(&waker);
             assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
         }
 
         drop(waker);
         drop(data);
+        assert!(!receiver_dropped.get());
 
         // `sender_dropped_without_set` reaches DISCONNECTED and wakes, which drops the receiver,
         // which frees the event.
         drop(sender);
+
+        assert!(receiver_dropped.get(), "{REENTRANCY_REQUIRED}");
     }
 
-    /// Creates a waker that holds one reference to `data` and whose `wake()` and destructor both
-    /// merely release that reference. Any reentrant behavior under test therefore belongs in the
-    /// `Drop` implementation of `T`, which runs once the last reference is released.
-    ///
-    /// This is a Miri-compatible alternative to [`ReentrantWakerData`], so tests built on it can
-    /// exercise the aliasing rules that only Miri enforces.
-    fn arc_drop_waker<T: Send + Sync + 'static>(data: Arc<T>) -> Waker {
-        unsafe { Waker::from_raw(ArcDropWaker::<T>::raw_waker(data)) }
+    /// Owns an event endpoint on behalf of a waker, dropping that endpoint once the last waker
+    /// reference goes away. When the event under test releases its stored waker while completing
+    /// or cancelling, the endpoint drop therefore happens reentrantly, from inside the operation
+    /// being tested.
+    struct DropEndpointOnWakerDrop<T> {
+        endpoint: RefCell<Option<T>>,
+        dropped: Rc<Cell<bool>>,
     }
 
-    /// Carries the [`RawWakerVTable`] for [`arc_drop_waker`], one instance per payload type.
-    struct ArcDropWaker<T>(PhantomData<T>);
+    impl<T> DropEndpointOnWakerDrop<T> {
+        /// Returns the payload together with a flag that records whether the endpoint has been
+        /// dropped, letting a test prove that the reentrancy it targets actually occurred.
+        fn new(endpoint: T) -> (Arc<Self>, Rc<Cell<bool>>) {
+            let dropped = Rc::new(Cell::new(false));
 
-    impl<T: Send + Sync + 'static> ArcDropWaker<T> {
-        const VTABLE: RawWakerVTable = RawWakerVTable::new(
-            Self::clone_raw,
-            Self::wake_raw,
-            Self::wake_by_ref_raw,
-            Self::drop_raw,
-        );
+            let data = Arc::new(Self {
+                endpoint: RefCell::new(Some(endpoint)),
+                dropped: Rc::clone(&dropped),
+            });
 
-        fn raw_waker(data: Arc<T>) -> RawWaker {
-            RawWaker::new(Arc::into_raw(data).cast(), &Self::VTABLE)
-        }
-
-        unsafe fn clone_raw(data: *const ()) -> RawWaker {
-            let arc = unsafe { Arc::from_raw(data.cast::<T>()) };
-            let clone = Arc::clone(&arc);
-            // Keep the original reference alive; we only wanted to bump the count.
-            mem::forget(arc);
-            Self::raw_waker(clone)
-        }
-
-        unsafe fn wake_raw(data: *const ()) {
-            unsafe { Self::drop_raw(data) }
-        }
-
-        unsafe fn wake_by_ref_raw(_data: *const ()) {}
-
-        unsafe fn drop_raw(data: *const ()) {
-            drop(unsafe { Arc::from_raw(data.cast::<T>()) });
+            (data, dropped)
         }
     }
+
+    impl<T> Drop for DropEndpointOnWakerDrop<T> {
+        fn drop(&mut self) {
+            drop(self.endpoint.borrow_mut().take());
+            self.dropped.set(true);
+        }
+    }
+
+    /// Explains a failure to reach the reentrant drop that a regression test exists to exercise.
+    /// Without it the test would pass no matter how the code under test behaved.
+    const REENTRANCY_REQUIRED: &str =
+        "the event must have held a waker clone whose drop reentered the operation under test";
 }

--- a/packages/events_once/src/pool/local_ref.rs
+++ b/packages/events_once/src/pool/local_ref.rs
@@ -1,4 +1,5 @@
 use std::any::type_name;
+use std::cell::UnsafeCell;
 use std::fmt;
 use std::ops::Deref;
 use std::ptr::NonNull;
@@ -15,14 +16,14 @@ pub(crate) struct PooledLocalRef<T: 'static> {
     #[cfg(debug_assertions)]
     core: Rc<LocalPoolCore<T>>,
 
-    event: NonNull<LocalEvent<T>>,
+    event: NonNull<UnsafeCell<LocalEvent<T>>>,
 }
 
 impl<T: 'static> PooledLocalRef<T> {
     #[must_use]
     pub(crate) fn new(
         #[cfg(debug_assertions)] core: Rc<LocalPoolCore<T>>,
-        event: NonNull<LocalEvent<T>>,
+        event: NonNull<UnsafeCell<LocalEvent<T>>>,
     ) -> Self {
         Self {
             #[cfg(debug_assertions)]
@@ -58,7 +59,7 @@ impl<T: 'static> LocalRef<T> for PooledLocalRef<T> {
 }
 
 impl<T: 'static> Deref for PooledLocalRef<T> {
-    type Target = LocalEvent<T>;
+    type Target = UnsafeCell<LocalEvent<T>>;
 
     fn deref(&self) -> &Self::Target {
         // SAFETY: The event state machine guarantees that the event stays alive for as long as

--- a/packages/events_once/src/pool/local_state.rs
+++ b/packages/events_once/src/pool/local_state.rs
@@ -1,8 +1,10 @@
 use std::any::type_name;
 #[cfg(debug_assertions)]
 use std::backtrace::Backtrace;
+use std::cell::UnsafeCell;
 use std::fmt;
-use std::ptr::NonNull;
+use std::mem::MaybeUninit;
+use std::ptr::{self, NonNull};
 #[cfg(debug_assertions)]
 use std::sync::Arc;
 
@@ -23,10 +25,10 @@ use crate::{EVENT_COUNT_FITS_IN_USIZE, LocalEvent};
 /// [`rent()`][Self::rent] returns and is given back by [`destroy_local_event()`], which needs
 /// neither the pool nor a borrow of it.
 pub(crate) struct LocalPoolState<T: 'static> {
-    events: Pool<LocalEvent<T>>,
+    events: Pool<UnsafeCell<LocalEvent<T>>>,
 
     #[cfg(debug_assertions)]
-    registry: EventRegistry<LocalEvent<T>>,
+    registry: EventRegistry<UnsafeCell<LocalEvent<T>>>,
 }
 
 impl<T: 'static> LocalPoolState<T> {
@@ -52,13 +54,20 @@ impl<T: 'static> LocalPoolState<T> {
                       the signature stays uniform so callers need not differ"
         )
     )]
-    pub(crate) fn rent(&mut self) -> NonNull<LocalEvent<T>> {
+    pub(crate) fn rent(&mut self) -> NonNull<UnsafeCell<LocalEvent<T>>> {
         let mut storage = self.events.alloc_uninit_box();
 
         // SAFETY: The slot is still uninitialized, so it carries no pinning invariant that
         // unwrapping the `Pin` could violate. We only use the reference to initialize the event
         // in place, which moves nothing.
         let place = unsafe { storage.as_pin_mut().get_unchecked_mut() };
+
+        let place = ptr::from_mut(place).cast::<UnsafeCell<MaybeUninit<LocalEvent<T>>>>();
+
+        // SAFETY: `MaybeUninit` and `UnsafeCell` are both transparent wrappers, so both nestings
+        // describe the same storage. We want the `UnsafeCell` on the outside because every
+        // reference to a live event goes through one.
+        let place = unsafe { &mut *place };
 
         LocalEvent::new_in_inner(place);
 
@@ -76,7 +85,7 @@ impl<T: 'static> LocalPoolState<T> {
 
     /// Stops enumerating an event that is about to be destroyed.
     #[cfg(debug_assertions)]
-    pub(crate) fn unregister(&mut self, event: NonNull<LocalEvent<T>>) {
+    pub(crate) fn unregister(&mut self, event: NonNull<UnsafeCell<LocalEvent<T>>>) {
         self.registry.unregister(event);
     }
 
@@ -103,9 +112,12 @@ impl<T: 'static> LocalPoolState<T> {
 
         for event in self.registry.iter() {
             // SAFETY: The registry only names events that have been rented and not yet released,
-            // so the slot is still occupied by a live event. We only ever create shared
-            // references to an event, so no exclusive reference can alias this one.
-            let event = unsafe { event.as_ref() };
+            // so the slot is still occupied by a live event.
+            let event_cell = unsafe { event.as_ref() };
+
+            // SAFETY: We only ever create shared references to an event, so no exclusive
+            // reference can alias this one.
+            let event = unsafe { &*event_cell.get() };
 
             if let Some(backtrace) = event.awaiter_backtrace() {
                 backtraces.push(backtrace);
@@ -126,10 +138,10 @@ impl<T: 'static> LocalPoolState<T> {
 ///
 /// The pointer must come from [`LocalPoolState::rent()`] and must not have been passed here
 /// before. Nothing may reference the event afterwards.
-pub(crate) unsafe fn destroy_local_event<T: 'static>(event: NonNull<LocalEvent<T>>) {
+pub(crate) unsafe fn destroy_local_event<T: 'static>(event: NonNull<UnsafeCell<LocalEvent<T>>>) {
     // SAFETY: Forwarding the guarantees of the caller, who promises that this is the single
     // `from_raw()` call matching the `into_raw()` that renting performed for this pointer.
-    drop(unsafe { plurality::Box::<LocalEvent<T>>::from_raw(event) });
+    drop(unsafe { plurality::Box::<UnsafeCell<LocalEvent<T>>>::from_raw(event) });
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))] // No API contract to test.

--- a/packages/events_once/src/pool/raw_local_ref.rs
+++ b/packages/events_once/src/pool/raw_local_ref.rs
@@ -1,5 +1,4 @@
 use std::any::type_name;
-#[cfg(debug_assertions)]
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::ops::Deref;
@@ -15,14 +14,14 @@ pub(crate) struct RawLocalPooledRef<T: 'static> {
     #[cfg(debug_assertions)]
     core: NonNull<UnsafeCell<RawLocalEventPoolCore<T>>>,
 
-    event: NonNull<LocalEvent<T>>,
+    event: NonNull<UnsafeCell<LocalEvent<T>>>,
 }
 
 impl<T: 'static> RawLocalPooledRef<T> {
     #[must_use]
     pub(crate) fn new(
         #[cfg(debug_assertions)] core: NonNull<UnsafeCell<RawLocalEventPoolCore<T>>>,
-        event: NonNull<LocalEvent<T>>,
+        event: NonNull<UnsafeCell<LocalEvent<T>>>,
     ) -> Self {
         Self {
             #[cfg(debug_assertions)]
@@ -69,7 +68,7 @@ impl<T: 'static> LocalRef<T> for RawLocalPooledRef<T> {
 }
 
 impl<T: 'static> Deref for RawLocalPooledRef<T> {
-    type Target = LocalEvent<T>;
+    type Target = UnsafeCell<LocalEvent<T>>;
 
     fn deref(&self) -> &Self::Target {
         // SAFETY: The event state machine guarantees that the event stays alive for as long as

--- a/packages/testing/src/drop_waker.rs
+++ b/packages/testing/src/drop_waker.rs
@@ -13,6 +13,12 @@ use std::{fmt, mem};
 /// the waker it stored, or discards that waker during cancellation. [`DropOnWakerRelease`]
 /// provides a ready-made payload for that pattern.
 ///
+/// [`Waker::wake_by_ref()`] does not consume a reference, so it does not release the payload and
+/// does not reach the behavior under test. A test must therefore observe that the payload really
+/// was dropped rather than assume it; the flag from [`DropOnWakerRelease::new()`] serves that
+/// purpose, and turns a primitive that only wakes by reference into a failure rather than a
+/// vacuous pass.
+///
 /// Prefer this over [`ReentrantWakerData`][crate::ReentrantWakerData] when the test must run
 /// under Miri: this waker owns its data outright, whereas `ReentrantWakerData` hands out a
 /// borrowed pointer to data the test still owns.
@@ -73,6 +79,7 @@ impl<T: 'static> VTable<T> {
         unsafe { Self::drop_raw(data) }
     }
 
+    /// Waking by reference does not consume a reference, so there is nothing to release.
     fn wake_by_ref_raw(_data: *const ()) {}
 
     /// # Safety

--- a/packages/testing/src/drop_waker.rs
+++ b/packages/testing/src/drop_waker.rs
@@ -1,13 +1,17 @@
+use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{RawWaker, RawWakerVTable, Waker};
+use std::{fmt, mem};
 
 /// Creates a [`Waker`] that owns one reference to `data`, whose `wake()` and destructor both
 /// merely release that reference.
 ///
 /// The reentrant behavior under test therefore belongs in the [`Drop`] implementation of `T`,
 /// which runs once the last reference goes away - typically when the primitive under test wakes
-/// the waker it stored, or discards that waker during cancellation.
+/// the waker it stored, or discards that waker during cancellation. [`DropOnWakerRelease`]
+/// provides a ready-made payload for that pattern.
 ///
 /// Prefer this over [`ReentrantWakerData`][crate::ReentrantWakerData] when the test must run
 /// under Miri: this waker owns its data outright, whereas `ReentrantWakerData` hands out a
@@ -19,11 +23,13 @@ use std::task::{RawWaker, RawWakerVTable, Waker};
 /// on the calling thread. [`Waker`] is `Send + Sync` regardless of `T`, so this cannot be
 /// expressed in the type system.
 pub unsafe fn drop_waker<T: 'static>(data: Arc<T>) -> Waker {
+    let raw = raw_waker(data);
+
     // SAFETY: The vtable upholds the `RawWaker` contract for an `Arc<T>` payload - it is only
-    // ever paired with a pointer from `Arc::into_raw`, and each operation is an atomic reference
+    // ever paired with a pointer from `Arc::into_raw`, and every operation is an atomic reference
     // count operation, which satisfies the thread-safety requirement on `RawWakerVTable`. The
     // caller upholds the remaining requirement, that `T` is only dropped where it may be dropped.
-    unsafe { Waker::from_raw(raw_waker(data)) }
+    unsafe { Waker::from_raw(raw) }
 }
 
 fn raw_waker<T: 'static>(data: Arc<T>) -> RawWaker {
@@ -43,8 +49,8 @@ impl<T: 'static> VTable<T> {
 
     /// # Safety
     ///
-    /// `data` must be a pointer obtained from `Arc::<T>::into_raw()` whose reference is still
-    /// owned by the waker being cloned.
+    /// `data` must come from `Arc::<T>::into_raw()` and its reference must still be owned by the
+    /// waker being cloned.
     unsafe fn clone_raw(data: *const ()) -> RawWaker {
         // SAFETY: Forwarding the guarantees of the caller.
         let arc = unsafe { Arc::from_raw(data.cast::<T>()) };
@@ -53,15 +59,15 @@ impl<T: 'static> VTable<T> {
 
         // The reference we reconstructed still belongs to the waker we were cloned from, so we
         // must not release it here.
-        std::mem::forget(arc);
+        mem::forget(arc);
 
         raw_waker(clone)
     }
 
     /// # Safety
     ///
-    /// `data` must be a pointer obtained from `Arc::<T>::into_raw()` whose reference is being
-    /// consumed by this call.
+    /// `data` must come from `Arc::<T>::into_raw()` and its reference must be consumed by this
+    /// call.
     unsafe fn wake_raw(data: *const ()) {
         // SAFETY: Forwarding the guarantees of the caller.
         unsafe { Self::drop_raw(data) }
@@ -71,10 +77,149 @@ impl<T: 'static> VTable<T> {
 
     /// # Safety
     ///
-    /// `data` must be a pointer obtained from `Arc::<T>::into_raw()` whose reference is being
-    /// consumed by this call.
+    /// `data` must come from `Arc::<T>::into_raw()` and its reference must be consumed by this
+    /// call.
     unsafe fn drop_raw(data: *const ()) {
         // SAFETY: Forwarding the guarantees of the caller.
-        drop(unsafe { Arc::from_raw(data.cast::<T>()) });
+        let arc = unsafe { Arc::from_raw(data.cast::<T>()) };
+
+        drop(arc);
+    }
+}
+
+/// Owns a value on behalf of a [`drop_waker`] waker, dropping that value once the last waker
+/// reference goes away.
+///
+/// When a primitive under test releases a waker it had stored - while completing, while waking or
+/// while cancelling - the value is dropped reentrantly, from inside the operation under test.
+/// Parking one of the primitive's own endpoints in here is how callback-safety tests reach back
+/// into the primitive at exactly that moment.
+///
+/// This type is single-threaded, so wakers built from it must stay on one thread.
+pub struct DropOnWakerRelease<T> {
+    value: RefCell<Option<T>>,
+    dropped: Rc<Cell<bool>>,
+}
+
+impl<T> DropOnWakerRelease<T> {
+    /// Wraps `value`, returning it alongside a flag that records whether it has been dropped.
+    ///
+    /// The flag lets a test prove that the reentrancy it targets actually occurred, instead of
+    /// passing vacuously because the primitive never held on to a waker.
+    #[must_use]
+    pub fn new(value: T) -> (Arc<Self>, Rc<Cell<bool>>) {
+        let dropped = Rc::new(Cell::new(false));
+
+        let data = Arc::new(Self {
+            value: RefCell::new(Some(value)),
+            dropped: Rc::clone(&dropped),
+        });
+
+        (data, dropped)
+    }
+
+    /// Calls `f` with the still-owned value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value has already been dropped.
+    pub fn with_value<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let mut value = self.value.borrow_mut();
+
+        f(value.as_mut().expect("the value has already been dropped"))
+    }
+}
+
+impl<T> Drop for DropOnWakerRelease<T> {
+    fn drop(&mut self) {
+        drop(self.value.borrow_mut().take());
+        self.dropped.set(true);
+    }
+}
+
+impl<T> fmt::Debug for DropOnWakerRelease<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(std::any::type_name::<Self>())
+            .field("dropped", &self.dropped.get())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    use super::*;
+
+    /// Enough concurrent users to interleave reference count operations from several threads,
+    /// while staying small enough for Miri to execute the test quickly.
+    const THREAD_COUNT: usize = 4;
+
+    #[test]
+    fn concurrent_clone_wake_and_drop_releases_payload_exactly_once() {
+        struct Payload {
+            drop_count: Arc<AtomicUsize>,
+        }
+
+        impl Drop for Payload {
+            fn drop(&mut self) {
+                self.drop_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let payload = Arc::new(Payload {
+            drop_count: Arc::clone(&drop_count),
+        });
+
+        // SAFETY: The payload is `Send + Sync`, so the waker may travel between threads.
+        let waker = unsafe { drop_waker(payload) };
+
+        let barrier = Barrier::new(THREAD_COUNT);
+
+        thread::scope(|scope| {
+            for _ in 0..THREAD_COUNT {
+                let waker = waker.clone();
+                let barrier = &barrier;
+
+                scope.spawn(move || {
+                    barrier.wait();
+
+                    let clone = waker.clone();
+                    clone.wake_by_ref();
+                    clone.wake();
+
+                    drop(waker);
+                });
+            }
+        });
+
+        assert_eq!(
+            drop_count.load(Ordering::Relaxed),
+            0,
+            "the payload must survive while the original waker still holds a reference"
+        );
+
+        drop(waker);
+
+        assert_eq!(drop_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn releasing_the_last_waker_drops_the_value() {
+        let (data, dropped) = DropOnWakerRelease::new(42_u32);
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let waker = unsafe { drop_waker(Arc::clone(&data)) };
+
+        assert_eq!(data.with_value(|value| *value), 42);
+
+        drop(data);
+        assert!(!dropped.get());
+
+        waker.wake();
+        assert!(dropped.get());
     }
 }

--- a/packages/testing/src/drop_waker.rs
+++ b/packages/testing/src/drop_waker.rs
@@ -1,0 +1,80 @@
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::task::{RawWaker, RawWakerVTable, Waker};
+
+/// Creates a [`Waker`] that owns one reference to `data`, whose `wake()` and destructor both
+/// merely release that reference.
+///
+/// The reentrant behavior under test therefore belongs in the [`Drop`] implementation of `T`,
+/// which runs once the last reference goes away - typically when the primitive under test wakes
+/// the waker it stored, or discards that waker during cancellation.
+///
+/// Prefer this over [`ReentrantWakerData`][crate::ReentrantWakerData] when the test must run
+/// under Miri: this waker owns its data outright, whereas `ReentrantWakerData` hands out a
+/// borrowed pointer to data the test still owns.
+///
+/// # Safety
+///
+/// Unless `T` is `Send + Sync`, the returned waker and every clone of it must be used and dropped
+/// on the calling thread. [`Waker`] is `Send + Sync` regardless of `T`, so this cannot be
+/// expressed in the type system.
+pub unsafe fn drop_waker<T: 'static>(data: Arc<T>) -> Waker {
+    // SAFETY: The vtable upholds the `RawWaker` contract for an `Arc<T>` payload - it is only
+    // ever paired with a pointer from `Arc::into_raw`, and each operation is an atomic reference
+    // count operation, which satisfies the thread-safety requirement on `RawWakerVTable`. The
+    // caller upholds the remaining requirement, that `T` is only dropped where it may be dropped.
+    unsafe { Waker::from_raw(raw_waker(data)) }
+}
+
+fn raw_waker<T: 'static>(data: Arc<T>) -> RawWaker {
+    RawWaker::new(Arc::into_raw(data).cast(), &VTable::<T>::VTABLE)
+}
+
+/// Carries the [`RawWakerVTable`] for [`drop_waker`], one instance per payload type.
+struct VTable<T>(PhantomData<T>);
+
+impl<T: 'static> VTable<T> {
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(
+        Self::clone_raw,
+        Self::wake_raw,
+        Self::wake_by_ref_raw,
+        Self::drop_raw,
+    );
+
+    /// # Safety
+    ///
+    /// `data` must be a pointer obtained from `Arc::<T>::into_raw()` whose reference is still
+    /// owned by the waker being cloned.
+    unsafe fn clone_raw(data: *const ()) -> RawWaker {
+        // SAFETY: Forwarding the guarantees of the caller.
+        let arc = unsafe { Arc::from_raw(data.cast::<T>()) };
+
+        let clone = Arc::clone(&arc);
+
+        // The reference we reconstructed still belongs to the waker we were cloned from, so we
+        // must not release it here.
+        std::mem::forget(arc);
+
+        raw_waker(clone)
+    }
+
+    /// # Safety
+    ///
+    /// `data` must be a pointer obtained from `Arc::<T>::into_raw()` whose reference is being
+    /// consumed by this call.
+    unsafe fn wake_raw(data: *const ()) {
+        // SAFETY: Forwarding the guarantees of the caller.
+        unsafe { Self::drop_raw(data) }
+    }
+
+    fn wake_by_ref_raw(_data: *const ()) {}
+
+    /// # Safety
+    ///
+    /// `data` must be a pointer obtained from `Arc::<T>::into_raw()` whose reference is being
+    /// consumed by this call.
+    unsafe fn drop_raw(data: *const ()) {
+        // SAFETY: Forwarding the guarantees of the caller.
+        drop(unsafe { Arc::from_raw(data.cast::<T>()) });
+    }
+}

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -6,12 +6,14 @@
 
 mod assert_panics;
 mod cwd_guard;
+mod drop_waker;
 mod float;
 mod reentrant_waker;
 mod watchdog;
 
 pub use assert_panics::{assert_panics, assert_panics_with};
 pub use cwd_guard::CwdGuard;
+pub use drop_waker::drop_waker;
 pub use float::f64_diff_abs;
 pub use reentrant_waker::ReentrantWakerData;
 pub use watchdog::with_watchdog;

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -13,7 +13,7 @@ mod watchdog;
 
 pub use assert_panics::{assert_panics, assert_panics_with};
 pub use cwd_guard::CwdGuard;
-pub use drop_waker::drop_waker;
+pub use drop_waker::{DropOnWakerRelease, drop_waker};
 pub use float::f64_diff_abs;
 pub use reentrant_waker::ReentrantWakerData;
 pub use watchdog::with_watchdog;


### PR DESCRIPTION
[Copilot speaking]

Fixes #472.

## Motivation

`LocalEvent::set` and `LocalEvent::sender_dropped_without_set` invoke the awaiting task's waker while a `&self` argument is live. A reference passed as a function argument is strongly protected for the duration of the call, so a wake callback that reentrantly drops the receiver - releasing the event storage - deallocates memory out from under a live protected reference. Miri reports this as "deallocating while item is strongly protected".

The `final_poll` ordering fix in #463 does not cover this. That one decides *who* cleans up during cancellation; this one is about the shape of the reference that the completion paths hold while user code runs.

## Changes

The single-threaded deref chain now carries `&UnsafeCell<LocalEvent<T>>` instead of `&LocalEvent<T>`, all the way from the endpoint types down through the pool, matching what the thread-safe `Event` already does:

```
                    before                          after
  LocalRef      Deref<Target = LocalEvent<T>>   Deref<Target = UnsafeCell<LocalEvent<T>>>
                        |                                     |
  completion    set(&self, value)               set(&UnsafeCell<Self>, value)
  paths         sender_dropped_without_set(&self)  sender_dropped_without_set(&UnsafeCell<Self>)
                final_poll(&self)               final_poll(&UnsafeCell<Self>)
```

An `&UnsafeCell<T>` argument carries no protector, and references derived from it inside a function body are free to dangle once the callback has run. Each completion path derives its reference locally and touches nothing in the event after waking.

`Event` and `LocalEvent` now both document, as part of their public API contract, what a wake callback may do to the event it belongs to: poll the receiver to completion, and drop an endpoint, including the last one. Both variants carry matching parity tests for every one of those operations on both the set and the disconnect path, per `docs/callback-safety.md`. The tests run under Miri, which is what detects a regression, and they assert that the reentrant drop actually happened so they cannot pass vacuously.

The waker those tests need - one that hands ownership of a payload to the primitive under test, so that releasing the waker runs the payload's destructor reentrantly - now lives in the `testing` package alongside the existing `ReentrantWakerData`, which cannot be used under Miri.

## Noted separately

While reviewing the surrounding code I filed #474: `LocalEvent::poll` commits `EVENT_AWAITING` unconditionally after calling `Waker::clone`, so a clone callback that sends or drops the sender has its state transition overwritten. `Event::poll_bound` does the equivalent transition with a compare-exchange and handles every losing outcome. That is a separate liveness defect and is not addressed here.

