### PR TITLE
events_once: observe reentrant sender actions in LocalEvent::poll

### DIFF
--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -30,6 +30,11 @@ use crate::{
 /// it. Such a callback may operate on the endpoints of the event it belongs to: it may poll the
 /// receiver to completion, and it may drop an endpoint - including the last one, which releases
 /// the event storage.
+///
+/// A poll that registers the task for later notification runs the waker's clone operation, which
+/// is likewise user-supplied code. Such a callback may operate on the sender endpoint of the event
+/// being polled: it may send a value and it may drop the sender. The poll observes the resulting
+/// state.
 pub struct LocalEvent<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: Cell<u8>,
@@ -379,9 +384,35 @@ impl<T: 'static> LocalEvent<T> {
         self.backtrace.replace(Some(capture_backtrace()));
 
         match self.state.get() {
-            EVENT_BOUND => {
-                // The sender has not yet set any value, so we will have to wait.
+            EVENT_BOUND => self.poll_bound(waker),
+            EVENT_SET => Some(Ok(self.poll_set())),
+            EVENT_AWAITING => self.poll_awaiting(waker),
+            EVENT_DISCONNECTED => {
+                // There is no result coming, ever! This is the end.
+                Some(Err(Disconnected))
+            }
+            // Defensive: state machine guarantees this is unreachable.
+            state => {
+                unreachable!("unreachable LocalEvent state on poll: {state}");
+            }
+        }
+    }
 
+    /// `poll()` impl for the `EVENT_BOUND` state.
+    #[must_use]
+    fn poll_bound(&self, waker: &Waker) -> Option<Result<T, Disconnected>> {
+        // The sender has not yet set any value, so we will have to wait.
+
+        // `Waker::clone` runs arbitrary user code, which is free to operate on the sender endpoint
+        // of this same event and thereby move the event into a terminal state. We therefore clone
+        // before touching the event and consult the state again afterwards. This mirrors the
+        // compare-exchange in the sync `Event::poll_bound`: reentrancy hands the single-threaded
+        // variant the same interleavings that concurrency hands the thread-safe one.
+        // Ref: docs/callback-safety.md.
+        let new_waker = waker.clone();
+
+        match self.state.get() {
+            EVENT_BOUND => {
                 // SAFETY: The only other potential references to the field are other short-lived
                 // references in this type, which cannot exist at the moment because
                 // the type is single-threaded and does not let any references escape.
@@ -389,40 +420,74 @@ impl<T: 'static> LocalEvent<T> {
                 // SAFETY: UnsafeCell pointer is never null.
                 let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
 
-                awaiter_cell.write(waker.clone());
+                awaiter_cell.write(new_waker);
 
                 // The sender will wake us up when it has set the value.
                 self.state.set(EVENT_AWAITING);
                 None
             }
             EVENT_SET => {
-                // The sender has delivered a value and we can complete the event.
+                // A reentrant sender delivered the value while we were cloning the waker. Nobody
+                // would ever consume a registration made now, so we release the clone instead.
+                // Releasing it runs user code, which must not see the event mid-extraction: the
+                // value comes out only once no callback can run, so an unwinding destructor leaves
+                // `EVENT_SET` still backed by an initialized value for the receiver to clean up.
+                // Ref: docs/callback-safety.md.
+                drop(new_waker);
 
-                // SAFETY: The only other potential references to the field are other short-lived
-                // references in this type, which cannot exist at the moment because
-                // the type is single-threaded and does not let any references escape.
-                let value_cell_maybe = unsafe { self.value.get().as_ref() };
-                // SAFETY: UnsafeCell pointer is never null.
-                let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
-
-                // We extract the value and consider the cell uninitialized.
-                //
-                // SAFETY: We were in EVENT_SET which guarantees there is a value in there.
-                let value = unsafe { value_cell.assume_init_read() };
-
-                Some(Ok(value))
+                Some(Ok(self.poll_set()))
             }
+            EVENT_DISCONNECTED => {
+                // A reentrant sender drop disconnected while we were cloning the waker, so there
+                // is no result coming, ever. We release the clone that nobody would consume.
+                drop(new_waker);
+
+                Some(Err(Disconnected))
+            }
+            // Defensive: only the receiver enters EVENT_AWAITING and it is right here, so the
+            // state machine guarantees this is unreachable.
+            state => {
+                unreachable!("unreachable LocalEvent state on poll of bound event: {state}");
+            }
+        }
+    }
+
+    /// `poll()` impl for the `EVENT_SET` state.
+    #[must_use]
+    fn poll_set(&self) -> T {
+        // The sender has delivered a value and we can complete the event.
+
+        // SAFETY: The only other potential references to the field are other short-lived
+        // references in this type, which cannot exist at the moment because
+        // the type is single-threaded and does not let any references escape.
+        let value_cell_maybe = unsafe { self.value.get().as_ref() };
+        // SAFETY: UnsafeCell pointer is never null.
+        let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
+
+        // We extract the value and consider the cell uninitialized.
+        //
+        // SAFETY: We were in EVENT_SET which guarantees there is a value in there.
+        unsafe { value_cell.assume_init_read() }
+    }
+
+    /// `poll()` impl for the `EVENT_AWAITING` state.
+    #[must_use]
+    fn poll_awaiting(&self, waker: &Waker) -> Option<Result<T, Disconnected>> {
+        // We are re-polling after previously starting a wait. This is fine
+        // and we just need to clean up the previous waker, replacing it with
+        // a new one. The previous registration must be released exactly once;
+        // overwriting it without dropping would leak a `Waker` reference.
+
+        // Clone the incoming waker before touching the cell. `Waker::clone` runs arbitrary user
+        // code, so it must not observe the cell in the transiently-uninitialized window between
+        // the read and the write below. That code is also free to operate on the sender endpoint
+        // of this same event, which moves the event into a terminal state and takes the
+        // previously registered waker along the way, so we consult the state again afterwards.
+        // Ref: docs/callback-safety.md.
+        let new_waker = waker.clone();
+
+        match self.state.get() {
             EVENT_AWAITING => {
-                // We are re-polling after previously starting a wait. This is fine
-                // and we just need to clean up the previous waker, replacing it with
-                // a new one. The previous registration must be released exactly once;
-                // overwriting it without dropping would leak a `Waker` reference.
-
-                // Clone the incoming waker before touching the cell. `Waker::clone`
-                // runs arbitrary vtable code, so it must not observe the cell in the
-                // transiently-uninitialized window between the read and the write below.
-                let new_waker = waker.clone();
-
                 // Extract the previous waker in a tight scope so the
                 // `&mut MaybeUninit<Waker>` borrow is released before we drop it below:
                 // a waker's drop runs arbitrary vtable code that must not observe an
@@ -448,17 +513,33 @@ impl<T: 'static> LocalEvent<T> {
                 };
 
                 // Release the previous registration exactly once, now that the borrow is gone.
+                // A reentrant sender that completes the event from this destructor takes the
+                // registration we just made and wakes it, so the caller is still told to come
+                // back even though we report being pending. We touch nothing in the event after
+                // this point.
                 drop(previous_waker);
 
                 None
             }
+            EVENT_SET => {
+                // A reentrant sender delivered the value while we were cloning the waker, taking
+                // the previous registration with it. See the equivalent arm of `poll_bound()` for
+                // why the unused clone is released before the value comes out.
+                drop(new_waker);
+
+                Some(Ok(self.poll_set()))
+            }
             EVENT_DISCONNECTED => {
-                // There is no result coming, ever! This is the end.
+                // A reentrant sender drop disconnected while we were cloning the waker, taking
+                // the previous registration with it. There is no result coming, ever.
+                drop(new_waker);
+
                 Some(Err(Disconnected))
             }
-            // Defensive: state machine guarantees this is unreachable.
+            // Defensive: only the receiver leaves EVENT_AWAITING for a non-terminal state and it
+            // is right here, so the state machine guarantees this is unreachable.
             state => {
-                unreachable!("unreachable LocalEvent state on poll: {state}");
+                unreachable!("unreachable LocalEvent state on poll of awaited event: {state}");
             }
         }
     }
@@ -662,7 +743,9 @@ mod tests {
     use std::task::{self, Poll};
 
     use static_assertions::{assert_impl_all, assert_not_impl_any};
-    use testing::{DropOnWakerRelease, ReentrantWakerData, drop_waker, with_watchdog};
+    use testing::{
+        DropOnWakerRelease, ReentrantWakerData, clone_action_waker, drop_waker, with_watchdog,
+    };
 
     use super::*;
     use crate::IntoValueError;
@@ -1570,4 +1653,126 @@ mod tests {
     /// Without it the test would pass no matter how the code under test behaved.
     const REENTRANCY_REQUIRED: &str =
         "the event must have held a waker clone whose drop reentered the operation under test";
+
+    /// Explains a failure to reach the reentrant clone that a regression test exists to exercise.
+    /// Without it the test would pass no matter how the code under test behaved.
+    const WAKER_CLONE_REQUIRED: &str =
+        "the poll must have cloned the waker it was given, which is what re-enters the sender";
+
+    // Regression tests for the reentrancy hazard in `poll`. Registering an awaiter clones the
+    // waker, which is user code that may operate on the sender endpoint of the same event and
+    // move it into a terminal state. The poll must observe the state the clone left behind
+    // instead of overwriting it with EVENT_AWAITING, which would strand the receiver and lose
+    // the result. Ref: docs/callback-safety.md.
+    #[test]
+    fn boxed_poll_with_reentrant_send_during_waker_clone_observes_set() {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, cloned) = unsafe { clone_action_waker(move || sender.send(42)) };
+
+        let mut cx = task::Context::from_waker(&waker);
+        let poll_result = receiver.as_mut().poll(&mut cx);
+
+        assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+        assert!(matches!(poll_result, Poll::Ready(Ok(42))));
+    }
+
+    #[test]
+    fn boxed_poll_with_reentrant_sender_drop_during_waker_clone_observes_disconnected() {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, cloned) = unsafe { clone_action_waker(move || drop(sender)) };
+
+        let mut cx = task::Context::from_waker(&waker);
+        let poll_result = receiver.as_mut().poll(&mut cx);
+
+        assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+        assert!(matches!(poll_result, Poll::Ready(Err(Disconnected))));
+    }
+
+    // The same hazard on the re-poll path, where the reentrant sender additionally consumes the
+    // previously registered waker on its way to the terminal state.
+    #[test]
+    fn boxed_repoll_with_reentrant_send_during_waker_clone_observes_set() {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        // First poll transitions BOUND -> AWAITING and registers a waker for the sender to take.
+        let mut cx = task::Context::from_waker(Waker::noop());
+        assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, cloned) = unsafe { clone_action_waker(move || sender.send(42)) };
+
+        let mut cx = task::Context::from_waker(&waker);
+        let poll_result = receiver.as_mut().poll(&mut cx);
+
+        assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+        assert!(matches!(poll_result, Poll::Ready(Ok(42))));
+    }
+
+    #[test]
+    fn boxed_repoll_with_reentrant_sender_drop_during_waker_clone_observes_disconnected() {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        let mut cx = task::Context::from_waker(Waker::noop());
+        assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, cloned) = unsafe { clone_action_waker(move || drop(sender)) };
+
+        let mut cx = task::Context::from_waker(&waker);
+        let poll_result = receiver.as_mut().poll(&mut cx);
+
+        assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+        assert!(matches!(poll_result, Poll::Ready(Err(Disconnected))));
+    }
+
+    // The re-poll path releases the registration made by the previous poll, which is user code
+    // that may drop the sender and thereby complete the event from inside the re-poll. The
+    // replacement registration is written before that destructor runs, so the completion finds it
+    // and wakes it. Reporting pending therefore loses no wakeup.
+    // Ref: docs/callback-safety.md.
+    #[test]
+    #[cfg_attr(miri, ignore)] // Custom raw waker is not Miri-compatible.
+    fn boxed_repoll_with_reentrant_sender_drop_during_previous_waker_release_wakes_new_waker() {
+        let (sender, receiver) = LocalEvent::<i32>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        let (data, sender_dropped) = DropOnWakerRelease::new(sender);
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let previous_waker = unsafe { drop_waker(data) };
+
+        // First poll transitions BOUND -> AWAITING and registers a clone of `previous_waker`.
+        let mut cx = task::Context::from_waker(&previous_waker);
+        assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+        // Release our own reference so the registration inside the event is the last one and
+        // dropping it drops the sender it carries.
+        drop(previous_waker);
+        assert!(!sender_dropped.get());
+
+        let new_waker_data = ReentrantWakerData::new(|| {});
+        // SAFETY: `new_waker_data` outlives the waker and the test is single-threaded.
+        let new_waker = unsafe { new_waker_data.waker() };
+
+        let mut cx = task::Context::from_waker(&new_waker);
+        assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+        assert!(sender_dropped.get(), "{REENTRANCY_REQUIRED}");
+        assert!(
+            new_waker_data.was_woken(),
+            "the completion must have reached the registration made by this poll"
+        );
+
+        assert!(matches!(
+            receiver.as_mut().poll(&mut cx),
+            Poll::Ready(Err(Disconnected))
+        ));
+    }
 }

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -736,6 +736,7 @@ impl<T: 'static> fmt::Debug for LocalEvent<T> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::RefCell;
+    use std::mem;
     use std::panic::{RefUnwindSafe, UnwindSafe};
     use std::pin::Pin;
     use std::rc::Rc;
@@ -744,7 +745,8 @@ mod tests {
 
     use static_assertions::{assert_impl_all, assert_not_impl_any};
     use testing::{
-        DropOnWakerRelease, ReentrantWakerData, clone_action_waker, drop_waker, with_watchdog,
+        DropOnWakerRelease, ReentrantWakerData, assert_panics_with, clone_action_waker,
+        clone_action_waker_panicking_on_clone_release, drop_waker, with_watchdog,
     };
 
     use super::*;
@@ -1774,5 +1776,98 @@ mod tests {
             receiver.as_mut().poll(&mut cx),
             Poll::Ready(Err(Disconnected))
         ));
+    }
+
+    /// Counts its own drops, so a test can tell a value that was delivered exactly once apart from
+    /// one that was extracted twice or lost.
+    struct DropCounter {
+        drops: Rc<Cell<usize>>,
+    }
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            self.drops.set(self.drops.get().saturating_add(1));
+        }
+    }
+
+    // Releasing the waker clone that a reentrant send made useless is user code, so it may unwind.
+    // The value must still be inside the event at that moment: a poll that extracts the value
+    // first leaves EVENT_SET backed by an uninitialized cell, which the receiver's own cleanup
+    // then reads a second time. Ref: docs/callback-safety.md.
+    #[test]
+    fn boxed_poll_unwinding_during_waker_clone_release_leaves_value_in_event() {
+        let drops = Rc::new(Cell::new(0_usize));
+
+        let (sender, receiver) = LocalEvent::<DropCounter>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        let value = DropCounter {
+            drops: Rc::clone(&drops),
+        };
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, cloned) =
+            unsafe { clone_action_waker_panicking_on_clone_release(move || sender.send(value)) };
+
+        let mut cx = task::Context::from_waker(&waker);
+        assert_panics_with(
+            || receiver.as_mut().poll(&mut cx),
+            |message| assert!(message.contains("waker clone release")),
+        );
+
+        assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+
+        if drops.get() != 0 {
+            // The poll extracted the value before running the callback, so the event now claims a
+            // value it no longer holds. Letting the receiver clean up would read that cell again,
+            // so leak the event instead of escalating the failure into undefined behavior.
+            mem::forget(receiver);
+
+            panic!("the value must stay in the event while a callback can still unwind past it");
+        }
+
+        // The event still owns the value, so the receiver's cleanup delivers exactly one drop.
+        drop(receiver);
+
+        assert_eq!(drops.get(), 1);
+    }
+
+    // The same hazard on the re-poll path, which releases the useless clone through the same arm.
+    #[test]
+    fn boxed_repoll_unwinding_during_waker_clone_release_leaves_value_in_event() {
+        let drops = Rc::new(Cell::new(0_usize));
+
+        let (sender, receiver) = LocalEvent::<DropCounter>::boxed();
+        let mut receiver = Box::pin(receiver);
+
+        // First poll transitions BOUND -> AWAITING and registers a waker for the sender to take.
+        let mut cx = task::Context::from_waker(Waker::noop());
+        assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+        let value = DropCounter {
+            drops: Rc::clone(&drops),
+        };
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, cloned) =
+            unsafe { clone_action_waker_panicking_on_clone_release(move || sender.send(value)) };
+
+        let mut cx = task::Context::from_waker(&waker);
+        assert_panics_with(
+            || receiver.as_mut().poll(&mut cx),
+            |message| assert!(message.contains("waker clone release")),
+        );
+
+        assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+
+        if drops.get() != 0 {
+            mem::forget(receiver);
+
+            panic!("the value must stay in the event while a callback can still unwind past it");
+        }
+
+        drop(receiver);
+
+        assert_eq!(drops.get(), 1);
     }
 }

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -991,12 +991,13 @@ mod tests {
     use std::rc::Rc;
     use std::sync::Barrier;
     use std::task::Poll;
-    use std::{task, thread};
+    use std::{mem, task, thread};
 
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
     use testing::{
-        DropOnWakerRelease, ReentrantWakerData, clone_action_waker, drop_waker, with_watchdog,
+        DropOnWakerRelease, ReentrantWakerData, assert_panics_with, clone_action_waker,
+        clone_action_waker_panicking_on_clone_release, drop_waker, with_watchdog,
     };
 
     use super::*;
@@ -2430,6 +2431,66 @@ mod tests {
 
             assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
             assert!(matches!(poll_result, Poll::Ready(Err(Disconnected))));
+        });
+    }
+
+    /// Counts its own drops, so a test can tell a value that was delivered exactly once apart from
+    /// one that was extracted twice or lost.
+    struct DropCounter {
+        drops: Arc<atomic::AtomicUsize>,
+    }
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, atomic::Ordering::Relaxed);
+        }
+    }
+
+    // Parity counterpart of the local unwinding test. Releasing the awaiter that a racing send
+    // made useless is user code, so it may unwind. The value must still be inside the event at
+    // that moment, or the receiver's own cleanup reads an extracted cell a second time.
+    // Ref: docs/callback-safety.md.
+    #[test]
+    fn boxed_poll_unwinding_during_waker_clone_release_leaves_value_in_event() {
+        with_watchdog(|| {
+            let drops = Arc::new(atomic::AtomicUsize::new(0));
+
+            let (sender, receiver) = Event::<DropCounter>::boxed();
+            let mut receiver = Box::pin(receiver);
+
+            let value = DropCounter {
+                drops: Arc::clone(&drops),
+            };
+
+            // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+            let (waker, cloned) = unsafe {
+                clone_action_waker_panicking_on_clone_release(move || sender.send(value))
+            };
+
+            let mut cx = task::Context::from_waker(&waker);
+            assert_panics_with(
+                || receiver.as_mut().poll(&mut cx),
+                |message| assert!(message.contains("waker clone release")),
+            );
+
+            assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+
+            if drops.load(atomic::Ordering::Relaxed) != 0 {
+                // The poll extracted the value before running the callback, so the event now
+                // claims a value it no longer holds. Letting the receiver clean up would read
+                // that cell again, so leak the event instead of escalating the failure into
+                // undefined behavior.
+                mem::forget(receiver);
+
+                panic!(
+                    "the value must stay in the event while a callback can still unwind past it"
+                );
+            }
+
+            // The event still owns the value, so the receiver's cleanup delivers exactly one drop.
+            drop(receiver);
+
+            assert_eq!(drops.load(atomic::Ordering::Relaxed), 1);
         });
     }
 }

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -62,6 +62,11 @@ thread_local! {
 /// it. Such a callback may operate on the endpoints of the event it belongs to: it may poll the
 /// receiver to completion, and it may drop an endpoint - including the last one, which releases
 /// the event storage.
+///
+/// A poll that registers the task for later notification runs the waker's clone operation, which
+/// is likewise user-supplied code. Such a callback may operate on the sender endpoint of the event
+/// being polled: it may send a value and it may drop the sender. The poll observes the resulting
+/// state.
 pub struct Event<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: AtomicU8,
@@ -990,7 +995,9 @@ mod tests {
 
     use futures::executor::block_on;
     use static_assertions::assert_impl_all;
-    use testing::{DropOnWakerRelease, ReentrantWakerData, drop_waker, with_watchdog};
+    use testing::{
+        DropOnWakerRelease, ReentrantWakerData, clone_action_waker, drop_waker, with_watchdog,
+    };
 
     use super::*;
     use crate::IntoValueError;
@@ -2340,4 +2347,89 @@ mod tests {
     /// Without it the test would pass no matter how the code under test behaved.
     const REENTRANCY_REQUIRED: &str =
         "the event must have held a waker clone whose drop reentered the operation under test";
+
+    /// Explains a failure to reach the reentrant clone that a regression test exists to exercise.
+    /// Without it the test would pass no matter how the code under test behaved.
+    const WAKER_CLONE_REQUIRED: &str =
+        "the poll must have cloned the waker it was given, which is what re-enters the sender";
+
+    // Parity counterparts of the `LocalEvent` waker-clone reentrancy regression tests in
+    // `core/local.rs`. Registering an awaiter clones the waker, which is user code that may
+    // operate on the sender endpoint of the same event and move it into a terminal state. The
+    // poll must observe the state the clone left behind. Ref: docs/callback-safety.md.
+    #[test]
+    fn boxed_poll_with_reentrant_send_during_waker_clone_observes_set() {
+        with_watchdog(|| {
+            let (sender, receiver) = Event::<i32>::boxed();
+            let mut receiver = Box::pin(receiver);
+
+            // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+            let (waker, cloned) = unsafe { clone_action_waker(move || sender.send(42)) };
+
+            let mut cx = task::Context::from_waker(&waker);
+            let poll_result = receiver.as_mut().poll(&mut cx);
+
+            assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+            assert!(matches!(poll_result, Poll::Ready(Ok(42))));
+        });
+    }
+
+    #[test]
+    fn boxed_poll_with_reentrant_sender_drop_during_waker_clone_observes_disconnected() {
+        with_watchdog(|| {
+            let (sender, receiver) = Event::<i32>::boxed();
+            let mut receiver = Box::pin(receiver);
+
+            // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+            let (waker, cloned) = unsafe { clone_action_waker(move || drop(sender)) };
+
+            let mut cx = task::Context::from_waker(&waker);
+            let poll_result = receiver.as_mut().poll(&mut cx);
+
+            assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+            assert!(matches!(poll_result, Poll::Ready(Err(Disconnected))));
+        });
+    }
+
+    #[test]
+    fn boxed_repoll_with_reentrant_send_during_waker_clone_observes_set() {
+        with_watchdog(|| {
+            let (sender, receiver) = Event::<i32>::boxed();
+            let mut receiver = Box::pin(receiver);
+
+            // First poll transitions BOUND -> AWAITING and registers a waker for the sender to
+            // take.
+            let mut cx = task::Context::from_waker(Waker::noop());
+            assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+            // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+            let (waker, cloned) = unsafe { clone_action_waker(move || sender.send(42)) };
+
+            let mut cx = task::Context::from_waker(&waker);
+            let poll_result = receiver.as_mut().poll(&mut cx);
+
+            assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+            assert!(matches!(poll_result, Poll::Ready(Ok(42))));
+        });
+    }
+
+    #[test]
+    fn boxed_repoll_with_reentrant_sender_drop_during_waker_clone_observes_disconnected() {
+        with_watchdog(|| {
+            let (sender, receiver) = Event::<i32>::boxed();
+            let mut receiver = Box::pin(receiver);
+
+            let mut cx = task::Context::from_waker(Waker::noop());
+            assert!(matches!(receiver.as_mut().poll(&mut cx), Poll::Pending));
+
+            // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+            let (waker, cloned) = unsafe { clone_action_waker(move || drop(sender)) };
+
+            let mut cx = task::Context::from_waker(&waker);
+            let poll_result = receiver.as_mut().poll(&mut cx);
+
+            assert!(cloned.get(), "{WAKER_CLONE_REQUIRED}");
+            assert!(matches!(poll_result, Poll::Ready(Err(Disconnected))));
+        });
+    }
 }

--- a/packages/testing/src/clone_waker.rs
+++ b/packages/testing/src/clone_waker.rs
@@ -26,6 +26,42 @@ use std::{fmt, mem};
 /// expressed in the type system.
 #[must_use]
 pub unsafe fn clone_action_waker(action: impl FnOnce() + 'static) -> (Waker, Rc<Cell<bool>>) {
+    // SAFETY: Forwarding the guarantees of the caller.
+    unsafe { new_clone_action_waker(action, false) }
+}
+
+/// Creates a [`Waker`] that behaves like one from [`clone_action_waker()`] but whose clones panic
+/// when they are released.
+///
+/// Releasing a waker clone is one of the callback sites an async primitive must survive. A
+/// destructor that unwinds is how a test proves the primitive keeps its shared state consistent
+/// across that callback: a primitive that releases the clone while its own storage is half
+/// extracted is caught by the unwind escaping mid-operation, leaving the inconsistency observable.
+///
+/// Only clones panic. The waker returned here releases quietly, so a test can still drop the waker
+/// it owns once the primitive under test has unwound.
+///
+/// The panic message contains "waker clone release", which a test can use as a canary to tell this
+/// panic apart from an unexpected one.
+///
+/// # Safety
+///
+/// As for [`clone_action_waker()`].
+#[must_use]
+pub unsafe fn clone_action_waker_panicking_on_clone_release(
+    action: impl FnOnce() + 'static,
+) -> (Waker, Rc<Cell<bool>>) {
+    // SAFETY: Forwarding the guarantees of the caller.
+    unsafe { new_clone_action_waker(action, true) }
+}
+
+/// # Safety
+///
+/// As for [`clone_action_waker()`].
+unsafe fn new_clone_action_waker(
+    action: impl FnOnce() + 'static,
+    clone_release_panics: bool,
+) -> (Waker, Rc<Cell<bool>>) {
     let has_run = Rc::new(Cell::new(false));
 
     // The payload is deliberately single-threaded, as the safety contract above requires, while
@@ -38,6 +74,7 @@ pub unsafe fn clone_action_waker(action: impl FnOnce() + 'static) -> (Waker, Rc<
     let data = Arc::new(CloneAction {
         action: RefCell::new(Some(Box::new(action))),
         has_run: Rc::clone(&has_run),
+        clone_release_panics,
     });
 
     // SAFETY: The vtable upholds the `RawWaker` contract for an `Arc<CloneAction>` payload - it is
@@ -53,6 +90,11 @@ pub unsafe fn clone_action_waker(action: impl FnOnce() + 'static) -> (Waker, Rc<
 struct CloneAction {
     action: RefCell<Option<Box<dyn FnOnce()>>>,
     has_run: Rc<Cell<bool>>,
+
+    /// Whether clones of the original waker unwind when they are released. The original waker
+    /// always releases quietly, so the two cases need separate vtables and the clone operation
+    /// consults this to pick the one its result carries.
+    clone_release_panics: bool,
 }
 
 impl CloneAction {
@@ -75,6 +117,18 @@ fn raw_waker(data: Arc<CloneAction>) -> RawWaker {
     RawWaker::new(Arc::into_raw(data).cast(), &VTABLE)
 }
 
+/// Builds the raw waker that a clone operation hands back, which unwinds on release only when the
+/// payload asks for it.
+fn raw_clone_waker(data: Arc<CloneAction>) -> RawWaker {
+    let vtable = if data.clone_release_panics {
+        &PANICKING_CLONE_VTABLE
+    } else {
+        &VTABLE
+    };
+
+    RawWaker::new(Arc::into_raw(data).cast(), vtable)
+}
+
 /// # Safety
 ///
 /// `data` must come from `Arc::<CloneAction>::into_raw()` and its reference must still be owned by
@@ -93,7 +147,7 @@ unsafe fn clone_raw(data: *const ()) -> RawWaker {
     // cloning us all the way to completion, including paths that release this very waker.
     clone.run();
 
-    raw_waker(clone)
+    raw_clone_waker(clone)
 }
 
 /// # Safety
@@ -119,7 +173,37 @@ unsafe fn drop_raw(data: *const ()) {
     drop(arc);
 }
 
+/// # Safety
+///
+/// As for [`wake_raw()`].
+unsafe fn wake_and_panic_raw(data: *const ()) {
+    // SAFETY: Forwarding the guarantees of the caller.
+    unsafe { drop_and_panic_raw(data) }
+}
+
+/// # Safety
+///
+/// As for [`drop_raw()`].
+unsafe fn drop_and_panic_raw(data: *const ()) {
+    // The reference is released before we unwind, so the payload outlives no more than it would
+    // have without the panic and the test observes only the effect it is looking for.
+    // SAFETY: Forwarding the guarantees of the caller.
+    unsafe { drop_raw(data) }
+
+    panic!("waker clone release");
+}
+
 static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_raw, wake_raw, wake_by_ref_raw, drop_raw);
+
+/// Carried by clones of a [`clone_action_waker_panicking_on_clone_release()`] waker. Clones of
+/// those clones unwind on release too, so the behavior does not depend on how many times the
+/// primitive under test copies the registration it was given.
+static PANICKING_CLONE_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    clone_raw,
+    wake_and_panic_raw,
+    wake_by_ref_raw,
+    drop_and_panic_raw,
+);
 
 impl fmt::Debug for CloneAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -132,6 +216,7 @@ impl fmt::Debug for CloneAction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assert_panics_with;
 
     #[test]
     fn first_clone_runs_the_action() {
@@ -169,5 +254,39 @@ mod tests {
         waker.wake();
 
         assert!(!has_run.get());
+    }
+
+    #[test]
+    fn releasing_a_panicking_clone_unwinds_while_the_original_does_not() {
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, has_run) = unsafe { clone_action_waker_panicking_on_clone_release(|| {}) };
+
+        let clone = waker.clone();
+        assert!(has_run.get());
+
+        assert_panics_with(
+            || drop(clone),
+            |message| assert!(message.contains("waker clone release")),
+        );
+
+        // The original waker is what the test under observation still holds, so it must remain
+        // droppable after the clone has unwound.
+        drop(waker);
+    }
+
+    #[test]
+    fn waking_a_panicking_clone_unwinds() {
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, has_run) = unsafe { clone_action_waker_panicking_on_clone_release(|| {}) };
+
+        let clone = waker.clone();
+        assert!(has_run.get());
+
+        assert_panics_with(
+            || clone.wake(),
+            |message| assert!(message.contains("waker clone release")),
+        );
+
+        drop(waker);
     }
 }

--- a/packages/testing/src/clone_waker.rs
+++ b/packages/testing/src/clone_waker.rs
@@ -1,0 +1,173 @@
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::task::{RawWaker, RawWakerVTable, Waker};
+use std::{fmt, mem};
+
+/// Creates a [`Waker`] that runs `action` the first time it is cloned, returning it alongside a
+/// flag that records whether the action has run.
+///
+/// An async primitive registers an awaiting task by cloning the waker it was handed, so the clone
+/// is user code that runs while the primitive is midway through its own registration logic. This
+/// waker is how a callback-safety test re-enters a primitive at exactly that moment, typically to
+/// complete or cancel the very operation that is registering.
+///
+/// Only the first clone runs the action, so the action may consume values that exist once, such as
+/// the sender endpoint of a one-shot event. Every other waker operation merely maintains the
+/// reference count of the shared payload.
+///
+/// The flag lets a test prove that the reentrancy it targets actually occurred, instead of passing
+/// vacuously because the primitive never cloned the waker.
+///
+/// # Safety
+///
+/// The action is not `Send`, so the returned waker and every clone of it must be used and dropped
+/// on the calling thread. [`Waker`] is `Send + Sync` regardless of its payload, so this cannot be
+/// expressed in the type system.
+#[must_use]
+pub unsafe fn clone_action_waker(action: impl FnOnce() + 'static) -> (Waker, Rc<Cell<bool>>) {
+    let has_run = Rc::new(Cell::new(false));
+
+    // The payload is deliberately single-threaded, as the safety contract above requires, while
+    // the atomic reference counting keeps the waker's clone and drop operations thread-safe on
+    // their own - the same split `drop_waker()` relies on.
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "the reference count must be atomic even though the payload stays on one thread"
+    )]
+    let data = Arc::new(CloneAction {
+        action: RefCell::new(Some(Box::new(action))),
+        has_run: Rc::clone(&has_run),
+    });
+
+    // SAFETY: The vtable upholds the `RawWaker` contract for an `Arc<CloneAction>` payload - it is
+    // only ever paired with a pointer from `Arc::into_raw` and every reference count operation is
+    // an atomic one. The caller upholds the remaining requirement, that the payload only travels
+    // where it may travel.
+    let waker = unsafe { Waker::from_raw(raw_waker(data)) };
+
+    (waker, has_run)
+}
+
+/// Carries the one-shot action of a [`clone_action_waker`] waker, shared by every clone of it.
+struct CloneAction {
+    action: RefCell<Option<Box<dyn FnOnce()>>>,
+    has_run: Rc<Cell<bool>>,
+}
+
+impl CloneAction {
+    /// Runs the action, if it has not already run.
+    fn run(&self) {
+        // The action is taken out before it runs, so that the borrow is released before user code
+        // that may clone the waker again observes the payload.
+        // Ref: docs/callback-safety.md, "No callbacks under borrows of shared state".
+        let Some(action) = self.action.borrow_mut().take() else {
+            return;
+        };
+
+        action();
+
+        self.has_run.set(true);
+    }
+}
+
+fn raw_waker(data: Arc<CloneAction>) -> RawWaker {
+    RawWaker::new(Arc::into_raw(data).cast(), &VTABLE)
+}
+
+/// # Safety
+///
+/// `data` must come from `Arc::<CloneAction>::into_raw()` and its reference must still be owned by
+/// the waker being cloned.
+unsafe fn clone_raw(data: *const ()) -> RawWaker {
+    // SAFETY: Forwarding the guarantees of the caller.
+    let arc = unsafe { Arc::from_raw(data.cast::<CloneAction>()) };
+
+    let clone = Arc::clone(&arc);
+
+    // The reference we reconstructed still belongs to the waker we were cloned from, so we must
+    // not release it here.
+    mem::forget(arc);
+
+    // The clone already owns its reference, so the action is free to drive the primitive that is
+    // cloning us all the way to completion, including paths that release this very waker.
+    clone.run();
+
+    raw_waker(clone)
+}
+
+/// # Safety
+///
+/// `data` must come from `Arc::<CloneAction>::into_raw()` and its reference must be consumed by
+/// this call.
+unsafe fn wake_raw(data: *const ()) {
+    // SAFETY: Forwarding the guarantees of the caller.
+    unsafe { drop_raw(data) }
+}
+
+/// Waking by reference does not consume a reference, so there is nothing to release.
+fn wake_by_ref_raw(_data: *const ()) {}
+
+/// # Safety
+///
+/// `data` must come from `Arc::<CloneAction>::into_raw()` and its reference must be consumed by
+/// this call.
+unsafe fn drop_raw(data: *const ()) {
+    // SAFETY: Forwarding the guarantees of the caller.
+    let arc = unsafe { Arc::from_raw(data.cast::<CloneAction>()) };
+
+    drop(arc);
+}
+
+static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_raw, wake_raw, wake_by_ref_raw, drop_raw);
+
+impl fmt::Debug for CloneAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(std::any::type_name::<Self>())
+            .field("has_run", &self.has_run.get())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_clone_runs_the_action() {
+        let runs = Rc::new(Cell::new(0_usize));
+        let runs_in_action = Rc::clone(&runs);
+
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, has_run) = unsafe {
+            clone_action_waker(move || runs_in_action.set(runs_in_action.get().saturating_add(1)))
+        };
+
+        assert!(!has_run.get());
+
+        let clone = waker.clone();
+        assert!(has_run.get());
+        assert_eq!(runs.get(), 1);
+
+        // Later clones share the payload but find the action already consumed.
+        let another_clone = clone.clone();
+        assert_eq!(runs.get(), 1);
+
+        drop(another_clone);
+        clone.wake();
+        waker.wake_by_ref();
+        drop(waker);
+
+        assert_eq!(runs.get(), 1);
+    }
+
+    #[test]
+    fn unused_waker_never_runs_the_action() {
+        // SAFETY: The payload is not `Send`, and this test keeps the waker on one thread.
+        let (waker, has_run) = unsafe { clone_action_waker(|| unreachable!("never cloned")) };
+
+        waker.wake();
+
+        assert!(!has_run.get());
+    }
+}

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -5,6 +5,7 @@
 //! Private helpers for testing and examples in Folo packages.
 
 mod assert_panics;
+mod clone_waker;
 mod cwd_guard;
 mod drop_waker;
 mod float;
@@ -12,6 +13,7 @@ mod reentrant_waker;
 mod watchdog;
 
 pub use assert_panics::{assert_panics, assert_panics_with};
+pub use clone_waker::clone_action_waker;
 pub use cwd_guard::CwdGuard;
 pub use drop_waker::{DropOnWakerRelease, drop_waker};
 pub use float::f64_diff_abs;

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -13,7 +13,7 @@ mod reentrant_waker;
 mod watchdog;
 
 pub use assert_panics::{assert_panics, assert_panics_with};
-pub use clone_waker::clone_action_waker;
+pub use clone_waker::{clone_action_waker, clone_action_waker_panicking_on_clone_release};
 pub use cwd_guard::CwdGuard;
 pub use drop_waker::{DropOnWakerRelease, drop_waker};
 pub use float::f64_diff_abs;


### PR DESCRIPTION
[Copilot speaking]

Fixes #474.

## Motivation

`Waker::clone()` is user-supplied code, and `LocalEvent` hands the receiver's waker to it while the sender endpoint is still reachable. A clone implementation is therefore free to reentrantly send a value or drop the sender in the middle of a poll. `LocalEvent::poll` cloned the waker and then unconditionally committed `EVENT_AWAITING`, overwriting whatever terminal state that callback had just established. The value was lost and the receiver waited forever.

The same class of interleaving is handled correctly by the thread-safe `Event`, whose compare-exchange loop simply observes that the state moved and re-dispatches.

## Changes

`LocalEvent::poll` now re-reads the event state after the waker clone completes and acts on what it finds, instead of assuming the state it saw before the callback still holds:

```
                 poll
                   |
        +----------+-----------+
        |          |           |
      BOUND     AWAITING      SET / DISCONNECTED
        |          |           |
   clone waker  clone waker   (no callback runs)
        |          |
   re-read state, re-dispatch:
        SET          -> release the clone, then take the value
        DISCONNECTED -> release the clone, then report disconnection
        otherwise    -> register the clone and return Pending
```

In the `AWAITING` case the new registration is stored before the previous waker is released, so a completion driven from that destructor targets the new waker and no wakeup is dropped.

The clone is released *before* the value is extracted. `EVENT_SET` means the value cell is initialized, and that has to remain true across every user callback; releasing the clone afterwards would let a panicking waker destructor unwind while the event still advertised a value that had already been moved out, and the receiver's own drop would then read the uninitialized cell.

The `# Reentrancy` contract on `LocalEvent` and `Event` now states that a poll which registers the task runs user code, and that a send or a sender drop performed from that code is observed by the poll.

Test support gained `testing::clone_action_waker()`, which runs a caller-supplied action on the first clone of a waker, and a variant whose clones unwind when released.
