### PR TITLE
cargo-bench-history: correct only the directions a mode reports

### DIFF
--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -314,9 +314,10 @@ gh-analyze-bench-history dir keydir:
 # ancestry's clean points as the baseline, and reports how the branch tip's level moved. `{{base}}`
 # is passed EXPLICITLY (the pr-bench-history.yml `analyze` job passes `origin/main`) because the PR
 # head is checked out detached, so there is no local `main` branch to auto-resolve, whereas
-# `fetch-depth: 0` populates the `origin/main` remote-tracking ref the merge-base needs.
-# `--include-improvements` is added so the rolling PR comment can also surface detected speedups, not
-# only regressions. Everything else matches the main analyze: the EXACT machine keys collected this
+# `fetch-depth: 0` populates the `origin/main` remote-tracking ref the merge-base needs. Branch mode
+# reports improvements alongside regressions on its own, so the rolling PR comment surfaces detected
+# speedups without any flag asking for them. Everything else matches the main analyze: the EXACT
+# machine keys collected this
 # run (threaded from {{keydir}} via Get-MachineKeyArgument, not the removed fixed `github` key), all
 # engines and triples, findings never fail the recipe (the tool always exits 0), `--verbose` logs the
 # effective machine-key selection, and `--cache` mirrors fetched cloud objects under {{dir}}/cache. A
@@ -371,7 +372,7 @@ gh-analyze-pr-bench-history dir base keydir:
     $common = @('--engine', 'all', '--target-triple', 'all') + $keyArgs
 
     Write-Verbose "Analyzing PR benchmark history in branch mode (context HEAD vs base {{base}}); writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, including improvements as well as regressions, and mirroring fetched cloud objects under $cacheDir." -Verbose
-    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --context HEAD --base '{{base}}' --include-improvements --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
+    cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --context HEAD --base '{{base}}' --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
     $notable = if (($json.PSObject.Properties.Name -contains 'notable') -and $json.notable) { 'true' } else { 'false' }

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -371,7 +371,7 @@ gh-analyze-pr-bench-history dir base keydir:
 
     $common = @('--engine', 'all', '--target-triple', 'all') + $keyArgs
 
-    Write-Verbose "Analyzing PR benchmark history in branch mode (context HEAD vs base {{base}}); writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, including improvements as well as regressions, and mirroring fetched cloud objects under $cacheDir." -Verbose
+    Write-Verbose "Analyzing PR benchmark history in branch mode (context HEAD vs base {{base}}); writing the full Markdown to $reportPath, the full JSON to $jsonPath and the condensed top-findings Markdown summary to $summaryPath, and mirroring fetched cloud objects under $cacheDir. Branch mode judges the tip against the base in both directions, so the reports carry improvements as well as regressions." -Verbose
     cargo run -p cargo-bench-history --bin cargo-bench-history --locked -- analyze @common --verbose --context HEAD --base '{{base}}' --cache=$cacheDir --no-text --markdown $reportPath --json $jsonPath --markdown-summary $summaryPath
     Write-Verbose "Computing the notable flag from the JSON report." -Verbose
     $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json

--- a/packages/cargo-bench-history-figures/src/figures/coverage.rs
+++ b/packages/cargo-bench-history-figures/src/figures/coverage.rs
@@ -1,12 +1,12 @@
 //! Figures and worked examples for the Multiplicity and coverage chapter.
 //!
 //! The chapter makes two arithmetic claims — that the rank threshold tightens with the
-//! size of the family, and that correcting before filtering the display is the more
-//! sensitive of the two possible orders — and one accounting claim, that every series an
-//! analysis did not judge is named. Each figure here is the arithmetic itself: the
-//! step-up decisions come from the real [`benjamini_hochberg`](cbh_stats::benjamini_hochberg)
-//! procedure and the coverage account from a real [`SeriesCensus`], so a change in either
-//! rewrites the chapter rather than leaving its numbers behind.
+//! size of the family, and that filtering direction before correction is stricter than
+//! correcting both directions first — and one accounting claim, that every series an analysis
+//! did not judge is named. Each figure here is the arithmetic itself: the step-up decisions
+//! come from the real [`benjamini_hochberg`](cbh_stats::benjamini_hochberg) procedure and the
+//! coverage account from a real [`SeriesCensus`], so a change in either rewrites the chapter
+//! rather than leaving its numbers behind.
 
 use std::fmt::Write as _;
 
@@ -290,14 +290,14 @@ const DIRECTION_FAMILY: usize = 10;
 
 /// The improvement's chance level.
 ///
-/// Decisive enough that no ordering could drop it, which is what makes it a rank the
-/// regression has to sit behind rather than a second marginal case.
+/// Decisive enough that the alternate order keeps it, isolating the comparison to the
+/// regression's rank instead of making both candidates marginal.
 const IMPROVEMENT_CHANCE: f64 = 0.001;
 
 /// The regression's chance level.
 ///
 /// Between the thresholds for the first and second rank in this family, which is exactly the
-/// range where the two orders disagree.
+/// range where the table can demonstrate the cost of filtering first.
 const REGRESSION_CHANCE: f64 = 0.015;
 
 /// How the appendix names the improvement.
@@ -306,8 +306,7 @@ const IMPROVEMENT_SERIES: &str = "checksum";
 /// How the appendix names the regression.
 const REGRESSION_SERIES: &str = "tokenize";
 
-/// The worked example showing that correcting before filtering the display is the more
-/// sensitive order.
+/// The worked example comparing direction filtering before and after correction.
 fn direction_order_table() -> String {
     let corrected_first = judge(
         &[
@@ -316,9 +315,8 @@ fn direction_order_table() -> String {
         ],
         DIRECTION_FAMILY,
     );
-    // Filtering first hands the procedure a shorter list. The family it divides by is
-    // unchanged — the same series were judged either way — so the whole of the difference
-    // is the rank the regression lands on.
+    // Filtering first removes the improvement from the corrected list without changing the
+    // judged family, so the whole difference is the rank the regression lands on.
     let filtered_first = judge(&[(REGRESSION_SERIES, REGRESSION_CHANCE)], DIRECTION_FAMILY);
 
     let mut table =
@@ -351,14 +349,14 @@ fn direction_order_table() -> String {
     let filtered = regression_outcome(&filtered_first);
     writeln!(
         table,
-        "\nBoth orders divide by the same {DIRECTION_FAMILY} judged series. Correcting \
-         first leaves the regression at rank {}, where it is {}; filtering the \
-         improvement out first moves it to rank {}, where it is {}. The display then \
-         omits the improvement either way.",
-        corrected.rank,
-        corrected.outcome(),
+        "\nBoth orders divide by the same {DIRECTION_FAMILY} judged series. The tool \
+         filters, then corrects: the regression is at rank {}, where it is {}. Correcting \
+         both directions first would leave it at rank {}, where it is {}, before the \
+         display would hide the improvement.",
         filtered.rank,
-        filtered.outcome()
+        filtered.outcome(),
+        corrected.rank,
+        corrected.outcome()
     )
     .expect("writing to a String never fails");
 
@@ -705,10 +703,10 @@ mod tests {
         assert!(table.contains(&format!("| {LARGE_FAMILY} |")));
     }
 
-    /// The chapter asserts that correcting first is the more sensitive order. The
-    /// arithmetic has to show it rather than the prose claiming it.
+    /// The chapter states that filtering first is stricter, so the arithmetic has to show
+    /// the regression moving to a stricter rank.
     #[test]
-    fn the_regression_survives_correcting_first_and_not_filtering_first() {
+    fn filtering_first_is_stricter_for_the_regression() {
         let corrected_first = judge(
             &[
                 (IMPROVEMENT_SERIES, IMPROVEMENT_CHANCE),
@@ -723,9 +721,9 @@ mod tests {
 
         assert!(
             corrected.kept,
-            "correcting first must report the regression"
+            "correcting both directions first would keep the regression"
         );
-        assert!(!filtered.kept, "filtering first must suppress it");
+        assert!(!filtered.kept, "filtering first must suppress the regression");
         assert_eq!(corrected.rank, 2);
         assert_eq!(filtered.rank, 1);
         assert!(
@@ -734,9 +732,9 @@ mod tests {
         );
     }
 
-    /// The improvement is there to occupy a rank, not to be a second marginal case.
+    /// The improvement is decisive under the alternate order, not a second marginal case.
     #[test]
-    fn the_improvement_survives_the_correction_it_is_part_of() {
+    fn the_alternate_order_keeps_the_decisive_improvement() {
         let judged = judge(
             &[
                 (IMPROVEMENT_SERIES, IMPROVEMENT_CHANCE),
@@ -760,6 +758,8 @@ mod tests {
 
         assert!(table.contains("correct, then filter"));
         assert!(table.contains("filter, then correct"));
+        assert!(table.contains("The tool filters, then corrects"));
+        assert!(table.contains("Correcting both directions first would leave it"));
         assert!(table.contains(&chance(IMPROVEMENT_CHANCE)));
         assert!(table.contains(&chance(REGRESSION_CHANCE)));
     }

--- a/packages/cargo-bench-history-figures/src/figures/coverage.rs
+++ b/packages/cargo-bench-history-figures/src/figures/coverage.rs
@@ -723,7 +723,10 @@ mod tests {
             corrected.kept,
             "correcting both directions first would keep the regression"
         );
-        assert!(!filtered.kept, "filtering first must suppress the regression");
+        assert!(
+            !filtered.kept,
+            "filtering first must suppress the regression"
+        );
         assert_eq!(corrected.rank, 2);
         assert_eq!(filtered.rank, 1);
         assert!(

--- a/packages/cargo-bench-history-figures/src/figures/reporting.rs
+++ b/packages/cargo-bench-history-figures/src/figures/reporting.rs
@@ -116,7 +116,6 @@ fn suite_context(suite: &[Series]) -> AnalysisContext {
         merge_base_index: None,
         base_ref_index: None,
         tip_index,
-        include_improvements: false,
     }
 }
 

--- a/packages/cargo-bench-history-stress/README.md
+++ b/packages/cargo-bench-history-stress/README.md
@@ -55,8 +55,8 @@ magnitudes — so the seeded findings still surface while the noise-aware detect
 exercised too. Each benchmark belongs to a *family* (`index % 5`) that fixes its
 timeline shape (gradual drift, mid-step up, step down, blessable step, stable), and a
 cross-cutting rule injects a `branch`-only change. The result
-is that each mode reports a sensible, explainable *mix* of regressions and
-improvements rather than flagging everything or nothing. See the module docs in
+is that each mode reports a sensible, explainable *subset* of the seeded shapes
+rather than flagging everything or nothing. See the module docs in
 `src/scenario.rs` for the exact family/divisor math.
 
 A seeded shape only becomes a *finding* once the history carries the evidence the
@@ -155,7 +155,7 @@ upload:           <seconds>
 
 mode        duration        cpu   cpu%   objects   series  regressions  improvements  notable
 ----        -------- ----------   ----   -------   ------  -----------  ------------  -------
-history       <secs>     <secs>  <pct>   <count>  <count>      <count>       <count>   yes/no
+history       <secs>     <secs>  <pct>   <count>  <count>      <count>           n/a   yes/no
 branch        <secs>     <secs>  <pct>   <count>  <count>      <count>       <count>   yes/no
 ```
 
@@ -170,7 +170,7 @@ and what each seeding phase cost. Each mode row then reports:
 | `cpu%` | Processor time as a fraction of `duration × cores` — full saturation is 100%. |
 | `objects` | Stored objects the run loaded. |
 | `series` | Reconstructed `(set, benchmark, metric)` series. |
-| `regressions` / `improvements` | Findings the detectors reported. |
+| `regressions` / `improvements` | Findings the detectors reported. `improvements` reads `n/a` in `history` mode, which watches for regressions only. |
 | `notable` | Whether the run reported anything at all. |
 
 Finding counts are a joint property of the sizing and the detectors' evidence gates,

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -67,8 +67,8 @@ pub(crate) struct MeasureResult {
     pub(crate) series: usize,
     /// Flagged regressions.
     pub(crate) regressions: usize,
-    /// Flagged improvements.
-    pub(crate) improvements: usize,
+    /// Flagged improvements, or `None` in a mode that does not report them.
+    pub(crate) improvements: Option<usize>,
     /// Whether any finding survived (the downstream signal).
     pub(crate) notable: bool,
 }
@@ -82,8 +82,9 @@ struct ReportCounts {
     series: usize,
     /// Flagged regressions.
     regressions: usize,
-    /// Flagged improvements.
-    improvements: usize,
+    /// Flagged improvements. Absent from the report in a mode that does not report
+    /// improvements.
+    improvements: Option<usize>,
     /// Whether any finding survived.
     notable: bool,
 }

--- a/packages/cargo-bench-history-stress/src/measure.rs
+++ b/packages/cargo-bench-history-stress/src/measure.rs
@@ -272,7 +272,6 @@ fn build_options(
         markdown: None,
         json: Some(PathBuf::from(ANALYZE_REPORT_FILE)),
         markdown_summary: None,
-        include_improvements: true,
         verbose: false,
         timing,
     }

--- a/packages/cargo-bench-history-stress/src/report.rs
+++ b/packages/cargo-bench-history-stress/src/report.rs
@@ -90,11 +90,16 @@ pub(crate) fn print(
             result.runs,
             result.series,
             result.regressions,
-            result.improvements,
+            count_or_absent(result.improvements),
             if result.notable { "yes" } else { "no" },
         );
     }
     println!();
+}
+
+/// Formats a tally the analysis reports, or `n/a` for one it does not look for.
+fn count_or_absent(count: Option<usize>) -> String {
+    count.map_or_else(|| "n/a".to_owned(), |count| count.to_string())
 }
 
 /// Formats a duration as seconds with millisecond precision.

--- a/packages/cargo-bench-history-stress/src/scenario.rs
+++ b/packages/cargo-bench-history-stress/src/scenario.rs
@@ -19,7 +19,8 @@
 //! * family 0 — a gradual upward drift across the whole history (a `history`-mode
 //!   drift finding),
 //! * family 1 — a sustained step up at the midpoint (a `history`-mode regression),
-//! * family 2 — a sustained step down at ~70% (a `history`-mode improvement),
+//! * family 2 — a sustained step down at ~70% (a real move `history` mode judges and
+//!   declines to report, since it watches for regressions only),
 //! * family 3 — a sustained step up at ~75% that a blessing re-baselines in some
 //!   sets but not others (so the same step is suppressed in blessed sets and
 //!   flagged elsewhere),

--- a/packages/cargo-bench-history-stress/tests/stress_smoke.rs
+++ b/packages/cargo-bench-history-stress/tests/stress_smoke.rs
@@ -65,10 +65,6 @@ const SERIES: usize = BENCHMARKS * DISCRIMINANT_SETS;
 /// set no blessing re-baselined.
 const HISTORY_REGRESSIONS: usize = 2 * DISCRIMINANT_SETS + (DISCRIMINANT_SETS - BLESSED_SETS);
 
-/// History-mode improvements the seeded shapes produce: the step-down family, in
-/// every set.
-const HISTORY_IMPROVEMENTS: usize = DISCRIMINANT_SETS;
-
 /// Branch-mode regressions the seeded shapes produce: the two seeded benchmarks the
 /// feature branch elevates, in every set.
 const BRANCH_REGRESSIONS: usize = 2 * DISCRIMINANT_SETS;
@@ -93,8 +89,8 @@ struct ModeRow {
     series: usize,
     /// Regressions the mode flagged.
     regressions: usize,
-    /// Improvements the mode flagged.
-    improvements: usize,
+    /// Improvements the mode flagged, or `None` for a mode that does not report them.
+    improvements: Option<usize>,
     /// Whether any finding survived.
     notable: bool,
 }
@@ -169,13 +165,17 @@ fn parse_mode_row(line: &str) -> Option<(String, ModeRow)> {
         "no" => false,
         _ => return None,
     };
+    let improvements = match *improvements {
+        "n/a" => None,
+        count => Some(count.parse().ok()?),
+    };
     Some((
         (*mode).to_owned(),
         ModeRow {
             objects: objects.parse().ok()?,
             series: series.parse().ok()?,
             regressions: regressions.parse().ok()?,
-            improvements: improvements.parse().ok()?,
+            improvements,
             notable,
         },
     ))
@@ -218,14 +218,14 @@ fn expected_row(mode: &str, with_runs: usize) -> ModeRow {
             objects: with_runs * DISCRIMINANT_SETS,
             series: SERIES,
             regressions: HISTORY_REGRESSIONS,
-            improvements: HISTORY_IMPROVEMENTS,
+            improvements: None,
             notable: true,
         },
         "branch" => ModeRow {
             objects: (with_runs + BRANCH_COMMITS + DIRTY_RUNS) * DISCRIMINANT_SETS,
             series: SERIES,
             regressions: BRANCH_REGRESSIONS,
-            improvements: BRANCH_IMPROVEMENTS,
+            improvements: Some(BRANCH_IMPROVEMENTS),
             notable: true,
         },
         other => panic!("the report only ever carries the seeded modes, not {other}"),

--- a/packages/cargo-bench-history/AGENTS.md
+++ b/packages/cargo-bench-history/AGENTS.md
@@ -52,9 +52,9 @@ New per-series logic must be side-effect-free. Flow and rationale: [`docs/analyz
 inside the `analyze` module tree (`list.rs`, `prune.rs`, `examine.rs`, each
 `pub(crate) mod`; `bless`/`unbless` in `bless.rs` reuse the same discriminant-filter
 selection). **A selection parameter added to one must be added to all four** unless
-genuinely inapplicable. The analysis-only flag `--include-improvements` and the
-analyze-only condensed `--markdown-summary` output are **not** part of the lockstep —
-only `analyze` detects; `list`/`prune`/`examine` reuse the selection but never analyze.
+genuinely inapplicable. The analyze-only condensed `--markdown-summary` output is **not**
+part of the lockstep — only `analyze` detects; `list`/`prune`/`examine` reuse the selection
+but never analyze.
 The always-on **ghost filter** likewise changes only *which reconstructed series are detected
 on* (it drops benchmarks absent at the context commit), not which runs are *selected*,
 so `list runs` may report more series than `analyze` now analyzes. Each is

--- a/packages/cargo-bench-history/book/src/appendix/coverage.md
+++ b/packages/cargo-bench-history/book/src/appendix/coverage.md
@@ -23,12 +23,12 @@ are working. As the judged family grows, the expected number of false candidates
 does the probability of seeing at least one.
 
 So a per-series check is not enough. The tool applies a **group-wide correction**: sort every
-candidate by chance level, and require the strongest to clear a strict bar, the next a
-slightly looser one, and so on down. What Benjamini-Hochberg controls is the false-discovery
-rate *averaged over many analyses* — the expected share of reported findings that are wrong is
-held below the target. It is not a promise about any single report: one report can still carry a
-higher wrong share than the target, and only across many analyses does the average settle back
-to it.
+candidate the mode can report by chance level, and require the strongest to clear a strict bar,
+the next a slightly looser one, and so on down. What Benjamini-Hochberg controls is the
+false-discovery rate *averaged over many analyses* — the expected share of reported findings
+that are wrong is held below the target, because every rejection is displayed. It is not a
+promise about any single report: one report can still carry a higher wrong share than the
+target, and only across many analyses does the average settle back to it.
 
 {{#include generated/coverage-staircase.svg}}
 
@@ -61,22 +61,31 @@ at once. The alternative — a fixed per-series bar — is a report where the ex
 false alarms grows with the size of your suite, which is precisely the failure that makes
 people stop reading benchmark reports.
 
-## Why improvements are corrected too
+## Why history filters direction first
 
-In history mode, improvements are not displayed by default. They are, however, still part of
-the family the correction divides by, and they still consume a rank.
+In history mode, improvements are neither displayed nor corrected. They leave the candidate set
+before the correction runs, so only regressions enter the sorted list. Branch mode reports both
+directions, so the same filter changes nothing there.
 
-That is deliberate, and the arithmetic shows why the obvious alternative is worse. Suppose
-ten series were judged, and two produced candidates: an improvement with a very low chance
-level, and a regression with a middling one.
+The judged family does not shrink; the denominator remains every series the analysis judged.
+Only the directions being corrected change. Suppose ten series were judged, and two produced
+candidates: an improvement with a very low chance level, and a regression with a middling one.
 
 {{#include generated/coverage-direction-order.md}}
 
-Filtering improvements out *before* the correction would shorten the sorted list, which moves
-the regression to an earlier rank and therefore a **stricter** bar. The regression that is
-reported today would be suppressed. Correcting first, then filtering the display, is both the
-more sensitive order and the honest one: an improvement is a real discovery that was really
-tested, and it is only the *display* that omits it.
+Filtering first is the stricter order. It shortens the sorted list, which moves the regression
+to an earlier rank and therefore a stricter bar. That costs findings: a regression the other
+order would have kept can be suppressed.
+
+That extra sensitivity is not legitimate for a regressions-only report. It is borrowed from a
+discovery the reader never sees: the improvement helps the regression pass, then disappears from
+the display. The full rejected set may still have a false-discovery bound, but the displayed
+findings do not.
+
+The order is conservative in another way too. The detectors' chance levels are two-sided, so an
+unchanged series has only about half that chance to raise a candidate in one named direction.
+The bar the correction sets is therefore met with room to spare, which is why the target is an
+upper bound rather than a level the tool aims at.
 
 ## What a report judged
 

--- a/packages/cargo-bench-history/book/src/appendix/coverage.md
+++ b/packages/cargo-bench-history/book/src/appendix/coverage.md
@@ -83,7 +83,7 @@ the display. The full rejected set may still have a false-discovery bound, but t
 findings do not.
 
 The order is conservative in another way too. The detectors' chance levels are two-sided, so an
-unchanged series has only about half that chance to raise a candidate in one named direction.
+unchanged series has at most half that chance to raise a candidate in one named direction.
 The bar the correction sets is therefore met with room to spare, which is why the target is an
 upper bound rather than a level the tool aims at.
 

--- a/packages/cargo-bench-history/book/src/appendix/detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/detection.md
@@ -180,7 +180,7 @@ That difference in question drives every difference in method.
 | Dirty snapshots | Never admitted | Only the context commit's newest snapshot is judged |
 | Window | The whole analyzed history | A fixed number of recent base-ref commits |
 | Test | Rank comparison, or trend check | Did the context run land inside the range a further measurement was expected in? |
-| Reports | Regressions only, by default | Regressions and improvements |
+| Reports | Regressions only | Regressions and improvements |
 | Blessings | Honored | Ignored |
 
 The branch's own intermediate commits are discarded. Only the analyzed context commit is the

--- a/packages/cargo-bench-history/book/src/appendix/generated/coverage-direction-order.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/coverage-direction-order.md
@@ -4,4 +4,4 @@
 | correct, then filter | `tokenize` (regression) | 2 | 0.015 | 0.02 | kept |
 | filter, then correct | `tokenize` (regression) | 1 | 0.015 | 0.01 | dropped |
 
-Both orders divide by the same 10 judged series. Correcting first leaves the regression at rank 2, where it is kept; filtering the improvement out first moves it to rank 1, where it is dropped. The display then omits the improvement either way.
+Both orders divide by the same 10 judged series. The tool filters, then corrects: the regression is at rank 1, where it is dropped. Correcting both directions first would leave it at rank 2, where it is kept, before the display would hide the improvement.

--- a/packages/cargo-bench-history/book/src/appendix/generated/reporting-json.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/reporting-json.md
@@ -10,7 +10,6 @@
   "runs": 128,
   "series": 8,
   "regressions": 2,
-  "improvements": 0,
   "ghosts_excluded": 2,
   "census": {
     "total": 10,
@@ -73,8 +72,7 @@
       "machine_key": "a1b2c3d4",
       "runs": 128,
       "series": 8,
-      "regressions": 2,
-      "improvements": 0
+      "regressions": 2
     }
   ]
 }

--- a/packages/cargo-bench-history/book/src/appendix/insights.md
+++ b/packages/cargo-bench-history/book/src/appendix/insights.md
@@ -176,8 +176,8 @@ Work down this list. Each step names the chapter that explains it.
 6. **Is the judged family large?** Read the report's judged count. A marginal finding must clear
    a stricter bar for an analysis that judged many series than for one that judged few.
    → [Multiplicity and coverage](coverage.md)
-7. **Was it an improvement in history mode?** Improvements are detected and corrected, but not
-   displayed by default. → [Reporting](reporting.md)
+7. **Was it an improvement in history mode?** History mode watches for regressions only, so a
+   move that made things faster never becomes a finding there. → [Reporting](reporting.md)
 8. **Was it blessed?** A blessing re-baselines the series, so moves before the blessed commit
    are no longer considered. → [Reconstruction](reconstruction.md)
 

--- a/packages/cargo-bench-history/book/src/commands/index.md
+++ b/packages/cargo-bench-history/book/src/commands/index.md
@@ -29,6 +29,5 @@ filters mean the same thing wherever they appear. Some commands also take a bare
 `analyze`, `list runs`, `prune`, and `examine` share selection option meanings, but not every
 default or admission policy is identical. Use `list runs` to preview the data set an
 `analyze` pass would consume, `examine` to inspect one series from that selection, and
-`prune --dry-run` to preview the exact deletion plan. The analysis-only flag
-`--include-improvements` and the condensed Markdown summary are exceptions because the other
-commands select data but never detect findings.
+`prune --dry-run` to preview the exact deletion plan. The condensed Markdown summary is an
+exception because the other commands select data but never detect findings.

--- a/packages/cargo-bench-history/book/src/concepts/analysis.md
+++ b/packages/cargo-bench-history/book/src/concepts/analysis.md
@@ -162,10 +162,10 @@ modes, auto-detected from git topology (there is no flag to force a mode):
 | Monotonic drift (Mann–Kendall + Theil–Sen) | ✅ | — |
 | Context commit vs. base (Student-t prediction interval) | — | ✅ |
 | Benjamini–Hochberg false-discovery filter | ✅ | ✅ |
-| Improvements reported | opt-in | ✅ |
+| Improvements reported | — | ✅ |
 
 - **history** — the base-branch view: long-range change-point and drift detection; reports
-  regressions only by default.
+  regressions only.
 - **branch** — the feature-branch view: judges the context commit's latest state against the
   base ref, reporting both directions. The branch's own intermediate history is ignored.
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -747,8 +747,7 @@ gives; when runs enter but none carry the named `(benchmark, metric)` pair, a di
 pointing at the unmatched benchmark id or metric name.
 
 `examine` runs **no detection and no re-baselining** — it has no findings, modes, or
-blessings, which is why the analysis-only improvements flag is not
-part of its surface. It lists **every commit** from the earliest one at which any matching
+blessings. It lists **every commit** from the earliest one at which any matching
 set carries the series through to the analyzed context commit: a commit carrying data contributes a row
 per **observation** (clean run before dirty snapshots, each flagged, so a value's provenance
 is unambiguous), and a commit carrying none is marked `n/a`. That opening is a union across
@@ -1061,6 +1060,16 @@ false positive. Testability is one mode-aware predicate (enough points in the wi
 mode's detector reads), and detection short-circuits on that same predicate, so a series is
 either judged *and* counted or neither.
 
+The correction and the report must cover the same set, because a rate controlled over one
+set says nothing about a subset of it. A mode that reports only one direction (§8.5)
+therefore discards the other direction's candidates **before** the correction runs, so every
+hypothesis the correction rejects is a finding the report goes on to show and the controlled
+rate is the rate among what the reader sees. The family size is unaffected: it still counts
+every judged series, whichever direction that series moved. Screening to one named direction
+only makes the guarantee safer, since an unchanged series has half the chance of raising a
+candidate in a direction chosen in advance as it does of raising one either way; the target
+is an upper bound, and this order keeps the true rate under it.
+
 Because every mode's verdict rests on a real p-value and on that one family definition, the
 correction applies uniformly to history and branch analysis rather than being a history-mode
 concept.
@@ -1093,8 +1102,8 @@ never a silent fall-through to history.
 * **history** — the base-branch view: auto-selected when the analyzed context commit *is* the
   merge-base with the base and no dirty run is recorded on top of it. It applies the
   long-range change-point and drift techniques, and reports regressions
-  only by default (steady improvement on the base branch is expected; a flag opts into
-  improvements).
+  only (steady improvement on the base branch is expected, so a report of it would be
+  noise in a channel whose whole purpose is to raise alarms).
 * **branch** — auto-selected otherwise (commits past the merge-base, a context line whose
   merge-base is off first-parent because the base was merged into the branch, or a dirty run
   admitted on the base tip by the exception above). It judges the analyzed context commit
@@ -1106,7 +1115,7 @@ The two driving scenarios are a scheduled base-branch regression watch (history)
 per-PR feature-branch evaluation (branch). Long-range trend analysis is meaningless on one
 or two branch points, which is why the techniques differ by mode. The false-discovery
 correction is not one of the differences: it spans whichever series the running mode found
-testable (§8.3).
+testable, over the directions that mode reports (§8.3).
 
 | Technique | history | branch |
 |---|---|---|
@@ -1114,11 +1123,11 @@ testable (§8.3).
 | Monotonic drift (Mann–Kendall + Theil–Sen) | ✅ | — |
 | Context commit vs. base (Student-t prediction interval) | — | ✅ |
 | Benjamini–Hochberg false-discovery filter | ✅ | ✅ |
-| Improvements reported | opt-in | ✅ |
+| Improvements reported | — | ✅ |
 
 Modes apply to `analyze` only; `list`, `prune`, and `examine` reuse the shared selection
-options and pipeline but never analyze, so the mode selection and improvements flag are
-analyze-only and not part of the shared option model. The **ghost filter** (§7.3) is likewise
+options and pipeline but never analyze, so the mode selection is analyze-only and not part of
+the shared option model. The **ghost filter** (§7.3) is likewise
 analyze-only and outside that shared selection model: it applies in both modes, dropping —
 before detection — any benchmark absent at the context commit. In branch
 mode a benchmark removed on the branch is a ghost and a benchmark newly

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1065,10 +1065,10 @@ set says nothing about a subset of it. A mode that reports only one direction (Â
 therefore discards the other direction's candidates **before** the correction runs, so every
 hypothesis the correction rejects is a finding the report goes on to show and the controlled
 rate is the rate among what the reader sees. The family size is unaffected: it still counts
-every judged series, whichever direction that series moved. Screening to one named direction
-only makes the guarantee safer, since an unchanged series has half the chance of raising a
-candidate in a direction chosen in advance as it does of raising one either way; the target
-is an upper bound, and this order keeps the true rate under it.
+every judged series, whichever direction that series moved. Screening to one named direction only makes the guarantee safer, since an unchanged series
+has at most half the chance of raising a candidate in a direction chosen in advance as it
+does of raising one either way; the target is an upper bound, and this order keeps the true
+rate under it.
 
 Because every mode's verdict rests on a real p-value and on that one family definition, the
 correction applies uniformly to history and branch analysis rather than being a history-mode

--- a/packages/cargo-bench-history/src/lib.rs
+++ b/packages/cargo-bench-history/src/lib.rs
@@ -230,8 +230,7 @@
 //! * **history** — long-range trend watch over the base branch (selected when you
 //!   analyze a clean checkout of the base branch). It detects sustained
 //!   change-points and slow drifts, defaults `--since` to the last six months, and
-//!   reports only **regressions** (steady improvement over time is expected) unless
-//!   `--include-improvements` is given.
+//!   reports only **regressions** (steady improvement over time is expected).
 //! * **branch** — "how does my feature compare" (selected for a feature branch, or
 //!   a dirty base checkout). It judges the branch by its **tip commit** versus the
 //!   base — the intermediate commits are ignored, since only the tip lands in the

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1453,10 +1453,21 @@ async fn analyze_history_mode_never_reports_improvements() {
         "the improvement was judged and then withheld, not left untested: {report}"
     );
     assert_eq!(parsed["notable"], false, "{report}");
+    // The key must be absent rather than null: `parsed["improvements"]` cannot tell the
+    // two apart, so the object is asked directly. Both the top-level document and every
+    // per-set entry carry the tally, so both must omit it.
+    let object = parsed.as_object().expect("the report is a JSON object");
     assert!(
-        parsed["improvements"].is_null(),
+        !object.contains_key("improvements"),
         "history mode states no improvement tally: {report}"
     );
+    for set in parsed["sets"].as_array().expect("the report lists its sets") {
+        let set = set.as_object().expect("a set entry is a JSON object");
+        assert!(
+            !set.contains_key("improvements"),
+            "a history-mode set states no improvement tally: {report}"
+        );
+    }
     assert!(
         parsed["findings"].as_array().is_some_and(Vec::is_empty),
         "improvements are never reported in history mode: {report}"

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -628,20 +628,33 @@ async fn analyze_ranks_findings_by_relative_move_across_benchmarks() {
     );
 }
 
+/// Branch mode reports a speedup as a finding in its own right: a tip that runs
+/// faster than the base is an improvement, counted apart from the regressions,
+/// and the improvement tally is stated because the mode looks in both directions.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_reports_improvement_without_regression() {
+async fn analyze_branch_mode_reports_an_improvement_without_regression() {
     let workspace = Workspace::repo(&storage_only_config());
-    workspace.seed_stepped_callgrind("2024-01-01", "c", 100.0, 70.0);
+    for (index, date) in sequential_dates("2024-01-01", MIN_SERIES_POINTS)
+        .into_iter()
+        .enumerate()
+    {
+        let label = format!("c{}", index + 1);
+        workspace.commit_dated(&date, &label);
+        workspace.seed_callgrind(&label, 100.0);
+    }
+    workspace.checkout_new_branch("feature");
+    workspace.commit_dated("2024-02-01", "f1");
+    workspace.seed_callgrind("f1", 70.0);
 
-    let report = workspace
-        .drive_json(&["analyze", "--include-improvements"])
-        .await;
+    let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(parsed["mode"], "branch", "{report}");
     assert_eq!(
         parsed["regressions"], 0,
         "a drop in instructions is not a regression: {report}"
     );
+    assert_eq!(parsed["improvements"], 1, "{report}");
     assert_eq!(parsed["findings"][0]["direction"], "improvement");
 }
 
@@ -1421,17 +1434,17 @@ async fn analyze_branch_mode_stays_silent_on_a_flat_branch() {
     );
 }
 
-/// History mode reports only regressions by default: steady improvement on the
-/// base branch over time is expected and not noteworthy, so a sustained drop is
-/// suppressed unless `--include-improvements` is given, which then surfaces it.
+/// History mode reports only regressions: steady improvement on the base branch
+/// over time is expected and not noteworthy, so a sustained drop never becomes a
+/// finding — and the report states no improvement tally rather than a zero it
+/// never looked for.
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn analyze_history_mode_suppresses_improvements_by_default() {
+async fn analyze_history_mode_never_reports_improvements() {
     let workspace = Workspace::repo(&storage_only_config());
     // A clean base branch with a sustained downward step (an improvement).
     workspace.seed_stepped_callgrind("2024-01-01", "c", 100.0, 70.0);
 
-    // By default history mode stays silent about the improvement.
     let report = workspace.drive_json(&["analyze"]).await;
     let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
     assert_eq!(parsed["mode"], "history", "{report}");
@@ -1440,21 +1453,13 @@ async fn analyze_history_mode_suppresses_improvements_by_default() {
         "the improvement was judged and then withheld, not left untested: {report}"
     );
     assert_eq!(parsed["notable"], false, "{report}");
-    assert_eq!(parsed["improvements"], 0, "{report}");
+    assert!(
+        parsed["improvements"].is_null(),
+        "history mode states no improvement tally: {report}"
+    );
     assert!(
         parsed["findings"].as_array().is_some_and(Vec::is_empty),
-        "improvements are suppressed by default in history mode: {report}"
-    );
-
-    // Opting in surfaces the very same improvement.
-    let report = workspace
-        .drive_json(&["analyze", "--include-improvements"])
-        .await;
-    let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
-    assert_eq!(parsed["improvements"], 1, "{report}");
-    assert_eq!(
-        parsed["findings"][0]["direction"], "improvement",
-        "{report}"
+        "improvements are never reported in history mode: {report}"
     );
 }
 

--- a/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/analyze.rs
@@ -1461,7 +1461,10 @@ async fn analyze_history_mode_never_reports_improvements() {
         !object.contains_key("improvements"),
         "history mode states no improvement tally: {report}"
     );
-    for set in parsed["sets"].as_array().expect("the report lists its sets") {
+    for set in parsed["sets"]
+        .as_array()
+        .expect("the report lists its sets")
+    {
         let set = set.as_object().expect("a set entry is a JSON object");
         assert!(
             !set.contains_key("improvements"),

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -292,7 +292,6 @@ where
         merge_base_index: dataset.merge_base_index,
         base_ref_index: dataset.base_ref_index,
         tip_index: dataset.tip_index,
-        include_improvements: options.include_improvements,
     };
     // Share the series across the detection's blocking tasks without copying; the
     // remaining per-set reporting reads them back through this same handle.

--- a/packages/cbh_cli/src/cli.rs
+++ b/packages/cbh_cli/src/cli.rs
@@ -25,7 +25,6 @@ const HEADING_COMMIT: &str = "Commit selection";
 const HEADING_FILTER: &str = "Data filtering";
 const HEADING_SCOPE: &str = "Benchmark scope";
 const HEADING_FEATURES: &str = "Feature selection";
-const HEADING_ANALYSIS: &str = "Analysis";
 
 /// Maintain a history of benchmark results over time and analyze it for trends.
 #[derive(Debug, Parser)]
@@ -542,12 +541,6 @@ struct AnalyzeCommand {
     #[arg(long, help_heading = HEADING_FILTER)]
     no_dirty: bool,
 
-    /// In history mode, also report sustained improvements (by default only
-    /// regressions are reported, since improvement over time is expected). Branch
-    /// mode always reports all findings, so this flag has no effect there.
-    #[arg(long, help_heading = HEADING_ANALYSIS)]
-    include_improvements: bool,
-
     /// Also write a condensed Markdown summary — only the most significant findings
     /// — to this path (a relative path resolves against the working directory). The
     /// full `--markdown` report carries every finding; this summary is capped so a
@@ -575,7 +568,6 @@ impl AnalyzeCommand {
             markdown: self.output.markdown,
             json: self.output.json,
             markdown_summary: self.markdown_summary,
-            include_improvements: self.include_improvements,
             verbose: self.env.verbose,
             timing: false,
         }
@@ -1575,15 +1567,6 @@ mod tests {
             panic!("expected analyze command");
         };
         assert!(!options.verbose);
-    }
-
-    #[test]
-    fn analyze_collects_switches() {
-        let command = parse(&["analyze", "--include-improvements"]);
-        let Command::Analyze(options) = command else {
-            panic!("expected analyze command");
-        };
-        assert!(options.include_improvements);
     }
 
     #[test]

--- a/packages/cbh_command/src/command.rs
+++ b/packages/cbh_command/src/command.rs
@@ -287,9 +287,6 @@ pub struct AnalyzeOptions {
     /// against the working directory. Analyze-only, so a large analysis still fits
     /// within a GitHub issue body.
     pub markdown_summary: Option<PathBuf>,
-    /// In history mode, also report sustained improvements (regressions only by
-    /// default, since improvement over time on the base branch is expected).
-    pub include_improvements: bool,
     /// Emit detailed diagnostic notes to standard error describing each step.
     pub verbose: bool,
     /// Emit per-stage wall-clock timings to standard error, independent of

--- a/packages/cbh_detect/src/detect/examples.rs
+++ b/packages/cbh_detect/src/detect/examples.rs
@@ -206,8 +206,9 @@ pub fn with_base_window(mut series: Series, base_ref_index: usize) -> Series {
 /// A history-mode context over `series` under the default configuration: what a
 /// scheduled analysis of one benchmark's stored history runs.
 ///
-/// Improvements are reported, so an example that moves in either direction is visible
-/// rather than silently filtered.
+/// History mode reports regressions only, so an example that moves downwards is a
+/// non-finding here; use [`branch_context`] for an example that must be visible in
+/// either direction.
 #[must_use]
 pub fn history_context(series: &Series) -> AnalysisContext {
     AnalysisContext {
@@ -216,7 +217,6 @@ pub fn history_context(series: &Series) -> AnalysisContext {
         merge_base_index: None,
         base_ref_index: None,
         tip_index: tip_index_of(series),
-        include_improvements: true,
     }
 }
 
@@ -232,7 +232,6 @@ pub fn branch_context(series: &Series, merge_base_index: usize) -> AnalysisConte
         merge_base_index: Some(merge_base_index),
         base_ref_index: Some(merge_base_index),
         tip_index: tip_index_of(series),
-        include_improvements: true,
     }
 }
 

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -2107,10 +2107,8 @@ fn finalize_findings(
     // raising one either way. The p-values the correction sees therefore overstate the
     // risk of what it admits, and the bound holds with room to spare.
     // Ref: DESIGN.md §8.3.
-    let candidates: Vec<Candidate> = candidates
-        .into_iter()
-        .filter(|candidate| context.keeps(candidate.finding.direction))
-        .collect();
+    let mut candidates = candidates;
+    candidates.retain(|candidate| context.keeps(candidate.finding.direction));
 
     // Control the false-discovery rate across every series that was actually judged,
     // not merely those that raised a candidate. Feeding the filter only its own
@@ -4716,6 +4714,139 @@ mod tests {
         // directions.
         assert!(!context(AnalysisMode::History).reports_improvements());
         assert!(context(AnalysisMode::Branch).reports_improvements());
+    }
+
+    /// The judged family the direction-order case is corrected against. Ten makes the
+    /// first two Benjamini–Hochberg thresholds `FDR_Q / 10` and `FDR_Q / 5`, far enough
+    /// apart to seat a p-value strictly between them.
+    const DIRECTION_ORDER_FAMILY: usize = 10;
+
+    /// The improvement's p-value, as a fraction of `FDR_Q`. Well under the rank-1
+    /// threshold (`FDR_Q / 10`), so it is rejected under either order and always takes
+    /// rank 1 away from the regression.
+    const DIRECTION_ORDER_IMPROVEMENT_P: f64 = 0.01;
+
+    /// The regression's p-value, as a fraction of `FDR_Q`. Chosen to sit strictly
+    /// between the rank-1 threshold (`FDR_Q / 10`) and the rank-2 one (`FDR_Q / 5`), so
+    /// its survival depends entirely on which rank it lands at — which is exactly what
+    /// the screening order decides.
+    const DIRECTION_ORDER_REGRESSION_P: f64 = 0.15;
+
+    /// Builds a candidate carrying `direction` and `bh_p`, drawn from `source`.
+    ///
+    /// `comparison_base_index` is the branch-mode chart anchor, left `None` for history
+    /// mode. Everything the false-discovery filter does not read is left at a neutral
+    /// value: the filter arbitrates on `bh_p` alone, and the surviving finding's
+    /// charting points are materialised from `source` afterwards.
+    fn direction_order_candidate(
+        source: &Series,
+        source_index: usize,
+        direction: Direction,
+        bh_p: f64,
+        comparison_base_index: Option<usize>,
+    ) -> Candidate {
+        Candidate {
+            finding: Finding {
+                set: source.set.clone(),
+                id: source.id.clone(),
+                kind: source.kind,
+                method: FindingMethod::ChangePoint,
+                direction,
+                baseline: 100.0,
+                latest: 110.0,
+                delta: 10.0,
+                relative_delta: 0.1,
+                confidence: 1.0 - bh_p,
+                commit: None,
+                window_start_commit: None,
+                blessed_at: None,
+                blessed_commit_time: None,
+                series: Vec::new(),
+                comparison_base_index,
+                chart_base_ref: None,
+            },
+            source_index,
+            bh_p,
+            split: None,
+            line: None,
+        }
+    }
+
+    /// The mode's direction screen runs *before* the false-discovery correction, so a
+    /// regression is corrected against the ranks its own direction occupies rather than
+    /// borrowing an earlier one from an improvement the report would never show.
+    ///
+    /// The two candidates are sized so the orders disagree: correcting both directions
+    /// seats the regression at rank 2, where it clears the looser threshold, while
+    /// screening first leaves it alone at rank 1, where it does not. History mode must
+    /// therefore report nothing, and branch mode — which reports both directions, so the
+    /// screen is a no-op — must report both.
+    #[test]
+    fn history_screens_direction_before_the_correction() {
+        let config = AnalysisConfig::default();
+        let improvement_p = config.fdr_q * DIRECTION_ORDER_IMPROVEMENT_P;
+        let regression_p = config.fdr_q * DIRECTION_ORDER_REGRESSION_P;
+
+        // Bind the case to the thresholds it is built around, so a moved gate fails here
+        // rather than silently leaving the two orders in agreement.
+        let family = count_to_f64(DIRECTION_ORDER_FAMILY);
+        assert!(improvement_p < config.fdr_q / family);
+        assert!(regression_p > config.fdr_q / family);
+        assert!(regression_p < config.fdr_q * 2.0 / family);
+
+        let series = vec![
+            named_series("improving", &[100.0, 70.0]),
+            named_series("regressing", &[100.0, 110.0]),
+        ];
+        let mut census = SeriesCensus::default();
+        for _ in 0..DIRECTION_ORDER_FAMILY {
+            census.record(Testability::Judged);
+        }
+
+        let candidates = |comparison_base_index| {
+            vec![
+                direction_order_candidate(
+                    &series[0],
+                    0,
+                    Direction::Improvement,
+                    improvement_p,
+                    comparison_base_index,
+                ),
+                direction_order_candidate(
+                    &series[1],
+                    1,
+                    Direction::Regression,
+                    regression_p,
+                    comparison_base_index,
+                ),
+            ]
+        };
+
+        // History charts against the analyzed tip; branch charts against the base ref,
+        // so each leg supplies the anchors its own charting path reads.
+        let history_context = AnalysisContext {
+            mode: AnalysisMode::History,
+            config,
+            merge_base_index: None,
+            base_ref_index: None,
+            tip_index: 1,
+        };
+        let branch_context = AnalysisContext {
+            mode: AnalysisMode::Branch,
+            config,
+            merge_base_index: Some(1),
+            base_ref_index: Some(1),
+            tip_index: 1,
+        };
+
+        let history = finalize_findings(candidates(None), &census, &series, &history_context);
+        assert!(
+            history.is_empty(),
+            "the regression alone sits at rank 1, where it does not clear the bar: {history:?}"
+        );
+
+        let branch = finalize_findings(candidates(Some(1)), &census, &series, &branch_context);
+        assert_eq!(branch.len(), 2, "{branch:?}");
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -38,9 +38,11 @@
 //!   move as measurement noise. The veto direction is one-way: it can only
 //!   suppress a candidate the other gates would have reported — it can never
 //!   promote a move into a finding.
-//! * Surviving candidates then pass a Benjamini–Hochberg false-discovery filter,
-//!   taken over every series judged rather than only those that raised a candidate,
-//!   so a batch of series does not manufacture spurious findings.
+//! * Surviving candidates are screened to the directions the mode reports, then pass
+//!   a Benjamini–Hochberg false-discovery filter, taken over every series judged
+//!   rather than only those that raised a candidate, so a batch of series does not
+//!   manufacture spurious findings and the rate the filter controls is the rate among
+//!   the findings actually reported.
 //!
 //! A separate slow-[`Drift`](FindingMethod::Drift) finding is raised from a
 //! Mann–Kendall trend test plus a Theil–Sen slope, gated by the same practical
@@ -332,8 +334,8 @@ impl AnalysisMode {
 
 /// The context a [`find_changes_spawned`] pass runs in.
 ///
-/// Carries which analysis to perform, the tuned parameters, the topology anchors
-/// the mode needs, and whether improvements are reported alongside regressions.
+/// Carries which analysis to perform, the tuned parameters, and the topology anchors
+/// the mode needs.
 #[derive(Clone, Copy, Debug)]
 pub struct AnalysisContext {
     /// The analysis to perform.
@@ -354,25 +356,26 @@ pub struct AnalysisContext {
     /// target so a series that stops short of the context renders the data-less commits
     /// after its last observation as a gap. Consulted only in [`AnalysisMode::History`].
     pub tip_index: usize,
-    /// Whether improvements are reported. History mode defaults to regressions only
-    /// (scheduled drift watch); branch mode always reports both.
-    pub include_improvements: bool,
 }
 
 impl AnalysisContext {
     /// Whether a finding of the given `direction` is reported in this mode.
+    ///
+    /// The two modes ask differently shaped questions, so they keep different
+    /// directions (DESIGN §8.3, §8.5). History mode is a drift watch over the base
+    /// branch, where improvement over time is the expected background and only a
+    /// worsening warrants attention, so it is one-directional. Branch mode judges one
+    /// change against its base, where any movement is what the reader came for.
     fn keeps(&self, direction: Direction) -> bool {
         match self.mode {
-            AnalysisMode::History => {
-                direction == Direction::Regression || self.include_improvements
-            }
+            AnalysisMode::History => direction == Direction::Regression,
             AnalysisMode::Branch => true,
         }
     }
 
-    /// Whether this analysis reports improvements at all. `false` for the
-    /// regressions-only case (history mode's default drift watch), where an
-    /// always-zero improvement tally is noise the report omits.
+    /// Whether this analysis reports improvements at all. `false` in history mode's
+    /// regressions-only drift watch, where an always-zero improvement tally is noise
+    /// the report omits.
     #[must_use]
     pub fn reports_improvements(&self) -> bool {
         self.keeps(Direction::Improvement)
@@ -2009,10 +2012,10 @@ pub fn find_changes(series: &[Series], context: &AnalysisContext) -> Detection {
 /// the branch's latest state against its base. A series that cannot be judged (see
 /// [`testability`]) is never evaluated and is accounted for in the returned
 /// [`SeriesCensus`] instead.
-/// Surviving candidates pass a Benjamini–Hochberg false-discovery filter at
-/// `config.fdr_q`. Findings are then filtered to the directions the mode reports and
-/// ordered by descending relative move, then method, then a stable identity
-/// tie-break.
+/// Surviving candidates are screened to the directions the mode reports and then pass
+/// a Benjamini–Hochberg false-discovery filter at `config.fdr_q`, so every reported
+/// finding is one the correction rejected. Findings are ordered by descending relative
+/// move, then method, then a stable identity tie-break.
 ///
 /// Detection is per-series independent, so the series are split into one balanced
 /// contiguous chunk per worker and each chunk runs on its own blocking task via
@@ -2092,6 +2095,21 @@ fn finalize_findings(
 ) -> Vec<Finding> {
     let config = &context.config;
 
+    // Screen to the directions this mode reports *before* the correction, so that every
+    // hypothesis the correction rejects is a finding the report goes on to show.
+    // Correcting over both directions and discarding one afterwards would attach the
+    // false-discovery guarantee to a set larger than the reported one: discarding true
+    // improvements shrinks the denominator the rate is defined over while leaving false
+    // regressions in place, so the regressions actually shown would inherit no bound.
+    // Screening first costs only power — for an unchanged series the chance of raising a
+    // candidate in one named direction is half the two-sided p-value the detectors
+    // report, so the surviving p-values are conservative and the bound holds with room
+    // to spare. Ref: DESIGN.md §8.3.
+    let candidates: Vec<Candidate> = candidates
+        .into_iter()
+        .filter(|candidate| context.keeps(candidate.finding.direction))
+        .collect();
+
     // Control the false-discovery rate across every series that was actually judged,
     // not merely those that raised a candidate. Feeding the filter only its own
     // survivors would make it a no-op: each has already cleared `change_alpha`, which
@@ -2104,9 +2122,8 @@ fn finalize_findings(
     let mut keep_iter = keep.into_iter();
 
     // `candidates` and `candidate_p` were built in the same order, so advancing
-    // `keep_iter` for each candidate keeps the mask aligned. A surviving finding that
-    // the mode keeps materialises its charting points here — a dropped candidate never
-    // pays for them.
+    // `keep_iter` for each candidate keeps the mask aligned. A surviving finding
+    // materialises its charting points here — a dropped candidate never pays for them.
     let mut findings: Vec<Finding> = candidates
         .into_iter()
         .filter_map(|candidate| {
@@ -2118,9 +2135,6 @@ fn finalize_findings(
                 source_index,
                 ..
             } = candidate;
-            if !context.keeps(finding.direction) {
-                return None;
-            }
             let source = series
                 .get(source_index)
                 .expect("the source index was assigned from this series slice");
@@ -2512,8 +2526,7 @@ mod tests {
         super::evaluate_branch(series, config, context_index, log)
     }
 
-    /// Runs the history-mode detector with default config, reporting both
-    /// directions.
+    /// Runs the history-mode detector with default config.
     fn changes(series: &[Series]) -> Vec<Finding> {
         find_changes(series, &history_context(series)).findings
     }
@@ -2526,7 +2539,6 @@ mod tests {
             merge_base_index: None,
             base_ref_index: None,
             tip_index: max_topo_index(series),
-            include_improvements: true,
         }
     }
 
@@ -2580,7 +2592,6 @@ mod tests {
             merge_base_index: None,
             base_ref_index: None,
             tip_index: max_topo_index(&series),
-            include_improvements: true,
         };
 
         let serial = find_changes(&series, &context);
@@ -3484,7 +3495,6 @@ mod tests {
             merge_base_index,
             base_ref_index: merge_base_index,
             tip_index: max_topo_index(series),
-            include_improvements: false,
         }
     }
 
@@ -3622,8 +3632,7 @@ mod tests {
 
     #[test]
     fn branch_mode_reports_an_improvement_over_the_base() {
-        // Branch mode always reports both directions, regardless of
-        // `include_improvements` (which only governs history mode).
+        // Branch mode reports both directions; only history is regressions-only.
         let series = branch_over_base(100.0, 70.0, 3);
         let finding = only(branch_changes(&[series], Some(base_merge_base())));
         assert_eq!(finding.direction, Direction::Improvement);
@@ -3970,7 +3979,6 @@ mod tests {
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 20,
-            include_improvements: true,
         };
         let finding = only(find_changes(slice::from_ref(&series), &context).findings);
         assert_eq!(finding.chart_base_ref, Some(20));
@@ -4679,37 +4687,33 @@ mod tests {
     }
 
     #[test]
-    fn history_keeps_regressions_and_optionally_improvements() {
-        let context = |include_improvements| AnalysisContext {
+    fn history_reports_regressions_only() {
+        let context = AnalysisContext {
             mode: AnalysisMode::History,
             config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 0,
-            include_improvements,
         };
-        // Regressions are always reported; improvements only when opted in.
-        assert!(context(false).keeps(Direction::Regression));
-        assert!(!context(false).keeps(Direction::Improvement));
-        assert!(context(true).keeps(Direction::Improvement));
+        // A drift watch over the base branch is one-directional: improvement over time
+        // is the expected background there, so only a worsening is a finding.
+        assert!(context.keeps(Direction::Regression));
+        assert!(!context.keeps(Direction::Improvement));
     }
 
     #[test]
     fn reports_improvements_reflects_the_mode() {
-        let context = |mode, include_improvements| AnalysisContext {
+        let context = |mode| AnalysisContext {
             mode,
             config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 0,
-            include_improvements,
         };
-        // History reports improvements only when opted in; branch always compares
-        // both directions. Pinning both a true and a false case keeps the flag from
-        // collapsing to a constant.
-        assert!(!context(AnalysisMode::History, false).reports_improvements());
-        assert!(context(AnalysisMode::History, true).reports_improvements());
-        assert!(context(AnalysisMode::Branch, false).reports_improvements());
+        // History is the regressions-only drift watch; branch compares both
+        // directions.
+        assert!(!context(AnalysisMode::History).reports_improvements());
+        assert!(context(AnalysisMode::Branch).reports_improvements());
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -2101,10 +2101,12 @@ fn finalize_findings(
     // false-discovery guarantee to a set larger than the reported one: discarding true
     // improvements shrinks the denominator the rate is defined over while leaving false
     // regressions in place, so the regressions actually shown would inherit no bound.
-    // Screening first costs only power — for an unchanged series the chance of raising a
-    // candidate in one named direction is half the two-sided p-value the detectors
-    // report, so the surviving p-values are conservative and the bound holds with room
-    // to spare. Ref: DESIGN.md §8.3.
+    // Screening first costs only power, and it is conservative: the detectors report
+    // two-sided p-values from symmetric nulls, so for an unchanged series the chance of
+    // raising a candidate in a direction named in advance is at most half the chance of
+    // raising one either way. The p-values the correction sees therefore overstate the
+    // risk of what it admits, and the bound holds with room to spare.
+    // Ref: DESIGN.md §8.3.
     let candidates: Vec<Candidate> = candidates
         .into_iter()
         .filter(|candidate| context.keeps(candidate.finding.direction))

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -129,19 +129,13 @@ impl Mode {
     const ALL: [Self; 2] = [Self::History, Self::Branch];
 
     /// Whether this mode reports improvements as findings. Only branch does: history is
-    /// run here as a regressions-only drift watch (`include_improvements = false`), so
-    /// for it an improvement is a non-finding.
+    /// a regressions-only drift watch, so for it an improvement is a non-finding.
     fn reports_improvements(self) -> bool {
         matches!(self, Self::Branch)
     }
 
     /// The analysis context this mode is evaluated under. `merge_base_index` and
     /// `tip_index` are consulted only by branch mode; history ignores them.
-    ///
-    /// `include_improvements` is set from [`reports_improvements`](Self::reports_improvements)
-    /// so the context matches the mode's intended reporting semantics: branch (which
-    /// reports both directions) opts in, history opts out. Branch mode ignores the
-    /// flag today, but pinning it consistently keeps the context correct if that changes.
     fn context(self, merge_base_index: Option<usize>, tip_index: usize) -> AnalysisContext {
         let mode = match self {
             Self::History => AnalysisMode::History,
@@ -153,7 +147,6 @@ impl Mode {
             merge_base_index,
             base_ref_index: merge_base_index,
             tip_index,
-            include_improvements: self.reports_improvements(),
         }
     }
 }
@@ -823,9 +816,10 @@ fn companion_crowds_report_nothing_of_their_own() {
     // The stricter reading — that companions raise no *candidate* at all — is not a
     // property flat noisy series can have. Fifty of them tested at `change_alpha` will now
     // and then throw one that clears it, which is what that threshold means. What they may
-    // not do is throw one in the direction the mode reports, so the second assertion pins
-    // the crowd's whole contribution to the improvement side, where a regressions-only
-    // drift watch discards it.
+    // not do is carry one through to a reported finding. The branch leg covers both
+    // directions on its own, since branch mode reports improvements as well as
+    // regressions; the history leg covers the regression side, which is all a
+    // regressions-only drift watch can report.
     for case in cases() {
         let values = case.values();
         for scale in [1.0, SCALE_MULTIPLE] {
@@ -847,21 +841,6 @@ fn companion_crowds_report_nothing_of_their_own() {
                     case.name,
                     detection.findings.len(),
                 );
-
-                let both_directions = AnalysisContext {
-                    include_improvements: true,
-                    ..mode.context(case.merge_base_index(), case.tip_index())
-                };
-                for finding in find_changes(&crowd, &both_directions).findings {
-                    assert_eq!(
-                        finding.direction,
-                        Direction::Improvement,
-                        "case '{}' mode={mode:?} scale={scale}: companion '{}' raised a \
-                         regression of its own",
-                        case.name,
-                        finding.id.qualified(),
-                    );
-                }
             }
         }
     }

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -148,9 +148,8 @@ pub struct ReportInput<'a> {
     /// entered the analysis.
     pub commit_span: Option<(&'a str, &'a str)>,
     /// Whether this analysis reports improvements. When `false` (history mode's
-    /// default regressions-only watch) the text and Markdown reports
-    /// omit the improvement tally, which would always be zero. The JSON report always
-    /// carries it.
+    /// regressions-only watch) every rendering omits the improvement tally rather
+    /// than stating a zero the analysis never looked for.
     pub report_improvements: bool,
     /// Every set's findings, globally ranked most-notable first.
     pub findings: &'a [Finding],
@@ -253,8 +252,10 @@ struct JsonSet<'a> {
     series: usize,
     /// Flagged regressions in this set.
     regressions: usize,
-    /// Flagged improvements in this set.
-    improvements: usize,
+    /// Flagged improvements in this set. Absent in a mode that does not report
+    /// improvements, so the document never states a tally the analysis did not look for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    improvements: Option<usize>,
     /// How far this set's comparison base(s) lag the base ref, with the reason for
     /// each distinct lag (branch mode only). Omitted when the comparison base reaches
     /// the base ref — the usual case — and in history mode.
@@ -351,8 +352,10 @@ struct JsonReport<'a> {
     series: usize,
     /// Number of flagged regressions.
     regressions: usize,
-    /// Number of flagged improvements.
-    improvements: usize,
+    /// Number of flagged improvements. Absent in a mode that does not report
+    /// improvements, so the document never states a tally the analysis did not look for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    improvements: Option<usize>,
     /// Benchmarks dropped as ghosts (present only for past commits, not at the
     /// context commit) before detection. Zero when nothing was dropped.
     ghosts_excluded: usize,
@@ -1148,7 +1151,9 @@ fn render_json(input: &ReportInput<'_>) -> String {
             runs: summary.runs,
             series: summary.series,
             regressions: count_direction(&summary.findings, Direction::Regression),
-            improvements: count_direction(&summary.findings, Direction::Improvement),
+            improvements: input
+                .report_improvements
+                .then(|| count_direction(&summary.findings, Direction::Improvement)),
             comparison_base_lags: &summary.comparison_base_lags,
         })
         .collect();
@@ -1162,7 +1167,9 @@ fn render_json(input: &ReportInput<'_>) -> String {
         runs: input.runs,
         series: input.series,
         regressions: count_top(input.findings, Direction::Regression),
-        improvements: count_top(input.findings, Direction::Improvement),
+        improvements: input
+            .report_improvements
+            .then(|| count_top(input.findings, Direction::Improvement)),
         ghosts_excluded: input.ghosts_excluded,
         census: JsonCensus::from_coverage(&Coverage::from_census(&input.census)),
         hint: input.hint,


### PR DESCRIPTION
[Copilot speaking]

Closes #438.

## Motivation

`analyze` runs in one of two modes. History mode is a scheduled watch over the base branch that reports only regressions; branch mode judges a feature branch's tip against its base and reports both directions. Which directions a mode reports was governed by an opt-in `--include-improvements` flag that only history mode consulted, and the one place automation passed it was the branch-mode PR recipe, where it was inert.

That flag also concealed a statistical defect. The Benjamini–Hochberg correction ran over both directions, and the mode's direction filter ran afterwards, on the display:

```
candidates ──► [Benjamini-Hochberg] ──► [direction filter] ──► report
```

BH bounds the false-discovery rate over the set it *rejects*. Displaying a subset of that set inherits no bound: discarding true improvements shrinks the denominator the rate is defined over while leaving false regressions in the numerator. A realistic trigger — a runner change or toolchain upgrade producing a mass of same-direction shifts plus stray opposite-direction noise — could yield a report whose overall rejected set is well within the target while every regression the reader actually sees is false. The book stated the promise the code did not keep, and its "Why improvements are corrected too" appendix argued for this ordering and called it "the honest one".

## Changes

**The correction covers exactly what the report shows.** The direction screen moves ahead of BH, so every hypothesis the correction rejects is a finding the report goes on to display:

```
candidates ──► [direction screen] ──► [Benjamini-Hochberg] ──► report
```

The family size is untouched — it still counts every judged series, whichever direction that series moved. Branch mode is unaffected, since it keeps both directions. History mode reports weakly fewer regressions than before: that is the honest cost of the guarantee. The order is also conservative, because a two-sided chance level overstates the risk of a move in a direction named in advance.

**`--include-improvements` is removed.** History mode reports regressions only, branch mode reports both, and neither is configurable.

**Reports no longer state a tally they did not look for.** The JSON `improvements` key is now absent in a mode that does not report improvements, matching what the text and Markdown renderings already did. The stress harness renders `n/a` in that column.

**Documentation matches the behavior.** DESIGN.md §8.3 gains the invariant that the corrected set and the reported set are the same, §8.5 states the per-mode direction policy as intrinsic, and the coverage appendix's worked example now justifies filtering first — including the power it costs and where the old order's extra sensitivity was borrowed from.