### PR TITLE
many_cpus, cargo-bench-history: derive the Linux ID space from kernel masks and fingerprint the usable hardware

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,3 +32,16 @@ retries = { backoff = "exponential", count = 2, delay = "2m", jitter = true }
 [[profile.default.overrides]]
 filter = 'test(=panic_on_next_alloc_resets_automatically)'
 retries = 3
+
+# These tests observe how the hardware appears to a process that the operating system has
+# narrowed, which is only reachable on a machine that has enough processors (and, on Windows,
+# only one processor group) to narrow in the first place. A machine that does not qualify makes
+# them skip themselves at run time and report why on stderr. The test runner hides the output of
+# a passing test, which would make a machine where they silently stopped testing anything look
+# exactly like one where they still do, so their output is surfaced in the run summary.
+[[profile.default.overrides]]
+filter = """
+test(=narrowed_affinity_reveals_sparse_processor_ids) \
++ test(=job_affinity_limit_reveals_sparse_processor_ids) \
++ test(=obeys_processor_selection_limits)"""
+success-output = "final"

--- a/packages/cbh_model/src/context.rs
+++ b/packages/cbh_model/src/context.rs
@@ -97,9 +97,9 @@ impl RunContext {
 /// models). It records the host's auto-detected fingerprint used to partition storage.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MachineInfo {
-    /// Number of logical processors the host reported.
+    /// Number of logical processors the run could use.
     pub processors: usize,
-    /// Number of NUMA memory regions the host reported.
+    /// Number of NUMA memory regions holding processors the run could use.
     pub memory_regions: usize,
     /// Distinct processor model strings the host reported, sorted ascending.
     /// Defaults to empty when reading older records that predate this factor.

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -17,6 +17,11 @@
 //! history into incomparable pieces, which is the failure the fingerprint exists
 //! to prevent.
 //!
+//! The counts describe the hardware the current process can actually use rather
+//! than everything the system could hold. A run confined to part of a machine
+//! measures that part, so it is a different machine for comparison purposes and
+//! belongs under its own key.
+//!
 //! The key is surfaced two ways for operators. [`resolve_machine_key`] yields the
 //! key `collect`, `import`, and `backfill` stamp every result with (the same key the
 //! `machine-key` command prints), while [`describe_fingerprint_components`] renders the
@@ -45,20 +50,20 @@ const FINGERPRINT_HEX_LEN: usize = 16;
 /// partitioned by; the rest are provenance recorded beside them.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HardwareProfile {
-    /// Number of logical processors active on the system.
+    /// Number of logical processors the current process can use.
     ///
-    /// Counted rather than taken from the width of the processor ID space, which the
-    /// kernel is free to pad with IDs reserved for processors that could be hot-added
-    /// later. That padding is a property of the kernel build rather than of the
-    /// hardware, and virtual machines commonly pad to one fixed width whatever their
-    /// size, which would file guests of quite different capacity under a single key.
+    /// Counted from the processors the process may actually run on, rather than taken
+    /// from the width of the processor ID space. The kernel pads that space with IDs
+    /// reserved for processors that could be hot-added later, which is a property of
+    /// the kernel build rather than of the hardware; virtual machines commonly pad to
+    /// one fixed width whatever their size, which would file guests of quite different
+    /// capacity under a single key.
     pub processors: usize,
-    /// Maximum number of NUMA memory regions the system reports.
+    /// Number of NUMA memory regions holding processors the current process can use.
     ///
-    /// The ID space width, unlike [`processors`][Self::processors] above, because the
-    /// count of regions that actually hold processors is only reachable through the
-    /// enumerated processors, which on some platforms are filtered by the affinity of
-    /// the probing process — making the key depend on how the probe was launched.
+    /// Counted from the same processors as [`processors`][Self::processors], so both
+    /// factors describe the same hardware, and for the same reason: the ID space is
+    /// padded with regions that need hold nothing.
     pub memory_regions: usize,
     /// Distinct processor model strings the system reports, sorted ascending.
     ///
@@ -144,6 +149,13 @@ fn distinct_models(models: impl IntoIterator<Item = String>) -> Vec<String> {
     distinct.into_iter().collect()
 }
 
+/// Counts the distinct memory regions a sequence of per-processor region IDs covers
+/// (pure). The IDs are those of the processors the process can use, so regions that hold
+/// no such processor are not counted no matter how the ID space is numbered.
+fn distinct_memory_regions(regions: impl IntoIterator<Item = many_cpus::MemoryRegionId>) -> usize {
+    regions.into_iter().collect::<BTreeSet<_>>().len()
+}
+
 /// The stable machine fingerprint of `profile`: the lowercase hex of the first
 /// [`FINGERPRINT_HEX_LEN`] characters of the SHA-256 of its canonical string.
 pub(crate) fn fingerprint(profile: &HardwareProfile) -> String {
@@ -195,16 +207,20 @@ pub fn describe_fingerprint_components(profile: &HardwareProfile) -> String {
 
 /// Profiles the host hardware (best effort).
 ///
-/// The processor and memory-region counts, the distinct processor models and the
-/// per-processor speed histogram all come from `many_cpus`, so the fingerprint and the
-/// provenance recorded beside it are built from a single, consistent hardware source.
+/// Every factor is counted from one set of processors — those the current process can
+/// use — so the fingerprint describes the hardware the measurements were actually taken
+/// on, and the provenance recorded beside it comes from that same consistent source.
 #[cfg_attr(test, mutants::skip)] // Queries the host; the pure logic it feeds is tested.
 pub(crate) fn system_profile() -> HardwareProfile {
     let hardware = many_cpus::SystemHardware::current();
     let all_processors = hardware.all_processors();
     HardwareProfile {
-        processors: hardware.active_processor_count(),
-        memory_regions: hardware.max_memory_region_count(),
+        processors: all_processors.len(),
+        memory_regions: distinct_memory_regions(
+            all_processors
+                .iter()
+                .map(many_cpus::Processor::memory_region_id),
+        ),
         processor_models: distinct_models(
             all_processors
                 .iter()
@@ -428,15 +444,40 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // Queries real hardware, which Miri cannot model.
-    fn system_profile_counts_processors_rather_than_the_id_space() {
-        // On a machine whose processor ID space is padded — with IDs reserved for
-        // hot-add, or left behind by a processor taken offline — the two differ, and
-        // only the count says how much machine there is to measure with.
+    fn system_profile_counts_usable_hardware_rather_than_the_id_space() {
+        // The ID space is padded — with IDs reserved for hot-add, or left behind by a
+        // processor taken offline — and covers hardware this process may not touch.
+        // Only a count of the usable processors says how much machine there is to
+        // measure with, so the factors must track that count and not the space.
         let hardware = many_cpus::SystemHardware::current();
-        assert_eq!(
-            system_profile().processors,
-            hardware.active_processor_count()
+        let usable = hardware.all_processors();
+        let profile = system_profile();
+
+        assert_eq!(profile.processors, usable.len(), "{profile:?}");
+        assert!(
+            profile.processors <= hardware.max_processor_count(),
+            "{profile:?}"
         );
+
+        let usable_regions = usable
+            .iter()
+            .map(many_cpus::Processor::memory_region_id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(profile.memory_regions, usable_regions.len(), "{profile:?}");
+        assert!(
+            profile.memory_regions <= hardware.max_memory_region_count(),
+            "{profile:?}"
+        );
+    }
+
+    #[test]
+    fn distinct_memory_regions_counts_each_region_once() {
+        // Several processors share a region, so the count is of regions and not of
+        // processors; the IDs need not be contiguous or start at zero, because the
+        // padded ID space is exactly what this count avoids inheriting.
+        assert_eq!(distinct_memory_regions([0, 0, 0]), 1);
+        assert_eq!(distinct_memory_regions([3, 0, 3, 7]), 3);
+        assert_eq!(distinct_memory_regions([]), 0);
     }
 
     #[test]

--- a/packages/cbh_probe/src/machine.rs
+++ b/packages/cbh_probe/src/machine.rs
@@ -45,9 +45,20 @@ const FINGERPRINT_HEX_LEN: usize = 16;
 /// partitioned by; the rest are provenance recorded beside them.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HardwareProfile {
-    /// Maximum number of logical processors the system reports.
+    /// Number of logical processors active on the system.
+    ///
+    /// Counted rather than taken from the width of the processor ID space, which the
+    /// kernel is free to pad with IDs reserved for processors that could be hot-added
+    /// later. That padding is a property of the kernel build rather than of the
+    /// hardware, and virtual machines commonly pad to one fixed width whatever their
+    /// size, which would file guests of quite different capacity under a single key.
     pub processors: usize,
     /// Maximum number of NUMA memory regions the system reports.
+    ///
+    /// The ID space width, unlike [`processors`][Self::processors] above, because the
+    /// count of regions that actually hold processors is only reachable through the
+    /// enumerated processors, which on some platforms are filtered by the affinity of
+    /// the probing process — making the key depend on how the probe was launched.
     pub memory_regions: usize,
     /// Distinct processor model strings the system reports, sorted ascending.
     ///
@@ -192,7 +203,7 @@ pub(crate) fn system_profile() -> HardwareProfile {
     let hardware = many_cpus::SystemHardware::current();
     let all_processors = hardware.all_processors();
     HardwareProfile {
-        processors: hardware.max_processor_count(),
+        processors: hardware.active_processor_count(),
         memory_regions: hardware.max_memory_region_count(),
         processor_models: distinct_models(
             all_processors
@@ -413,6 +424,19 @@ mod tests {
         assert!(hardware.memory_regions >= 1, "{hardware:?}");
         // The fingerprint of whatever this machine is must be well-formed.
         assert_eq!(fingerprint(&hardware).len(), FINGERPRINT_HEX_LEN);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Queries real hardware, which Miri cannot model.
+    fn system_profile_counts_processors_rather_than_the_id_space() {
+        // On a machine whose processor ID space is padded — with IDs reserved for
+        // hot-add, or left behind by a processor taken offline — the two differ, and
+        // only the count says how much machine there is to measure with.
+        let hardware = many_cpus::SystemHardware::current();
+        assert_eq!(
+            system_profile().processors,
+            hardware.active_processor_count()
+        );
     }
 
     #[test]

--- a/packages/many_cpus/docs/design.md
+++ b/packages/many_cpus/docs/design.md
@@ -21,12 +21,18 @@ space, but the reverse does not hold: an ID in the space need not name a process
 caller can observe, because the machine may be described more generously than any single
 process is permitted to use it. A process constrained to a subset of the machine therefore
 sees a sparse set of IDs with holes where the processors it may not use would have been.
+Holes also appear where a processor exists but is inactive, and the extent of the space
+stays the same whether such a processor is activated or deactivated.
 
 A caller that keeps per-processor state indexed by processor ID sizes that state by the
 extent of the ID space and tolerates unoccupied entries. It must not assume that the
 processors it sees are numbered consecutively, that the lowest ID is zero, or that the
 count of processors it sees says anything about the extent of the ID space. Memory region
 IDs behave the same way and carry the same reservations.
+
+Separately from the processors a caller may use, the package reports how many processors
+the system currently has active. That count describes the machine, so a constraint on
+which processors the current process may use does not change it.
 
 ## Processor model
 

--- a/packages/many_cpus/docs/design.md
+++ b/packages/many_cpus/docs/design.md
@@ -13,6 +13,21 @@ speed and its model — is descriptive metadata about that processor, not part o
 identity. Two handles to the same processor are the same processor even if the metadata
 they carry was gathered differently.
 
+## The ID space is larger than what a caller can see
+
+Processor IDs are drawn from an ID space whose extent the package reports separately from
+the processors it describes. Every processor a caller can observe has an ID within that
+space, but the reverse does not hold: an ID in the space need not name a processor the
+caller can observe, because the machine may be described more generously than any single
+process is permitted to use it. A process constrained to a subset of the machine therefore
+sees a sparse set of IDs with holes where the processors it may not use would have been.
+
+A caller that keeps per-processor state indexed by processor ID sizes that state by the
+extent of the ID space and tolerates unoccupied entries. It must not assume that the
+processors it sees are numbered consecutively, that the lowest ID is zero, or that the
+count of processors it sees says anything about the extent of the ID space. Memory region
+IDs behave the same way and carry the same reservations.
+
 ## Processor model
 
 The model is a human-oriented label that identifies the kind of silicon a processor is.

--- a/packages/many_cpus/examples/many_cpus_observe_hardware.rs
+++ b/packages/many_cpus/examples/many_cpus_observe_hardware.rs
@@ -1,0 +1,75 @@
+//! We inspect the hardware from the perspective of the current process and write every
+//! observation to the terminal as a `key: value` line, one observation per line, so the output
+//! of two runs can be compared directly.
+//!
+//! The numbers need not agree with each other. The extent of the ID space is reported
+//! separately from the processors the current process may use, and an ID within that space
+//! need not name a processor this process can see. Constraining the process - for example by
+//! giving it a subset of the machine's processors - is what makes the two diverge, which is
+//! exactly what this example exists to reveal.
+//!
+//! The example terminates immediately, so it is usable as a one-shot probe of a machine.
+
+use std::fmt::Display;
+
+use many_cpus::{Processor, SystemHardware};
+
+fn main() {
+    let hw = SystemHardware::current();
+
+    print_counts(hw);
+    print_processor_ids(hw);
+    print_memory_region_ids(hw);
+}
+
+/// Prints how large the machine is, from each of the perspectives the package offers.
+fn print_counts(hw: &SystemHardware) {
+    println!("max_processor_count: {}", hw.max_processor_count());
+    println!("active_processor_count: {}", hw.active_processor_count());
+    println!("max_memory_region_count: {}", hw.max_memory_region_count());
+
+    // `all_processors()` ignores the resource quota of the process, `processors()` obeys it,
+    // so the two differ when the process is quota-limited but not processor-limited.
+    println!("all_processors_count: {}", hw.all_processors().len());
+    println!("processors_count: {}", hw.processors().len());
+}
+
+/// Prints the ID of every processor the current process can use, in ascending order.
+///
+/// The IDs need not be contiguous - a process constrained to a subset of the machine sees
+/// only the IDs of the processors in that subset, with the rest of the ID space missing.
+fn print_processor_ids(hw: &SystemHardware) {
+    let mut ids = hw
+        .all_processors()
+        .iter()
+        .map(Processor::id)
+        .collect::<Vec<_>>();
+
+    ids.sort_unstable();
+
+    println!("all_processor_ids: {}", format_ids(&ids));
+}
+
+/// Prints the ID of every memory region that the processors of the current process belong to,
+/// in ascending order and without repetition.
+fn print_memory_region_ids(hw: &SystemHardware) {
+    let mut ids = hw
+        .all_processors()
+        .iter()
+        .map(Processor::memory_region_id)
+        .collect::<Vec<_>>();
+
+    ids.sort_unstable();
+    ids.dedup();
+
+    println!("all_memory_region_ids: {}", format_ids(&ids));
+}
+
+/// Formats a list of IDs as a single line, in a form that survives copy-paste into a shell
+/// that expects a comma-separated processor list (e.g. the argument of `taskset -c`).
+fn format_ids(ids: &[impl Display]) -> String {
+    ids.iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}

--- a/packages/many_cpus_impl/src/pal/linux/filesystem/abstractions.rs
+++ b/packages/many_cpus_impl/src/pal/linux/filesystem/abstractions.rs
@@ -18,11 +18,33 @@ use std::fmt::Debug;
 pub(crate) trait Filesystem: Debug + Send + Sync + 'static {
     /// Get the contents of the /proc/cpuinfo file.
     ///
-    /// NB! This file also includes offline processors. To check if a processor is online, you must
-    /// look in /sys/devices/system/cpu/cpu*/online (which has either 0 and 1 as content).
+    /// Mainstream kernels describe only the online processors here - a processor that goes
+    /// offline disappears from the file entirely. Read
+    /// [`get_possible_cpus_contents()`][Self::get_possible_cpus_contents] to learn the extent of
+    /// the processor ID space and [`get_online_cpus_contents()`][Self::get_online_cpus_contents]
+    /// to learn how many processors are online.
     ///
     /// This is a plaintext file with "key    : value" pairs, blocks separated by empty lines.
     fn get_cpuinfo_contents(&self) -> String;
+
+    /// Get the contents of the /sys/devices/system/cpu/possible file or `None` if it does not
+    /// exist.
+    ///
+    /// This lists every processor that could possibly exist in the system, including processors
+    /// that are offline and processors that the current process may not use. The kernel fixes
+    /// this set at boot, so it does not change over the lifetime of the system.
+    ///
+    /// This is a cpulist format file ("0,1,2-4,5-10:2" style list).
+    fn get_possible_cpus_contents(&self) -> Option<String>;
+
+    /// Get the contents of the /sys/devices/system/cpu/online file or `None` if it does not
+    /// exist.
+    ///
+    /// This lists every processor that is currently online, across the whole system and
+    /// regardless of which processors the current process may use.
+    ///
+    /// This is a cpulist format file ("0,1,2-4,5-10:2" style list).
+    fn get_online_cpus_contents(&self) -> Option<String>;
 
     /// Get the contents of the /sys/devices/system/node/possible file or `None` if it does
     /// not exist.
@@ -33,15 +55,20 @@ pub(crate) trait Filesystem: Debug + Send + Sync + 'static {
     /// This is a cpulist format file ("0,1,2-4,5-10:2" style list).
     fn get_numa_node_possible_contents(&self) -> Option<String>;
 
-    /// Get the contents of the /sys/devices/system/node/node{}/cpulist file.
+    /// Get the contents of the /sys/devices/system/node/node{}/cpulist file or `None` if it does
+    /// not exist.
+    ///
+    /// A node that holds no online processor publishes an empty list, and a node that was never
+    /// onlined at all publishes no such file.
     ///
     /// This is a cpulist format file ("0,1,2-4,5-10:2" style list).
-    fn get_numa_node_cpulist_contents(&self, node_index: u32) -> String;
+    fn get_numa_node_cpulist_contents(&self, node_index: u32) -> Option<String>;
 
     /// Gets the contents of the /sys/devices/system/cpu/cpu{}/online file.
     ///
     /// This is a single line file with either 0 or 1 as content (+ newline).
-    /// This file may be absent on some Linux flavors, in which case we assume every CPU is online.
+    /// This file may be absent on some Linux flavors and is absent for processor 0 on kernels
+    /// that cannot take that processor offline, in which case we assume the processor is online.
     fn get_cpu_online_contents(&self, cpu_index: u32) -> Option<String>;
 
     /// Gets the contents of the /prod/{pid}/status file for the current process.

--- a/packages/many_cpus_impl/src/pal/linux/filesystem/facade.rs
+++ b/packages/many_cpus_impl/src/pal/linux/filesystem/facade.rs
@@ -37,11 +37,27 @@ impl Filesystem for FilesystemFacade {
         }
     }
 
-    fn get_numa_node_cpulist_contents(&self, node_index: u32) -> String {
+    fn get_numa_node_cpulist_contents(&self, node_index: u32) -> Option<String> {
         match self {
             Self::Target(filesystem) => filesystem.get_numa_node_cpulist_contents(node_index),
             #[cfg(test)]
             Self::Mock(mock) => mock.get_numa_node_cpulist_contents(node_index),
+        }
+    }
+
+    fn get_possible_cpus_contents(&self) -> Option<String> {
+        match self {
+            Self::Target(filesystem) => filesystem.get_possible_cpus_contents(),
+            #[cfg(test)]
+            Self::Mock(mock) => mock.get_possible_cpus_contents(),
+        }
+    }
+
+    fn get_online_cpus_contents(&self) -> Option<String> {
+        match self {
+            Self::Target(filesystem) => filesystem.get_online_cpus_contents(),
+            #[cfg(test)]
+            Self::Mock(mock) => mock.get_online_cpus_contents(),
         }
     }
 

--- a/packages/many_cpus_impl/src/pal/linux/filesystem/real.rs
+++ b/packages/many_cpus_impl/src/pal/linux/filesystem/real.rs
@@ -20,13 +20,20 @@ impl Filesystem for BuildTargetFilesystem {
             .expect("failed to read /proc/cpuinfo - cannot continue execution")
     }
 
+    fn get_possible_cpus_contents(&self) -> Option<String> {
+        fs::read_to_string("/sys/devices/system/cpu/possible").ok()
+    }
+
+    fn get_online_cpus_contents(&self) -> Option<String> {
+        fs::read_to_string("/sys/devices/system/cpu/online").ok()
+    }
+
     fn get_numa_node_possible_contents(&self) -> Option<String> {
         fs::read_to_string("/sys/devices/system/node/possible").ok()
     }
 
-    fn get_numa_node_cpulist_contents(&self, node_index: u32) -> String {
-        fs::read_to_string(format!("/sys/devices/system/node/node{node_index}/cpulist"))
-            .expect("failed to read NUMA node cpulist - cannot continue execution")
+    fn get_numa_node_cpulist_contents(&self, node_index: u32) -> Option<String> {
+        fs::read_to_string(format!("/sys/devices/system/node/node{node_index}/cpulist")).ok()
     }
 
     fn get_cpu_online_contents(&self, cpu_index: u32) -> Option<String> {

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::iter::once;
 use std::mem;
+use std::num::NonZero;
 use std::sync::{Arc, OnceLock};
 
 use foldhash::HashMap;
@@ -33,6 +34,9 @@ pub(crate) struct BuildTargetPlatform {
 
     // Only active.
     all_active_processors: OnceLock<NonEmpty<ProcessorFacade>>,
+
+    // System-wide, so not narrowed by what the current process may use.
+    active_processor_count: OnceLock<NonZero<usize>>,
 }
 
 impl Platform for BuildTargetPlatform {
@@ -78,7 +82,18 @@ impl Platform for BuildTargetPlatform {
     }
 
     fn current_thread_processors(&self) -> NonEmpty<ProcessorId> {
-        let max_processor_id = self.get_max_processor_id();
+        // The affinity mask is a fixed-size bit set, so a processor whose ID the mask cannot name
+        // is not part of the affinity of any thread - and reading such a bit would read past the
+        // end of the mask. The processor ID space can reach that far even on a small machine
+        // because the kernel sizes it for the processors that could possibly be present.
+        let max_affinity_mask_processor_id = ProcessorId::try_from(libc::CPU_SETSIZE)
+            .ok()
+            .and_then(|capacity| capacity.checked_sub(1))
+            .expect("CPU_SETSIZE is a positive constant that fits in a processor ID");
+
+        let max_processor_id = self
+            .get_max_processor_id()
+            .min(max_affinity_mask_processor_id);
 
         let affinity = self
             .bindings
@@ -87,7 +102,6 @@ impl Platform for BuildTargetPlatform {
 
         NonEmpty::from_vec(
             (0..=max_processor_id)
-                // TODO: Do we need to check for cpuset overflow here to avoid panic?
                 // SAFETY: No safety requirements.
                 .filter(|processor_id| unsafe { libc::CPU_ISSET(*processor_id as usize, &affinity) })
                 .collect_vec())
@@ -112,7 +126,7 @@ impl Platform for BuildTargetPlatform {
     }
 
     fn active_processor_count(&self) -> usize {
-        self.get_active_processors().len()
+        self.get_active_processor_count().get()
     }
 }
 
@@ -125,6 +139,7 @@ impl BuildTargetPlatform {
             all_active_processors: OnceLock::new(),
             max_processor_id: OnceLock::new(),
             max_memory_region_id: OnceLock::new(),
+            active_processor_count: OnceLock::new(),
         }
     }
 
@@ -148,20 +163,58 @@ impl BuildTargetPlatform {
 
     fn get_max_memory_region_id(&self) -> MemoryRegionId {
         *self.max_memory_region_id.get_or_init(|| {
-            self.get_all_processors_impl()
-                .iter()
-                .map(|p| p.memory_region_id)
-                .max()
-                .expect("NonEmpty always has at least one item")
+            // The ID space of memory regions is what the kernel says could possibly exist, which
+            // is what `Platform::max_memory_region_id()` promises: a constant that covers offline
+            // regions and regions this process may not use.
+            //
+            // A kernel that publishes no node mask describes a machine with no NUMA topology for
+            // us to read, which `load_all_processors()` treats as the single memory region that
+            // every processor belongs to. That region is then the whole ID space.
+            parse_kernel_id_list(self.fs.get_numa_node_possible_contents())
+                .map_or(SINGLE_MEMORY_REGION_ID, |ids| *ids.maximum())
         })
     }
 
     fn get_max_processor_id(&self) -> ProcessorId {
         *self.max_processor_id.get_or_init(|| {
+            // The ID space of processors is what the kernel says could possibly exist. The
+            // kernel fixes that set at boot, so the value stays constant as processors go
+            // offline and regardless of which processors this process may use - which is what
+            // `Platform::max_processor_id()` promises.
+            if let Some(possible_processors) =
+                parse_kernel_id_list(self.fs.get_possible_cpus_contents())
+            {
+                return *possible_processors.maximum();
+            }
+
+            // A kernel that publishes no readable mask leaves us with the machine we managed to
+            // enumerate. That ID space is narrower than the contract asks for, but it is the
+            // widest one we have evidence for and it still covers every processor a caller can
+            // observe through this package.
             self.get_all_processors_impl()
                 .iter()
                 .map(|p| p.id)
                 .max()
+                .expect("NonEmpty always has at least one item")
+        })
+    }
+
+    fn get_active_processor_count(&self) -> NonZero<usize> {
+        *self.active_processor_count.get_or_init(|| {
+            // The count is a fact about the machine, not about this process, so it comes from
+            // the system-wide online mask rather than from the processors we enumerated (which
+            // are narrowed to those the process may use).
+            if let Some(online_processors) =
+                parse_kernel_id_list(self.fs.get_online_cpus_contents())
+                    .and_then(|ids| NonZero::new(ids.len()))
+            {
+                return online_processors;
+            }
+
+            // A kernel that publishes no readable mask leaves us with the processors we
+            // enumerated. They are all online, so counting them undercounts the machine at
+            // worst, which beats reporting nothing at all.
+            NonZero::new(self.get_active_processors().len())
                 .expect("NonEmpty always has at least one item")
         })
     }
@@ -183,6 +236,9 @@ impl BuildTargetPlatform {
         // 3. /sys/devices/system/cpu/cpu*/online says whether a processor is online.
         // 4. /proc/self/status gives us the set of processors allowed for the current process.
         // Note: /sys/devices/system/node may be missing if there is only one NUMA node.
+        //
+        // The extent of the ID space is a separate question that none of these files answer -
+        // see `get_max_processor_id()` and `get_max_memory_region_id()`.
         let cpu_infos = self.get_cpuinfo();
         let numa_nodes = self.get_numa_nodes();
         let allowed_processors = self.get_processors_allowed_for_current_process();
@@ -194,8 +250,13 @@ impl BuildTargetPlatform {
             .collect_vec()).expect("found no allowed processors after filtering out forbidden processors - so how is this code even executing?");
 
         // If we did not get any NUMA node info, construct an imaginary NUMA node containing all.
-        let numa_nodes = numa_nodes
-            .unwrap_or_else(|| once((0, cpu_infos.clone().map(|info| info.index))).collect());
+        let numa_nodes = numa_nodes.unwrap_or_else(|| {
+            once((
+                SINGLE_MEMORY_REGION_ID,
+                cpu_infos.clone().map(|info| info.index),
+            ))
+            .collect()
+        });
 
         // We identify efficiency cores by comparing the bogomips of each processor to the maximum
         // bogomips of all processors. If the bogomips is less than the maximum, we consider it an
@@ -228,8 +289,14 @@ impl BuildTargetPlatform {
                 EfficiencyClass::Performance
             };
 
-            // Some Linux flavors do not report this, so just assume online by default.
-            // Sometimes this is also omitted for a specific processor because... it just is.
+            // Mainstream kernels drop a processor from /proc/cpuinfo the moment it goes offline,
+            // so this check normally finds every enumerated processor online. We keep it because
+            // the per-processor file is the kernel's authoritative answer and a kernel that does
+            // list an offline processor must not have it reported as usable.
+            //
+            // Some Linux flavors do not report this at all, and mainstream kernels omit it for
+            // processor 0 because that processor cannot be taken offline, so an absent file
+            // means online.
             let is_online = self
                 .fs
                 .get_cpu_online_contents(info.index)
@@ -422,14 +489,18 @@ impl BuildTargetPlatform {
         Some(
             node_indexes
                 .into_iter()
-                .map(|node| {
-                    let cpulist_str = self.fs.get_numa_node_cpulist_contents(node);
+                .filter_map(|node| {
+                    // A node that could possibly exist need not hold any online processor, in
+                    // which case the kernel publishes no member list for it or an empty one.
+                    // Such a node maps no processor to itself while still occupying an ID in the
+                    // memory region ID space - see `get_max_memory_region_id()`.
+                    let cpulist_str = self.fs.get_numa_node_cpulist_contents(node)?;
                     let cpulist = NonEmpty::from_vec(
                         cpulist::parse(cpulist_str.trim())
-                            .expect("platform provided invalid cpulist for NUMA node members"))
-                        .expect("platform provided empty cpulist for NUMA node members - at least one processor must be present to make a NUMA node");
+                            .expect("platform provided invalid cpulist for NUMA node members"),
+                    )?;
 
-                    (node, cpulist)
+                    Some((node, cpulist))
                 })
                 .collect(),
         )
@@ -513,6 +584,10 @@ const CPUINFO_KEY_PART: &str = "cpu part";
 /// being reported as a whole by the kernel.
 const SYNTHESIZED_MODEL_PREFIX: &str = "cpuinfo";
 
+/// The memory region every processor belongs to on a machine whose kernel discloses no NUMA
+/// topology, which is also then the only ID in the memory region ID space.
+const SINGLE_MEMORY_REGION_ID: MemoryRegionId = 0;
+
 // A `model name` field is not universal: a 64-bit ARM kernel emits one only when the reading
 // process has a 32-bit personality, so a native 64-bit process sees none at all. Such kernels
 // describe the processor through numeric identity fields instead, and reading `model name` alone
@@ -588,6 +663,22 @@ fn canonical_identity_value(value: &str) -> Cow<'_, str> {
         })
 }
 
+/// Reads one of the kernel's cpulist-format ID masks into the IDs it names.
+///
+/// The kernel publishes the extent of the processor and memory region ID spaces as such masks
+/// (for example `/sys/devices/system/cpu/possible`), which is where the values promised to be
+/// constant and system-wide come from.
+///
+/// Returns `None` when the platform publishes no such file, publishes something we cannot read,
+/// or names no ID at all. Every caller then falls back to a derivation from the machine we did
+/// manage to enumerate, because a machine we can describe imperfectly is worth more to a caller
+/// than a machine we refuse to describe.
+fn parse_kernel_id_list(contents: Option<String>) -> Option<NonEmpty<u32>> {
+    let ids = cpulist::parse(contents?.trim()).ok()?;
+
+    NonEmpty::from_vec(ids)
+}
+
 /// This is the relative path of the cgroup the current process belongs to (e.g. `/foo/bar`)
 /// or `None` if no cgroup is assigned.
 ///
@@ -659,6 +750,10 @@ mod tests {
     use crate::pal::linux::{MockBindings, MockFilesystem};
 
     const PROCESSOR_TIME_CLOSE_ENOUGH: f64 = 0.01;
+
+    /// The processor that mainstream kernels cannot take offline and therefore publish no
+    /// `/sys/devices/system/cpu/cpu{}/online` file for.
+    const FIRST_PROCESSOR_ID: ProcessorId = 0;
 
     #[test]
     fn get_all_processors_smoke_test() {
@@ -919,15 +1014,15 @@ mod tests {
     }
 
     #[test]
-    fn one_active_one_inactive_numa_node() {
+    fn numa_node_without_online_processors_stays_in_the_id_space() {
         let mut fs = MockFilesystem::new();
-        // Node 0 -> inactive, Node 1 -> [Performance, Efficiency, Performance]
+        // Node 1 has no online processor, Node 0 -> [Performance, Efficiency, Performance]
         simulate_processor_layout(
             &mut fs,
             [0, 1, 2, 3, 4, 5],
             Some([false, false, false, true, true, true]),
             None,
-            [0, 0, 0, 1, 1, 1],
+            [1, 1, 1, 0, 0, 0],
             [3400.0, 2000.0, 3400.0, 3400.0, 2000.0, 3400.0],
         );
 
@@ -938,10 +1033,10 @@ mod tests {
         let processors = platform.get_all_processors();
         assert_eq!(processors.len(), 3);
 
-        // Node 1 => [Perf, Eff, Perf]
+        // Node 0 => [Perf, Eff, Perf]
         let p0 = &processors[0];
         assert_eq!(p0.as_target().id, 3);
-        assert_eq!(p0.as_target().memory_region_id, 1);
+        assert_eq!(p0.as_target().memory_region_id, 0);
         assert_eq!(
             p0.as_target().efficiency_class,
             EfficiencyClass::Performance
@@ -949,16 +1044,183 @@ mod tests {
 
         let p1 = &processors[1];
         assert_eq!(p1.as_target().id, 4);
-        assert_eq!(p1.as_target().memory_region_id, 1);
+        assert_eq!(p1.as_target().memory_region_id, 0);
         assert_eq!(p1.as_target().efficiency_class, EfficiencyClass::Efficiency);
 
         let p2 = &processors[2];
         assert_eq!(p2.as_target().id, 5);
-        assert_eq!(p2.as_target().memory_region_id, 1);
+        assert_eq!(p2.as_target().memory_region_id, 0);
         assert_eq!(
             p2.as_target().efficiency_class,
             EfficiencyClass::Performance
         );
+
+        // Node 1 holds no processor a caller can observe but remains part of the ID space, so
+        // both nodes are still described by the extent of that space.
+        assert_eq!(platform.max_memory_region_id(), 1);
+
+        // The processors of node 1 are offline, not absent from the machine.
+        assert_eq!(platform.max_processor_id(), 5);
+        assert_eq!(platform.active_processor_count(), 3);
+    }
+
+    #[test]
+    fn numa_node_that_was_never_onlined_publishes_no_member_list() {
+        // A node named in the possible set need not have been onlined at all, in which case the
+        // kernel publishes no directory for the node and therefore no member list either.
+        let cpuinfo = "processor       : 0
+bogomips        : 50.00
+";
+
+        let mut fs = MockFilesystem::new();
+
+        fs.expect_get_cpuinfo_contents()
+            .return_const(cpuinfo.to_string());
+        fs.expect_get_possible_cpus_contents()
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_online_cpus_contents()
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_possible_contents()
+            .return_const(Some("0-1\n".to_string()));
+        fs.expect_get_numa_node_cpulist_contents()
+            .withf(|n| *n == 0)
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_cpulist_contents()
+            .withf(|n| *n == 1)
+            .return_const(None);
+        fs.expect_get_cpu_online_contents()
+            .withf(|p| *p == 0)
+            .return_const(None);
+        fs.expect_get_proc_self_status_contents()
+            .return_const("Cpus_allowed_list: 0".to_string());
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 1);
+        assert_eq!(processors[0].as_target().memory_region_id, 0);
+        assert_eq!(platform.max_memory_region_id(), 1);
+    }
+
+    #[test]
+    fn offline_processors_stay_in_the_processor_id_space() {
+        let mut fs = MockFilesystem::new();
+
+        simulate_processor_layout(
+            &mut fs,
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            Some([true, true, true, true, false, false, false, false]),
+            None,
+            [0; 8],
+            [2000.0; 8],
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        // Taking a processor offline does not remove it from the machine, so the ID space keeps
+        // its extent while only the online processors can be observed and used.
+        assert_eq!(platform.max_processor_id(), 7);
+        assert_eq!(platform.active_processor_count(), 4);
+        assert_eq!(platform.get_all_processors().len(), 4);
+    }
+
+    #[test]
+    fn forbidden_processors_stay_in_the_processor_id_space() {
+        let mut fs = MockFilesystem::new();
+
+        simulate_processor_layout(
+            &mut fs,
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            None,
+            Some([true, true, false, false, false, false, false, false]),
+            [0; 8],
+            [2000.0; 8],
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        // Both the extent of the ID space and the count of online processors describe the
+        // machine, so a constraint on what this process may use leaves them untouched.
+        assert_eq!(platform.max_processor_id(), 7);
+        assert_eq!(platform.active_processor_count(), 8);
+        assert_eq!(platform.get_all_processors().len(), 2);
+    }
+
+    #[test]
+    fn machine_without_id_space_masks_is_described_by_its_processors() {
+        let mut fs = MockFilesystem::new();
+
+        simulate_processor_layout_without_id_space_masks(
+            &mut fs,
+            [0, 1, 2, 3],
+            Some([true, true, false, true]),
+            [2000.0; 4],
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        // With no mask to read, the machine we enumerated is all the evidence we have.
+        assert_eq!(platform.max_processor_id(), 3);
+        assert_eq!(platform.max_memory_region_id(), 0);
+        assert_eq!(platform.active_processor_count(), 3);
+        assert_eq!(platform.get_all_processors().len(), 3);
+    }
+
+    #[test]
+    fn cpuinfo_listing_offline_processor_excludes_the_processor() {
+        // Mainstream kernels drop an offline processor from /proc/cpuinfo, but a kernel that
+        // lists one anyway must not have it reported as a processor a caller may use.
+        let cpuinfo = "processor       : 0
+bogomips        : 50.00
+
+processor       : 1
+bogomips        : 50.00
+";
+
+        let mut fs = MockFilesystem::new();
+
+        fs.expect_get_cpuinfo_contents()
+            .return_const(cpuinfo.to_string());
+        fs.expect_get_possible_cpus_contents()
+            .return_const(Some("0-1\n".to_string()));
+        fs.expect_get_online_cpus_contents()
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_possible_contents()
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_cpulist_contents()
+            .withf(|n| *n == 0)
+            .return_const(Some("0-1\n".to_string()));
+        fs.expect_get_cpu_online_contents()
+            .withf(|p| *p == 0)
+            .return_const(None);
+        fs.expect_get_cpu_online_contents()
+            .withf(|p| *p == 1)
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_proc_self_status_contents()
+            .return_const("Cpus_allowed_list: 0-1".to_string());
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 1);
+        assert_eq!(processors[0].as_target().id, 0);
     }
 
     #[test]
@@ -1012,29 +1274,88 @@ mod tests {
         );
     }
 
-    /// Configures mock bindings and filesystem to simulate a particular type of processor layout.
+    /// Configures the mock filesystem to simulate a particular machine.
     ///
-    /// The simulation is valid for one call to `get_all_processors_impl()`.
+    /// The processors named here are the processors the machine could possibly have, which is
+    /// what the kernel publishes in `/sys/devices/system/cpu/possible` and what defines the
+    /// processor ID space. A processor that is offline is absent from `/proc/cpuinfo` and from
+    /// `/sys/devices/system/cpu/online`, matching what mainstream kernels publish, so the
+    /// simulated machine can have an ID space wider than the set of processors it currently
+    /// runs. The same holds for memory regions: every region named here is published in
+    /// `/sys/devices/system/node/possible`, while a region whose every processor is offline
+    /// publishes no member list at all.
     fn simulate_processor_layout<const PROCESSOR_COUNT: usize>(
         fs: &mut MockFilesystem,
         processor_index: [ProcessorId; PROCESSOR_COUNT],
-        // If None, all are active.
-        processor_is_active: Option<[bool; PROCESSOR_COUNT]>,
+        // If None, all are online.
+        processor_is_online: Option<[bool; PROCESSOR_COUNT]>,
         // If None, all are allowed.
         processor_is_allowed: Option<[bool; PROCESSOR_COUNT]>,
         memory_region_index: [MemoryRegionId; PROCESSOR_COUNT],
         bogomips_per_processor: [f64; PROCESSOR_COUNT],
     ) {
-        let processor_is_active = processor_is_active.unwrap_or([true; PROCESSOR_COUNT]);
-        let processor_is_allowed = processor_is_allowed.unwrap_or([true; PROCESSOR_COUNT]);
+        simulate_machine(
+            fs,
+            processor_index,
+            processor_is_online.unwrap_or([true; PROCESSOR_COUNT]),
+            processor_is_allowed.unwrap_or([true; PROCESSOR_COUNT]),
+            memory_region_index,
+            bogomips_per_processor,
+            IdSpaceMasks::Published,
+        );
+    }
 
-        // Remember that the cpuinfo list will return all processors, including inactive ones.
+    /// Configures the mock filesystem to simulate a machine whose kernel publishes none of the
+    /// masks that describe the ID space, which is what the fallback derivations exist for.
+    ///
+    /// Such a kernel discloses no NUMA topology either, so every processor of the simulated
+    /// machine belongs to one memory region and every processor is online.
+    fn simulate_processor_layout_without_id_space_masks<const PROCESSOR_COUNT: usize>(
+        fs: &mut MockFilesystem,
+        processor_index: [ProcessorId; PROCESSOR_COUNT],
+        // If None, all are allowed.
+        processor_is_allowed: Option<[bool; PROCESSOR_COUNT]>,
+        bogomips_per_processor: [f64; PROCESSOR_COUNT],
+    ) {
+        simulate_machine(
+            fs,
+            processor_index,
+            [true; PROCESSOR_COUNT],
+            processor_is_allowed.unwrap_or([true; PROCESSOR_COUNT]),
+            [SINGLE_MEMORY_REGION_ID; PROCESSOR_COUNT],
+            bogomips_per_processor,
+            IdSpaceMasks::Absent,
+        );
+    }
+
+    /// Whether the simulated kernel publishes the masks that describe the extent of the ID space.
+    ///
+    /// These are virtually always present on a real machine, so `Absent` exists to reach the
+    /// derivations we fall back to when a kernel discloses no mask.
+    #[derive(Clone, Copy)]
+    enum IdSpaceMasks {
+        Published,
+        Absent,
+    }
+
+    fn simulate_machine<const PROCESSOR_COUNT: usize>(
+        fs: &mut MockFilesystem,
+        processor_index: [ProcessorId; PROCESSOR_COUNT],
+        processor_is_online: [bool; PROCESSOR_COUNT],
+        processor_is_allowed: [bool; PROCESSOR_COUNT],
+        memory_region_index: [MemoryRegionId; PROCESSOR_COUNT],
+        bogomips_per_processor: [f64; PROCESSOR_COUNT],
+        id_space_masks: IdSpaceMasks,
+    ) {
+        let online_positions = || (0..PROCESSOR_COUNT).filter(|index| processor_is_online[*index]);
 
         let mut cpuinfo = String::new();
 
-        for (processor_index, bogomips) in processor_index.iter().zip(bogomips_per_processor.iter())
-        {
-            writeln!(cpuinfo, "processor       : {processor_index}").unwrap();
+        for position in online_positions() {
+            let processor_id = processor_index[position];
+            let bogomips = bogomips_per_processor[position];
+
+            writeln!(cpuinfo, "processor       : {processor_id}").unwrap();
             writeln!(cpuinfo, "model name      : Test Processor Model").unwrap();
             writeln!(cpuinfo, "bogomips        : {bogomips}").unwrap();
             writeln!(cpuinfo, "whatever        : 123").unwrap();
@@ -1042,80 +1363,79 @@ mod tests {
             writeln!(cpuinfo).unwrap();
         }
 
-        let node_indexes =
-            NonEmpty::from_vec(memory_region_index.iter().copied().unique().collect_vec())
-                .expect("simulating zero nodes is not supported");
-        let mut node_indexes_cpulist = cpulist::emit(node_indexes);
-        // \n might or might not be present, so let us verify that it gets
-        // trimmed if it is.
-        node_indexes_cpulist.push('\n');
+        fs.expect_get_cpuinfo_contents().return_const(cpuinfo);
 
-        let processors_per_node = memory_region_index
-            .iter()
-            .copied()
-            .zip(processor_index.iter().copied())
-            .into_group_map();
+        let node_indexes = memory_region_index.iter().copied().unique().collect_vec();
 
-        fs.expect_get_cpuinfo_contents()
-            .times(1)
-            .return_const(cpuinfo);
+        // A trailing newline might or might not be present in a real file, so we add one
+        // everywhere to verify that it gets trimmed.
+        let possible_processors = format!("{}\n", cpulist::emit(processor_index));
+        let online_processor_ids = online_positions()
+            .map(|position| processor_index[position])
+            .collect_vec();
+        let online_processors = format!("{}\n", cpulist::emit(online_processor_ids));
+        let possible_nodes = format!("{}\n", cpulist::emit(node_indexes.iter().copied()));
 
-        fs.expect_get_numa_node_possible_contents()
-            .times(1)
-            .return_const(Some(node_indexes_cpulist));
+        match id_space_masks {
+            IdSpaceMasks::Published => {
+                fs.expect_get_possible_cpus_contents()
+                    .return_const(Some(possible_processors));
+                fs.expect_get_online_cpus_contents()
+                    .return_const(Some(online_processors));
+                fs.expect_get_numa_node_possible_contents()
+                    .return_const(Some(possible_nodes));
+            }
+            IdSpaceMasks::Absent => {
+                fs.expect_get_possible_cpus_contents().return_const(None);
+                fs.expect_get_online_cpus_contents().return_const(None);
+                fs.expect_get_numa_node_possible_contents()
+                    .return_const(None);
+            }
+        }
 
-        for (index, processor_id) in processor_index.iter().copied().enumerate() {
-            if !processor_is_allowed[index] {
+        for position in online_positions() {
+            if !processor_is_allowed[position] {
                 // Forbidden processors are not probed.
                 continue;
             }
 
-            let is_online = processor_is_active[processor_id as usize];
+            let processor_id = processor_index[position];
+
             fs.expect_get_cpu_online_contents()
                 .withf(move |p| *p == processor_id)
-                .times(1)
-                .return_const(if is_online {
-                    // \n might or might not be present, so let us verify
-                    // that it gets trimmed if it is.
-                    Some("1\n".to_string())
+                .return_const(if processor_id == FIRST_PROCESSOR_ID {
+                    // Mainstream kernels publish no such file for the first processor because
+                    // that processor cannot be taken offline.
+                    None
                 } else {
-                    Some("0".to_string())
+                    Some("1\n".to_string())
                 });
         }
 
-        for (node, processors) in processors_per_node {
-            let mut cpulist = processors
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(",");
+        for node in node_indexes {
+            let members = online_positions()
+                .filter(|position| memory_region_index[*position] == node)
+                .map(|position| processor_index[position])
+                .collect_vec();
 
-            // This might or might not be present, so let us verify that it gets trimmed if it is.
-            cpulist.push('\n');
+            // A node that holds no online processor publishes an empty member list.
+            let members = format!("{}\n", cpulist::emit(members));
 
             fs.expect_get_numa_node_cpulist_contents()
                 .withf(move |n| *n == node)
-                .times(1)
-                .return_const(cpulist);
+                .return_const(Some(members));
         }
 
-        let allowed_processors = NonEmpty::from_vec(processor_index
-            .iter()
-            .copied()
-            .enumerate()
-            .filter_map(|(index, processor_id)| {
-                if processor_is_allowed[index] {
-                    Some(processor_id)
-                } else {
-                    None
-                }
-            })
-            .collect_vec()).expect("simulated configuration allows zero processors - this is not valid, as some processor must be present to execute the code under test");
+        let allowed_processors = (0..PROCESSOR_COUNT)
+            .filter(|position| processor_is_allowed[*position])
+            .map(|position| processor_index[position])
+            .collect_vec();
+
+        assert!(!allowed_processors.is_empty());
 
         let allowed_cpus = cpulist::emit(allowed_processors);
 
         fs.expect_get_proc_self_status_contents()
-            .times(1)
             .return_const(format!("Cpus_allowed_list: {allowed_cpus}"));
     }
 
@@ -1360,6 +1680,57 @@ mod tests {
         let current_thread_processors = platform.current_thread_processors();
         assert_eq!(current_thread_processors.len(), 1);
         assert_eq!(current_thread_processors[0], 2);
+    }
+
+    #[test]
+    fn processor_id_space_beyond_affinity_mask_capacity_is_ignored() {
+        // The kernel can size the processor ID space beyond what a fixed-size affinity mask is
+        // able to name. The processors the mask cannot name are not part of the affinity of any
+        // thread, and asking the mask about them would read past its end.
+        let beyond_affinity_mask = ProcessorId::try_from(libc::CPU_SETSIZE).unwrap();
+
+        let cpuinfo = "processor       : 0
+bogomips        : 50.00
+";
+
+        let mut fs = MockFilesystem::new();
+
+        fs.expect_get_cpuinfo_contents()
+            .return_const(cpuinfo.to_string());
+        fs.expect_get_possible_cpus_contents()
+            .return_const(Some(format!("0-{beyond_affinity_mask}\n")));
+        fs.expect_get_online_cpus_contents()
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_possible_contents()
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_cpulist_contents()
+            .withf(|n| *n == 0)
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_cpu_online_contents()
+            .withf(|p| *p == 0)
+            .return_const(None);
+        fs.expect_get_proc_self_status_contents()
+            .return_const("Cpus_allowed_list: 0".to_string());
+
+        let mut bindings = MockBindings::new();
+
+        let affinity = cpuset_from([0]);
+
+        bindings
+            .expect_sched_getaffinity_current()
+            .times(1)
+            .returning(move || Ok(affinity));
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(bindings),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        assert_eq!(platform.max_processor_id(), beyond_affinity_mask);
+
+        let current_thread_processors = platform.current_thread_processors();
+        assert_eq!(current_thread_processors.len(), 1);
+        assert_eq!(current_thread_processors[0], 0);
     }
 
     #[test]
@@ -1763,12 +2134,12 @@ CPU revision    : 1
         fs.expect_get_numa_node_cpulist_contents()
             .withf(move |n| *n == 0)
             .times(1)
-            .return_const("0,1\n".to_string());
+            .return_const(Some("0,1\n".to_string()));
 
         fs.expect_get_cpu_online_contents()
             .withf(move |p| *p == 0)
             .times(1)
-            .return_const(Some("1\n".to_string()));
+            .return_const(None);
 
         fs.expect_get_cpu_online_contents()
             .withf(move |p| *p == 1)
@@ -2180,7 +2551,7 @@ model name      : Example Processor 9000
         fs.expect_get_numa_node_cpulist_contents()
             .withf(|node| *node == MEMORY_REGION)
             .times(1)
-            .return_const(format!("{cpulist}\n"));
+            .return_const(Some(format!("{cpulist}\n")));
 
         for processor_id in processor_ids {
             fs.expect_get_cpu_online_contents()
@@ -2230,7 +2601,7 @@ other           : ignored
         fs.expect_get_numa_node_cpulist_contents()
             .withf(move |n| *n == 0)
             .times(1)
-            .return_const("0,1\n".to_string());
+            .return_const(Some("0,1\n".to_string()));
 
         fs.expect_get_cpu_online_contents()
             .withf(move |p| *p == 0)

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -37,6 +37,14 @@ pub(crate) struct BuildTargetPlatform {
 
     // System-wide, so not narrowed by what the current process may use.
     active_processor_count: OnceLock<NonZero<usize>>,
+
+    // The kernel's ID space masks, as published in /sys. Each is read and interpreted once, so
+    // that every derivation made from a mask is made from the same reading of it - two
+    // derivations that disagreed about whether a mask is usable would describe a machine that
+    // does not exist (for example, more active processors than the ID space has room for).
+    possible_processor_ids: OnceLock<Option<NonEmpty<ProcessorId>>>,
+    online_processor_ids: OnceLock<Option<NonEmpty<ProcessorId>>>,
+    possible_memory_region_ids: OnceLock<Option<NonEmpty<MemoryRegionId>>>,
 }
 
 impl Platform for BuildTargetPlatform {
@@ -86,10 +94,18 @@ impl Platform for BuildTargetPlatform {
         // is not part of the affinity of any thread - and reading such a bit would read past the
         // end of the mask. The processor ID space can reach that far even on a small machine
         // because the kernel sizes it for the processors that could possibly be present.
-        let max_affinity_mask_processor_id = ProcessorId::try_from(libc::CPU_SETSIZE)
+        //
+        // The capacity comes from the size of the structure because `CPU_ISSET` bounds-checks
+        // the index against the bit array inside it, which makes that array's bit capacity the
+        // real limit. `libc::CPU_SETSIZE` disagrees with it on some libc implementations - musl
+        // publishes a value well below the capacity of the structure it ships - and clamping to
+        // the lower value would hide every processor above it on a large machine.
+        let max_affinity_mask_processor_id = usize::try_from(u8::BITS)
             .ok()
+            .and_then(|bits_per_byte| size_of::<libc::cpu_set_t>().checked_mul(bits_per_byte))
             .and_then(|capacity| capacity.checked_sub(1))
-            .expect("CPU_SETSIZE is a positive constant that fits in a processor ID");
+            .and_then(|max_id| ProcessorId::try_from(max_id).ok())
+            .expect("affinity mask capacity is at least one bit and fits a processor ID");
 
         let max_processor_id = self
             .get_max_processor_id()
@@ -140,6 +156,9 @@ impl BuildTargetPlatform {
             max_processor_id: OnceLock::new(),
             max_memory_region_id: OnceLock::new(),
             active_processor_count: OnceLock::new(),
+            possible_processor_ids: OnceLock::new(),
+            online_processor_ids: OnceLock::new(),
+            possible_memory_region_ids: OnceLock::new(),
         }
     }
 
@@ -167,10 +186,12 @@ impl BuildTargetPlatform {
             // is what `Platform::max_memory_region_id()` promises: a constant that covers offline
             // regions and regions this process may not use.
             //
-            // A kernel that publishes no node mask describes a machine with no NUMA topology for
-            // us to read, which `load_all_processors()` treats as the single memory region that
-            // every processor belongs to. That region is then the whole ID space.
-            parse_kernel_id_list(self.fs.get_numa_node_possible_contents())
+            // A kernel that discloses no usable node mask describes a machine with no NUMA
+            // topology for us to read, which `load_all_processors()` treats as the single memory
+            // region that every processor belongs to. That region is then the whole ID space.
+            // Both readings are made from the same interpretation of the mask, so they always
+            // agree on whether there is a topology to read.
+            self.get_possible_memory_region_ids()
                 .map_or(SINGLE_MEMORY_REGION_ID, |ids| *ids.maximum())
         })
     }
@@ -181,16 +202,23 @@ impl BuildTargetPlatform {
             // kernel fixes that set at boot, so the value stays constant as processors go
             // offline and regardless of which processors this process may use - which is what
             // `Platform::max_processor_id()` promises.
-            if let Some(possible_processors) =
-                parse_kernel_id_list(self.fs.get_possible_cpus_contents())
-            {
+            if let Some(possible_processors) = self.get_possible_processor_ids() {
                 return *possible_processors.maximum();
             }
 
-            // A kernel that publishes no readable mask leaves us with the machine we managed to
-            // enumerate. That ID space is narrower than the contract asks for, but it is the
-            // widest one we have evidence for and it still covers every processor a caller can
-            // observe through this package.
+            // A kernel that publishes no possible mask may still publish the online one, which
+            // describes the machine just as system-wide a fact. It is the next best evidence
+            // because it is also where the count of active processors comes from: deriving the
+            // two from different sources could place the count outside the ID space, which is a
+            // machine that cannot exist.
+            if let Some(online_processors) = self.get_online_processor_ids() {
+                return *online_processors.maximum();
+            }
+
+            // A kernel that publishes no readable mask at all leaves us with the machine we
+            // managed to enumerate. That ID space is narrower than the contract asks for, but it
+            // is the widest one we have evidence for and it still covers every processor a
+            // caller can observe through this package.
             self.get_all_processors_impl()
                 .iter()
                 .map(|p| p.id)
@@ -204,11 +232,9 @@ impl BuildTargetPlatform {
             // The count is a fact about the machine, not about this process, so it comes from
             // the system-wide online mask rather than from the processors we enumerated (which
             // are narrowed to those the process may use).
-            if let Some(online_processors) =
-                parse_kernel_id_list(self.fs.get_online_cpus_contents())
-                    .and_then(|ids| NonZero::new(ids.len()))
-            {
-                return online_processors;
+            if let Some(online_processors) = self.get_online_processor_ids() {
+                return NonZero::new(online_processors.len())
+                    .expect("NonEmpty always has at least one item");
             }
 
             // A kernel that publishes no readable mask leaves us with the processors we
@@ -217,6 +243,30 @@ impl BuildTargetPlatform {
             NonZero::new(self.get_active_processors().len())
                 .expect("NonEmpty always has at least one item")
         })
+    }
+
+    /// The processors that could possibly exist in the system, or `None` when the kernel
+    /// discloses no usable mask.
+    fn get_possible_processor_ids(&self) -> Option<&NonEmpty<ProcessorId>> {
+        self.possible_processor_ids
+            .get_or_init(|| parse_kernel_id_list(self.fs.get_possible_cpus_contents()))
+            .as_ref()
+    }
+
+    /// The processors that are currently online across the whole system, or `None` when the
+    /// kernel discloses no usable mask.
+    fn get_online_processor_ids(&self) -> Option<&NonEmpty<ProcessorId>> {
+        self.online_processor_ids
+            .get_or_init(|| parse_kernel_id_list(self.fs.get_online_cpus_contents()))
+            .as_ref()
+    }
+
+    /// The memory regions that could possibly exist in the system, or `None` when the kernel
+    /// discloses no usable mask - which is the machine that discloses no NUMA topology at all.
+    fn get_possible_memory_region_ids(&self) -> Option<&NonEmpty<MemoryRegionId>> {
+        self.possible_memory_region_ids
+            .get_or_init(|| parse_kernel_id_list(self.fs.get_numa_node_possible_contents()))
+            .as_ref()
     }
 
     fn load_all_processors(&self) -> NonEmpty<ProcessorImpl> {
@@ -276,7 +326,16 @@ impl BuildTargetPlatform {
 
                     None
                 })
-                .expect("processor not found in any NUMA node");
+                // A processor that no node claims is not a machine we may refuse to describe, so
+                // it belongs to the region that every processor belongs to on a machine with no
+                // disclosed topology. Two situations reach here. The member list of each node
+                // and /proc/cpuinfo both name only the online processors and are read at two
+                // different instants, so a processor onlined or offlined in between is named by
+                // one and not the other - letting an unrelated hotplug event take down a process
+                // that merely asked about hardware is not an option. A kernel that lists an
+                // offline processor in /proc/cpuinfo at all also reaches here, because no node
+                // lists that processor either.
+                .unwrap_or(SINGLE_MEMORY_REGION_ID);
 
             let is_slower_than_the_fastest = info
                 .bogomips
@@ -478,29 +537,32 @@ impl BuildTargetPlatform {
         )
     }
 
-    // May return None if everything is in a single NUMA node.
-    //
-    // Otherwise, returns a list of NUMA nodes, where each entry is a list of processor
-    // indexes that belong to that node.
+    /// The processors of each NUMA node the kernel says could possibly exist, or `None` when the
+    /// kernel discloses no node mask we can read a single ID out of - the machine with no NUMA
+    /// topology for us to read.
+    ///
+    /// A node that holds no online processor maps no processor to itself, so the result can be
+    /// empty and need not claim every processor the machine enumerates.
     fn get_numa_nodes(&self) -> Option<HashMap<MemoryRegionId, NonEmpty<ProcessorId>>> {
-        let node_indexes = cpulist::parse(self.fs.get_numa_node_possible_contents()?.trim())
-            .expect("platform provided invalid cpulist for list of NUMA nodes");
+        // The same interpretation of the node mask that `get_max_memory_region_id()` derives the
+        // ID space from, so a mask that names no node we can read means "no topology" to both.
+        let node_indexes = self.get_possible_memory_region_ids()?;
 
         Some(
             node_indexes
-                .into_iter()
+                .iter()
                 .filter_map(|node| {
                     // A node that could possibly exist need not hold any online processor, in
                     // which case the kernel publishes no member list for it or an empty one.
                     // Such a node maps no processor to itself while still occupying an ID in the
                     // memory region ID space - see `get_max_memory_region_id()`.
-                    let cpulist_str = self.fs.get_numa_node_cpulist_contents(node)?;
+                    let cpulist_str = self.fs.get_numa_node_cpulist_contents(*node)?;
                     let cpulist = NonEmpty::from_vec(
                         cpulist::parse(cpulist_str.trim())
                             .expect("platform provided invalid cpulist for NUMA node members"),
                     )?;
 
-                    Some((node, cpulist))
+                    Some((*node, cpulist))
                 })
                 .collect(),
         )
@@ -585,7 +647,9 @@ const CPUINFO_KEY_PART: &str = "cpu part";
 const SYNTHESIZED_MODEL_PREFIX: &str = "cpuinfo";
 
 /// The memory region every processor belongs to on a machine whose kernel discloses no NUMA
-/// topology, which is also then the only ID in the memory region ID space.
+/// topology, which is also then the only ID in the memory region ID space. It is additionally
+/// where a processor lands when the kernel does disclose a topology but no node claims that
+/// processor - see `load_all_processors()`.
 const SINGLE_MEMORY_REGION_ID: MemoryRegionId = 0;
 
 // A `model name` field is not universal: a 64-bit ARM kernel emits one only when the reading
@@ -670,8 +734,8 @@ fn canonical_identity_value(value: &str) -> Cow<'_, str> {
 /// constant and system-wide come from.
 ///
 /// Returns `None` when the platform publishes no such file, publishes something we cannot read,
-/// or names no ID at all. Every caller then falls back to a derivation from the machine we did
-/// manage to enumerate, because a machine we can describe imperfectly is worth more to a caller
+/// or names no ID at all. Every caller then falls back to describing the machine from whatever
+/// other evidence it has, because a machine we can describe imperfectly is worth more to a caller
 /// than a machine we refuse to describe.
 fn parse_kernel_id_list(contents: Option<String>) -> Option<NonEmpty<u32>> {
     let ids = cpulist::parse(contents?.trim()).ok()?;
@@ -1075,23 +1139,29 @@ bogomips        : 50.00
         let mut fs = MockFilesystem::new();
 
         fs.expect_get_cpuinfo_contents()
+            .times(1)
             .return_const(cpuinfo.to_string());
         fs.expect_get_possible_cpus_contents()
             .return_const(Some("0\n".to_string()));
         fs.expect_get_online_cpus_contents()
             .return_const(Some("0\n".to_string()));
         fs.expect_get_numa_node_possible_contents()
+            .times(1)
             .return_const(Some("0-1\n".to_string()));
         fs.expect_get_numa_node_cpulist_contents()
             .withf(|n| *n == 0)
+            .times(1)
             .return_const(Some("0\n".to_string()));
         fs.expect_get_numa_node_cpulist_contents()
             .withf(|n| *n == 1)
+            .times(1)
             .return_const(None);
         fs.expect_get_cpu_online_contents()
             .withf(|p| *p == 0)
+            .times(1)
             .return_const(None);
         fs.expect_get_proc_self_status_contents()
+            .times(1)
             .return_const("Cpus_allowed_list: 0".to_string());
 
         let platform = BuildTargetPlatform::new(
@@ -1180,9 +1250,44 @@ bogomips        : 50.00
     }
 
     #[test]
+    fn machine_with_only_the_online_mask_derives_the_id_space_from_it() {
+        let mut fs = MockFilesystem::new();
+
+        // A machine of 8 processors whose kernel discloses which of them are online but not
+        // which of them could possibly exist, with the process narrowed to two of them.
+        simulate_processor_layout_with_only_the_online_mask(
+            &mut fs,
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            Some([true, true, false, false, false, false, false, false]),
+            [2000.0; 8],
+        );
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        // The online mask describes the machine and not this process, so the extent of the ID
+        // space follows it rather than the two processors this process may use.
+        assert_eq!(platform.max_processor_id(), 7);
+        assert_eq!(platform.active_processor_count(), 8);
+        assert_eq!(platform.get_all_processors().len(), 2);
+
+        // Every active processor occupies an ID, so an ID space that cannot name them all
+        // describes a machine that cannot exist. Deriving both from the same mask is what
+        // guarantees this.
+        assert!(
+            usize::try_from(platform.max_processor_id()).unwrap() + 1
+                >= platform.active_processor_count()
+        );
+    }
+
+    #[test]
     fn cpuinfo_listing_offline_processor_excludes_the_processor() {
         // Mainstream kernels drop an offline processor from /proc/cpuinfo, but a kernel that
-        // lists one anyway must not have it reported as a processor a caller may use.
+        // lists one anyway must not have it reported as a processor a caller may use. The node
+        // member list is what the kernel really publishes for such a machine: it names only the
+        // online processor, leaving the offline one claimed by no node at all.
         let cpuinfo = "processor       : 0
 bogomips        : 50.00
 
@@ -1193,23 +1298,29 @@ bogomips        : 50.00
         let mut fs = MockFilesystem::new();
 
         fs.expect_get_cpuinfo_contents()
+            .times(1)
             .return_const(cpuinfo.to_string());
         fs.expect_get_possible_cpus_contents()
             .return_const(Some("0-1\n".to_string()));
         fs.expect_get_online_cpus_contents()
             .return_const(Some("0\n".to_string()));
         fs.expect_get_numa_node_possible_contents()
+            .times(1)
             .return_const(Some("0\n".to_string()));
         fs.expect_get_numa_node_cpulist_contents()
             .withf(|n| *n == 0)
-            .return_const(Some("0-1\n".to_string()));
+            .times(1)
+            .return_const(Some("0\n".to_string()));
         fs.expect_get_cpu_online_contents()
             .withf(|p| *p == 0)
+            .times(1)
             .return_const(None);
         fs.expect_get_cpu_online_contents()
             .withf(|p| *p == 1)
+            .times(1)
             .return_const(Some("0\n".to_string()));
         fs.expect_get_proc_self_status_contents()
+            .times(1)
             .return_const("Cpus_allowed_list: 0-1".to_string());
 
         let platform = BuildTargetPlatform::new(
@@ -1221,6 +1332,109 @@ bogomips        : 50.00
 
         assert_eq!(processors.len(), 1);
         assert_eq!(processors[0].as_target().id, 0);
+    }
+
+    #[test]
+    fn processor_claimed_by_no_numa_node_is_still_reported() {
+        // A processor can be onlined between the moment we read /proc/cpuinfo and the moment we
+        // read the member list of each node, which leaves it named by the former and claimed by
+        // no node. Losing the machine to that race is not an option, so the processor belongs to
+        // the memory region that a machine without a disclosed topology uses.
+        let cpuinfo = "processor       : 0
+bogomips        : 50.00
+
+processor       : 1
+bogomips        : 50.00
+";
+
+        let mut fs = MockFilesystem::new();
+
+        fs.expect_get_cpuinfo_contents()
+            .times(1)
+            .return_const(cpuinfo.to_string());
+        fs.expect_get_possible_cpus_contents()
+            .return_const(Some("0-1\n".to_string()));
+        fs.expect_get_online_cpus_contents()
+            .return_const(Some("0-1\n".to_string()));
+        fs.expect_get_numa_node_possible_contents()
+            .times(1)
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_numa_node_cpulist_contents()
+            .withf(|n| *n == 0)
+            .times(1)
+            .return_const(Some("0\n".to_string()));
+        fs.expect_get_cpu_online_contents()
+            .withf(|p| *p == 0)
+            .times(1)
+            .return_const(None);
+        fs.expect_get_cpu_online_contents()
+            .withf(|p| *p == 1)
+            .times(1)
+            .return_const(Some("1\n".to_string()));
+        fs.expect_get_proc_self_status_contents()
+            .times(1)
+            .return_const("Cpus_allowed_list: 0-1".to_string());
+
+        let platform = BuildTargetPlatform::new(
+            BindingsFacade::from_mock(MockBindings::new()),
+            FilesystemFacade::from_mock(fs),
+        );
+
+        let processors = platform.get_all_processors();
+
+        assert_eq!(processors.len(), 2);
+        assert_eq!(processors[1].as_target().id, 1);
+        assert_eq!(
+            processors[1].as_target().memory_region_id,
+            SINGLE_MEMORY_REGION_ID
+        );
+    }
+
+    #[test]
+    fn numa_node_mask_that_names_nothing_is_a_machine_without_topology() {
+        // A node mask we cannot read a single ID out of tells us nothing about the topology,
+        // which must leave the machine described exactly as one whose kernel publishes no mask
+        // at all - the alternative is a topology that claims no processor, which describes no
+        // machine that could exist.
+        let cpuinfo = "processor       : 0
+bogomips        : 50.00
+";
+
+        for node_mask in ["", "\n", ",", "this is not a cpulist"] {
+            let mut fs = MockFilesystem::new();
+
+            fs.expect_get_cpuinfo_contents()
+                .times(1)
+                .return_const(cpuinfo.to_string());
+            fs.expect_get_possible_cpus_contents()
+                .return_const(Some("0\n".to_string()));
+            fs.expect_get_online_cpus_contents()
+                .return_const(Some("0\n".to_string()));
+            fs.expect_get_numa_node_possible_contents()
+                .times(1)
+                .return_const(Some(node_mask.to_string()));
+            fs.expect_get_cpu_online_contents()
+                .withf(|p| *p == 0)
+                .times(1)
+                .return_const(None);
+            fs.expect_get_proc_self_status_contents()
+                .times(1)
+                .return_const("Cpus_allowed_list: 0".to_string());
+
+            let platform = BuildTargetPlatform::new(
+                BindingsFacade::from_mock(MockBindings::new()),
+                FilesystemFacade::from_mock(fs),
+            );
+
+            let processors = platform.get_all_processors();
+
+            assert_eq!(processors.len(), 1);
+            assert_eq!(
+                processors[0].as_target().memory_region_id,
+                SINGLE_MEMORY_REGION_ID
+            );
+            assert_eq!(platform.max_memory_region_id(), SINGLE_MEMORY_REGION_ID);
+        }
     }
 
     #[test]
@@ -1283,7 +1497,7 @@ bogomips        : 50.00
     /// simulated machine can have an ID space wider than the set of processors it currently
     /// runs. The same holds for memory regions: every region named here is published in
     /// `/sys/devices/system/node/possible`, while a region whose every processor is offline
-    /// publishes no member list at all.
+    /// publishes an empty member list.
     fn simulate_processor_layout<const PROCESSOR_COUNT: usize>(
         fs: &mut MockFilesystem,
         processor_index: [ProcessorId; PROCESSOR_COUNT],
@@ -1328,14 +1542,40 @@ bogomips        : 50.00
         );
     }
 
-    /// Whether the simulated kernel publishes the masks that describe the extent of the ID space.
+    /// Configures the mock filesystem to simulate a machine whose kernel publishes the online
+    /// processor mask but not the possible one, which is the mixed state where one system-wide
+    /// mask is available to describe the machine and the other is not.
     ///
-    /// These are virtually always present on a real machine, so `Absent` exists to reach the
-    /// derivations we fall back to when a kernel discloses no mask.
+    /// Such a kernel discloses no NUMA topology either, so every processor of the simulated
+    /// machine belongs to one memory region and every processor is online.
+    fn simulate_processor_layout_with_only_the_online_mask<const PROCESSOR_COUNT: usize>(
+        fs: &mut MockFilesystem,
+        processor_index: [ProcessorId; PROCESSOR_COUNT],
+        // If None, all are allowed.
+        processor_is_allowed: Option<[bool; PROCESSOR_COUNT]>,
+        bogomips_per_processor: [f64; PROCESSOR_COUNT],
+    ) {
+        simulate_machine(
+            fs,
+            processor_index,
+            [true; PROCESSOR_COUNT],
+            processor_is_allowed.unwrap_or([true; PROCESSOR_COUNT]),
+            [SINGLE_MEMORY_REGION_ID; PROCESSOR_COUNT],
+            bogomips_per_processor,
+            IdSpaceMasks::OnlyOnlineProcessors,
+        );
+    }
+
+    /// Which of the masks that describe the extent of the ID space the simulated kernel
+    /// publishes.
+    ///
+    /// A mainstream kernel publishes all of them, so the other variants exist to reach the
+    /// derivations we fall back to when a kernel discloses less.
     #[derive(Clone, Copy)]
     enum IdSpaceMasks {
         Published,
         Absent,
+        OnlyOnlineProcessors,
     }
 
     fn simulate_machine<const PROCESSOR_COUNT: usize>(
@@ -1363,7 +1603,14 @@ bogomips        : 50.00
             writeln!(cpuinfo).unwrap();
         }
 
-        fs.expect_get_cpuinfo_contents().return_const(cpuinfo);
+        // Each file below answers a question the platform derives once and remembers, so asking
+        // the platform repeatedly must not read it again - asserting the exact count is what
+        // keeps that memoization honest. The processor ID space masks are pinned by the tests
+        // that read them rather than here, because most simulated scenarios ask no question
+        // that reaches them.
+        fs.expect_get_cpuinfo_contents()
+            .times(1)
+            .return_const(cpuinfo);
 
         let node_indexes = memory_region_index.iter().copied().unique().collect_vec();
 
@@ -1376,22 +1623,37 @@ bogomips        : 50.00
         let online_processors = format!("{}\n", cpulist::emit(online_processor_ids));
         let possible_nodes = format!("{}\n", cpulist::emit(node_indexes.iter().copied()));
 
-        match id_space_masks {
+        let (possible_processors, possible_nodes) = match id_space_masks {
             IdSpaceMasks::Published => {
-                fs.expect_get_possible_cpus_contents()
-                    .return_const(Some(possible_processors));
                 fs.expect_get_online_cpus_contents()
                     .return_const(Some(online_processors));
-                fs.expect_get_numa_node_possible_contents()
-                    .return_const(Some(possible_nodes));
+
+                (Some(possible_processors), Some(possible_nodes))
             }
             IdSpaceMasks::Absent => {
-                fs.expect_get_possible_cpus_contents().return_const(None);
                 fs.expect_get_online_cpus_contents().return_const(None);
-                fs.expect_get_numa_node_possible_contents()
-                    .return_const(None);
+
+                (None, None)
             }
-        }
+            IdSpaceMasks::OnlyOnlineProcessors => {
+                // Both the extent of the ID space and the count of active processors come from
+                // this one mask on such a machine, so reading it exactly once is what says the
+                // two are derived from the same reading of it.
+                fs.expect_get_online_cpus_contents()
+                    .times(1)
+                    .return_const(Some(online_processors));
+
+                (None, None)
+            }
+        };
+
+        let publishes_numa_topology = possible_nodes.is_some();
+
+        fs.expect_get_possible_cpus_contents()
+            .return_const(possible_processors);
+        fs.expect_get_numa_node_possible_contents()
+            .times(1)
+            .return_const(possible_nodes);
 
         for position in online_positions() {
             if !processor_is_allowed[position] {
@@ -1403,6 +1665,7 @@ bogomips        : 50.00
 
             fs.expect_get_cpu_online_contents()
                 .withf(move |p| *p == processor_id)
+                .times(1)
                 .return_const(if processor_id == FIRST_PROCESSOR_ID {
                     // Mainstream kernels publish no such file for the first processor because
                     // that processor cannot be taken offline.
@@ -1412,18 +1675,23 @@ bogomips        : 50.00
                 });
         }
 
-        for node in node_indexes {
-            let members = online_positions()
-                .filter(|position| memory_region_index[*position] == node)
-                .map(|position| processor_index[position])
-                .collect_vec();
+        // The kernel publishes a directory per node only for a machine whose topology it
+        // discloses at all, so a machine without the node mask publishes no member list either.
+        if publishes_numa_topology {
+            for node in node_indexes {
+                let members = online_positions()
+                    .filter(|position| memory_region_index[*position] == node)
+                    .map(|position| processor_index[position])
+                    .collect_vec();
 
-            // A node that holds no online processor publishes an empty member list.
-            let members = format!("{}\n", cpulist::emit(members));
+                // A node that holds no online processor publishes an empty member list.
+                let members = format!("{}\n", cpulist::emit(members));
 
-            fs.expect_get_numa_node_cpulist_contents()
-                .withf(move |n| *n == node)
-                .return_const(Some(members));
+                fs.expect_get_numa_node_cpulist_contents()
+                    .withf(move |n| *n == node)
+                    .times(1)
+                    .return_const(Some(members));
+            }
         }
 
         let allowed_processors = (0..PROCESSOR_COUNT)
@@ -1436,6 +1704,7 @@ bogomips        : 50.00
         let allowed_cpus = cpulist::emit(allowed_processors);
 
         fs.expect_get_proc_self_status_contents()
+            .times(1)
             .return_const(format!("Cpus_allowed_list: {allowed_cpus}"));
     }
 
@@ -1658,14 +1927,13 @@ bogomips        : 50.00
             .returning(move || Ok(expected_set_2));
 
         let mut fs = MockFilesystem::new();
-        simulate_processor_layout(
-            &mut fs,
-            [0, 1, 2],
-            None,
-            None,
-            [0, 0, 0],
-            [2000.0, 2000.0, 1000.0],
-        );
+
+        // The affinity mask and the extent of the processor ID space are all this operation
+        // reads - it never enumerates the machine - and the ID space is remembered after the
+        // first reading, so the mask that describes it is read once for both calls below.
+        fs.expect_get_possible_cpus_contents()
+            .times(1)
+            .return_const(Some("0-2\n".to_string()));
 
         let platform = BuildTargetPlatform::new(
             BindingsFacade::from_mock(bindings),
@@ -1687,7 +1955,21 @@ bogomips        : 50.00
         // The kernel can size the processor ID space beyond what a fixed-size affinity mask is
         // able to name. The processors the mask cannot name are not part of the affinity of any
         // thread, and asking the mask about them would read past its end.
-        let beyond_affinity_mask = ProcessorId::try_from(libc::CPU_SETSIZE).unwrap();
+        //
+        // The capacity is the number of bits the mask structure holds, which is the bound
+        // `libc::CPU_ISSET` enforces. It is deliberately not derived from `libc::CPU_SETSIZE`,
+        // which is what the code under test must not use either: some libc implementations
+        // publish a value below the capacity of the structure they ship, and clamping to it
+        // would silently drop every processor above it.
+        let mask_capacity = size_of::<libc::cpu_set_t>() * usize::try_from(u8::BITS).unwrap();
+        let highest_nameable = ProcessorId::try_from(mask_capacity - 1).unwrap();
+        let beyond_affinity_mask = ProcessorId::try_from(mask_capacity).unwrap();
+
+        // The scan reaches the highest ID the mask can name, so the mask must be able to answer
+        // for that ID rather than panic on an index past the end of its bit array.
+        let probe = cpuset_from([highest_nameable]);
+        // SAFETY: No safety requirements.
+        assert!(unsafe { libc::CPU_ISSET(highest_nameable as usize, &probe) });
 
         let cpuinfo = "processor       : 0
 bogomips        : 50.00
@@ -1698,6 +1980,7 @@ bogomips        : 50.00
         fs.expect_get_cpuinfo_contents()
             .return_const(cpuinfo.to_string());
         fs.expect_get_possible_cpus_contents()
+            .times(1)
             .return_const(Some(format!("0-{beyond_affinity_mask}\n")));
         fs.expect_get_online_cpus_contents()
             .return_const(Some("0\n".to_string()));
@@ -1714,7 +1997,9 @@ bogomips        : 50.00
 
         let mut bindings = MockBindings::new();
 
-        let affinity = cpuset_from([0]);
+        // The thread may use the lowest processor and the highest one the mask can name, which
+        // is what tells a scan bounded by the true capacity from one bounded by anything less.
+        let affinity = cpuset_from([0, highest_nameable]);
 
         bindings
             .expect_sched_getaffinity_current()
@@ -1729,8 +2014,9 @@ bogomips        : 50.00
         assert_eq!(platform.max_processor_id(), beyond_affinity_mask);
 
         let current_thread_processors = platform.current_thread_processors();
-        assert_eq!(current_thread_processors.len(), 1);
+        assert_eq!(current_thread_processors.len(), 2);
         assert_eq!(current_thread_processors[0], 0);
+        assert_eq!(current_thread_processors[1], highest_nameable);
     }
 
     #[test]
@@ -2095,6 +2381,7 @@ bogomips        : 50.00
         assert_eq!(platform.current_processor_id(), 5);
         assert_eq!(platform.max_processor_id(), 8);
         assert_eq!(platform.max_memory_region_id(), 2);
+        assert_eq!(platform.get_all_processors().len(), 9);
     }
 
     #[test]

--- a/packages/many_cpus_impl/src/system_hardware.rs
+++ b/packages/many_cpus_impl/src/system_hardware.rs
@@ -476,7 +476,10 @@ impl SystemHardware {
 
     /// Returns the highest possible value for a processor ID.
     ///
-    /// Processor IDs are in the range `0..=max_processor_id()`.
+    /// Processor IDs are in the range `0..=max_processor_id()`. The ID space covers every
+    /// processor the system could have, including processors that are inactive and processors
+    /// the current process is not permitted to use, and does not change over the lifetime of
+    /// the system.
     ///
     /// # Example
     ///
@@ -495,7 +498,10 @@ impl SystemHardware {
 
     /// Returns the highest possible value for a memory region ID.
     ///
-    /// Memory region IDs are in the range `0..=max_memory_region_id()`.
+    /// Memory region IDs are in the range `0..=max_memory_region_id()`. The ID space covers
+    /// every memory region the system could have, including regions that hold no active
+    /// processor and regions the current process is not permitted to use, and does not change
+    /// over the lifetime of the system.
     ///
     /// # Example
     ///

--- a/packages/many_cpus_impl/tests/many_cpus_sparse_processors_linux.rs
+++ b/packages/many_cpus_impl/tests/many_cpus_sparse_processors_linux.rs
@@ -46,17 +46,19 @@ fn narrowed_affinity_reveals_sparse_processor_ids() {
 
     assert_eq!(observed_ids, [lowest, highest]);
 
-    // The ID space reaches up to the highest processor we kept, while only the two processors we
-    // kept are usable - this is the gap between the maximum and the available that we are here
-    // to exercise on real hardware.
-    let expected_max_processor_count = usize::try_from(highest).unwrap().checked_add(1).unwrap();
-    assert_eq!(hw.max_processor_count(), expected_max_processor_count);
+    // The ID space covers the whole machine, while only the two processors we kept are usable -
+    // this is the gap between the maximum and the available that we are here to exercise on real
+    // hardware.
     assert!(hw.max_processor_count() > all_processors.len());
 
-    // Linux counts as active only the processors that are both online and permitted to the
-    // process, so narrowing the affinity narrows the active count along with it.
-    assert_eq!(hw.active_processor_count(), all_processors.len());
-    assert!(hw.max_processor_count() > hw.active_processor_count());
+    // The active count describes the machine, which a constraint on the process does not change,
+    // so the active count also exceeds what the process may use. Narrowing the affinity of the
+    // process therefore cannot make the active count differ from the maximum count.
+    assert!(hw.active_processor_count() > all_processors.len());
+
+    // Every active processor occupies an ID, while the ID space may additionally cover
+    // processors that are not currently active.
+    assert!(hw.max_processor_count() >= hw.active_processor_count());
 
     // The default processor set obeys the resource quota on top of the affinity, so it can only
     // be a subset of what the affinity permits.

--- a/packages/many_cpus_impl/tests/many_cpus_sparse_processors_linux.rs
+++ b/packages/many_cpus_impl/tests/many_cpus_sparse_processors_linux.rs
@@ -1,0 +1,146 @@
+//! A process may be permitted to use a non-contiguous subset of the machine's processors, in
+//! which case the ID space the machine describes is larger than the set of processors the
+//! process can actually use and has holes in it. Simulated hardware is otherwise our only way
+//! to reach that state, so this test reaches it on the real machine by narrowing the processor
+//! affinity of the current process to its lowest and highest processor.
+//!
+//! One test per file to enforce process isolation: processor affinity is process-level state
+//! and hardware observations are cached on first use, so the constraint must be in place before
+//! anything in the process looks at the hardware.
+
+#![cfg(target_os = "linux")]
+
+use std::mem;
+
+use libc::cpu_set_t;
+use many_cpus::{Processor, ProcessorId, SystemHardware};
+
+#[test]
+#[cfg_attr(miri, ignore)] // Miri cannot call platform APIs.
+fn narrowed_affinity_reveals_sparse_processor_ids() {
+    let available = available_processor_ids();
+
+    // With fewer than three processors there is no processor between the lowest and the highest
+    // to leave out, so the ID space we observe stays contiguous and there is nothing to test.
+    if available.len() < 3 {
+        eprintln!("Skipping test: fewer than three processors available.");
+        return;
+    }
+
+    let lowest = *available.first().unwrap();
+    let highest = *available.last().unwrap();
+
+    if !narrow_process_affinity_to(&[lowest, highest]) {
+        eprintln!("Skipping test: the environment does not permit narrowing processor affinity.");
+        return;
+    }
+
+    // Nothing in this process has observed the hardware before this point, so what we see here
+    // is the machine as it appears under the narrowed affinity.
+    let hw = SystemHardware::current();
+
+    let all_processors = hw.all_processors();
+
+    let mut observed_ids = all_processors.iter().map(Processor::id).collect::<Vec<_>>();
+    observed_ids.sort_unstable();
+
+    assert_eq!(observed_ids, [lowest, highest]);
+
+    // The ID space reaches up to the highest processor we kept, while only the two processors we
+    // kept are usable - this is the gap between the maximum and the available that we are here
+    // to exercise on real hardware.
+    let expected_max_processor_count = usize::try_from(highest).unwrap().checked_add(1).unwrap();
+    assert_eq!(hw.max_processor_count(), expected_max_processor_count);
+    assert!(hw.max_processor_count() > all_processors.len());
+
+    // Linux counts as active only the processors that are both online and permitted to the
+    // process, so narrowing the affinity narrows the active count along with it.
+    assert_eq!(hw.active_processor_count(), all_processors.len());
+    assert!(hw.max_processor_count() > hw.active_processor_count());
+
+    // The default processor set obeys the resource quota on top of the affinity, so it can only
+    // be a subset of what the affinity permits.
+    let default_processors = hw.processors();
+    assert!(default_processors.len() <= all_processors.len());
+    assert!(
+        default_processors
+            .iter()
+            .all(|processor| observed_ids.contains(&processor.id()))
+    );
+
+    // The thread executing this test can only be on a processor the affinity permits, which the
+    // package must report through the sparse ID space rather than through a dense position.
+    assert!(observed_ids.contains(&hw.current_processor_id()));
+
+    // The memory region reported for the current processor must be one of the regions the
+    // permitted processors belong to. Looking the processor up by an ID that is no longer the
+    // position of the processor in the set is what makes this more than a formality.
+    let current_memory_region_id = hw.current_memory_region_id();
+
+    assert!(
+        all_processors
+            .iter()
+            .any(|processor| processor.memory_region_id() == current_memory_region_id)
+    );
+}
+
+/// Returns the IDs of the processors the calling thread is currently permitted to use, in
+/// ascending order.
+///
+/// This asks the operating system directly instead of going through the package under test, so
+/// that the package makes its first observation of the hardware under the narrowed affinity.
+fn available_processor_ids() -> Vec<ProcessorId> {
+    // SAFETY: All zeroes is a valid `cpu_set_t` - it is a plain bit set.
+    let mut cpu_set: cpu_set_t = unsafe { mem::zeroed() };
+
+    // A process ID of 0 means the calling thread.
+    // SAFETY: The buffer we point at is a live `cpu_set_t` of exactly the size we declare.
+    let result = unsafe { libc::sched_getaffinity(0, size_of::<cpu_set_t>(), &raw mut cpu_set) };
+    assert_eq!(result, 0);
+
+    let cpu_set_size = usize::try_from(libc::CPU_SETSIZE).unwrap();
+
+    (0..cpu_set_size)
+        // SAFETY: The index is within the set size and the set is initialized.
+        .filter(|index| unsafe { libc::CPU_ISSET(*index, &cpu_set) })
+        .map(|index| ProcessorId::try_from(index).unwrap())
+        .collect()
+}
+
+/// Narrows the processor affinity of the current process to the given processors, returning
+/// whether the operating system permitted the change.
+///
+/// Both the main thread and the calling thread are narrowed: the package reads the processors
+/// permitted to the process from `/proc/self/status`, which reports the affinity of the main
+/// thread, while the processors permitted to the caller come from the affinity of the calling
+/// thread, and the test harness need not run the test on the main thread.
+fn narrow_process_affinity_to(processor_ids: &[ProcessorId]) -> bool {
+    // SAFETY: All zeroes is a valid `cpu_set_t` - it is a plain bit set.
+    let mut cpu_set: cpu_set_t = unsafe { mem::zeroed() };
+
+    for &processor_id in processor_ids {
+        let index = usize::try_from(processor_id).unwrap();
+
+        // SAFETY: The index came from a `cpu_set_t` we read, so it is within the set size, and
+        // the set we write into is initialized.
+        unsafe {
+            libc::CPU_SET(index, &mut cpu_set);
+        }
+    }
+
+    // SAFETY: No safety requirements.
+    let main_thread = unsafe { libc::getpid() };
+
+    // A process ID of 0 means the calling thread.
+    for target in [main_thread, 0] {
+        // SAFETY: The buffer we point at is a live `cpu_set_t` of exactly the size we declare.
+        let result =
+            unsafe { libc::sched_setaffinity(target, size_of::<cpu_set_t>(), &raw const cpu_set) };
+
+        if result != 0 {
+            return false;
+        }
+    }
+
+    true
+}

--- a/packages/many_cpus_impl/tests/many_cpus_sparse_processors_linux.rs
+++ b/packages/many_cpus_impl/tests/many_cpus_sparse_processors_linux.rs
@@ -100,9 +100,15 @@ fn available_processor_ids() -> Vec<ProcessorId> {
     let result = unsafe { libc::sched_getaffinity(0, size_of::<cpu_set_t>(), &raw mut cpu_set) };
     assert_eq!(result, 0);
 
-    let cpu_set_size = usize::try_from(libc::CPU_SETSIZE).unwrap();
+    // The bound is the number of bits the structure holds, which is what `CPU_ISSET` checks the
+    // index against. `libc::CPU_SETSIZE` is not that number on every libc implementation - musl
+    // publishes a value below the capacity of the structure it ships - and scanning only that
+    // far would hide the processors above it on a large machine.
+    let cpu_set_capacity = size_of::<cpu_set_t>()
+        .checked_mul(usize::try_from(u8::BITS).unwrap())
+        .unwrap();
 
-    (0..cpu_set_size)
+    (0..cpu_set_capacity)
         // SAFETY: The index is within the set size and the set is initialized.
         .filter(|index| unsafe { libc::CPU_ISSET(*index, &cpu_set) })
         .map(|index| ProcessorId::try_from(index).unwrap())

--- a/packages/many_cpus_impl/tests/many_cpus_sparse_processors_windows.rs
+++ b/packages/many_cpus_impl/tests/many_cpus_sparse_processors_windows.rs
@@ -70,10 +70,14 @@ fn job_affinity_limit_reveals_sparse_processor_ids() {
     // exercise on real hardware.
     assert!(hw.max_processor_count() > all_processors.len());
 
-    // Windows counts the active processors of the machine, which a constraint on the process
-    // does not change, so the active count also exceeds what the process may use. A job object
-    // affinity limit therefore cannot make the active count differ from the maximum count.
+    // The active count describes the machine, which a constraint on the process does not change,
+    // so the active count also exceeds what the process may use. A job object affinity limit
+    // therefore cannot make the active count differ from the maximum count.
     assert!(hw.active_processor_count() > all_processors.len());
+
+    // Every active processor occupies an ID, while the ID space may additionally cover
+    // processors that are not currently active.
+    assert!(hw.max_processor_count() >= hw.active_processor_count());
 
     // The default processor set obeys the resource quota on top of the affinity limit, so it can
     // only be a subset of what the limit permits.

--- a/packages/many_cpus_impl/tests/many_cpus_sparse_processors_windows.rs
+++ b/packages/many_cpus_impl/tests/many_cpus_sparse_processors_windows.rs
@@ -1,0 +1,141 @@
+//! A process may be permitted to use a non-contiguous subset of the machine's processors, in
+//! which case the ID space the machine describes is larger than the set of processors the
+//! process can actually use and has holes in it. Simulated hardware is otherwise our only way
+//! to reach that state, so this test reaches it on the real machine by placing the current
+//! process in a job object whose affinity limit keeps only the lowest and highest processor
+//! that the process is permitted to use.
+//!
+//! Windows describes the machine and the constraints on the process separately: a job object
+//! affinity limit changes which processors the process may use but does not change how many
+//! processors Windows says the machine has, whether at maximum or currently active. The gap
+//! this exercises is therefore between the machine and the process, and the count of active
+//! processors stays with the machine.
+//!
+//! One test per file to enforce process isolation: job objects are process-level state and
+//! hardware observations are cached on first use, so the limit must be in place before anything
+//! in the process looks at the hardware.
+
+#![cfg(windows)]
+
+use std::num::NonZero;
+
+use many_cpus::{Processor, ProcessorId, SystemHardware};
+use testing::Job;
+use windows::Win32::System::Threading::{
+    GetActiveProcessorGroupCount, GetCurrentProcess, GetProcessAffinityMask,
+};
+
+#[test]
+#[cfg_attr(miri, ignore)] // Miri cannot call platform APIs.
+fn job_affinity_limit_reveals_sparse_processor_ids() {
+    // The package numbers processors across all processor groups, whereas both the affinity mask
+    // of a process and the affinity limit of a job object address a single group. The two ways of
+    // naming a processor coincide only on a machine that has a single processor group, which is
+    // the only kind of machine on which this test can translate between them.
+    // SAFETY: No safety requirements.
+    if unsafe { GetActiveProcessorGroupCount() } != 1 {
+        eprintln!("Skipping test: the machine has more than one processor group.");
+        return;
+    }
+
+    let available = available_processor_ids();
+
+    // With fewer than three processors there is no processor between the lowest and the highest
+    // to leave out, so the ID space we observe stays contiguous and there is nothing to test.
+    if available.len() < 3 {
+        eprintln!("Skipping test: fewer than three processors available.");
+        return;
+    }
+
+    let lowest = *available.first().unwrap();
+    let highest = *available.last().unwrap();
+
+    // Nothing in this process observes the hardware before the job limit is in place, so what we
+    // see below is the machine as it appears to a process constrained to these two processors.
+    let job = Job::builder()
+        .processor_affinity_mask(processor_mask(&[lowest, highest]))
+        .build();
+
+    let hw = SystemHardware::current();
+
+    let all_processors = hw.all_processors();
+
+    let mut observed_ids = all_processors.iter().map(Processor::id).collect::<Vec<_>>();
+    observed_ids.sort_unstable();
+
+    assert_eq!(observed_ids, [lowest, highest]);
+
+    // The ID space covers the whole machine, while only the two processors the job permits are
+    // usable - this is the gap between the maximum and the available that we are here to
+    // exercise on real hardware.
+    assert!(hw.max_processor_count() > all_processors.len());
+
+    // Windows counts the active processors of the machine, which a constraint on the process
+    // does not change, so the active count also exceeds what the process may use. A job object
+    // affinity limit therefore cannot make the active count differ from the maximum count.
+    assert!(hw.active_processor_count() > all_processors.len());
+
+    // The default processor set obeys the resource quota on top of the affinity limit, so it can
+    // only be a subset of what the limit permits.
+    let default_processors = hw.processors();
+    assert!(default_processors.len() <= all_processors.len());
+    assert!(
+        default_processors
+            .iter()
+            .all(|processor| observed_ids.contains(&processor.id()))
+    );
+
+    // The thread executing this test can only be on a processor the job permits, which the
+    // package must report through the sparse ID space rather than through a dense position.
+    assert!(observed_ids.contains(&hw.current_processor_id()));
+
+    // The memory region reported for the current processor must be one of the regions the
+    // permitted processors belong to. Looking the processor up by an ID that is no longer the
+    // position of the processor in the set is what makes this more than a formality.
+    let current_memory_region_id = hw.current_memory_region_id();
+
+    assert!(
+        all_processors
+            .iter()
+            .any(|processor| processor.memory_region_id() == current_memory_region_id)
+    );
+
+    drop(job);
+}
+
+/// Returns the IDs of the processors the current process is permitted to use, in ascending
+/// order.
+///
+/// This asks the operating system directly instead of going through the package under test, so
+/// that the package makes its first observation of the hardware under the job affinity limit.
+/// The caller guarantees that the machine has a single processor group, so the affinity mask of
+/// the process describes every processor of the machine and the position of a bit in it is the
+/// ID of the processor it selects.
+fn available_processor_ids() -> Vec<ProcessorId> {
+    let mut process_mask: usize = 0;
+    let mut system_mask: usize = 0;
+
+    // SAFETY: No safety requirements. The handle does not need to be closed.
+    let current_process = unsafe { GetCurrentProcess() };
+
+    // SAFETY: Both output buffers are live local variables for the duration of the call.
+    unsafe {
+        GetProcessAffinityMask(current_process, &raw mut process_mask, &raw mut system_mask)
+            .unwrap();
+    }
+
+    // With a single processor group, the ID of a processor is the position of its bit in the
+    // affinity mask.
+    (0..ProcessorId::try_from(usize::BITS).unwrap())
+        .filter(|bit| process_mask & (1_usize << bit) != 0)
+        .collect()
+}
+
+/// Builds a processor affinity mask that selects exactly the given processors.
+fn processor_mask(processor_ids: &[ProcessorId]) -> NonZero<usize> {
+    let mask = processor_ids.iter().fold(0_usize, |mask, &processor_id| {
+        mask | (1_usize << processor_id)
+    });
+
+    NonZero::new(mask).unwrap()
+}

--- a/packages/testing/src/windows/job.rs
+++ b/packages/testing/src/windows/job.rs
@@ -99,7 +99,7 @@ pub type ProcessorTimePct = int!(1, 100);
 /// Configures instances of [`Job`] before creation.
 #[derive(Debug, Default)]
 pub struct JobBuilder {
-    processor_count: Option<NonZero<u32>>,
+    affinity_mask: Option<NonZero<usize>>,
     max_processor_time_pct: Option<ProcessorTimePct>,
 }
 
@@ -115,8 +115,31 @@ impl JobBuilder {
     /// The implementation will choose the specific processors, all you can do as caller is
     /// to specify the number of processors.
     #[must_use]
-    pub fn processor_count(mut self, processor_count: NonZero<u32>) -> Self {
-        self.processor_count = Some(processor_count);
+    pub fn processor_count(self, processor_count: NonZero<u32>) -> Self {
+        // We are just going to assume that the primary processor group of this process
+        // has a sufficient number of processors to satisfy the request. Good enough
+        // for test/example purposes, though obviously not production-quality logic.
+
+        // We set the first `processor_count` bits of the processor affinity mask to 1.
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "side effects are intentional here"
+        )]
+        let affinity_mask = (1_usize << processor_count.get()) - 1;
+
+        self.processor_affinity_mask(
+            NonZero::new(affinity_mask).expect("a nonzero processor count sets at least one bit"),
+        )
+    }
+
+    /// Restricts the job to only execute on the processors selected by an affinity mask.
+    ///
+    /// Bit N of the mask selects the processor with index N in the primary processor group of
+    /// the process. In contrast to [`processor_count()`][Self::processor_count], the caller
+    /// picks the processors, which is what makes it possible to select a non-contiguous set.
+    #[must_use]
+    pub fn processor_affinity_mask(mut self, affinity_mask: NonZero<usize>) -> Self {
+        self.affinity_mask = Some(affinity_mask);
         self
     }
 
@@ -176,22 +199,11 @@ impl JobBuilder {
             }
         }
 
-        if let Some(processor_count) = self.processor_count {
-            // We are just going to assume that the primary processor group of this process
-            // has a sufficient number of processors to satisfy the request. Good enough
-            // for test/example purposes, though obviously not production-quality logic.
-
-            // We set the first `processor_count` bits of the processor affinity mask to 1.
-            #[expect(
-                clippy::arithmetic_side_effects,
-                reason = "side effects are intentional here"
-            )]
-            let affinity_mask = (1_usize << processor_count.get()) - 1;
-
+        if let Some(affinity_mask) = self.affinity_mask {
             let limit = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
                 BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
                     LimitFlags: JOB_OBJECT_LIMIT_AFFINITY,
-                    Affinity: affinity_mask,
+                    Affinity: affinity_mask.get(),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -224,7 +236,7 @@ impl JobBuilder {
 
         Job {
             handle: job,
-            affinity_active: self.processor_count.is_some(),
+            affinity_active: self.affinity_mask.is_some(),
             rate_control_active: self.max_processor_time_pct.is_some(),
             mutex_guard,
         }

--- a/packages/testing/src/windows/job.rs
+++ b/packages/testing/src/windows/job.rs
@@ -119,13 +119,7 @@ impl JobBuilder {
         // We are just going to assume that the primary processor group of this process
         // has a sufficient number of processors to satisfy the request. Good enough
         // for test/example purposes, though obviously not production-quality logic.
-
-        // We set the first `processor_count` bits of the processor affinity mask to 1.
-        #[expect(
-            clippy::arithmetic_side_effects,
-            reason = "side effects are intentional here"
-        )]
-        let affinity_mask = (1_usize << processor_count.get()) - 1;
+        let affinity_mask = low_processor_bits_mask(processor_count);
 
         self.processor_affinity_mask(
             NonZero::new(affinity_mask).expect("a nonzero processor count sets at least one bit"),
@@ -243,6 +237,26 @@ impl JobBuilder {
     }
 }
 
+/// Builds an affinity mask whose lowest `count` bits are set.
+///
+/// A Windows processor group holds at most `usize::BITS` processors, so a request for the full
+/// group width sets every bit. The narrow case is handled apart because `1 << count` overflows the
+/// shift once `count` reaches the integer width.
+fn low_processor_bits_mask(count: NonZero<u32>) -> usize {
+    let count = count.get();
+
+    if count >= usize::BITS {
+        usize::MAX
+    } else {
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "count < usize::BITS here, so the shift and subtraction cannot overflow"
+        )]
+        let mask = (1_usize << count) - 1;
+        mask
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -255,6 +269,22 @@ mod tests {
 
     assert_impl_all!(Job<'static>: UnwindSafe, RefUnwindSafe);
     assert_impl_all!(JobBuilder: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn low_processor_bits_mask_sets_expected_bits() {
+        assert_eq!(low_processor_bits_mask(nz!(1)), 0b1);
+        assert_eq!(low_processor_bits_mask(nz!(2)), 0b11);
+
+        // The widest request that still leaves the top bit clear.
+        let widest = NonZero::new(usize::BITS.wrapping_sub(1)).unwrap();
+        assert_eq!(low_processor_bits_mask(widest), usize::MAX >> 1);
+
+        // At and beyond the integer width every bit is set, without overflowing the shift.
+        let full = NonZero::new(usize::BITS).unwrap();
+        let over = NonZero::new(usize::BITS.wrapping_add(1)).unwrap();
+        assert_eq!(low_processor_bits_mask(full), usize::MAX);
+        assert_eq!(low_processor_bits_mask(over), usize::MAX);
+    }
 
     #[test]
     #[cfg_attr(miri, ignore)] // Miri cannot use the real operating system APIs.


### PR DESCRIPTION
[Copilot speaking]

## Motivation

On Linux the `many_cpus` platform layer derived the processor and memory-region ID spaces and the active-processor count from `/proc/cpuinfo`, after filtering it by the processors the current process is permitted to use. Those are contractually system-wide facts, so a `taskset` restriction or an offline processor made them shrink — and several downstream defects followed: a musl `CPU_SETSIZE` mismatch that hid every processor above ID 127, a processor claimed by no NUMA node taking the whole process down, concurrent-hotplug races between two files read at different instants, and an ID space that could report fewer IDs than the machine has active processors. The state where the ID space is larger than the usable processor set — `active != max` — was only reachable through simulated hardware, leaving those code paths without evidence from a real machine (Refs #51).

Separately, the `cargo-bench-history` machine key was built from the *width* of the processor and memory-region ID spaces. The kernel pads that width with IDs reserved for processors that could be hot-added later, and virtual machines commonly pad to one fixed width whatever their size — so guests of quite different capacity were filed under a single key and their measurements averaged together.

## Changes

**`many_cpus` (Linux).** The extent of the processor and memory-region ID spaces and the active-processor count now come from the kernel masks — `/sys/devices/system/cpu/possible`, `/sys/devices/system/node/possible` and `/sys/devices/system/cpu/online` — none of which is narrowed by the process's own affinity, falling back to the enumerated machine when a kernel publishes no readable mask. Each mask is read and interpreted exactly once, so every derivation agrees, and a processor claimed by no NUMA node joins the single memory region rather than aborting the process. The affinity-mask scan is bounded by the mask's own capacity, so the ID space may exceed what a fixed-size mask can name. The set of processors a caller may use still obeys the permitted set, so a 32-processor machine under `taskset -c 0,1` now reports the same `32 / 32 / 2` (max / active / usable) that Windows reports under an equivalent job-object affinity limit.

A `many_cpus_observe_hardware` example and sparse-processor integration tests for Linux and Windows exercise these paths on real hardware.

**`cargo-bench-history`.** Both machine-key factors now come from the processors the current process may run on — one set feeding every factor. A run confined to part of a machine measures that part, so it is a different machine for comparison purposes and belongs under its own key. Where the ID space is unpadded and the process is unconfined the counts are unchanged, so keys already in use keep their history and the fingerprint version tag stands.

## Data flow

```
   kernel masks (cpu/possible, node/possible, cpu/online)
        |  each read and interpreted once
        v
  many_cpus Linux ID space
   |-- max_processor_count / max_memory_region_count   (padded ID-space width)
   '-- active_processor_count / all_processors()        (usable hardware)
        |
        v
  cargo-bench-history machine key  <-- counts usable hardware, not the padded width
```

Refs #51.