### PR TITLE
cbh_detect: discard isolated measurement excursions from branch comparison windows

### DIFF
--- a/packages/cargo-bench-history-figures/src/figures/detection.rs
+++ b/packages/cargo-bench-history-figures/src/figures/detection.rs
@@ -27,6 +27,7 @@ pub fn assets() -> Vec<Asset> {
     assets.extend(flat_noisy());
     assets.extend(branch());
     assets.extend(branch_base_moved());
+    assets.extend(branch_contended_runner());
     assets.extend(confidence_examples());
     assets.extend(minimums());
     assets
@@ -240,6 +241,103 @@ fn branch_base_moved() -> Vec<Asset> {
                 &finding,
                 "the prediction is centered on the newer base regime, not on the whole \
                  mixed window",
+                AnalysisMode::Branch,
+            ),
+        ),
+    ]
+}
+
+/// How much the contended-runner figure's context run moves above its base level.
+///
+/// A move well clear of the practical floor but far smaller than the recorded excursion,
+/// so the figure is about whether the excursion hides an ordinary regression rather than
+/// about an extreme one.
+const CONTENDED_TIP_RELATIVE: f64 = 1.10;
+
+/// Builds the contended-runner example and returns its values, the index the excursion
+/// sits at, and the detector's verdict.
+fn contended_runner_finding() -> (Vec<f64>, usize, Option<Finding>) {
+    let base = examples::CONTENDED_RUNNER_EXCURSION
+        .get(examples::CONTENDED_RUNNER_LEVEL_START..examples::CONTENDED_RUNNER_BASE)
+        .expect("the recording is longer than the span the branch cases take from it");
+    let excursion = base
+        .iter()
+        .enumerate()
+        .max_by(|left, right| left.1.total_cmp(right.1))
+        .map(|(index, _)| index)
+        .expect("the contended-runner base side is not empty");
+
+    let mut values = base.to_vec();
+    values.push(examples::CONTENDED_RUNNER_LEVEL * CONTENDED_TIP_RELATIVE);
+    let base_ref_index = base.len().saturating_sub(1);
+    let series = examples::with_base_window(
+        examples::series("collect_mt", &values, MetricKind::WallTime, 0),
+        base_ref_index,
+    );
+    let context = examples::branch_context(&series, base_ref_index);
+    let (finding, _) = evaluate_with_log(&series, &context);
+    (values, excursion, finding)
+}
+
+/// A base window holding one commit the runner lost time on, drawn from real stored results.
+fn branch_contended_runner() -> Vec<Asset> {
+    let (values, excursion, finding) = contended_runner_finding();
+    let finding = finding.expect(
+        "the contended-runner example places an ordinary regression against a window whose only \
+         unusual reading is discarded, so it must report",
+    );
+    let tip_index = values.len().saturating_sub(1);
+    let window_start = tip_index.saturating_sub(AnalysisConfig::default().compare_window);
+    let prediction = branch_prediction_band(
+        &values
+            .get(window_start..tip_index)
+            .expect("the contended-runner example has a base window before its context run")
+            .iter()
+            .enumerate()
+            .filter(|&(index, _)| index.saturating_add(window_start) != excursion)
+            .map(|(_, &value)| value)
+            .collect::<Vec<f64>>(),
+    );
+
+    let plot = Plot::new(
+        "a context commit against a window the runner disturbed",
+        values.len(),
+    )
+    .value_label("ns")
+    .scattered()
+    .observations(values.iter().enumerate().map(|(index, &value)| {
+        let observation = Observation::new(index, value);
+        if index == excursion {
+            observation.marked(Mark::Removed)
+        } else if index == tip_index {
+            observation.marked(Mark::Regression)
+        } else {
+            observation
+        }
+    }))
+    .band(
+        window_start,
+        tip_index.saturating_sub(1),
+        "base window",
+        theme::HIGHLIGHT,
+    )
+    .value_band(
+        window_start,
+        tip_index,
+        prediction,
+        "predicted range without the discarded reading",
+        theme::ALTERNATE,
+    )
+    .split(tip_index, "context commit");
+
+    vec![
+        Asset::new("detection-branch-contended.svg", plot.render()),
+        Asset::new(
+            "detection-branch-contended.md",
+            verdict::reported(
+                &finding,
+                "the isolated reading is left out of the comparison, so the window still \
+                 describes the level the context run is judged against",
                 AnalysisMode::Branch,
             ),
         ),
@@ -780,6 +878,8 @@ mod tests {
             "detection-branch-quiet.md",
             "detection-branch-base-moved.svg",
             "detection-branch-base-moved.md",
+            "detection-branch-contended.svg",
+            "detection-branch-contended.md",
             "detection-confidence-high.svg",
             "detection-confidence-high.md",
             "detection-confidence-lower.svg",
@@ -830,6 +930,19 @@ mod tests {
             "a sustained excursion that returned to baseline must not report"
         );
         assert!(noisy.is_none(), "scatter around one level must not report");
+    }
+
+    /// The contended-runner figure's whole lesson is that the disturbed reading does not cost
+    /// the window its sight. Were the reading averaged in, this comparison would fall silent
+    /// while the figure still claimed otherwise, so the claim is pinned against the detector.
+    #[test]
+    fn the_contended_window_still_sees_an_ordinary_regression() {
+        let (_, _, finding) = contended_runner_finding();
+
+        let finding =
+            finding.expect("a window whose only unusual reading is discarded must report");
+
+        assert_eq!(finding.direction, Direction::Regression);
     }
 
     #[test]

--- a/packages/cargo-bench-history-figures/src/figures/detection.rs
+++ b/packages/cargo-bench-history-figures/src/figures/detection.rs
@@ -8,7 +8,7 @@
 
 use cbh_detect::{AnalysisConfig, AnalysisMode, Finding, Series, evaluate_with_log, examples};
 use cbh_model::MetricKind;
-use cbh_stats::{mean, sample_std_dev};
+use cbh_stats::{mean, sample_std_dev, student_t_two_sided_p};
 use plotters::style::RGBColor;
 
 use crate::assets::Asset;
@@ -112,20 +112,45 @@ const BRANCH_CASES: [(&str, f64, &str); 2] = [
     ),
 ];
 
-/// How wide the branch figures draw their illustrative prediction range.
-///
-/// The detector records the p-value, not a plotted cutoff. This multiple makes the range
-/// visibly cover ordinary base scatter while keeping the reporting context run outside it.
-const BRANCH_PREDICTION_SIGMAS: f64 = 3.0;
-
 /// The value interval the branch figures shade as the base window's prediction.
+///
+/// This is the detector's prediction interval at its own significance level, not an
+/// illustrative width: from the same cleaned base sample the significance gate reads, it is
+/// the range a single further measurement stays inside unless its two-sided Student-t
+/// p-value falls below `change_alpha`. A context run drawn outside this band is therefore
+/// exactly one the significance gate rejects, so the band is the real cutoff the figure's
+/// verdict turns on.
 fn branch_prediction_band(values: &[f64]) -> (f64, f64) {
     let centre = mean(values).expect("the branch figure's base window is not empty");
     let scatter = sample_std_dev(values)
         .expect("the branch figure's base window has enough points to estimate scatter");
     let sample_count = crate::coord::of(values.len());
-    let half_width = scatter * (1.0 + 1.0 / sample_count).sqrt() * BRANCH_PREDICTION_SIGMAS;
+    let standard_error = scatter * (1.0 + 1.0 / sample_count).sqrt();
+    let half_width =
+        standard_error * critical_t(AnalysisConfig::default().change_alpha, sample_count - 1.0);
     (centre - half_width, centre + half_width)
+}
+
+/// The two-sided Student-t statistic whose p-value equals `alpha`.
+///
+/// [`student_t_two_sided_p`] has no closed form to invert, but it falls monotonically from
+/// `1.0` at `t = 0` toward `0.0`, so bisection converges on the one statistic that yields
+/// `alpha`. That statistic is the significance gate's cutoff: a measurement falls outside
+/// the prediction interval exactly when its own statistic exceeds it.
+fn critical_t(alpha: f64, degrees_of_freedom: f64) -> f64 {
+    // `t = 0` gives `p = 1.0`, above any `alpha`; this upper bound gives a p-value far below
+    // it, so the two bracket the root. Halving to convergence needs a fixed, generous count.
+    let mut low = 0.0_f64;
+    let mut high = 1.0e6_f64;
+    for _ in 0..100 {
+        let mid = f64::midpoint(low, high);
+        if student_t_two_sided_p(mid, degrees_of_freedom) > alpha {
+            low = mid;
+        } else {
+            high = mid;
+        }
+    }
+    f64::midpoint(low, high)
 }
 
 /// Runs the real branch detector over the shared base window with `tip` appended, and

--- a/packages/cargo-bench-history-figures/src/figures/reporting.rs
+++ b/packages/cargo-bench-history-figures/src/figures/reporting.rs
@@ -164,10 +164,15 @@ fn silent_suite() -> Vec<Series> {
 
 /// One batch detection pass over `suite`, with ghosts accounted for after the pass.
 fn detect_suite(suite: &[Series]) -> Detection {
-    let Detection { findings, census } = find_changes(suite, &suite_context(suite));
+    let Detection {
+        findings,
+        census,
+        discarded,
+    } = find_changes(suite, &suite_context(suite));
     Detection {
         findings,
         census: attach_ghosts(census),
+        discarded,
     }
 }
 
@@ -264,7 +269,9 @@ fn judge_branch(name: &str, values: &[f64], kind: MetricKind) -> Finding {
 /// The worked analysis the chapter's report excerpts are rendered from: one batch
 /// detection pass, so the findings and the census are the same account.
 fn worked_analysis() -> Analysis {
-    let Detection { findings, census } = detect_suite(&worked_suite());
+    let Detection {
+        findings, census, ..
+    } = detect_suite(&worked_suite());
     Analysis {
         mode: AnalysisMode::History,
         set: worked_set(),
@@ -276,7 +283,9 @@ fn worked_analysis() -> Analysis {
 
 /// The same kind of pass with nothing to report: the case the coverage line exists for.
 fn silent_analysis() -> Analysis {
-    let Detection { findings, census } = detect_suite(&silent_suite());
+    let Detection {
+        findings, census, ..
+    } = detect_suite(&silent_suite());
     Analysis {
         mode: AnalysisMode::History,
         set: worked_set(),

--- a/packages/cargo-bench-history/book/src/appendix/detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/detection.md
@@ -191,12 +191,13 @@ out the range a single further measurement was expected to land in, and asks whe
 landed outside it. That is a different question from "are these two groups different" —
 there is only one context observation, not a group.
 
-In the figures below, the shaded value band illustrates that predicted range. It is drawn at a
-fixed width around the base window's centre rather than at the exact cutoff the tool computes,
-which is a chance level rather than a plotted boundary; every verdict shown beneath a figure is
-the real one. The base window itself is the recent base-ref first-parent commit sample for the
-same discriminant set, capped by the branch comparison window. It is anchored at the base ref,
-not at the merge base.
+In the figures below, the shaded value band is that predicted range: the interval a single
+further measurement stays inside unless the tool judges it a change. Its edges are the real
+cutoff, computed from the same base window the tool uses — a context run drawn outside the band
+is one the tool reports, and one drawn inside is one it passes over. Every verdict shown beneath
+a figure is the real one. The base window itself is the recent base-ref first-parent commit
+sample for the same discriminant set, capped by the branch comparison window. It is anchored at
+the base ref, not at the merge base.
 
 {{#include generated/detection-branch-reported.svg}}
 

--- a/packages/cargo-bench-history/book/src/appendix/detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/detection.md
@@ -250,13 +250,21 @@ commits on either side of it agree with each other, it stands far clear of them,
 one in the window — a window offering a second is a benchmark that visits more than one level, and
 how often it does so is exactly what the context run is being measured against.
 
+One more thing can disqualify it: the run being judged standing at that same level. That run is
+evidence consistent with the window's odd reading being a level the series returns to, and a level
+it may return to cannot safely be dropped from the description of what the series does. Dropping it
+would leave the window describing a steadiness the benchmark does not actually hold, and the very
+run that contradicted it would then be read as a large, confident regression against what remained.
+
 {{#include generated/detection-branch-contended.svg}}
 
 {{#include generated/detection-branch-contended.md}}
 
 The reading is left out of the comparison only. It is still stored, still charted, and still
 counted as one of the commits whose existence lets the window be judged at all — a window is
-never made eligible by discarding.
+never made eligible by discarding. `--verbose` names each reading left out, what it measured,
+and the level its neighbours agreed on, so a narrowed comparison can be told from an ordinary
+one and the removal judged rather than merely discovered.
 
 History mode does not do this. Its arithmetic is built on medians and ranks, which a lone
 reading barely moves, so it has nothing to gain and evidence to lose.

--- a/packages/cargo-bench-history/book/src/appendix/detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/detection.md
@@ -230,6 +230,34 @@ scatter is re-estimated from what remains. A wrong boundary can collapse a noisy
 to almost nothing and make the next tip read as certain. A decision that discards data has to be
 more certain than one that merely reports something.
 
+### When one reading came from a disturbed runner
+
+A base window is a sample of what the base ref measures, and a shared machine occasionally
+contributes a reading that measures something else — another job on the same host, a thermal
+event, a noisy neighbour. Such a reading is not a level and not a trend: it stands well clear of
+its neighbours in one direction and is gone at the very next commit.
+
+Averaging one in would be quietly expensive. It drags the window's center toward the tip and
+inflates the window's apparent scatter several times over, and a wider predicted range is a range
+almost nothing falls outside of. The window would still look like a window, and the comparison
+would still run, but it would have lost most of its ability to see an ordinary move.
+
+So branch mode leaves such a reading out of the comparison. A reading qualifies only when the
+commits on either side of it agree with each other, it stands far clear of them, and it is the only
+one in the window — a window offering a second is a benchmark that visits more than one level, and
+how often it does so is exactly what the context run is being measured against.
+
+{{#include generated/detection-branch-contended.svg}}
+
+{{#include generated/detection-branch-contended.md}}
+
+The reading is left out of the comparison only. It is still stored, still charted, and still
+counted as one of the commits whose existence lets the window be judged at all — a window is
+never made eligible by discarding.
+
+History mode does not do this. Its arithmetic is built on medians and ranks, which a lone
+reading barely moves, so it has nothing to gain and evidence to lose.
+
 ## Confidence, and what it is not
 
 Every finding carries a confidence, and it is **one minus the chance level of whichever test

--- a/packages/cargo-bench-history/book/src/appendix/detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/detection.md
@@ -191,9 +191,12 @@ out the range a single further measurement was expected to land in, and asks whe
 landed outside it. That is a different question from "are these two groups different" —
 there is only one context observation, not a group.
 
-In the figures below, the shaded value band is that predicted range. The base window itself
-is the recent base-ref first-parent commit sample for the same discriminant set, capped by the
-branch comparison window. It is anchored at the base ref, not at the merge base.
+In the figures below, the shaded value band illustrates that predicted range. It is drawn at a
+fixed width around the base window's centre rather than at the exact cutoff the tool computes,
+which is a chance level rather than a plotted boundary; every verdict shown beneath a figure is
+the real one. The base window itself is the recent base-ref first-parent commit sample for the
+same discriminant set, capped by the branch comparison window. It is anchored at the base ref,
+not at the merge base.
 
 {{#include generated/detection-branch-reported.svg}}
 

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-base-moved.svg
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-base-moved.svg
@@ -94,8 +94,8 @@ commit position
 <text x="74" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#969BA0">
 discarded older base level
 </text>
-<rect x="353" y="78" width="314" height="61" opacity="0.15" fill="#9664BE" stroke="none"/>
-<text x="353" y="78" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
+<rect x="353" y="84" width="314" height="48" opacity="0.15" fill="#9664BE" stroke="none"/>
+<text x="353" y="84" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
 predicted range from current base
 </text>
 <polyline fill="none" opacity="1" stroke="#D64541" stroke-width="2" points="353,253 353,34 "/>

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-contended.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-contended.md
@@ -1,0 +1,5 @@
+> **Reported.** A regression of +10.02% at the context commit against the base prediction interval, at 100% confidence.
+>
+> The context run is 1150 against a base level of 1045.
+>
+> The isolated reading is left out of the comparison, so the window still describes the level the context run is judged against.

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-contended.svg
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-contended.svg
@@ -1,0 +1,132 @@
+<svg style="width:100%;height:auto" viewBox="0 0 680 300" xmlns="http://www.w3.org/2000/svg">
+<text x="340" y="17" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="12.096774193548388" opacity="1" fill="currentColor">
+a context commit against a window the runner disturbed
+</text>
+<text x="12" y="144" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor" transform="rotate(270, 12, 144)">
+ns
+</text>
+<text x="371" y="288" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+commit position
+</text>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="88" y1="253" x2="88" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="148" y1="253" x2="148" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="207" y1="253" x2="207" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="266" y1="253" x2="266" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="326" y1="253" x2="326" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="385" y1="253" x2="385" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="444" y1="253" x2="444" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="503" y1="253" x2="503" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="563" y1="253" x2="563" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="622" y1="253" x2="622" y2="34"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="237" x2="667" y2="237"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="206" x2="667" y2="206"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="176" x2="667" y2="176"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="145" x2="667" y2="145"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="115" x2="667" y2="115"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="84" x2="667" y2="84"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="54" x2="667" y2="54"/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="73,34 73,253 "/>
+<text x="64" y="237" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1000.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,237 73,237 "/>
+<text x="64" y="206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1100.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,206 73,206 "/>
+<text x="64" y="176" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1200.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,176 73,176 "/>
+<text x="64" y="145" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1300.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,145 73,145 "/>
+<text x="64" y="115" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1400.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,115 73,115 "/>
+<text x="64" y="84" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1500.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,84 73,84 "/>
+<text x="64" y="54" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+1600.0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,54 73,54 "/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="74,254 667,254 "/>
+<text x="88" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="88,254 88,259 "/>
+<text x="148" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="148,254 148,259 "/>
+<text x="207" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+4
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="207,254 207,259 "/>
+<text x="266" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+6
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="266,254 266,259 "/>
+<text x="326" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+8
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="326,254 326,259 "/>
+<text x="385" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+10
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="385,254 385,259 "/>
+<text x="444" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+12
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="444,254 444,259 "/>
+<text x="503" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+14
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="503,254 503,259 "/>
+<text x="563" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+16
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="563,254 563,259 "/>
+<text x="622" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+18
+</text>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="622,254 622,259 "/>
+<rect x="162" y="34" width="475" height="219" opacity="0.15" fill="#306EC8" stroke="none"/>
+<text x="162" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#306EC8">
+base window
+</text>
+<rect x="162" y="218" width="505" height="10" opacity="0.15" fill="#9664BE" stroke="none"/>
+<text x="162" y="218" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
+predicted range without the discarded reading
+</text>
+<polyline fill="none" opacity="1" stroke="#D64541" stroke-width="2" points="637,253 637,34 "/>
+<text x="637" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#D64541">
+context commit
+</text>
+<circle cx="88" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="118" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="148" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="177" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="207" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="237" cy="220" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="266" cy="221" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="326" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="355" cy="60" r="3" opacity="1" fill="#969BA0" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#969BA0" stroke-width="2" points="345,66 366,53 "/>
+<polyline fill="none" opacity="1" stroke="#969BA0" stroke-width="2" points="345,53 366,66 "/>
+<circle cx="385" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="414" cy="221" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="474" cy="222" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="503" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="533" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="592" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="622" cy="222" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="652" cy="191" r="3" opacity="1" fill="#D64541" stroke="none" stroke-width="1"/>
+</svg>

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-contended.svg
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-contended.svg
@@ -18,38 +18,38 @@ commit position
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="503" y1="253" x2="503" y2="34"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="563" y1="253" x2="563" y2="34"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="622" y1="253" x2="622" y2="34"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="237" x2="667" y2="237"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="206" x2="667" y2="206"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="176" x2="667" y2="176"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="145" x2="667" y2="145"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="238" x2="667" y2="238"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="207" x2="667" y2="207"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="177" x2="667" y2="177"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="146" x2="667" y2="146"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="115" x2="667" y2="115"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="84" x2="667" y2="84"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="85" x2="667" y2="85"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="54" x2="667" y2="54"/>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="73,34 73,253 "/>
-<text x="64" y="237" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<text x="64" y="238" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1000.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,237 73,237 "/>
-<text x="64" y="206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,238 73,238 "/>
+<text x="64" y="207" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1100.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,206 73,206 "/>
-<text x="64" y="176" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,207 73,207 "/>
+<text x="64" y="177" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1200.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,176 73,176 "/>
-<text x="64" y="145" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,177 73,177 "/>
+<text x="64" y="146" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1300.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,145 73,145 "/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,146 73,146 "/>
 <text x="64" y="115" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1400.0
 </text>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,115 73,115 "/>
-<text x="64" y="84" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<text x="64" y="85" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1500.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,84 73,84 "/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,85 73,85 "/>
 <text x="64" y="54" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 1600.0
 </text>
@@ -99,34 +99,34 @@ commit position
 <text x="162" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#306EC8">
 base window
 </text>
-<rect x="162" y="218" width="505" height="10" opacity="0.15" fill="#9664BE" stroke="none"/>
-<text x="162" y="218" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
+<rect x="162" y="221" width="505" height="7" opacity="0.15" fill="#9664BE" stroke="none"/>
+<text x="162" y="221" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
 predicted range without the discarded reading
 </text>
 <polyline fill="none" opacity="1" stroke="#D64541" stroke-width="2" points="637,253 637,34 "/>
 <text x="637" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#D64541">
 context commit
 </text>
-<circle cx="88" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="118" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="148" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="177" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="207" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="237" cy="220" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="266" cy="221" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="296" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="326" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="88" cy="225" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="118" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="148" cy="225" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="177" cy="225" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="207" cy="227" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="237" cy="221" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="266" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="228" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="326" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
 <circle cx="355" cy="60" r="3" opacity="1" fill="#969BA0" stroke="none" stroke-width="1"/>
 <polyline fill="none" opacity="1" stroke="#969BA0" stroke-width="2" points="345,66 366,53 "/>
 <polyline fill="none" opacity="1" stroke="#969BA0" stroke-width="2" points="345,53 366,66 "/>
-<circle cx="385" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="414" cy="221" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="444" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="474" cy="222" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="503" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="533" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="563" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="592" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="622" cy="222" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="652" cy="191" r="3" opacity="1" fill="#D64541" stroke="none" stroke-width="1"/>
+<circle cx="385" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="414" cy="222" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="444" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="474" cy="224" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="503" cy="225" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="533" cy="225" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="563" cy="226" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="592" cy="225" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="622" cy="223" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="652" cy="192" r="3" opacity="1" fill="#D64541" stroke="none" stroke-width="1"/>
 </svg>

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-quiet.svg
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-quiet.svg
@@ -18,57 +18,42 @@ commit position
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="526" y1="253" x2="526" y2="34"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="588" y1="253" x2="588" y2="34"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="651" y1="253" x2="651" y2="34"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="249" x2="667" y2="249"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="227" x2="667" y2="227"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="205" x2="667" y2="205"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="183" x2="667" y2="183"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="161" x2="667" y2="161"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="139" x2="667" y2="139"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="117" x2="667" y2="117"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="95" x2="667" y2="95"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="73" x2="667" y2="73"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="51" x2="667" y2="51"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="231" x2="667" y2="231"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="200" x2="667" y2="200"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="168" x2="667" y2="168"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="137" x2="667" y2="137"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="106" x2="667" y2="106"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="74" x2="667" y2="74"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="43" x2="667" y2="43"/>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="73,34 73,253 "/>
-<text x="64" y="249" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
-90.0
-</text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,249 73,249 "/>
-<text x="64" y="227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
-92.0
-</text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,227 73,227 "/>
-<text x="64" y="205" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<text x="64" y="231" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 94.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,205 73,205 "/>
-<text x="64" y="183" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,231 73,231 "/>
+<text x="64" y="200" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 96.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,183 73,183 "/>
-<text x="64" y="161" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,200 73,200 "/>
+<text x="64" y="168" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 98.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,161 73,161 "/>
-<text x="64" y="139" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,168 73,168 "/>
+<text x="64" y="137" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 100.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,139 73,139 "/>
-<text x="64" y="117" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,137 73,137 "/>
+<text x="64" y="106" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 102.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,117 73,117 "/>
-<text x="64" y="95" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,106 73,106 "/>
+<text x="64" y="74" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 104.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,95 73,95 "/>
-<text x="64" y="73" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,74 73,74 "/>
+<text x="64" y="43" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 106.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,73 73,73 "/>
-<text x="64" y="51" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
-108.0
-</text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,51 73,51 "/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,43 73,43 "/>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="74,254 667,254 "/>
 <text x="89" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 0
@@ -122,23 +107,23 @@ predicted range
 <text x="635" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#D64541">
 context commit
 </text>
-<circle cx="89" cy="136" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="120" cy="172" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="152" cy="137" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="183" cy="171" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="214" cy="166" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="245" cy="107" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="276" cy="100" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="308" cy="157" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="339" cy="175" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="370" cy="102" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="401" cy="154" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="432" cy="106" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="464" cy="111" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="495" cy="169" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="526" cy="151" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="557" cy="170" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="133" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="120" cy="184" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="152" cy="134" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="183" cy="182" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="214" cy="175" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="245" cy="92" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="276" cy="82" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="308" cy="162" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="339" cy="188" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="84" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="401" cy="159" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="432" cy="89" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="464" cy="97" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="495" cy="180" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="526" cy="154" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="181" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
 <circle cx="588" cy="145" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="620" cy="163" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="651" cy="139" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="620" cy="171" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="651" cy="137" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
 </svg>

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-reported.svg
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-branch-reported.svg
@@ -18,57 +18,57 @@ commit position
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="526" y1="253" x2="526" y2="34"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="588" y1="253" x2="588" y2="34"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="651" y1="253" x2="651" y2="34"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="237" x2="667" y2="237"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="215" x2="667" y2="215"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="192" x2="667" y2="192"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="170" x2="667" y2="170"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="148" x2="667" y2="148"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="126" x2="667" y2="126"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="104" x2="667" y2="104"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="82" x2="667" y2="82"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="248" x2="667" y2="248"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="224" x2="667" y2="224"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="201" x2="667" y2="201"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="177" x2="667" y2="177"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="154" x2="667" y2="154"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="130" x2="667" y2="130"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="107" x2="667" y2="107"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="83" x2="667" y2="83"/>
 <line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="60" x2="667" y2="60"/>
-<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="38" x2="667" y2="38"/>
+<line opacity="0.12" stroke="currentColor" stroke-width="1" x1="74" y1="36" x2="667" y2="36"/>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="73,34 73,253 "/>
-<text x="64" y="237" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<text x="64" y="248" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 90.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,237 73,237 "/>
-<text x="64" y="215" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,248 73,248 "/>
+<text x="64" y="224" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 95.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,215 73,215 "/>
-<text x="64" y="192" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,224 73,224 "/>
+<text x="64" y="201" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 100.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,192 73,192 "/>
-<text x="64" y="170" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,201 73,201 "/>
+<text x="64" y="177" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 105.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,170 73,170 "/>
-<text x="64" y="148" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,177 73,177 "/>
+<text x="64" y="154" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 110.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,148 73,148 "/>
-<text x="64" y="126" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,154 73,154 "/>
+<text x="64" y="130" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 115.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,126 73,126 "/>
-<text x="64" y="104" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,130 73,130 "/>
+<text x="64" y="107" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 120.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,104 73,104 "/>
-<text x="64" y="82" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,107 73,107 "/>
+<text x="64" y="83" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 125.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,82 73,82 "/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,83 73,83 "/>
 <text x="64" y="60" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 130.0
 </text>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,60 73,60 "/>
-<text x="64" y="38" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
+<text x="64" y="36" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 135.0
 </text>
-<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,38 73,38 "/>
+<polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="68,36 73,36 "/>
 <polyline fill="none" opacity="1" stroke="currentColor" stroke-width="1" points="74,254 667,254 "/>
 <text x="89" y="264" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="currentColor">
 0
@@ -114,31 +114,31 @@ commit position
 <text x="74" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#306EC8">
 base window
 </text>
-<rect x="74" y="161" width="593" height="67" opacity="0.15" fill="#9664BE" stroke="none"/>
-<text x="74" y="161" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
+<rect x="74" y="178" width="593" height="50" opacity="0.15" fill="#9664BE" stroke="none"/>
+<text x="74" y="178" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9664BE">
 predicted range
 </text>
 <polyline fill="none" opacity="1" stroke="#D64541" stroke-width="2" points="635,253 635,34 "/>
 <text x="635" y="34" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#D64541">
 context commit
 </text>
-<circle cx="89" cy="191" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="120" cy="206" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="152" cy="192" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="183" cy="205" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="214" cy="203" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="245" cy="180" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="276" cy="177" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="308" cy="200" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="339" cy="207" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="370" cy="177" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="401" cy="199" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="432" cy="179" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="464" cy="181" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="495" cy="205" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="526" cy="197" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="557" cy="205" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="588" cy="195" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
-<circle cx="620" cy="202" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="200" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="120" cy="215" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="152" cy="200" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="183" cy="214" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="214" cy="212" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="245" cy="187" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="276" cy="184" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="308" cy="208" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="339" cy="216" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="185" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="401" cy="207" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="432" cy="187" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="464" cy="189" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="495" cy="214" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="526" cy="206" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="214" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="588" cy="203" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
+<circle cx="620" cy="211" r="3" opacity="1" fill="#306EC8" stroke="none" stroke-width="1"/>
 <circle cx="651" cy="60" r="3" opacity="1" fill="#D64541" stroke="none" stroke-width="1"/>
 </svg>

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1039,20 +1039,20 @@ whose baseline is a couple of nanoseconds turns scheduling jitter into a double-
 percentage move; without the relative floor a large baseline would flag on a move that is
 noise at its scale.
 
-Branch mode also **discards isolated measurement excursions** from the base window before it
+Branch mode also **discards an isolated measurement excursion** from the base window before it
 compares anything. A shared runner occasionally loses time to something else and records one
 commit far above the level its neighbours agree on; that reading describes the runner rather
 than the code, and left in the window it both pulls the comparison's centre toward itself and
 inflates the scatter the move is judged against, so a genuine regression passes unreported.
 The failure is silent, which is what makes it worth correcting rather than tolerating. A level
 is discarded only when the levels on either side of it agree with one another, it stands far
-clear of them, and few enough levels in the window qualify — jointly, "the series was doing one
-thing, this one commit was not, and then it went back to doing it". A window where many levels
-qualify is not a clean window with a bad reading in it but a benchmark that genuinely
-oscillates between levels, and it is left exactly as measured; so are the window's oldest and
-newest levels, which have no surroundings on both sides to be judged against. Discarding a
-level *tightens* the window and so makes the mode readier to report, which is why the rule is
-narrow: it removes what no amount of unchanged code would reproduce, and nothing else.
+clear of them, and it is the window's only such level — jointly, "the series was doing one
+thing, this one commit was not, and then it went back to doing it". A window offering a second
+candidate is not a clean window with a bad reading in it but a benchmark that visits more than
+one level, and how often it does so is exactly what the context run is measured against; such a
+window is left exactly as measured. So are levels near the window's ends, which lack the
+surroundings on both sides that the judgment consults. Discarding a level *tightens* the window
+and so makes the mode readier to report, which is why the rule is this narrow.
 Whether a series is judged at all is decided on its window as recorded, before anything is
 discarded from it: that floor asks whether the series has a recent base history to be compared
 against, and a bad reading within that history does not change the answer.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1039,31 +1039,32 @@ whose baseline is a couple of nanoseconds turns scheduling jitter into a double-
 percentage move; without the relative floor a large baseline would flag on a move that is
 noise at its scale.
 
-Branch mode also **discards an isolated measurement excursion** from the base window before it
-compares anything. A shared runner occasionally loses time to something else and records one
-commit far above the level its neighbours agree on; that reading describes the runner rather
-than the code, and left in the window it both pulls the comparison's centre toward itself and
-inflates the scatter the move is judged against, so a genuine regression passes unreported.
-The failure is silent, which is what makes it worth correcting rather than tolerating. A level
-is discarded only when the levels on either side of it agree with one another, it stands far
-clear of them, and it is the window's only such level — jointly, "the series was doing one
-thing, this one commit was not, and then it went back to doing it". A window offering a second
-candidate is not a clean window with a bad reading in it but a benchmark that visits more than
-one level, and how often it does so is exactly what the context run is measured against; such a
-window is left exactly as measured. So are levels near the window's ends, which lack the
-surroundings on both sides that the judgment consults. And so is a level the context run itself
-stands at: the run being judged is evidence consistent with the base window's level recurring,
-and a level the series may well return to cannot safely be discarded from the description of
-what it does. Discarding a level *tightens* the window and so makes the mode readier to report,
-which is why the rule is this narrow.
-Whether a series is judged at all is decided on its window as recorded, before anything is
-discarded from it: that floor asks whether the series has a recent base history to be compared
-against, and a bad reading within that history does not change the answer.
-A discarded reading is named under `--verbose`, along with what it measured and the level its
-neighbours agreed on, since narrowing a window changes a verdict without any gate declining and
-would otherwise leave no trace.
-History mode does not clean its evidence, because its gates take their level and their scatter
-from medians, which absorb a single wild reading on their own.
+Branch mode also **discards a single isolated measurement excursion** from the base window before
+it compares anything. A shared runner occasionally loses time to something else and records one
+commit far above the level its neighbours agree on; left in the window, that reading drags the
+comparison's centre and inflates its scatter, so a genuine regression passes silently unreported.
+
+A level is discarded only when three conditions hold together — its neighbours on either side
+agree with one another, it stands far clear of them, and it is the window's only such level:
+*the series was doing one thing, this one commit was not, and then it went back*. The rule is
+deliberately narrow, because discarding **tightens** the window and so makes the mode readier to
+report. These are therefore left exactly as measured:
+
+* a window offering a **second** candidate, which is a benchmark visiting more than one level —
+  precisely what the context run is measured against — not a clean window with one bad reading;
+* a level near the window's **ends**, which lacks the neighbours on both sides the judgment
+  consults;
+* a level the **context run itself stands at**, since the series may return to that level and so
+  it cannot be dropped from the description of what the series does.
+
+Two tenets bound the behaviour. Whether a series is judged at all is decided on the window **as
+recorded**, before anything is discarded — that check only asks whether a recent base history
+exists to compare against. And a discarded reading is named under `--verbose`, with what it
+measured and its neighbours' level, since narrowing a window changes a verdict without any gate
+declining and would otherwise leave no trace.
+
+History mode does not clean its evidence: its gates take their level and scatter from medians,
+which absorb a single wild reading on their own.
 
 The gate thresholds are centralized as a single policy rather than embedded throughout the
 detectors, so maintainers can review and tune the complete policy together. Each threshold is

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1051,11 +1051,17 @@ thing, this one commit was not, and then it went back to doing it". A window off
 candidate is not a clean window with a bad reading in it but a benchmark that visits more than
 one level, and how often it does so is exactly what the context run is measured against; such a
 window is left exactly as measured. So are levels near the window's ends, which lack the
-surroundings on both sides that the judgment consults. Discarding a level *tightens* the window
-and so makes the mode readier to report, which is why the rule is this narrow.
+surroundings on both sides that the judgment consults. And so is a level the context run itself
+stands at: the run being judged is evidence consistent with the base window's level recurring,
+and a level the series may well return to cannot safely be discarded from the description of
+what it does. Discarding a level *tightens* the window and so makes the mode readier to report,
+which is why the rule is this narrow.
 Whether a series is judged at all is decided on its window as recorded, before anything is
 discarded from it: that floor asks whether the series has a recent base history to be compared
 against, and a bad reading within that history does not change the answer.
+A discarded reading is named under `--verbose`, along with what it measured and the level its
+neighbours agreed on, since narrowing a window changes a verdict without any gate declining and
+would otherwise leave no trace.
 History mode does not clean its evidence, because its gates take their level and their scatter
 from medians, which absorb a single wild reading on their own.
 

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -1039,6 +1039,26 @@ whose baseline is a couple of nanoseconds turns scheduling jitter into a double-
 percentage move; without the relative floor a large baseline would flag on a move that is
 noise at its scale.
 
+Branch mode also **discards isolated measurement excursions** from the base window before it
+compares anything. A shared runner occasionally loses time to something else and records one
+commit far above the level its neighbours agree on; that reading describes the runner rather
+than the code, and left in the window it both pulls the comparison's centre toward itself and
+inflates the scatter the move is judged against, so a genuine regression passes unreported.
+The failure is silent, which is what makes it worth correcting rather than tolerating. A level
+is discarded only when the levels on either side of it agree with one another, it stands far
+clear of them, and few enough levels in the window qualify — jointly, "the series was doing one
+thing, this one commit was not, and then it went back to doing it". A window where many levels
+qualify is not a clean window with a bad reading in it but a benchmark that genuinely
+oscillates between levels, and it is left exactly as measured; so are the window's oldest and
+newest levels, which have no surroundings on both sides to be judged against. Discarding a
+level *tightens* the window and so makes the mode readier to report, which is why the rule is
+narrow: it removes what no amount of unchanged code would reproduce, and nothing else.
+Whether a series is judged at all is decided on its window as recorded, before anything is
+discarded from it: that floor asks whether the series has a recent base history to be compared
+against, and a bad reading within that history does not change the answer.
+History mode does not clean its evidence, because its gates take their level and their scatter
+from medians, which absorb a single wild reading on their own.
+
 The gate thresholds are centralized as a single policy rather than embedded throughout the
 detectors, so maintainers can review and tune the complete policy together. Each threshold is
 documented there with the reasoning that sets its value; this document describes the rules

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -16,9 +16,9 @@ use cbh_config::{
     resolve_project_id, resolve_repo, storage_env,
 };
 use cbh_detect::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, Series, SeriesCensus, SeriesFilter,
-    Testability, UnjudgedReason, apply_blessings, find_changes_spawned, retain_present_at_context,
-    short_commit, testability,
+    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, DiscardedBaseReading,
+    DiscardedReading, Series, SeriesCensus, SeriesFilter, Testability, UnjudgedReason,
+    apply_blessings, find_changes_spawned, retain_present_at_context, short_commit, testability,
 };
 use cbh_diag::{Reporter, ReporterExt, StderrReporter, count_noun};
 use cbh_git::{GitHistory, SystemGitHistory};
@@ -301,6 +301,7 @@ where
     let Detection {
         findings,
         mut census,
+        discarded,
     } = find_changes_spawned(Arc::clone(&series), context, spawner).await;
     // The ghost filter judged nothing either, and it ran before detection could see
     // those series, so its exclusions join the same account.
@@ -309,6 +310,7 @@ where
         "change detection (find_changes: per-series detectors + FDR filter)",
         detect_started.elapsed(),
     );
+    note_discarded_readings(reporter, &discarded);
     note_series_census(reporter, &series, &context, &census);
     let regressions = findings
         .iter()
@@ -417,6 +419,51 @@ fn all_ghosts_hint(tip_commit: &str) -> String {
         from history.",
         short_commit(tip_commit)
     )
+}
+
+/// Explains, under `--verbose`, which base-window readings branch mode left out of its
+/// comparisons.
+///
+/// Discarding narrows the evidence a verdict rests on and so can change that verdict, in
+/// either direction, without any gate declining and without anything appearing in the
+/// report. Naming each discarded reading, what it measured, and the level its neighbours
+/// agreed on lets a reader tell a comparison that was narrowed from one that was not, and
+/// judge for themselves whether the reading deserved to go.
+fn note_discarded_readings<R: Reporter + ?Sized>(reporter: &R, discarded: &[DiscardedBaseReading]) {
+    if discarded.is_empty() {
+        return;
+    }
+    reporter.if_enabled(|notes| {
+        for one in discarded {
+            notes.note(&format!(
+                "discarding base commit at first-parent index {} from the comparison for {} {} \
+                 in {}: it measured {}, while the commits on both sides of it agree on {} — an \
+                 isolated excursion of {:+.1}%, which describes the runner rather than the code",
+                one.reading.topo_index,
+                one.id.qualified(),
+                one.kind.as_str(),
+                one.set,
+                one.reading.value,
+                one.reading.neighbour_level,
+                relative_excursion(&one.reading) * 100.0,
+            ));
+        }
+        notes.note(&format!(
+            "excursion filter: left {} out of the branch comparisons named above, each dropped \
+             rather than replaced by an estimate; every reading remains stored, charted, and \
+             counted toward whether its series had enough base history to be judged at all",
+            count_noun(discarded.len(), "isolated reading"),
+        ));
+    });
+}
+
+/// How far a discarded reading stood from the level its neighbours agreed on, as a
+/// fraction of that level.
+fn relative_excursion(reading: &DiscardedReading) -> f64 {
+    if reading.neighbour_level.abs() <= f64::EPSILON {
+        return 0.0;
+    }
+    (reading.value - reading.neighbour_level) / reading.neighbour_level
 }
 
 /// Explains, under `--verbose`, which series the detectors judged and what each of
@@ -821,11 +868,17 @@ mod tests {
     }
 
     /// Seeds a flat base line of `base_commits` clean runs (`c0 …`) plus a raised
-    /// feature regime: clean `f1` and `f2` runs and a dirty `f2` snapshot on top of
-    /// them. Returns the number of runs stored.
+    /// feature regime. Returns the number of runs stored.
     fn seed_raised_feature(storage: &MemoryStorage, base_commits: usize) -> usize {
-        seed_master(storage, &vec![100.0; base_commits]);
-        let observed = i64::try_from(base_commits).unwrap();
+        seed_feature_over(storage, &vec![100.0; base_commits])
+    }
+
+    /// Seeds `base` as the base line (`c0 …`) plus a raised feature regime: clean `f1`
+    /// and `f2` runs and a dirty `f2` snapshot on top of them. Returns the number of runs
+    /// stored.
+    fn seed_feature_over(storage: &MemoryStorage, base: &[f64]) -> usize {
+        seed_master(storage, base);
+        let observed = i64::try_from(base.len()).unwrap();
         let dirty_at = observed.saturating_add(2);
         store(storage, &clean_key("f1"), &ir_set(observed, "f1", 130.0));
         store(
@@ -838,7 +891,7 @@ mod tests {
             &dirty_key("f2", dirty_at),
             &ir_set(dirty_at, "f2", 130.0),
         );
-        base_commits.saturating_add(3)
+        base.len().saturating_add(3)
     }
 
     /// The observation second the extra merge-base run in a lagging-base fixture
@@ -1470,6 +1523,58 @@ mod tests {
         serde_json::from_str::<serde_json::Value>(report).unwrap()["census"]["judged"]
             .as_u64()
             .expect("every report carries a census")
+    }
+
+    #[test]
+    fn the_trail_names_a_base_reading_left_out_of_a_branch_comparison() {
+        // Discarding a base reading narrows the evidence a verdict rests on without any
+        // gate declining, so nothing else in the output would reveal that the comparison
+        // was not run against the window as measured. The trail must name the commit,
+        // what it measured, what its neighbours agreed on, and how far apart those are,
+        // so a reader can judge the removal rather than merely discover it.
+        let storage = MemoryStorage::new();
+        // Far enough clear of its neighbours to qualify, with a full set of them on both
+        // sides — the shape the filter exists for.
+        let excursion_at = BASE_COMMITS.checked_div(2).unwrap();
+        let mut base = vec![100.0; BASE_COMMITS];
+        base[excursion_at] = 200.0;
+        seed_feature_over(&storage, &base);
+
+        let (report, _, reporter) = analyze_json(&branch_git(), &storage, "folo", &options());
+        assert!(
+            reporter.contains(&format!(
+                "discarding base commit at first-parent index {excursion_at} from the comparison"
+            )),
+            "the trail must name the discarded commit: {report}"
+        );
+        assert!(
+            reporter.contains(
+                "it measured 200, while the commits on both sides of it agree on \
+                 100 — an isolated excursion of +100.0%"
+            ),
+            "the trail must state what was discarded and what it stood clear of: {report}"
+        );
+        assert!(
+            reporter.contains(
+                "excursion filter: left 1 isolated reading out of the branch \
+                 comparisons named above"
+            ),
+            "the trail must summarise how much was left out: {report}"
+        );
+    }
+
+    #[test]
+    fn the_trail_stays_silent_when_no_base_reading_is_left_out() {
+        // The filter reports only what it did. An ordinary window must produce no note at
+        // all, so the presence of one is itself the signal that a comparison was narrowed.
+        let storage = MemoryStorage::new();
+        seed_raised_feature(&storage, BASE_COMMITS);
+
+        let (report, _, reporter) = analyze_json(&branch_git(), &storage, "folo", &options());
+        assert!(
+            !reporter.contains("excursion filter"),
+            "an undisturbed window must not be described as narrowed: {report}"
+        );
     }
 
     #[test]

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -1537,7 +1537,10 @@ mod tests {
         // sides — the shape the filter exists for.
         let excursion_at = BASE_COMMITS.checked_div(2).unwrap();
         let mut base = vec![100.0; BASE_COMMITS];
-        base[excursion_at] = 200.0;
+        // Half again above its neighbours: clear of the magnitude floor, and a ratio the
+        // reported percentage cannot match by accident, so the trail must have computed it
+        // from the reading rather than emitting a constant.
+        base[excursion_at] = 150.0;
         seed_feature_over(&storage, &base);
 
         let (report, _, reporter) = analyze_json(&branch_git(), &storage, "folo", &options());
@@ -1549,8 +1552,8 @@ mod tests {
         );
         assert!(
             reporter.contains(
-                "it measured 200, while the commits on both sides of it agree on \
-                 100 — an isolated excursion of +100.0%"
+                "it measured 150, while the commits on both sides of it agree on \
+                 100 — an isolated excursion of +50.0%"
             ),
             "the trail must state what was discarded and what it stood clear of: {report}"
         );

--- a/packages/cbh_detect/docs/implementation.md
+++ b/packages/cbh_detect/docs/implementation.md
@@ -17,17 +17,19 @@ that sets it. Detectors read those thresholds through the analysis configuration
 lets tests vary a single policy value in isolation.
 
 Evidence selection is separated from evidence judgment. Deciding which base-window levels a branch
-comparison may see — discarding a stale prefix when the base itself moved, and discarding isolated
-measurement excursions — happens before any comparison gate runs, so those gates judge one
+comparison may see — discarding a stale prefix when the base itself moved, and discarding an
+isolated measurement excursion — happens before any comparison gate runs, so those gates judge one
 already-chosen sample and the prediction interval's centre and scatter always come from that same
 sample. This is a hard constraint rather than a tidiness preference: a robust scale estimator
 paired with a non-robust centre was measured to invent regressions on unchanged code.
 
-Selection is nonetheless bounded by the evidence floor rather than the reverse. Whether a series
-can be judged at all is settled on its window as recorded, which keeps that decision in exact
-correspondence with the public testability projection the census counts and the false-discovery
-family is sized from. Narrowing that happens afterwards cannot make the census untruthful,
-because the floor was met before anything was discarded.
+Selection is nonetheless bounded by the eligibility gate rather than the reverse. That one gate
+runs first, so whether a series can be judged at all is settled on its window as recorded, which
+keeps the decision in exact correspondence with the public testability projection the census counts
+and the false-discovery family is sized from. Narrowing that happens afterwards cannot make the
+census untruthful, because the floor was met before anything was discarded. It follows that no
+selection step may discard so much that the remainder falls under the minimum regime length; the
+configured removal allowance is set far below that margin.
 
 Parallel work is supplied through an executor abstraction, preserving the same deterministic
 analysis logic for production execution and synchronous component tests.

--- a/packages/cbh_detect/docs/implementation.md
+++ b/packages/cbh_detect/docs/implementation.md
@@ -11,5 +11,29 @@ and findings. It composes the kernels in `cbh_stats` with analysis-specific grou
 ranking policy. Storage loading and history queries remain in `cbh_analyze`, while presentation of
 the resulting findings remains in `cbh_render`.
 
+Gating policy is centralized: every threshold a detector turns on lives in one module rather than
+at its point of use, so the policy can be reviewed as a whole and each value carries the reasoning
+that sets it. Detectors read those thresholds through the analysis configuration, which is what
+lets tests vary a single policy value in isolation.
+
+Evidence selection is separated from evidence judgment. Deciding which base-window levels a branch
+comparison may see — discarding a stale prefix when the base itself moved, and discarding isolated
+measurement excursions — happens before any comparison gate runs, so those gates judge one
+already-chosen sample and the prediction interval's centre and scatter always come from that same
+sample. This is a hard constraint rather than a tidiness preference: a robust scale estimator
+paired with a non-robust centre was measured to invent regressions on unchanged code.
+
+Selection is nonetheless bounded by the evidence floor rather than the reverse. Whether a series
+can be judged at all is settled on its window as recorded, which keeps that decision in exact
+correspondence with the public testability projection the census counts and the false-discovery
+family is sized from. Narrowing that happens afterwards cannot make the census untruthful,
+because the floor was met before anything was discarded.
+
 Parallel work is supplied through an executor abstraction, preserving the same deterministic
 analysis logic for production execution and synchronous component tests.
+
+Test data comes from two sources with different jobs. A deterministic generator supplies realistic
+*spread* for curated shapes, and verbatim recordings of this project's own stored series supply
+realistic *shape* — bimodality and one-sided excursions — which no generator here produces. A gate
+whose purpose is to survive a pathological shape is pinned against a recording of that shape
+rather than against a model of it.

--- a/packages/cbh_detect/docs/implementation.md
+++ b/packages/cbh_detect/docs/implementation.md
@@ -18,9 +18,9 @@ lets tests vary a single policy value in isolation.
 
 Evidence selection is separated from evidence judgment. Deciding which base-window levels a branch
 comparison may see — discarding a stale prefix when the base itself moved, and discarding an
-isolated measurement excursion — happens before any comparison gate runs, so those gates judge one
-already-chosen sample and the prediction interval's centre and scatter always come from that same
-sample. This is a hard constraint rather than a tidiness preference: a robust scale estimator
+isolated measurement excursion — happens once, before the comparison itself is judged, so the
+judgment gates see one already-chosen sample and the prediction interval's centre and scatter
+always come from that same sample. This is a hard constraint rather than a tidiness preference: a robust scale estimator
 paired with a non-robust centre was measured to invent regressions on unchanged code.
 
 Selection is nonetheless bounded by the eligibility gate rather than the reverse. That one gate

--- a/packages/cbh_detect/src/detect/examples.rs
+++ b/packages/cbh_detect/src/detect/examples.rs
@@ -28,7 +28,9 @@ use nonempty::nonempty;
 use crate::detect::findings::count_to_f64;
 use crate::detect::noise_gates::MIN_REGIME;
 pub use crate::detect::recorded::{
-    STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH, STATIONARY_BIMODAL_NOISE,
+    CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL,
+    CONTENDED_RUNNER_LEVEL_START, STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH,
+    STATIONARY_BIMODAL_NOISE,
 };
 pub use crate::detect::scatter::{TIMING_NOISE_CV, scattered, seed_of};
 use crate::detect::{

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -30,16 +30,21 @@ use super::AnalysisConfig;
 use super::findings::relative_delta_of;
 use super::series::BaseLevel;
 
-/// `window` with its isolated measurement excursions removed, oldest first.
+/// `window` with its isolated measurement excursion removed, oldest first.
+///
+/// `context_level` is the level the context run sits at, which is evidence about the
+/// window: a candidate the context run agrees with is a level this series reaches rather
+/// than a moment its runner lost.
 ///
 /// Borrows `window` unchanged in the ordinary case, which is every window that holds no
 /// excursion at all.
 pub(super) fn cleaned_window<'a>(
     window: &'a [BaseLevel],
+    context_level: Option<f64>,
     config: &AnalysisConfig,
 ) -> Cow<'a, [BaseLevel]> {
     let levels: Vec<f64> = window.iter().map(|level| level.value).collect();
-    let discarded = isolated_excursions(&levels, config);
+    let discarded = isolated_excursions(&levels, context_level, config);
     if discarded.is_empty() {
         return Cow::Borrowed(window);
     }
@@ -67,14 +72,13 @@ pub(super) fn cleaned_window<'a>(
 /// 2. **It stands far clear of them.** It must differ from its surroundings by at least
 ///    [`excursion_relative_magnitude`](AnalysisConfig::excursion_relative_magnitude),
 ///    which is set well above ordinary measurement wobble.
-/// 3. **It is the only one.** If more than
+/// 3. **It is the only one, and the context run does not agree with it.** If more than
 ///    [`excursion_max_removals`](AnalysisConfig::excursion_max_removals) levels qualify,
-///    nothing is removed at all. A window offering a second candidate is not a clean
-///    window with a bad reading in it: two separated levels agreeing on a value their
-///    surroundings do not is a benchmark that visits more than one level, and how often it
-///    does so is exactly what the context run is measured against. Stripping a recurring
-///    level away would leave a spuriously tight window in which the benchmark's own
-///    ordinary values read as large, certain regressions.
+///    nothing is removed at all, and a level the context run itself sits at is never
+///    removed. Either way the window has shown the level twice, and twice is a level the
+///    series reaches rather than a moment its runner lost. Stripping a recurring level
+///    away would leave a window describing a level the benchmark does not reliably hold,
+///    against which its own ordinary values read as large, certain regressions.
 ///
 /// A level without a full set of neighbours on *both* sides is never removed, since test 1
 /// has nothing complete to consult. That is deliberate rather than incidental at the
@@ -86,7 +90,11 @@ pub(super) fn cleaned_window<'a>(
 /// exactly across runs of unchanged code, so an isolated excursion in one is as much a
 /// measurement artifact as it is in a timing series, and is as unrepresentative of the
 /// level a pull request would merge into.
-pub(super) fn isolated_excursions(levels: &[f64], config: &AnalysisConfig) -> Vec<usize> {
+pub(super) fn isolated_excursions(
+    levels: &[f64],
+    context_level: Option<f64>,
+    config: &AnalysisConfig,
+) -> Vec<usize> {
     let mut found = Vec::new();
     for index in 0..levels.len() {
         let Some(surroundings) = Surroundings::around(index, levels, config.excursion_neighbours)
@@ -100,6 +108,11 @@ pub(super) fn isolated_excursions(levels: &[f64], config: &AnalysisConfig) -> Ve
             continue;
         };
         if !surroundings.stands_clear(level, config.excursion_relative_magnitude) {
+            continue;
+        }
+        if context_level.is_some_and(|context| {
+            surroundings.same_level(level, context, config.excursion_neighbour_agreement)
+        }) {
             continue;
         }
         found.push(index);
@@ -156,7 +169,13 @@ impl Surroundings {
 
     /// Whether the two sides describe the same level, to within `tolerance`.
     fn agree(&self, tolerance: f64) -> bool {
-        relative_delta_of(self.after - self.before, self.level).abs() <= tolerance
+        self.same_level(self.before, self.after, tolerance)
+    }
+
+    /// Whether `left` and `right` describe the same level, measured on this
+    /// neighbourhood's scale so every judgment about the candidate shares one reference.
+    fn same_level(&self, left: f64, right: f64, tolerance: f64) -> bool {
+        relative_delta_of(right - left, self.level).abs() <= tolerance
     }
 
     /// Whether `level` differs from these surroundings by at least `magnitude`.
@@ -191,21 +210,21 @@ mod tests {
 
     #[test]
     fn a_flat_window_has_no_excursions() {
-        assert!(isolated_excursions(&flat(16), &config()).is_empty());
+        assert!(isolated_excursions(&flat(16), None, &config()).is_empty());
     }
 
     #[test]
     fn a_lone_excursion_is_found() {
         let mut levels = flat(16);
         levels[8] = EXCURSION;
-        assert_eq!(isolated_excursions(&levels, &config()), vec![8]);
+        assert_eq!(isolated_excursions(&levels, None, &config()), vec![8]);
     }
 
     #[test]
     fn a_lone_dip_is_found_as_readily_as_a_spike() {
         let mut levels = flat(16);
         levels[8] = LEVEL / 2.0;
-        assert_eq!(isolated_excursions(&levels, &config()), vec![8]);
+        assert_eq!(isolated_excursions(&levels, None, &config()), vec![8]);
     }
 
     #[test]
@@ -213,7 +232,7 @@ mod tests {
         // Every level past the step sits at the new level, so no level's surroundings
         // agree across it — which is the whole point: a real change must survive.
         let levels: Vec<f64> = flat(8).into_iter().chain(vec![EXCURSION; 8]).collect();
-        assert!(isolated_excursions(&levels, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None, &config()).is_empty());
     }
 
     #[test]
@@ -221,21 +240,40 @@ mod tests {
         let config = config();
         let mut levels = flat(16);
         levels[8] = LEVEL * (1.0 + config.excursion_relative_magnitude / 2.0);
-        assert!(isolated_excursions(&levels, &config).is_empty());
+        assert!(isolated_excursions(&levels, None, &config).is_empty());
     }
 
     #[test]
     fn levels_without_full_surroundings_are_never_removed() {
         // The outer `excursion_neighbours` levels at each end have no complete side to be
-        // judged against, so an excursion there is kept however far it stands out.
+        // judged against, so an excursion there is kept however far it stands out. Each
+        // position is tried in an otherwise clean window, so the test fails if a
+        // truncated neighbourhood is ever consulted instead of the position being skipped.
         let config = config();
-        let mut levels = flat(16);
-        let last = levels.len() - 1;
-        for offset in 0..config.excursion_neighbours {
-            levels[offset] = EXCURSION;
-            levels[last - offset] = EXCURSION;
+        let length = 16;
+        let last = length - 1;
+        let protected =
+            (0..config.excursion_neighbours).chain((last - config.excursion_neighbours + 1)..=last);
+
+        for index in protected {
+            let mut levels = flat(length);
+            levels[index] = EXCURSION;
+            assert!(
+                isolated_excursions(&levels, None, &config).is_empty(),
+                "index {index} has no complete surroundings and must be kept",
+            );
         }
-        assert!(isolated_excursions(&levels, &config).is_empty());
+    }
+
+    #[test]
+    fn a_level_with_complete_surroundings_just_inside_the_edge_is_removable() {
+        // The counterpart of the test above: protection stops exactly where complete
+        // surroundings begin, so the guard cannot quietly widen into the window.
+        let config = config();
+        let index = config.excursion_neighbours;
+        let mut levels = flat(16);
+        levels[index] = EXCURSION;
+        assert_eq!(isolated_excursions(&levels, None, &config), vec![index]);
     }
 
     #[test]
@@ -248,7 +286,35 @@ mod tests {
         let mut levels = flat(16);
         levels[5] = EXCURSION;
         levels[11] = EXCURSION;
-        assert!(isolated_excursions(&levels, &config).is_empty());
+        assert!(isolated_excursions(&levels, None, &config).is_empty());
+    }
+
+    #[test]
+    fn a_level_the_context_run_also_sits_at_is_kept() {
+        // The context run is the window's second sighting of that level, and two
+        // sightings are a level the series reaches rather than a moment its runner lost.
+        // Discarding it would leave the window describing a level the series does not
+        // reliably hold, and the context run would read as a large, certain regression
+        // against what remained.
+        let config = config();
+        let mut levels = flat(16);
+        levels[8] = EXCURSION;
+        assert!(isolated_excursions(&levels, Some(EXCURSION), &config).is_empty());
+    }
+
+    #[test]
+    fn a_context_run_elsewhere_does_not_protect_the_excursion() {
+        // Only a context run at the candidate's own level is evidence of recurrence. One
+        // that moved somewhere else says nothing about it, and the window is still
+        // cleaned — which is the ordinary case the rule exists to serve.
+        let config = config();
+        let mut levels = flat(16);
+        levels[8] = EXCURSION;
+        let elsewhere = LEVEL * (1.0 + config.excursion_relative_magnitude / 2.0);
+        assert_eq!(
+            isolated_excursions(&levels, Some(elsewhere), &config),
+            vec![8]
+        );
     }
 
     #[test]
@@ -257,7 +323,7 @@ mod tests {
         for index in [5, 11, 16] {
             levels[index] = EXCURSION;
         }
-        assert!(isolated_excursions(&levels, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None, &config()).is_empty());
     }
 
     #[test]
@@ -268,7 +334,7 @@ mod tests {
         let window = STATIONARY_BIMODAL_NOISE
             .get(..STATIONARY_BIMODAL_BASE)
             .expect("the base prefix is within the recording");
-        assert!(isolated_excursions(window, &config()).is_empty());
+        assert!(isolated_excursions(window, None, &config()).is_empty());
     }
 
     #[test]
@@ -282,7 +348,7 @@ mod tests {
             .max_by(|(_, left), (_, right)| left.total_cmp(right))
             .map(|(index, _)| index)
             .expect("the window is not empty");
-        assert_eq!(isolated_excursions(window, &config()), vec![expected]);
+        assert_eq!(isolated_excursions(window, None, &config()), vec![expected]);
     }
 
     #[test]
@@ -292,29 +358,34 @@ mod tests {
         // whose magnitude gate is inert there.
         let mut levels = vec![0.0; 16];
         levels[8] = 1.0;
-        assert!(isolated_excursions(&levels, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None, &config()).is_empty());
     }
 
     #[test]
     fn an_all_zero_window_has_no_excursions() {
-        assert!(isolated_excursions(&[0.0; 16], &config()).is_empty());
+        assert!(isolated_excursions(&[0.0; 16], None, &config()).is_empty());
     }
 
     #[test]
     fn a_window_too_short_to_have_surroundings_is_left_untouched() {
         // A candidate needs a full set of neighbours on each side, so a window shorter
-        // than that plus the candidate itself has nowhere a level could be judged.
+        // than that plus the candidate itself has nowhere a level could be judged. Each
+        // length is tried with a genuine excursion at every position, so the test would
+        // fail if a short window fell back to judging against what neighbours it has.
         let config = config();
         let shortest_with_interior = config
             .excursion_neighbours
             .saturating_mul(2)
             .saturating_add(1);
         for length in 0..shortest_with_interior {
-            let levels = vec![EXCURSION; length];
-            assert!(
-                isolated_excursions(&levels, &config).is_empty(),
-                "a window of {length} level(s) has no judgeable interior",
-            );
+            for index in 0..length {
+                let mut levels = flat(length);
+                levels[index] = EXCURSION;
+                assert!(
+                    isolated_excursions(&levels, None, &config).is_empty(),
+                    "a window of {length} level(s) has no judgeable interior at {index}",
+                );
+            }
         }
     }
 
@@ -333,7 +404,7 @@ mod tests {
     #[test]
     fn a_clean_window_is_passed_through_without_copying() {
         let window = window_of(&flat(16));
-        let cleaned = cleaned_window(&window, &config());
+        let cleaned = cleaned_window(&window, None, &config());
         assert!(matches!(cleaned, Cow::Borrowed(_)));
         assert_eq!(cleaned.as_ref(), window.as_slice());
     }
@@ -343,7 +414,7 @@ mod tests {
         let mut levels = flat(16);
         levels[8] = EXCURSION;
         let window = window_of(&levels);
-        let cleaned = cleaned_window(&window, &config());
+        let cleaned = cleaned_window(&window, None, &config());
         let expected: Vec<BaseLevel> = window
             .iter()
             .filter(|level| level.topo_index != 8)

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -30,7 +30,24 @@ use super::AnalysisConfig;
 use super::findings::relative_delta_of;
 use super::series::BaseLevel;
 
-/// `window` with its isolated measurement excursion removed, oldest first.
+/// One base-window reading branch mode left out of a comparison.
+///
+/// Discarding a reading changes a verdict without declining anything, so no gate records
+/// it and it would otherwise be invisible. This carries what a reader needs to reconstruct
+/// the decision — which commit, what it measured, and the level its neighbours agreed on
+/// that it stood clear of — so `--verbose` can explain a comparison that silently narrowed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DiscardedReading {
+    /// First-parent topological index of the base-ref commit the reading came from.
+    pub topo_index: usize,
+    /// The value that was left out.
+    pub value: f64,
+    /// The level its neighbours on both sides agreed on, which it stood clear of.
+    pub neighbour_level: f64,
+}
+
+/// `window` with its isolated measurement excursion removed, oldest first, and what was
+/// removed.
 ///
 /// `context_level` is the level the context run sits at, which is evidence about the
 /// window: a candidate the context run agrees with is a level this series reaches rather
@@ -42,20 +59,33 @@ pub(super) fn cleaned_window<'a>(
     window: &'a [BaseLevel],
     context_level: Option<f64>,
     config: &AnalysisConfig,
-) -> Cow<'a, [BaseLevel]> {
+) -> (Cow<'a, [BaseLevel]>, Vec<DiscardedReading>) {
     let levels: Vec<f64> = window.iter().map(|level| level.value).collect();
     let discarded = isolated_excursions(&levels, context_level, config);
     if discarded.is_empty() {
-        return Cow::Borrowed(window);
+        return (Cow::Borrowed(window), Vec::new());
     }
-    Cow::Owned(
-        window
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| !discarded.contains(index))
-            .map(|(_, level)| level.clone())
-            .collect(),
-    )
+    // Reported against the same neighbourhood the judgment consulted, so the explanation
+    // and the decision cannot describe different surroundings.
+    let reported = discarded
+        .iter()
+        .filter_map(|&index| {
+            let level = window.get(index)?;
+            let surroundings = Surroundings::around(index, &levels, config.excursion_neighbours)?;
+            Some(DiscardedReading {
+                topo_index: level.topo_index,
+                value: level.value,
+                neighbour_level: surroundings.level,
+            })
+        })
+        .collect();
+    let kept = window
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !discarded.contains(index))
+        .map(|(_, level)| level.clone())
+        .collect();
+    (Cow::Owned(kept), reported)
 }
 
 /// The indices of `levels` that are isolated measurement excursions, oldest first.
@@ -404,9 +434,10 @@ mod tests {
     #[test]
     fn a_clean_window_is_passed_through_without_copying() {
         let window = window_of(&flat(16));
-        let cleaned = cleaned_window(&window, None, &config());
+        let (cleaned, discarded) = cleaned_window(&window, None, &config());
         assert!(matches!(cleaned, Cow::Borrowed(_)));
         assert_eq!(cleaned.as_ref(), window.as_slice());
+        assert!(discarded.is_empty());
     }
 
     #[test]
@@ -414,12 +445,22 @@ mod tests {
         let mut levels = flat(16);
         levels[8] = EXCURSION;
         let window = window_of(&levels);
-        let cleaned = cleaned_window(&window, None, &config());
+        let (cleaned, discarded) = cleaned_window(&window, None, &config());
         let expected: Vec<BaseLevel> = window
             .iter()
             .filter(|level| level.topo_index != 8)
             .cloned()
             .collect();
         assert_eq!(cleaned.as_ref(), expected.as_slice());
+        assert_eq!(
+            discarded,
+            vec![DiscardedReading {
+                topo_index: 8,
+                value: EXCURSION,
+                neighbour_level: LEVEL,
+            }],
+            "what was reported must be exactly what was removed, described against the \
+             neighbourhood the judgment consulted"
+        );
     }
 }

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -266,6 +266,21 @@ mod tests {
     }
 
     #[test]
+    fn a_step_reaching_the_window_end_is_never_an_excursion() {
+        // The new level fills only the window's trailing edge, which is never a candidate,
+        // so the last commit at the old level is the *only* position with a full set of
+        // neighbours — and those neighbours disagree, its own side at the old level and the
+        // far side at the new. The surroundings-agree test is therefore the sole thing
+        // between this step and being read as a lone excursion: unlike the centred step
+        // above, there is no second qualifying candidate to trip the removal limit and mask
+        // a bypassed agreement check. Were that check dropped, this commit would be
+        // discarded as a bad reading, tightening the window against the very move that just
+        // landed.
+        let levels: Vec<f64> = flat(11).into_iter().chain(vec![EXCURSION; 3]).collect();
+        assert!(isolated_excursions(&levels, None, &config()).is_empty());
+    }
+
+    #[test]
     fn a_move_below_the_magnitude_is_ordinary_scatter() {
         let config = config();
         let mut levels = flat(16);

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -67,16 +67,18 @@ pub(super) fn cleaned_window<'a>(
 /// 2. **It stands far clear of them.** It must differ from its surroundings by at least
 ///    [`excursion_relative_magnitude`](AnalysisConfig::excursion_relative_magnitude),
 ///    which is set well above ordinary measurement wobble.
-/// 3. **There are few of them.** If more than
+/// 3. **It is the only one.** If more than
 ///    [`excursion_max_removals`](AnalysisConfig::excursion_max_removals) levels qualify,
-///    nothing is removed at all. A window full of candidates is not a clean window with
-///    a bad reading in it; it is a benchmark that genuinely oscillates, and stripping one
-///    of its two levels away would leave a spuriously tight window in which the
-///    benchmark's own ordinary values read as large, certain regressions.
+///    nothing is removed at all. A window offering a second candidate is not a clean
+///    window with a bad reading in it: two separated levels agreeing on a value their
+///    surroundings do not is a benchmark that visits more than one level, and how often it
+///    does so is exactly what the context run is measured against. Stripping a recurring
+///    level away would leave a spuriously tight window in which the benchmark's own
+///    ordinary values read as large, certain regressions.
 ///
-/// The window's first and last levels are never removed, since neither has surroundings
-/// on both sides for test 1 to consult. That is deliberate rather than incidental at the
-/// newest end: a level shift that landed on the base branch at its final commit is
+/// A level without a full set of neighbours on *both* sides is never removed, since test 1
+/// has nothing complete to consult. That is deliberate rather than incidental at the
+/// newest end: a level shift that landed on the base branch near its final commit is
 /// indistinguishable, from inside the window, from a bad reading there, and the two call
 /// for opposite treatment.
 ///
@@ -126,22 +128,20 @@ struct Surroundings {
 }
 
 impl Surroundings {
-    /// The surroundings of `levels[index]`, taking up to `reach` neighbours on each side.
+    /// The surroundings of `levels[index]`, taking `reach` neighbours on each side.
     ///
-    /// `None` when either side is empty, which is what excludes the window's endpoints,
-    /// and `None` when the neighbourhood sits at zero. Both tests are proportional, and
-    /// against a zero reference the magnitude test admits every nonzero level however
-    /// small — so the rule would lose the very narrowness that makes it safe. A window
-    /// resting at zero is left exactly as measured; the absolute floors already keep
-    /// branch mode from reporting a move there.
+    /// `None` unless both sides are complete. A shorter side would let one adjacent level
+    /// speak for that side, which is what `reach` exists to outvote, so the window's outer
+    /// `reach` levels at each end are never candidates. It is also `None` when the
+    /// neighbourhood sits at zero: both tests are proportional, and against a zero
+    /// reference the magnitude test admits every nonzero level however small — the rule
+    /// would lose the very narrowness that makes it safe. A window resting at zero is left
+    /// exactly as measured; the absolute floors already keep branch mode from reporting a
+    /// move there.
     fn around(index: usize, levels: &[f64], reach: usize) -> Option<Self> {
-        let before = levels.get(index.saturating_sub(reach)..index)?;
+        let before = levels.get(index.checked_sub(reach)?..index)?;
         let after_start = index.checked_add(1)?;
-        let after_end = after_start.saturating_add(reach).min(levels.len());
-        let after = levels.get(after_start..after_end)?;
-        if before.is_empty() || after.is_empty() {
-            return None;
-        }
+        let after = levels.get(after_start..after_start.checked_add(reach)?)?;
         let neighbours: Vec<f64> = before.iter().chain(after).copied().collect();
         let level = stats::median(&neighbours)?;
         if level.abs() <= f64::EPSILON {
@@ -174,7 +174,6 @@ mod tests {
         CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL_START,
         STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_NOISE,
     };
-
     /// A level far enough above its surroundings to qualify, used where a test needs an
     /// excursion and does not care about its exact size.
     const EXCURSION: f64 = 200.0;
@@ -226,30 +225,36 @@ mod tests {
     }
 
     #[test]
-    fn the_window_endpoints_are_never_removed() {
+    fn levels_without_full_surroundings_are_never_removed() {
+        // The outer `excursion_neighbours` levels at each end have no complete side to be
+        // judged against, so an excursion there is kept however far it stands out.
+        let config = config();
         let mut levels = flat(16);
-        levels[0] = EXCURSION;
         let last = levels.len() - 1;
-        levels[last] = EXCURSION;
-        assert!(isolated_excursions(&levels, &config()).is_empty());
+        for offset in 0..config.excursion_neighbours {
+            levels[offset] = EXCURSION;
+            levels[last - offset] = EXCURSION;
+        }
+        assert!(isolated_excursions(&levels, &config).is_empty());
     }
 
     #[test]
-    fn excursions_up_to_the_limit_are_all_found() {
+    fn a_second_candidate_stops_the_window_being_cleaned() {
+        // Two separated levels agreeing on a value their surroundings do not is a
+        // benchmark that visits more than one level, which the comparison must account
+        // for rather than edit away. This is the sparse counterpart of the bimodal
+        // recording below, where the second level is too rare to look like a mode.
         let config = config();
         let mut levels = flat(16);
-        // Spaced so neither lands in the other's surroundings, which is the case the
-        // limit is meant to admit: independent bad moments, not an oscillation.
-        levels[4] = EXCURSION;
-        levels[12] = EXCURSION;
-        assert_eq!(config.excursion_max_removals, 2);
-        assert_eq!(isolated_excursions(&levels, &config), vec![4, 12]);
+        levels[5] = EXCURSION;
+        levels[11] = EXCURSION;
+        assert!(isolated_excursions(&levels, &config).is_empty());
     }
 
     #[test]
     fn a_window_past_the_limit_is_left_untouched() {
         let mut levels = flat(20);
-        for index in [4, 10, 16] {
+        for index in [5, 11, 16] {
             levels[index] = EXCURSION;
         }
         assert!(isolated_excursions(&levels, &config()).is_empty());
@@ -297,11 +302,18 @@ mod tests {
 
     #[test]
     fn a_window_too_short_to_have_surroundings_is_left_untouched() {
-        for length in 0..=2 {
+        // A candidate needs a full set of neighbours on each side, so a window shorter
+        // than that plus the candidate itself has nowhere a level could be judged.
+        let config = config();
+        let shortest_with_interior = config
+            .excursion_neighbours
+            .saturating_mul(2)
+            .saturating_add(1);
+        for length in 0..shortest_with_interior {
             let levels = vec![EXCURSION; length];
             assert!(
-                isolated_excursions(&levels, &config()).is_empty(),
-                "a window of {length} level(s) has no interior",
+                isolated_excursions(&levels, &config).is_empty(),
+                "a window of {length} level(s) has no judgeable interior",
             );
         }
     }

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -167,6 +167,8 @@ impl Surroundings {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
+
     use super::*;
     use crate::detect::recorded::{
         CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL_START,
@@ -290,7 +292,7 @@ mod tests {
 
     #[test]
     fn an_all_zero_window_has_no_excursions() {
-        assert!(isolated_excursions(&vec![0.0; 16], &config()).is_empty());
+        assert!(isolated_excursions(&[0.0; 16], &config()).is_empty());
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -1,0 +1,340 @@
+//! Isolated measurement excursions in a branch-mode comparison window.
+//!
+//! A shared CI runner occasionally has a bad moment — another tenant takes the cores —
+//! and one commit's measurement lands far above the level its neighbours agree on. The
+//! reading describes the runner, not the code, and it does not belong in the evidence
+//! branch mode judges a pull request against.
+//!
+//! Leaving it there is not merely untidy. Branch mode measures how far a context run
+//! sits from the base level in units of the window's own scatter (see
+//! [`prediction_interval_p`](super::findings)), so one wild reading both drags the
+//! window's centre toward it and inflates its scatter several-fold. The window then
+//! finds nothing surprising, and a genuine regression passes unreported — the failure is
+//! silent, which is what makes it worth removing rather than tolerating.
+//!
+//! History mode does not use this. Its gates take their level and their scatter from
+//! medians, which absorb a single wild reading on their own, so cleaning would change
+//! the evidence without improving the verdict.
+//!
+//! What counts as such a reading is deliberately narrow, because discarding a level
+//! *tightens* the window and so makes branch mode readier to report: a rule that removes
+//! too much manufactures the false positives the analysis was narrowed to eliminate.
+//! Three tests must all hold, and [`isolated_excursions`] documents what each defends
+//! against.
+
+use std::borrow::Cow;
+
+use cbh_stats as stats;
+
+use super::AnalysisConfig;
+use super::findings::relative_delta_of;
+use super::series::BaseLevel;
+
+/// `window` with its isolated measurement excursions removed, oldest first.
+///
+/// Borrows `window` unchanged in the ordinary case, which is every window that holds no
+/// excursion at all.
+pub(super) fn cleaned_window<'a>(
+    window: &'a [BaseLevel],
+    config: &AnalysisConfig,
+) -> Cow<'a, [BaseLevel]> {
+    let levels: Vec<f64> = window.iter().map(|level| level.value).collect();
+    let discarded = isolated_excursions(&levels, config);
+    if discarded.is_empty() {
+        return Cow::Borrowed(window);
+    }
+    Cow::Owned(
+        window
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !discarded.contains(index))
+            .map(|(_, level)| level.clone())
+            .collect(),
+    )
+}
+
+/// The indices of `levels` that are isolated measurement excursions, oldest first.
+///
+/// `levels` are the base window's per-commit levels, oldest first. A level qualifies
+/// only when all three of these hold:
+///
+/// 1. **Its surroundings agree with each other.** The levels immediately before it and
+///    the levels immediately after it must describe the same level, within
+///    [`excursion_neighbour_agreement`](AnalysisConfig::excursion_neighbour_agreement).
+///    This is what separates a bad measurement from a real step: when the code genuinely
+///    changes, the levels after the change sit at the *new* level and disagree with the
+///    ones before it, so a step is never mistaken for an excursion however large it is.
+/// 2. **It stands far clear of them.** It must differ from its surroundings by at least
+///    [`excursion_relative_magnitude`](AnalysisConfig::excursion_relative_magnitude),
+///    which is set well above ordinary measurement wobble.
+/// 3. **There are few of them.** If more than
+///    [`excursion_max_removals`](AnalysisConfig::excursion_max_removals) levels qualify,
+///    nothing is removed at all. A window full of candidates is not a clean window with
+///    a bad reading in it; it is a benchmark that genuinely oscillates, and stripping one
+///    of its two levels away would leave a spuriously tight window in which the
+///    benchmark's own ordinary values read as large, certain regressions.
+///
+/// The window's first and last levels are never removed, since neither has surroundings
+/// on both sides for test 1 to consult. That is deliberate rather than incidental at the
+/// newest end: a level shift that landed on the base branch at its final commit is
+/// indistinguishable, from inside the window, from a bad reading there, and the two call
+/// for opposite treatment.
+///
+/// The tests apply to every metric kind. A count or an allocation figure reproduces
+/// exactly across runs of unchanged code, so an isolated excursion in one is as much a
+/// measurement artifact as it is in a timing series, and is as unrepresentative of the
+/// level a pull request would merge into.
+pub(super) fn isolated_excursions(levels: &[f64], config: &AnalysisConfig) -> Vec<usize> {
+    let mut found = Vec::new();
+    for index in 0..levels.len() {
+        let Some(surroundings) = Surroundings::around(index, levels, config.excursion_neighbours)
+        else {
+            continue;
+        };
+        if !surroundings.agree(config.excursion_neighbour_agreement) {
+            continue;
+        }
+        let Some(&level) = levels.get(index) else {
+            continue;
+        };
+        if !surroundings.stands_clear(level, config.excursion_relative_magnitude) {
+            continue;
+        }
+        found.push(index);
+        if found.len() > config.excursion_max_removals {
+            return Vec::new();
+        }
+    }
+    found
+}
+
+/// The levels neighbouring one candidate, and what they say about its surroundings.
+///
+/// The candidate is judged against its own neighbourhood rather than against the whole
+/// window because the window may legitimately hold a level shift: measured against a
+/// window spanning two regimes, ordinary levels of either regime stand clear of the
+/// middle and would be mistaken for excursions.
+#[derive(Debug)]
+struct Surroundings {
+    /// The level the neighbours before the candidate sit at.
+    before: f64,
+    /// The level the neighbours after the candidate sit at.
+    after: f64,
+    /// The level of the neighbourhood as a whole, and the reference both tests measure
+    /// against so that the two are expressed on one scale.
+    level: f64,
+}
+
+impl Surroundings {
+    /// The surroundings of `levels[index]`, taking up to `reach` neighbours on each side.
+    ///
+    /// `None` when either side is empty, which is what excludes the window's endpoints,
+    /// and `None` when the neighbourhood sits at zero. Both tests are proportional, and
+    /// against a zero reference the magnitude test admits every nonzero level however
+    /// small — so the rule would lose the very narrowness that makes it safe. A window
+    /// resting at zero is left exactly as measured; the absolute floors already keep
+    /// branch mode from reporting a move there.
+    fn around(index: usize, levels: &[f64], reach: usize) -> Option<Self> {
+        let before = levels.get(index.saturating_sub(reach)..index)?;
+        let after_start = index.checked_add(1)?;
+        let after_end = after_start.saturating_add(reach).min(levels.len());
+        let after = levels.get(after_start..after_end)?;
+        if before.is_empty() || after.is_empty() {
+            return None;
+        }
+        let neighbours: Vec<f64> = before.iter().chain(after).copied().collect();
+        let level = stats::median(&neighbours)?;
+        if level.abs() <= f64::EPSILON {
+            return None;
+        }
+        Some(Self {
+            before: stats::median(before)?,
+            after: stats::median(after)?,
+            level,
+        })
+    }
+
+    /// Whether the two sides describe the same level, to within `tolerance`.
+    fn agree(&self, tolerance: f64) -> bool {
+        relative_delta_of(self.after - self.before, self.level).abs() <= tolerance
+    }
+
+    /// Whether `level` differs from these surroundings by at least `magnitude`.
+    fn stands_clear(&self, level: f64, magnitude: f64) -> bool {
+        relative_delta_of(level - self.level, self.level).abs() >= magnitude
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::recorded::{
+        CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL_START,
+        STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_NOISE,
+    };
+
+    /// A level far enough above its surroundings to qualify, used where a test needs an
+    /// excursion and does not care about its exact size.
+    const EXCURSION: f64 = 200.0;
+
+    /// The level the synthetic windows sit at when nothing is happening.
+    const LEVEL: f64 = 100.0;
+
+    fn config() -> AnalysisConfig {
+        AnalysisConfig::default()
+    }
+
+    fn flat(count: usize) -> Vec<f64> {
+        vec![LEVEL; count]
+    }
+
+    #[test]
+    fn a_flat_window_has_no_excursions() {
+        assert!(isolated_excursions(&flat(16), &config()).is_empty());
+    }
+
+    #[test]
+    fn a_lone_excursion_is_found() {
+        let mut levels = flat(16);
+        levels[8] = EXCURSION;
+        assert_eq!(isolated_excursions(&levels, &config()), vec![8]);
+    }
+
+    #[test]
+    fn a_lone_dip_is_found_as_readily_as_a_spike() {
+        let mut levels = flat(16);
+        levels[8] = LEVEL / 2.0;
+        assert_eq!(isolated_excursions(&levels, &config()), vec![8]);
+    }
+
+    #[test]
+    fn a_step_is_never_an_excursion_however_large() {
+        // Every level past the step sits at the new level, so no level's surroundings
+        // agree across it — which is the whole point: a real change must survive.
+        let levels: Vec<f64> = flat(8).into_iter().chain(vec![EXCURSION; 8]).collect();
+        assert!(isolated_excursions(&levels, &config()).is_empty());
+    }
+
+    #[test]
+    fn a_move_below_the_magnitude_is_ordinary_scatter() {
+        let config = config();
+        let mut levels = flat(16);
+        levels[8] = LEVEL * (1.0 + config.excursion_relative_magnitude / 2.0);
+        assert!(isolated_excursions(&levels, &config).is_empty());
+    }
+
+    #[test]
+    fn the_window_endpoints_are_never_removed() {
+        let mut levels = flat(16);
+        levels[0] = EXCURSION;
+        let last = levels.len() - 1;
+        levels[last] = EXCURSION;
+        assert!(isolated_excursions(&levels, &config()).is_empty());
+    }
+
+    #[test]
+    fn excursions_up_to_the_limit_are_all_found() {
+        let config = config();
+        let mut levels = flat(16);
+        // Spaced so neither lands in the other's surroundings, which is the case the
+        // limit is meant to admit: independent bad moments, not an oscillation.
+        levels[4] = EXCURSION;
+        levels[12] = EXCURSION;
+        assert_eq!(config.excursion_max_removals, 2);
+        assert_eq!(isolated_excursions(&levels, &config), vec![4, 12]);
+    }
+
+    #[test]
+    fn a_window_past_the_limit_is_left_untouched() {
+        let mut levels = flat(20);
+        for index in [4, 10, 16] {
+            levels[index] = EXCURSION;
+        }
+        assert!(isolated_excursions(&levels, &config()).is_empty());
+    }
+
+    #[test]
+    fn a_bimodal_recording_is_left_untouched() {
+        // The adversarial case. Half this recording's commits sit at each of two levels,
+        // so many of them look isolated; removing them would leave a spuriously tight
+        // window in which the series' own ordinary values read as certain regressions.
+        let window = STATIONARY_BIMODAL_NOISE
+            .get(..STATIONARY_BIMODAL_BASE)
+            .expect("the base prefix is within the recording");
+        assert!(isolated_excursions(window, &config()).is_empty());
+    }
+
+    #[test]
+    fn a_recorded_contended_commit_is_found() {
+        let window = CONTENDED_RUNNER_EXCURSION
+            .get(CONTENDED_RUNNER_LEVEL_START..CONTENDED_RUNNER_BASE)
+            .expect("the base slice is within the recording");
+        let expected = window
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| left.total_cmp(right))
+            .map(|(index, _)| index)
+            .expect("the window is not empty");
+        assert_eq!(isolated_excursions(window, &config()), vec![expected]);
+    }
+
+    #[test]
+    fn a_window_resting_at_zero_is_left_untouched() {
+        // Both tests are proportional and have nothing to say against a zero reference,
+        // so such a window is left exactly as measured rather than cleaned by a rule
+        // whose magnitude gate is inert there.
+        let mut levels = vec![0.0; 16];
+        levels[8] = 1.0;
+        assert!(isolated_excursions(&levels, &config()).is_empty());
+    }
+
+    #[test]
+    fn an_all_zero_window_has_no_excursions() {
+        assert!(isolated_excursions(&vec![0.0; 16], &config()).is_empty());
+    }
+
+    #[test]
+    fn a_window_too_short_to_have_surroundings_is_left_untouched() {
+        for length in 0..=2 {
+            let levels = vec![EXCURSION; length];
+            assert!(
+                isolated_excursions(&levels, &config()).is_empty(),
+                "a window of {length} level(s) has no interior",
+            );
+        }
+    }
+
+    fn window_of(levels: &[f64]) -> Vec<BaseLevel> {
+        levels
+            .iter()
+            .enumerate()
+            .map(|(index, &value)| BaseLevel {
+                topo_index: index,
+                value,
+                interval: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_clean_window_is_passed_through_without_copying() {
+        let window = window_of(&flat(16));
+        let cleaned = cleaned_window(&window, &config());
+        assert!(matches!(cleaned, Cow::Borrowed(_)));
+        assert_eq!(cleaned.as_ref(), window.as_slice());
+    }
+
+    #[test]
+    fn cleaning_drops_the_excursion_and_keeps_every_other_level_intact() {
+        let mut levels = flat(16);
+        levels[8] = EXCURSION;
+        let window = window_of(&levels);
+        let cleaned = cleaned_window(&window, &config());
+        let expected: Vec<BaseLevel> = window
+            .iter()
+            .filter(|level| level.topo_index != 8)
+            .cloned()
+            .collect();
+        assert_eq!(cleaned.as_ref(), expected.as_slice());
+    }
+}

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1983,18 +1983,12 @@ fn evaluate_branch(
     // which is what the census counts and what sizes the false-discovery family, and it
     // is the same order the regime narrowing below already follows: the question this
     // gate asks is whether the series has a recent base history at all, and it does.
-    let recorded_spans = level_spans(
-        &series
-            .base_window
-            .iter()
-            .map(|level| level.value)
-            .collect::<Vec<f64>>(),
-    );
+    let recorded_levels = series.base_window.len();
     if !log.stage(GateStage::Branch).numeric(
         Gate::MinBaseCommits,
-        count_to_f64(recorded_spans.len()),
+        count_to_f64(recorded_levels),
         count_to_f64(config.min_series_points),
-        recorded_spans.len() >= config.min_series_points,
+        recorded_levels >= config.min_series_points,
     ) {
         return None;
     }

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -73,7 +73,7 @@ use serde::Serialize;
 
 use crate::detect::gate_log::{Gate, GateLog, GateStage, StageLog};
 use crate::detect::parallel::{balanced_chunk_sizes, worker_count};
-use crate::detect::{BaseLevel, Series, SeriesPoint, noise_gates};
+use crate::detect::{BaseLevel, Series, SeriesPoint, excursions, noise_gates};
 
 /// Tunable parameters of the engine-aware analysis.
 ///
@@ -272,6 +272,44 @@ pub struct AnalysisConfig {
     /// precise probability: with the smallest regimes on both sides it admits one
     /// contradicting pair in twenty-five and no more.
     pub min_base_split_separation: f64,
+    /// How far a base-window level must stand from its surroundings for branch mode to
+    /// read it as a measurement excursion and discard it.
+    ///
+    /// A shared runner occasionally loses time to something else and records one commit
+    /// far above the level its neighbours agree on. Such a level describes the runner
+    /// rather than the code, and left in the window it both displaces the comparison's
+    /// centre and inflates its scatter, silently costing branch mode much of its
+    /// sensitivity. Discarding it is guarded by
+    /// [`excursion_neighbour_agreement`](Self::excursion_neighbour_agreement) and
+    /// [`excursion_max_removals`](Self::excursion_max_removals), which together confine
+    /// it to levels that are genuinely isolated.
+    ///
+    /// Raising this admits more interference into the comparison; lowering it starts
+    /// discarding the ordinary scatter that comparison is judged against, and every level
+    /// discarded tightens the window and makes branch mode readier to report.
+    pub excursion_relative_magnitude: f64,
+    /// How closely the levels on either side of a candidate excursion must agree before
+    /// it may be discarded.
+    ///
+    /// This is what keeps a genuine level shift out of the excursion rule: after a real
+    /// change the levels following it sit at the new level and disagree with those
+    /// before it, so its opening level is kept however large the step is. Only a level
+    /// its own surroundings straddle can be discarded.
+    pub excursion_neighbour_agreement: f64,
+    /// How many levels on each side of a candidate excursion form the surroundings it is
+    /// judged against.
+    ///
+    /// The candidate is judged locally rather than against the whole window, because a
+    /// window may legitimately span a level shift, and measured against such a window's
+    /// middle the ordinary levels of both regimes stand clear.
+    pub excursion_neighbours: usize,
+    /// How many excursions a base window may contain before it is left alone entirely.
+    ///
+    /// Above this the window is read as a benchmark that genuinely oscillates rather than
+    /// as a clean window with a bad reading in it. Removing levels from such a window
+    /// would leave a spuriously tight comparison in which the benchmark's own ordinary
+    /// values read as large, certain regressions — so it is left exactly as measured.
+    pub excursion_max_removals: usize,
 }
 
 impl Default for AnalysisConfig {
@@ -297,6 +335,10 @@ impl Default for AnalysisConfig {
             residual_noise_multiple: noise_gates::RESIDUAL_NOISE_MULTIPLE,
             min_regime_separation: noise_gates::MIN_REGIME_SEPARATION,
             min_base_split_separation: noise_gates::MIN_BASE_SPLIT_SEPARATION,
+            excursion_relative_magnitude: noise_gates::EXCURSION_RELATIVE_MAGNITUDE,
+            excursion_neighbour_agreement: noise_gates::EXCURSION_NEIGHBOUR_AGREEMENT,
+            excursion_neighbours: noise_gates::EXCURSION_NEIGHBOURS,
+            excursion_max_removals: noise_gates::EXCURSION_MAX_REMOVALS,
         }
     }
 }
@@ -809,7 +851,7 @@ fn direction_of(delta: f64) -> Direction {
 ///
 /// A move away from a (near-)zero baseline is proportionally unbounded; its sign
 /// is returned as a full-magnitude move so it ranks as major.
-fn relative_delta_of(delta: f64, baseline: f64) -> f64 {
+pub(super) fn relative_delta_of(delta: f64, baseline: f64) -> f64 {
     if baseline.abs() <= f64::EPSILON {
         delta.signum()
     } else {
@@ -1884,8 +1926,9 @@ fn test_base_levels(points: &[&SeriesPoint]) -> Vec<BaseLevel> {
 /// in the base. A new benchmark introduced on the context (no base-ref points) or
 /// an empty context yields nothing, since there is no baseline to compare.
 ///
-/// The recent base window is first collapsed to per-commit levels and checked for
-/// enough evidence as a whole. If that window contains a genuine level shift, located
+/// The recent base window is first cleared of isolated measurement excursions (see
+/// [`excursions`]) and collapsed to per-commit levels, then checked for enough evidence
+/// as a whole. If that window contains a genuine level shift, located
 /// with Pettitt and accepted only by the same Mann–Whitney significance, separation,
 /// relative-floor, and absolute-floor gates that make such a split trustworthy, the
 /// stale prefix before the newest accepted split is discarded. The prediction interval
@@ -1900,7 +1943,13 @@ fn evaluate_branch(
     // The base window arrives already capped to the recent `compare_window` levels
     // (attach_base_windows/`base_window_levels` own that truncation), so detection reads
     // it whole rather than re-slicing it here.
-    let base_window = &series.base_window[..];
+    //
+    // Isolated measurement excursions are discarded before anything is counted or
+    // compared, because a reading that describes the runner rather than the code is not
+    // evidence: it should neither prop up the minimum-commits count nor enter the
+    // comparison's centre and scatter. A window left too short by the removals is judged
+    // unjudgeable below, which is the honest outcome.
+    let base_window = excursions::cleaned_window(&series.base_window, config);
     let levels: Vec<f64> = base_window.iter().map(|level| level.value).collect();
     let base_spans = level_spans(&levels);
     if !log.stage(GateStage::Branch).numeric(

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1926,12 +1926,12 @@ fn test_base_levels(points: &[&SeriesPoint]) -> Vec<BaseLevel> {
 /// in the base. A new benchmark introduced on the context (no base-ref points) or
 /// an empty context yields nothing, since there is no baseline to compare.
 ///
-/// The recent base window is first cleared of isolated measurement excursions (see
-/// [`excursions`]) and collapsed to per-commit levels, then checked for enough evidence
-/// as a whole. If that window contains a genuine level shift, located
+/// The recent base window is first checked, exactly as recorded, for enough evidence as a
+/// whole. Only then is it narrowed: isolated measurement excursions are discarded (see
+/// [`excursions`]), and if what remains contains a genuine level shift, located
 /// with Pettitt and accepted only by the same Mann–Whitney significance, separation,
 /// relative-floor, and absolute-floor gates that make such a split trustworthy, the
-/// stale prefix before the newest accepted split is discarded. The prediction interval
+/// stale prefix before the newest accepted split is discarded too. The prediction interval
 /// then compares the context run against the trailing regime, moving its centre and
 /// scatter together onto the base level the context would merge into.
 fn evaluate_branch(
@@ -1944,22 +1944,33 @@ fn evaluate_branch(
     // (attach_base_windows/`base_window_levels` own that truncation), so detection reads
     // it whole rather than re-slicing it here.
     //
-    // Isolated measurement excursions are discarded before anything is counted or
-    // compared, because a reading that describes the runner rather than the code is not
-    // evidence: it should neither prop up the minimum-commits count nor enter the
-    // comparison's centre and scatter. A window left too short by the removals is judged
-    // unjudgeable below, which is the honest outcome.
-    let base_window = excursions::cleaned_window(&series.base_window, config);
-    let levels: Vec<f64> = base_window.iter().map(|level| level.value).collect();
-    let base_spans = level_spans(&levels);
+    // The evidence floor is applied to the window as recorded, before anything is
+    // discarded from it. That keeps this gate in exact correspondence with `testability`,
+    // which is what the census counts and what sizes the false-discovery family, and it
+    // is the same order the regime narrowing below already follows: the question this
+    // gate asks is whether the series has a recent base history at all, and it does.
+    let recorded_spans = level_spans(
+        &series
+            .base_window
+            .iter()
+            .map(|level| level.value)
+            .collect::<Vec<f64>>(),
+    );
     if !log.stage(GateStage::Branch).numeric(
         Gate::MinBaseCommits,
-        count_to_f64(base_spans.len()),
+        count_to_f64(recorded_spans.len()),
         count_to_f64(config.min_series_points),
-        base_spans.len() >= config.min_series_points,
+        recorded_spans.len() >= config.min_series_points,
     ) {
         return None;
     }
+    // Isolated measurement excursions come out before the window is searched for a regime
+    // boundary or compared against, because a reading that describes the runner rather
+    // than the code would otherwise both invite a spurious boundary and distort the
+    // comparison's centre and scatter.
+    let base_window = excursions::cleaned_window(&series.base_window, config);
+    let levels: Vec<f64> = base_window.iter().map(|level| level.value).collect();
+    let base_spans = level_spans(&levels);
     let comparison_start = current_base_regime_start(
         series,
         &base_spans,
@@ -2112,10 +2123,11 @@ pub fn testability(series: &Series, context: &AnalysisContext) -> Testability {
                 return Testability::Unjudged(UnjudgedReason::NotMeasuredOnBranch);
             }
             // Testability asks whether the full recent base window contains enough
-            // evidence to run a branch comparison at all. Detection may then narrow to
-            // a `min_regime`-sized trailing regime after an accepted base-side shift;
-            // that does not make this census reason untruthful, because the evidence
-            // floor was met before any history was discarded.
+            // evidence to run a branch comparison at all. Detection may then narrow it —
+            // discarding isolated measurement excursions, and narrowing to a
+            // `min_regime`-sized trailing regime after an accepted base-side shift. That
+            // does not make this census reason untruthful, because the evidence floor was
+            // met before any of it was discarded.
             let base_points = series.base_window.len().min(config.compare_window);
             if base_points < config.min_series_points {
                 return Testability::Unjudged(UnjudgedReason::TooFewBaseCommits);
@@ -5610,6 +5622,29 @@ mod tests {
         let detection = find_changes(&judged, &context);
         assert_eq!(detection.findings.len(), 1);
         assert_eq!(detection.census.judged(), 1);
+    }
+
+    #[test]
+    fn a_window_at_the_evidence_floor_is_judged_despite_an_excursion_in_it() {
+        // The evidence floor is answered on the window as recorded. Applying it to what
+        // survives excursion cleaning instead would let a discarded reading silence a
+        // series that `testability` — and so the census, and the false-discovery family
+        // sized from it — has already counted as judged.
+        //
+        // The finding is the other half of the statement: the excursion is gone from the
+        // comparison, so the context run is judged against the level the base actually
+        // sits at rather than against a window that reading has widened and pulled up.
+        let mut points = base_run(100.0);
+        points[MIN_SERIES_POINTS / 2].1 = 200.0;
+        points.push((MIN_SERIES_POINTS, 130.0, false));
+        let mut series = placed_series(&points);
+        attach_test_base_windows(slice::from_mut(&mut series), Some(base_merge_base()));
+        let series = [series];
+        let context = branch_context(&series, Some(base_merge_base()));
+        assert_eq!(testability(&series[0], &context), Testability::Judged);
+        let detection = find_changes(&series, &context);
+        assert_eq!(detection.census.judged(), 1);
+        assert_eq!(detection.findings.len(), 1);
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -71,6 +71,7 @@ use cbh_model::{BenchmarkId, DiscriminantSet, MetricKind};
 use cbh_stats as stats;
 use serde::Serialize;
 
+use crate::detect::excursions::DiscardedReading;
 use crate::detect::gate_log::{Gate, GateLog, GateStage, StageLog};
 use crate::detect::parallel::{balanced_chunk_sizes, worker_count};
 use crate::detect::{BaseLevel, Series, SeriesPoint, excursions, noise_gates};
@@ -612,6 +613,29 @@ pub struct Detection {
     pub findings: Vec<Finding>,
     /// What the pass judged, and why it left the rest unjudged.
     pub census: SeriesCensus,
+    /// Base-window readings branch mode left out of a comparison, in series order.
+    ///
+    /// Discarding narrows the evidence a verdict rests on without declining anything, so
+    /// it is reported here rather than through the gate log, which speaks only of gates
+    /// that declined.
+    pub discarded: Vec<DiscardedBaseReading>,
+}
+
+/// One base-window reading branch mode left out of a comparison, and the series it
+/// belongs to.
+///
+/// Carries its own identity because discards are collected across the whole pass, well
+/// away from the series that produced them.
+#[derive(Clone, Debug)]
+pub struct DiscardedBaseReading {
+    /// The comparable discriminant set the series belongs to.
+    pub set: DiscriminantSet,
+    /// The benchmark identity.
+    pub id: BenchmarkId,
+    /// The category of the metric whose reading was discarded.
+    pub kind: MetricKind,
+    /// What was discarded, and what it stood clear of.
+    pub reading: DiscardedReading,
 }
 
 /// Which detector produced a finding.
@@ -1948,6 +1972,7 @@ fn evaluate_branch(
     config: &AnalysisConfig,
     context_index: usize,
     log: &mut GateLog,
+    discarded: &mut Vec<DiscardedReading>,
 ) -> Option<Candidate> {
     // The base window arrives already capped to the recent `compare_window` levels
     // (attach_base_windows/`base_window_levels` own that truncation), so detection reads
@@ -1985,7 +2010,9 @@ fn evaluate_branch(
             .map(|point| point.value)
             .collect::<Vec<f64>>(),
     );
-    let base_window = excursions::cleaned_window(&series.base_window, context_level, config);
+    let (base_window, removed) =
+        excursions::cleaned_window(&series.base_window, context_level, config);
+    discarded.extend(removed);
     let levels: Vec<f64> = base_window.iter().map(|level| level.value).collect();
     let base_spans = level_spans(&levels);
     let comparison_start = current_base_regime_start(
@@ -2071,9 +2098,13 @@ pub fn short_commit(commit: &str) -> String {
 #[cfg(any(test, feature = "private-test-util"))]
 #[must_use]
 pub fn find_changes(series: &[Series], context: &AnalysisContext) -> Detection {
-    let (candidates, census) = detect_all(series, context);
+    let (candidates, census, discarded) = detect_all(series, context);
     let findings = finalize_findings(candidates, &census, series, context);
-    Detection { findings, census }
+    Detection {
+        findings,
+        census,
+        discarded,
+    }
 }
 
 /// Evaluates every series and returns the surviving findings, ranked
@@ -2106,9 +2137,13 @@ pub async fn find_changes_spawned(
     context: AnalysisContext,
     spawner: &Spawner,
 ) -> Detection {
-    let (candidates, census) = detect_all_spawned(&series, context, spawner).await;
+    let (candidates, census, discarded) = detect_all_spawned(&series, context, spawner).await;
     let findings = finalize_findings(candidates, &census, &series, &context);
-    Detection { findings, census }
+    Detection {
+        findings,
+        census,
+        discarded,
+    }
 }
 
 /// Whether `series` carries enough evidence for its mode's detector to reach a
@@ -2225,7 +2260,10 @@ fn finalize_findings(
 /// order — the order [`finalize_findings`] relies on — and the census of what was
 /// judged.
 #[cfg(any(test, feature = "private-test-util"))]
-fn detect_all(series: &[Series], context: &AnalysisContext) -> (Vec<Candidate>, SeriesCensus) {
+fn detect_all(
+    series: &[Series],
+    context: &AnalysisContext,
+) -> (Vec<Candidate>, SeriesCensus, Vec<DiscardedBaseReading>) {
     detect_range(series, 0..series.len(), context, &mut GateLog::disabled())
 }
 
@@ -2243,7 +2281,7 @@ async fn detect_all_spawned(
     series: &Arc<[Series]>,
     context: AnalysisContext,
     spawner: &Spawner,
-) -> (Vec<Candidate>, SeriesCensus) {
+) -> (Vec<Candidate>, SeriesCensus, Vec<DiscardedBaseReading>) {
     let len = series.len();
     let workers = worker_count(len);
 
@@ -2265,12 +2303,14 @@ async fn detect_all_spawned(
     // must be absorbed or the family would shrink to whatever one worker saw.
     let mut candidates = Vec::new();
     let mut census = SeriesCensus::default();
+    let mut discarded = Vec::new();
     for handle in handles {
-        let (chunk_candidates, chunk_census) = handle.await;
+        let (chunk_candidates, chunk_census, chunk_discarded) = handle.await;
         candidates.extend(chunk_candidates);
         census.merge(&chunk_census);
+        discarded.extend(chunk_discarded);
     }
-    (candidates, census)
+    (candidates, census, discarded)
 }
 
 /// Detects the series in `range`, returning the raised candidates in index order and
@@ -2284,9 +2324,10 @@ fn detect_range(
     range: Range<usize>,
     context: &AnalysisContext,
     log: &mut GateLog,
-) -> (Vec<Candidate>, SeriesCensus) {
+) -> (Vec<Candidate>, SeriesCensus, Vec<DiscardedBaseReading>) {
     let mut candidates = Vec::new();
     let mut census = SeriesCensus::default();
+    let mut discarded = Vec::new();
     for index in range {
         let one = series
             .get(index)
@@ -2296,12 +2337,12 @@ fn detect_range(
         // Judging and counting are the same decision, so a series the census reports
         // as unjudged provably never reached a detector.
         if verdict.is_judged()
-            && let Some(candidate) = detect_one(index, one, context, log)
+            && let Some(candidate) = detect_one(index, one, context, log, &mut discarded)
         {
             candidates.push(candidate);
         }
     }
-    (candidates, census)
+    (candidates, census, discarded)
 }
 
 /// Runs the mode-appropriate detector on the series at `index` and returns its
@@ -2319,6 +2360,7 @@ fn detect_one(
     one: &Series,
     context: &AnalysisContext,
     log: &mut GateLog,
+    discarded: &mut Vec<DiscardedBaseReading>,
 ) -> Option<Candidate> {
     let config = &context.config;
     let candidate = match context.mode {
@@ -2334,7 +2376,17 @@ fn detect_one(
                 candidate
             })
         }
-        AnalysisMode::Branch => evaluate_branch(one, config, context.tip_index, log),
+        AnalysisMode::Branch => {
+            let mut readings = Vec::new();
+            let candidate = evaluate_branch(one, config, context.tip_index, log, &mut readings);
+            discarded.extend(readings.into_iter().map(|reading| DiscardedBaseReading {
+                set: one.set.clone(),
+                id: one.id.clone(),
+                kind: one.kind,
+                reading,
+            }));
+            candidate
+        }
     };
     candidate.map(|mut candidate| {
         candidate.source_index = index;
@@ -2362,7 +2414,7 @@ fn detect_one(
 pub fn evaluate_with_log(series: &Series, context: &AnalysisContext) -> (Option<Finding>, GateLog) {
     let mut log = GateLog::recording();
     let batch = slice::from_ref(series);
-    let (candidates, census) = detect_range(batch, 0..batch.len(), context, &mut log);
+    let (candidates, census, _) = detect_range(batch, 0..batch.len(), context, &mut log);
     let findings = finalize_findings(candidates, &census, batch, context);
     (findings.into_iter().next(), log)
 }
@@ -2581,12 +2633,13 @@ mod tests {
         log: &mut GateLog,
     ) -> Option<Candidate> {
         let context_index = max_topo_index(slice::from_ref(series));
+        let mut discarded = Vec::new();
         if series.base_window.is_empty() {
             let mut series = series.clone();
             attach_test_base_windows(slice::from_mut(&mut series), context_index.checked_sub(1));
-            return super::evaluate_branch(&series, config, context_index, log);
+            return super::evaluate_branch(&series, config, context_index, log, &mut discarded);
         }
-        super::evaluate_branch(series, config, context_index, log)
+        super::evaluate_branch(series, config, context_index, log, &mut discarded)
     }
 
     /// Runs the history-mode detector with default config, reporting both

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -302,13 +302,22 @@ pub struct AnalysisConfig {
     /// The candidate is judged locally rather than against the whole window, because a
     /// window may legitimately span a level shift, and measured against such a window's
     /// middle the ordinary levels of both regimes stand clear.
+    ///
+    /// A level without this many neighbours on *both* sides is never discarded, so the
+    /// window's outermost levels are always kept.
     pub excursion_neighbours: usize,
     /// How many excursions a base window may contain before it is left alone entirely.
     ///
-    /// Above this the window is read as a benchmark that genuinely oscillates rather than
-    /// as a clean window with a bad reading in it. Removing levels from such a window
-    /// would leave a spuriously tight comparison in which the benchmark's own ordinary
-    /// values read as large, certain regressions — so it is left exactly as measured.
+    /// Above this the window is read as a benchmark that visits more than one level
+    /// rather than as a clean window with a bad reading in it. Removing levels from such
+    /// a window would leave a spuriously tight comparison in which the benchmark's own
+    /// ordinary values read as large, certain regressions — so it is left exactly as
+    /// measured.
+    ///
+    /// Keep it far below the difference between [`min_series_points`](Self::min_series_points)
+    /// and [`min_regime`](Self::min_regime): eligibility is settled on the window as
+    /// recorded, so a window that gave up more than that margin would be counted as judged
+    /// while holding too little evidence to compare.
     pub excursion_max_removals: usize,
 }
 
@@ -5635,7 +5644,8 @@ mod tests {
         // comparison, so the context run is judged against the level the base actually
         // sits at rather than against a window that reading has widened and pulled up.
         let mut points = base_run(100.0);
-        points[MIN_SERIES_POINTS / 2].1 = 200.0;
+        let excursion_at = MIN_SERIES_POINTS.checked_div(2).unwrap();
+        points[excursion_at].1 = 200.0;
         points.push((MIN_SERIES_POINTS, 130.0, false));
         let mut series = placed_series(&points);
         attach_test_base_windows(slice::from_mut(&mut series), Some(base_merge_base()));
@@ -5645,6 +5655,22 @@ mod tests {
         let detection = find_changes(&series, &context);
         assert_eq!(detection.census.judged(), 1);
         assert_eq!(detection.findings.len(), 1);
+    }
+
+    #[test]
+    fn the_removal_allowance_cannot_starve_a_window_that_was_judged_eligible() {
+        // Eligibility is settled on the window as recorded, so the levels cleaning may
+        // take have to come out of the margin between the evidence floor and the minimum
+        // a comparison needs. Were the allowance set above that margin, a window could be
+        // counted as judged and then hold too little evidence to compare — the census and
+        // the false-discovery family would both be describing work that cannot happen.
+        let config = AnalysisConfig::default();
+        let margin = config
+            .min_series_points
+            .checked_sub(config.min_regime)
+            .expect("the evidence floor is at least the minimum regime length");
+
+        assert!(config.excursion_max_removals <= margin);
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1976,8 +1976,16 @@ fn evaluate_branch(
     // Isolated measurement excursions come out before the window is searched for a regime
     // boundary or compared against, because a reading that describes the runner rather
     // than the code would otherwise both invite a spurious boundary and distort the
-    // comparison's centre and scatter.
-    let base_window = excursions::cleaned_window(&series.base_window, config);
+    // comparison's centre and scatter. The context run's own level is part of that
+    // judgment, so it is established first.
+    let latest_points = latest_context_run(&series.points, context_index);
+    let context_level = stats::median(
+        &latest_points
+            .iter()
+            .map(|point| point.value)
+            .collect::<Vec<f64>>(),
+    );
+    let base_window = excursions::cleaned_window(&series.base_window, context_level, config);
     let levels: Vec<f64> = base_window.iter().map(|level| level.value).collect();
     let base_spans = level_spans(&levels);
     let comparison_start = current_base_regime_start(
@@ -1987,7 +1995,6 @@ fn evaluate_branch(
         config.branch_practical_relative,
     );
     let comparison_base = base_window.get(comparison_start..).unwrap_or_default();
-    let latest_points = latest_context_run(&series.points, context_index);
     let commit = latest_points.last().and_then(|point| owned_commit(point));
     // The newest base-ref point in the selected comparison sample is this series'
     // comparison base. Truncating stale levels changes the sample's start, not this

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -1998,12 +1998,11 @@ fn evaluate_branch(
     // comparison's centre and scatter. The context run's own level is part of that
     // judgment, so it is established first.
     let latest_points = latest_context_run(&series.points, context_index);
-    let context_level = stats::median(
-        &latest_points
-            .iter()
-            .map(|point| point.value)
-            .collect::<Vec<f64>>(),
-    );
+    // `latest_context_run` yields the single run a merge would land — at most one point —
+    // so the context level is that point's value directly, with no median over a one-element
+    // sample and no allocation on the analysis path. Ref: docs/performance.md, no allocation
+    // on the hot path.
+    let context_level = latest_points.first().map(|point| point.value);
     let (base_window, removed) =
         excursions::cleaned_window(&series.base_window, context_level, config);
     discarded.extend(removed);

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -11,6 +11,7 @@
 pub(crate) mod discriminant;
 #[cfg(any(test, feature = "private-test-util"))]
 pub mod examples;
+mod excursions;
 pub(crate) mod findings;
 pub(crate) mod gate_log;
 mod noise_gates;

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -27,10 +27,11 @@ pub(crate) mod series;
 mod signal_validation;
 
 pub use discriminant::{DiscriminantFilter, DiscriminantSetQuery};
+pub use excursions::DiscardedReading;
 pub use findings::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, Direction, Finding, FindingMethod,
-    SeriesCensus, SeriesValue, Testability, UnjudgedReason, find_changes_spawned, short_commit,
-    testability,
+    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, Direction, DiscardedBaseReading,
+    Finding, FindingMethod, SeriesCensus, SeriesValue, Testability, UnjudgedReason,
+    find_changes_spawned, short_commit, testability,
 };
 #[cfg(any(test, feature = "private-test-util"))]
 pub use findings::{evaluate_with_log, find_changes};

--- a/packages/cbh_detect/src/detect/noise_gates.rs
+++ b/packages/cbh_detect/src/detect/noise_gates.rs
@@ -129,6 +129,52 @@ pub(crate) const COMPARE_WINDOW: usize = 16;
 /// raised above the history floor, to keep pull-request false positives down.
 pub(crate) const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
 
+/// Default `excursion_relative_magnitude`: how far a base-window level must stand from
+/// its surroundings before branch mode treats it as a measurement excursion rather than
+/// as evidence.
+///
+/// Set where measurement wobble stops and runner interference starts, measured on this
+/// project's own stored history: across the wall-time series, isolated levels straying up
+/// to roughly a quarter from their surroundings stray high and low about equally often —
+/// the two-sided signature of ordinary measurement scatter — while beyond this threshold
+/// they are almost exclusively *slow*, which is the one-sided signature of a runner
+/// losing time to something else. Setting it lower would discard ordinary scatter, which
+/// is the sample's own dispersion and the very thing the comparison is judged against.
+///
+/// It also sits far above [`BRANCH_PRACTICAL_RELATIVE`], so no level a branch move could
+/// be reported against is anywhere near being treated as an excursion.
+pub(crate) const EXCURSION_RELATIVE_MAGNITUDE: f64 = 0.30;
+
+/// Default `excursion_neighbour_agreement`: how closely the levels on either side of a
+/// candidate excursion must agree before it can be discarded.
+///
+/// Held equal to [`BRANCH_PRACTICAL_RELATIVE`] because that is the smallest move branch
+/// mode would report: surroundings that agree to within it describe one level as far as
+/// any verdict is concerned, and surroundings that do not are a level shift, whose levels
+/// must be kept whatever their magnitude.
+pub(crate) const EXCURSION_NEIGHBOUR_AGREEMENT: f64 = BRANCH_PRACTICAL_RELATIVE;
+
+/// Default `excursion_neighbours`: how many levels on each side of a candidate form the
+/// surroundings it is judged against.
+///
+/// Enough that one *further* excursion adjacent to the candidate cannot by itself decide
+/// what a side says, since these arrive in clusters, and few enough that the surroundings
+/// stay local to the candidate rather than reaching across a level shift the window may
+/// legitimately contain.
+pub(crate) const EXCURSION_NEIGHBOURS: usize = 3;
+
+/// Default `excursion_max_removals`: how many excursions a window may contain before it
+/// is left alone entirely.
+///
+/// A window holding more than this is not a clean window with a bad reading in it. It is
+/// a benchmark that genuinely oscillates between levels, where roughly half the levels
+/// look isolated from their neighbours and discarding them would leave a spuriously tight
+/// window in which the benchmark's own ordinary values read as large, certain
+/// regressions. The stored history puts two excursions inside one window at well under a
+/// percent of comparisons, so this is above what real interference produces while staying
+/// far below what an oscillating series offers.
+pub(crate) const EXCURSION_MAX_REMOVALS: usize = 2;
+
 /// Default `branch_noise_multiple`: multiple of the per-measurement noise floor a
 /// branch move must exceed where the engine reports per-point confidence intervals.
 ///

--- a/packages/cbh_detect/src/detect/noise_gates.rs
+++ b/packages/cbh_detect/src/detect/noise_gates.rs
@@ -161,19 +161,26 @@ pub(crate) const EXCURSION_NEIGHBOUR_AGREEMENT: f64 = BRANCH_PRACTICAL_RELATIVE;
 /// what a side says, since these arrive in clusters, and few enough that the surroundings
 /// stay local to the candidate rather than reaching across a level shift the window may
 /// legitimately contain.
+///
+/// A candidate without this many levels on *both* sides is never discarded. Judging one
+/// against a shorter side would let a single adjacent level speak for a whole side, which
+/// is precisely the case this count exists to outvote.
 pub(crate) const EXCURSION_NEIGHBOURS: usize = 3;
 
 /// Default `excursion_max_removals`: how many excursions a window may contain before it
 /// is left alone entirely.
 ///
-/// A window holding more than this is not a clean window with a bad reading in it. It is
-/// a benchmark that genuinely oscillates between levels, where roughly half the levels
-/// look isolated from their neighbours and discarding them would leave a spuriously tight
-/// window in which the benchmark's own ordinary values read as large, certain
-/// regressions. The stored history puts two excursions inside one window at well under a
-/// percent of comparisons, so this is above what real interference produces while staying
-/// far below what an oscillating series offers.
-pub(crate) const EXCURSION_MAX_REMOVALS: usize = 2;
+/// One. A window offering a second is not a clean window with a bad reading in it: two
+/// separated levels agreeing on a value their surroundings do not is the signature of a
+/// benchmark that visits more than one level, and how often it does so is exactly what the
+/// comparison measures the context run against. Discarding a recurring level would leave a
+/// spuriously tight window in which the benchmark's own ordinary values read as large,
+/// certain regressions — the failure this whole rule exists to avoid causing.
+///
+/// Runner interference is rare enough per window that requiring uniqueness costs almost
+/// nothing: the stored history puts a second excursion inside the same window at well
+/// under a percent of comparisons.
+pub(crate) const EXCURSION_MAX_REMOVALS: usize = 1;
 
 /// Default `branch_noise_multiple`: multiple of the per-measurement noise floor a
 /// branch move must exceed where the engine reports per-point confidence intervals.

--- a/packages/cbh_detect/src/detect/recorded.rs
+++ b/packages/cbh_detect/src/detect/recorded.rs
@@ -35,3 +35,45 @@ pub const STATIONARY_BIMODAL_BASE: usize = 19;
 /// entirely ordinary value for that series, and so the context run that must not be
 /// reported as a move.
 pub const STATIONARY_BIMODAL_HIGH: f64 = 24.97;
+
+/// A wall-time series holding one commit where the runner lost time to something else,
+/// recorded from this project's own stored results.
+///
+/// It opens on one level, steps down to another, and then holds that second level for the
+/// rest of its history apart from a single commit that measures around half as much again
+/// as its neighbours. That commit is not a property of the code: the same run recorded
+/// comparably inflated figures across the whole family of multithreaded benchmarks
+/// measured alongside it, and the series returns to its established level at the very next
+/// commit and stays there.
+///
+/// This is the workspace's reference case for runner interference. Its value is that no
+/// noise model produces it: a generator's deviates are bounded and symmetric, whereas the
+/// excursion here is one-sided, several times the series' own spread, and gone as
+/// abruptly as it arrived — the shape branch mode has to discard rather than average in.
+pub(crate) const CONTENDED_RUNNER_EXCURSION: [f64; 32] = [
+    1141.117, 1139.266, 1129.181, 1155.445, 1146.464, 1139.776, 1143.118, 1155.482, 1041.326,
+    1041.057, 1044.074, 1044.310, 1034.942, 1054.552, 1050.274, 1034.325, 1045.818, 1581.042,
+    1045.424, 1051.638, 1040.738, 1047.509, 1044.247, 1043.722, 1040.797, 1044.360, 1049.268,
+    1060.142, 1051.753, 1042.930, 1042.876, 1043.306,
+];
+
+/// Where the level [`CONTENDED_RUNNER_EXCURSION`] settles on begins: the commit that
+/// stepped it down off its opening level.
+///
+/// A base window taken from here holds one level and one excursion, which is the shape
+/// the branch-mode rows exercise. Taken from the recording's start it would straddle the
+/// step as well, mixing two questions into one case.
+pub(crate) const CONTENDED_RUNNER_LEVEL_START: usize = 8;
+
+/// How much of [`CONTENDED_RUNNER_EXCURSION`] a branch-mode case takes as its base side.
+///
+/// Chosen so that the recent window branch mode reads holds the excursion with several
+/// ordinary commits on either side of it. The excursion has to sit clear of both window
+/// edges for the case to be about the excursion rather than about the window's endpoint
+/// handling.
+pub(crate) const CONTENDED_RUNNER_BASE: usize = 27;
+
+/// A value [`CONTENDED_RUNNER_EXCURSION`] settles at once past
+/// [`CONTENDED_RUNNER_LEVEL_START`] — an entirely ordinary commit for that series, and so
+/// the context run that must not be reported as a move.
+pub(crate) const CONTENDED_RUNNER_LEVEL: f64 = 1045.0;

--- a/packages/cbh_detect/src/detect/recorded.rs
+++ b/packages/cbh_detect/src/detect/recorded.rs
@@ -50,7 +50,7 @@ pub const STATIONARY_BIMODAL_HIGH: f64 = 24.97;
 /// noise model produces it: a generator's deviates are bounded and symmetric, whereas the
 /// excursion here is one-sided, several times the series' own spread, and gone as
 /// abruptly as it arrived — the shape branch mode has to discard rather than average in.
-pub(crate) const CONTENDED_RUNNER_EXCURSION: [f64; 32] = [
+pub const CONTENDED_RUNNER_EXCURSION: [f64; 32] = [
     1141.117, 1139.266, 1129.181, 1155.445, 1146.464, 1139.776, 1143.118, 1155.482, 1041.326,
     1041.057, 1044.074, 1044.310, 1034.942, 1054.552, 1050.274, 1034.325, 1045.818, 1581.042,
     1045.424, 1051.638, 1040.738, 1047.509, 1044.247, 1043.722, 1040.797, 1044.360, 1049.268,
@@ -63,7 +63,7 @@ pub(crate) const CONTENDED_RUNNER_EXCURSION: [f64; 32] = [
 /// A base window taken from here holds one level and one excursion, which is the shape
 /// the branch-mode rows exercise. Taken from the recording's start it would straddle the
 /// step as well, mixing two questions into one case.
-pub(crate) const CONTENDED_RUNNER_LEVEL_START: usize = 8;
+pub const CONTENDED_RUNNER_LEVEL_START: usize = 8;
 
 /// How much of [`CONTENDED_RUNNER_EXCURSION`] a branch-mode case takes as its base side.
 ///
@@ -71,9 +71,9 @@ pub(crate) const CONTENDED_RUNNER_LEVEL_START: usize = 8;
 /// ordinary commits on either side of it. The excursion has to sit clear of both window
 /// edges for the case to be about the excursion rather than about the window's endpoint
 /// handling.
-pub(crate) const CONTENDED_RUNNER_BASE: usize = 27;
+pub const CONTENDED_RUNNER_BASE: usize = 27;
 
 /// A value [`CONTENDED_RUNNER_EXCURSION`] settles at once past
 /// [`CONTENDED_RUNNER_LEVEL_START`] — an entirely ordinary commit for that series, and so
 /// the context run that must not be reported as a move.
-pub(crate) const CONTENDED_RUNNER_LEVEL: f64 = 1045.0;
+pub const CONTENDED_RUNNER_LEVEL: f64 = 1045.0;

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -87,15 +87,21 @@
 //! Shapes like that reach this suite as declared values instead — recorded from a real
 //! series where one exists, and hand-built where the case needs a shape stated exactly.
 //!
-//! Two cases are exempt from the model: the `stationary_bimodal_noise` rows are verbatim
-//! recordings of one real series and carry the dispersion it was measured with — flatly
-//! bimodal, oscillating between two levels, which is the pathological shape the generator
-//! cannot produce and the one the noise gates are most easily fooled by. A human
-//! reading its chart answers "noisy, but nothing changed" without hesitation, so it is
-//! exactly the kind of obvious-answer input this suite exists to pin — and it guards the
-//! noise gates against reading structured jitter as a step. The pair puts it in front of
-//! both detectors: one row hands the whole recording to history mode, the other cuts it
-//! into a base window and a tip so branch mode judges it too.
+//! Among the declared cases, some are verbatim recordings. The `stationary_bimodal_noise`
+//! rows carry one real series' own dispersion — flatly bimodal, oscillating between two
+//! levels, which is the pathological shape the generator cannot produce and the one the
+//! noise gates are most easily fooled by. A human reading its chart answers "noisy, but
+//! nothing changed" without hesitation, so it is exactly the kind of obvious-answer input
+//! this suite exists to pin — and it guards the noise gates against reading structured
+//! jitter as a step. The pair puts it in front of both detectors: one row hands the whole
+//! recording to history mode, the other cuts it into a base window and a tip so branch
+//! mode judges it too. The `contended_runner_*` rows are likewise real, taken from a
+//! series a shared runner disturbed for exactly one commit.
+//!
+//! The rest are hand-built, because what they pin is a shape rather than a dispersion:
+//! how many times a window visits a level, and where those visits sit relative to the run
+//! being judged. Generated scatter would blur exactly the structure under test, so those
+//! rows state their values outright.
 
 #![cfg_attr(coverage_nightly, coverage(off))]
 

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -84,7 +84,8 @@
 //! What the generator supplies is realistic *spread*, not realistic *shape*: its deviates
 //! are bounded, symmetric, and light-tailed (see [`scattered`]), while real timing noise
 //! is right-skewed with occasional large excursions and can settle into distinct modes.
-//! Shapes like that reach this suite through recorded series instead.
+//! Shapes like that reach this suite as declared values instead — recorded from a real
+//! series where one exists, and hand-built where the case needs a shape stated exactly.
 //!
 //! Two cases are exempt from the model: the `stationary_bimodal_noise` rows are verbatim
 //! recordings of one real series and carry the dispersion it was measured with — flatly
@@ -196,9 +197,10 @@ enum Scatter {
     /// The declared values are flat regime levels, and the suite adds the measurement
     /// scatter the case's metric kind actually shows (see [`with_noise`]).
     Modelled,
-    /// The declared values were recorded from a real series and already carry their own
-    /// dispersion, so they are analysed exactly as given.
-    Recorded,
+    /// The declared values already carry their own dispersion — recorded from a real
+    /// series, or hand-built because the exact shape is the point — so they are analysed
+    /// exactly as given.
+    Declared,
 }
 
 /// One curated series — its base and branch sides — and the outcome each mode is
@@ -285,9 +287,9 @@ impl SignalCase {
         self
     }
 
-    /// Declares the values a verbatim recording, to be analysed without added scatter.
-    fn recorded(mut self) -> Self {
-        self.scatter = Scatter::Recorded;
+    /// Declares the values complete as written, to be analysed without added scatter.
+    fn declared(mut self) -> Self {
+        self.scatter = Scatter::Declared;
         self
     }
 
@@ -297,7 +299,7 @@ impl SignalCase {
         let levels = [self.base.as_slice(), self.branch.as_slice()].concat();
         match self.scatter {
             Scatter::Modelled => with_noise(&levels, self.kind, seed_of(self.name)),
-            Scatter::Recorded => levels,
+            Scatter::Declared => levels,
         }
     }
 
@@ -420,11 +422,11 @@ const CONTENDED_WINDOW_REGRESSION: f64 = 1.10;
 /// The base window of `recurrent_high_mode`, oldest first.
 ///
 /// A benchmark resting at one level with ordinary scatter around it, which twice in
-/// sixteen commits visits a level a third higher. Each visit is individually
-/// indistinguishable from a reading a disturbed runner produced — the commits on either
-/// side of it agree with each other, and it stands far clear of them — so nothing local
-/// to either visit can tell them apart from interference. What the window has to be read
-/// by instead is that there are two of them.
+/// sixteen commits visits a level far enough above it to stand clear of its neighbours.
+/// Each visit is individually indistinguishable from a reading a disturbed runner
+/// produced — the commits on either side of it agree with each other, and it stands far
+/// clear of them — so nothing local to either visit can tell them apart from
+/// interference. What the window has to be read by instead is that there are two of them.
 const RECURRENT_HIGH_MODE: [f64; 16] = [
     82.5, 100.0, 100.0, 100.0, 135.0, 100.0, 100.0, 117.5, 100.0, 100.0, 135.0, 100.0, 100.0,
     100.0, 117.5, 82.5,
@@ -433,6 +435,22 @@ const RECURRENT_HIGH_MODE: [f64; 16] = [
 /// The context run `recurrent_high_mode` is judged on: the same high level the window's
 /// own commits already reach, and so not a move at all.
 const RECURRENT_HIGH_MODE_TIP: f64 = 135.0;
+
+/// The base window of `rare_high_mode`, oldest first.
+///
+/// The harder counterpart of [`RECURRENT_HIGH_MODE`]: the high level appears just once,
+/// so nothing inside the window distinguishes it from a reading a disturbed runner
+/// produced. Its scatter sits at the window's ends, where it cannot be mistaken for a
+/// candidate, leaving that single visit as the only one — which is what makes the context
+/// run the deciding evidence.
+const RARE_HIGH_MODE: [f64; 16] = [
+    76.0, 124.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 135.0, 100.0, 100.0, 100.0, 100.0,
+    100.0, 76.0, 124.0,
+];
+
+/// The context run `rare_high_mode` is judged on: the same high level the window visits
+/// once, and so not a move at all.
+const RARE_HIGH_MODE_TIP: f64 = 135.0;
 
 /// The hand-curated cases. New "obvious answer" series are added as one row each.
 fn cases() -> Vec<SignalCase> {
@@ -479,7 +497,7 @@ fn cases() -> Vec<SignalCase> {
         // whole series and must stay quiet; branch has no branch side.
         SignalCase::new("stationary_bimodal_noise", MetricKind::WallTime)
             .base(STATIONARY_BIMODAL_NOISE.to_vec())
-            .recorded(),
+            .declared(),
         // The same recording judged by branch mode, which reads only the recent base
         // window and one context commit. The window is cut where the recording happens to
         // end on five consecutive low-mode commits, and the tip sits at the high mode the
@@ -497,7 +515,7 @@ fn cases() -> Vec<SignalCase> {
                     .to_vec(),
             )
             .branch(vec![STATIONARY_BIMODAL_HIGH])
-            .recorded(),
+            .declared(),
         // A wall-time series that holds one level apart from a single commit where the
         // runner lost time to something else — recorded, so the excursion is the real
         // shape rather than a modelled one. History reads the recording whole: it opens
@@ -507,7 +525,7 @@ fn cases() -> Vec<SignalCase> {
         SignalCase::new("contended_runner_excursion", MetricKind::WallTime)
             .base(CONTENDED_RUNNER_EXCURSION.to_vec())
             .expects(Outcome::Fall, Outcome::Quiet)
-            .recorded(),
+            .declared(),
         // Matched pair, part one. The same recording cut so branch mode's recent window
         // holds the excursion with ordinary commits on either side, and a context run at
         // the level the series actually sits at. Branch mode discards the excursion as
@@ -526,7 +544,7 @@ fn cases() -> Vec<SignalCase> {
                 .to_vec(),
         )
         .branch(vec![CONTENDED_RUNNER_LEVEL])
-        .recorded(),
+        .declared(),
         // Matched pair, part two: the same window, with a context run that genuinely
         // regressed. This is the case the excursion silences if it is left in the window.
         // A move of this size stands several times clear of what the series' own commits
@@ -548,17 +566,28 @@ fn cases() -> Vec<SignalCase> {
         )
         .branch(vec![CONTENDED_RUNNER_LEVEL * CONTENDED_WINDOW_REGRESSION])
         .expects(Outcome::Quiet, Outcome::Rise)
-        .recorded(),
+        .declared(),
         // The counterweight to the pair above, and the reason a window may give up only
-        // one reading. This benchmark visits a level a third above its resting one twice
-        // in sixteen commits — too rarely for either visit to look like anything but a
+        // one reading. This benchmark visits a level well above its resting one twice in
+        // sixteen commits — too rarely for either visit to look like anything but a
         // disturbed runner from where it sits, since its neighbours agree with each other
         // and it stands far clear of them. The context run lands on that same perfectly
         // ordinary high level. Both modes must stay quiet: nothing changed.
         SignalCase::new("recurrent_high_mode", MetricKind::WallTime)
             .base(RECURRENT_HIGH_MODE.to_vec())
             .branch(vec![RECURRENT_HIGH_MODE_TIP])
-            .recorded(),
+            .declared(),
+        // The same lesson where the window alone cannot teach it. Here the high level
+        // appears once, so it looks exactly like a disturbed reading from every angle
+        // inside the window — and the only thing saying otherwise is that the context run
+        // is standing on it. A level the context run itself sits at is never discarded,
+        // because discarding it would leave the window describing a level this benchmark
+        // does not reliably hold and turn an ordinary value into a large, certain
+        // regression against what remained. Both modes must stay quiet: nothing changed.
+        SignalCase::new("rare_high_mode", MetricKind::WallTime)
+            .base(RARE_HIGH_MODE.to_vec())
+            .branch(vec![RARE_HIGH_MODE_TIP])
+            .declared(),
         // A branch that got slower but was fixed in the last commit.
         // History sees the regression, but branch sees only the final commit and must stay quiet.
         SignalCase::new("branch_with_regression_then_fix", MetricKind::WallTime)

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -105,7 +105,9 @@ use cbh_model::MetricKind;
 use crate::detect::findings::find_changes;
 use crate::detect::noise_gates::{MIN_REGIME, MIN_SERIES_POINTS};
 use crate::detect::recorded::{
-    STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH, STATIONARY_BIMODAL_NOISE,
+    CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL,
+    CONTENDED_RUNNER_LEVEL_START, STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH,
+    STATIONARY_BIMODAL_NOISE,
 };
 use crate::detect::scatter::{TIMING_NOISE_CV, scattered, seed_of};
 use crate::detect::{
@@ -405,6 +407,16 @@ const FLOOR_REGIME_POINTS: usize = 50;
 /// first regime, so branch mode sees the whole second regime as the branch side.
 const FLOOR_MERGE_BASE: usize = FLOOR_REGIME_POINTS - 1;
 
+/// The move the context run of `a_regression_through_a_contended_window_is_reported`
+/// carries, as a multiple of the base level.
+///
+/// Twice the smallest move branch mode reports at all, so the case turns on whether the
+/// window is clean rather than on where the reporting floor sits, and several times what
+/// the recording's own ordinary commits vary by, so a human reading the chart calls it
+/// without hesitation. It is nonetheless far below what the same window silences while it
+/// still holds the excursion, which is what makes the case discriminating.
+const CONTENDED_WINDOW_REGRESSION: f64 = 1.10;
+
 /// The hand-curated cases. New "obvious answer" series are added as one row each.
 fn cases() -> Vec<SignalCase> {
     vec![
@@ -469,6 +481,54 @@ fn cases() -> Vec<SignalCase> {
             )
             .branch(vec![STATIONARY_BIMODAL_HIGH])
             .recorded(),
+        // A wall-time series that holds one level apart from a single commit where the
+        // runner lost time to something else — recorded, so the excursion is the real
+        // shape rather than a modelled one. History reads the recording whole: it opens
+        // on a higher level and steps down, which is an improvement history does not
+        // report, and the lone excursion past that step is not a sustained trend. Branch
+        // has no branch side.
+        SignalCase::new("contended_runner_excursion", MetricKind::WallTime)
+            .base(CONTENDED_RUNNER_EXCURSION.to_vec())
+            .expects(Outcome::Fall, Outcome::Quiet)
+            .recorded(),
+        // Matched pair, part one. The same recording cut so branch mode's recent window
+        // holds the excursion with ordinary commits on either side, and a context run at
+        // the level the series actually sits at. Branch mode discards the excursion as
+        // the measurement artifact it is, and must still find nothing to report about a
+        // context run that agrees with everything around it — discarding evidence
+        // tightens the window, so the pair's job is to prove that tightening does not
+        // manufacture a verdict.
+        SignalCase::new("contended_runner_excursion_branch_tip", MetricKind::WallTime)
+            .base(
+                CONTENDED_RUNNER_EXCURSION
+                    .get(CONTENDED_RUNNER_LEVEL_START..CONTENDED_RUNNER_BASE)
+                    .unwrap()
+                    .to_vec(),
+            )
+            .branch(vec![CONTENDED_RUNNER_LEVEL])
+            .recorded(),
+        // Matched pair, part two: the same window, with a context run that genuinely
+        // regressed. This is the case the excursion silences if it is left in the window.
+        // A move of this size stands several times clear of what the series' own commits
+        // vary by, so a human reading the chart calls it immediately; averaged in, the
+        // excursion both drags the window's centre up toward the context run and inflates
+        // the window's spread severalfold, and the move disappears into a window that
+        // finds nothing surprising. Together the pair states that clearing the excursion
+        // restores the sensitivity it costs without inventing findings on branches that
+        // changed nothing.
+        SignalCase::new(
+            "a_regression_through_a_contended_window_is_reported",
+            MetricKind::WallTime,
+        )
+        .base(
+            CONTENDED_RUNNER_EXCURSION
+                .get(CONTENDED_RUNNER_LEVEL_START..CONTENDED_RUNNER_BASE)
+                .unwrap()
+                .to_vec(),
+        )
+        .branch(vec![CONTENDED_RUNNER_LEVEL * CONTENDED_WINDOW_REGRESSION])
+        .expects(Outcome::Quiet, Outcome::Rise)
+        .recorded(),
         // A branch that got slower but was fixed in the last commit.
         // History sees the regression, but branch sees only the final commit and must stay quiet.
         SignalCase::new("branch_with_regression_then_fix", MetricKind::WallTime)

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -417,6 +417,23 @@ const FLOOR_MERGE_BASE: usize = FLOOR_REGIME_POINTS - 1;
 /// still holds the excursion, which is what makes the case discriminating.
 const CONTENDED_WINDOW_REGRESSION: f64 = 1.10;
 
+/// The base window of `recurrent_high_mode`, oldest first.
+///
+/// A benchmark resting at one level with ordinary scatter around it, which twice in
+/// sixteen commits visits a level a third higher. Each visit is individually
+/// indistinguishable from a reading a disturbed runner produced — the commits on either
+/// side of it agree with each other, and it stands far clear of them — so nothing local
+/// to either visit can tell them apart from interference. What the window has to be read
+/// by instead is that there are two of them.
+const RECURRENT_HIGH_MODE: [f64; 16] = [
+    82.5, 100.0, 100.0, 100.0, 135.0, 100.0, 100.0, 117.5, 100.0, 100.0, 135.0, 100.0, 100.0,
+    100.0, 117.5, 82.5,
+];
+
+/// The context run `recurrent_high_mode` is judged on: the same high level the window's
+/// own commits already reach, and so not a move at all.
+const RECURRENT_HIGH_MODE_TIP: f64 = 135.0;
+
 /// The hand-curated cases. New "obvious answer" series are added as one row each.
 fn cases() -> Vec<SignalCase> {
     vec![
@@ -532,6 +549,16 @@ fn cases() -> Vec<SignalCase> {
         .branch(vec![CONTENDED_RUNNER_LEVEL * CONTENDED_WINDOW_REGRESSION])
         .expects(Outcome::Quiet, Outcome::Rise)
         .recorded(),
+        // The counterweight to the pair above, and the reason a window may give up only
+        // one reading. This benchmark visits a level a third above its resting one twice
+        // in sixteen commits — too rarely for either visit to look like anything but a
+        // disturbed runner from where it sits, since its neighbours agree with each other
+        // and it stands far clear of them. The context run lands on that same perfectly
+        // ordinary high level. Both modes must stay quiet: nothing changed.
+        SignalCase::new("recurrent_high_mode", MetricKind::WallTime)
+            .base(RECURRENT_HIGH_MODE.to_vec())
+            .branch(vec![RECURRENT_HIGH_MODE_TIP])
+            .recorded(),
         // A branch that got slower but was fixed in the last commit.
         // History sees the regression, but branch sees only the final commit and must stay quiet.
         SignalCase::new("branch_with_regression_then_fix", MetricKind::WallTime)

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -498,15 +498,18 @@ fn cases() -> Vec<SignalCase> {
         // context run that agrees with everything around it — discarding evidence
         // tightens the window, so the pair's job is to prove that tightening does not
         // manufacture a verdict.
-        SignalCase::new("contended_runner_excursion_branch_tip", MetricKind::WallTime)
-            .base(
-                CONTENDED_RUNNER_EXCURSION
-                    .get(CONTENDED_RUNNER_LEVEL_START..CONTENDED_RUNNER_BASE)
-                    .unwrap()
-                    .to_vec(),
-            )
-            .branch(vec![CONTENDED_RUNNER_LEVEL])
-            .recorded(),
+        SignalCase::new(
+            "contended_runner_excursion_branch_tip",
+            MetricKind::WallTime,
+        )
+        .base(
+            CONTENDED_RUNNER_EXCURSION
+                .get(CONTENDED_RUNNER_LEVEL_START..CONTENDED_RUNNER_BASE)
+                .unwrap()
+                .to_vec(),
+        )
+        .branch(vec![CONTENDED_RUNNER_LEVEL])
+        .recorded(),
         // Matched pair, part two: the same window, with a context run that genuinely
         // regressed. This is the case the excursion silences if it is left in the window.
         // A move of this size stands several times clear of what the series' own commits


### PR DESCRIPTION
[Copilot speaking]

Triage of #437 confirmed that branch mode is blinded by isolated measurement excursions, though not for the reason the issue proposed. The signal-validation suite already carries isolated-outlier fixtures; the defect is not missing coverage but the detector's response to a shape it does see.

## The problem

Branch mode judges a context run against the base window's mean and sample standard deviation. Both come from the same sample by design (#429), so a single wild reading damages the comparison twice over: it drags the centre toward the tip, eating most of the practical-relevance floor, and it inflates the scatter several-fold, which widens the prediction interval into a range almost nothing falls outside.

Measured on the production `COMPARE_WINDOW` of 16 commits, the smallest regression branch mode can still see:

```
  clean window                       +6.25 %
  one +51 % reading in the window   +32.25 %
  two                               +45.50 %
```

The excursion used there is real: `nm_performance/collection/collect_mt` recorded 1581.042 ns against a 1043.41 ns neighbourhood. Thirteen of 289 benchmarks in that run were at least 20 % high, all multithreaded — whole-run runner contention rather than per-series noise.

A sign inversion follows from the same arithmetic: an excursion in the base window with an unchanged tip reads as a 3.5–3.9 % *improvement*.

The failure is silent. Nothing declines, nothing is reported, and the comparison looks exactly like one that found nothing to say.

History mode is unaffected — its gates are median-based and absorb a lone reading on their own.

## The change

Branch mode now discards an isolated measurement excursion from its base comparison window before comparing anything. A reading qualifies only when every one of these holds:

```
  1. its surroundings agree      median of 3 neighbours before ≈ median of 3 after
  2. it stands clear of them     ≥ 30 % from the neighbourhood median
  3. it is the only one          a second candidate discards nothing at all
  4. the context run disagrees   a tip at that level is a second visit to it
```

Test 1 is what separates a bad measurement from a real step: after a genuine change the later commits sit at the *new* level and disagree with the earlier ones, so a step is never mistaken for an excursion however large. Tests 3 and 4 are what stop the rule manufacturing the false positives #429 eliminated — a level the window reaches more than once, or that the run being judged is standing on, is a level the benchmark visits, and stripping it away would leave the window describing a steadiness the benchmark does not hold. Readings near the window's ends are never candidates, since test 1 has nothing complete to consult; at the newest end that is deliberate, because a base-side shift landing near the final commit is indistinguishable from a bad reading there and the two call for opposite treatment.

The 30 % threshold is empirical. Across 2 638 production series and 29 379 isolated interior readings, the up/down ratio crosses over between 25 % and 30 % — below that, excursions are symmetric noise; above it, they are overwhelmingly upward, which is what contention looks like.

```
  ≥ 30 %    206 up     13 down
  ≥ 50 %    107 up      2 down
  ≥ 75 %     48 up      0 down
```

Ordering matters and is fixed: eligibility is decided on the window **as recorded**, before anything is discarded. That keeps the gate in exact correspondence with `testability`, which is what the census counts and what sizes the false-discovery family — a window is never made eligible by discarding.

Discarding is now reported under `--verbose`, naming each reading left out, what it measured, and the level its neighbours agreed on. Narrowing a window changes a verdict without any gate declining, so it would otherwise leave no trace at all.

## Not addressed here

CI already runs `--best-of 3`, and the 1581 ns reading still reached storage. Repeat-based filtering cannot help when the whole run is contended, since every repeat is disturbed together. That contradicts a premise in DESIGN.md §7.1 and deserves its own issue.