### PR TITLE
many_cpus: support machines with more than 1024 processors on Linux

### DIFF
--- a/packages/many_cpus/docs/design.md
+++ b/packages/many_cpus/docs/design.md
@@ -7,9 +7,10 @@ package draws the distinctions it does.
 
 ## Machine size
 
-The package imposes no ceiling of its own on how many processors a machine may have. Every
-processor that the operating system reports can be inspected, selected and pinned to, and a
-thread's affinity can be read back, on machines of any size the operating system supports.
+The package imposes no ceiling of its own on how large a machine may be, within the range of
+machines that operating systems support. Every processor that the operating system reports can
+be inspected, selected and pinned to, and a thread's affinity can be read back, however many
+processors there are.
 
 ## Processor identity
 

--- a/packages/many_cpus/docs/design.md
+++ b/packages/many_cpus/docs/design.md
@@ -8,9 +8,9 @@ package draws the distinctions it does.
 ## Machine size
 
 The package imposes no ceiling of its own on how large a machine may be, within the range of
-machines that operating systems support. However many processors there are, every one the
-operating system reports can be inspected and selected, and on a platform with native affinity
-support a thread can be pinned to any of them and its affinity read back.
+machines that operating systems support. Every processor that the operating system reports can
+be inspected, selected and pinned to, and a thread's affinity can be read back, however many
+processors there are.
 
 ## Processor identity
 

--- a/packages/many_cpus/docs/design.md
+++ b/packages/many_cpus/docs/design.md
@@ -8,9 +8,9 @@ package draws the distinctions it does.
 ## Machine size
 
 The package imposes no ceiling of its own on how large a machine may be, within the range of
-machines that operating systems support. Every processor that the operating system reports can
-be inspected, selected and pinned to, and a thread's affinity can be read back, however many
-processors there are.
+machines that operating systems support. However many processors there are, every one the
+operating system reports can be inspected and selected, and on a platform with native affinity
+support a thread can be pinned to any of them and its affinity read back.
 
 ## Processor identity
 

--- a/packages/many_cpus/docs/design.md
+++ b/packages/many_cpus/docs/design.md
@@ -5,6 +5,12 @@ callers can place work deliberately on specific hardware. This document covers t
 identity that the package attaches to a processor: what a caller can rely on and why the
 package draws the distinctions it does.
 
+## Machine size
+
+The package imposes no ceiling of its own on how many processors a machine may have. Every
+processor that the operating system reports can be inspected, selected and pinned to, and a
+thread's affinity can be read back, on machines of any size the operating system supports.
+
 ## Processor identity
 
 A processor is identified by the numeric ID the operating system assigns to it. Every

--- a/packages/many_cpus/docs/implementation.md
+++ b/packages/many_cpus/docs/implementation.md
@@ -37,7 +37,7 @@ terms.
 The only way to learn the required width is therefore to offer wider and wider masks until one
 is accepted. The search doubles the width each time so that the number of attempts stays
 logarithmic in the size of the machine, and it makes a fixed number of attempts so that it
-always ends: the final width describes more processors than any operating system can boot, so
+always ends: the final width describes a machine far larger than operating systems support, so
 reaching the end means something other than a large machine is wrong, and the error that the
 last attempt produced is reported rather than a conclusion of our own. An invalid-argument error
 has causes other than a narrow mask — a sandbox may forbid the call outright — which is why that
@@ -45,11 +45,11 @@ error is preserved and why any other error ends the search immediately.
 
 A width that the operating system accepted is remembered and tried first next time. It is a
 hint and not a conclusion: a process can outlive a change in the machine it runs on, so a width
-that stops working simply starts the search over.
+that stops working merely sends the search widening again from there.
 
 Writing a mask needs none of this. The operating system accepts a mask of any width when setting
 affinity and treats the processors beyond it as absent from the set, so a write is a single call
-with a mask exactly wide enough for the processors it names.
+with a mask wide enough for the processors it names.
 
 ### Comparing masks
 

--- a/packages/many_cpus/docs/implementation.md
+++ b/packages/many_cpus/docs/implementation.md
@@ -1,0 +1,59 @@
+# many_cpus implementation
+
+`many_cpus` is a thin published shell over `many_cpus_impl`, which holds the implementation and
+carries a platform abstraction layer (see `docs/pal.md`) with one implementation per operating
+system plus a fallback for systems we do not describe in detail. This document covers the parts
+of that implementation whose reasoning is not evident from the code alone.
+
+## Thread affinity masks
+
+An operating system describes which processors a thread may run on as a bit per processor,
+packed into an array of machine words. The width of that array is not fixed by the operating
+system: the caller allocates the array and passes its size along on every call. The fixed-size
+type that the C library offers for this purpose (`cpu_set_t` on Linux) is a convenience for the
+common case and not the limit of what the kernel supports; it describes a machine of a
+particular size and nothing larger. Machines larger than that exist and are rented by the hour,
+so the package represents a mask as a sequence of machine words whose width it chooses.
+
+The mask keeps as many words inline as the platform's own fixed-size type holds, and spills to
+the heap only beyond that. Every machine that the C library could have described therefore
+imposes no allocation, and only machines it could not describe at all pay for one.
+
+Counting a mask in words rather than bytes is not a stylistic choice: the operating system
+rejects a mask whose size is not a whole number of machine words, so making a word the unit of
+width means the requirement cannot be violated. It also makes the buffer's alignment correct by
+construction.
+
+### Reading an affinity mask
+
+The operating system refuses to report an affinity mask into a buffer too narrow to describe
+every processor it knows of, and it reports that refusal as a plain invalid-argument error
+without saying how wide the buffer needs to be. Nor can the required width be computed from the
+hardware inventory: the operating system sizes its answer by the processors it could ever have,
+which includes processors that are absent, offline, or forbidden to the process. A container
+restricted to a handful of processors on a very large host is still answered in the host's
+terms.
+
+The only way to learn the required width is therefore to offer wider and wider masks until one
+is accepted. The search doubles the width each time so that the number of attempts stays
+logarithmic in the size of the machine, and it makes a fixed number of attempts so that it
+always ends: the final width describes more processors than any operating system can boot, so
+reaching the end means something other than a large machine is wrong, and the error that the
+last attempt produced is reported rather than a conclusion of our own. An invalid-argument error
+has causes other than a narrow mask — a sandbox may forbid the call outright — which is why that
+error is preserved and why any other error ends the search immediately.
+
+A width that the operating system accepted is remembered and tried first next time. It is a
+hint and not a conclusion: a process can outlive a change in the machine it runs on, so a width
+that stops working simply starts the search over.
+
+Writing a mask needs none of this. The operating system accepts a mask of any width when setting
+affinity and treats the processors beyond it as absent from the set, so a write is a single call
+with a mask exactly wide enough for the processors it names.
+
+### Comparing masks
+
+Two masks that name the same processors are the same set even when one of them is wider, so
+mask comparison ignores width. Width is a property of the buffer handed to the operating system,
+not of the set. A consequence is that comparing masks says nothing about how wide a mask was —
+tests that care about the width of a request must inspect the width itself.

--- a/packages/many_cpus/docs/implementation.md
+++ b/packages/many_cpus/docs/implementation.md
@@ -5,55 +5,8 @@ carries a platform abstraction layer (see `docs/pal.md`) with one implementation
 system plus a fallback for systems we do not describe in detail. This document covers the parts
 of that implementation whose reasoning is not evident from the code alone.
 
-## Thread affinity masks
+Each operating system answers the same questions in its own terms, and those answers differ
+enough in shape that the reasoning behind an individual platform implementation belongs to that
+platform's own document rather than here:
 
-An operating system describes which processors a thread may run on as a bit per processor,
-packed into an array of machine words. The width of that array is not fixed by the operating
-system: the caller allocates the array and passes its size along on every call. The fixed-size
-type that the C library offers for this purpose (`cpu_set_t` on Linux) is a convenience for the
-common case and not the limit of what the kernel supports; it describes a machine of a
-particular size and nothing larger. Machines larger than that exist and are rented by the hour,
-so the package represents a mask as a sequence of machine words whose width it chooses.
-
-The mask keeps as many words inline as the platform's own fixed-size type holds, and spills to
-the heap only beyond that. Every machine that the C library could have described therefore
-imposes no allocation, and only machines it could not describe at all pay for one.
-
-Counting a mask in words rather than bytes is not a stylistic choice: the operating system
-rejects a mask whose size is not a whole number of machine words, so making a word the unit of
-width means the requirement cannot be violated. It also makes the buffer's alignment correct by
-construction.
-
-### Reading an affinity mask
-
-The operating system refuses to report an affinity mask into a buffer too narrow to describe
-every processor it knows of, and it reports that refusal as a plain invalid-argument error
-without saying how wide the buffer needs to be. Nor can the required width be computed from the
-hardware inventory: the operating system sizes its answer by the processors it could ever have,
-which includes processors that are absent, offline, or forbidden to the process. A container
-restricted to a handful of processors on a very large host is still answered in the host's
-terms.
-
-The only way to learn the required width is therefore to offer wider and wider masks until one
-is accepted. The search doubles the width each time so that the number of attempts stays
-logarithmic in the size of the machine, and it makes a fixed number of attempts so that it
-always ends: the final width describes a machine far larger than operating systems support, so
-reaching the end means something other than a large machine is wrong, and the error that the
-last attempt produced is reported rather than a conclusion of our own. An invalid-argument error
-has causes other than a narrow mask — a sandbox may forbid the call outright — which is why that
-error is preserved and why any other error ends the search immediately.
-
-A width that the operating system accepted is remembered and tried first next time. It is a
-hint and not a conclusion: a process can outlive a change in the machine it runs on, so a width
-that stops working merely sends the search widening again from there.
-
-Writing a mask needs none of this. The operating system accepts a mask of any width when setting
-affinity and treats the processors beyond it as absent from the set, so a write is a single call
-with a mask wide enough for the processors it names.
-
-### Comparing masks
-
-Two masks that name the same processors are the same set even when one of them is wider, so
-mask comparison ignores width. Width is a property of the buffer handed to the operating system,
-not of the set. A consequence is that comparing masks says nothing about how wide a mask was —
-tests that care about the width of a request must inspect the width itself.
+* [Linux](linux.md)

--- a/packages/many_cpus/docs/linux.md
+++ b/packages/many_cpus/docs/linux.md
@@ -1,0 +1,56 @@
+# many_cpus on Linux
+
+The Linux implementation of the platform abstraction layer described in
+[implementation.md](implementation.md). This document covers the parts of it whose reasoning is
+not evident from the code alone.
+
+## Thread affinity masks
+
+Linux describes which processors a thread may run on as a bit per processor, packed into an
+array of machine words. The width of that array is not fixed by the kernel: the caller allocates
+the array and passes its size along on every call. The fixed-size `cpu_set_t` that the C library
+offers for this purpose is a convenience for the common case and not the limit of what the
+kernel supports; it describes a machine of a particular size and nothing larger. Machines larger
+than that exist and are rented by the hour, so the package represents a mask as a sequence of
+machine words whose width it chooses.
+
+The mask keeps as many words inline as `cpu_set_t` holds, and spills to the heap only beyond
+that. Every machine that the C library could have described therefore imposes no allocation, and
+only machines it could not describe at all pay for one.
+
+Counting a mask in words rather than bytes is not a stylistic choice: the kernel rejects a mask
+whose size is not a whole number of machine words, so making a word the unit of width means the
+requirement cannot be violated. It also makes the buffer's alignment correct by construction.
+
+### Reading an affinity mask
+
+The kernel refuses to report an affinity mask into a buffer too narrow to describe every
+processor it knows of, and it reports that refusal as a plain invalid-argument error without
+saying how wide the buffer needs to be. Nor can the required width be computed from the hardware
+inventory: the kernel sizes its answer by the processors it could ever have, which includes
+processors that are absent, offline, or forbidden to the process. A container restricted to a
+handful of processors on a very large host is still answered in the host's terms.
+
+The only way to learn the required width is therefore to offer wider and wider masks until one
+is accepted. The search doubles the width each time so that the number of attempts stays
+logarithmic in the size of the machine, and it makes a fixed number of attempts so that it
+always ends: the final width describes a machine far larger than operating systems support, so
+reaching the end means something other than a large machine is wrong, and the error that the
+last attempt produced is reported rather than a conclusion of our own. An invalid-argument error
+has causes other than a narrow mask — a sandbox may forbid the call outright — which is why that
+error is preserved and why any other error ends the search immediately.
+
+A width that the kernel accepted is remembered and tried first next time. It is a hint and not a
+conclusion: a process can outlive a change in the machine it runs on, so a width that stops
+working merely sends the search widening again from there.
+
+Writing a mask needs none of this. The kernel accepts a mask of any width when setting affinity
+and treats the processors beyond it as absent from the set, so a write is a single call with a
+mask wide enough for the processors it names.
+
+### Comparing masks
+
+Two masks that name the same processors are the same set even when one of them is wider, so
+mask comparison ignores width. Width is a property of the buffer handed to the kernel, not of
+the set. A consequence is that comparing masks says nothing about how wide a mask was — tests
+that care about the width of a request must inspect the width itself.

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -33,8 +33,6 @@ itertools = { workspace = true }
 new_zealand = { workspace = true }
 nonempty = { workspace = true }
 rand = { workspace = true, features = ["thread_rng"] }
-
-[target.'cfg(any(target_os = "linux", windows))'.dependencies]
 smallvec = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -34,13 +34,15 @@ new_zealand = { workspace = true }
 nonempty = { workspace = true }
 rand = { workspace = true, features = ["thread_rng"] }
 
+[target.'cfg(any(target_os = "linux", windows))'.dependencies]
+smallvec = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 folo_ffi = { workspace = true }
 heapless = { workspace = true }
-smallvec = { workspace = true }
 windows = { workspace = true, features = [
     "Win32_System_JobObjects",
     "Win32_System_Kernel",

--- a/packages/many_cpus_impl/src/pal/linux.rs
+++ b/packages/many_cpus_impl/src/pal/linux.rs
@@ -1,9 +1,11 @@
 mod bindings;
+mod cpu_mask;
 mod filesystem;
 mod platform;
 mod processor;
 
 use bindings::*;
+use cpu_mask::*;
 use filesystem::*;
 pub(crate) use platform::*;
 pub(crate) use processor::*;

--- a/packages/many_cpus_impl/src/pal/linux/bindings/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/abstractions.rs
@@ -8,8 +8,9 @@
 
 use std::fmt::Debug;
 use std::io;
+use std::num::NonZero;
 
-use libc::cpu_set_t;
+use crate::pal::linux::CpuMask;
 
 /// Bindings for FFI calls into external libraries (either provided by operating system or not).
 ///
@@ -17,10 +18,13 @@ use libc::cpu_set_t;
 #[cfg_attr(test, mockall::automock)]
 pub(crate) trait Bindings: Debug + Send + Sync + 'static {
     // sched_setaffinity() for the current thread
-    fn sched_setaffinity_current(&self, cpuset: &cpu_set_t) -> Result<(), io::Error>;
+    fn sched_setaffinity_current(&self, mask: &CpuMask) -> Result<(), io::Error>;
 
-    // sched_getaffinity() for the current thread
-    fn sched_getaffinity_current(&self) -> Result<cpu_set_t, io::Error>;
+    /// `sched_getaffinity()` for the current thread, into a mask of the requested width.
+    ///
+    /// The operating system refuses to fill a mask that is too narrow to describe every
+    /// processor that it knows of, so the width is the caller's choice to make and to correct.
+    fn sched_getaffinity_current(&self, words: NonZero<usize>) -> Result<CpuMask, io::Error>;
 
     fn sched_getcpu(&self) -> i32;
 }

--- a/packages/many_cpus_impl/src/pal/linux/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/facade.rs
@@ -2,14 +2,13 @@
 
 use std::fmt::Debug;
 use std::io;
+use std::num::NonZero;
 #[cfg(test)]
 use std::sync::Arc;
 
-use libc::cpu_set_t;
-
 #[cfg(test)]
 use crate::pal::linux::MockBindings;
-use crate::pal::linux::{Bindings, BuildTargetBindings};
+use crate::pal::linux::{Bindings, BuildTargetBindings, CpuMask};
 
 /// Enum to hide the real/mock choice behind a single wrapper type.
 #[derive(Clone)]
@@ -32,11 +31,11 @@ impl BindingsFacade {
 }
 
 impl Bindings for BindingsFacade {
-    fn sched_setaffinity_current(&self, cpuset: &cpu_set_t) -> Result<(), io::Error> {
+    fn sched_setaffinity_current(&self, mask: &CpuMask) -> Result<(), io::Error> {
         match self {
-            Self::Target(bindings) => bindings.sched_setaffinity_current(cpuset),
+            Self::Target(bindings) => bindings.sched_setaffinity_current(mask),
             #[cfg(test)]
-            Self::Mock(mock) => mock.sched_setaffinity_current(cpuset),
+            Self::Mock(mock) => mock.sched_setaffinity_current(mask),
         }
     }
 
@@ -48,11 +47,11 @@ impl Bindings for BindingsFacade {
         }
     }
 
-    fn sched_getaffinity_current(&self) -> Result<cpu_set_t, io::Error> {
+    fn sched_getaffinity_current(&self, words: NonZero<usize>) -> Result<CpuMask, io::Error> {
         match self {
-            Self::Target(bindings) => bindings.sched_getaffinity_current(),
+            Self::Target(bindings) => bindings.sched_getaffinity_current(words),
             #[cfg(test)]
-            Self::Mock(mock) => mock.sched_getaffinity_current(),
+            Self::Mock(mock) => mock.sched_getaffinity_current(words),
         }
     }
 }

--- a/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
@@ -110,7 +110,7 @@ mod tests {
                 Err(error) => {
                     // The only rejection we expect is the one that says the mask is too narrow.
                     // Any other rejection would mean the search rests on a false premise.
-                    assert_eq!(error.raw_os_error(), Some(libc::EINVAL), "{error}");
+                    assert_eq!(error.raw_os_error(), Some(libc::EINVAL));
                 }
             }
         }
@@ -122,11 +122,10 @@ mod tests {
     fn affinity_is_readable_once_the_mask_is_wide_enough() {
         let (_, mask) = read_affinity_by_widening();
 
-        let current_processor = ProcessorId::try_from(BuildTargetBindings.sched_getcpu())
-            .expect("the current thread runs on a processor with a valid identifier");
+        let current_processor = ProcessorId::try_from(BuildTargetBindings.sched_getcpu()).unwrap();
 
         // A thread is always allowed to run where it is already running.
-        assert!(mask.contains(current_processor), "{mask:?}");
+        assert!(mask.contains(current_processor));
     }
 
     #[test]
@@ -137,7 +136,7 @@ mod tests {
         // test, while still exercising the full path into the operating system.
         BuildTargetBindings
             .sched_setaffinity_current(&mask)
-            .expect("the operating system accepts the affinity it just reported");
+            .unwrap();
     }
 
     #[test]
@@ -147,11 +146,11 @@ mod tests {
         // beyond the fixed-size mask exercises it on every machine.
         let words = CpuMask::default_words()
             .checked_mul(OVERSIZED_MASK_GROWTH)
-            .expect("a mask a few times the platform mask cannot overflow a machine word");
+            .unwrap();
 
         let mask = BuildTargetBindings
             .sched_getaffinity_current(words)
-            .expect("a mask wider than the operating system needs is wide enough for it");
+            .unwrap();
 
         assert_eq!(mask.words(), words);
 
@@ -161,6 +160,6 @@ mod tests {
 
         BuildTargetBindings
             .sched_setaffinity_current(&mask)
-            .expect("the operating system accepts the affinity it just reported");
+            .unwrap();
     }
 }

--- a/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
@@ -2,9 +2,19 @@ use std::fmt::Debug;
 use std::io;
 use std::num::NonZero;
 
-use libc::cpu_set_t;
+use libc::{c_ulong, cpu_set_t};
 
 use crate::pal::linux::{Bindings, CpuMask};
+
+/// The bindings hand a mask to the C API where the C API's own fixed-size mask type is expected.
+/// A mask is a sequence of machine words and the fixed-size mask is the same sequence under
+/// another name, so a pointer into one is aligned for the other. That is a property of the ABI
+/// rather than something we control, so it is pinned here: an ABI that ever stops defining its
+/// mask in terms of machine words breaks the build rather than the pointer.
+const _: () = assert!(
+    align_of::<cpu_set_t>() <= align_of::<c_ulong>(),
+    "a mask must be aligned for the fixed-size mask type that it stands in for"
+);
 
 /// FFI bindings that target the real operating system that the build is targeting.
 ///
@@ -21,8 +31,7 @@ impl Bindings for BuildTargetBindings {
     fn sched_setaffinity_current(&self, mask: &CpuMask) -> Result<(), io::Error> {
         // The mask is typed as `cpu_set_t` in the C API but the operating system only ever
         // touches the number of bytes we declare, so a mask of any width may be passed as long
-        // as its size accompanies it. A mask is a sequence of machine words, so it satisfies the
-        // alignment that `cpu_set_t` demands.
+        // as its size accompanies it. Alignment is guaranteed by the assertion above.
         let mask_ptr = mask.as_ptr().cast::<cpu_set_t>();
 
         // 0 means current thread.

--- a/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
@@ -1,9 +1,10 @@
 use std::fmt::Debug;
-use std::{io, mem};
+use std::io;
+use std::num::NonZero;
 
 use libc::cpu_set_t;
 
-use crate::pal::linux::Bindings;
+use crate::pal::linux::{Bindings, CpuMask};
 
 /// FFI bindings that target the real operating system that the build is targeting.
 ///
@@ -17,10 +18,17 @@ pub(crate) struct BuildTargetBindings;
 // 2. Error paths require OS-level failures that are impractical to trigger in tests.
 #[cfg_attr(coverage_nightly, coverage(off))]
 impl Bindings for BuildTargetBindings {
-    fn sched_setaffinity_current(&self, cpuset: &cpu_set_t) -> Result<(), io::Error> {
+    fn sched_setaffinity_current(&self, mask: &CpuMask) -> Result<(), io::Error> {
+        // The mask is typed as `cpu_set_t` in the C API but the operating system only ever
+        // touches the number of bytes we declare, so a mask of any width may be passed as long
+        // as its size accompanies it. A mask is a sequence of machine words, so it satisfies the
+        // alignment that `cpu_set_t` demands.
+        let mask_ptr = mask.as_ptr().cast::<cpu_set_t>();
+
         // 0 means current thread.
-        // SAFETY: No safety requirements beyond passing valid arguments.
-        let result = unsafe { libc::sched_setaffinity(0, size_of::<cpu_set_t>(), cpuset) };
+        // SAFETY: The mask is a valid buffer of the size we declare, for as long as the call
+        // lasts, and the operating system reads no more than that.
+        let result = unsafe { libc::sched_setaffinity(0, mask.len_bytes(), mask_ptr) };
 
         if result == 0 {
             Ok(())
@@ -34,18 +42,87 @@ impl Bindings for BuildTargetBindings {
         unsafe { libc::sched_getcpu() }
     }
 
-    fn sched_getaffinity_current(&self) -> Result<cpu_set_t, io::Error> {
-        // SAFETY: All zeroes is a valid cpu_set_t.
-        let mut cpuset: cpu_set_t = unsafe { mem::zeroed() };
+    fn sched_getaffinity_current(&self, words: NonZero<usize>) -> Result<CpuMask, io::Error> {
+        let mut mask = CpuMask::with_words(words);
+        let len_bytes = mask.len_bytes();
+
+        // See `sched_setaffinity_current` for why a mask may stand in for a `cpu_set_t`.
+        let mask_ptr = mask.as_mut_ptr().cast::<cpu_set_t>();
 
         // 0 means current thread.
-        // SAFETY: No safety requirements beyond passing valid arguments.
-        let result = unsafe { libc::sched_getaffinity(0, size_of::<cpu_set_t>(), &raw mut cpuset) };
+        // SAFETY: The mask is a valid buffer of the size we declare, for as long as the call
+        // lasts, and the operating system writes no more than that.
+        let result = unsafe { libc::sched_getaffinity(0, len_bytes, mask_ptr) };
 
         if result == 0 {
-            Ok(cpuset)
+            Ok(mask)
         } else {
             Err(io::Error::last_os_error())
         }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::iter;
+
+    use new_zealand::nz;
+
+    use super::*;
+    use crate::ProcessorId;
+
+    /// How many mask widths a test may try before concluding that the operating system is not
+    /// going to accept any of them. The last one describes more processors than any machine has,
+    /// so reaching the end means something is wrong rather than that the machine is large.
+    const MASK_WIDTH_ATTEMPTS: usize = 20;
+
+    /// The narrowest mask that the operating system may be asked to fill.
+    const NARROWEST_MASK: NonZero<usize> = nz!(1);
+
+    /// Ratio between one mask width and the next one to try.
+    const MASK_GROWTH: NonZero<usize> = nz!(2);
+
+    /// Reads the affinity of the current thread the way the platform does, and reports how wide
+    /// the mask had to be, so that tests can assert on the search as well as on its outcome.
+    fn read_affinity_by_widening() -> (NonZero<usize>, CpuMask) {
+        let bindings = BuildTargetBindings;
+
+        for words in iter::successors(Some(NARROWEST_MASK), |words| words.checked_mul(MASK_GROWTH))
+            .take(MASK_WIDTH_ATTEMPTS)
+        {
+            match bindings.sched_getaffinity_current(words) {
+                Ok(mask) => return (words, mask),
+                Err(error) => {
+                    // The only rejection we expect is the one that says the mask is too narrow.
+                    // Any other rejection would mean the search rests on a false premise.
+                    assert_eq!(error.raw_os_error(), Some(libc::EINVAL), "{error}");
+                }
+            }
+        }
+
+        panic!("the operating system accepted no mask, however wide");
+    }
+
+    #[test]
+    fn affinity_is_readable_once_the_mask_is_wide_enough() {
+        let (_, mask) = read_affinity_by_widening();
+
+        let current_processor = ProcessorId::try_from(BuildTargetBindings.sched_getcpu())
+            .expect("the current thread runs on a processor with a valid identifier");
+
+        // A thread is always allowed to run where it is already running.
+        assert!(mask.contains(current_processor), "{mask:?}");
+    }
+
+    #[test]
+    fn affinity_is_writable_in_the_width_the_operating_system_offered() {
+        let (_, mask) = read_affinity_by_widening();
+
+        // Writing back the mask we just read changes nothing, which makes it safe to do in a
+        // test, while still exercising the full path into the operating system.
+        BuildTargetBindings
+            .sched_setaffinity_current(&mask)
+            .expect("the operating system accepts the affinity it just reported");
     }
 }

--- a/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/real.rs
@@ -83,6 +83,11 @@ mod tests {
     /// Ratio between one mask width and the next one to try.
     const MASK_GROWTH: NonZero<usize> = nz!(2);
 
+    /// How much wider than the platform's own fixed-size mask a deliberately oversized mask is.
+    /// Any factor above one exercises the same path; this one keeps the mask small enough that
+    /// its cost is irrelevant.
+    const OVERSIZED_MASK_GROWTH: NonZero<usize> = nz!(4);
+
     /// Reads the affinity of the current thread the way the platform does, and reports how wide
     /// the mask had to be, so that tests can assert on the search as well as on its outcome.
     fn read_affinity_by_widening() -> (NonZero<usize>, CpuMask) {
@@ -121,6 +126,30 @@ mod tests {
 
         // Writing back the mask we just read changes nothing, which makes it safe to do in a
         // test, while still exercising the full path into the operating system.
+        BuildTargetBindings
+            .sched_setaffinity_current(&mask)
+            .expect("the operating system accepts the affinity it just reported");
+    }
+
+    #[test]
+    fn a_mask_wider_than_the_fixed_size_one_reaches_the_operating_system_intact() {
+        // Exceeding the platform's own fixed-size mask is the entire point of the type, yet only
+        // a machine large enough to demand it would otherwise take that path. Asking for a width
+        // beyond the fixed-size mask exercises it on every machine.
+        let words = CpuMask::default_words()
+            .checked_mul(OVERSIZED_MASK_GROWTH)
+            .expect("a mask a few times the platform mask cannot overflow a machine word");
+
+        let mask = BuildTargetBindings
+            .sched_getaffinity_current(words)
+            .expect("a mask wider than the operating system needs is wide enough for it");
+
+        assert_eq!(mask.words(), words);
+
+        // A wider buffer must not change the answer, only where there is room to put it.
+        let (_, reference) = read_affinity_by_widening();
+        assert_eq!(mask, reference);
+
         BuildTargetBindings
             .sched_setaffinity_current(&mask)
             .expect("the operating system accepts the affinity it just reported");

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -1,3 +1,4 @@
+use std::any::type_name;
 use std::fmt::{self, Debug, Formatter};
 use std::num::NonZero;
 
@@ -122,6 +123,12 @@ impl CpuMask {
             .iter()
             .copied()
             .enumerate()
+            // The width of a mask is chosen by the operating system and can far exceed the
+            // processors in it: a process confined to a few processors on a very large machine
+            // is still answered in the machine's terms. Empty words are therefore the common
+            // case on exactly the machines this mask exists for, and skipping them keeps the
+            // cost of a read close to the number of processors rather than the width.
+            .filter(|(_, bits)| *bits != EMPTY_WORD)
             .flat_map(|(word, bits)| {
                 (0..WORD_BITS)
                     .map(move |offset| BitPosition { word, offset })
@@ -222,7 +229,7 @@ impl Debug for CpuMask {
         write!(
             f,
             "{}({})",
-            std::any::type_name::<Self>(),
+            type_name::<Self>(),
             cpulist::emit(self.processor_ids())
         )
     }
@@ -306,14 +313,21 @@ mod tests {
     #[test]
     fn processor_beyond_inline_width_widens_the_mask() {
         let mut mask = CpuMask::new();
+        mask.insert(0);
+        mask.insert(LAST_INLINE_PROCESSOR);
 
         mask.insert(INLINE_BITS);
 
         assert!(mask.contains(INLINE_BITS));
         assert_eq!(mask.words().get(), INLINE_WORDS + 1);
 
-        // The processors that were already representable are unaffected by the widening.
-        assert!(!mask.contains(LAST_INLINE_PROCESSOR));
+        // Widening moves no bits: the processors already in the mask are still in it.
+        assert!(mask.contains(0));
+        assert!(mask.contains(LAST_INLINE_PROCESSOR));
+        assert_eq!(
+            mask.processor_ids().collect::<Vec<_>>(),
+            vec![0, LAST_INLINE_PROCESSOR, INLINE_BITS]
+        );
     }
 
     #[test]
@@ -388,8 +402,8 @@ mod tests {
 
         let rendered = format!("{mask:?}");
 
-        assert!(rendered.contains("0-2"), "{rendered}");
-        assert!(rendered.contains('5'), "{rendered}");
+        assert!(rendered.contains("0-2"));
+        assert!(rendered.contains('5'));
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -14,8 +14,8 @@ use crate::ProcessorId;
 /// in terms of processor identifiers.
 ///
 /// Small masks live on the stack and only sufficiently large ones reach for the heap. See
-/// `packages/many_cpus/docs/implementation.md`, "Thread affinity masks", for why the mask is
-/// counted in words and why the inline capacity is the size that it is.
+/// `packages/many_cpus/docs/linux.md`, "Thread affinity masks", for why the mask is counted in
+/// words and why the inline capacity is the size that it is.
 #[derive(Clone)]
 pub(crate) struct CpuMask {
     words: SmallVec<[c_ulong; INLINE_WORDS]>,

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -438,12 +438,15 @@ mod tests {
         }
 
         // SAFETY: A `cpu_set_t` holds no padding, so all of its bytes are initialized, and the
-        // borrow keeps it alive for as long as the slice.
+        // borrow keeps it alive for as long as the slice. `expected` is a local that nothing
+        // mutates while `expected_bytes` is live, so the shared borrow has no aliasing conflict.
         let expected_bytes = unsafe {
             slice::from_raw_parts((&raw const expected).cast::<u8>(), size_of::<cpu_set_t>())
         };
 
-        // SAFETY: The mask owns this many initialized bytes and outlives the slice.
+        // SAFETY: The mask owns this many initialized bytes and outlives the slice. `mask` is a
+        // local that nothing mutates while `actual_bytes` is live, so the shared borrow has no
+        // aliasing conflict.
         let actual_bytes =
             unsafe { slice::from_raw_parts(mask.as_ptr().cast::<u8>(), mask.len_bytes()) };
 

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -83,9 +83,10 @@ impl CpuMask {
             .checked_add(1)
             .expect("a processor identifier is a u32, so its word index cannot overflow a usize");
 
-        if self.words.len() < required_words {
-            self.words.resize(required_words, EMPTY_WORD);
-        }
+        // A mask never becomes narrower, because its width may be one that the operating system
+        // demanded rather than one that the processors in it call for.
+        self.words
+            .resize(self.words.len().max(required_words), EMPTY_WORD);
 
         let word = self
             .words

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -1,0 +1,391 @@
+use std::fmt::{self, Debug, Formatter};
+use std::num::NonZero;
+
+use libc::{c_ulong, cpu_set_t};
+use smallvec::{SmallVec, smallvec};
+
+use crate::ProcessorId;
+
+/// A set of processors, in the shape that the operating system's thread affinity API expects.
+///
+/// The kernel expresses thread affinity as a bit per processor, packed into an array of machine
+/// words, whose length in bytes the caller provides on every call. This type owns such an array
+/// and the bit arithmetic over it, so that the rest of the platform abstraction layer can speak
+/// in terms of processor identifiers.
+///
+/// Small masks live on the stack and only sufficiently large ones reach for the heap. See
+/// `packages/many_cpus/docs/implementation.md`, "Thread affinity masks", for why the mask is
+/// counted in words and why the inline capacity is the size that it is.
+#[derive(Clone)]
+pub(crate) struct CpuMask {
+    words: SmallVec<[c_ulong; INLINE_WORDS]>,
+}
+
+/// Mask words kept inline, before a mask spills to the heap.
+///
+/// This matches the width of the fixed-size mask that the platform's own C API offers, so every
+/// machine that the platform can describe using that mask keeps the entire mask on the stack and
+/// only machines that the C API cannot describe at all pay for an allocation.
+const INLINE_WORDS: usize = size_of::<cpu_set_t>().div_euclid(size_of::<c_ulong>());
+
+/// Bits in one mask word.
+const WORD_BITS: u32 = c_ulong::BITS;
+
+/// A mask word with no processors in it.
+const EMPTY_WORD: c_ulong = 0;
+
+/// A mask word with only the lowest bit set, from which single-processor masks are built.
+const LOW_BIT: c_ulong = 1;
+
+impl CpuMask {
+    /// Creates a mask that contains no processors, wide enough for the processors that the
+    /// platform's own fixed-size mask can describe.
+    pub(crate) fn new() -> Self {
+        Self::with_words(Self::default_words())
+    }
+
+    /// The width of a mask that has not been asked to describe any particular processor.
+    pub(crate) fn default_words() -> NonZero<usize> {
+        NonZero::new(INLINE_WORDS).expect("the platform mask is at least one word wide")
+    }
+
+    /// Creates a mask that contains no processors, exactly `words` machine words wide.
+    ///
+    /// The width matters when the operating system fills the mask: it rejects a buffer that is
+    /// too narrow to describe every processor the kernel knows of.
+    pub(crate) fn with_words(words: NonZero<usize>) -> Self {
+        Self {
+            words: smallvec![EMPTY_WORD; words.get()],
+        }
+    }
+
+    /// The width of the mask in machine words.
+    #[cfg(test)]
+    pub(crate) fn words(&self) -> NonZero<usize> {
+        NonZero::new(self.words.len())
+            .expect("a mask is created at least one word wide and never becomes narrower")
+    }
+
+    /// The size of the mask in bytes, which is what the operating system asks for.
+    pub(crate) fn len_bytes(&self) -> usize {
+        self.words
+            .len()
+            .checked_mul(size_of::<c_ulong>())
+            .expect("the mask occupies this many bytes of memory already, so this cannot overflow")
+    }
+
+    /// Adds a processor to the mask, widening the mask if the processor does not fit.
+    pub(crate) fn insert(&mut self, processor_id: ProcessorId) {
+        let position = BitPosition::of(processor_id);
+
+        let required_words = position
+            .word
+            .checked_add(1)
+            .expect("a processor identifier is a u32, so its word index cannot overflow a usize");
+
+        if self.words.len() < required_words {
+            self.words.resize(required_words, EMPTY_WORD);
+        }
+
+        let word = self
+            .words
+            .get_mut(position.word)
+            .expect("the mask was just widened to include this word");
+
+        *word |= position.bit();
+    }
+
+    /// Whether the mask contains a processor.
+    ///
+    /// A processor that lies beyond the width of the mask is not in the mask.
+    #[cfg(test)]
+    pub(crate) fn contains(&self, processor_id: ProcessorId) -> bool {
+        let position = BitPosition::of(processor_id);
+
+        self.words
+            .get(position.word)
+            .is_some_and(|word| word & position.bit() != EMPTY_WORD)
+    }
+
+    /// The processors in the mask, in ascending order.
+    pub(crate) fn processor_ids(&self) -> impl Iterator<Item = ProcessorId> {
+        self.words
+            .iter()
+            .copied()
+            .enumerate()
+            .flat_map(|(word, bits)| {
+                (0..WORD_BITS)
+                    .map(move |offset| BitPosition { word, offset })
+                    .filter(move |position| bits & position.bit() != EMPTY_WORD)
+                    .map(BitPosition::processor_id)
+            })
+    }
+
+    /// A pointer to the start of the mask, for handing to the operating system.
+    pub(crate) fn as_ptr(&self) -> *const c_ulong {
+        self.words.as_ptr()
+    }
+
+    /// A pointer to the start of the mask, for the operating system to fill.
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut c_ulong {
+        self.words.as_mut_ptr()
+    }
+
+    /// The word at an index, with words beyond the mask reading as empty.
+    ///
+    /// Padding a narrow mask with empty words is what lets masks of different widths describe
+    /// the same set of processors.
+    fn word(&self, index: usize) -> c_ulong {
+        self.words.get(index).copied().unwrap_or(EMPTY_WORD)
+    }
+}
+
+/// Where a processor's bit sits in a mask.
+#[derive(Clone, Copy, Debug)]
+struct BitPosition {
+    /// The word that holds the bit.
+    word: usize,
+
+    /// The bit within that word.
+    offset: u32,
+}
+
+impl BitPosition {
+    /// Locates the bit that represents a processor.
+    fn of(processor_id: ProcessorId) -> Self {
+        let word = processor_id
+            .checked_div(WORD_BITS)
+            .expect("a machine word is never zero bits wide");
+
+        let offset = processor_id
+            .checked_rem(WORD_BITS)
+            .expect("a machine word is never zero bits wide");
+
+        Self {
+            word: word as usize,
+            offset,
+        }
+    }
+
+    /// A word in which only this position's bit is set.
+    fn bit(self) -> c_ulong {
+        LOW_BIT
+            .checked_shl(self.offset)
+            .expect("the offset is a remainder of the word width, so it is within the word")
+    }
+
+    /// The processor that this position represents.
+    fn processor_id(self) -> ProcessorId {
+        let first_in_word = ProcessorId::try_from(self.word)
+            .ok()
+            .and_then(|word| word.checked_mul(WORD_BITS))
+            .expect("masks only ever cover processors whose identifiers fit in a ProcessorId");
+
+        first_in_word
+            .checked_add(self.offset)
+            .expect("masks only ever cover processors whose identifiers fit in a ProcessorId")
+    }
+}
+
+impl PartialEq for CpuMask {
+    /// Masks are equal when they contain the same processors, whatever their widths.
+    ///
+    /// Width is a property of the buffer handed to the operating system, not of the set of
+    /// processors that the mask describes, so it does not take part in the comparison.
+    fn eq(&self, other: &Self) -> bool {
+        let words = self.words.len().max(other.words.len());
+
+        (0..words).all(|index| self.word(index) == other.word(index))
+    }
+}
+
+impl Eq for CpuMask {}
+
+impl Default for CpuMask {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Debug for CpuMask {
+    /// Renders the processors in the mask, as the raw words say little to a reader.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}({})",
+            std::any::type_name::<Self>(),
+            cpulist::emit(self.processor_ids())
+        )
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use new_zealand::nz;
+    use static_assertions::assert_impl_all;
+
+    use super::*;
+
+    assert_impl_all!(CpuMask: UnwindSafe, RefUnwindSafe);
+
+    /// The processor count that the inline part of a mask describes.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the inline width is a handful of words, so it fits in any integer type"
+    )]
+    const INLINE_BITS: ProcessorId = INLINE_WORDS as ProcessorId * WORD_BITS;
+
+    /// The highest processor that fits in a mask of the inline width.
+    const LAST_INLINE_PROCESSOR: ProcessorId = INLINE_BITS - 1;
+
+    #[test]
+    fn new_mask_is_empty_and_inline() {
+        let mask = CpuMask::new();
+
+        assert_eq!(mask.words().get(), INLINE_WORDS);
+        assert_eq!(mask.processor_ids().count(), 0);
+        assert!(!mask.contains(0));
+    }
+
+    #[test]
+    fn with_words_uses_exactly_the_requested_width() {
+        let mask = CpuMask::with_words(nz!(1));
+
+        assert_eq!(mask.words().get(), 1);
+        assert_eq!(mask.len_bytes(), size_of::<c_ulong>());
+    }
+
+    #[test]
+    fn len_bytes_is_a_whole_number_of_words() {
+        // The operating system rejects a mask whose size is not a whole number of words, so this
+        // is a contract with the kernel and not merely an implementation detail.
+        for words in [1_usize, 3, INLINE_WORDS, INLINE_WORDS * 2] {
+            let mask = CpuMask::with_words(NonZero::new(words).unwrap());
+
+            assert_eq!(mask.len_bytes() % size_of::<c_ulong>(), 0);
+            assert_eq!(mask.len_bytes(), words * size_of::<c_ulong>());
+        }
+    }
+
+    #[test]
+    fn insert_and_contains_agree() {
+        let mut mask = CpuMask::new();
+
+        mask.insert(0);
+        mask.insert(1);
+        mask.insert(LAST_INLINE_PROCESSOR);
+
+        assert!(mask.contains(0));
+        assert!(mask.contains(1));
+        assert!(mask.contains(LAST_INLINE_PROCESSOR));
+        assert!(!mask.contains(2));
+    }
+
+    #[test]
+    fn inline_processors_do_not_widen_the_mask() {
+        let mut mask = CpuMask::new();
+
+        mask.insert(LAST_INLINE_PROCESSOR);
+
+        assert_eq!(mask.words().get(), INLINE_WORDS);
+    }
+
+    #[test]
+    fn processor_beyond_inline_width_widens_the_mask() {
+        let mut mask = CpuMask::new();
+
+        mask.insert(INLINE_BITS);
+
+        assert!(mask.contains(INLINE_BITS));
+        assert_eq!(mask.words().get(), INLINE_WORDS + 1);
+
+        // The processors that were already representable are unaffected by the widening.
+        assert!(!mask.contains(LAST_INLINE_PROCESSOR));
+    }
+
+    #[test]
+    fn far_away_processor_widens_the_mask_to_fit() {
+        let mut mask = CpuMask::new();
+        let processor_id = INLINE_BITS * 4;
+
+        mask.insert(processor_id);
+
+        assert!(mask.contains(processor_id));
+        assert_eq!(mask.processor_ids().collect::<Vec<_>>(), vec![processor_id]);
+    }
+
+    #[test]
+    fn contains_beyond_mask_width_is_false() {
+        let mask = CpuMask::with_words(nz!(1));
+
+        assert!(!mask.contains(WORD_BITS));
+        assert!(!mask.contains(ProcessorId::MAX));
+    }
+
+    #[test]
+    fn processor_ids_are_ascending() {
+        let mut mask = CpuMask::new();
+        let expected = vec![0, 1, WORD_BITS, LAST_INLINE_PROCESSOR, INLINE_BITS * 2];
+
+        // Insert out of order to prove that the order comes from the mask, not from the caller.
+        for processor_id in expected.iter().rev() {
+            mask.insert(*processor_id);
+        }
+
+        assert_eq!(mask.processor_ids().collect::<Vec<_>>(), expected);
+    }
+
+    #[test]
+    fn masks_of_different_widths_are_equal_when_they_hold_the_same_processors() {
+        let mut narrow = CpuMask::with_words(nz!(1));
+        narrow.insert(1);
+
+        let mut wide = CpuMask::with_words(nz!(64));
+        wide.insert(1);
+
+        assert_eq!(narrow, wide);
+        assert_eq!(wide, narrow);
+    }
+
+    #[test]
+    fn masks_holding_different_processors_are_not_equal() {
+        let mut narrow = CpuMask::with_words(nz!(1));
+        narrow.insert(1);
+
+        let mut wide = CpuMask::with_words(nz!(64));
+        wide.insert(1);
+        wide.insert(INLINE_BITS);
+
+        assert_ne!(narrow, wide);
+        assert_ne!(wide, narrow);
+    }
+
+    #[test]
+    fn default_mask_equals_new_mask() {
+        assert_eq!(CpuMask::default(), CpuMask::new());
+    }
+
+    #[test]
+    fn debug_names_the_processors() {
+        let mut mask = CpuMask::new();
+        mask.insert(0);
+        mask.insert(1);
+        mask.insert(2);
+        mask.insert(5);
+
+        let rendered = format!("{mask:?}");
+
+        assert!(rendered.contains("0-2"), "{rendered}");
+        assert!(rendered.contains('5'), "{rendered}");
+    }
+
+    #[test]
+    fn inline_width_matches_the_platform_mask() {
+        // The whole point of the inline width is that a mask of the size the platform's C API
+        // offers needs no allocation, so guard that relationship.
+        assert_eq!(CpuMask::new().len_bytes(), size_of::<cpu_set_t>());
+    }
+}

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -224,6 +224,7 @@ impl Debug for CpuMask {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::panic::{RefUnwindSafe, UnwindSafe};
+    use std::{mem, slice};
 
     use new_zealand::nz;
     use static_assertions::assert_impl_all;
@@ -388,5 +389,42 @@ mod tests {
         // The whole point of the inline width is that a mask of the size the platform's C API
         // offers needs no allocation, so guard that relationship.
         assert_eq!(CpuMask::new().len_bytes(), size_of::<cpu_set_t>());
+    }
+
+    #[test]
+    fn mask_bytes_match_the_platform_mask() {
+        // The operating system, not this type, interprets the bits, so where a processor's bit
+        // lands is a contract with the platform. Every other test here both writes and reads the
+        // bits through this type, which cannot tell a correct layout apart from one that is
+        // merely self-consistent, so the layout is compared against the platform's own.
+        let processors = [0, 1, WORD_BITS - 1, WORD_BITS, LAST_INLINE_PROCESSOR];
+
+        // SAFETY: A `cpu_set_t` is an array of machine words, for which an all-zero bit pattern
+        // is valid and means that the set is empty.
+        let mut expected: cpu_set_t = unsafe { mem::zeroed() };
+
+        for processor in processors {
+            // SAFETY: Every processor here is one that the fixed-size mask can describe, which
+            // is what `CPU_SET` requires.
+            unsafe { libc::CPU_SET(processor as usize, &mut expected) }
+        }
+
+        let mut mask = CpuMask::new();
+
+        for processor in processors {
+            mask.insert(processor);
+        }
+
+        // SAFETY: A `cpu_set_t` holds no padding, so all of its bytes are initialized, and the
+        // borrow keeps it alive for as long as the slice.
+        let expected_bytes = unsafe {
+            slice::from_raw_parts((&raw const expected).cast::<u8>(), size_of::<cpu_set_t>())
+        };
+
+        // SAFETY: The mask owns this many initialized bytes and outlives the slice.
+        let actual_bytes =
+            unsafe { slice::from_raw_parts(mask.as_ptr().cast::<u8>(), mask.len_bytes()) };
+
+        assert_eq!(actual_bytes, expected_bytes);
     }
 }

--- a/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
+++ b/packages/many_cpus_impl/src/pal/linux/cpu_mask.rs
@@ -28,6 +28,14 @@ pub(crate) struct CpuMask {
 /// only machines that the C API cannot describe at all pay for an allocation.
 const INLINE_WORDS: usize = size_of::<cpu_set_t>().div_euclid(size_of::<c_ulong>());
 
+/// The inline width above accounts for the whole of the platform's own mask only while that mask
+/// is a whole number of machine words. Every ABI defines it that way, so this is pinned rather
+/// than handled: an ABI that ever stops doing so breaks the build rather than the arithmetic.
+const _: () = assert!(
+    size_of::<cpu_set_t>().is_multiple_of(size_of::<c_ulong>()),
+    "the platform's fixed-size mask must be a whole number of machine words"
+);
+
 /// Bits in one mask word.
 const WORD_BITS: u32 = c_ulong::BITS;
 

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -715,7 +715,7 @@ mod tests {
     use std::sync::Barrier;
     use std::{io, thread};
 
-    use testing::{assert_panics, f64_diff_abs};
+    use testing::{assert_panics, f64_diff_abs, with_watchdog};
 
     use super::*;
     use crate::pal::linux::{MockBindings, MockFilesystem};
@@ -1593,23 +1593,27 @@ mod tests {
         // Releasing every thread at once is what makes them contend for the remembered width.
         let start = Barrier::new(READER_COUNT);
 
-        thread::scope(|scope| {
-            for _ in 0..READER_COUNT {
-                scope.spawn(|| {
-                    start.wait();
+        // The barrier and thread joins block, so a scheduling or mutation defect could hang the
+        // test rather than fail it; the watchdog turns such a hang into a failure instead.
+        with_watchdog(move || {
+            thread::scope(|scope| {
+                for _ in 0..READER_COUNT {
+                    scope.spawn(|| {
+                        start.wait();
 
-                    for _ in 0..READS_PER_READER {
-                        assert_eq!(
-                            platform
-                                .current_thread_processors()
-                                .iter()
-                                .copied()
-                                .collect_vec(),
-                            affinity.to_vec()
-                        );
-                    }
-                });
-            }
+                        for _ in 0..READS_PER_READER {
+                            assert_eq!(
+                                platform
+                                    .current_thread_processors()
+                                    .iter()
+                                    .copied()
+                                    .collect_vec(),
+                                affinity.to_vec()
+                            );
+                        }
+                    });
+                }
+            });
         });
     }
 

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -38,11 +38,15 @@ pub(crate) struct BuildTargetPlatform {
 
     /// Width, in machine words, of the affinity mask that the operating system last accepted.
     ///
-    /// Zero means that no width has been established yet. This is a hint and not a conclusion:
-    /// the required width can grow while the process runs, so a width that stops working merely
-    /// sends the search widening again from there.
+    /// This is a hint and not a conclusion: the required width can grow while the process runs,
+    /// so a width that stops working merely sends the search widening again from there.
     affinity_mask_words: AtomicUsize,
 }
+
+/// The value of `affinity_mask_words` before the operating system has accepted any width.
+///
+/// A mask is never zero words wide, so zero cannot be mistaken for a width that worked.
+const AFFINITY_MASK_WIDTH_UNKNOWN: usize = 0;
 
 /// How many affinity mask widths to try before giving up on reading a thread's affinity.
 ///
@@ -136,7 +140,7 @@ impl BuildTargetPlatform {
             all_active_processors: OnceLock::new(),
             max_processor_id: OnceLock::new(),
             max_memory_region_id: OnceLock::new(),
-            affinity_mask_words: AtomicUsize::new(0),
+            affinity_mask_words: AtomicUsize::new(AFFINITY_MASK_WIDTH_UNKNOWN),
         }
     }
 
@@ -708,7 +712,8 @@ mod tests {
         reason = "we need not worry in tests"
     )]
     use std::fmt::Write;
-    use std::io;
+    use std::sync::Barrier;
+    use std::{io, thread};
 
     use testing::{assert_panics, f64_diff_abs};
 
@@ -1369,22 +1374,39 @@ mod tests {
         mask
     }
 
+    /// A mask as the operating system would have filled it: exactly as wide as it was asked to be.
+    ///
+    /// The real bindings hand over a buffer of the requested width and the operating system fills
+    /// that buffer, so it can never answer with a processor that the requested width cannot
+    /// describe. A mock that answers otherwise describes something that cannot happen, which
+    /// would let a test pass on an impossible response, so the width is enforced here.
+    fn mask_of_width<const PROCESSOR_COUNT: usize>(
+        words: NonZero<usize>,
+        processors: [ProcessorId; PROCESSOR_COUNT],
+    ) -> CpuMask {
+        let mut mask = CpuMask::with_words(words);
+
+        for processor in processors {
+            mask.insert(processor);
+            assert_eq!(mask.words(), words);
+        }
+
+        mask
+    }
+
     #[test]
     fn current_thread_processors_smoke_test() {
         let mut bindings = MockBindings::new();
 
-        let expected_mask_1 = mask_from([0, 1]);
-        let expected_mask_2 = mask_from([2]);
+        bindings
+            .expect_sched_getaffinity_current()
+            .times(1)
+            .returning(|words| Ok(mask_of_width(words, [0, 1])));
 
         bindings
             .expect_sched_getaffinity_current()
             .times(1)
-            .returning(move |_| Ok(expected_mask_1.clone()));
-
-        bindings
-            .expect_sched_getaffinity_current()
-            .times(1)
-            .returning(move |_| Ok(expected_mask_2.clone()));
+            .returning(|words| Ok(mask_of_width(words, [2])));
 
         let mut fs = MockFilesystem::new();
         simulate_processor_layout(
@@ -1425,7 +1447,7 @@ mod tests {
             .times(1)
             .returning(|_| Err(io::Error::from_raw_os_error(libc::EINVAL)));
 
-        let affinity = mask_from([1024, 1500, 2047]);
+        let affinity = [1024, 1500, 2047];
 
         // Both reads are expected to use the wider mask - the second one because the first one
         // already established the width that this operating system wants.
@@ -1433,7 +1455,7 @@ mod tests {
             .expect_sched_getaffinity_current()
             .withf(move |words| *words == wide)
             .times(2)
-            .returning(move |_| Ok(affinity.clone()));
+            .returning(move |words| Ok(mask_of_width(words, affinity)));
 
         let mut fs = MockFilesystem::new();
         simulate_processor_layout(
@@ -1467,15 +1489,17 @@ mod tests {
         let narrow = CpuMask::default_words();
         let wide = narrow.checked_mul(AFFINITY_MASK_GROWTH).unwrap();
 
-        let before = mask_from([1024]);
-        let after = mask_from([1024, 1500, 2047]);
+        // Every processor here fits in the narrower mask, which is what makes the first read
+        // succeed at that width.
+        let before = [0, 1023];
+        let after = [1024, 1500, 2047];
 
         // The first read settles on a width and it is remembered.
         bindings
             .expect_sched_getaffinity_current()
             .withf(move |words| *words == narrow)
             .times(1)
-            .returning(move |_| Ok(before.clone()));
+            .returning(move |words| Ok(mask_of_width(words, before)));
 
         // The machine can grow while the process runs, so a remembered width is a hint and not a
         // conclusion - once it stops working, the search must widen again rather than give up.
@@ -1489,7 +1513,7 @@ mod tests {
             .expect_sched_getaffinity_current()
             .withf(move |words| *words == wide)
             .times(1)
-            .returning(move |_| Ok(after.clone()));
+            .returning(move |words| Ok(mask_of_width(words, after)));
 
         let mut fs = MockFilesystem::new();
         simulate_processor_layout(
@@ -1512,7 +1536,7 @@ mod tests {
                 .iter()
                 .copied()
                 .collect_vec(),
-            vec![1024]
+            vec![0, 1023]
         );
 
         assert_eq!(
@@ -1526,17 +1550,97 @@ mod tests {
     }
 
     #[test]
-    fn current_thread_processors_ignores_processors_beyond_the_known_hardware() {
+    fn current_thread_processors_shares_the_remembered_width_across_threads() {
+        // The remembered width is the one piece of shared mutable state in the platform, so it
+        // is read and written concurrently in practice. Every thread must come away with the
+        // same answer no matter how their reads interleave.
+        const READER_COUNT: usize = 8;
+        const READS_PER_READER: usize = 16;
+
         let mut bindings = MockBindings::new();
 
-        // The operating system may know of processors that the hardware inventory does not, as
-        // the two are read at different moments.
-        let affinity = mask_from([1024, 4096]);
+        let narrow = CpuMask::default_words();
+        let wide = narrow.checked_mul(AFFINITY_MASK_GROWTH).unwrap();
+        let affinity = [1024, 1500, 2047];
+
+        // How many threads try the narrower width before one of them establishes the wider one
+        // depends on how the threads interleave, so no count is expected here.
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == narrow)
+            .returning(|_| Err(io::Error::from_raw_os_error(libc::EINVAL)));
 
         bindings
             .expect_sched_getaffinity_current()
+            .withf(move |words| *words == wide)
+            .returning(move |words| Ok(mask_of_width(words, affinity)));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(
+            &mut fs,
+            GIANT_MACHINE_PROCESSORS,
+            None,
+            None,
+            GIANT_MACHINE_MEMORY_REGIONS,
+            GIANT_MACHINE_BOGOMIPS,
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        // Releasing every thread at once is what makes them contend for the remembered width.
+        let start = Barrier::new(READER_COUNT);
+
+        thread::scope(|scope| {
+            for _ in 0..READER_COUNT {
+                scope.spawn(|| {
+                    start.wait();
+
+                    for _ in 0..READS_PER_READER {
+                        assert_eq!(
+                            platform
+                                .current_thread_processors()
+                                .iter()
+                                .copied()
+                                .collect_vec(),
+                            affinity.to_vec()
+                        );
+                    }
+                });
+            }
+        });
+    }
+
+    #[test]
+    fn current_thread_processors_ignores_processors_beyond_the_known_hardware() {
+        // The operating system sizes its answer by the processors it could ever have, which can
+        // exceed the processors that the hardware inventory lists, so it may name a processor
+        // that the inventory knows nothing about.
+        const UNKNOWN_PROCESSOR: ProcessorId = 3000;
+
+        let mut bindings = MockBindings::new();
+
+        // Naming a processor beyond the known hardware takes a mask wide enough to describe one,
+        // so the operating system here is one that demands a mask two widenings out.
+        let accepted = CpuMask::default_words()
+            .checked_mul(AFFINITY_MASK_GROWTH)
+            .unwrap()
+            .checked_mul(AFFINITY_MASK_GROWTH)
+            .unwrap();
+
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words < accepted)
+            .times(2)
+            .returning(|_| Err(io::Error::from_raw_os_error(libc::EINVAL)));
+
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == accepted)
             .times(1)
-            .returning(move |_| Ok(affinity.clone()));
+            .returning(|words| Ok(mask_of_width(words, [1024, UNKNOWN_PROCESSOR])));
 
         let mut fs = MockFilesystem::new();
         simulate_processor_layout(

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -49,8 +49,7 @@ pub(crate) struct BuildTargetPlatform {
 /// Each attempt doubles the width of the previous one, starting from a mask that already covers
 /// every processor that the platform's own fixed-size mask can describe, so the final attempt
 /// describes a machine far larger than operating systems support. The limit exists to guarantee
-/// that the search ends. Ref: `packages/many_cpus/docs/implementation.md`,
-/// "Thread affinity masks".
+/// that the search ends. Ref: `packages/many_cpus/docs/linux.md`, "Thread affinity masks".
 const AFFINITY_MASK_ATTEMPTS: usize = 11;
 
 /// Ratio between one affinity mask width that the operating system rejected and the next one to
@@ -146,7 +145,7 @@ impl BuildTargetPlatform {
     /// The operating system refuses to fill an affinity mask that is too narrow to describe
     /// every processor that it knows of, without saying how wide the mask needs to be, so the
     /// only way to learn the required width is to offer wider and wider masks until one is
-    /// accepted. Ref: `packages/many_cpus/docs/implementation.md`, "Thread affinity masks".
+    /// accepted. Ref: `packages/many_cpus/docs/linux.md`, "Thread affinity masks".
     fn get_current_thread_affinity(&self) -> CpuMask {
         let mut last_error = None;
 

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -1,14 +1,16 @@
 use std::borrow::Cow;
-use std::iter::once;
-use std::mem;
+use std::iter::{self, once};
+use std::num::NonZero;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use foldhash::HashMap;
 use itertools::Itertools;
+use new_zealand::nz;
 use nonempty::NonEmpty;
 
 use crate::pal::linux::filesystem::FilesystemFacade;
-use crate::pal::linux::{Bindings, BindingsFacade, Filesystem};
+use crate::pal::linux::{Bindings, BindingsFacade, CpuMask, Filesystem};
 use crate::pal::{Platform, ProcessorFacade, ProcessorImpl};
 use crate::{EfficiencyClass, MemoryRegionId, ProcessorId, RelativeSpeed};
 
@@ -33,7 +35,27 @@ pub(crate) struct BuildTargetPlatform {
 
     // Only active.
     all_active_processors: OnceLock<NonEmpty<ProcessorFacade>>,
+
+    /// Width, in machine words, of the affinity mask that the operating system last accepted.
+    ///
+    /// Zero means that no width has been established yet. This is a hint and not a conclusion:
+    /// the required width can grow while the process runs, so a width that stops working merely
+    /// starts the search again.
+    affinity_mask_words: AtomicUsize,
 }
+
+/// How many affinity mask widths to try before giving up on reading a thread's affinity.
+///
+/// Each attempt doubles the width of the previous one, starting from a mask that already covers
+/// every processor that the platform's own fixed-size mask can describe, so the final attempt
+/// describes more processors than any operating system can boot. The limit exists to guarantee
+/// that the search ends. Ref: `packages/many_cpus/docs/implementation.md`,
+/// "Thread affinity masks".
+const AFFINITY_MASK_ATTEMPTS: usize = 11;
+
+/// Ratio between one affinity mask width that the operating system rejected and the next one to
+/// try. Doubling keeps the number of attempts logarithmic in the size of the machine.
+const AFFINITY_MASK_GROWTH: NonZero<usize> = nz!(2);
 
 impl Platform for BuildTargetPlatform {
     fn get_all_processors(&self) -> NonEmpty<ProcessorFacade> {
@@ -44,20 +66,14 @@ impl Platform for BuildTargetPlatform {
     where
         P: AsRef<ProcessorFacade>,
     {
-        // SAFETY: Zero-initialized cpu_set_t is a valid value.
-        let mut cpu_set: libc::cpu_set_t = unsafe { mem::zeroed() };
+        let mut mask = CpuMask::new();
 
         for processor in processors.iter() {
-            // SAFETY: No safety requirements.
-            unsafe {
-                // TODO: This can go out of bounds with giant CPU set (1000+), we would need to use
-                // dynamically allocated CPU sets instead of relying on the fixed-size one in libc.
-                libc::CPU_SET(processor.as_ref().as_target().id as usize, &mut cpu_set);
-            }
+            mask.insert(processor.as_ref().as_target().id);
         }
 
         self.bindings
-            .sched_setaffinity_current(&cpu_set)
+            .sched_setaffinity_current(&mask)
             .expect("failed to configure thread affinity");
     }
 
@@ -80,16 +96,12 @@ impl Platform for BuildTargetPlatform {
     fn current_thread_processors(&self) -> NonEmpty<ProcessorId> {
         let max_processor_id = self.get_max_processor_id();
 
-        let affinity = self
-            .bindings
-            .sched_getaffinity_current()
-            .expect("failed to get current thread processor affinity");
+        let affinity = self.get_current_thread_affinity();
 
         NonEmpty::from_vec(
-            (0..=max_processor_id)
-                // TODO: Do we need to check for cpuset overflow here to avoid panic?
-                // SAFETY: No safety requirements.
-                .filter(|processor_id| unsafe { libc::CPU_ISSET(*processor_id as usize, &affinity) })
+            affinity
+                .processor_ids()
+                .filter(|processor_id| *processor_id <= max_processor_id)
                 .collect_vec())
                 .expect("current thread has no processors in its affinity mask - impossible because this code is running on an active processor")
     }
@@ -125,7 +137,54 @@ impl BuildTargetPlatform {
             all_active_processors: OnceLock::new(),
             max_processor_id: OnceLock::new(),
             max_memory_region_id: OnceLock::new(),
+            affinity_mask_words: AtomicUsize::new(0),
         }
+    }
+
+    /// Reads the set of processors that the current thread is allowed to run on.
+    ///
+    /// The operating system refuses to fill an affinity mask that is too narrow to describe
+    /// every processor that it knows of, without saying how wide the mask needs to be, so the
+    /// only way to learn the required width is to offer wider and wider masks until one is
+    /// accepted. Ref: `packages/many_cpus/docs/implementation.md`, "Thread affinity masks".
+    fn get_current_thread_affinity(&self) -> CpuMask {
+        let mut last_error = None;
+
+        for words in self.affinity_mask_widths() {
+            match self.bindings.sched_getaffinity_current(words) {
+                Ok(mask) => {
+                    self.affinity_mask_words
+                        .store(words.get(), Ordering::Relaxed);
+
+                    return mask;
+                }
+                // A mask that is too narrow is rejected as an invalid argument. Other causes of
+                // this error exist, so a wider mask is merely the most likely remedy and not a
+                // certain one - which is why the error is preserved for the final report.
+                Err(error) if error.raw_os_error() == Some(libc::EINVAL) => {
+                    last_error = Some(error);
+                }
+                Err(error) => panic!("failed to get current thread processor affinity: {error}"),
+            }
+        }
+
+        panic!(
+            "failed to get current thread processor affinity, even with a mask wider than any operating system can fill: {}",
+            last_error.expect("the search only ends without a mask once an attempt has failed")
+        );
+    }
+
+    /// The affinity mask widths to offer the operating system, in the order to offer them.
+    fn affinity_mask_widths(&self) -> impl Iterator<Item = NonZero<usize>> {
+        // A width that worked before is likely to work again, so we start there. The machine can
+        // grow while the process runs, so this is only a starting point.
+        let first = NonZero::new(self.affinity_mask_words.load(Ordering::Relaxed))
+            .unwrap_or_else(CpuMask::default_words);
+
+        iter::successors(Some(first), |words| {
+            words.checked_mul(AFFINITY_MASK_GROWTH)
+        })
+        .take(AFFINITY_MASK_ATTEMPTS)
     }
 
     fn get_all_processors_impl(&self) -> &NonEmpty<ProcessorImpl> {
@@ -652,6 +711,7 @@ mod tests {
         reason = "we need not worry in tests"
     )]
     use std::fmt::Write;
+    use std::io;
 
     use testing::{assert_panics, f64_diff_abs};
 
@@ -659,6 +719,16 @@ mod tests {
     use crate::pal::linux::{MockBindings, MockFilesystem};
 
     const PROCESSOR_TIME_CLOSE_ENOUGH: f64 = 0.01;
+
+    /// A machine with more processors than the operating system's own fixed-size mask can
+    /// describe. The identifiers straddle the edge of that mask on purpose.
+    const GIANT_MACHINE_PROCESSORS: [ProcessorId; 5] = [0, 1023, 1024, 1500, 2047];
+
+    /// Memory regions of the processors in `GIANT_MACHINE_PROCESSORS`.
+    const GIANT_MACHINE_MEMORY_REGIONS: [MemoryRegionId; 5] = [0; 5];
+
+    /// Speed of the processors in `GIANT_MACHINE_PROCESSORS`, which the tests do not care about.
+    const GIANT_MACHINE_BOGOMIPS: [f64; 5] = [2000.0; 5];
 
     #[test]
     fn get_all_processors_smoke_test() {
@@ -1070,7 +1140,7 @@ mod tests {
                 continue;
             }
 
-            let is_online = processor_is_active[processor_id as usize];
+            let is_online = processor_is_active[index];
             fs.expect_get_cpu_online_contents()
                 .withf(move |p| *p == processor_id)
                 .times(1)
@@ -1187,14 +1257,11 @@ mod tests {
     fn pin_current_thread_to_single_processor() {
         let mut bindings = MockBindings::new();
 
-        let expected_set = cpuset_from([0]);
+        let expected_mask = mask_from([0]);
 
         bindings
             .expect_sched_setaffinity_current()
-            .withf(move |cpu_set| {
-                // SAFETY: No safety requirements.
-                unsafe { libc::CPU_EQUAL(cpu_set, &expected_set) }
-            })
+            .withf(move |mask| *mask == expected_mask)
             .times(1)
             .returning(|_| Ok(()));
 
@@ -1213,14 +1280,11 @@ mod tests {
     fn pin_current_thread_to_multiple_processors() {
         let mut bindings = MockBindings::new();
 
-        let expected_set = cpuset_from([0, 1]);
+        let expected_mask = mask_from([0, 1]);
 
         bindings
             .expect_sched_setaffinity_current()
-            .withf(move |cpu_set| {
-                // SAFETY: No safety requirements.
-                unsafe { libc::CPU_EQUAL(cpu_set, &expected_set) }
-            })
+            .withf(move |mask| *mask == expected_mask)
             .times(1)
             .returning(|_| Ok(()));
 
@@ -1239,14 +1303,11 @@ mod tests {
     fn pin_current_thread_to_multiple_memory_regions() {
         let mut bindings = MockBindings::new();
 
-        let expected_set = cpuset_from([0, 1]);
+        let expected_mask = mask_from([0, 1]);
 
         bindings
             .expect_sched_setaffinity_current()
-            .withf(move |cpu_set| {
-                // SAFETY: No safety requirements.
-                unsafe { libc::CPU_EQUAL(cpu_set, &expected_set) }
-            })
+            .withf(move |mask| *mask == expected_mask)
             .times(1)
             .returning(|_| Ok(()));
 
@@ -1265,14 +1326,11 @@ mod tests {
     fn pin_current_thread_to_efficiency_processors() {
         let mut bindings = MockBindings::new();
 
-        let expected_set = cpuset_from([1, 2]);
+        let expected_mask = mask_from([1, 2]);
 
         bindings
             .expect_sched_setaffinity_current()
-            .withf(move |cpu_set| {
-                // SAFETY: No safety requirements.
-                unsafe { libc::CPU_EQUAL(cpu_set, &expected_set) }
-            })
+            .withf(move |mask| *mask == expected_mask)
             .times(1)
             .returning(|_| Ok(()));
 
@@ -1302,40 +1360,34 @@ mod tests {
         platform.pin_current_thread_to(&efficiency_processors);
     }
 
-    fn cpuset_from<const PROCESSOR_COUNT: usize>(
+    fn mask_from<const PROCESSOR_COUNT: usize>(
         processors: [ProcessorId; PROCESSOR_COUNT],
-    ) -> libc::cpu_set_t {
-        // SAFETY: Zero-initialized CPU set is correct.
-        let mut cpu_set: libc::cpu_set_t = unsafe { mem::zeroed() };
+    ) -> CpuMask {
+        let mut mask = CpuMask::new();
 
         for processor in processors {
-            // SAFETY: No safety requirements.
-            unsafe {
-                // TODO: This can go out of bounds with giant CPU set, we need to use dynamically
-                // allocated CPU sets instead of relying on the fixed-size one in libc.
-                libc::CPU_SET(processor as usize, &mut cpu_set);
-            }
+            mask.insert(processor);
         }
 
-        cpu_set
+        mask
     }
 
     #[test]
     fn current_thread_processors_smoke_test() {
         let mut bindings = MockBindings::new();
 
-        let expected_set_1 = cpuset_from([0, 1]);
-        let expected_set_2 = cpuset_from([2]);
+        let expected_mask_1 = mask_from([0, 1]);
+        let expected_mask_2 = mask_from([2]);
 
         bindings
             .expect_sched_getaffinity_current()
             .times(1)
-            .returning(move || Ok(expected_set_1));
+            .returning(move |_| Ok(expected_mask_1.clone()));
 
         bindings
             .expect_sched_getaffinity_current()
             .times(1)
-            .returning(move || Ok(expected_set_2));
+            .returning(move |_| Ok(expected_mask_2.clone()));
 
         let mut fs = MockFilesystem::new();
         simulate_processor_layout(
@@ -1360,6 +1412,176 @@ mod tests {
         let current_thread_processors = platform.current_thread_processors();
         assert_eq!(current_thread_processors.len(), 1);
         assert_eq!(current_thread_processors[0], 2);
+    }
+
+    #[test]
+    fn current_thread_processors_widens_mask_until_operating_system_accepts_it() {
+        let mut bindings = MockBindings::new();
+
+        let narrow = CpuMask::default_words();
+        let wide = narrow.checked_mul(AFFINITY_MASK_GROWTH).unwrap();
+
+        // A mask too narrow to describe every processor is rejected as an invalid argument.
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == narrow)
+            .times(1)
+            .returning(|_| Err(io::Error::from_raw_os_error(libc::EINVAL)));
+
+        let affinity = mask_from([1024, 1500, 2047]);
+
+        // Both reads are expected to use the wider mask - the second one because the first one
+        // already established the width that this operating system wants.
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == wide)
+            .times(2)
+            .returning(move |_| Ok(affinity.clone()));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(
+            &mut fs,
+            GIANT_MACHINE_PROCESSORS,
+            None,
+            None,
+            GIANT_MACHINE_MEMORY_REGIONS,
+            GIANT_MACHINE_BOGOMIPS,
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        for _ in 0..2 {
+            let current_thread_processors = platform.current_thread_processors();
+
+            assert_eq!(
+                current_thread_processors.iter().copied().collect_vec(),
+                vec![1024, 1500, 2047]
+            );
+        }
+    }
+
+    #[test]
+    fn current_thread_processors_ignores_processors_beyond_the_known_hardware() {
+        let mut bindings = MockBindings::new();
+
+        // The operating system may know of processors that the hardware inventory does not, as
+        // the two are read at different moments.
+        let affinity = mask_from([1024, 4096]);
+
+        bindings
+            .expect_sched_getaffinity_current()
+            .times(1)
+            .returning(move |_| Ok(affinity.clone()));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(
+            &mut fs,
+            GIANT_MACHINE_PROCESSORS,
+            None,
+            None,
+            GIANT_MACHINE_MEMORY_REGIONS,
+            GIANT_MACHINE_BOGOMIPS,
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        let current_thread_processors = platform.current_thread_processors();
+
+        assert_eq!(
+            current_thread_processors.iter().copied().collect_vec(),
+            vec![1024]
+        );
+    }
+
+    #[test]
+    fn current_thread_processors_panics_on_unexpected_error() {
+        let mut bindings = MockBindings::new();
+
+        // Only an invalid argument suggests that a wider mask might help.
+        bindings
+            .expect_sched_getaffinity_current()
+            .times(1)
+            .returning(|_| Err(io::Error::from_raw_os_error(libc::EPERM)));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(&mut fs, [0], None, None, [0], [2000.0]);
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        assert_panics(|| platform.current_thread_processors());
+    }
+
+    #[test]
+    fn current_thread_processors_gives_up_when_no_mask_is_accepted() {
+        let mut bindings = MockBindings::new();
+
+        // An operating system that rejects every mask must not send us searching forever.
+        bindings
+            .expect_sched_getaffinity_current()
+            .times(AFFINITY_MASK_ATTEMPTS)
+            .returning(|_| Err(io::Error::from_raw_os_error(libc::EINVAL)));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(&mut fs, [0], None, None, [0], [2000.0]);
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        assert_panics(|| platform.current_thread_processors());
+    }
+
+    #[test]
+    fn pin_current_thread_to_processor_beyond_fixed_size_mask() {
+        let mut bindings = MockBindings::new();
+
+        let expected_mask = mask_from([1500]);
+
+        bindings
+            .expect_sched_setaffinity_current()
+            .withf(move |mask| {
+                // A processor that the operating system's own fixed-size mask cannot describe
+                // must arrive in a mask that is wider than that.
+                *mask == expected_mask && mask.words() > CpuMask::default_words()
+            })
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(
+            &mut fs,
+            GIANT_MACHINE_PROCESSORS,
+            None,
+            None,
+            GIANT_MACHINE_MEMORY_REGIONS,
+            GIANT_MACHINE_BOGOMIPS,
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        let processors = platform.get_all_processors();
+        let target = NonEmpty::from_vec(
+            processors
+                .iter()
+                .filter(|processor| processor.as_target().id == 1500)
+                .collect_vec(),
+        )
+        .unwrap();
+
+        platform.pin_current_thread_to(&target);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -40,7 +40,7 @@ pub(crate) struct BuildTargetPlatform {
     ///
     /// Zero means that no width has been established yet. This is a hint and not a conclusion:
     /// the required width can grow while the process runs, so a width that stops working merely
-    /// starts the search again.
+    /// sends the search widening again from there.
     affinity_mask_words: AtomicUsize,
 }
 
@@ -48,7 +48,7 @@ pub(crate) struct BuildTargetPlatform {
 ///
 /// Each attempt doubles the width of the previous one, starting from a mask that already covers
 /// every processor that the platform's own fixed-size mask can describe, so the final attempt
-/// describes more processors than any operating system can boot. The limit exists to guarantee
+/// describes a machine far larger than operating systems support. The limit exists to guarantee
 /// that the search ends. Ref: `packages/many_cpus/docs/implementation.md`,
 /// "Thread affinity masks".
 const AFFINITY_MASK_ATTEMPTS: usize = 11;
@@ -1459,6 +1459,71 @@ mod tests {
                 vec![1024, 1500, 2047]
             );
         }
+    }
+
+    #[test]
+    fn current_thread_processors_widens_again_when_the_remembered_width_stops_working() {
+        let mut bindings = MockBindings::new();
+
+        let narrow = CpuMask::default_words();
+        let wide = narrow.checked_mul(AFFINITY_MASK_GROWTH).unwrap();
+
+        let before = mask_from([1024]);
+        let after = mask_from([1024, 1500, 2047]);
+
+        // The first read settles on a width and it is remembered.
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == narrow)
+            .times(1)
+            .returning(move |_| Ok(before.clone()));
+
+        // The machine can grow while the process runs, so a remembered width is a hint and not a
+        // conclusion - once it stops working, the search must widen again rather than give up.
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == narrow)
+            .times(1)
+            .returning(|_| Err(io::Error::from_raw_os_error(libc::EINVAL)));
+
+        bindings
+            .expect_sched_getaffinity_current()
+            .withf(move |words| *words == wide)
+            .times(1)
+            .returning(move |_| Ok(after.clone()));
+
+        let mut fs = MockFilesystem::new();
+        simulate_processor_layout(
+            &mut fs,
+            GIANT_MACHINE_PROCESSORS,
+            None,
+            None,
+            GIANT_MACHINE_MEMORY_REGIONS,
+            GIANT_MACHINE_BOGOMIPS,
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        assert_eq!(
+            platform
+                .current_thread_processors()
+                .iter()
+                .copied()
+                .collect_vec(),
+            vec![1024]
+        );
+
+        assert_eq!(
+            platform
+                .current_thread_processors()
+                .iter()
+                .copied()
+                .collect_vec(),
+            vec![1024, 1500, 2047]
+        );
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -181,10 +181,8 @@ impl BuildTargetPlatform {
         let first = NonZero::new(self.affinity_mask_words.load(Ordering::Relaxed))
             .unwrap_or_else(CpuMask::default_words);
 
-        iter::successors(Some(first), |words| {
-            words.checked_mul(AFFINITY_MASK_GROWTH)
-        })
-        .take(AFFINITY_MASK_ATTEMPTS)
+        iter::successors(Some(first), |words| words.checked_mul(AFFINITY_MASK_GROWTH))
+            .take(AFFINITY_MASK_ATTEMPTS)
     }
 
     fn get_all_processors_impl(&self) -> &NonEmpty<ProcessorImpl> {


### PR DESCRIPTION
[Copilot speaking]

Closes #48.

## Motivation

`many_cpus` described Linux thread affinity using `libc::cpu_set_t`, which holds one bit per processor for 1024 processors and no more. Machines larger than that are rented by the hour — an AWS `u7inh-32tb.metal` instance reports 1920 vCPUs — and on such a machine the package did not degrade, it killed the process:

`libc::CPU_SET` and `libc::CPU_ISSET` index a bounds-checked array, so a processor identifier of 1024 or above panics inside them. Because libc declares them `extern "C"`, the panic cannot unwind and the process takes a SIGABRT that no caller can catch.

The kernel side has a second, less obvious trap. `sched_getaffinity` refuses to fill a buffer that is too narrow to describe every processor the kernel could ever have, and it counts processors the process is forbidden to use. A container pinned to two processors on a 2048-processor host is still answered in the host's terms, so a fixed 1024-bit buffer fails there too. The refusal arrives as a plain `EINVAL` that does not say how wide the buffer needs to be, and there is no interface that discloses the required width.

## Changes

Affinity masks are now a `CpuMask` whose width the package chooses, replacing `cpu_set_t` throughout the Linux platform abstraction layer. The mask keeps as many machine words inline as `cpu_set_t` holds and reaches for the heap only past that point, so every machine the C API could have described costs no allocation and only machines it could not describe at all pay for one.

```
                    ┌─────────────────────────────────────────┐
   processors 0..N  │             CpuMask                     │
   ──────────────►  │  ┌───────────────────┬───────────────┐  │
                    │  │  inline words     │  heap words   │  │
                    │  │  (= cpu_set_t)    │  (only if the │  │
                    │  │                   │   machine is  │  │
                    │  │                   │   larger)     │  │
                    │  └───────────────────┴───────────────┘  │
                    └────────────────┬────────────────────────┘
                                     │ pointer + length in bytes
                                     ▼
                            sched_{get,set}affinity
```

Words are machine words rather than a fixed-width integer type, which makes the kernel's demand for a whole number of words — and the alignment it expects — hold by construction on every ABI rather than by convention.

Reading a thread's affinity now discovers the width the kernel wants by offering wider and wider masks until one is accepted, doubling each time and stopping after a fixed number of attempts so the search always ends. Only the invalid-argument refusal is retried; any other failure ends the search at once, and exhausting the attempts reports the kernel's own last error rather than a conclusion of our own. A width that worked is remembered and tried first next time, as a hint rather than a conclusion — a process can outlive a change in the machine it runs on, and a width that stops working simply sends the search widening again. Writing affinity needs none of this, as the kernel accepts a mask of any width there.

Behavior on machines of 1024 processors or fewer is unchanged, down to the number of syscalls made and the absence of allocation.

A latent defect in a test helper is also fixed: it indexed one of its inputs by processor identifier and another by enumeration position, which agreed only as long as every test used processors numbered contiguously from zero. Nothing in the package depended on that agreement until the new tests described machines with sparse, high processor identifiers.

`many_cpus` gains an implementation guide covering affinity masks, and its design document now states what the package promises about machine size.