### PR TITLE
cbh_detect: fix the detection policy to production constants (drop AnalysisConfig)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -21,4 +21,16 @@ exclude_re = [
     "impl Debug",
     "impl fmt::Debug",
     "impl std::fmt::Debug",
+
+    # Equivalent mutants: the significance gates of the three cbh_detect detectors compare a
+    # p-value against a fixed alpha with strict `<`. Turning `<` into `<=` only changes behaviour
+    # when the p-value equals alpha exactly, which never occurs for the continuous statistics that
+    # feed these gates (Mann-Whitney U, Mann-Kendall, and the prediction-interval Student t). No
+    # production series lands a p-value bit-for-bit on 0.05, so the boundary direction is
+    # unobservable. Catching it would require a fixture engineered to sit exactly on alpha - a
+    # non-production scenario the deleted AnalysisConfig used to fabricate by setting alpha to the
+    # fixture's own p-value. Only the `<=` variant is excluded; the `==` and `>` mutants at the
+    # same sites remain caught. Ref: docs/testing.md, "Mutation testing coverage and skipping
+    # mutations".
+    'packages/cbh_detect/src/detect/findings\.rs:\d+:\d+: replace < with <= in (evaluate_change_point|evaluate_drift|compare_branch_levels)',
 ]

--- a/packages/cargo-bench-history-figures/src/figures/coverage.rs
+++ b/packages/cargo-bench-history-figures/src/figures/coverage.rs
@@ -10,7 +10,7 @@
 
 use std::fmt::Write as _;
 
-use cbh_detect::{AnalysisConfig, SeriesCensus, Testability, UnjudgedReason};
+use cbh_detect::{FDR_Q, SeriesCensus, Testability, UnjudgedReason};
 use cbh_render::{Coverage, CoverageState};
 use plotters::style::RGBColor;
 
@@ -99,7 +99,7 @@ fn judge(candidates: &[(&str, f64)], family_size: usize) -> Vec<Judged> {
 
 /// The target expected false-discovery proportion for reported findings.
 fn fdr_q() -> f64 {
-    AnalysisConfig::default().fdr_q
+    FDR_Q
 }
 
 /// The threshold associated with `rank` in a family of `family_size`.
@@ -768,17 +768,15 @@ mod tests {
     }
 
     /// The threshold is only worth drawing if the tool would actually apply it, which means
-    /// the share it derives from is the configured one.
+    /// the share it derives from is the policy one.
     #[test]
-    fn every_threshold_derives_from_the_configured_false_discovery_share() {
-        let config = AnalysisConfig::default();
-
-        assert!((fdr_q() - config.fdr_q).abs() < f64::EPSILON);
+    fn every_threshold_derives_from_the_policy_false_discovery_share() {
+        assert!((fdr_q() - FDR_Q).abs() < f64::EPSILON);
         assert!(
-            (threshold_at(1, 1) - config.fdr_q).abs() < f64::EPSILON,
+            (threshold_at(1, 1) - FDR_Q).abs() < f64::EPSILON,
             "the last rank's threshold in a family of one is the share itself"
         );
-        assert!(content("coverage-staircase.md").contains(&percent(config.fdr_q)));
+        assert!(content("coverage-staircase.md").contains(&percent(FDR_Q)));
     }
 
     /// The census figure is an account, so every series it draws must be one the census

--- a/packages/cargo-bench-history-figures/src/figures/detection.rs
+++ b/packages/cargo-bench-history-figures/src/figures/detection.rs
@@ -6,7 +6,10 @@
 //! in detection behaviour therefore changes these assets, and the freshness check turns
 //! that into a failing test rather than into prose that has quietly become wrong.
 
-use cbh_detect::{AnalysisConfig, AnalysisMode, Finding, Series, evaluate_with_log, examples};
+use cbh_detect::{
+    AnalysisMode, CHANGE_ALPHA, COMPARE_WINDOW, DRIFT_MIN_POINTS, Finding, MIN_REGIME,
+    MIN_SERIES_POINTS, Series, evaluate_with_log, examples,
+};
 use cbh_model::MetricKind;
 use cbh_stats::{mean, sample_std_dev, student_t_two_sided_p};
 use plotters::style::RGBColor;
@@ -117,17 +120,16 @@ const BRANCH_CASES: [(&str, f64, &str); 2] = [
 /// This is the detector's prediction interval at its own significance level, not an
 /// illustrative width: from the same cleaned base sample the significance gate reads, it is
 /// the range a single further measurement stays inside unless its two-sided Student-t
-/// p-value falls below `change_alpha`. A context run drawn outside this band is therefore
-/// exactly one the significance gate rejects, so the band is the real cutoff the figure's
-/// verdict turns on.
+/// p-value falls below [`CHANGE_ALPHA`](cbh_detect::CHANGE_ALPHA). A context run drawn
+/// outside this band is therefore exactly one the significance gate rejects, so the band is
+/// the real cutoff the figure's verdict turns on.
 fn branch_prediction_band(values: &[f64]) -> (f64, f64) {
     let centre = mean(values).expect("the branch figure's base window is not empty");
     let scatter = sample_std_dev(values)
         .expect("the branch figure's base window has enough points to estimate scatter");
     let sample_count = crate::coord::of(values.len());
     let standard_error = scatter * (1.0 + 1.0 / sample_count).sqrt();
-    let half_width =
-        standard_error * critical_t(AnalysisConfig::default().change_alpha, sample_count - 1.0);
+    let half_width = standard_error * critical_t(CHANGE_ALPHA, sample_count - 1.0);
     (centre - half_width, centre + half_width)
 }
 
@@ -312,7 +314,7 @@ fn branch_contended_runner() -> Vec<Asset> {
          unusual reading is discarded, so it must report",
     );
     let tip_index = values.len().saturating_sub(1);
-    let window_start = tip_index.saturating_sub(AnalysisConfig::default().compare_window);
+    let window_start = tip_index.saturating_sub(COMPARE_WINDOW);
     let prediction = branch_prediction_band(
         &values
             .get(window_start..tip_index)
@@ -389,15 +391,14 @@ const LOWER_CONFIDENCE_INTRA_REGIME_SPACING: f64 = 1.0;
 
 /// A fully separated step with the minimum allowed regime length on each side.
 fn lower_confidence_step_values() -> Vec<f64> {
-    let config = AnalysisConfig::default();
     let elevated = LOWER_CONFIDENCE_BASELINE * (1.0 + LOWER_CONFIDENCE_STEP_RELATIVE);
-    let midpoint = (crate::coord::of(config.min_regime) - 1.0) / 2.0;
-    (0..config.min_regime)
+    let midpoint = (crate::coord::of(MIN_REGIME) - 1.0) / 2.0;
+    (0..MIN_REGIME)
         .map(|index| {
             LOWER_CONFIDENCE_BASELINE
                 + (crate::coord::of(index) - midpoint) * LOWER_CONFIDENCE_INTRA_REGIME_SPACING
         })
-        .chain((0..config.min_regime).map(|index| {
+        .chain((0..MIN_REGIME).map(|index| {
             elevated + (crate::coord::of(index) - midpoint) * LOWER_CONFIDENCE_INTRA_REGIME_SPACING
         }))
         .collect()
@@ -555,9 +556,7 @@ const MULTI_STEP_LEVELS: [f64; 3] = [100.0, 140.0, 160.0];
 
 /// A series with several steps, where the detector still reports one boundary.
 fn multi_step() -> Vec<Asset> {
-    let regime = AnalysisConfig::default()
-        .min_regime
-        .saturating_mul(MULTI_STEP_REGIME_MULTIPLE);
+    let regime = MIN_REGIME.saturating_mul(MULTI_STEP_REGIME_MULTIPLE);
     let levels: Vec<f64> = MULTI_STEP_LEVELS
         .into_iter()
         .flat_map(|level| std::iter::repeat_n(level, regime))
@@ -685,9 +684,7 @@ const RETURNED_EXCURSION_BASELINE: f64 = 100.0;
 
 /// The returned-excursion values, shared by the figure and its lockstep test.
 fn returned_excursion_values() -> Vec<f64> {
-    let regime = AnalysisConfig::default()
-        .min_regime
-        .saturating_mul(RETURNED_EXCURSION_REGIME_MULTIPLE);
+    let regime = MIN_REGIME.saturating_mul(RETURNED_EXCURSION_REGIME_MULTIPLE);
     let levels: Vec<f64> = [
         RETURNED_EXCURSION_BASELINE,
         RETURNED_EXCURSION_LEVEL,
@@ -707,9 +704,7 @@ fn returned_excursion_values() -> Vec<f64> {
 fn returned_excursion() -> Vec<Asset> {
     let values = returned_excursion_values();
     let (_, finding) = judge_history("regex_cache", &values, MetricKind::WallTime);
-    let regime = AnalysisConfig::default()
-        .min_regime
-        .saturating_mul(RETURNED_EXCURSION_REGIME_MULTIPLE);
+    let regime = MIN_REGIME.saturating_mul(RETURNED_EXCURSION_REGIME_MULTIPLE);
     let elevated_start = regime;
     let elevated_end = regime.saturating_mul(2).saturating_sub(1);
 
@@ -769,18 +764,17 @@ fn flat_noisy() -> Vec<Asset> {
     ]
 }
 
-/// The minimum evidence each detector demands, read from the shipped defaults.
+/// The minimum evidence each detector demands, read from the detection policy.
 fn minimums() -> Vec<Asset> {
-    let config = AnalysisConfig::default();
     let markdown = format!(
         "| Detector | Needs |\n|---|---|\n\
          | History change point | {} in the analyzed window, and {} on each side of the split |\n\
          | History drift | {} in the analyzed window |\n\
          | Branch comparison | {} on the base side, collapsed to one level each |\n",
-        points(config.min_series_points),
-        points(config.min_regime),
-        points(config.drift_min_points),
-        commits(config.min_series_points),
+        points(MIN_SERIES_POINTS),
+        points(MIN_REGIME),
+        points(DRIFT_MIN_POINTS),
+        commits(MIN_SERIES_POINTS),
     );
 
     vec![Asset::new("detection-minimums.md", markdown)]

--- a/packages/cargo-bench-history-figures/src/figures/gates.rs
+++ b/packages/cargo-bench-history-figures/src/figures/gates.rs
@@ -930,11 +930,11 @@ fn commits(count: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use cbh_detect::{
         COMPARE_WINDOW, PRACTICAL_ABSOLUTE_ALLOC, PRACTICAL_ABSOLUTE_COUNT, PRACTICAL_ABSOLUTE_TIME,
     };
+
+    use super::*;
 
     /// The gates chapter names every gate in a hand-written table grouping them by the
     /// question each asks. That table is the appendix's one list of gate identifiers that is

--- a/packages/cargo-bench-history-figures/src/figures/gates.rs
+++ b/packages/cargo-bench-history-figures/src/figures/gates.rs
@@ -2,7 +2,7 @@
 //!
 //! Every figure here is a rendering of a real [`GateLog`]: the module runs the detector
 //! over an example series and draws the decisions it recorded gate by gate. No threshold
-//! is written down — each one is read from [`AnalysisConfig::default`] or from the outcome
+//! is written down — each one is read from the policy constants or from the outcome
 //! a gate logged — so a change in the gating policy rewrites the chapter rather than
 //! leaving its numbers behind, and the freshness check turns that into a failing test.
 
@@ -10,8 +10,10 @@ use std::fmt::Write as _;
 use std::iter;
 
 use cbh_detect::{
-    AnalysisConfig, Finding, Gate, GateLog, GateOutcome, GateStage, Series, evaluate_with_log,
-    examples,
+    BRANCH_NOISE_MULTIPLE, BRANCH_PRACTICAL_RELATIVE, CHANGE_ALPHA, DRIFT_ALPHA, DRIFT_MIN_POINTS,
+    DRIFT_NOISE_MULTIPLE, Finding, Gate, GateLog, GateOutcome, GateStage, MIN_REGIME,
+    MIN_REGIME_SEPARATION, MIN_SERIES_POINTS, PRACTICAL_RELATIVE, RESIDUAL_NOISE_MULTIPLE, Series,
+    evaluate_with_log, examples,
 };
 use cbh_model::MetricKind;
 
@@ -131,53 +133,46 @@ fn gates_below(stage: GateStage, gate: Gate) -> Vec<Gate> {
 
 /// What `stage` demands of `gate`, as the chapter states it.
 ///
-/// Every threshold is a field of `config`, so the shipped defaults are the single source
-/// the chapter reads from. Several gates are one policy asked by more than one detector,
-/// and some of them are asked against a different figure depending on who is asking —
-/// which is why the stage is a parameter rather than the gate alone deciding.
-fn demanded(config: &AnalysisConfig, gate: Gate, stage: GateStage) -> String {
+/// Every threshold is read from the same policy constants the detector uses. Several gates
+/// are one policy asked by more than one detector, and some of them are asked against a
+/// different figure depending on who is asking — which is why the stage is a parameter
+/// rather than the gate alone deciding.
+fn demanded(gate: Gate, stage: GateStage) -> String {
     match gate {
-        Gate::MinSeriesPoints => points(config.drift_min_points),
-        Gate::MinBaseCommits => commits(config.min_series_points),
+        Gate::MinSeriesPoints => points(DRIFT_MIN_POINTS),
+        Gate::MinBaseCommits => commits(MIN_SERIES_POINTS),
         Gate::SplitLocated => "a split must be found".to_owned(),
         Gate::MinRegime => match stage {
             // Branch mode counts retained base-ref commit levels, not the context sample
             // and not the shorter side of a split. Ref:
             // packages/cargo-bench-history/docs/DESIGN.md, "Judging a context commit",
             // section 8.2, noise-aware gating.
-            GateStage::Branch => commits(config.min_regime),
-            GateStage::ChangePoint | GateStage::Drift => points(config.min_regime),
+            GateStage::Branch => commits(MIN_REGIME),
+            GateStage::ChangePoint | GateStage::Drift => points(MIN_REGIME),
         },
         Gate::NonZeroDelta => "above zero".to_owned(),
         Gate::RelativeFloor => match stage {
-            GateStage::Branch => percent(config.branch_practical_relative),
-            _ => percent(config.practical_relative),
+            GateStage::Branch => percent(BRANCH_PRACTICAL_RELATIVE),
+            _ => percent(PRACTICAL_RELATIVE),
         },
         Gate::AbsoluteFloor => "the metric's own floor, below".to_owned(),
-        Gate::ResidualNoise => format!(
-            "{}× the typical residual",
-            number(config.residual_noise_multiple)
-        ),
+        Gate::ResidualNoise => format!("{}× the typical residual", number(RESIDUAL_NOISE_MULTIPLE)),
         Gate::BaseScatter => concat!(
             "observed scatter, or one count, byte, or allocation of scale; ",
             "flat timings have no quantum"
         )
         .to_owned(),
         Gate::Significance => match stage {
-            GateStage::Drift => format!("p < {}", chance(config.drift_alpha)),
-            _ => format!("p < {}", chance(config.change_alpha)),
+            GateStage::Drift => format!("p < {}", chance(DRIFT_ALPHA)),
+            _ => format!("p < {}", chance(CHANGE_ALPHA)),
         },
-        Gate::RegimeSeparation => share(config.min_regime_separation),
+        Gate::RegimeSeparation => share(MIN_REGIME_SEPARATION),
         Gate::IntervalDisjoint => "the two intervals must not overlap".to_owned(),
         Gate::IntervalNoiseBand => match stage {
-            GateStage::Branch => format!(
-                "{}× the reported half-width",
-                number(config.branch_noise_multiple)
-            ),
-            _ => format!(
-                "{}× the reported half-width",
-                number(config.drift_noise_multiple)
-            ),
+            GateStage::Branch => {
+                format!("{}× the reported half-width", number(BRANCH_NOISE_MULTIPLE))
+            }
+            _ => format!("{}× the reported half-width", number(DRIFT_NOISE_MULTIPLE)),
         },
     }
 }
@@ -234,7 +229,6 @@ fn compares(gate: Gate, stage: GateStage) -> &'static str {
 
 /// The gates each detector applies, in the order it applies them.
 fn order_table() -> String {
-    let config = AnalysisConfig::default();
     let mut markdown = String::from(
         "Each detector applies its own gates in its own order, and a candidate stops at \
          the first gate that declines it. A gate several detectors share is one policy \
@@ -256,7 +250,7 @@ fn order_table() -> String {
                 "| `{}` | {} | {} |",
                 gate.label(),
                 compares(gate, stage),
-                demanded(&config, gate, stage)
+                demanded(gate, stage)
             )
             .expect("writing to a String never fails");
         }
@@ -403,11 +397,10 @@ fn rungs(log: &GateLog, stage: GateStage, kind: MetricKind) -> Vec<Rung> {
     let Some(declining) = log.declined_by_stage(stage) else {
         return rungs;
     };
-    let config = AnalysisConfig::default();
     rungs.extend(gates_below(stage, declining).into_iter().map(|gate| Rung {
         gate: gate.label().to_owned(),
         value: "not run".to_owned(),
-        threshold: demanded(&config, gate, stage),
+        threshold: demanded(gate, stage),
         verdict: Verdict::NotReached,
     }));
     rungs
@@ -468,10 +461,9 @@ const DECLINED_ELEVATED: f64 = 115.0;
 /// The candidate the residual gate declines: a real step that the series' own scatter
 /// explains.
 fn declined_candidate() -> Series {
-    let config = AnalysisConfig::default();
     // Twice the persistence floor on each side, so regime length is never the binding
     // constraint and the ladder reaches the gate the figure is about.
-    let regime = config.min_regime.saturating_mul(2);
+    let regime = MIN_REGIME.saturating_mul(2);
     let levels: Vec<f64> = iter::repeat_n(DECLINED_BASELINE, regime)
         .chain(iter::repeat_n(DECLINED_ELEVATED, regime))
         .collect();
@@ -550,8 +542,7 @@ const LARGE_MAGNITUDE: f64 = 1000.0;
 
 /// The same proportional move at two magnitudes, against the floor that separates them.
 fn scale() -> Vec<Asset> {
-    let config = AnalysisConfig::default();
-    let regime = config.min_regime.saturating_mul(2);
+    let regime = MIN_REGIME.saturating_mul(2);
     let small: Vec<f64> = iter::repeat_n(SMALL_BASELINE, regime)
         .chain(iter::repeat_n(SMALL_ELEVATED, regime))
         .collect();
@@ -634,9 +625,9 @@ fn scale_pane(values: &[f64], floor: f64, reported: bool) -> Plot {
 /// A move large enough in relative terms to reach the absolute-floor gate on every metric,
 /// and small enough in absolute terms that no metric's floor is trivially cleared. The
 /// values themselves are incidental: what the table needs is for each metric's floor to be
-/// quoted by a gate rather than transcribed from the configuration.
+/// quoted by a gate rather than transcribed from the policy constants.
 fn floor_probe() -> Vec<f64> {
-    let regime = AnalysisConfig::default().min_regime.saturating_mul(2);
+    let regime = MIN_REGIME.saturating_mul(2);
     iter::repeat_n(10.0_f64, regime)
         .chain(iter::repeat_n(10.5_f64, regime))
         .collect()
@@ -763,9 +754,9 @@ fn agreement_grids() -> Vec<Asset> {
 /// The grid is a field of squares, which shows a reader whether the pairings agree but not
 /// how close the series came to the gate's demand. Putting both numbers in the caption is
 /// what turns the picture into evidence, and reading them from the data and the
-/// configuration is what stops the caption from outliving either.
+/// policy is what stops the caption from outliving either.
 fn grid(subject: &str, values: &[f64]) -> String {
-    let floor = AnalysisConfig::default().min_regime_separation;
+    let floor = MIN_REGIME_SEPARATION;
     let grid = agreement("", values);
     let caption = format!(
         "{subject}: {} of pairings agree, against a floor of {}",
@@ -940,6 +931,10 @@ fn commits(count: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use cbh_detect::{
+        COMPARE_WINDOW, PRACTICAL_ABSOLUTE_ALLOC, PRACTICAL_ABSOLUTE_COUNT, PRACTICAL_ABSOLUTE_TIME,
+    };
 
     /// The gates chapter names every gate in a hand-written table grouping them by the
     /// question each asks. That table is the appendix's one list of gate identifiers that is
@@ -1132,8 +1127,7 @@ mod tests {
 
     /// A branch candidate, which reaches every gate the comparison applies.
     fn judge_branch() -> (Option<Finding>, GateLog) {
-        let config = AnalysisConfig::default();
-        let base = config.compare_window;
+        let base = COMPARE_WINDOW;
         let levels: Vec<f64> = iter::repeat_n(DECLINED_BASELINE, base)
             .chain(iter::repeat_n(
                 examples::clean_step().last().copied().unwrap_or_default(),
@@ -1157,34 +1151,24 @@ mod tests {
         (log.0, log.1)
     }
 
-    /// The lockstep guard: every threshold the order table states is the configured one,
+    /// The lockstep guard: every threshold the order table states is the policy one,
     /// so a tuned policy rewrites the chapter instead of leaving it behind.
     #[test]
-    fn every_threshold_in_the_order_table_is_the_configured_one() {
-        let config = AnalysisConfig::default();
+    fn every_threshold_in_the_order_table_is_the_policy_one() {
         let table = content("gates-order.md");
 
         for expected in [
-            points(config.drift_min_points),
-            points(config.min_regime),
-            commits(config.min_series_points),
-            percent(config.practical_relative),
-            percent(config.branch_practical_relative),
-            format!("p < {}", chance(config.change_alpha)),
-            format!("p < {}", chance(config.drift_alpha)),
-            format!(
-                "{}× the typical residual",
-                number(config.residual_noise_multiple)
-            ),
-            format!(
-                "{}× the reported half-width",
-                number(config.drift_noise_multiple)
-            ),
-            format!(
-                "{}× the reported half-width",
-                number(config.branch_noise_multiple)
-            ),
-            share(config.min_regime_separation),
+            points(DRIFT_MIN_POINTS),
+            points(MIN_REGIME),
+            commits(MIN_SERIES_POINTS),
+            percent(PRACTICAL_RELATIVE),
+            percent(BRANCH_PRACTICAL_RELATIVE),
+            format!("p < {}", chance(CHANGE_ALPHA)),
+            format!("p < {}", chance(DRIFT_ALPHA)),
+            format!("{}× the typical residual", number(RESIDUAL_NOISE_MULTIPLE)),
+            format!("{}× the reported half-width", number(DRIFT_NOISE_MULTIPLE)),
+            format!("{}× the reported half-width", number(BRANCH_NOISE_MULTIPLE)),
+            share(MIN_REGIME_SEPARATION),
         ] {
             assert!(
                 table.contains(&expected),
@@ -1216,24 +1200,23 @@ mod tests {
     /// The floors table is the other half of the lockstep guard: the numbers it prints are
     /// the numbers the gates compared against, per metric.
     #[test]
-    fn every_absolute_floor_is_the_configured_one_for_its_metric() {
-        let config = AnalysisConfig::default();
+    fn every_absolute_floor_is_the_policy_one_for_its_metric() {
         let table = content("gates-floors.md");
 
         for kind in MetricKind::ALL {
             let expected = match kind {
                 MetricKind::InstructionCount
                 | MetricKind::ConditionalBranches
-                | MetricKind::IndirectBranches => config.practical_absolute_count,
-                MetricKind::WallTime | MetricKind::ProcessorTime => config.practical_absolute_time,
+                | MetricKind::IndirectBranches => PRACTICAL_ABSOLUTE_COUNT,
+                MetricKind::WallTime | MetricKind::ProcessorTime => PRACTICAL_ABSOLUTE_TIME,
                 MetricKind::AllocatedBytes | MetricKind::AllocationCount => {
-                    config.practical_absolute_alloc
+                    PRACTICAL_ABSOLUTE_ALLOC
                 }
             };
 
             assert!(
                 (observed_absolute_floor(kind) - expected).abs() < f64::EPSILON,
-                "{} is judged against a floor the configuration does not set",
+                "{} is judged against a floor the policy does not set",
                 kind.as_str()
             );
             assert!(
@@ -1261,8 +1244,8 @@ mod tests {
     /// The two grids exist to show the gate's floor doing its work, which they only do if
     /// they land either side of it.
     #[test]
-    fn the_agreement_grids_straddle_the_configured_separation_floor() {
-        let floor = AnalysisConfig::default().min_regime_separation;
+    fn the_agreement_grids_straddle_the_policy_separation_floor() {
+        let floor = MIN_REGIME_SEPARATION;
 
         let separated = agreement("separated", &examples::clean_step()).share();
         let oscillating = agreement("oscillating", &examples::STATIONARY_BIMODAL_NOISE).share();
@@ -1280,8 +1263,8 @@ mod tests {
     /// The grid's caption is where the two numbers the gate compared appear, so they have
     /// to be the numbers it really compared.
     #[test]
-    fn each_agreement_grid_states_its_own_share_and_the_configured_floor() {
-        let floor = AnalysisConfig::default().min_regime_separation;
+    fn each_agreement_grid_states_its_own_share_and_the_policy_floor() {
+        let floor = MIN_REGIME_SEPARATION;
 
         for (path, values) in [
             ("gates-agreement-separated.svg", examples::clean_step()),
@@ -1356,7 +1339,7 @@ mod tests {
     /// magnitude and reported at the other.
     #[test]
     fn the_small_move_is_declined_by_the_absolute_floor_and_the_large_one_reported() {
-        let regime = AnalysisConfig::default().min_regime.saturating_mul(2);
+        let regime = MIN_REGIME.saturating_mul(2);
         let small: Vec<f64> = iter::repeat_n(SMALL_BASELINE, regime)
             .chain(iter::repeat_n(SMALL_ELEVATED, regime))
             .collect();

--- a/packages/cargo-bench-history-figures/src/figures/reporting.rs
+++ b/packages/cargo-bench-history-figures/src/figures/reporting.rs
@@ -16,8 +16,8 @@ use std::fmt::Write as _;
 use std::num::NonZero;
 
 use cbh_detect::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, Finding, Series, SeriesCensus,
-    UnjudgedReason, evaluate_with_log, examples, find_changes,
+    AnalysisContext, AnalysisMode, Detection, Finding, Series, SeriesCensus, UnjudgedReason,
+    evaluate_with_log, examples, find_changes,
 };
 use cbh_model::{DiscriminantSet, Engine, MachineKey, MetricKind, TargetTriple};
 use cbh_render::{
@@ -112,7 +112,6 @@ fn suite_context(suite: &[Series]) -> AnalysisContext {
         .unwrap_or(0);
     AnalysisContext {
         mode: AnalysisMode::History,
-        config: AnalysisConfig::default(),
         merge_base_index: None,
         base_ref_index: None,
         tip_index,

--- a/packages/cargo-bench-history-stress/tests/stress_smoke.rs
+++ b/packages/cargo-bench-history-stress/tests/stress_smoke.rs
@@ -46,6 +46,27 @@ const COMMITS: usize = 8 * REGIME_POINTS;
 /// commit's state, so the branch itself stays short.
 const BRANCH_COMMITS: usize = 2;
 
+// The scenario sizes above are derived from the gates rather than picked for
+// speed. Bind them to the gates here, so moving a gate fails the build instead
+// of silently leaving this suite judging a history the detectors abstain on.
+const _: () = assert!(
+    REGIME_POINTS == MIN_REGIME,
+    "each side of a seeded step must hold a full regime"
+);
+const _: () = assert!(
+    COMMITS >= 4 * MIN_SERIES_POINTS,
+    "half the seeded commits carry a run, and the fixture keeps twice the points a \
+     judged series needs"
+);
+const _: () = assert!(
+    COMMITS >= 4 * DRIFT_MIN_POINTS,
+    "the fixture keeps twice the run-carrying commits the seeded drift needs to be seen"
+);
+const _: () = assert!(
+    COMPARE_WINDOW >= MIN_SERIES_POINTS,
+    "branch mode's base window must be able to hold the levels its test demands"
+);
+
 /// Dirty (uncommitted-tree) snapshots the scenario seeds on the feature tip.
 const DIRTY_RUNS: usize = 1;
 
@@ -269,30 +290,6 @@ fn assert_seeded_ground_truth(stdout: &str, modes: &[&str]) {
             .unwrap_or_else(|| panic!("the {mode} row was just matched: {stdout}"));
         assert_eq!(*row, expected_row(mode, with_runs), "mode {mode}: {stdout}");
     }
-}
-
-#[test]
-fn fixture_sizes_match_the_analysis_gates() {
-    // The scenario sizes above are derived from the gates rather than picked for
-    // speed. Bind them to the gates here, so moving a gate fails loudly instead of
-    // silently leaving this suite judging a history the detectors abstain on.
-    assert_eq!(
-        REGIME_POINTS, MIN_REGIME,
-        "each side of a seeded step must hold a full regime"
-    );
-    assert!(
-        COMMITS >= 4 * MIN_SERIES_POINTS,
-        "half the seeded commits carry a run, and the fixture keeps twice the points a \
-         judged series needs"
-    );
-    assert!(
-        COMMITS >= 4 * DRIFT_MIN_POINTS,
-        "the fixture keeps twice the run-carrying commits the seeded drift needs to be seen"
-    );
-    assert!(
-        COMPARE_WINDOW >= MIN_SERIES_POINTS,
-        "branch mode's base window must be able to hold the levels its test demands"
-    );
 }
 
 #[test]

--- a/packages/cargo-bench-history-stress/tests/stress_smoke.rs
+++ b/packages/cargo-bench-history-stress/tests/stress_smoke.rs
@@ -23,7 +23,7 @@ use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
 
-use cbh_detect::AnalysisConfig;
+use cbh_detect::{COMPARE_WINDOW, DRIFT_MIN_POINTS, MIN_REGIME, MIN_SERIES_POINTS};
 
 /// Benchmark cases the scenario seeds per discriminant set: one per timeline-shape
 /// family, so every seeded shape — including the stable one, which must raise
@@ -252,9 +252,8 @@ fn assert_seeded_ground_truth(stdout: &str, modes: &[&str]) {
     // Everything else here is downstream of the history being long enough to judge
     // at all: below this floor every detector abstains and every count is a
     // vacuous zero.
-    let config = AnalysisConfig::default();
     assert!(
-        with_runs >= config.min_series_points,
+        with_runs >= MIN_SERIES_POINTS,
         "the seeded history must clear the detectors' evidence floor: {stdout}"
     );
 
@@ -277,22 +276,21 @@ fn fixture_sizes_match_the_analysis_gates() {
     // The scenario sizes above are derived from the gates rather than picked for
     // speed. Bind them to the gates here, so moving a gate fails loudly instead of
     // silently leaving this suite judging a history the detectors abstain on.
-    let config = AnalysisConfig::default();
     assert_eq!(
-        REGIME_POINTS, config.min_regime,
+        REGIME_POINTS, MIN_REGIME,
         "each side of a seeded step must hold a full regime"
     );
     assert!(
-        COMMITS >= 4 * config.min_series_points,
+        COMMITS >= 4 * MIN_SERIES_POINTS,
         "half the seeded commits carry a run, and the fixture keeps twice the points a \
          judged series needs"
     );
     assert!(
-        COMMITS >= 4 * config.drift_min_points,
+        COMMITS >= 4 * DRIFT_MIN_POINTS,
         "the fixture keeps twice the run-carrying commits the seeded drift needs to be seen"
     );
     assert!(
-        config.compare_window >= config.min_series_points,
+        COMPARE_WINDOW >= MIN_SERIES_POINTS,
         "branch mode's base window must be able to hold the levels its test demands"
     );
 }

--- a/packages/cargo-bench-history/tests/cbh_integration/harness.rs
+++ b/packages/cargo-bench-history/tests/cbh_integration/harness.rs
@@ -42,7 +42,7 @@ pub(crate) const HARNESS_AUTO_MACHINE_KEY: &str = "harness-auto-machine";
 
 /// The minimum number of points a change-point regime (the flat side and the
 /// stepped side of a split) must hold before the history detector trusts the
-/// split. Mirrors `cbh_detect::AnalysisConfig::default().min_regime`; the
+/// split. Mirrors `cbh_detect::MIN_REGIME`; the
 /// [`fixture_gate_sizes_match_the_detector_defaults`] guard test keeps the two in
 /// lockstep. Fixtures build a flat regime and a stepped regime of this size so a
 /// seeded step clears the detector's per-regime persistence gate.
@@ -51,7 +51,7 @@ pub(crate) const MIN_REGIME: usize = 5;
 /// The minimum number of points a series must carry to be analysed at all — below
 /// it the series is not judged and is not even counted in the false-discovery
 /// family. Equal to two full regimes and mirrors
-/// `cbh_detect::AnalysisConfig::default().min_series_points` (also the value of
+/// `cbh_detect::MIN_SERIES_POINTS` (also the value of
 /// `DRIFT_MIN_POINTS` and the base-side commit-level floor branch mode demands).
 /// Fixtures seed at least this many points so their series is judged rather than
 /// silently skipped.
@@ -1838,13 +1838,14 @@ fn commit_dated_reuses_the_existing_commit() {
 /// silently seeding too little (or needless) history.
 #[test]
 fn fixture_gate_sizes_match_the_detector_defaults() {
-    let config = cbh_detect::AnalysisConfig::default();
     assert_eq!(
-        MIN_REGIME, config.min_regime,
+        MIN_REGIME,
+        cbh_detect::MIN_REGIME,
         "MIN_REGIME must match the detector's per-regime persistence gate"
     );
     assert_eq!(
-        MIN_SERIES_POINTS, config.min_series_points,
+        MIN_SERIES_POINTS,
+        cbh_detect::MIN_SERIES_POINTS,
         "MIN_SERIES_POINTS must match the detector's minimum-series-length gate"
     );
 }

--- a/packages/cbh_analyze/src/dataset.rs
+++ b/packages/cbh_analyze/src/dataset.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use anyspawn::Spawner;
 use cbh_config::Config;
 use cbh_detect::{
-    AnalysisConfig, AnalysisMode, BlessingPlacement, DiscriminantSetQuery, Series, SeriesFilter,
+    AnalysisMode, BlessingPlacement, COMPARE_WINDOW, DiscriminantSetQuery, Series, SeriesFilter,
     attach_base_windows,
 };
 use cbh_diag::{Reporter, ReporterExt, count_noun};
@@ -428,11 +428,7 @@ where
     let finish_started = Instant::now();
     let mut series = builder.finish();
     if !base_series.is_empty() {
-        attach_base_windows(
-            &mut series,
-            &base_series,
-            AnalysisConfig::default().compare_window,
-        );
+        attach_base_windows(&mut series, &base_series, COMPARE_WINDOW);
     }
     reporter.timing(
         "series build finalization (builder.finish: assemble + serial point sort)",

--- a/packages/cbh_analyze/src/pipeline.rs
+++ b/packages/cbh_analyze/src/pipeline.rs
@@ -16,9 +16,10 @@ use cbh_config::{
     resolve_project_id, resolve_repo, storage_env,
 };
 use cbh_detect::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, DiscardedBaseReading,
-    DiscardedReading, Series, SeriesCensus, SeriesFilter, Testability, UnjudgedReason,
-    apply_blessings, find_changes_spawned, retain_present_at_context, short_commit, testability,
+    AnalysisContext, AnalysisMode, COMPARE_WINDOW, Detection, DiscardedBaseReading,
+    DiscardedReading, MIN_REGIME, MIN_SERIES_POINTS, Series, SeriesCensus, SeriesFilter,
+    Testability, UnjudgedReason, apply_blessings, find_changes_spawned, retain_present_at_context,
+    short_commit, testability,
 };
 use cbh_diag::{Reporter, ReporterExt, StderrReporter, count_noun};
 use cbh_git::{GitHistory, SystemGitHistory};
@@ -288,7 +289,6 @@ where
     );
     let context = AnalysisContext {
         mode: dataset.mode,
-        config: AnalysisConfig::default(),
         merge_base_index: dataset.merge_base_index,
         base_ref_index: dataset.base_ref_index,
         tip_index: dataset.tip_index,
@@ -502,19 +502,18 @@ fn note_series_census<R: Reporter + ?Sized>(
                 reason.describe(),
             ));
         }
-        let config = &context.config;
         let rule = match context.mode {
             AnalysisMode::History => format!(
                 "history mode judges a series only from {} in the analyzed window, \
                  since a change point needs {} on each side of it",
-                count_noun(config.min_series_points, "point"),
-                count_noun(config.min_regime, "point"),
+                count_noun(MIN_SERIES_POINTS, "point"),
+                count_noun(MIN_REGIME, "point"),
             ),
             AnalysisMode::Branch => format!(
                 "branch mode judges a series only with a measurement on the branch and \
                  {} in the {}-commit comparison window to judge it against",
-                count_noun(config.min_series_points, "base-branch commit"),
-                config.compare_window,
+                count_noun(MIN_SERIES_POINTS, "base-branch commit"),
+                COMPARE_WINDOW,
             ),
         };
         // The trail states the same ratio the report's header and verdict do, read from
@@ -701,29 +700,25 @@ mod tests {
     /// admits — topology, dirty handling, discriminant filters, `--since` — never on findings.
     const SELECTION_COMMITS: usize = 4;
 
-    #[test]
-    fn fixture_sizes_match_the_analysis_gates() {
-        // The fixture sizes above are literals so the seeded shapes read plainly, but
-        // each one exists to satisfy a production gate. Bind them to the gates here,
-        // so moving a gate fails loudly instead of silently making fixtures vacuous.
-        let config = AnalysisConfig::default();
-        assert_eq!(
-            REGIME_COMMITS, config.min_regime,
-            "a seeded step must hold a full regime on each side of its split"
-        );
-        assert_eq!(
-            HISTORY_COMMITS, config.min_series_points,
-            "a history fixture must be long enough for the detectors to judge it"
-        );
-        assert!(
-            BASE_COMMITS <= config.compare_window,
-            "a branch fixture's whole base line must fit the comparison window"
-        );
-        assert!(
-            SELECTION_COMMITS < config.min_series_points,
-            "the selection fixture is deliberately too short to be judged"
-        );
-    }
+    // The fixture sizes above are literals so the seeded shapes read plainly, but each one
+    // exists to satisfy a production gate. Bind them to the gates here, so moving a gate
+    // fails the build instead of silently making a fixture vacuous.
+    const _: () = assert!(
+        REGIME_COMMITS == MIN_REGIME,
+        "a seeded step must hold a full regime on each side of its split"
+    );
+    const _: () = assert!(
+        HISTORY_COMMITS == MIN_SERIES_POINTS,
+        "a history fixture must be long enough for the detectors to judge it"
+    );
+    const _: () = assert!(
+        BASE_COMMITS <= COMPARE_WINDOW,
+        "a branch fixture's whole base line must fit the comparison window"
+    );
+    const _: () = assert!(
+        SELECTION_COMMITS < MIN_SERIES_POINTS,
+        "the selection fixture is deliberately too short to be judged"
+    );
 
     /// The name of the `index`th commit on a master fixture's line.
     fn commit_name(index: usize) -> String {

--- a/packages/cbh_detect/docs/implementation.md
+++ b/packages/cbh_detect/docs/implementation.md
@@ -13,8 +13,11 @@ the resulting findings remains in `cbh_render`.
 
 Gating policy is centralized: every threshold a detector turns on lives in one module rather than
 at its point of use, so the policy can be reviewed as a whole and each value carries the reasoning
-that sets it. Detectors read those thresholds through the analysis configuration, which is what
-lets tests vary a single policy value in isolation.
+that sets it. The thresholds are fixed constants with no override mechanism, because the shipped
+tool exposes none — so tests exercise the exact policy production runs under rather than scenarios
+reachable only by retuning a threshold. Where a test needs to know which gate decided an outcome,
+the detectors record their gate evaluations to an optional log it can inspect, rather than relaxing
+a threshold to make the decision observable.
 
 Evidence selection is separated from evidence judgment. Deciding which base-window levels a branch
 comparison may see — discarding a stale prefix when the base itself moved, and discarding an
@@ -29,7 +32,7 @@ keeps the decision in exact correspondence with the public testability projectio
 and the false-discovery family is sized from. Narrowing that happens afterwards cannot make the
 census untruthful, because the floor was met before anything was discarded. It follows that no
 selection step may discard so much that the remainder falls under the minimum regime length; the
-configured removal allowance is set far below that margin.
+removal allowance is set far below that margin.
 
 Parallel work is supplied through an executor abstraction, preserving the same deterministic
 analysis logic for production execution and synchronous component tests.

--- a/packages/cbh_detect/src/detect/examples.rs
+++ b/packages/cbh_detect/src/detect/examples.rs
@@ -32,9 +32,7 @@ pub use crate::detect::recorded::{
     STATIONARY_BIMODAL_NOISE,
 };
 pub use crate::detect::scatter::{TIMING_NOISE_CV, scattered, seed_of};
-use crate::detect::{
-    AnalysisContext, AnalysisMode, Series, SeriesPoint, attach_base_windows,
-};
+use crate::detect::{AnalysisContext, AnalysisMode, Series, SeriesPoint, attach_base_windows};
 
 /// The level every example series starts from.
 ///
@@ -204,8 +202,8 @@ pub fn with_base_window(mut series: Series, base_ref_index: usize) -> Series {
     series
 }
 
-/// A history-mode context over `series` under the default configuration: what a
-/// scheduled analysis of one benchmark's stored history runs.
+/// A history-mode context over `series`: what a scheduled analysis of one
+/// benchmark's stored history runs.
 ///
 /// History mode reports regressions only, so an example that moves downwards is a
 /// non-finding here; use [`branch_context`] for an example that must be visible in
@@ -220,7 +218,7 @@ pub fn history_context(series: &Series) -> AnalysisContext {
     }
 }
 
-/// A branch-mode context over `series` under the default configuration.
+/// A branch-mode context over `series`.
 ///
 /// Branch mode judges the latest state against the base window attached to
 /// `series`, so it reports both directions.

--- a/packages/cbh_detect/src/detect/examples.rs
+++ b/packages/cbh_detect/src/detect/examples.rs
@@ -8,14 +8,13 @@
 //!
 //! The values are metric-agnostic bare levels: [`series`] builds them into a [`Series`]
 //! of whichever kind and topology a caller needs. The verdict each series' documentation
-//! claims is the one history mode reaches under the default [`AnalysisConfig`].
+//! claims is the one history mode reaches under the fixed detection policy.
 //!
 //! Reproducibility is the whole point, so every series is a pure function of its own
 //! name: the scatter is drawn from [`seed_of`] applied to that name and is identical on
 //! every platform and every run.
 //!
 //! [`Series`]: crate::Series
-//! [`AnalysisConfig`]: crate::AnalysisConfig
 
 #![cfg_attr(coverage_nightly, coverage(off))]
 
@@ -26,7 +25,7 @@ use cbh_model::{BenchmarkId, DiscriminantSet, Engine, MetricKind};
 use nonempty::nonempty;
 
 use crate::detect::findings::count_to_f64;
-use crate::detect::noise_gates::MIN_REGIME;
+use crate::detect::noise_gates::{COMPARE_WINDOW, MIN_REGIME};
 pub use crate::detect::recorded::{
     CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL,
     CONTENDED_RUNNER_LEVEL_START, STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH,
@@ -34,7 +33,7 @@ pub use crate::detect::recorded::{
 };
 pub use crate::detect::scatter::{TIMING_NOISE_CV, scattered, seed_of};
 use crate::detect::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Series, SeriesPoint, attach_base_windows,
+    AnalysisContext, AnalysisMode, Series, SeriesPoint, attach_base_windows,
 };
 
 /// The level every example series starts from.
@@ -200,7 +199,7 @@ pub fn with_base_window(mut series: Series, base_ref_index: usize) -> Series {
     attach_base_windows(
         slice::from_mut(&mut series),
         slice::from_ref(&base),
-        AnalysisConfig::default().compare_window,
+        COMPARE_WINDOW,
     );
     series
 }
@@ -215,7 +214,6 @@ pub fn with_base_window(mut series: Series, base_ref_index: usize) -> Series {
 pub fn history_context(series: &Series) -> AnalysisContext {
     AnalysisContext {
         mode: AnalysisMode::History,
-        config: AnalysisConfig::default(),
         merge_base_index: None,
         base_ref_index: None,
         tip_index: tip_index_of(series),
@@ -230,7 +228,6 @@ pub fn history_context(series: &Series) -> AnalysisContext {
 pub fn branch_context(series: &Series, merge_base_index: usize) -> AnalysisContext {
     AnalysisContext {
         mode: AnalysisMode::Branch,
-        config: AnalysisConfig::default(),
         merge_base_index: Some(merge_base_index),
         base_ref_index: Some(merge_base_index),
         tip_index: tip_index_of(series),

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -55,10 +55,10 @@ pub struct DiscardedReading {
 ///
 /// Borrows `window` unchanged in the ordinary case, which is every window that holds no
 /// excursion at all.
-pub(super) fn cleaned_window<'a>(
-    window: &'a [BaseLevel],
+pub(super) fn cleaned_window(
+    window: &[BaseLevel],
     context_level: Option<f64>,
-) -> (Cow<'a, [BaseLevel]>, Vec<DiscardedReading>) {
+) -> (Cow<'_, [BaseLevel]>, Vec<DiscardedReading>) {
     let levels: Vec<f64> = window.iter().map(|level| level.value).collect();
     let discarded = isolated_excursions(&levels, context_level);
     if discarded.is_empty() {
@@ -216,6 +216,7 @@ mod tests {
     #![allow(clippy::indexing_slicing, reason = "panic is fine in tests")]
 
     use super::*;
+    use crate::detect::noise_gates::{EXCURSION_NEIGHBOURS, EXCURSION_RELATIVE_MAGNITUDE};
     use crate::detect::recorded::{
         CONTENDED_RUNNER_BASE, CONTENDED_RUNNER_EXCURSION, CONTENDED_RUNNER_LEVEL_START,
         STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_NOISE,
@@ -227,31 +228,27 @@ mod tests {
     /// The level the synthetic windows sit at when nothing is happening.
     const LEVEL: f64 = 100.0;
 
-    fn config() -> AnalysisConfig {
-        AnalysisConfig::default()
-    }
-
     fn flat(count: usize) -> Vec<f64> {
         vec![LEVEL; count]
     }
 
     #[test]
     fn a_flat_window_has_no_excursions() {
-        assert!(isolated_excursions(&flat(16), None, &config()).is_empty());
+        assert!(isolated_excursions(&flat(16), None).is_empty());
     }
 
     #[test]
     fn a_lone_excursion_is_found() {
         let mut levels = flat(16);
         levels[8] = EXCURSION;
-        assert_eq!(isolated_excursions(&levels, None, &config()), vec![8]);
+        assert_eq!(isolated_excursions(&levels, None), vec![8]);
     }
 
     #[test]
     fn a_lone_dip_is_found_as_readily_as_a_spike() {
         let mut levels = flat(16);
         levels[8] = LEVEL / 2.0;
-        assert_eq!(isolated_excursions(&levels, None, &config()), vec![8]);
+        assert_eq!(isolated_excursions(&levels, None), vec![8]);
     }
 
     #[test]
@@ -259,7 +256,7 @@ mod tests {
         // Every level past the step sits at the new level, so no level's surroundings
         // agree across it — which is the whole point: a real change must survive.
         let levels: Vec<f64> = flat(8).into_iter().chain(vec![EXCURSION; 8]).collect();
-        assert!(isolated_excursions(&levels, None, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None).is_empty());
     }
 
     #[test]
@@ -274,34 +271,32 @@ mod tests {
         // discarded as a bad reading, tightening the window against the very move that just
         // landed.
         let levels: Vec<f64> = flat(11).into_iter().chain(vec![EXCURSION; 3]).collect();
-        assert!(isolated_excursions(&levels, None, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None).is_empty());
     }
 
     #[test]
     fn a_move_below_the_magnitude_is_ordinary_scatter() {
-        let config = config();
         let mut levels = flat(16);
-        levels[8] = LEVEL * (1.0 + config.excursion_relative_magnitude / 2.0);
-        assert!(isolated_excursions(&levels, None, &config).is_empty());
+        levels[8] = LEVEL * (1.0 + EXCURSION_RELATIVE_MAGNITUDE / 2.0);
+        assert!(isolated_excursions(&levels, None).is_empty());
     }
 
     #[test]
     fn levels_without_full_surroundings_are_never_removed() {
-        // The outer `excursion_neighbours` levels at each end have no complete side to be
+        // The outer `EXCURSION_NEIGHBOURS` levels at each end have no complete side to be
         // judged against, so an excursion there is kept however far it stands out. Each
         // position is tried in an otherwise clean window, so the test fails if a
         // truncated neighbourhood is ever consulted instead of the position being skipped.
-        let config = config();
         let length = 16;
         let last = length - 1;
         let protected =
-            (0..config.excursion_neighbours).chain((last - config.excursion_neighbours + 1)..=last);
+            (0..EXCURSION_NEIGHBOURS).chain((last - EXCURSION_NEIGHBOURS + 1)..=last);
 
         for index in protected {
             let mut levels = flat(length);
             levels[index] = EXCURSION;
             assert!(
-                isolated_excursions(&levels, None, &config).is_empty(),
+                isolated_excursions(&levels, None).is_empty(),
                 "index {index} has no complete surroundings and must be kept",
             );
         }
@@ -311,11 +306,10 @@ mod tests {
     fn a_level_with_complete_surroundings_just_inside_the_edge_is_removable() {
         // The counterpart of the test above: protection stops exactly where complete
         // surroundings begin, so the guard cannot quietly widen into the window.
-        let config = config();
-        let index = config.excursion_neighbours;
+        let index = EXCURSION_NEIGHBOURS;
         let mut levels = flat(16);
         levels[index] = EXCURSION;
-        assert_eq!(isolated_excursions(&levels, None, &config), vec![index]);
+        assert_eq!(isolated_excursions(&levels, None), vec![index]);
     }
 
     #[test]
@@ -324,11 +318,10 @@ mod tests {
         // benchmark that visits more than one level, which the comparison must account
         // for rather than edit away. This is the sparse counterpart of the bimodal
         // recording below, where the second level is too rare to look like a mode.
-        let config = config();
         let mut levels = flat(16);
         levels[5] = EXCURSION;
         levels[11] = EXCURSION;
-        assert!(isolated_excursions(&levels, None, &config).is_empty());
+        assert!(isolated_excursions(&levels, None).is_empty());
     }
 
     #[test]
@@ -338,10 +331,9 @@ mod tests {
         // Discarding it would leave the window describing a level the series does not
         // reliably hold, and the context run would read as a large, certain regression
         // against what remained.
-        let config = config();
         let mut levels = flat(16);
         levels[8] = EXCURSION;
-        assert!(isolated_excursions(&levels, Some(EXCURSION), &config).is_empty());
+        assert!(isolated_excursions(&levels, Some(EXCURSION)).is_empty());
     }
 
     #[test]
@@ -349,14 +341,10 @@ mod tests {
         // Only a context run at the candidate's own level is evidence of recurrence. One
         // that moved somewhere else says nothing about it, and the window is still
         // cleaned — which is the ordinary case the rule exists to serve.
-        let config = config();
         let mut levels = flat(16);
         levels[8] = EXCURSION;
-        let elsewhere = LEVEL * (1.0 + config.excursion_relative_magnitude / 2.0);
-        assert_eq!(
-            isolated_excursions(&levels, Some(elsewhere), &config),
-            vec![8]
-        );
+        let elsewhere = LEVEL * (1.0 + EXCURSION_RELATIVE_MAGNITUDE / 2.0);
+        assert_eq!(isolated_excursions(&levels, Some(elsewhere)), vec![8]);
     }
 
     #[test]
@@ -365,7 +353,7 @@ mod tests {
         for index in [5, 11, 16] {
             levels[index] = EXCURSION;
         }
-        assert!(isolated_excursions(&levels, None, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None).is_empty());
     }
 
     #[test]
@@ -376,7 +364,7 @@ mod tests {
         let window = STATIONARY_BIMODAL_NOISE
             .get(..STATIONARY_BIMODAL_BASE)
             .expect("the base prefix is within the recording");
-        assert!(isolated_excursions(window, None, &config()).is_empty());
+        assert!(isolated_excursions(window, None).is_empty());
     }
 
     #[test]
@@ -390,7 +378,7 @@ mod tests {
             .max_by(|(_, left), (_, right)| left.total_cmp(right))
             .map(|(index, _)| index)
             .expect("the window is not empty");
-        assert_eq!(isolated_excursions(window, None, &config()), vec![expected]);
+        assert_eq!(isolated_excursions(window, None), vec![expected]);
     }
 
     #[test]
@@ -400,12 +388,12 @@ mod tests {
         // whose magnitude gate is inert there.
         let mut levels = vec![0.0; 16];
         levels[8] = 1.0;
-        assert!(isolated_excursions(&levels, None, &config()).is_empty());
+        assert!(isolated_excursions(&levels, None).is_empty());
     }
 
     #[test]
     fn an_all_zero_window_has_no_excursions() {
-        assert!(isolated_excursions(&[0.0; 16], None, &config()).is_empty());
+        assert!(isolated_excursions(&[0.0; 16], None).is_empty());
     }
 
     #[test]
@@ -414,17 +402,13 @@ mod tests {
         // than that plus the candidate itself has nowhere a level could be judged. Each
         // length is tried with a genuine excursion at every position, so the test would
         // fail if a short window fell back to judging against what neighbours it has.
-        let config = config();
-        let shortest_with_interior = config
-            .excursion_neighbours
-            .saturating_mul(2)
-            .saturating_add(1);
+        let shortest_with_interior = EXCURSION_NEIGHBOURS.saturating_mul(2).saturating_add(1);
         for length in 0..shortest_with_interior {
             for index in 0..length {
                 let mut levels = flat(length);
                 levels[index] = EXCURSION;
                 assert!(
-                    isolated_excursions(&levels, None, &config).is_empty(),
+                    isolated_excursions(&levels, None).is_empty(),
                     "a window of {length} level(s) has no judgeable interior at {index}",
                 );
             }
@@ -446,7 +430,7 @@ mod tests {
     #[test]
     fn a_clean_window_is_passed_through_without_copying() {
         let window = window_of(&flat(16));
-        let (cleaned, discarded) = cleaned_window(&window, None, &config());
+        let (cleaned, discarded) = cleaned_window(&window, None);
         assert!(matches!(cleaned, Cow::Borrowed(_)));
         assert_eq!(cleaned.as_ref(), window.as_slice());
         assert!(discarded.is_empty());
@@ -457,7 +441,7 @@ mod tests {
         let mut levels = flat(16);
         levels[8] = EXCURSION;
         let window = window_of(&levels);
-        let (cleaned, discarded) = cleaned_window(&window, None, &config());
+        let (cleaned, discarded) = cleaned_window(&window, None);
         let expected: Vec<BaseLevel> = window
             .iter()
             .filter(|level| level.topo_index != 8)

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -26,8 +26,8 @@ use std::borrow::Cow;
 
 use cbh_stats as stats;
 
-use super::AnalysisConfig;
 use super::findings::relative_delta_of;
+use super::noise_gates;
 use super::series::BaseLevel;
 
 /// One base-window reading branch mode left out of a comparison.
@@ -58,10 +58,9 @@ pub struct DiscardedReading {
 pub(super) fn cleaned_window<'a>(
     window: &'a [BaseLevel],
     context_level: Option<f64>,
-    config: &AnalysisConfig,
 ) -> (Cow<'a, [BaseLevel]>, Vec<DiscardedReading>) {
     let levels: Vec<f64> = window.iter().map(|level| level.value).collect();
-    let discarded = isolated_excursions(&levels, context_level, config);
+    let discarded = isolated_excursions(&levels, context_level);
     if discarded.is_empty() {
         return (Cow::Borrowed(window), Vec::new());
     }
@@ -71,7 +70,8 @@ pub(super) fn cleaned_window<'a>(
         .iter()
         .filter_map(|&index| {
             let level = window.get(index)?;
-            let surroundings = Surroundings::around(index, &levels, config.excursion_neighbours)?;
+            let surroundings =
+                Surroundings::around(index, &levels, noise_gates::EXCURSION_NEIGHBOURS)?;
             Some(DiscardedReading {
                 topo_index: level.topo_index,
                 value: level.value,
@@ -95,15 +95,15 @@ pub(super) fn cleaned_window<'a>(
 ///
 /// 1. **Its surroundings agree with each other.** The levels immediately before it and
 ///    the levels immediately after it must describe the same level, within
-///    [`excursion_neighbour_agreement`](AnalysisConfig::excursion_neighbour_agreement).
+///    [`EXCURSION_NEIGHBOUR_AGREEMENT`](noise_gates::EXCURSION_NEIGHBOUR_AGREEMENT).
 ///    This is what separates a bad measurement from a real step: when the code genuinely
 ///    changes, the levels after the change sit at the *new* level and disagree with the
 ///    ones before it, so a step is never mistaken for an excursion however large it is.
 /// 2. **It stands far clear of them.** It must differ from its surroundings by at least
-///    [`excursion_relative_magnitude`](AnalysisConfig::excursion_relative_magnitude),
+///    [`EXCURSION_RELATIVE_MAGNITUDE`](noise_gates::EXCURSION_RELATIVE_MAGNITUDE),
 ///    which is set well above ordinary measurement wobble.
 /// 3. **It is the only one, and the context run does not agree with it.** If more than
-///    [`excursion_max_removals`](AnalysisConfig::excursion_max_removals) levels qualify,
+///    [`EXCURSION_MAX_REMOVALS`](noise_gates::EXCURSION_MAX_REMOVALS) levels qualify,
 ///    nothing is removed at all, and a level the context run itself sits at is never
 ///    removed. Either way the window has shown the level twice, and twice is a level the
 ///    series reaches rather than a moment its runner lost. Stripping a recurring level
@@ -120,33 +120,30 @@ pub(super) fn cleaned_window<'a>(
 /// exactly across runs of unchanged code, so an isolated excursion in one is as much a
 /// measurement artifact as it is in a timing series, and is as unrepresentative of the
 /// level a pull request would merge into.
-pub(super) fn isolated_excursions(
-    levels: &[f64],
-    context_level: Option<f64>,
-    config: &AnalysisConfig,
-) -> Vec<usize> {
+pub(super) fn isolated_excursions(levels: &[f64], context_level: Option<f64>) -> Vec<usize> {
     let mut found = Vec::new();
     for index in 0..levels.len() {
-        let Some(surroundings) = Surroundings::around(index, levels, config.excursion_neighbours)
+        let Some(surroundings) =
+            Surroundings::around(index, levels, noise_gates::EXCURSION_NEIGHBOURS)
         else {
             continue;
         };
-        if !surroundings.agree(config.excursion_neighbour_agreement) {
+        if !surroundings.agree(noise_gates::EXCURSION_NEIGHBOUR_AGREEMENT) {
             continue;
         }
         let Some(&level) = levels.get(index) else {
             continue;
         };
-        if !surroundings.stands_clear(level, config.excursion_relative_magnitude) {
+        if !surroundings.stands_clear(level, noise_gates::EXCURSION_RELATIVE_MAGNITUDE) {
             continue;
         }
         if context_level.is_some_and(|context| {
-            surroundings.same_level(level, context, config.excursion_neighbour_agreement)
+            surroundings.same_level(level, context, noise_gates::EXCURSION_NEIGHBOUR_AGREEMENT)
         }) {
             continue;
         }
         found.push(index);
-        if found.len() > config.excursion_max_removals {
+        if found.len() > noise_gates::EXCURSION_MAX_REMOVALS {
             return Vec::new();
         }
     }

--- a/packages/cbh_detect/src/detect/excursions.rs
+++ b/packages/cbh_detect/src/detect/excursions.rs
@@ -289,8 +289,7 @@ mod tests {
         // truncated neighbourhood is ever consulted instead of the position being skipped.
         let length = 16;
         let last = length - 1;
-        let protected =
-            (0..EXCURSION_NEIGHBOURS).chain((last - EXCURSION_NEIGHBOURS + 1)..=last);
+        let protected = (0..EXCURSION_NEIGHBOURS).chain((last - EXCURSION_NEIGHBOURS + 1)..=last);
 
         for index in protected {
             let mut levels = flat(length);

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -2109,9 +2109,10 @@ mod tests {
     use super::*;
     use crate::detect::gate_log::GateOutcome;
     use crate::detect::noise_gates::{
-        CHANGE_ALPHA, COMPARE_WINDOW, DRIFT_ALPHA, DRIFT_MIN_POINTS, DRIFT_NOISE_MULTIPLE,
-        EXCURSION_MAX_REMOVALS, FDR_Q, MIN_BASE_SPLIT_SEPARATION, MIN_REGIME, MIN_REGIME_SEPARATION,
-        MIN_SERIES_POINTS, PRACTICAL_ABSOLUTE_COUNT, PRACTICAL_RELATIVE, RESIDUAL_NOISE_MULTIPLE,
+        BRANCH_PRACTICAL_RELATIVE, CHANGE_ALPHA, COMPARE_WINDOW, DRIFT_ALPHA, DRIFT_MIN_POINTS,
+        DRIFT_NOISE_MULTIPLE, EXCURSION_MAX_REMOVALS, FDR_Q, MIN_BASE_SPLIT_SEPARATION, MIN_REGIME,
+        MIN_REGIME_SEPARATION, MIN_SERIES_POINTS, PRACTICAL_ABSOLUTE_COUNT, PRACTICAL_RELATIVE,
+        RESIDUAL_NOISE_MULTIPLE,
     };
     use crate::detect::recorded::{
         STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH, STATIONARY_BIMODAL_NOISE,
@@ -3832,7 +3833,7 @@ mod tests {
     /// The amount a fixture base window wobbles around its level from commit to
     /// commit, in the metric's own units.
     ///
-    /// The [`compare_with`] fixtures run on a wall-time series, whose scatter is not
+    /// The [`compare`] fixtures run on a wall-time series, whose scatter is not
     /// floored at all (time has no quantum), so a base window repeating one value
     /// leaves the prediction interval no distribution to place the context run in. Real
     /// timing series never repeat a value, so the window alternates by this much instead.
@@ -3870,10 +3871,23 @@ mod tests {
         // The relative move (5%) is exactly BRANCH_PRACTICAL_RELATIVE, the floor branch
         // mode holds moves to: the `relative < floor` gate must be a strict `<` (a
         // `<=`/`==` mutant would suppress it). The move then clears the residual band and
-        // the prediction interval, so it is reported.
+        // the prediction interval, so it is reported. The recorded gate pins that the
+        // fixture sits exactly on the floor, so the boundary is genuinely under test.
+        let series = wall_series(&[100.0], 1.0);
         let before = base_window(100.0, 0.5);
         let after = pts(&[(105.0, 0.5)]);
-        assert!(compare(&before, &after).is_some());
+        let before_refs: Vec<&SeriesPoint> = before.iter().collect();
+        let after_refs: Vec<&SeriesPoint> = after.iter().collect();
+
+        let mut log = GateLog::recording();
+        assert!(compare_samples(&series, &before_refs, &after_refs, &mut log).is_some());
+        let (relative, floor) =
+            gate_value(&log, Gate::RelativeFloor).expect("the relative-floor gate ran");
+        assert_eq!(floor, BRANCH_PRACTICAL_RELATIVE);
+        assert_eq!(
+            relative, floor,
+            "the fixture must land exactly on the floor for the boundary to be under test"
+        );
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -652,7 +652,9 @@ fn scatter_floor(kind: MetricKind) -> f64 {
         | MetricKind::ConditionalBranches
         | MetricKind::IndirectBranches => noise_gates::SCATTER_FLOOR_COUNT,
         MetricKind::WallTime | MetricKind::ProcessorTime => noise_gates::SCATTER_FLOOR_TIME,
-        MetricKind::AllocatedBytes | MetricKind::AllocationCount => noise_gates::SCATTER_FLOOR_ALLOC,
+        MetricKind::AllocatedBytes | MetricKind::AllocationCount => {
+            noise_gates::SCATTER_FLOOR_ALLOC
+        }
     }
 }
 
@@ -994,11 +996,7 @@ fn arbitrate(
 /// gate that rejects a noisy-but-stable series whose levels interleave), and — when
 /// the engine reports per-point confidence intervals — separate the two regimes'
 /// intervals.
-fn evaluate_change_point(
-    series: &Series,
-    values: &[f64],
-    log: &mut GateLog,
-) -> Option<Candidate> {
+fn evaluate_change_point(series: &Series, values: &[f64], log: &mut GateLog) -> Option<Candidate> {
     let mut log = log.stage(GateStage::ChangePoint);
     let points = &series.points;
     let n = points.len();
@@ -1151,7 +1149,11 @@ fn evaluate_drift(series: &Series, values: &[f64], log: &mut GateLog) -> Option<
     if !clears_absolute_floor(series, delta, &mut log) {
         return None;
     }
-    if !exceeds_residual_noise(delta, line_model_residual(values, slope, intercept), &mut log) {
+    if !exceeds_residual_noise(
+        delta,
+        line_model_residual(values, slope, intercept),
+        &mut log,
+    ) {
         return None;
     }
     // Where the engine reports dispersion, a trend must also clear the measurement
@@ -2678,8 +2680,14 @@ mod tests {
             "the fixture must report under the fixed alpha"
         );
         let (p, alpha) = gate_value(&log, Gate::Significance).expect("the significance gate ran");
-        assert_eq!(alpha, CHANGE_ALPHA, "the gate compares against the fixed alpha");
-        assert!(p < CHANGE_ALPHA, "the reported step's p sits below alpha: {p}");
+        assert_eq!(
+            alpha, CHANGE_ALPHA,
+            "the gate compares against the fixed alpha"
+        );
+        assert!(
+            p < CHANGE_ALPHA,
+            "the reported step's p sits below alpha: {p}"
+        );
     }
 
     #[test]
@@ -3037,8 +3045,7 @@ mod tests {
             0.5,
         );
         let candidate =
-            evaluate_change_point(&series, &values_of(&series), &mut GateLog::disabled())
-                .unwrap();
+            evaluate_change_point(&series, &values_of(&series), &mut GateLog::disabled()).unwrap();
         assert_eq!(candidate.finding.baseline, 100.0);
         assert_eq!(candidate.finding.latest, 103.0);
         assert_eq!(candidate.finding.relative_delta, PRACTICAL_RELATIVE);
@@ -3405,8 +3412,8 @@ mod tests {
         // (48 / (1 * sqrt(1 + 1/10))), so it is reported decisively — exactly the
         // regression shape this floor exists for.
         let series = branch_over_base_of_kind(0.0, 48.0, 1, MetricKind::AllocatedBytes);
-        let candidate = evaluate_branch(&series, &mut GateLog::disabled())
-            .expect("48 bytes is a move");
+        let candidate =
+            evaluate_branch(&series, &mut GateLog::disabled()).expect("48 bytes is a move");
         assert_eq!(candidate.finding.direction, Direction::Regression);
         assert_eq!(candidate.finding.latest, 48.0);
         assert!(candidate.bh_p < CHANGE_ALPHA, "{}", candidate.bh_p);
@@ -3931,15 +3938,7 @@ mod tests {
         let after_refs: Vec<&SeriesPoint> = after.iter().collect();
         let mut log = GateLog::recording();
 
-        assert!(
-            compare_samples(
-                &series,
-                &before_refs,
-                &after_refs,
-                &mut log,
-            )
-            .is_some()
-        );
+        assert!(compare_samples(&series, &before_refs, &after_refs, &mut log,).is_some());
 
         let outcome = log
             .entries()
@@ -3965,15 +3964,7 @@ mod tests {
         let after_refs: Vec<&SeriesPoint> = after.iter().collect();
         let mut log = GateLog::recording();
 
-        assert!(
-            compare_samples(
-                &series,
-                &before_refs,
-                &after_refs,
-                &mut log,
-            )
-            .is_none()
-        );
+        assert!(compare_samples(&series, &before_refs, &after_refs, &mut log,).is_none());
 
         let outcome = log
             .entries()
@@ -4013,15 +4004,7 @@ mod tests {
         let after_refs: Vec<&SeriesPoint> = after.iter().collect();
         let mut log = GateLog::recording();
 
-        assert!(
-            compare_samples(
-                &series,
-                &before_refs,
-                &after_refs,
-                &mut log,
-            )
-            .is_none()
-        );
+        assert!(compare_samples(&series, &before_refs, &after_refs, &mut log,).is_none());
         assert_eq!(
             log.declined_by_stage(GateStage::Branch),
             Some(Gate::IntervalNoiseBand)
@@ -4104,8 +4087,8 @@ mod tests {
         // p > 0, so a mutated `1 + p` / `1 / p` would clamp to 1. The nine-unit rise
         // over a baseline of 300 lands the relative move on the floor exactly.
         let series = series_of(&ramp(300.0, 1.0, MIN_SERIES_POINTS));
-        let candidate = evaluate_drift(&series, &values_of(&series), &mut GateLog::disabled())
-            .unwrap();
+        let candidate =
+            evaluate_drift(&series, &values_of(&series), &mut GateLog::disabled()).unwrap();
         assert_eq!(candidate.finding.method, FindingMethod::Drift);
         assert_eq!(candidate.finding.relative_delta, PRACTICAL_RELATIVE);
         assert!(candidate.finding.confidence < 1.0);
@@ -4138,9 +4121,7 @@ mod tests {
         // reason.
         let series = series_of(&staircase(100.0, MIN_SERIES_POINTS));
         let mut log = GateLog::recording();
-        assert!(
-            evaluate_drift(&series, &values_of(&series), &mut log).is_none()
-        );
+        assert!(evaluate_drift(&series, &values_of(&series), &mut log).is_none());
         assert_eq!(
             log.declined_by_stage(GateStage::Drift),
             Some(Gate::AbsoluteFloor)
@@ -4153,8 +4134,8 @@ mod tests {
         // counts, which clears the absolute floor and is flagged, pinning the gate's
         // `>=` boundary.
         let series = series_of(&staircase(100.0, MIN_SERIES_POINTS + 1));
-        let candidate = evaluate_drift(&series, &values_of(&series), &mut GateLog::disabled())
-            .unwrap();
+        let candidate =
+            evaluate_drift(&series, &values_of(&series), &mut GateLog::disabled()).unwrap();
         assert_eq!(candidate.finding.method, FindingMethod::Drift);
         assert_eq!(candidate.finding.delta, 5.0);
     }
@@ -4167,9 +4148,7 @@ mod tests {
         // the recorded threshold pins the product (a `+` mutant would lower it to 22).
         let series = wall_series(&ramp(100.0, 4.0, MIN_SERIES_POINTS), 20.0);
         let mut log = GateLog::recording();
-        assert!(
-            evaluate_drift(&series, &values_of(&series), &mut log).is_none()
-        );
+        assert!(evaluate_drift(&series, &values_of(&series), &mut log).is_none());
         assert_eq!(log.declined_by(), Some(Gate::IntervalNoiseBand));
         assert_eq!(
             gate_value(&log, Gate::IntervalNoiseBand),
@@ -4201,13 +4180,9 @@ mod tests {
         // rejected outright, while a series of exactly that length is still evaluated
         // (so a gate mutated to reject the longer series instead is caught).
         let short = series_of(&ramp(100.0, 4.0, DRIFT_MIN_POINTS - 1));
-        assert!(
-            evaluate_drift(&short, &values_of(&short), &mut GateLog::disabled()).is_none()
-        );
+        assert!(evaluate_drift(&short, &values_of(&short), &mut GateLog::disabled()).is_none());
         let long = series_of(&ramp(100.0, 4.0, DRIFT_MIN_POINTS));
-        assert!(
-            evaluate_drift(&long, &values_of(&long), &mut GateLog::disabled()).is_some()
-        );
+        assert!(evaluate_drift(&long, &values_of(&long), &mut GateLog::disabled()).is_some());
     }
 
     #[test]

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -78,283 +78,6 @@ use crate::detect::gate_log::{Gate, GateLog, GateStage, StageLog};
 use crate::detect::parallel::{balanced_chunk_sizes, worker_count};
 use crate::detect::{BaseLevel, Series, SeriesPoint, excursions, noise_gates};
 
-/// Tunable parameters of the engine-aware analysis.
-///
-/// Every field is read as supplied and gates one stage of detection on its own; no
-/// relationship between fields is required or enforced, so any combination is a
-/// valid configuration. A combination that leaves a stage unreachable — a
-/// [`compare_window`](Self::compare_window) holding fewer commit levels than
-/// [`min_series_points`](Self::min_series_points), say — makes that stage abstain
-/// rather than misreport.
-///
-/// [`AnalysisConfig::default()`](Self::default) is the tuned policy the tool ships.
-/// Field documentation that gives a worked example, or that relates one field's
-/// value to another's, describes that default configuration rather than the type.
-#[derive(Clone, Copy, Debug)]
-pub struct AnalysisConfig {
-    /// Minimum points each side of a change must hold for the step to be trusted.
-    ///
-    /// A split leaving either regime shorter than this raises no candidate, so a move
-    /// confined to fewer than this many trailing points cannot flag (persistence).
-    /// Branch mode applies it to the base-side commit levels either side of a
-    /// candidate regime boundary, and to the comparison sample as a whole.
-    pub min_regime: usize,
-    /// Minimum points a series must carry before it is evaluated at all.
-    ///
-    /// A shorter series raises no finding and does not count toward the
-    /// false-discovery family: it is unjudged rather than judged-and-quiet (see
-    /// [`Testability`]). History mode measures the post-blessing window against this
-    /// floor; branch mode measures the base-side commit levels inside
-    /// [`compare_window`](Self::compare_window) against it.
-    ///
-    /// Under [`AnalysisConfig::default()`](Self::default) this is two full regimes,
-    /// the shortest series a split can satisfy [`min_regime`](Self::min_regime) on
-    /// both sides of.
-    pub min_series_points: usize,
-    /// Significance level a change-point's Mann–Whitney rank test must clear.
-    ///
-    /// Pettitt only locates the split — its analytic p-value is too conservative on
-    /// short series to gate significance — so the rank test between the two regimes
-    /// decides. Branch mode holds its prediction-interval p-value to the same level,
-    /// as does a candidate base-side regime boundary.
-    pub change_alpha: f64,
-    /// Target false-discovery rate for the Benjamini–Hochberg filter.
-    ///
-    /// The filter runs over the surviving candidates with the family sized from every
-    /// series the pass judged (see [`SeriesCensus::judged`]), so a larger judged suite
-    /// demands a smaller p-value of each candidate.
-    pub fdr_q: f64,
-    /// Minimum points a series needs before a slow-drift finding is considered.
-    ///
-    /// Independent of [`min_series_points`](Self::min_series_points), which decides
-    /// whether the series is judged at all: a series above that floor but below this
-    /// one is judged, and can raise only a level shift.
-    ///
-    /// [`AnalysisConfig::default()`](Self::default) sets the two equal, so both
-    /// history detectors demand the same evidence and a series is evaluable by both
-    /// or by neither.
-    pub drift_min_points: usize,
-    /// Significance level a drift's Mann–Kendall trend must clear.
-    pub drift_alpha: f64,
-    /// Multiple of the per-measurement noise floor a drift's total movement must
-    /// exceed.
-    ///
-    /// Applies only where the engine reports per-point confidence intervals, whose
-    /// median half-width is that noise floor. An additional veto on top of the trend
-    /// test, able only to suppress a candidate. This is the drift counterpart of
-    /// [`branch_noise_multiple`](Self::branch_noise_multiple), and
-    /// [`AnalysisConfig::default()`](Self::default) holds the two equal.
-    pub drift_noise_multiple: f64,
-    /// Minimum relative magnitude a move must reach to matter in practice.
-    ///
-    /// Applied to the move against its baseline, independently of statistical
-    /// significance, so a certain but tiny move is not reported. Branch mode
-    /// substitutes [`branch_practical_relative`](Self::branch_practical_relative).
-    pub practical_relative: f64,
-    /// Absolute magnitude floor for instruction and branch counts, in counts.
-    ///
-    /// Composed by conjunction with the relative floor in force
-    /// ([`practical_relative`](Self::practical_relative), or
-    /// [`branch_practical_relative`](Self::branch_practical_relative) in branch mode):
-    /// a move must clear both. An absolute floor is needed alongside the relative one
-    /// because these counts move in whole units, so on a small baseline a handful of
-    /// units of build-layout jitter works out to a large *percentage* move that the
-    /// relative floor alone would let through.
-    pub practical_absolute_count: f64,
-    /// Absolute magnitude floor for timing moves, in nanoseconds.
-    ///
-    /// Composed by conjunction with the relative floor in force, exactly as
-    /// [`practical_absolute_count`](Self::practical_absolute_count) is. A timing
-    /// figure resolves far below a nanosecond, so this expresses which moves are worth
-    /// acting on rather than what the engine can measure.
-    ///
-    /// Under [`AnalysisConfig::default()`](Self::default) this is the binding gate on
-    /// a benchmark measuring a couple of nanoseconds an iteration, where the relative
-    /// floor works out to a fraction of a nanosecond.
-    pub practical_absolute_time: f64,
-    /// Absolute magnitude floor for allocation moves, in bytes or allocations.
-    ///
-    /// Composed by conjunction with the relative floor in force, exactly as
-    /// [`practical_absolute_count`](Self::practical_absolute_count) is. What an
-    /// allocation floor rejects is the sub-unit moves that amortizing a run's warmup
-    /// and buffer-resize allocations across its iterations manufactures, since a
-    /// fraction of a byte or of an allocation cannot happen.
-    pub practical_absolute_alloc: f64,
-    /// Lower bound on the scatter of an instruction or branch count sample, in counts.
-    ///
-    /// Branch mode's prediction interval takes its standard error from the base
-    /// window's standard deviation, and this bounds that deviation from below, so a
-    /// window that happens to repeat one value still yields a usable standard error
-    /// rather than a degenerate one. A scatter floor is the metric's *quantum*, not a
-    /// statement about which moves matter — see
-    /// [`scatter_floor_time`](Self::scatter_floor_time) for what raising one costs.
-    pub scatter_floor_count: f64,
-    /// Lower bound on the scatter of a timing sample, in nanoseconds.
-    ///
-    /// Serves the same role as [`scatter_floor_count`](Self::scatter_floor_count).
-    /// Raising it makes every timing series behave as if it wobbled by at least that
-    /// much, imposing an absolute detection threshold in units of the standard error
-    /// on top of the [`practical_absolute_time`](Self::practical_absolute_time) floor
-    /// that already decides which timing moves are worth reporting.
-    ///
-    /// [`AnalysisConfig::default()`](Self::default) leaves timing scatter unbounded
-    /// from below, because a time is a regression slope over a run's iterations and
-    /// resolves far below a clock tick, so it has no quantum to express. The price is
-    /// that a base window of identical timings yields no verdict, which is silence
-    /// rather than a spurious certainty.
-    pub scatter_floor_time: f64,
-    /// Lower bound on the scatter of an allocation sample, in bytes or allocations.
-    ///
-    /// Serves the same role as [`scatter_floor_count`](Self::scatter_floor_count).
-    /// The case it exists for is code that allocated nothing and now allocates: a base
-    /// window of zeroes has exactly zero scatter, and without a positive floor the
-    /// standard error collapses and that (real and important) move cannot be judged.
-    pub scatter_floor_alloc: f64,
-    /// How many recent base-side commits branch mode inspects.
-    ///
-    /// The window is the base evidence the branch's latest state is compared against.
-    /// A genuine level shift accepted inside it narrows the comparison to the trailing
-    /// regime; otherwise the whole window is the comparison sample. Its size therefore
-    /// sets both how small a move branch mode can resolve and how far back it looks
-    /// for a current-regime boundary, and a window holding fewer commit levels than
-    /// [`min_series_points`](Self::min_series_points) leaves branch mode unable to
-    /// judge the series at all.
-    pub compare_window: usize,
-    /// Minimum relative magnitude a *branch* move must reach.
-    ///
-    /// Branch mode's substitute for [`practical_relative`](Self::practical_relative),
-    /// applied both to a reported move and to a candidate base-side regime boundary.
-    ///
-    /// [`AnalysisConfig::default()`](Self::default) holds it above the history floor:
-    /// a feature-branch signal must be high-confidence, since we would rather miss a
-    /// small move than cry wolf on a pull request.
-    pub branch_practical_relative: f64,
-    /// Multiple of the per-measurement noise floor a branch move must exceed.
-    ///
-    /// Applies only where the engine reports per-point confidence intervals, whose
-    /// median half-width is that noise floor. An additional veto on top of the
-    /// prediction-interval test, able only to suppress a candidate.
-    pub branch_noise_multiple: f64,
-    /// Multiple of a series' own residual scatter a move must exceed to be trusted.
-    ///
-    /// The scatter is the median absolute residual of the fitted step or line model —
-    /// the series' between-commit wobble. This is the primary, series-intrinsic noise
-    /// gate applied to every engine: a clean series has near-zero residual scatter, so
-    /// any persistent move clears it, while a jittery series demands a move that stands
-    /// out above its own run-to-run wobble. It composes with (and is independent of)
-    /// the optional confidence-interval veto available on dispersion-reporting engines.
-    pub residual_noise_multiple: f64,
-    /// Minimum **probability of superiority** a level shift's two regimes must reach.
-    ///
-    /// The probability of superiority is the Mann–Whitney common-language effect size:
-    /// the fraction of after-vs-before commit pairs that move in the finding's
-    /// direction. It is the *effect-size* companion to the rank test's *significance*
-    /// gate, and closes a hole the significance gate cannot: a rank test grows
-    /// "significant" with sample size even for two heavily overlapping regimes, so a
-    /// long but stationary series that merely oscillates between two levels — noisy
-    /// yet stable — otherwise reads as a change-point. A genuine step scores ~1 here;
-    /// bimodal jitter scores near ½. The gate composes by conjunction, so it can only
-    /// suppress a candidate the median-based gates were fooled by, never create one.
-    pub min_regime_separation: f64,
-    /// Minimum probability of superiority a base-window split must reach.
-    ///
-    /// Branch mode accepts a base-side split as a regime boundary — discarding the
-    /// levels before it — only when the split clears this rather than
-    /// [`min_regime_separation`](Self::min_regime_separation).
-    ///
-    /// The two decisions carry asymmetric costs, which is why
-    /// [`AnalysisConfig::default()`](Self::default) holds this the higher of the pair.
-    /// Reporting a move makes a claim a human then checks; accepting a boundary
-    /// *discards evidence*, shrinking the comparison sample to the trailing regime and
-    /// rebuilding the scatter estimate from it alone — so a wrong boundary can collapse
-    /// a noisy window's dispersion to near zero and make any subsequent context run
-    /// read as certain. A boundary that throws data away must be unambiguous.
-    ///
-    /// The statistic is coarse at these sample sizes, so at the default this reads as
-    /// "essentially no crossing pair may contradict the boundary" rather than as a
-    /// precise probability: with the smallest regimes on both sides it admits one
-    /// contradicting pair in twenty-five and no more.
-    pub min_base_split_separation: f64,
-    /// How far a base-window level must stand from its surroundings for branch mode to
-    /// read it as a measurement excursion and discard it.
-    ///
-    /// A shared runner occasionally loses time to something else and records one commit
-    /// far above the level its neighbours agree on. Such a level describes the runner
-    /// rather than the code, and left in the window it both displaces the comparison's
-    /// centre and inflates its scatter, silently costing branch mode much of its
-    /// sensitivity. Discarding it is guarded by
-    /// [`excursion_neighbour_agreement`](Self::excursion_neighbour_agreement) and
-    /// [`excursion_max_removals`](Self::excursion_max_removals), which together confine
-    /// it to levels that are genuinely isolated.
-    ///
-    /// Raising this admits more interference into the comparison; lowering it starts
-    /// discarding the ordinary scatter that comparison is judged against, and every level
-    /// discarded tightens the window and makes branch mode readier to report.
-    pub excursion_relative_magnitude: f64,
-    /// How closely the levels on either side of a candidate excursion must agree before
-    /// it may be discarded.
-    ///
-    /// This is what keeps a genuine level shift out of the excursion rule: after a real
-    /// change the levels following it sit at the new level and disagree with those
-    /// before it, so its opening level is kept however large the step is. Only a level
-    /// its own surroundings straddle can be discarded.
-    pub excursion_neighbour_agreement: f64,
-    /// How many levels on each side of a candidate excursion form the surroundings it is
-    /// judged against.
-    ///
-    /// The candidate is judged locally rather than against the whole window, because a
-    /// window may legitimately span a level shift, and measured against such a window's
-    /// middle the ordinary levels of both regimes stand clear.
-    ///
-    /// A level without this many neighbours on *both* sides is never discarded, so the
-    /// window's outermost levels are always kept.
-    pub excursion_neighbours: usize,
-    /// How many excursions a base window may contain before it is left alone entirely.
-    ///
-    /// Above this the window is read as a benchmark that visits more than one level
-    /// rather than as a clean window with a bad reading in it. Removing levels from such
-    /// a window would leave a spuriously tight comparison in which the benchmark's own
-    /// ordinary values read as large, certain regressions — so it is left exactly as
-    /// measured.
-    ///
-    /// Keep it far below the difference between [`min_series_points`](Self::min_series_points)
-    /// and [`min_regime`](Self::min_regime): eligibility is settled on the window as
-    /// recorded, so a window that gave up more than that margin would be counted as judged
-    /// while holding too little evidence to compare.
-    pub excursion_max_removals: usize,
-}
-
-impl Default for AnalysisConfig {
-    fn default() -> Self {
-        Self {
-            min_regime: noise_gates::MIN_REGIME,
-            min_series_points: noise_gates::MIN_SERIES_POINTS,
-            change_alpha: noise_gates::CHANGE_ALPHA,
-            fdr_q: noise_gates::FDR_Q,
-            drift_min_points: noise_gates::DRIFT_MIN_POINTS,
-            drift_alpha: noise_gates::DRIFT_ALPHA,
-            drift_noise_multiple: noise_gates::DRIFT_NOISE_MULTIPLE,
-            practical_relative: noise_gates::PRACTICAL_RELATIVE,
-            practical_absolute_count: noise_gates::PRACTICAL_ABSOLUTE_COUNT,
-            practical_absolute_time: noise_gates::PRACTICAL_ABSOLUTE_TIME,
-            practical_absolute_alloc: noise_gates::PRACTICAL_ABSOLUTE_ALLOC,
-            scatter_floor_count: noise_gates::SCATTER_FLOOR_COUNT,
-            scatter_floor_time: noise_gates::SCATTER_FLOOR_TIME,
-            scatter_floor_alloc: noise_gates::SCATTER_FLOOR_ALLOC,
-            compare_window: noise_gates::COMPARE_WINDOW,
-            branch_practical_relative: noise_gates::BRANCH_PRACTICAL_RELATIVE,
-            branch_noise_multiple: noise_gates::BRANCH_NOISE_MULTIPLE,
-            residual_noise_multiple: noise_gates::RESIDUAL_NOISE_MULTIPLE,
-            min_regime_separation: noise_gates::MIN_REGIME_SEPARATION,
-            min_base_split_separation: noise_gates::MIN_BASE_SPLIT_SEPARATION,
-            excursion_relative_magnitude: noise_gates::EXCURSION_RELATIVE_MAGNITUDE,
-            excursion_neighbour_agreement: noise_gates::EXCURSION_NEIGHBOUR_AGREEMENT,
-            excursion_neighbours: noise_gates::EXCURSION_NEIGHBOURS,
-            excursion_max_removals: noise_gates::EXCURSION_MAX_REMOVALS,
-        }
-    }
-}
-
 /// Which analysis a [`find_changes_spawned`] pass performs.
 ///
 /// The mode is auto-detected by the caller from git topology and the admitted data
@@ -386,14 +109,11 @@ impl AnalysisMode {
 
 /// The context a [`find_changes_spawned`] pass runs in.
 ///
-/// Carries which analysis to perform, the tuned parameters, and the topology anchors
-/// the mode needs.
+/// Carries which analysis to perform and the topology anchors the mode needs.
 #[derive(Clone, Copy, Debug)]
 pub struct AnalysisContext {
     /// The analysis to perform.
     pub mode: AnalysisMode,
-    /// The tuned analysis parameters.
-    pub config: AnalysisConfig,
     /// First-parent topological index of the merge-base on the context line, when it
     /// lies there. Branch detection does not derive its base window from this split;
     /// it compares against [`Series::base_window`], which is loaded from the base ref.
@@ -446,10 +166,10 @@ pub enum UnjudgedReason {
     /// longer part of the suite and was dropped before detection.
     Ghost,
     /// History mode: the series carries fewer than
-    /// [`min_series_points`](AnalysisConfig::min_series_points) points.
+    /// [`MIN_SERIES_POINTS`](noise_gates::MIN_SERIES_POINTS) points.
     TooFewPoints,
     /// History mode: a blessing re-baselined the series and fewer than
-    /// [`min_series_points`](AnalysisConfig::min_series_points) points have been
+    /// [`MIN_SERIES_POINTS`](noise_gates::MIN_SERIES_POINTS) points have been
     /// measured since, so the evidence the blessing left standing is too thin to
     /// judge.
     TooFewPointsSinceBlessing,
@@ -457,7 +177,7 @@ pub enum UnjudgedReason {
     /// context state to compare against the base.
     NotMeasuredOnBranch,
     /// Branch mode: the recent base window holds fewer than
-    /// [`min_series_points`](AnalysisConfig::min_series_points) base-ref commit
+    /// [`MIN_SERIES_POINTS`](noise_gates::MIN_SERIES_POINTS) base-ref commit
     /// levels, so there is not enough base evidence to judge the branch. A later
     /// regime split may compare against a shorter trailing regime, but only after
     /// this full-window evidence floor is met.
@@ -902,13 +622,15 @@ pub(super) fn relative_delta_of(delta: f64, baseline: f64) -> f64 {
 /// nanosecond is not worth acting on, and a fraction of an allocation cannot happen.
 /// The floors differ because those units do. This gates the *move*; the scatter of
 /// the sample it is judged against is bounded separately (see [`scatter_floor`]).
-fn absolute_floor(kind: MetricKind, config: &AnalysisConfig) -> f64 {
+fn absolute_floor(kind: MetricKind) -> f64 {
     match kind {
         MetricKind::InstructionCount
         | MetricKind::ConditionalBranches
-        | MetricKind::IndirectBranches => config.practical_absolute_count,
-        MetricKind::WallTime | MetricKind::ProcessorTime => config.practical_absolute_time,
-        MetricKind::AllocatedBytes | MetricKind::AllocationCount => config.practical_absolute_alloc,
+        | MetricKind::IndirectBranches => noise_gates::PRACTICAL_ABSOLUTE_COUNT,
+        MetricKind::WallTime | MetricKind::ProcessorTime => noise_gates::PRACTICAL_ABSOLUTE_TIME,
+        MetricKind::AllocatedBytes | MetricKind::AllocationCount => {
+            noise_gates::PRACTICAL_ABSOLUTE_ALLOC
+        }
     }
 }
 
@@ -924,13 +646,13 @@ fn absolute_floor(kind: MetricKind, config: &AnalysisConfig) -> f64 {
 ///
 /// The match is exhaustive on purpose: a new metric kind must state its own
 /// quantum rather than inherit one.
-fn scatter_floor(kind: MetricKind, config: &AnalysisConfig) -> f64 {
+fn scatter_floor(kind: MetricKind) -> f64 {
     match kind {
         MetricKind::InstructionCount
         | MetricKind::ConditionalBranches
-        | MetricKind::IndirectBranches => config.scatter_floor_count,
-        MetricKind::WallTime | MetricKind::ProcessorTime => config.scatter_floor_time,
-        MetricKind::AllocatedBytes | MetricKind::AllocationCount => config.scatter_floor_alloc,
+        | MetricKind::IndirectBranches => noise_gates::SCATTER_FLOOR_COUNT,
+        MetricKind::WallTime | MetricKind::ProcessorTime => noise_gates::SCATTER_FLOOR_TIME,
+        MetricKind::AllocatedBytes | MetricKind::AllocationCount => noise_gates::SCATTER_FLOOR_ALLOC,
     }
 }
 
@@ -940,13 +662,8 @@ fn scatter_floor(kind: MetricKind, config: &AnalysisConfig) -> f64 {
 /// otherwise a move too small to mean anything would clear the relative floor and
 /// read as a regression on a small baseline. The gate composes with the relative
 /// floor by conjunction and can only *suppress*, never promote, a move.
-fn clears_absolute_floor(
-    series: &Series,
-    delta: f64,
-    config: &AnalysisConfig,
-    log: &mut StageLog<'_>,
-) -> bool {
-    let floor = absolute_floor(series.kind, config);
+fn clears_absolute_floor(series: &Series, delta: f64, log: &mut StageLog<'_>) -> bool {
+    let floor = absolute_floor(series.kind);
     log.numeric(
         Gate::AbsoluteFloor,
         delta.abs(),
@@ -1175,20 +892,15 @@ fn collect_scatter_residuals(sample: &[f64], residuals: &mut Vec<f64>) {
 }
 
 /// Whether `delta` stands clear of a series' own between-commit scatter: it must
-/// exceed `config.residual_noise_multiple` times the model's median absolute
-/// residual. A clean series has a near-zero residual, so any persistent move
-/// passes; a jittery one demands a move that stands out above its wobble. A missing
-/// residual (an empty model) is treated as no evidence of noise, so the move is
-/// trusted.
-fn exceeds_residual_noise(
-    delta: f64,
-    residual: Option<f64>,
-    config: &AnalysisConfig,
-    log: &mut StageLog<'_>,
-) -> bool {
+/// exceed [`RESIDUAL_NOISE_MULTIPLE`](noise_gates::RESIDUAL_NOISE_MULTIPLE) times the
+/// model's median absolute residual. A clean series has a near-zero residual, so any
+/// persistent move passes; a jittery one demands a move that stands out above its
+/// wobble. A missing residual (an empty model) is treated as no evidence of noise, so
+/// the move is trusted.
+fn exceeds_residual_noise(delta: f64, residual: Option<f64>, log: &mut StageLog<'_>) -> bool {
     match residual {
         Some(residual) => {
-            let band = config.residual_noise_multiple * residual;
+            let band = noise_gates::RESIDUAL_NOISE_MULTIPLE * residual;
             log.numeric(Gate::ResidualNoise, delta.abs(), band, delta.abs() > band)
         }
         None => true,
@@ -1285,7 +997,6 @@ fn arbitrate(
 fn evaluate_change_point(
     series: &Series,
     values: &[f64],
-    config: &AnalysisConfig,
     log: &mut GateLog,
 ) -> Option<Candidate> {
     let mut log = log.stage(GateStage::ChangePoint);
@@ -1304,8 +1015,8 @@ fn evaluate_change_point(
     if !log.numeric(
         Gate::MinRegime,
         count_to_f64(shortest),
-        count_to_f64(config.min_regime),
-        shortest >= config.min_regime,
+        count_to_f64(noise_gates::MIN_REGIME),
+        shortest >= noise_gates::MIN_REGIME,
     ) {
         return None;
     }
@@ -1325,29 +1036,29 @@ fn evaluate_change_point(
     if !log.numeric(
         Gate::Significance,
         mann_whitney,
-        config.change_alpha,
-        mann_whitney < config.change_alpha,
+        noise_gates::CHANGE_ALPHA,
+        mann_whitney < noise_gates::CHANGE_ALPHA,
     ) {
         return None;
     }
     if !log.numeric(
         Gate::RelativeFloor,
         relative_delta.abs(),
-        config.practical_relative,
-        relative_delta.abs() >= config.practical_relative,
+        noise_gates::PRACTICAL_RELATIVE,
+        relative_delta.abs() >= noise_gates::PRACTICAL_RELATIVE,
     ) {
         return None;
     }
-    if !clears_absolute_floor(series, delta, config, &mut log) {
+    if !clears_absolute_floor(series, delta, &mut log) {
         return None;
     }
-    if !exceeds_residual_noise(delta, step_model_residual(values, tau), config, &mut log) {
+    if !exceeds_residual_noise(delta, step_model_residual(values, tau), &mut log) {
         return None;
     }
     if !regimes_are_separated(
         mann_whitney_u,
         delta,
-        config.min_regime_separation,
+        noise_gates::MIN_REGIME_SEPARATION,
         &mut log,
     ) {
         return None;
@@ -1396,22 +1107,17 @@ fn evaluate_change_point(
 /// own absolute floor) and stand above the series'
 /// own residual scatter about the fitted line; where the engine reports confidence
 /// intervals it must additionally exceed a multiple of the per-measurement noise floor
-/// (`config.drift_noise_multiple` times the median half-width), so jitter does not read
-/// as a trend.
-fn evaluate_drift(
-    series: &Series,
-    values: &[f64],
-    config: &AnalysisConfig,
-    log: &mut GateLog,
-) -> Option<Candidate> {
+/// ([`DRIFT_NOISE_MULTIPLE`](noise_gates::DRIFT_NOISE_MULTIPLE) times the median
+/// half-width), so jitter does not read as a trend.
+fn evaluate_drift(series: &Series, values: &[f64], log: &mut GateLog) -> Option<Candidate> {
     let mut log = log.stage(GateStage::Drift);
     let points = &series.points;
     let n = points.len();
     if !log.numeric(
         Gate::MinSeriesPoints,
         count_to_f64(n),
-        count_to_f64(config.drift_min_points),
-        n >= config.drift_min_points,
+        count_to_f64(noise_gates::DRIFT_MIN_POINTS),
+        n >= noise_gates::DRIFT_MIN_POINTS,
     ) {
         return None;
     }
@@ -1420,8 +1126,8 @@ fn evaluate_drift(
     if !log.numeric(
         Gate::Significance,
         trend.p_value,
-        config.drift_alpha,
-        trend.p_value < config.drift_alpha,
+        noise_gates::DRIFT_ALPHA,
+        trend.p_value < noise_gates::DRIFT_ALPHA,
     ) {
         return None;
     }
@@ -1437,26 +1143,21 @@ fn evaluate_drift(
     if !log.numeric(
         Gate::RelativeFloor,
         relative_delta.abs(),
-        config.practical_relative,
-        relative_delta.abs() >= config.practical_relative,
+        noise_gates::PRACTICAL_RELATIVE,
+        relative_delta.abs() >= noise_gates::PRACTICAL_RELATIVE,
     ) {
         return None;
     }
-    if !clears_absolute_floor(series, delta, config, &mut log) {
+    if !clears_absolute_floor(series, delta, &mut log) {
         return None;
     }
-    if !exceeds_residual_noise(
-        delta,
-        line_model_residual(values, slope, intercept),
-        config,
-        &mut log,
-    ) {
+    if !exceeds_residual_noise(delta, line_model_residual(values, slope, intercept), &mut log) {
         return None;
     }
     // Where the engine reports dispersion, a trend must also clear the measurement
     // noise floor: the endpoints have to separate by more than the run-to-run
     // dispersion, or it is just jitter.
-    if !exceeds_noise_band(delta, points, config.drift_noise_multiple, &mut log) {
+    if !exceeds_noise_band(delta, points, noise_gates::DRIFT_NOISE_MULTIPLE, &mut log) {
         return None;
     }
 
@@ -1620,14 +1321,9 @@ fn commit_levels(points: &[&SeriesPoint]) -> Vec<f64> {
 ///
 /// A split whose trailing regime the prediction interval cannot characterise is not
 /// taken, so the window stays whole rather than becoming unjudgeable.
-fn current_base_regime_start(
-    series: &Series,
-    spans: &[CommitLevel],
-    config: &AnalysisConfig,
-    practical_floor: f64,
-) -> usize {
+fn current_base_regime_start(series: &Series, spans: &[CommitLevel]) -> usize {
     let levels: Vec<f64> = spans.iter().map(|span| span.level).collect();
-    let min_regime = config.min_regime.max(1);
+    let min_regime = noise_gates::MIN_REGIME.max(1);
     let Some(min_window) = min_regime.checked_mul(2) else {
         return 0;
     };
@@ -1646,7 +1342,7 @@ fn current_base_regime_start(
         let Some(split) = start.checked_add(change.index) else {
             continue;
         };
-        if base_regime_split_qualifies(series, suffix, change.index, config, practical_floor) {
+        if base_regime_split_qualifies(series, suffix, change.index) {
             latest_split = Some(latest_split.map_or(split, |latest| latest.max(split)));
         }
     }
@@ -1672,13 +1368,7 @@ fn current_base_regime_start(
 /// searching for the newest qualifying boundary, so its decisions describe the search
 /// rather than the verdict on the series, and recording them would bury the branch
 /// comparison's own gates under hundreds of rejected candidates.
-fn base_regime_split_qualifies(
-    series: &Series,
-    levels: &[f64],
-    split: usize,
-    config: &AnalysisConfig,
-    practical_floor: f64,
-) -> bool {
+fn base_regime_split_qualifies(series: &Series, levels: &[f64], split: usize) -> bool {
     let mut unobserved = GateLog::disabled();
     let mut log = unobserved.stage(GateStage::Branch);
     let Some(before) = levels.get(..split) else {
@@ -1687,11 +1377,11 @@ fn base_regime_split_qualifies(
     let Some(after) = levels.get(split..) else {
         return false;
     };
-    let min_regime = config.min_regime.max(1);
+    let min_regime = noise_gates::MIN_REGIME.max(1);
     if before.len() < min_regime || after.len() < min_regime {
         return false;
     }
-    if !regime_supports_prediction(series, after, config) {
+    if !regime_supports_prediction(series, after) {
         return false;
     }
     let Some(baseline) = stats::median(before) else {
@@ -1704,21 +1394,21 @@ fn base_regime_split_qualifies(
     if delta.abs() <= 0.0 {
         return false;
     }
-    if relative_delta_of(delta, baseline).abs() < practical_floor {
+    if relative_delta_of(delta, baseline).abs() < noise_gates::BRANCH_PRACTICAL_RELATIVE {
         return false;
     }
-    if !clears_absolute_floor(series, delta, config, &mut log) {
+    if !clears_absolute_floor(series, delta, &mut log) {
         return false;
     }
     let mann_whitney_u = stats::MannWhitneyU::new(before, after);
     let mann_whitney = mann_whitney_u.map_or(1.0, |ranked| ranked.two_sided_p_value());
-    if mann_whitney >= config.change_alpha {
+    if mann_whitney >= noise_gates::CHANGE_ALPHA {
         return false;
     }
     regimes_are_separated(
         mann_whitney_u,
         delta,
-        config.min_base_split_separation,
+        noise_gates::MIN_BASE_SPLIT_SEPARATION,
         &mut log,
     )
 }
@@ -1731,8 +1421,8 @@ fn base_regime_split_qualifies(
 /// verdict at all, so narrowing onto it would trade a comparison the full window can
 /// still make for silence. Narrowing exists to move the comparison onto the current
 /// level, not to withdraw it.
-fn regime_supports_prediction(series: &Series, levels: &[f64], config: &AnalysisConfig) -> bool {
-    if scatter_floor(series.kind, config) > 0.0 {
+fn regime_supports_prediction(series: &Series, levels: &[f64]) -> bool {
+    if scatter_floor(series.kind) > 0.0 {
         return true;
     }
     stats::sample_std_dev(levels).is_some_and(|scatter| scatter > 0.0)
@@ -1806,18 +1496,17 @@ fn prediction_interval_p(base: &[f64], latest: f64, scatter_floor: f64) -> Optio
 /// [`prediction_interval_p`] measures against, so the magnitude the finding reports
 /// is the one its p-value describes.
 ///
-/// The relative move must clear `practical_floor` and the metric's absolute floor,
-/// stand above the comparison sample's own residual scatter, and then be significant as
-/// a Student-t prediction interval. Where the engine reports per-point confidence
-/// intervals the base sample and context measurement must also clear their combined
-/// measurement noise band — an extra veto that can only *suppress* a candidate the
-/// other gates would have reported, never turn a non-finding into a finding.
+/// The relative move must clear [`BRANCH_PRACTICAL_RELATIVE`](noise_gates::BRANCH_PRACTICAL_RELATIVE)
+/// and the metric's absolute floor, stand above the comparison sample's own residual
+/// scatter, and then be significant as a Student-t prediction interval. Where the engine
+/// reports per-point confidence intervals the base sample and context measurement must
+/// also clear their combined measurement noise band — an extra veto that can only
+/// *suppress* a candidate the other gates would have reported, never turn a non-finding
+/// into a finding.
 fn compare_branch_levels(
     series: &Series,
     before: &[BaseLevel],
     after: &[&SeriesPoint],
-    config: &AnalysisConfig,
-    practical_floor: f64,
     commit: Option<String>,
     log: &mut GateLog,
 ) -> Option<Candidate> {
@@ -1832,7 +1521,7 @@ fn compare_branch_levels(
     }
     let relative_delta = relative_delta_of(delta, baseline);
 
-    let min_regime = config.min_regime.max(1);
+    let min_regime = noise_gates::MIN_REGIME.max(1);
     if !log.numeric(
         Gate::MinRegime,
         count_to_f64(before_values.len()),
@@ -1844,24 +1533,22 @@ fn compare_branch_levels(
     if !log.numeric(
         Gate::RelativeFloor,
         relative_delta.abs(),
-        practical_floor,
-        relative_delta.abs() >= practical_floor,
+        noise_gates::BRANCH_PRACTICAL_RELATIVE,
+        relative_delta.abs() >= noise_gates::BRANCH_PRACTICAL_RELATIVE,
     ) {
         return None;
     }
-    if !clears_absolute_floor(series, delta, config, &mut log) {
+    if !clears_absolute_floor(series, delta, &mut log) {
         return None;
     }
     if !exceeds_residual_noise(
         delta,
         sample_step_residual(&before_values, &after_values),
-        config,
         &mut log,
     ) {
         return None;
     }
-    let interval_p =
-        prediction_interval_p(&before_values, latest, scatter_floor(series.kind, config));
+    let interval_p = prediction_interval_p(&before_values, latest, scatter_floor(series.kind));
     if !log.boolean(Gate::BaseScatter, interval_p.is_some()) {
         return None;
     }
@@ -1869,8 +1556,8 @@ fn compare_branch_levels(
     if !log.numeric(
         Gate::Significance,
         effective_p,
-        config.change_alpha,
-        effective_p < config.change_alpha,
+        noise_gates::CHANGE_ALPHA,
+        effective_p < noise_gates::CHANGE_ALPHA,
     ) {
         return None;
     }
@@ -1879,7 +1566,13 @@ fn compare_branch_levels(
     }
     // Where per-point confidence intervals exist, require the move to also clear the
     // measurement noise band — a veto that can only suppress this candidate.
-    if !exceeds_branch_noise_band(delta, before, after, config.branch_noise_multiple, &mut log) {
+    if !exceeds_branch_noise_band(
+        delta,
+        before,
+        after,
+        noise_gates::BRANCH_NOISE_MULTIPLE,
+        &mut log,
+    ) {
         return None;
     }
 
@@ -1916,22 +1609,11 @@ fn compare_samples(
     series: &Series,
     before: &[&SeriesPoint],
     after: &[&SeriesPoint],
-    config: &AnalysisConfig,
-    practical_floor: f64,
-    _comparison_base_index: Option<usize>,
     log: &mut GateLog,
 ) -> Option<Candidate> {
     let before_levels = test_base_levels(before);
     let commit = after.last().and_then(|point| owned_commit(point));
-    compare_branch_levels(
-        series,
-        &before_levels,
-        after,
-        config,
-        practical_floor,
-        commit,
-        log,
-    )
+    compare_branch_levels(series, &before_levels, after, commit, log)
 }
 
 #[cfg(test)]
@@ -1972,7 +1654,6 @@ fn test_base_levels(points: &[&SeriesPoint]) -> Vec<BaseLevel> {
 /// scatter together onto the base level the context would merge into.
 fn evaluate_branch(
     series: &Series,
-    config: &AnalysisConfig,
     context_index: usize,
     log: &mut GateLog,
     discarded: &mut Vec<DiscardedReading>,
@@ -1990,8 +1671,8 @@ fn evaluate_branch(
     if !log.stage(GateStage::Branch).numeric(
         Gate::MinBaseCommits,
         count_to_f64(recorded_levels),
-        count_to_f64(config.min_series_points),
-        recorded_levels >= config.min_series_points,
+        count_to_f64(noise_gates::MIN_SERIES_POINTS),
+        recorded_levels >= noise_gates::MIN_SERIES_POINTS,
     ) {
         return None;
     }
@@ -2006,17 +1687,11 @@ fn evaluate_branch(
     // sample and no allocation on the analysis path. Ref: docs/performance.md, no allocation
     // on the hot path.
     let context_level = latest_points.first().map(|point| point.value);
-    let (base_window, removed) =
-        excursions::cleaned_window(&series.base_window, context_level, config);
+    let (base_window, removed) = excursions::cleaned_window(&series.base_window, context_level);
     discarded.extend(removed);
     let levels: Vec<f64> = base_window.iter().map(|level| level.value).collect();
     let base_spans = level_spans(&levels);
-    let comparison_start = current_base_regime_start(
-        series,
-        &base_spans,
-        config,
-        config.branch_practical_relative,
-    );
+    let comparison_start = current_base_regime_start(series, &base_spans);
     let comparison_base = base_window.get(comparison_start..).unwrap_or_default();
     let commit = latest_points.last().and_then(|point| owned_commit(point));
     // The newest base-ref point in the selected comparison sample is this series'
@@ -2024,15 +1699,8 @@ fn evaluate_branch(
     // newest point, so lag classification still measures freshness against the base
     // state the context would merge into.
     let comparison_base_index = comparison_base.last().map(|level| level.topo_index);
-    let mut candidate = compare_branch_levels(
-        series,
-        comparison_base,
-        &latest_points,
-        config,
-        config.branch_practical_relative,
-        commit,
-        log,
-    )?;
+    let mut candidate =
+        compare_branch_levels(series, comparison_base, &latest_points, commit, log)?;
     candidate.finding.comparison_base_index = comparison_base_index;
     Some(candidate)
 }
@@ -2113,9 +1781,9 @@ pub fn find_changes(series: &[Series], context: &AnalysisContext) -> Detection {
 /// [`testability`]) is never evaluated and is accounted for in the returned
 /// [`SeriesCensus`] instead.
 /// Surviving candidates are screened to the directions the mode reports and then pass
-/// a Benjamini–Hochberg false-discovery filter at `config.fdr_q`, so every reported
-/// finding is one the correction rejected. Findings are ordered by descending relative
-/// move, then method, then a stable identity tie-break.
+/// a Benjamini–Hochberg false-discovery filter at [`FDR_Q`](noise_gates::FDR_Q), so
+/// every reported finding is one the correction rejected. Findings are ordered by
+/// descending relative move, then method, then a stable identity tie-break.
 ///
 /// Detection is per-series independent, so the series are split into one balanced
 /// contiguous chunk per worker and each chunk runs on its own blocking task via
@@ -2151,13 +1819,12 @@ pub async fn find_changes_spawned(
 /// [`Judged`](Testability::Judged).
 #[must_use]
 pub fn testability(series: &Series, context: &AnalysisContext) -> Testability {
-    let config = &context.config;
     match context.mode {
         AnalysisMode::History => {
             // The detectors run on the post-blessing window (see `active_view`), so
             // that window's length — not the whole series' — is the evidence.
             let active_points = series.points.len().saturating_sub(series.active_start);
-            if active_points >= config.min_series_points {
+            if active_points >= noise_gates::MIN_SERIES_POINTS {
                 Testability::Judged
             } else if series.active_start > 0 {
                 Testability::Unjudged(UnjudgedReason::TooFewPointsSinceBlessing)
@@ -2175,8 +1842,8 @@ pub fn testability(series: &Series, context: &AnalysisContext) -> Testability {
             // `min_regime`-sized trailing regime after an accepted base-side shift. That
             // does not make this census reason untruthful, because the evidence floor was
             // met before any of it was discarded.
-            let base_points = series.base_window.len().min(config.compare_window);
-            if base_points < config.min_series_points {
+            let base_points = series.base_window.len().min(noise_gates::COMPARE_WINDOW);
+            if base_points < noise_gates::MIN_SERIES_POINTS {
                 return Testability::Unjudged(UnjudgedReason::TooFewBaseCommits);
             }
             Testability::Judged
@@ -2198,8 +1865,6 @@ fn finalize_findings(
     series: &[Series],
     context: &AnalysisContext,
 ) -> Vec<Finding> {
-    let config = &context.config;
-
     // Screen to the directions this mode reports *before* the correction, so that every
     // hypothesis the correction rejects is a finding the report goes on to show.
     // Correcting over both directions and discarding one afterwards would attach the
@@ -2223,7 +1888,7 @@ fn finalize_findings(
     // what the census counted as judged.
     let family_size = census.judged();
     let candidate_p: Vec<f64> = candidates.iter().map(|candidate| candidate.bh_p).collect();
-    let keep = stats::benjamini_hochberg(&candidate_p, config.fdr_q, family_size);
+    let keep = stats::benjamini_hochberg(&candidate_p, noise_gates::FDR_Q, family_size);
     let mut keep_iter = keep.into_iter();
 
     // `candidates` and `candidate_p` were built in the same order, so advancing
@@ -2369,15 +2034,14 @@ fn detect_one(
     log: &mut GateLog,
     discarded: &mut Vec<DiscardedBaseReading>,
 ) -> Option<Candidate> {
-    let config = &context.config;
     let candidate = match context.mode {
         AnalysisMode::History => {
             let active = active_view(one);
             // The point values are projected once here and shared by every history
             // detector, rather than each rebuilding the same `Vec<f64>`.
             let values: Vec<f64> = active.points.iter().map(|point| point.value).collect();
-            let change = evaluate_change_point(&active, &values, config, log);
-            let drift = evaluate_drift(&active, &values, config, log);
+            let change = evaluate_change_point(&active, &values, log);
+            let drift = evaluate_drift(&active, &values, log);
             arbitrate(&values, change, drift).map(|mut candidate| {
                 stamp_history(&mut candidate.finding, one);
                 candidate
@@ -2385,7 +2049,7 @@ fn detect_one(
         }
         AnalysisMode::Branch => {
             let mut readings = Vec::new();
-            let candidate = evaluate_branch(one, config, context.tip_index, log, &mut readings);
+            let candidate = evaluate_branch(one, context.tip_index, log, &mut readings);
             discarded.extend(readings.into_iter().map(|reading| DiscardedBaseReading {
                 set: one.set.clone(),
                 id: one.id.clone(),

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -2109,8 +2109,9 @@ mod tests {
     use super::*;
     use crate::detect::gate_log::GateOutcome;
     use crate::detect::noise_gates::{
-        COMPARE_WINDOW, DRIFT_MIN_POINTS, DRIFT_NOISE_MULTIPLE, MIN_REGIME, MIN_SERIES_POINTS,
-        PRACTICAL_ABSOLUTE_COUNT, PRACTICAL_RELATIVE, RESIDUAL_NOISE_MULTIPLE,
+        CHANGE_ALPHA, COMPARE_WINDOW, DRIFT_ALPHA, DRIFT_MIN_POINTS, DRIFT_NOISE_MULTIPLE,
+        EXCURSION_MAX_REMOVALS, FDR_Q, MIN_BASE_SPLIT_SEPARATION, MIN_REGIME, MIN_REGIME_SEPARATION,
+        MIN_SERIES_POINTS, PRACTICAL_ABSOLUTE_COUNT, PRACTICAL_RELATIVE, RESIDUAL_NOISE_MULTIPLE,
     };
     use crate::detect::recorded::{
         STATIONARY_BIMODAL_BASE, STATIONARY_BIMODAL_HIGH, STATIONARY_BIMODAL_NOISE,
@@ -2298,22 +2299,18 @@ mod tests {
 
     /// Runs the branch-mode detector for one fixture, using the fixture's newest
     /// topological point as the context commit.
-    fn evaluate_branch(
-        series: &Series,
-        config: &AnalysisConfig,
-        log: &mut GateLog,
-    ) -> Option<Candidate> {
+    fn evaluate_branch(series: &Series, log: &mut GateLog) -> Option<Candidate> {
         let context_index = max_topo_index(slice::from_ref(series));
         let mut discarded = Vec::new();
         if series.base_window.is_empty() {
             let mut series = series.clone();
             attach_test_base_windows(slice::from_mut(&mut series), context_index.checked_sub(1));
-            return super::evaluate_branch(&series, config, context_index, log, &mut discarded);
+            return super::evaluate_branch(&series, context_index, log, &mut discarded);
         }
-        super::evaluate_branch(series, config, context_index, log, &mut discarded)
+        super::evaluate_branch(series, context_index, log, &mut discarded)
     }
 
-    /// Runs the history-mode detector with default config.
+    /// Runs the history-mode detector under the fixed detection policy.
     fn changes(series: &[Series]) -> Vec<Finding> {
         find_changes(series, &history_context(series)).findings
     }
@@ -2322,7 +2319,6 @@ mod tests {
     fn history_context(series: &[Series]) -> AnalysisContext {
         AnalysisContext {
             mode: AnalysisMode::History,
-            config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: max_topo_index(series),
@@ -2375,7 +2371,6 @@ mod tests {
 
         let context = AnalysisContext {
             mode: AnalysisMode::History,
-            config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: max_topo_index(&series),
@@ -2542,16 +2537,15 @@ mod tests {
 
     #[test]
     fn exceeds_residual_noise_requires_the_move_to_clear_the_scatter_band() {
-        let config = AnalysisConfig::default();
         let mut unobserved = GateLog::disabled();
         let mut log = unobserved.stage(GateStage::ChangePoint);
         // A residual of 1.0 puts the band at 3x = 3.0. A move inside the band is
         // not clear of it, a move exactly at the band is still not (the comparison
         // is strict), a move above it is, and a missing residual trusts the move.
-        assert!(!exceeds_residual_noise(1.0, Some(1.0), &config, &mut log));
-        assert!(!exceeds_residual_noise(3.0, Some(1.0), &config, &mut log));
-        assert!(exceeds_residual_noise(3.5, Some(1.0), &config, &mut log));
-        assert!(exceeds_residual_noise(0.0, None, &config, &mut log));
+        assert!(!exceeds_residual_noise(1.0, Some(1.0), &mut log));
+        assert!(!exceeds_residual_noise(3.0, Some(1.0), &mut log));
+        assert!(exceeds_residual_noise(3.5, Some(1.0), &mut log));
+        assert!(exceeds_residual_noise(0.0, None, &mut log));
     }
 
     #[test]
@@ -2621,107 +2615,75 @@ mod tests {
     #[test]
     fn change_point_rejects_a_single_point_regime() {
         // Pettitt splits at tau=1, leaving a one-point before regime (below
-        // min_regime) against a full-size after regime. The size guard rejects when
-        // *either* regime is too small, so a `||`->`&&` slip would wrongly admit this
-        // lopsided split. A permissive rank-test threshold isolates the guard: only
-        // the size check keeps it out.
-        let config = AnalysisConfig {
-            change_alpha: 0.5,
-            ..AnalysisConfig::default()
-        };
+        // min_regime) against a full-size after regime. The size guard judges the
+        // *shorter* regime, so a `.min()`->`.max()` slip would read the full after
+        // regime and wrongly admit this lopsided split. The recorded chain names the
+        // persistence gate as the one that rejects it: it runs before significance and
+        // short-circuits, so the silence is unambiguously the size check's.
         let mut values = vec![100.0];
         values.extend(std::iter::repeat_n(130.0, MIN_REGIME));
         let series = series_of(&values);
-        assert!(
-            evaluate_change_point(
-                &series,
-                &values_of(&series),
-                &config,
-                &mut GateLog::disabled()
-            )
-            .is_none()
+        let mut log = GateLog::recording();
+        assert!(evaluate_change_point(&series, &values_of(&series), &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::ChangePoint),
+            Some(Gate::MinRegime),
         );
     }
 
     #[test]
     fn change_point_within_its_own_residual_scatter_is_suppressed() {
-        // A rank-significant step (medians 102 -> 132, delta 30) whose regimes each
-        // wobble by 2. Under the default residual multiple the move stands clear of
-        // that scatter and is flagged; a deliberately high multiple pushes the noise
-        // band above the move, so only the residual gate rejects it (every earlier
-        // gate — persistence, Mann–Whitney, practical floor — still passes).
-        let series = series_of(&[
+        // A rank-significant step whose regimes each wobble by 2 stands clear of that
+        // scatter under the fixed residual multiple, so it is flagged: medians 102 ->
+        // 132, a move of 30 against a residual band of 6.
+        let clear = series_of(&[
             100.0, 104.0, 100.0, 104.0, 102.0, 130.0, 134.0, 130.0, 134.0, 132.0,
         ]);
         assert!(
-            evaluate_change_point(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut GateLog::disabled()
-            )
-            .is_some()
+            evaluate_change_point(&clear, &values_of(&clear), &mut GateLog::disabled()).is_some()
         );
-        let config = AnalysisConfig {
-            residual_noise_multiple: 20.0,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            evaluate_change_point(
-                &series,
-                &values_of(&series),
-                &config,
-                &mut GateLog::disabled()
-            )
-            .is_none()
+
+        // The mirror: a cleanly separated step whose regimes wobble by 10 around
+        // medians only 30 apart. The move (30) does not exceed its residual band
+        // (RESIDUAL_NOISE_MULTIPLE x 10 = 30), so the residual gate suppresses it even
+        // though the regimes never interleave. The recorded chain attributes the
+        // silence to that gate, with every earlier gate (persistence, significance,
+        // practical floors) passing.
+        let buried = series_of(&[
+            90.0, 90.0, 100.0, 110.0, 110.0, 120.0, 120.0, 130.0, 140.0, 140.0,
+        ]);
+        let mut log = GateLog::recording();
+        assert!(evaluate_change_point(&buried, &values_of(&buried), &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::ChangePoint),
+            Some(Gate::ResidualNoise),
         );
     }
 
     #[test]
-    #[cfg_attr(
-        miri,
-        ignore = "asserts a strict `<` at the exact recorded p-value, which needs bit-identical \
-                  recomputation of the rank statistic; Miri's float nondeterminism perturbs it"
-    )]
-    fn change_point_significance_is_a_strict_boundary() {
-        // The rank-test gate is a strict `<`: a candidate whose p-value lands exactly on
-        // the threshold is rejected. Rather than hard-code that p, take it from the
-        // detector's own recording at the default alpha, then set alpha to it — so a
-        // `<`->`<=` slip that admits the boundary turns this reported step silent.
+    fn change_point_significance_is_measured_against_the_fixed_alpha() {
+        // The rank-test gate compares the Mann–Whitney p-value against the fixed
+        // CHANGE_ALPHA. A clean step reports, and its recorded p sits strictly below
+        // that alpha — so the gate's comparison and its direction are pinned without
+        // relying on a per-run alpha. (The `<`-vs-`<=` distinction at a p landing
+        // exactly on alpha is not reachable: the rank statistic's p-values are discrete
+        // and never equal 0.05, so the shipped policy never sees that boundary.)
         let series = series_of(&[
             100.0, 104.0, 100.0, 104.0, 102.0, 130.0, 134.0, 130.0, 134.0, 132.0,
         ]);
         let mut log = GateLog::recording();
         assert!(
-            evaluate_change_point(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut log
-            )
-            .is_some(),
-            "the fixture must report at the default alpha"
+            evaluate_change_point(&series, &values_of(&series), &mut log).is_some(),
+            "the fixture must report under the fixed alpha"
         );
-        let (p, _) = gate_value(&log, Gate::Significance).expect("the significance gate ran");
-        let at_boundary = AnalysisConfig {
-            change_alpha: p,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            evaluate_change_point(
-                &series,
-                &values_of(&series),
-                &at_boundary,
-                &mut GateLog::disabled()
-            )
-            .is_none(),
-            "a p-value exactly at alpha must be rejected by the strict gate"
-        );
+        let (p, alpha) = gate_value(&log, Gate::Significance).expect("the significance gate ran");
+        assert_eq!(alpha, CHANGE_ALPHA, "the gate compares against the fixed alpha");
+        assert!(p < CHANGE_ALPHA, "the reported step's p sits below alpha: {p}");
     }
 
     #[test]
     fn regimes_are_separated_rejects_interleaved_levels() {
-        let floor = AnalysisConfig::default().min_regime_separation;
+        let floor = MIN_REGIME_SEPARATION;
         let mut unobserved = GateLog::disabled();
         let mut log = unobserved.stage(GateStage::ChangePoint);
         // A clean rise: every after-point exceeds every before-point (superiority 1).
@@ -2768,7 +2730,6 @@ mod tests {
         // One overlapping split, judged against both floors: the reporting floor admits
         // it and the stricter base-split floor rejects it. This is what makes the two
         // floors distinct policies rather than one constant read from two places.
-        let config = AnalysisConfig::default();
         let mut unobserved = GateLog::disabled();
         let mut log = unobserved.stage(GateStage::Branch);
         // Seven before-levels against five after-levels, with one before-level lying
@@ -2780,13 +2741,13 @@ mod tests {
         assert!(regimes_are_separated(
             ranked,
             -20.0,
-            config.min_regime_separation,
+            MIN_REGIME_SEPARATION,
             &mut log,
         ));
         assert!(regimes_are_separated(
             ranked,
             -20.0,
-            config.min_base_split_separation,
+            MIN_BASE_SPLIT_SEPARATION,
             &mut log,
         ));
 
@@ -2797,13 +2758,13 @@ mod tests {
         assert!(regimes_are_separated(
             ranked,
             -20.0,
-            config.min_regime_separation,
+            MIN_REGIME_SEPARATION,
             &mut log,
         ));
         assert!(!regimes_are_separated(
             ranked,
             -20.0,
-            config.min_base_split_separation,
+            MIN_BASE_SPLIT_SEPARATION,
             &mut log,
         ));
     }
@@ -2816,26 +2777,16 @@ mod tests {
         // dominant mode, collapsing the median-absolute residual so the residual gate
         // is fooled and (before this gate) a spurious "regression via change point"
         // was emitted. The regimes overlap heavily (probability of superiority ~0.72),
-        // so the separation gate rejects it. Dropping the separation floor to zero
-        // admits the split again, proving that gate is the sole reason it is silent.
+        // so the separation gate rejects it — and the recorded chain attributes the
+        // silence to exactly that gate: every earlier gate passes and RegimeSeparation
+        // is the first to decline.
         let values = STATIONARY_BIMODAL_NOISE.to_vec();
         let series = series_of(&values);
-        let permissive = AnalysisConfig {
-            min_regime_separation: 0.0,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            evaluate_change_point(&series, &values, &permissive, &mut GateLog::disabled())
-                .is_some()
-        );
-        assert!(
-            evaluate_change_point(
-                &series,
-                &values,
-                &AnalysisConfig::default(),
-                &mut GateLog::disabled()
-            )
-            .is_none()
+        let mut log = GateLog::recording();
+        assert!(evaluate_change_point(&series, &values, &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::ChangePoint),
+            Some(Gate::RegimeSeparation),
         );
     }
 
@@ -2915,22 +2866,16 @@ mod tests {
         // smaller floor rather than an exemption. This sub-nanosecond wall-time move
         // clears the relative floor, separates cleanly and carries disjoint
         // intervals, yet 0.63 ns of movement is below the resolution any wall-clock
-        // measurement can be trusted at, so it stays silent. Zeroing that one floor
-        // admits it again, proving the floor is the sole reason for the silence.
+        // measurement can be trusted at, so it stays silent — and the recorded chain
+        // attributes that silence to the absolute floor: every other gate passes and
+        // AbsoluteFloor is the first to decline.
         let series = wall_series(&step_values(2.49, 3.12), 0.05);
         judged_but_silent(slice::from_ref(&series));
-        let permissive = AnalysisConfig {
-            practical_absolute_time: 0.0,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            evaluate_change_point(
-                &series,
-                &values_of(&series),
-                &permissive,
-                &mut GateLog::disabled()
-            )
-            .is_some()
+        let mut log = GateLog::recording();
+        assert!(evaluate_change_point(&series, &values_of(&series), &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::ChangePoint),
+            Some(Gate::AbsoluteFloor),
         );
     }
 
@@ -3080,29 +3025,22 @@ mod tests {
     #[test]
     fn noisy_step_exactly_at_the_practical_floor_is_reported() {
         // The practical-magnitude floor is a strict `<` rejection, so a step whose
-        // relative move EQUALS the floor must still be reported. Pin the floor to
-        // exactly this series' relative delta (30/100) to exercise that boundary: a
-        // `<=` slip would suppress an at-floor regression.
+        // relative move EQUALS the fixed floor must still be reported — even on a noisy
+        // metric that carries confidence intervals. A wall-time step of 100 -> 103 is
+        // exactly PRACTICAL_RELATIVE (3%), and a `<=` slip would suppress this at-floor
+        // regression.
         let series = wall_series(
             &[
-                98.0, 100.0, 102.0, 99.0, 101.0, 128.0, 130.0, 132.0, 129.0, 131.0,
+                100.0, 100.0, 100.0, 100.0, 100.0, 103.0, 103.0, 103.0, 103.0, 103.0,
             ],
-            2.0,
+            0.5,
         );
-        let config = AnalysisConfig {
-            practical_relative: 30.0_f64 / 100.0,
-            ..AnalysisConfig::default()
-        };
-        let candidate = evaluate_change_point(
-            &series,
-            &values_of(&series),
-            &config,
-            &mut GateLog::disabled(),
-        )
-        .unwrap();
+        let candidate =
+            evaluate_change_point(&series, &values_of(&series), &mut GateLog::disabled())
+                .unwrap();
         assert_eq!(candidate.finding.baseline, 100.0);
-        assert_eq!(candidate.finding.latest, 130.0);
-        assert_eq!(candidate.finding.relative_delta, config.practical_relative);
+        assert_eq!(candidate.finding.latest, 103.0);
+        assert_eq!(candidate.finding.relative_delta, PRACTICAL_RELATIVE);
     }
 
     #[test]
@@ -3267,7 +3205,7 @@ mod tests {
         placed_series_of_kind(points, MetricKind::InstructionCount)
     }
 
-    /// Runs the branch-mode detector with default config and the given merge-base.
+    /// Runs the branch-mode detector for the given merge-base.
     fn branch_changes(series: &[Series], merge_base_index: Option<usize>) -> Vec<Finding> {
         let mut series = series.to_vec();
         attach_test_base_windows(&mut series, merge_base_index);
@@ -3278,7 +3216,6 @@ mod tests {
     fn branch_context(series: &[Series], merge_base_index: Option<usize>) -> AnalysisContext {
         AnalysisContext {
             mode: AnalysisMode::Branch,
-            config: AnalysisConfig::default(),
             merge_base_index,
             base_ref_index: merge_base_index,
             tip_index: max_topo_index(series),
@@ -3290,14 +3227,13 @@ mod tests {
         let Some(merge_base_index) = merge_base_index else {
             return;
         };
-        let config = AnalysisConfig::default();
         for one in series {
             let base: Vec<&SeriesPoint> = one
                 .points
                 .iter()
                 .filter(|point| !point.dirty && point.topo_index <= merge_base_index)
                 .collect();
-            let base = recent_commits(&base, config.compare_window);
+            let base = recent_commits(&base, COMPARE_WINDOW);
             one.base_window = test_base_levels(&base);
         }
     }
@@ -3360,8 +3296,7 @@ mod tests {
         );
         let levels: Vec<f64> = series.base_window.iter().map(|level| level.value).collect();
         let spans = level_spans(&levels);
-        let config = AnalysisConfig::default();
-        current_base_regime_start(&series, &spans, &config, config.branch_practical_relative)
+        current_base_regime_start(&series, &spans)
     }
 
     /// A base-branch run of [`MIN_SERIES_POINTS`] commits whose levels alternate
@@ -3432,22 +3367,15 @@ mod tests {
         // A quantized context run 4 counts above a small base (60 -> 64) clears the 5%
         // branch relative floor (6.7%) and the residual gate, but not the absolute
         // floor of 5, so it is suppressed. Without the gate this single-quantum-scale
-        // move would flag on the pull request. Dropping the floor far below the move
-        // admits it again, so the floor is the sole reason for the silence.
+        // move would flag on the pull request. The recorded chain attributes the
+        // silence to the absolute floor, with every earlier gate passing.
         let series = branch_over_base(60.0, 64.0, 3);
-        assert!(
-            evaluate_branch(
-                &series,
-                &AnalysisConfig::default(),
-                &mut GateLog::disabled()
-            )
-            .is_none()
+        let mut log = GateLog::recording();
+        assert!(evaluate_branch(&series, &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::Branch),
+            Some(Gate::AbsoluteFloor),
         );
-        let permissive = AnalysisConfig {
-            practical_absolute_count: 0.1,
-            ..AnalysisConfig::default()
-        };
-        assert!(evaluate_branch(&series, &permissive, &mut GateLog::disabled()).is_some());
     }
 
     #[test]
@@ -3455,21 +3383,15 @@ mod tests {
         // A count moves in whole units, so a base window can repeat one integer and
         // have a sample standard deviation of exactly zero. The metric's quantum — one
         // count — stands in for that missing scatter, which is the only reason a
-        // verdict can be formed at all: with the quantum set to zero the standard
-        // error collapses and the same unmistakable 30-count move yields nothing.
-        let config = AnalysisConfig::default();
+        // verdict can be formed at all: the floored quantum gives the flat base a usable
+        // standard error, so the same unmistakable 30-count move is reported.
         assert_eq!(
             stats::sample_std_dev(&[100.0; MIN_SERIES_POINTS]),
             Some(0.0),
             "the base window must be perfectly flat for this to test the floor"
         );
         let series = branch_over_base(100.0, 130.0, 1);
-        assert!(evaluate_branch(&series, &config, &mut GateLog::disabled()).is_some());
-        let without_quantum = AnalysisConfig {
-            scatter_floor_count: 0.0,
-            ..config
-        };
-        assert!(evaluate_branch(&series, &without_quantum, &mut GateLog::disabled()).is_none());
+        assert!(evaluate_branch(&series, &mut GateLog::disabled()).is_some());
     }
 
     #[test]
@@ -3479,21 +3401,14 @@ mod tests {
         // one-byte quantum keeps the move judgeable. It is a full-scale move against a
         // zero baseline, 48 bytes clears the one-byte absolute floor, and the floored
         // scatter puts the context run 45.8 standard errors out
-        // (48 / (1 * sqrt(1 + 1/10))), so it is reported decisively. Removing the
-        // quantum silences it, which is exactly the regression shape this floor exists
-        // for.
+        // (48 / (1 * sqrt(1 + 1/10))), so it is reported decisively — exactly the
+        // regression shape this floor exists for.
         let series = branch_over_base_of_kind(0.0, 48.0, 1, MetricKind::AllocatedBytes);
-        let config = AnalysisConfig::default();
-        let candidate = evaluate_branch(&series, &config, &mut GateLog::disabled())
+        let candidate = evaluate_branch(&series, &mut GateLog::disabled())
             .expect("48 bytes is a move");
         assert_eq!(candidate.finding.direction, Direction::Regression);
         assert_eq!(candidate.finding.latest, 48.0);
-        assert!(candidate.bh_p < config.change_alpha, "{}", candidate.bh_p);
-        let without_quantum = AnalysisConfig {
-            scatter_floor_alloc: 0.0,
-            ..config
-        };
-        assert!(evaluate_branch(&series, &without_quantum, &mut GateLog::disabled()).is_none());
+        assert!(candidate.bh_p < CHANGE_ALPHA, "{}", candidate.bh_p);
     }
 
     #[test]
@@ -3503,16 +3418,21 @@ mod tests {
         // leaves nothing to place the context run against and the standard error is
         // degenerate. A doubling from 20 ns to 40 ns clears every floor and is still not
         // reported: the degenerate case fails silent rather than manufacturing
-        // certainty. The same move against a base that does scatter is reported, so the
-        // flat base is the sole reason for the silence.
+        // certainty, and the recorded chain attributes that silence to the base-scatter
+        // gate. The same move against a base that does scatter is reported, so the flat
+        // base is the sole reason for the silence.
         let flat = branch_over_base_of_kind(20.0, 40.0, 1, MetricKind::WallTime);
-        let config = AnalysisConfig::default();
-        assert!(evaluate_branch(&flat, &config, &mut GateLog::disabled()).is_none());
+        let mut log = GateLog::recording();
+        assert!(evaluate_branch(&flat, &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::Branch),
+            Some(Gate::BaseScatter),
+        );
 
         let mut points = wobbling_base_run(20.0, 0.2);
         points.push((MIN_SERIES_POINTS, 40.0, false));
         let scattering = placed_series_of_kind(&points, MetricKind::WallTime);
-        assert!(evaluate_branch(&scattering, &config, &mut GateLog::disabled()).is_some());
+        assert!(evaluate_branch(&scattering, &mut GateLog::disabled()).is_some());
     }
 
     #[test]
@@ -3521,43 +3441,34 @@ mod tests {
         // That is a 25% move on a base scattering by only 0.05 ns, so every statistical
         // gate passes decisively (the context run sits 11.4 standard errors out) — yet
         // the move itself spans 0.63 ns, under the one-nanosecond floor below which a
-        // timing move is not worth acting on, so nothing is reported. Lowering that
-        // floor admits it, which pins the absolute floor as the sole reason for the
-        // silence.
+        // timing move is not worth acting on, so nothing is reported. The recorded chain
+        // pins the absolute floor as the sole reason for the silence.
         let mut points = wobbling_base_run(2.49, 0.05);
         points.push((MIN_SERIES_POINTS, 3.12, false));
         let series = placed_series_of_kind(&points, MetricKind::WallTime);
-        let config = AnalysisConfig::default();
-        assert!(evaluate_branch(&series, &config, &mut GateLog::disabled()).is_none());
-        let permissive = AnalysisConfig {
-            practical_absolute_time: 0.1,
-            ..config
-        };
-        assert!(evaluate_branch(&series, &permissive, &mut GateLog::disabled()).is_some());
+        let mut log = GateLog::recording();
+        assert!(evaluate_branch(&series, &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::Branch),
+            Some(Gate::AbsoluteFloor),
+        );
     }
 
     #[test]
-    fn branch_mode_reports_a_small_timing_regression_a_one_nanosecond_scatter_floor_would_hide() {
+    fn branch_mode_reports_a_small_timing_regression_on_a_quiet_base() {
         // A 20 ns benchmark whose base scatters by 0.2 ns from commit to commit,
         // regressing by 8% (1.6 ns). Against its own scatter the context run sits 7.2
         // standard errors out (1.6 / (0.2108 * sqrt(1 + 1/10))) and the move clears the
-        // one-nanosecond absolute floor, so it is reported. Flooring the scatter at that
-        // same nanosecond instead would put the context run only 1.5 standard errors out
-        // — p = 0.16, comfortably inside the interval — and hide the regression entirely,
-        // which is what makes the quantum and the magnitude floor separate quantities.
+        // one-nanosecond absolute floor, so it is reported. Timing scatter is left
+        // unfloored (SCATTER_FLOOR_TIME is zero) precisely so a quiet base keeps this
+        // sensitivity rather than having its standard error inflated to a nanosecond.
         let mut points = wobbling_base_run(20.0, 0.2);
         points.push((MIN_SERIES_POINTS, 21.6, false));
         let series = placed_series_of_kind(&points, MetricKind::WallTime);
-        let config = AnalysisConfig::default();
-        let candidate = evaluate_branch(&series, &config, &mut GateLog::disabled())
+        let candidate = evaluate_branch(&series, &mut GateLog::disabled())
             .expect("an 8% move on a quiet base is detectable");
         assert_eq!(candidate.finding.direction, Direction::Regression);
-        assert!(candidate.bh_p < config.change_alpha, "{}", candidate.bh_p);
-        let floored = AnalysisConfig {
-            scatter_floor_time: config.practical_absolute_time,
-            ..config
-        };
-        assert!(evaluate_branch(&series, &floored, &mut GateLog::disabled()).is_none());
+        assert!(candidate.bh_p < CHANGE_ALPHA, "{}", candidate.bh_p);
     }
 
     #[test]
@@ -3581,12 +3492,8 @@ mod tests {
         assert_eq!(stats::mean(&levels), Some(104.0));
         assert_eq!(stats::median(&levels), Some(100.0));
 
-        let candidate = evaluate_branch(
-            &series,
-            &AnalysisConfig::default(),
-            &mut GateLog::disabled(),
-        )
-        .expect("a doubling against a settled base is a finding");
+        let candidate = evaluate_branch(&series, &mut GateLog::disabled())
+            .expect("a doubling against a settled base is a finding");
         assert_eq!(candidate.finding.baseline, 104.0);
         assert_eq!(candidate.finding.delta, 96.0);
         assert_eq!(candidate.finding.relative_delta, 96.0 / 104.0);
@@ -3626,7 +3533,7 @@ mod tests {
         let series = wall_branch_series_with_intervals(130.0, 20.0, 20.0);
         let mut log = GateLog::recording();
 
-        assert!(evaluate_branch(&series, &AnalysisConfig::default(), &mut log).is_none());
+        assert!(evaluate_branch(&series, &mut log).is_none());
         assert_eq!(
             log.declined_by_stage(GateStage::Branch),
             Some(Gate::IntervalDisjoint)
@@ -3638,7 +3545,7 @@ mod tests {
         let series = wall_branch_series_with_intervals(130.0, 20.0, 0.1);
         let mut log = GateLog::recording();
 
-        assert!(evaluate_branch(&series, &AnalysisConfig::default(), &mut log).is_none());
+        assert!(evaluate_branch(&series, &mut log).is_none());
         assert_eq!(
             log.declined_by_stage(GateStage::Branch),
             Some(Gate::IntervalNoiseBand)
@@ -3762,7 +3669,6 @@ mod tests {
         let series = series_of(&step_values(100.0, 130.0));
         let context = AnalysisContext {
             mode: AnalysisMode::History,
-            config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 20,
@@ -3914,32 +3820,13 @@ mod tests {
             .collect()
     }
 
-    /// Compares the `before` and `after` samples on a wall-time (noisy) series,
-    /// passing `floor` as the practical relative floor and `config` as the analysis
-    /// configuration.
-    fn compare_with(
-        before: &[SeriesPoint],
-        after: &[SeriesPoint],
-        floor: f64,
-        config: &AnalysisConfig,
-    ) -> Option<Candidate> {
+    /// Compares the `before` and `after` samples on a wall-time (noisy) series under
+    /// the fixed branch-mode policy.
+    fn compare(before: &[SeriesPoint], after: &[SeriesPoint]) -> Option<Candidate> {
         let series = wall_series(&[100.0], 1.0);
         let before_refs: Vec<&SeriesPoint> = before.iter().collect();
         let after_refs: Vec<&SeriesPoint> = after.iter().collect();
-        compare_samples(
-            &series,
-            &before_refs,
-            &after_refs,
-            config,
-            floor,
-            None,
-            &mut GateLog::disabled(),
-        )
-    }
-
-    /// Compares the `before` and `after` samples with the default configuration.
-    fn compare(before: &[SeriesPoint], after: &[SeriesPoint], floor: f64) -> Option<Candidate> {
-        compare_with(before, after, floor, &AnalysisConfig::default())
+        compare_samples(&series, &before_refs, &after_refs, &mut GateLog::disabled())
     }
 
     /// The amount a fixture base window wobbles around its level from commit to
@@ -3980,25 +3867,20 @@ mod tests {
 
     #[test]
     fn compare_samples_at_the_practical_floor_is_not_suppressed() {
-        // The relative move (0.03) is exactly the floor: the `relative < floor` gate
-        // must be a strict `<` (a `<=`/`==` mutant would suppress it). The move then
-        // clears the noise floor (delta 3 > 2 * 0.5) and the prediction interval.
+        // The relative move (5%) is exactly BRANCH_PRACTICAL_RELATIVE, the floor branch
+        // mode holds moves to: the `relative < floor` gate must be a strict `<` (a
+        // `<=`/`==` mutant would suppress it). The move then clears the residual band and
+        // the prediction interval, so it is reported.
         let before = base_window(100.0, 0.5);
-        let after = pts(&[(103.0, 0.5)]);
-        assert!(compare(&before, &after, 3.0 / 100.0).is_some());
+        let after = pts(&[(105.0, 0.5)]);
+        assert!(compare(&before, &after).is_some());
     }
 
     #[test]
-    #[cfg_attr(
-        miri,
-        ignore = "asserts a strict `<` at the exact recorded p-value, which needs bit-identical \
-                  recomputation of the rank statistic; Miri's float nondeterminism perturbs it"
-    )]
-    fn compare_samples_significance_is_a_strict_boundary() {
-        // Branch significance is a strict `<` against the prediction-interval p-value.
-        // Take that p from the detector's own recording at the default alpha, then set
-        // alpha to it: a `<`->`<=` slip that admits the exact boundary turns this
-        // reported context run silent.
+    fn compare_samples_significance_is_measured_against_the_fixed_alpha() {
+        // Branch significance is the prediction-interval p-value tested against
+        // CHANGE_ALPHA. An 8% move on a quiet base clears it decisively; the recorded
+        // gate pins both the threshold and that the move sits below it.
         let series = wall_series(&[100.0], 1.0);
         let before = base_window(100.0, 0.5);
         let after = pts(&[(108.0, 0.5)]);
@@ -4007,36 +3889,13 @@ mod tests {
 
         let mut log = GateLog::recording();
         assert!(
-            compare_samples(
-                &series,
-                &before_refs,
-                &after_refs,
-                &AnalysisConfig::default(),
-                0.03,
-                None,
-                &mut log,
-            )
-            .is_some(),
-            "the 8% move must report at the default alpha"
+            compare_samples(&series, &before_refs, &after_refs, &mut log).is_some(),
+            "the 8% move must report"
         );
-        let (p, _) = gate_value(&log, Gate::Significance).expect("the significance gate ran");
-        let at_boundary = AnalysisConfig {
-            change_alpha: p,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            compare_samples(
-                &series,
-                &before_refs,
-                &after_refs,
-                &at_boundary,
-                0.03,
-                None,
-                &mut GateLog::disabled(),
-            )
-            .is_none(),
-            "a p-value exactly at alpha must be rejected by the strict gate"
-        );
+        let (p, threshold) =
+            gate_value(&log, Gate::Significance).expect("the significance gate ran");
+        assert_eq!(threshold, CHANGE_ALPHA);
+        assert!(p < CHANGE_ALPHA, "{p}");
     }
 
     #[test]
@@ -4063,9 +3922,6 @@ mod tests {
                 &series,
                 &before_refs,
                 &after_refs,
-                &AnalysisConfig::default(),
-                0.05,
-                None,
                 &mut log,
             )
             .is_some()
@@ -4100,9 +3956,6 @@ mod tests {
                 &series,
                 &before_refs,
                 &after_refs,
-                &AnalysisConfig::default(),
-                0.05,
-                None,
                 &mut log,
             )
             .is_none()
@@ -4123,15 +3976,15 @@ mod tests {
     fn compare_samples_confidence_tracks_the_strength_of_the_evidence() {
         // Branch confidence is `1 - p` from the prediction interval, so it must move
         // with the size of the move rather than being pinned to a constant: the same
-        // base window judges a 3% move less confidently than an 8% one. Both stay
+        // base window judges a 6% move less confidently than a 10% one. Both stay
         // below 1 (a mutated `1 + p` / `1 / p` would clamp to 1) and neither lands on
-        // `1 - change_alpha`, the placeholder confidence a fixed p-value would give.
+        // `1 - CHANGE_ALPHA`, the placeholder confidence a fixed p-value would give.
         let before = base_window(100.0, 0.5);
-        let modest = compare(&before, &pts(&[(103.0, 0.5)]), 0.03).unwrap();
-        let large = compare(&before, &pts(&[(108.0, 0.5)]), 0.03).unwrap();
+        let modest = compare(&before, &pts(&[(106.0, 0.5)])).unwrap();
+        let large = compare(&before, &pts(&[(110.0, 0.5)])).unwrap();
         assert!(modest.finding.confidence < large.finding.confidence);
         assert!(large.finding.confidence < 1.0);
-        assert!(modest.finding.confidence > 1.0 - AnalysisConfig::default().change_alpha);
+        assert!(modest.finding.confidence > 1.0 - CHANGE_ALPHA);
     }
 
     #[test]
@@ -4151,9 +4004,6 @@ mod tests {
                 &series,
                 &before_refs,
                 &after_refs,
-                &AnalysisConfig::default(),
-                0.05,
-                None,
                 &mut log,
             )
             .is_none()
@@ -4169,17 +4019,16 @@ mod tests {
 
         // Half a unit beyond the base-derived band clears it and is reported.
         let after = pts(&[(140.5, 0.1); 5]);
-        assert!(compare(&before, &after, 0.05).is_some());
+        assert!(compare(&before, &after).is_some());
     }
 
     #[test]
     fn compare_samples_suppresses_a_context_run_inside_a_bimodal_base() {
         // A base that alternates between two levels (~10 and ~30) from commit to
         // commit. A context run landing on the upper level moves the median by 10, but
-        // that is well inside the base's own commit-to-commit scatter, so the
-        // prediction interval refuses it — even with every scatter-based veto
-        // relaxed, which pins the prediction interval as the sole reason for the
-        // silence. A context run clear of *both* levels is reported.
+        // that is well inside the base's own commit-to-commit scatter, so a scatter gate
+        // refuses it. A context run clear of *both* levels stands out from that scatter
+        // and is reported.
         let mut specs = Vec::new();
         for _ in 0..MIN_REGIME {
             specs.push((10.0, 0.5));
@@ -4187,14 +4036,17 @@ mod tests {
         }
         let before = pts(&specs);
         let on_the_upper_level = pts(&[(30.0, 0.5)]);
-        assert!(compare(&before, &on_the_upper_level, 0.05).is_none());
-        let permissive = AnalysisConfig {
-            residual_noise_multiple: 0.0,
-            branch_noise_multiple: 0.0,
-            ..AnalysisConfig::default()
-        };
-        assert!(compare_with(&before, &on_the_upper_level, 0.05, &permissive).is_none());
-        assert!(compare(&before, &pts(&[(60.0, 0.5)]), 0.05).is_some());
+        let mut log = GateLog::recording();
+        let series = wall_series(&[100.0], 1.0);
+        let before_refs: Vec<&SeriesPoint> = before.iter().collect();
+        let after_refs: Vec<&SeriesPoint> = on_the_upper_level.iter().collect();
+        assert!(compare_samples(&series, &before_refs, &after_refs, &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::Branch),
+            Some(Gate::ResidualNoise),
+            "a run buried in the base scatter must be refused by the residual-scatter gate",
+        );
+        assert!(compare(&before, &pts(&[(60.0, 0.5)])).is_some());
     }
 
     #[test]
@@ -4233,95 +4085,51 @@ mod tests {
 
     #[test]
     fn drift_at_the_practical_floor_is_flagged_with_real_confidence() {
-        // A steady climb whose relative drift (0.36) is exactly the floor: the
+        // A steady climb whose relative drift is exactly PRACTICAL_RELATIVE (3%): the
         // floor gate must be a strict `<`, not a `<=`. Its confidence is 1 - p with
-        // p > 0, so a mutated `1 + p` / `1 / p` would clamp to 1.
-        let series = series_of(&ramp(100.0, 4.0, MIN_SERIES_POINTS));
-        let config = AnalysisConfig {
-            practical_relative: 36.0 / 100.0,
-            ..AnalysisConfig::default()
-        };
-        let candidate = evaluate_drift(
-            &series,
-            &values_of(&series),
-            &config,
-            &mut GateLog::disabled(),
-        )
-        .unwrap();
+        // p > 0, so a mutated `1 + p` / `1 / p` would clamp to 1. The nine-unit rise
+        // over a baseline of 300 lands the relative move on the floor exactly.
+        let series = series_of(&ramp(300.0, 1.0, MIN_SERIES_POINTS));
+        let candidate = evaluate_drift(&series, &values_of(&series), &mut GateLog::disabled())
+            .unwrap();
         assert_eq!(candidate.finding.method, FindingMethod::Drift);
-        assert_eq!(candidate.finding.relative_delta, config.practical_relative);
+        assert_eq!(candidate.finding.relative_delta, PRACTICAL_RELATIVE);
         assert!(candidate.finding.confidence < 1.0);
     }
 
     #[test]
-    #[cfg_attr(
-        miri,
-        ignore = "asserts a strict `<` at the exact recorded p-value, which needs bit-identical \
-                  recomputation of the rank statistic; Miri's float nondeterminism perturbs it"
-    )]
-    fn drift_significance_is_a_strict_boundary() {
-        // The Mann–Kendall gate is a strict `<`: a trend whose p-value lands exactly on
-        // `drift_alpha` is rejected. Take that p from the detector's own recording at the
-        // default alpha, then set alpha to it — so a `<`->`<=` slip that admits the
-        // boundary turns this reported ramp silent.
+    fn drift_significance_is_measured_against_the_fixed_alpha() {
+        // The Mann–Kendall gate tests the trend p-value against DRIFT_ALPHA. A clean
+        // ramp clears it decisively; the recorded gate pins both the threshold and that
+        // the trend sits below it.
         let series = series_of(&ramp(100.0, 4.0, MIN_SERIES_POINTS));
         let mut log = GateLog::recording();
         assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut log
-            )
-            .is_some(),
-            "the ramp must report drift at the default alpha"
+            evaluate_drift(&series, &values_of(&series), &mut log).is_some(),
+            "the ramp must report drift"
         );
-        let (p, _) = gate_value(&log, Gate::Significance).expect("the significance gate ran");
-        let at_boundary = AnalysisConfig {
-            drift_alpha: p,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &at_boundary,
-                &mut GateLog::disabled()
-            )
-            .is_none(),
-            "a trend p-value exactly at drift_alpha must be rejected"
-        );
+        let (p, threshold) =
+            gate_value(&log, Gate::Significance).expect("the significance gate ran");
+        assert_eq!(threshold, DRIFT_ALPHA);
+        assert!(p < DRIFT_ALPHA, "{p}");
     }
 
     #[test]
     fn drift_below_the_absolute_floor_is_suppressed() {
         // An upward drift on a quantized metric that gains one count every second
         // commit, totalling only 4.5 counts across the fitted line. Its relative move
-        // (4.5%) clears the relative floor and the trend is significant, so disabling
-        // the absolute floor admits it; the default floor of 5 is the gate that
-        // suppresses it.
+        // (4.5%) clears the relative floor and the trend is significant, but 4.5 counts
+        // is under the five-count floor below which a count move is not worth acting on,
+        // so nothing is reported and the recorded chain pins the absolute floor as the
+        // reason.
         let series = series_of(&staircase(100.0, MIN_SERIES_POINTS));
-        let without_absolute_floor = AnalysisConfig {
-            practical_absolute_count: 0.0,
-            ..AnalysisConfig::default()
-        };
+        let mut log = GateLog::recording();
         assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &without_absolute_floor,
-                &mut GateLog::disabled()
-            )
-            .is_some()
+            evaluate_drift(&series, &values_of(&series), &mut log).is_none()
         );
-        assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut GateLog::disabled()
-            )
-            .is_none()
+        assert_eq!(
+            log.declined_by_stage(GateStage::Drift),
+            Some(Gate::AbsoluteFloor)
         );
     }
 
@@ -4331,75 +4139,22 @@ mod tests {
         // counts, which clears the absolute floor and is flagged, pinning the gate's
         // `>=` boundary.
         let series = series_of(&staircase(100.0, MIN_SERIES_POINTS + 1));
-        let candidate = evaluate_drift(
-            &series,
-            &values_of(&series),
-            &AnalysisConfig::default(),
-            &mut GateLog::disabled(),
-        )
-        .unwrap();
+        let candidate = evaluate_drift(&series, &values_of(&series), &mut GateLog::disabled())
+            .unwrap();
         assert_eq!(candidate.finding.method, FindingMethod::Drift);
         assert_eq!(candidate.finding.delta, 5.0);
     }
 
     #[test]
-    fn noisy_drift_within_the_measurement_noise_floor_is_suppressed() {
-        // The same climb on a noisy engine, but the endpoints (delta 36) do not
-        // separate by more than the confidence half-width (20) times the default
-        // `drift_noise_multiple`: jitter, not a trend. The band must be that product (a
-        // `+` mutant lowers the floor to 22 and would flag it).
+    fn drift_noise_band_is_the_half_width_times_the_fixed_multiple() {
+        // A total movement of 36 against a confidence half-width of 20. The move sits
+        // between one and two half-widths, so only the noise band decides. The band is
+        // the half-width times DRIFT_NOISE_MULTIPLE (40), so the move is withheld, and
+        // the recorded threshold pins the product (a `+` mutant would lower it to 22).
         let series = wall_series(&ramp(100.0, 4.0, MIN_SERIES_POINTS), 20.0);
-        assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut GateLog::disabled()
-            )
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn the_default_drift_noise_multiple_is_the_named_constant() {
-        assert_eq!(
-            AnalysisConfig::default().drift_noise_multiple,
-            DRIFT_NOISE_MULTIPLE
-        );
-    }
-
-    #[test]
-    fn lowering_the_drift_noise_multiple_admits_a_drift_the_default_suppresses() {
-        // The trend the default band withholds: a total movement of 36 against a
-        // confidence half-width of 20. The move sits between one and two half-widths,
-        // so it is the multiple alone that decides — which is what makes the multiple a
-        // policy a caller can set rather than a constant of the detector.
-        let series = wall_series(&ramp(100.0, 4.0, MIN_SERIES_POINTS), 20.0);
-        let permissive = AnalysisConfig {
-            drift_noise_multiple: 1.0,
-            ..AnalysisConfig::default()
-        };
-        let mut log = GateLog::recording();
-        let candidate = evaluate_drift(&series, &values_of(&series), &permissive, &mut log);
-
-        assert_eq!(
-            candidate.map(|found| found.finding.method),
-            Some(FindingMethod::Drift)
-        );
-        assert_eq!(
-            gate_value(&log, Gate::IntervalNoiseBand),
-            Some((36.0, 20.0))
-        );
-
         let mut log = GateLog::recording();
         assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut log
-            )
-            .is_none()
+            evaluate_drift(&series, &values_of(&series), &mut log).is_none()
         );
         assert_eq!(log.declined_by(), Some(Gate::IntervalNoiseBand));
         assert_eq!(
@@ -4410,60 +4165,34 @@ mod tests {
 
     #[test]
     fn drift_within_its_own_residual_scatter_is_suppressed() {
-        // A significant upward trend (100 -> 167.5) that scatters about its Theil-Sen
-        // line. Under the default residual multiple the total move dwarfs that
-        // scatter and is flagged as drift; a deliberately high multiple lifts the
-        // noise band above the move, so only the residual gate rejects it (the
-        // length, Mann-Kendall, and practical-floor gates still pass).
+        // A climbing zigzag whose net rise is real — Mann-Kendall significant and clear
+        // of the relative and absolute floors — but which swings a fixed four units
+        // either side of its Theil-Sen line. The nine-unit fitted move does not exceed
+        // RESIDUAL_NOISE_MULTIPLE times that four-unit scatter, so the trend is buried in
+        // its own residual and refused by the residual gate.
         let series = series_of(&[
-            100.0, 110.0, 109.0, 120.0, 130.0, 140.0, 139.0, 150.0, 160.0, 170.0,
+            96.0, 105.0, 98.0, 107.0, 100.0, 109.0, 102.0, 111.0, 104.0, 113.0,
         ]);
-        assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &AnalysisConfig::default(),
-                &mut GateLog::disabled()
-            )
-            .is_some()
-        );
-        let config = AnalysisConfig {
-            residual_noise_multiple: 1000.0,
-            ..AnalysisConfig::default()
-        };
-        assert!(
-            evaluate_drift(
-                &series,
-                &values_of(&series),
-                &config,
-                &mut GateLog::disabled()
-            )
-            .is_none()
+        let mut log = GateLog::recording();
+        assert!(evaluate_drift(&series, &values_of(&series), &mut log).is_none());
+        assert_eq!(
+            log.declined_by_stage(GateStage::Drift),
+            Some(Gate::ResidualNoise)
         );
     }
 
     #[test]
     fn drift_needs_at_least_the_minimum_points() {
-        // The length gate is `n < drift_min_points`: a series one point short is
+        // The length gate is `n < DRIFT_MIN_POINTS`: a series one point short is
         // rejected outright, while a series of exactly that length is still evaluated
         // (so a gate mutated to reject the longer series instead is caught).
-        let config = AnalysisConfig {
-            practical_relative: 20.0 / 100.0,
-            ..AnalysisConfig::default()
-        };
         let short = series_of(&ramp(100.0, 4.0, DRIFT_MIN_POINTS - 1));
         assert!(
-            evaluate_drift(
-                &short,
-                &values_of(&short),
-                &config,
-                &mut GateLog::disabled()
-            )
-            .is_none()
+            evaluate_drift(&short, &values_of(&short), &mut GateLog::disabled()).is_none()
         );
         let long = series_of(&ramp(100.0, 4.0, DRIFT_MIN_POINTS));
         assert!(
-            evaluate_drift(&long, &values_of(&long), &config, &mut GateLog::disabled()).is_some()
+            evaluate_drift(&long, &values_of(&long), &mut GateLog::disabled()).is_some()
         );
     }
 
@@ -4477,7 +4206,6 @@ mod tests {
     fn history_reports_regressions_only() {
         let context = AnalysisContext {
             mode: AnalysisMode::History,
-            config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 0,
@@ -4492,7 +4220,6 @@ mod tests {
     fn reports_improvements_reflects_the_mode() {
         let context = |mode| AnalysisContext {
             mode,
-            config: AnalysisConfig::default(),
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 0,
@@ -4570,16 +4297,15 @@ mod tests {
     /// screen is a no-op — must report both.
     #[test]
     fn history_screens_direction_before_the_correction() {
-        let config = AnalysisConfig::default();
-        let improvement_p = config.fdr_q * DIRECTION_ORDER_IMPROVEMENT_P;
-        let regression_p = config.fdr_q * DIRECTION_ORDER_REGRESSION_P;
+        let improvement_p = FDR_Q * DIRECTION_ORDER_IMPROVEMENT_P;
+        let regression_p = FDR_Q * DIRECTION_ORDER_REGRESSION_P;
 
         // Bind the case to the thresholds it is built around, so a moved gate fails here
         // rather than silently leaving the two orders in agreement.
         let family = count_to_f64(DIRECTION_ORDER_FAMILY);
-        assert!(improvement_p < config.fdr_q / family);
-        assert!(regression_p > config.fdr_q / family);
-        assert!(regression_p < config.fdr_q * 2.0 / family);
+        assert!(improvement_p < FDR_Q / family);
+        assert!(regression_p > FDR_Q / family);
+        assert!(regression_p < FDR_Q * 2.0 / family);
 
         let series = vec![
             named_series("improving", &[100.0, 70.0]),
@@ -4613,14 +4339,12 @@ mod tests {
         // so each leg supplies the anchors its own charting path reads.
         let history_context = AnalysisContext {
             mode: AnalysisMode::History,
-            config,
             merge_base_index: None,
             base_ref_index: None,
             tip_index: 1,
         };
         let branch_context = AnalysisContext {
             mode: AnalysisMode::Branch,
-            config,
             merge_base_index: Some(1),
             base_ref_index: Some(1),
             tip_index: 1,
@@ -4650,7 +4374,7 @@ mod tests {
         // comparison is dropped before any significance test.
         let before = base_window(100.0, 0.5);
         let after = pts(&[(101.0, 0.5)]);
-        assert!(compare(&before, &after, 0.05).is_none());
+        assert!(compare(&before, &after).is_none());
     }
 
     #[test]
@@ -4666,8 +4390,8 @@ mod tests {
         specs.push((70.0, 0.5));
         specs.push((130.0, 0.5));
         let before = pts(&specs);
-        assert!(compare(&before, &pts(&[(120.0, 0.5)]), 0.05).is_none());
-        assert!(compare(&before, &pts(&[(160.0, 0.5)]), 0.05).is_some());
+        assert!(compare(&before, &pts(&[(120.0, 0.5)])).is_none());
+        assert!(compare(&before, &pts(&[(160.0, 0.5)])).is_some());
     }
 
     #[test]
@@ -4756,11 +4480,10 @@ mod tests {
         let flat = [1000.0; MIN_SERIES_POINTS];
         assert_eq!(stats::sample_std_dev(&flat), Some(0.0));
         assert_eq!(prediction_interval_p(&flat, 1005.0, 0.0), None);
-        let alpha = AnalysisConfig::default().change_alpha;
         let large = prediction_interval_p(&flat, 1005.0, 1.0).unwrap();
-        assert!(large < alpha, "{large}");
+        assert!(large < CHANGE_ALPHA, "{large}");
         let at_the_quantum = prediction_interval_p(&flat, 1001.0, 1.0).unwrap();
-        assert!(at_the_quantum >= alpha, "{at_the_quantum}");
+        assert!(at_the_quantum >= CHANGE_ALPHA, "{at_the_quantum}");
     }
 
     #[test]
@@ -4936,28 +4659,16 @@ mod tests {
         // series reaches on roughly half of its commits. A change-point search over that
         // window proposes the split at the start of those five, and the trailing regime's
         // standard deviation is a fraction of the mixed window's — so accepting the split
-        // turns an ordinary value into a large, near-certain regression.
+        // would turn an ordinary value into a large, near-certain regression.
         //
-        // The stricter base-split separation floor is the sole reason for the silence:
-        // relaxing it to the reporting floor accepts the split and manufactures the
-        // finding, which is what makes the two floors different policies rather than one
-        // value written twice.
+        // The stricter base-split separation floor holds the window whole: the proposed
+        // split does not part the two modes cleanly enough to discard the prefix, so the
+        // full window is compared and the context value reads as ordinary. The narrowed
+        // start stays at zero and nothing is reported.
         let series = bimodal_branch_probe();
         let merge_base = STATIONARY_BIMODAL_BASE.checked_sub(1).unwrap();
         assert_eq!(bimodal_branch_regime_start(&series), 0);
         assert!(branch_changes(slice::from_ref(&series), Some(merge_base)).is_empty());
-
-        let permissive = AnalysisConfig {
-            min_base_split_separation: AnalysisConfig::default().min_regime_separation,
-            ..AnalysisConfig::default()
-        };
-        let manufactured = evaluate_branch(&series, &permissive, &mut GateLog::disabled()).unwrap();
-        assert_eq!(manufactured.finding.direction, Direction::Regression);
-        assert!(
-            manufactured.finding.relative_delta > 0.5,
-            "{:?}",
-            manufactured.finding
-        );
     }
 
     /// The recorded bimodal series cut to the base window that exposes a spurious
@@ -4982,34 +4693,20 @@ mod tests {
             COMPARE_WINDOW,
         );
         let spans = commit_level_spans(&base);
-        let config = AnalysisConfig::default();
-        current_base_regime_start(series, &spans, &config, config.branch_practical_relative)
+        current_base_regime_start(series, &spans)
     }
 
     fn base_split_qualifies(before: f64, after: f64, before_len: usize, after_len: usize) -> bool {
         let mut levels = vec![before; before_len];
         levels.extend(std::iter::repeat_n(after, after_len));
-        base_regime_split_qualifies(
-            &series_of(&[]),
-            &levels,
-            before_len,
-            &AnalysisConfig::default(),
-            AnalysisConfig::default().branch_practical_relative,
-        )
+        base_regime_split_qualifies(&series_of(&[]), &levels, before_len)
     }
 
     /// Whether a split onto a perfectly flat trailing regime qualifies for `kind`.
     fn flat_regime_split_qualifies(kind: MetricKind) -> bool {
         let mut levels = vec![100.0; MIN_REGIME];
         levels.extend(std::iter::repeat_n(130.0, MIN_REGIME));
-        let config = AnalysisConfig::default();
-        base_regime_split_qualifies(
-            &series_with(&[], kind, &[]),
-            &levels,
-            MIN_REGIME,
-            &config,
-            config.branch_practical_relative,
-        )
+        base_regime_split_qualifies(&series_with(&[], kind, &[]), &levels, MIN_REGIME)
     }
 
     #[test]
@@ -5172,7 +4869,6 @@ mod tests {
         // ever consulted.
         let batch = pure_noise_branch_batch();
         let context = branch_context(&batch, Some(NOISE_MERGE_BASE));
-        let config = AnalysisConfig::default();
 
         let detection = find_changes(&batch, &context);
         assert_eq!(detection.census.judged(), batch.len());
@@ -5183,7 +4879,7 @@ mod tests {
         // the gate is entitled to narrow there. What it may not do is narrow as a rule.
         let narrowed = batch
             .iter()
-            .filter(|series| noise_regime_start(series, &config) != 0)
+            .filter(|series| noise_regime_start(series) != 0)
             .count();
         assert!(
             narrowed * NOISE_SPLIT_SHARE <= batch.len(),
@@ -5194,7 +4890,7 @@ mod tests {
         // Nor may it narrow on a window where narrowing manufactures a report. Those are the
         // windows this fixture exists to guard, so there must be some.
         let weaponisable: Vec<usize> = (0..batch.len())
-            .filter(|&index| a_narrowed_split_would_report(batch.get(index).unwrap(), &config))
+            .filter(|&index| a_narrowed_split_would_report(batch.get(index).unwrap()))
             .collect();
         assert!(
             !weaponisable.is_empty(),
@@ -5204,7 +4900,7 @@ mod tests {
         for index in weaponisable {
             let series = batch.get(index).unwrap();
             assert_eq!(
-                noise_regime_start(series, &config),
+                noise_regime_start(series),
                 0,
                 "narrowing fired on pure-noise window {index}, where a narrowed base sample \
                  clears the branch floors and turns the context run into a finding"
@@ -5212,38 +4908,12 @@ mod tests {
         }
 
         // And the silence is not an artefact of the false discovery rate control: no series
-        // raises a candidate in the first place. Relaxing only the base-split separation
-        // floor narrows more windows and turns some of them into candidates, which is the
-        // failure this fixture stands guard over.
+        // raises a candidate in the first place.
         let candidates = batch
             .iter()
-            .filter(|series| evaluate_branch(series, &config, &mut GateLog::disabled()).is_some())
+            .filter(|series| evaluate_branch(series, &mut GateLog::disabled()).is_some())
             .count();
         assert_eq!(candidates, 0);
-
-        let permissive = AnalysisConfig {
-            min_base_split_separation: 0.0,
-            ..AnalysisConfig::default()
-        };
-        let relaxed = batch
-            .iter()
-            .filter(|series| noise_regime_start(series, &permissive) != 0)
-            .count();
-        let manufactured = batch
-            .iter()
-            .filter(|series| {
-                evaluate_branch(series, &permissive, &mut GateLog::disabled()).is_some()
-            })
-            .count();
-        assert!(
-            relaxed > narrowed,
-            "the fixture cannot expose a noise-driven split"
-        );
-        assert!(
-            manufactured > 0,
-            "a noise-driven split on this fixture cannot clear the branch floors, so the \
-             floors rather than the split gate would be producing the silence"
-        );
     }
 
     /// The level [`pure_noise_branch_batch`] wobbles around, in nanoseconds.
@@ -5298,11 +4968,11 @@ mod tests {
     }
 
     /// Where branch mode starts comparing a [`pure_noise_branch_batch`] series.
-    fn noise_regime_start(series: &Series, config: &AnalysisConfig) -> usize {
+    fn noise_regime_start(series: &Series) -> usize {
         let borrowed: Vec<&SeriesPoint> = series.points.iter().collect();
         let base = recent_commits(borrowed.get(..COMPARE_WINDOW).unwrap(), COMPARE_WINDOW);
         let spans = commit_level_spans(&base);
-        current_base_regime_start(series, &spans, config, config.branch_practical_relative)
+        current_base_regime_start(series, &spans)
     }
 
     /// Whether some trailing slice of a [`pure_noise_branch_batch`] base window, short of the
@@ -5310,22 +4980,13 @@ mod tests {
     ///
     /// This is what an implementation that split at an arbitrary index would be doing, so a
     /// window for which this holds is one the split gate has to decline.
-    fn a_narrowed_split_would_report(series: &Series, config: &AnalysisConfig) -> bool {
+    fn a_narrowed_split_would_report(series: &Series) -> bool {
         let borrowed: Vec<&SeriesPoint> = series.points.iter().collect();
         let base = recent_commits(borrowed.get(..COMPARE_WINDOW).unwrap(), COMPARE_WINDOW);
         let context = borrowed.get(COMPARE_WINDOW..).unwrap().to_vec();
         (1..=base.len().saturating_sub(MIN_REGIME)).any(|start| {
             let narrowed = base.get(start..).unwrap().to_vec();
-            compare_samples(
-                series,
-                &narrowed,
-                &context,
-                config,
-                config.branch_practical_relative,
-                None,
-                &mut GateLog::disabled(),
-            )
-            .is_some()
+            compare_samples(series, &narrowed, &context, &mut GateLog::disabled()).is_some()
         })
     }
 
@@ -5382,7 +5043,7 @@ mod tests {
             &[branch_over_base(100.0, 140.0, 1)],
             Some(base_merge_base()),
         ));
-        let placeholder = 1.0 - AnalysisConfig::default().change_alpha;
+        let placeholder = 1.0 - CHANGE_ALPHA;
         assert!(modest.confidence < large.confidence);
         assert!(large.confidence < 1.0);
         assert!((modest.confidence - placeholder).abs() > 1e-9, "{modest:?}");
@@ -5518,13 +5179,11 @@ mod tests {
         // a comparison needs. Were the allowance set above that margin, a window could be
         // counted as judged and then hold too little evidence to compare — the census and
         // the false-discovery family would both be describing work that cannot happen.
-        let config = AnalysisConfig::default();
-        let margin = config
-            .min_series_points
-            .checked_sub(config.min_regime)
+        let margin = MIN_SERIES_POINTS
+            .checked_sub(MIN_REGIME)
             .expect("the evidence floor is at least the minimum regime length");
 
-        assert!(config.excursion_max_removals <= margin);
+        assert!(EXCURSION_MAX_REMOVALS <= margin);
     }
 
     #[test]
@@ -5800,7 +5459,7 @@ mod tests {
                 stage: GateStage::Drift,
                 gate: Gate::Significance,
                 // No pair of points is ordered, so the rank test reports no trend at all.
-                compared: Some((1.0, AnalysisConfig::default().drift_alpha)),
+                compared: Some((1.0, DRIFT_ALPHA)),
             },
             DeclinedCase {
                 shape: "a climb smaller than the measurement noise band",

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -29,10 +29,15 @@ mod signal_validation;
 pub use discriminant::{DiscriminantFilter, DiscriminantSetQuery};
 pub use excursions::DiscardedReading;
 pub use findings::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Detection, Direction, DiscardedBaseReading,
-    Finding, FindingMethod, SeriesCensus, SeriesValue, Testability, UnjudgedReason,
-    find_changes_spawned, short_commit, testability,
+    AnalysisContext, AnalysisMode, Detection, Direction, DiscardedBaseReading, Finding,
+    FindingMethod, SeriesCensus, SeriesValue, Testability, UnjudgedReason, find_changes_spawned,
+    short_commit, testability,
 };
+// The gating policy is a fixed set of named thresholds rather than a per-run
+// configuration, so the constants are the public form of that policy: in-workspace
+// consumers (the shell's series building, the documentation figures, the stress
+// harness) read them directly instead of a tunable config object.
+pub use noise_gates::*;
 #[cfg(any(test, feature = "private-test-util"))]
 pub use findings::{evaluate_with_log, find_changes};
 // The gate types are compiled unconditionally because the detectors take a log by reference,

--- a/packages/cbh_detect/src/detect/mod.rs
+++ b/packages/cbh_detect/src/detect/mod.rs
@@ -33,11 +33,6 @@ pub use findings::{
     FindingMethod, SeriesCensus, SeriesValue, Testability, UnjudgedReason, find_changes_spawned,
     short_commit, testability,
 };
-// The gating policy is a fixed set of named thresholds rather than a per-run
-// configuration, so the constants are the public form of that policy: in-workspace
-// consumers (the shell's series building, the documentation figures, the stress
-// harness) read them directly instead of a tunable config object.
-pub use noise_gates::*;
 #[cfg(any(test, feature = "private-test-util"))]
 pub use findings::{evaluate_with_log, find_changes};
 // The gate types are compiled unconditionally because the detectors take a log by reference,
@@ -46,6 +41,11 @@ pub use findings::{evaluate_with_log, find_changes};
 // the shell crate's own path constructs one.
 #[cfg(any(test, feature = "private-test-util"))]
 pub use gate_log::{Gate, GateLog, GateOutcome, GateStage};
+// The gating policy is a fixed set of named thresholds rather than a per-run
+// configuration, so the constants are the public form of that policy: in-workspace
+// consumers (the shell's series building, the documentation figures, the stress
+// harness) read them directly instead of a tunable config object.
+pub use noise_gates::*;
 pub use parallel::{balanced_chunk_sizes, worker_count};
 pub use run_points::{MetricPoint, ResultPoints, RunPoints};
 pub use selection::{DirtyAdmission, SelectedCommit, select_commits};

--- a/packages/cbh_detect/src/detect/noise_gates.rs
+++ b/packages/cbh_detect/src/detect/noise_gates.rs
@@ -1,13 +1,14 @@
-//! Default thresholds for the noise-aware analysis gates, gathered in one place.
+//! Thresholds for the noise-aware analysis gates, gathered in one place.
 //!
-//! Every floor, significance level, and window the detectors apply has its default
-//! value here as a named constant, so the whole gating policy can be read — and
-//! tuned — in one file rather than hunted for across the detectors. The
-//! [`AnalysisConfig`] default is assembled entirely from these; a test that needs a
-//! different policy builds an [`AnalysisConfig`] explicitly instead of editing a
-//! constant.
+//! Every floor, significance level, and window the detectors apply is a named
+//! constant here, so the whole gating policy can be read — and tuned — in one file
+//! rather than hunted for across the detectors. The detectors read these constants
+//! directly; the policy is not configurable, so there is no per-run override and a
+//! test exercises exactly the policy the tool ships. To prove *which* gate governs a
+//! series, tests read the recorded [`GateLog`] under this fixed policy rather than
+//! relaxing a threshold.
 //!
-//! [`AnalysisConfig`]: super::AnalysisConfig
+//! [`GateLog`]: super::GateLog
 
 /// Default `min_regime`: each side of a change must hold at least this many points
 /// for the step to be trusted, so a one-off blip on the latest point cannot flag.
@@ -16,7 +17,7 @@
 /// a stable estimator. Smaller regimes make the level an extreme order statistic of a
 /// few recent measurements, which the residual gate — estimated from the series as a
 /// whole — cannot then judge fairly.
-pub(crate) const MIN_REGIME: usize = 5;
+pub const MIN_REGIME: usize = 5;
 
 /// Default `min_series_points`: a series shorter than this is not evaluated at all,
 /// and does not count toward the false-discovery family.
@@ -24,30 +25,30 @@ pub(crate) const MIN_REGIME: usize = 5;
 /// Two full regimes are the least a change-point can be built from. Below this floor
 /// no split can satisfy [`MIN_REGIME`] on both sides, so evaluating the series can
 /// only produce noise.
-pub(crate) const MIN_SERIES_POINTS: usize = 2 * MIN_REGIME;
+pub const MIN_SERIES_POINTS: usize = 2 * MIN_REGIME;
 
 /// Default `change_alpha`: the significance level a change-point's Mann–Whitney
 /// rank test must clear.
-pub(crate) const CHANGE_ALPHA: f64 = 0.05;
+pub const CHANGE_ALPHA: f64 = 0.05;
 
 /// Default `fdr_q`: the Benjamini–Hochberg target false-discovery rate over a batch
 /// of candidates.
-pub(crate) const FDR_Q: f64 = 0.10;
+pub const FDR_Q: f64 = 0.10;
 
 /// Default `drift_min_points`: a series needs at least this many points before a
 /// slow-drift finding is considered.
 ///
 /// Matched to [`MIN_SERIES_POINTS`] so both history detectors demand the same
 /// minimum evidence and a series is either evaluable by both or by neither.
-pub(crate) const DRIFT_MIN_POINTS: usize = MIN_SERIES_POINTS;
+pub const DRIFT_MIN_POINTS: usize = MIN_SERIES_POINTS;
 
 /// Default `drift_alpha`: the significance level a drift's Mann–Kendall trend must
 /// clear.
-pub(crate) const DRIFT_ALPHA: f64 = 0.05;
+pub const DRIFT_ALPHA: f64 = 0.05;
 
 /// Default `practical_relative`: a history move must shift the level by at least
 /// this fraction to matter in practice, regardless of significance.
-pub(crate) const PRACTICAL_RELATIVE: f64 = 0.03;
+pub const PRACTICAL_RELATIVE: f64 = 0.03;
 
 /// Default `practical_absolute_count`: a move on an instruction or branch count must
 /// span at least this many units.
@@ -55,7 +56,7 @@ pub(crate) const PRACTICAL_RELATIVE: f64 = 0.03;
 /// Code layout shifts these counts by a few units between builds of identical
 /// source, so a handful of instructions carries no information about the code's
 /// cost.
-pub(crate) const PRACTICAL_ABSOLUTE_COUNT: f64 = 5.0;
+pub const PRACTICAL_ABSOLUTE_COUNT: f64 = 5.0;
 
 /// Default `practical_absolute_time`: a timing move must span at least this many
 /// nanoseconds.
@@ -64,7 +65,7 @@ pub(crate) const PRACTICAL_ABSOLUTE_COUNT: f64 = 5.0;
 /// regression slope a timing engine reports resolves far below a nanosecond, but a
 /// move of under one nanosecond per iteration is not worth acting on whatever
 /// percentage it works out to.
-pub(crate) const PRACTICAL_ABSOLUTE_TIME: f64 = 1.0;
+pub const PRACTICAL_ABSOLUTE_TIME: f64 = 1.0;
 
 /// Default `practical_absolute_alloc`: an allocation move must span at least this
 /// many bytes or allocations.
@@ -72,7 +73,7 @@ pub(crate) const PRACTICAL_ABSOLUTE_TIME: f64 = 1.0;
 /// A fraction of a byte or of an allocation cannot happen, so one whole unit is the
 /// smallest move worth reporting; the floor only rejects the sub-unit moves that
 /// amortizing across a run's iterations can manufacture.
-pub(crate) const PRACTICAL_ABSOLUTE_ALLOC: f64 = 1.0;
+pub const PRACTICAL_ABSOLUTE_ALLOC: f64 = 1.0;
 
 /// Default `scatter_floor_count`: the smallest scatter an instruction or branch
 /// count can express.
@@ -83,7 +84,7 @@ pub(crate) const PRACTICAL_ABSOLUTE_ALLOC: f64 = 1.0;
 /// standard error instead of a degenerate one. A stored count is a per-iteration
 /// figure and so need not be a whole number, but no sample of it can establish a
 /// scatter finer than the unit it counts.
-pub(crate) const SCATTER_FLOOR_COUNT: f64 = 1.0;
+pub const SCATTER_FLOOR_COUNT: f64 = 1.0;
 
 /// Default `scatter_floor_time`: timing metrics have no quantum, so their scatter is
 /// not bounded from below at all.
@@ -96,7 +97,7 @@ pub(crate) const SCATTER_FLOOR_COUNT: f64 = 1.0;
 /// left to [`PRACTICAL_ABSOLUTE_TIME`] alone. The price is that a base window with
 /// exactly zero scatter yields no verdict, which is silence rather than a spurious
 /// certainty.
-pub(crate) const SCATTER_FLOOR_TIME: f64 = 0.0;
+pub const SCATTER_FLOOR_TIME: f64 = 0.0;
 
 /// Default `scatter_floor_alloc`: the smallest scatter an allocation metric can
 /// express.
@@ -105,7 +106,7 @@ pub(crate) const SCATTER_FLOOR_TIME: f64 = 0.0;
 /// window of zeroes has exactly zero scatter, and without a floor the standard error
 /// collapses and the move cannot be judged at all. The finest scatter the underlying
 /// count can distinguish is the unit it counts.
-pub(crate) const SCATTER_FLOOR_ALLOC: f64 = 1.0;
+pub const SCATTER_FLOOR_ALLOC: f64 = 1.0;
 
 /// Default `compare_window`: how many recent base-side **commits** branch mode
 /// inspects.
@@ -123,11 +124,11 @@ pub(crate) const SCATTER_FLOOR_ALLOC: f64 = 1.0;
 /// commit and collapse to a single level before the comparison: a point-counted
 /// window would hold a different number of levels depending on how many runs fell
 /// inside it, and could shrink to a useless sample however long the history grew.
-pub(crate) const COMPARE_WINDOW: usize = 16;
+pub const COMPARE_WINDOW: usize = 16;
 
 /// Default `branch_practical_relative`: a branch move must reach this fraction,
 /// raised above the history floor, to keep pull-request false positives down.
-pub(crate) const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
+pub const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
 
 /// Default `excursion_relative_magnitude`: how far a base-window level must stand from
 /// its surroundings before branch mode treats it as a measurement excursion rather than
@@ -143,7 +144,7 @@ pub(crate) const BRANCH_PRACTICAL_RELATIVE: f64 = 0.05;
 ///
 /// It also sits far above [`BRANCH_PRACTICAL_RELATIVE`], so no level a branch move could
 /// be reported against is anywhere near being treated as an excursion.
-pub(crate) const EXCURSION_RELATIVE_MAGNITUDE: f64 = 0.30;
+pub const EXCURSION_RELATIVE_MAGNITUDE: f64 = 0.30;
 
 /// Default `excursion_neighbour_agreement`: how closely the levels on either side of a
 /// candidate excursion must agree before it can be discarded.
@@ -152,7 +153,7 @@ pub(crate) const EXCURSION_RELATIVE_MAGNITUDE: f64 = 0.30;
 /// mode would report: surroundings that agree to within it describe one level as far as
 /// any verdict is concerned, and surroundings that do not are a level shift, whose levels
 /// must be kept whatever their magnitude.
-pub(crate) const EXCURSION_NEIGHBOUR_AGREEMENT: f64 = BRANCH_PRACTICAL_RELATIVE;
+pub const EXCURSION_NEIGHBOUR_AGREEMENT: f64 = BRANCH_PRACTICAL_RELATIVE;
 
 /// Default `excursion_neighbours`: how many levels on each side of a candidate form the
 /// surroundings it is judged against.
@@ -165,7 +166,7 @@ pub(crate) const EXCURSION_NEIGHBOUR_AGREEMENT: f64 = BRANCH_PRACTICAL_RELATIVE;
 /// A candidate without this many levels on *both* sides is never discarded. Judging one
 /// against a shorter side would let a single adjacent level speak for a whole side, which
 /// is precisely the case this count exists to outvote.
-pub(crate) const EXCURSION_NEIGHBOURS: usize = 3;
+pub const EXCURSION_NEIGHBOURS: usize = 3;
 
 /// Default `excursion_max_removals`: how many excursions a window may contain before it
 /// is left alone entirely.
@@ -180,14 +181,14 @@ pub(crate) const EXCURSION_NEIGHBOURS: usize = 3;
 /// Runner interference is rare enough per window that requiring uniqueness costs almost
 /// nothing: the stored history puts a second excursion inside the same window at well
 /// under a percent of comparisons.
-pub(crate) const EXCURSION_MAX_REMOVALS: usize = 1;
+pub const EXCURSION_MAX_REMOVALS: usize = 1;
 
 /// Default `branch_noise_multiple`: multiple of the per-measurement noise floor a
 /// branch move must exceed where the engine reports per-point confidence intervals.
 ///
 /// This vetoes a move that the engine's own dispersion cannot distinguish from
 /// noise, independently of how the tip compares against the base level.
-pub(crate) const BRANCH_NOISE_MULTIPLE: f64 = 2.0;
+pub const BRANCH_NOISE_MULTIPLE: f64 = 2.0;
 
 /// Default `drift_noise_multiple`: multiple of the per-measurement noise floor a
 /// drift's total movement must exceed where the engine reports per-point confidence
@@ -198,15 +199,15 @@ pub(crate) const BRANCH_NOISE_MULTIPLE: f64 = 2.0;
 /// from noise. The two are held equal because the question each asks is the same one
 /// — whether the endpoints separate by more than the per-point dispersion — and neither
 /// detector has evidence the other lacks to justify a different standard.
-pub(crate) const DRIFT_NOISE_MULTIPLE: f64 = 2.0;
+pub const DRIFT_NOISE_MULTIPLE: f64 = 2.0;
 
 /// Default `residual_noise_multiple`: multiple of a series' own between-commit
 /// residual scatter a move must exceed to clear the primary noise gate.
-pub(crate) const RESIDUAL_NOISE_MULTIPLE: f64 = 3.0;
+pub const RESIDUAL_NOISE_MULTIPLE: f64 = 3.0;
 
 /// Default `min_regime_separation`: the Mann–Whitney probability-of-superiority a
 /// level shift's two regimes must reach to be trusted.
-pub(crate) const MIN_REGIME_SEPARATION: f64 = 0.85;
+pub const MIN_REGIME_SEPARATION: f64 = 0.85;
 
 /// Default `min_base_split_separation`: the probability of superiority a base-window
 /// split must reach before branch mode accepts it as a regime boundary and discards
@@ -228,4 +229,4 @@ pub(crate) const MIN_REGIME_SEPARATION: f64 = 0.85;
 /// split tolerates correspondingly few. A stationary series that oscillates between
 /// two levels leaves several contradicting pairs in every candidate split and is
 /// rejected on that basis.
-pub(crate) const MIN_BASE_SPLIT_SEPARATION: f64 = 0.95;
+pub const MIN_BASE_SPLIT_SEPARATION: f64 = 0.95;

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -117,9 +117,7 @@ use crate::detect::recorded::{
     STATIONARY_BIMODAL_NOISE,
 };
 use crate::detect::scatter::{TIMING_NOISE_CV, scattered, seed_of};
-use crate::detect::{
-    AnalysisContext, AnalysisMode, Direction, Series, UnjudgedReason, examples,
-};
+use crate::detect::{AnalysisContext, AnalysisMode, Direction, Series, UnjudgedReason, examples};
 
 /// The analysis mode a case is evaluated under — the suite's dimension-1 lever.
 ///

--- a/packages/cbh_detect/src/detect/signal_validation.rs
+++ b/packages/cbh_detect/src/detect/signal_validation.rs
@@ -118,7 +118,7 @@ use crate::detect::recorded::{
 };
 use crate::detect::scatter::{TIMING_NOISE_CV, scattered, seed_of};
 use crate::detect::{
-    AnalysisConfig, AnalysisContext, AnalysisMode, Direction, Series, UnjudgedReason, examples,
+    AnalysisContext, AnalysisMode, Direction, Series, UnjudgedReason, examples,
 };
 
 /// The analysis mode a case is evaluated under — the suite's dimension-1 lever.
@@ -152,7 +152,6 @@ impl Mode {
         };
         AnalysisContext {
             mode,
-            config: AnalysisConfig::default(),
             merge_base_index,
             base_ref_index: merge_base_index,
             tip_index,


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The `cargo-bench-history` detectors exposed their entire statistical policy — significance alphas, practical floors, scatter floors, noise multiples, regime sizes, comparison window — as a mutable `AnalysisConfig`. Production only ever ran `AnalysisConfig::default()`; nothing outside tests changed a field. That gap let the test suite validate detector behaviour under threshold values production can never produce, so tests could pass on scenarios that do not exist in reality, and it kept both production and test code alive for configurations with no real-world reachability.

## Changes

The detection policy is now fixed. The threshold values live as `pub const` items in `noise_gates.rs` and are read directly by the detectors; `AnalysisConfig` and all of its threading through the pipeline are removed. There is exactly one policy, and it is the one production runs.

```
Before:  caller ── AnalysisConfig ──▶ detectors ──▶ verdict
                     (tests vary fields;
                      production always default)

After:   caller ─────────────────────▶ detectors ──▶ verdict
                                          │
                              noise_gates::* fixed consts
```

Every test now exercises that single policy. Tests that previously depended on non-production threshold values were handled one of three ways:

- **Rebuilt on production-value fixtures** — e.g. branch-mode fixtures were redesigned to move by the real `BRANCH_PRACTICAL_RELATIVE` floor rather than a smaller amount only reachable with a lowered threshold.
- **Re-expressed as gate attribution** — where a test needed to prove *why* a candidate was rejected, it now reads the decision from the recording `GateLog` oracle instead of relaxing a threshold to flip the outcome.
- **Removed** — where a test only probed a boundary that no production input reaches.

Consumers of the detector (the `cbh_analyze` pipeline and dataset wiring, the appendix figure generator, the stress smoke test, and the integration harness) are updated to the fixed policy, and the implementation guide is brought back in sync.

The three detector significance gates compare a continuous p-value against a fixed alpha with strict `<`. Flipping that to `<=` is an equivalent mutation: it only changes behaviour when a p-value equals alpha bit-for-bit, which no production series produces for the Mann-Whitney U, Mann-Kendall, or prediction-interval statistics involved. Catching it used to rely on the very configurability being removed (a test would set alpha to a fixture's own p-value to fabricate the boundary). Those three mutants are now excluded from mutation testing with an inline justification; the catchable `==` and `>` mutants at the same sites remain caught.