### PR TITLE
cbh_analyze: assert error pass-through against the wrapped rendering

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,8 +12,11 @@ concurrency:
 
 # Emit a backtrace whenever a test (or any Rust process) panics, so a rare flake — such as the
 # alloc_tracker panic-on-next-alloc global-state race — is diagnosable straight from the failing
-# run's log instead of the log only advising a re-run with RUST_BACKTRACE set. This does not change
-# panic messages, so `#[should_panic]` matching and error-message assertions are unaffected.
+# run's log instead of the log only advising a re-run with RUST_BACKTRACE set. Panic messages are
+# unchanged, so `#[should_panic]` matching is unaffected. Rendered `ohno` error text is not: an
+# `ohno` error renders its captured backtrace as part of its `Display`, and `message()` renders an
+# error's source through `Display`. Assertions on rendered error text must therefore hold with
+# backtraces captured — see docs/error-handling.md.
 env:
   RUST_BACKTRACE: "1"
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -166,9 +166,10 @@ Further rules:
 Each error carries its own backtrace, so a wrapper chain prints one backtrace block
 per level under `RUST_BACKTRACE=1`. `message()` is no safer than `to_string()` here:
 it omits only the error's own backtrace but renders its source through `Display`, so
-a wrapper's `message()` carries every backtrace beneath it. Never assert that either
-rendering equals a fixed string, and never compare the renderings of two different
-errors; both hold only while backtrace capture is off. Assert on a substring, or, for
-a transparent wrapper, against the wrapped error's own `to_string()`, which it
-reproduces exactly. See the unwind-safety chapter for the manual
-`UnwindSafe`/`RefUnwindSafe` impls these types require.
+a wrapper's `message()` carries every backtrace beneath it. Never assert that a
+rendering equals a fixed string, and never pair two renderings that merely look
+interchangeable — a wrapper's `message()` against the wrapped error's `message()`
+holds only while backtrace capture is off. Assert on a substring, or pair renderings
+that are equal by construction: a transparent wrapper's `message()` reproduces the
+wrapped error's `to_string()` exactly, backtraces included. See the unwind-safety
+chapter for the manual `UnwindSafe`/`RefUnwindSafe` impls these types require.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -164,6 +164,11 @@ Further rules:
   field or accessor to `pub(crate)`, not adding a public accessor.
 
 Each error carries its own backtrace, so a wrapper chain prints one backtrace block
-per level under `RUST_BACKTRACE=1`. Never assert on a full `to_string()`. See the
-unwind-safety chapter for the manual `UnwindSafe`/`RefUnwindSafe` impls these types
-require.
+per level under `RUST_BACKTRACE=1`. `message()` is no safer than `to_string()` here:
+it omits only the error's own backtrace but renders its source through `Display`, so
+a wrapper's `message()` carries every backtrace beneath it. Never assert that either
+rendering equals a fixed string, and never compare the renderings of two different
+errors; both hold only while backtrace capture is off. Assert on a substring, or, for
+a transparent wrapper, against the wrapped error's own `to_string()`, which it
+reproduces exactly. See the unwind-safety chapter for the manual
+`UnwindSafe`/`RefUnwindSafe` impls these types require.

--- a/packages/cbh_analyze/src/error.rs
+++ b/packages/cbh_analyze/src/error.rs
@@ -448,20 +448,25 @@ mod tests {
     #[test]
     fn config_error_passes_through_unchanged() {
         let source = parse_config("invalid = [").unwrap_err();
-        let source_message = source.message();
+        // The source's `Display`, not its `message()`: `message()` omits an error's own
+        // backtrace but renders its source through `Display`, so a transparent wrapper
+        // reproduces the wrapped error's full rendering rather than its `message()`.
+        // Comparing against that rendering is exact whether or not `RUST_BACKTRACE`
+        // makes these errors capture a backtrace.
+        let source_rendering = source.to_string();
         let error = AnalyzeError::from(source);
 
-        assert_eq!(error.message(), source_message);
+        assert_eq!(error.message(), source_rendering);
         assert!(error.find_source::<ConfigError>().is_some());
     }
 
     #[test]
     fn storage_error_passes_through_unchanged() {
         let source = block_on(MemoryStorage::new().get("missing")).unwrap_err();
-        let source_message = source.message();
+        let source_rendering = source.to_string();
         let error = AnalyzeError::from(source);
 
-        assert_eq!(error.message(), source_message);
+        assert_eq!(error.message(), source_rendering);
         assert!(error.find_source::<StorageError>().is_some());
     }
 


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Two `cbh_analyze` tests failed on every CI run, on every platform:

- `error::tests::config_error_passes_through_unchanged`
- `error::tests::storage_error_passes_through_unchanged`

They broke the `test-x64` check on every pull request, which made a genuinely red `test-x64` indistinguishable from the baseline, and they are the sole cause of the push-to-`main` validation failures in #476 and #477 (both runs failed only in test-running steps, and only on these two tests).

Both tests compared the rendered message before and after a conversion:

```rust
let source_message = source.message();
let error = AnalyzeError::from(source);
assert_eq!(error.message(), source_message);
```

`message()` omits an error's *own* backtrace but renders its source through `Display`, and `Display` embeds the backtrace an error captured. Wrapping therefore moves the wrapped error's backtrace into the rendered text:

```
source.message()                    error.message()  (after wrapping)
─────────────────                   ────────────────────────────────
<inner text>                        <inner text>
<inner backtrace>                   <inner backtrace>
                                    <wrapped error's backtrace>   <- the difference
```

`Backtrace::capture()` only captures when `RUST_BACKTRACE` is set, so the assertion held only while backtrace capture was off. CI sets `RUST_BACKTRACE: "1"` workflow-wide, which is where the failures started.

The message text is identical on both sides, so the conversion really is a pass-through — the tests were asserting on a rendering that also carries environment-dependent diagnostics.

## Changes

The tests now compare against the wrapped error's own `Display` rather than its `message()`. A transparent wrapper reproduces the wrapped error's rendering exactly, so this is an exact equality in every environment, and it still fails if `AnalyzeError` ever gains a message of its own or stops being transparent. This is stronger than the original assertion rather than a relaxation of it.

Suppressing the extra backtrace instead was rejected: the backtrace in question belongs to `StorageError` and `ConfigError`, not to `AnalyzeError`, so making the original equality hold would mean giving up backtrace capture on two other packages' public errors to satisfy one test.

`docs/error-handling.md` previously said only "Never assert on a full `to_string()`", which left `message()` looking safe — the reasoning that produced these tests. It now states that `message()` carries every backtrace beneath it and gives the two safe alternatives.

The comment above `RUST_BACKTRACE` in `validation.yml` claimed that "error-message assertions are unaffected", telling the next reader this class of breakage was impossible. Corrected.

## Validation

The whole workspace suite (3434 tests) passes under `RUST_BACKTRACE=1`; the two tests were additionally confirmed with the variable unset and set to `0`, `1`, and `full`. A sweep for other assertions comparing rendered `ohno` error text — exact equality, `ends_with`, length or line-count checks, snapshots, CLI golden output, doctests — found no other affected site; everything else uses substring matching or asserts on errors with no `ohno` error in their source chain.

Fixes #478. Also resolves the test failures behind #476 and #477.