### PR TITLE
future_deque/vicinal: migrate allocator pools to plurality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,12 +57,6 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "allocator-api2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
@@ -2254,18 +2248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multitude"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69674a6bae9159f1002b3f82edb626699cee30d52c4f84ca068e5ddf0b0cc995"
-dependencies = [
- "allocator-api2 0.2.21",
- "allocator-api2 0.4.0",
- "loom",
- "ptr_meta",
-]
-
-[[package]]
 name = "mutants"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2598,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68994c15ad6f41972c9a5fc132f3467bf222353962d4c9827900c0e571e54ba4"
 dependencies = [
- "allocator-api2 0.4.0",
+ "allocator-api2",
  "loom",
 ]
 
@@ -2714,26 +2696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -4092,11 +4054,11 @@ dependencies = [
  "fast_time",
  "futures",
  "many_cpus",
- "multitude",
  "mutants",
  "new_zealand",
  "nm",
  "pin-project",
+ "plurality",
  "static_assertions",
  "testing",
  "threadpool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1160,9 +1160,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "either-or-both"
@@ -1815,9 +1815,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2256,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "multitude"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cc0e07644fdbc8347952678781b7e56f6999c5feef7dde7dc5049050235f94"
+checksum = "69674a6bae9159f1002b3f82edb626699cee30d52c4f84ca068e5ddf0b0cc995"
 dependencies = [
  "allocator-api2 0.2.21",
  "allocator-api2 0.4.0",
@@ -2613,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "plurality"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3dbdc8ce69f0886449469b18103566cdeb150e60326a58ef916782cb4cb913"
+checksum = "68994c15ad6f41972c9a5fc132f3467bf222353962d4c9827900c0e571e54ba4"
 dependencies = [
  "allocator-api2 0.4.0",
  "loom",
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3171,9 +3171,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3235,9 +3235,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "4.8.8"
+version = "4.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1836bad8bdc9c6d665b63202da3d9c6d60ed1e597cae63620e21ebf89a3595a9"
+checksum = "d6c0f6aa664d1a2a4d4a9d894bac41e27d518cb2ea90a00d68e9c77d02519116"
 dependencies = [
  "saa",
 ]
@@ -4563,9 +4563,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4574,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,6 @@ dependencies = [
  "futures",
  "futures-core",
  "gungraun",
- "multitude",
  "mutants",
  "plurality",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ plotters = { version = "0.3.7", default-features = false, features = [
     "point_series",
     "svg_backend",
 ] }
-plurality = { version = "0.2.1", default-features = false, features = ["std"] }
+plurality = { version = "0.2.2", default-features = false, features = ["std"] }
 proc-macro2 = { version = "1.0.106", default-features = false }
 quote = { version = "1.0.45", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ hash_hasher = { version = "2.0.0", default-features = false }
 hashbrown = { version = "0.17.1", default-features = false }
 heapless = { version = "0.9.1", default-features = false }
 http = { version = "1.2.0", default-features = false, features = ["std"] }
-infinity_pool = { version = "0.8.23", path = "packages/infinity_pool", default-features = false }
 itertools = { version = "0.15.0", default-features = false, features = [
     "use_std",
 ] }
@@ -84,7 +83,6 @@ many_cpus = { version = "2.4.15", path = "packages/many_cpus", default-features 
 many_cpus_impl = { version = "=2.4.15", path = "packages/many_cpus_impl", default-features = false }
 mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.15.0", default-features = false }
-multitude = { version = "0.8.0", default-features = false, features = ["std"] }
 mutants = { version = "0.0.4", default-features = false }
 negative-impl = { version = "0.1.0", default-features = false }
 new_zealand = { version = "1.0.7", path = "packages/new_zealand", default-features = false }

--- a/README.md
+++ b/README.md
@@ -89,15 +89,12 @@ general-purpose mechanism and it pays a price in performance for that generality
 allocating a large number of objects of specific sizes, we can benefit from special-purpose
 allocators that keep the memory around for reuse, so the next allocation is simple and fast.
 
-While allocator APIs are still an unstable Rust feature, there are stable-API alternatives.
-Another term for special-purpose allocators is object pools and [`infinity_pool`][infinity_pool]
-offers several of them, from basic `Vec<T>` style pinned object collections to type-agnostic object
-pools that can allocate any type of object, though it receives maintenance only. While the safe-API
-variants come with substantial overheads compared to the unsafe-API variants, they both can surpass
-the efficiency of using the global memory allocator under many conditions. Your mileage may vary -
-measure 100 times, cut 10 times. To pool values of a single named type, the packages here now reach
-for [`plurality`][plurality], and where many objects share a lifetime and can be reclaimed together
-they use the [`multitude`][multitude] arena instead of a pool.
+While allocator APIs are still an unstable Rust feature, object pools provide stable alternatives.
+[`plurality`][plurality] offers `Pool<T>` for one concrete type and `MultiPool` for heterogeneous
+types, retaining storage for per-object slot reuse. [`infinity_pool`][infinity_pool] receives
+maintenance only and remains available where its raw manual-lifetime handles or macro-generated
+trait-object casting are required. Special-purpose pools can surpass the efficiency of the global
+memory allocator under many conditions. Your mileage may vary - measure 100 times, cut 10 times.
 
 A surprising source of memory allocations in high-performance code can be signaling. We are used
 to thinking of oneshot channels as cheap and efficient things and while this is true, they are
@@ -188,7 +185,6 @@ Packages present in the repo but not relevant to a general audience:
 [linked]: packages/linked/README.md
 [many_cpus]: packages/many_cpus/README.md
 [many_cpus_b]: packages/many_cpus_benchmarking/README.md
-[multitude]: https://crates.io/crates/multitude
 [nm]: packages/nm/README.md
 [nm_otel]: packages/nm_otel/README.md
 [nonzero]: https://github.com/rust-lang/rfcs/pull/3786

--- a/packages/future_deque/Cargo.toml
+++ b/packages/future_deque/Cargo.toml
@@ -24,7 +24,6 @@ futures-stream = ["dep:futures-core"]
 
 [dependencies]
 futures-core = { workspace = true, optional = true }
-multitude = { workspace = true, features = ["dst"] }
 plurality = { workspace = true }
 
 [dev-dependencies]
@@ -51,4 +50,3 @@ harness = false
 [[bench]]
 name = "future_deque_cg"
 harness = false
-

--- a/packages/future_deque/benches/future_deque.rs
+++ b/packages/future_deque/benches/future_deque.rs
@@ -4,11 +4,11 @@
 //! ratios of active futures, and a steady-state churn shape at a small and a large
 //! long-lived population.
 //!
-//! The churn scenarios (`*_transient_churn`) primarily guard allocation behaviour. They
-//! hold a population of futures that never complete while repeatedly pushing, polling and
-//! popping a transient future of the same layout. An allocator with per-object reuse stops
-//! requesting backing allocations after warm-up. An allocator that only reclaims whole
-//! chunks continues requesting storage because the long-lived futures pin those chunks.
+//! The churn scenarios (`*_transient_churn`) guard steady-state allocation and execution
+//! costs. They hold a population of futures that never complete while repeatedly pushing,
+//! polling and popping a transient future of the same layout. The allocation report confirms
+//! that the bounded workload stops requesting backing storage after warm-up, while the low
+//! and high populations expose any occupancy-sensitive execution cost.
 //!
 //! Allocation counts and processor time are tracked alongside the wall-clock measurement
 //! and reported when the benchmark run finishes.

--- a/packages/future_deque/benches/future_deque.rs
+++ b/packages/future_deque/benches/future_deque.rs
@@ -4,19 +4,16 @@
 //! ratios of active futures, and a steady-state churn shape at a small and a large
 //! long-lived population.
 //!
-//! The churn scenarios (`*_transient_churn`) exist to guard allocation behaviour rather
-//! than wall-clock time. The arena allocator behind both deques reclaims backing memory a
-//! whole chunk at a time rather than a slot at a time, so a single long-lived value is
-//! enough to pin an entire chunk. These scenarios hold a population of futures that never
-//! complete while repeatedly pushing, polling and popping a transient future, and the
-//! tracked allocation count per iteration must plateau after warm-up: reclaimed slots are
-//! reused, so the per-iteration cost stays flat and independent of both the iteration count
-//! and the size of the long-lived population. Churn that cannot reuse reclaimed storage
-//! shows up here as a per-iteration allocation count that grows with the run.
+//! The churn scenarios (`*_transient_churn`) primarily guard allocation behaviour. They
+//! hold a population of futures that never complete while repeatedly pushing, polling and
+//! popping a transient future of the same layout. An allocator with per-object reuse stops
+//! requesting backing allocations after warm-up. An allocator that only reclaims whole
+//! chunks continues requesting storage because the long-lived futures pin those chunks.
 //!
 //! Allocation counts and processor time are tracked alongside the wall-clock measurement
 //! and reported when the benchmark run finishes.
 
+use std::alloc::Layout;
 use std::future::Future;
 use std::hint::black_box;
 use std::pin::Pin;
@@ -63,18 +60,22 @@ impl Future for CountdownFuture {
 /// A future that never completes and never wakes itself.
 ///
 /// The churn scenarios use it for the long-lived population: because it never signals
-/// activation, it is polled exactly once and then merely occupies its arena slot, which is
-/// precisely the state that pins backing storage for the whole run.
+/// activation, it is polled exactly once and then retains its allocation for the whole run.
 ///
 /// It carries a payload so that it occupies real storage; a zero-sized future would pin
-/// nothing and the scenario would lose its point.
+/// nothing and the scenario would lose its point. Its fields match [`CountdownFuture`] so
+/// the resident and transient allocations exercise the same allocator size class.
 struct NeverReadyFuture {
+    remaining: usize,
     value: u64,
 }
 
 impl NeverReadyFuture {
     fn new(value: u64) -> Self {
-        Self { value }
+        Self {
+            remaining: INACTIVE_POLL_COUNT,
+            value,
+        }
     }
 }
 
@@ -82,23 +83,40 @@ impl Future for NeverReadyFuture {
     type Output = u64;
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<u64> {
-        // Touching the payload keeps the future non-empty in practice as well as in
-        // layout, so the optimizer cannot reduce it back to a zero-sized value.
-        _ = black_box(self.value);
+        // Touching the fields keeps the future's layout observable to the optimizer.
+        _ = black_box((self.remaining, self.value));
         Poll::Pending
     }
 }
 
+/// Keeps the low case large enough to exercise deque traversal without dominating setup.
 const FEW_ITEMS: usize = 8;
+
+/// Exposes scaling and allocator-capacity behaviour in the high case.
 const MANY_ITEMS: usize = 1000;
+
+/// Represents a sparse active population in the high case.
 const ACTIVE_RATIO_LOW: usize = 10;
+
+/// Represents a dense active population in the high case.
 const ACTIVE_RATIO_HIGH: usize = 900;
 
 /// Payload of the transient future in the churn scenarios. Only its determinism matters.
 const CHURN_VALUE: u64 = 42;
 
+/// Keeps inactive futures pending throughout each benchmark iteration.
+const INACTIVE_POLL_COUNT: usize = 1000;
+
 /// Poll budget that makes the transient future complete the first time it is polled.
 const READY_ON_FIRST_POLL: usize = 0;
+
+/// Guards the allocator-size-class assumption underpinning the churn scenarios.
+fn assert_churn_layouts_match() {
+    assert_eq!(
+        Layout::new::<NeverReadyFuture>(),
+        Layout::new::<CountdownFuture>()
+    );
+}
 
 /// Builds the steady state shared by the churn scenarios: `long_lived` futures that never
 /// complete, polled once so all of them are resident and registered.
@@ -107,6 +125,8 @@ const READY_ON_FIRST_POLL: usize = 0;
 /// reused across every iteration of that sample, so the long-lived allocations are never
 /// attributed to the churn measurement and pin their backing storage for the whole sample.
 fn local_deque_with_long_lived(long_lived: usize) -> LocalFutureDeque<u64> {
+    assert_churn_layouts_match();
+
     let mut deque = LocalFutureDeque::new();
 
     for i in 0..long_lived {
@@ -128,6 +148,8 @@ fn local_deque_with_long_lived(long_lived: usize) -> LocalFutureDeque<u64> {
 
 /// The [`FutureDeque`] counterpart of [`local_deque_with_long_lived`].
 fn sync_deque_with_long_lived(long_lived: usize) -> FutureDeque<u64> {
+    assert_churn_layouts_match();
+
     let mut deque = FutureDeque::new();
 
     for i in 0..long_lived {
@@ -164,7 +186,7 @@ fn bench_local_future_deque(c: &mut Criterion, allocs: &AllocSession, times: &Ti
             for _ in 0..iterations {
                 let mut deque = LocalFutureDeque::new();
                 for i in 0..FEW_ITEMS {
-                    deque.push_back(CountdownFuture::new(0, i as u64));
+                    deque.push_back(CountdownFuture::new(READY_ON_FIRST_POLL, i as u64));
                 }
                 let waker = Waker::noop();
                 let cx = &mut Context::from_waker(waker);
@@ -196,7 +218,11 @@ fn bench_local_future_deque(c: &mut Criterion, allocs: &AllocSession, times: &Ti
             for _ in 0..iterations {
                 let mut deque = LocalFutureDeque::new();
                 for i in 0..MANY_ITEMS {
-                    let remaining = if i < ACTIVE_RATIO_LOW { 0 } else { 1000 };
+                    let remaining = if i < ACTIVE_RATIO_LOW {
+                        READY_ON_FIRST_POLL
+                    } else {
+                        INACTIVE_POLL_COUNT
+                    };
                     deque.push_back(CountdownFuture::new(remaining, i as u64));
                 }
                 let waker = Waker::noop();
@@ -231,7 +257,11 @@ fn bench_local_future_deque(c: &mut Criterion, allocs: &AllocSession, times: &Ti
             for _ in 0..iterations {
                 let mut deque = LocalFutureDeque::new();
                 for i in 0..MANY_ITEMS {
-                    let remaining = if i < ACTIVE_RATIO_HIGH { 0 } else { 1000 };
+                    let remaining = if i < ACTIVE_RATIO_HIGH {
+                        READY_ON_FIRST_POLL
+                    } else {
+                        INACTIVE_POLL_COUNT
+                    };
                     deque.push_back(CountdownFuture::new(remaining, i as u64));
                 }
                 let waker = Waker::noop();
@@ -328,7 +358,7 @@ fn bench_future_deque(c: &mut Criterion, allocs: &AllocSession, times: &TimeSess
             for _ in 0..iterations {
                 let mut deque = FutureDeque::new();
                 for i in 0..FEW_ITEMS {
-                    deque.push_back(CountdownFuture::new(0, i as u64));
+                    deque.push_back(CountdownFuture::new(READY_ON_FIRST_POLL, i as u64));
                 }
                 let waker = Waker::noop();
                 let cx = &mut Context::from_waker(waker);
@@ -360,7 +390,11 @@ fn bench_future_deque(c: &mut Criterion, allocs: &AllocSession, times: &TimeSess
             for _ in 0..iterations {
                 let mut deque = FutureDeque::new();
                 for i in 0..MANY_ITEMS {
-                    let remaining = if i < ACTIVE_RATIO_LOW { 0 } else { 1000 };
+                    let remaining = if i < ACTIVE_RATIO_LOW {
+                        READY_ON_FIRST_POLL
+                    } else {
+                        INACTIVE_POLL_COUNT
+                    };
                     deque.push_back(CountdownFuture::new(remaining, i as u64));
                 }
                 let waker = Waker::noop();
@@ -393,7 +427,11 @@ fn bench_future_deque(c: &mut Criterion, allocs: &AllocSession, times: &TimeSess
             for _ in 0..iterations {
                 let mut deque = FutureDeque::new();
                 for i in 0..MANY_ITEMS {
-                    let remaining = if i < ACTIVE_RATIO_HIGH { 0 } else { 1000 };
+                    let remaining = if i < ACTIVE_RATIO_HIGH {
+                        READY_ON_FIRST_POLL
+                    } else {
+                        INACTIVE_POLL_COUNT
+                    };
                     deque.push_back(CountdownFuture::new(remaining, i as u64));
                 }
                 let waker = Waker::noop();

--- a/packages/future_deque/docs/design.md
+++ b/packages/future_deque/docs/design.md
@@ -1,0 +1,27 @@
+# future_deque design
+
+`future_deque` manages groups of futures while preserving deque ordering for result
+retrieval.
+
+## Collection variants
+
+`FutureDeque` is thread-mobile and accepts futures that can move between threads.
+`LocalFutureDeque` remains on one thread and accepts futures without that requirement.
+Both variants otherwise provide the same polling and retrieval behavior.
+
+## Polling and activation
+
+Active futures are polled in deterministic front-to-back order. A pending future is not
+polled again until its waker signals that it may make progress. Waking may occur from any
+thread, including for a future stored in the local variant.
+
+The collection becomes ready when every contained future has completed or when it is
+empty. New futures may be inserted after readiness and make the collection pending again.
+
+## Result retrieval
+
+Completion does not change deque order. A result can be removed only when the item at the
+requested end has completed; completed items behind a pending item remain in place.
+
+The optional stream integration yields completed results from the front and therefore
+preserves the same deque semantics.

--- a/packages/future_deque/docs/implementation.md
+++ b/packages/future_deque/docs/implementation.md
@@ -1,0 +1,34 @@
+# future_deque implementation
+
+User-visible behavior is defined in the package [design](design.md).
+
+The two public collection variants share one deque core. Their behavioral logic is
+identical; their insertion bounds and storage sources establish the difference in thread
+mobility.
+
+## Future storage
+
+Each thread has separate heterogeneous pools for thread-mobile and local futures. Keeping
+the pools separate prevents the variants from affecting each other's retained capacity.
+Each concrete future layout is routed to reusable slots for that layout.
+
+Insertion moves a future into stable pool storage and erases its concrete type behind an
+owning handle. The handle owns the allocation independently of the thread-local pool
+facade, so a deque and its futures may outlive the thread that inserted them. Completed or
+removed entries release their individual slots for reuse.
+
+The erased handle deliberately does not carry a thread-mobility marker so both variants
+can use the same core. The thread-mobile variant restores the marker through its insertion
+bounds and manual trait implementations.
+
+## Polling and waking
+
+Each pending entry owns a waker that records activation and forwards wakeups to the current
+parent task. Activation state and parent-waker access remain thread-safe even for the local
+collection because a standard waker may be cloned and invoked from another thread.
+
+Waker metadata uses a separate typed pool because every entry has the same metadata layout.
+
+Polling visits entries front-to-back and polls only entries whose activation state was
+set. A completed future is replaced by its output value, releasing the pooled future
+without changing its position in the deque.

--- a/packages/future_deque/src/erased_future.rs
+++ b/packages/future_deque/src/erased_future.rs
@@ -2,8 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use multitude::dst::pointee;
-use multitude::{Arena, coerce};
+use plurality::{Box as PoolBox, MultiPool, coerce};
 
 /// Type erasure trait for futures stored in a future deque.
 ///
@@ -11,15 +10,6 @@ use multitude::{Arena, coerce};
 /// which leaves nothing for the deque to name its element type by. This trait restates
 /// `Future::poll` behind a type parameter so that `dyn ErasedFuture<T>` identifies the
 /// output type it produces.
-///
-/// The `pointee` attribute supplies the pointer-metadata implementation that
-/// [`multitude::Box`] requires of its unsized targets. `pointee` is `ptr_meta`'s macro,
-/// re-exported by `multitude`, and it emits `::ptr_meta::*` paths unless told otherwise;
-/// the `crate` argument redirects those at `multitude`'s re-export so this package needs
-/// no direct dependency on `ptr_meta`. Depending on `ptr_meta` directly would be worse: the
-/// generated impls must target the exact `ptr_meta` instance `multitude` was built against,
-/// so a version skew would surface as an unrelated-looking trait mismatch.
-#[pointee(crate = ::multitude::dst)]
 pub(crate) trait ErasedFuture<T> {
     /// Polls the underlying future.
     fn poll_erased(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T>;
@@ -33,19 +23,45 @@ impl<T, F: Future<Output = T>> ErasedFuture<T> for F {
 
 /// Owning handle to a type-erased future, as stored in a deque slot.
 ///
-/// Both deque variants store this same type. The handle keeps its backing arena chunk alive
-/// on its own, so it stays valid after the thread-local arena that produced it is gone.
-pub(crate) type ErasedFutureHandle<T> = Pin<multitude::Box<dyn ErasedFuture<T>>>;
+/// Both deque variants store this same type. The handle owns its pool slot, so it stays valid
+/// after the thread-local pool that produced it is gone.
+pub(crate) type ErasedFutureHandle<T> = PoolBox<dyn ErasedFuture<T>>;
 
-/// Moves `future` into the arena and erases its type.
+/// Moves `future` into the pool and erases its type.
 pub(crate) fn alloc_future<T, F: Future<Output = T> + 'static>(
-    arena: &Arena,
+    pool: &MultiPool,
     future: F,
 ) -> ErasedFutureHandle<T> {
-    let handle = arena.alloc_box(future);
+    let handle = pool.alloc_box(future);
 
-    multitude::Box::into_pin(multitude::Box::unsize(
-        handle,
-        coerce!(<T> dyn ErasedFuture<T>),
-    ))
+    PoolBox::unsize(handle, coerce!(<T> dyn ErasedFuture<T>))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::future::{Ready, ready};
+
+    use super::*;
+
+    /// Makes capacity growth observable after the initial allocations fill one chunk.
+    const TEST_CHUNK_SIZE: u32 = 2;
+
+    #[test]
+    fn released_slot_is_reused_with_live_neighbor() {
+        let pool = MultiPool::builder().chunk_size(TEST_CHUNK_SIZE).build();
+        let held = alloc_future(&pool, ready(1_u32));
+        let released = alloc_future(&pool, ready(2_u32));
+
+        assert_eq!(pool.capacity_of::<Ready<u32>>(), u64::from(TEST_CHUNK_SIZE));
+
+        drop(released);
+        let replacement = alloc_future(&pool, ready(3_u32));
+
+        assert_eq!(pool.capacity_of::<Ready<u32>>(), u64::from(TEST_CHUNK_SIZE));
+        assert_eq!(pool.len_of::<Ready<u32>>(), 2);
+
+        drop((held, replacement));
+        assert!(pool.is_empty());
+    }
 }

--- a/packages/future_deque/src/future_deque.rs
+++ b/packages/future_deque/src/future_deque.rs
@@ -4,16 +4,15 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use multitude::Arena;
+use plurality::MultiPool;
 
 use crate::erased_future::alloc_future;
 use crate::future_deque_core::FutureDequeCore;
 
-// Thread-local arena for storing type-erased futures. Each thread allocates from its own
-// arena, and the resulting handles keep their backing chunks alive independently, so a
-// handle stays valid after the arena — and the thread that owned it — is gone.
+// Each thread allocates from its own pool to avoid synchronization. Handles own their slots,
+// so they remain valid after the pool and its thread are gone.
 thread_local! {
-    static FUTURES_ARENA: Arena = Arena::new();
+    static FUTURES_POOL: MultiPool = MultiPool::new();
 }
 
 /// A deque of futures with deterministic front-to-back polling order.
@@ -109,13 +108,13 @@ impl<T> FutureDeque<T> {
 
     /// Adds a future to the back of the deque.
     pub fn push_back(&mut self, future: impl Future<Output = T> + Send + 'static) {
-        let handle = FUTURES_ARENA.with(|arena| alloc_future(arena, future));
+        let handle = FUTURES_POOL.with(|pool| alloc_future(pool, future));
         self.core.push_back_handle(handle);
     }
 
     /// Adds a future to the front of the deque.
     pub fn push_front(&mut self, future: impl Future<Output = T> + Send + 'static) {
-        let handle = FUTURES_ARENA.with(|arena| alloc_future(arena, future));
+        let handle = FUTURES_POOL.with(|pool| alloc_future(pool, future));
         self.core.push_front_handle(handle);
     }
 
@@ -218,13 +217,13 @@ impl<T> futures_core::Stream for FutureDeque<T> {
 }
 
 // SAFETY: The erased type `dyn ErasedFuture<T>` does not carry a `Send` bound, so
-// `multitude::Box<dyn ErasedFuture<T>>` is not automatically `Send`. However, `push_back`
+// `plurality::Box<dyn ErasedFuture<T>>` is not automatically `Send`. However, `push_back`
 // and `push_front` both require `F: Future + Send + 'static`, guaranteeing that every value
 // behind the trait object is in fact `Send`. Erasure deliberately drops the marker bound so
-// that a single erased handle type serves both deque variants. The arena chunk backing each
-// handle is reference-counted and safe to release from any thread. All other state — result
-// values of type `T`, the shared parent waker behind `Arc<Mutex<Waker>>`, and the waker
-// metadata reached through `MetaPtr` (itself declared `Send`) — is `Send` given `T: Send`.
+// that a single erased handle type serves both deque variants. Pool slots can be released
+// from any thread. All other state — result values of type `T`, the shared parent waker
+// behind `Arc<Mutex<Waker>>`, and the waker metadata reached through `MetaPtr` (itself
+// declared `Send`) — is `Send` given `T: Send`.
 unsafe impl<T: Send> Send for FutureDeque<T> {}
 
 // SAFETY: `Sync` is likewise blocked only by the erased `dyn ErasedFuture<T>`. Sharing

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -9,7 +9,7 @@ use crate::waker_meta::{self, MetaPtr};
 /// and [`LocalFutureDeque`][crate::LocalFutureDeque].
 ///
 /// Both variants store the same erased handle type, so their behaviour is identical; they
-/// differ only in the thread-safety they advertise and in which thread-local arena their
+/// differ only in the thread-safety they advertise and in which thread-local pool their
 /// handles come from. The `Send` variant asserts thread-safety manually on the strength of
 /// the `Send` bound its push methods require, while the local variant inherits the handle's
 /// `!Send`ness.
@@ -165,7 +165,7 @@ impl<T> FutureDequeCore<T> {
 
                 let sub_cx = &mut Context::from_waker(waker);
 
-                handle.as_mut().poll_erased(sub_cx)
+                handle.as_pin_mut().poll_erased(sub_cx)
             };
 
             if let Poll::Ready(value) = poll_result {
@@ -182,7 +182,7 @@ impl<T> FutureDequeCore<T> {
                 let old = std::mem::replace(slot, Slot::Ready { value });
 
                 // Release the Slot's metadata reference. The handle is dropped as
-                // part of the old Slot destruction, which returns the future's arena
+                // part of the old Slot destruction, which returns the future's pool
                 // storage.
                 if let Slot::Pending { meta, .. } = old {
                     waker_meta::release_ref(meta);
@@ -235,7 +235,7 @@ impl<T> Drop for FutureDequeCore<T> {
     // metadata references are released so the waker metadata pool entries can be freed.
     //
     // The future handles in each slot are dropped as part of normal Slot destruction,
-    // which returns their arena storage.
+    // which returns their pool storage.
     #[cfg_attr(coverage_nightly, coverage(off))]
     // Only runs when deque is dropped with
     // pending slots, which is a cleanup path.
@@ -251,9 +251,8 @@ impl<T> Drop for FutureDequeCore<T> {
     }
 }
 
-// The futures stored in the deque are pinned by their arena allocations (stable addresses
-// that outlive the handle's owner), not by FutureDequeCore's own fields. The struct only
-// holds handles and result values, none of which require pinning guarantees.
+// The futures are pinned in stable-address pool slots, not by FutureDequeCore's own fields.
+// The struct only holds handles and result values, none of which require pinning guarantees.
 impl<T> Unpin for FutureDequeCore<T> {}
 
 #[cfg(test)]
@@ -1138,7 +1137,7 @@ mod tests {
                 move || {
                     let mut deque = FutureDeque::new();
 
-                    // Pushing allocates the future in this thread's futures arena and the
+                    // Pushing allocates the future in this thread's future pool and the
                     // per-slot waker metadata in this thread's metadata pool.
                     deque.push_back(WakerCaptureFuture {
                         waker_tx: Some(waker_tx),
@@ -1169,7 +1168,7 @@ mod tests {
             assert!(deque.is_empty());
 
             // The deque remains fully usable after its origin thread is gone: a push from
-            // here allocates in this thread's arena and metadata pool and drains normally.
+            // here allocates in this thread's future and metadata pools and drains normally.
             deque.push_back(std::future::ready(7));
             assert_eq!(deque.poll_front(cx), Poll::Ready(Some(7)));
             assert!(deque.is_empty());
@@ -1610,8 +1609,8 @@ mod tests {
 
     // --- Zero-sized futures ---
 
-    /// A future that occupies no storage at all, used to prove that the futures arena
-    /// accepts zero-sized payloads.
+    /// A future that occupies no storage at all, used to prove that the future pool accepts
+    /// zero-sized payloads.
     struct ZeroSizedFuture;
 
     impl Future for ZeroSizedFuture {

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -70,6 +70,9 @@ impl<T> FutureDequeCore<T> {
     }
 
     /// Adds a pre-erased future handle to the back of the deque.
+    // Inlining keeps pooled waker allocation and deque insertion in the caller; the
+    // Callgrind push benchmarks exercise this hot path directly.
+    #[inline]
     pub(crate) fn push_back_handle(&mut self, handle: ErasedFutureHandle<T>) {
         let meta = waker_meta::create_waker_meta(&self.shared_parent);
         let waker = waker_meta::make_waker(meta);
@@ -81,6 +84,8 @@ impl<T> FutureDequeCore<T> {
     }
 
     /// Adds a pre-erased future handle to the front of the deque.
+    // Inlining mirrors the measured back-insertion path so both ends have the same cost model.
+    #[inline]
     pub(crate) fn push_front_handle(&mut self, handle: ErasedFutureHandle<T>) {
         let meta = waker_meta::create_waker_meta(&self.shared_parent);
         let waker = waker_meta::make_waker(meta);

--- a/packages/future_deque/src/local_future_deque.rs
+++ b/packages/future_deque/src/local_future_deque.rs
@@ -4,16 +4,15 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use multitude::Arena;
+use plurality::MultiPool;
 
 use crate::erased_future::alloc_future;
 use crate::future_deque_core::FutureDequeCore;
 
-// Thread-local arena for storing type-erased futures in the `!Send` variant. It is separate
-// from the arena used by `FutureDeque` so that the two variants do not share chunks and
-// their allocation behaviour stays independent.
+// This pool is separate from the pool used by `FutureDeque` so the variants do not share
+// storage and their allocation behaviour stays independent.
 thread_local! {
-    static LOCAL_FUTURES_ARENA: Arena = Arena::new();
+    static LOCAL_FUTURES_POOL: MultiPool = MultiPool::new();
 }
 
 /// A deque of futures with deterministic front-to-back polling order (single-threaded).
@@ -108,13 +107,13 @@ impl<T> LocalFutureDeque<T> {
 
     /// Adds a future to the back of the deque.
     pub fn push_back(&mut self, future: impl Future<Output = T> + 'static) {
-        let handle = LOCAL_FUTURES_ARENA.with(|arena| alloc_future(arena, future));
+        let handle = LOCAL_FUTURES_POOL.with(|pool| alloc_future(pool, future));
         self.core.push_back_handle(handle);
     }
 
     /// Adds a future to the front of the deque.
     pub fn push_front(&mut self, future: impl Future<Output = T> + 'static) {
-        let handle = LOCAL_FUTURES_ARENA.with(|arena| alloc_future(arena, future));
+        let handle = LOCAL_FUTURES_POOL.with(|pool| alloc_future(pool, future));
         self.core.push_front_handle(handle);
     }
 

--- a/packages/future_deque/src/waker_meta.rs
+++ b/packages/future_deque/src/waker_meta.rs
@@ -70,6 +70,9 @@ unsafe impl Sync for MetaPtr {}
 ///
 /// The returned pointer has a stable address and owns the pool slot. It stays valid until
 /// the refcount reaches zero, at which point [`release_ref`] returns the slot to the pool.
+// Inlining exposes the typed pool allocation to the deque insertion hot path measured by
+// the Callgrind push benchmarks.
+#[inline]
 pub(crate) fn create_waker_meta(shared_parent: &Arc<Mutex<Waker>>) -> MetaPtr {
     WAKER_META_POOL.with(|pool| {
         let handle = pool.alloc_box(WakerMeta {

--- a/packages/infinity_pool/README.md
+++ b/packages/infinity_pool/README.md
@@ -6,9 +6,10 @@ Object pools with trait object support and multiple access models. Provides fast
 
 This package receives maintenance only.
 
-For the pinned pooling scenario, prefer [`plurality`](https://crates.io/crates/plurality), whose `Pool<T>` is an equivalent of `PinnedPool`. It pools a single named type, so it is not an alternative to `OpaquePool` or `BlindPool`.
-
-Where all the objects can be reclaimed together, an arena allocator such as [`multitude`](https://crates.io/crates/multitude) can take the place of a type-agnostic pool, trading per-object slot reuse for cheaper allocation.
+For owned pinned values, prefer [`plurality`](https://crates.io/crates/plurality). It offers
+`Pool<T>` for one concrete type and `MultiPool` for heterogeneous types, with detachable owning
+handles that can be type-erased. `infinity_pool` remains available where its raw manual-lifetime
+handles or macro-generated trait-object casting are required.
 
 ## Pool types
 

--- a/packages/infinity_pool/src/lib.rs
+++ b/packages/infinity_pool/src/lib.rs
@@ -10,13 +10,10 @@
 //!
 //! This package receives maintenance only.
 //!
-//! For the pinned pooling scenario, prefer [`plurality`], whose `Pool<T>` is an equivalent
-//! of [`PinnedPool`]. It pools a single named type, so it is not an alternative to
-//! [`OpaquePool`] or [`BlindPool`].
-//!
-//! Where all the objects can be reclaimed together, an arena allocator such as [`multitude`]
-//! can take the place of a type-agnostic pool, trading per-object slot reuse for cheaper
-//! allocation.
+//! For owned pinned values, prefer [`plurality`]. It offers `Pool<T>` for one concrete type
+//! and `MultiPool` for heterogeneous types, with detachable owning handles that can be
+//! type-erased. This package remains available where its raw manual-lifetime handles or
+//! macro-generated trait-object casting are required.
 //!
 //! # Motivating scenario
 //!
@@ -144,7 +141,6 @@
 //! ```
 //!
 //! [casting]: define_pooled_dyn_cast
-//! [`multitude`]: https://crates.io/crates/multitude
 //! [`plurality`]: https://crates.io/crates/plurality
 
 mod blind;

--- a/packages/vicinal/Cargo.toml
+++ b/packages/vicinal/Cargo.toml
@@ -28,10 +28,10 @@ event-listener = { workspace = true }
 events_once = { workspace = true }
 fast_time = { workspace = true }
 many_cpus = { workspace = true }
-multitude = { workspace = true, features = ["dst"] }
 new_zealand = { workspace = true }
 nm = { workspace = true }
 pin-project = { workspace = true }
+plurality = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -52,4 +52,3 @@ workspace = true
 [[bench]]
 name = "vicinal"
 harness = false
-

--- a/packages/vicinal/benches/vicinal.rs
+++ b/packages/vicinal/benches/vicinal.rs
@@ -17,6 +17,25 @@ use vicinal::Pool;
 #[global_allocator]
 static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 
+/// Keeps the low and high cases distinct without making each sample excessively long.
+const TASK_BATCH_SIZE: usize = 100;
+
+/// Matches the number of workers Vicinal assigns to each processor.
+const THREADPOOL_WORKER_COUNT: usize = 2;
+
+/// Makes it likely that every comparison-pool worker executes the pinning callback.
+const THREADPOOL_PIN_TASK_COUNT: usize = 30;
+
+/// Provides enough arithmetic to keep the task body observable without masking dispatch costs.
+const WORK_STEP_COUNT: usize = 32;
+
+/// A deterministic input prevents the optimizer from replacing the task body with a constant.
+const WORK_SEED: u32 = 42;
+
+/// Standard LCG parameters provide inexpensive deterministic arithmetic.
+const LCG_MULTIPLIER: u32 = 1_664_525;
+const LCG_INCREMENT: u32 = 1_013_904_223;
+
 /// A small, deterministic, CPU-only stand-in for a real task body.
 ///
 /// These benchmarks measure the overhead of *dispatching* work onto a worker,
@@ -25,9 +44,11 @@ static ALLOCATOR: Allocator<std::alloc::System> = Allocator::system();
 /// noise unrelated to the scheduling under test. A handful of LCG steps seeded
 /// with `black_box` gives a fixed cost the optimizer cannot fold away.
 fn simulate_work() -> u32 {
-    let mut value = black_box(42_u32);
-    for _ in 0..32 {
-        value = value.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    let mut value = black_box(WORK_SEED);
+    for _ in 0..WORK_STEP_COUNT {
+        value = value
+            .wrapping_mul(LCG_MULTIPLIER)
+            .wrapping_add(LCG_INCREMENT);
     }
     value
 }
@@ -75,14 +96,14 @@ fn entrypoint(c: &mut Criterion) {
         let scheduler = pool.scheduler();
 
         b.iter_custom(|iterations| {
-            let mut handles = Vec::with_capacity(100);
+            let mut handles = Vec::with_capacity(TASK_BATCH_SIZE);
 
             let _alloc_span = spawn_100_alloc.measure_process().iterations(iterations);
             let _time_span = spawn_100_time.measure_process().iterations(iterations);
             let start = Instant::now();
 
             for _ in 0..iterations {
-                for _ in 0..100 {
+                for _ in 0..TASK_BATCH_SIZE {
                     handles.push(scheduler.spawn(move || black_box(simulate_work())));
                 }
 
@@ -132,7 +153,7 @@ fn entrypoint(c: &mut Criterion) {
         let scheduler = pool.scheduler();
 
         b.iter_custom(|iterations| {
-            let mut handles = Vec::with_capacity(100);
+            let mut handles = Vec::with_capacity(TASK_BATCH_SIZE);
 
             let _alloc_span = spawn_urgent_100_alloc
                 .measure_process()
@@ -143,7 +164,7 @@ fn entrypoint(c: &mut Criterion) {
             let start = Instant::now();
 
             for _ in 0..iterations {
-                for _ in 0..100 {
+                for _ in 0..TASK_BATCH_SIZE {
                     handles.push(scheduler.spawn_urgent(move || black_box(simulate_work())));
                 }
 
@@ -183,14 +204,14 @@ fn entrypoint(c: &mut Criterion) {
 
     g.bench_function("thread_100", |b| {
         b.iter_custom(|iterations| {
-            let mut handles = Vec::with_capacity(100);
+            let mut handles = Vec::with_capacity(TASK_BATCH_SIZE);
 
             let _alloc_span = thread_100_alloc.measure_process().iterations(iterations);
             let _time_span = thread_100_time.measure_process().iterations(iterations);
             let start = Instant::now();
 
             for _ in 0..iterations {
-                for _ in 0..100 {
+                for _ in 0..TASK_BATCH_SIZE {
                     handles.push(thread::spawn(move || black_box(simulate_work())));
                 }
 
@@ -211,14 +232,13 @@ fn entrypoint(c: &mut Criterion) {
     let threadpool_single_time = times.operation("vicinal/spawn/threadpool_single");
 
     g.bench_function("threadpool_single", |b| {
-        // Vicinal pool defaults to 2 threads per processor, so we match.
-        let pool = ThreadPool::new(2);
+        // Match the number of workers Vicinal assigns to the selected processor.
+        let pool = ThreadPool::new(THREADPOOL_WORKER_COUNT);
         let event_pool = EventPool::<u32>::new();
 
-        // Ensure the thread pool threads are pinned to the same processor as main().
-        // There is no guarantee on what thread each task gets scheduled on, so we
-        // spam a whole bunch of these to make it more likely we hit both threads.
-        for _ in 0..30 {
+        // Submit more pinning callbacks than workers because the pool does not guarantee
+        // which worker runs each callback.
+        for _ in 0..THREADPOOL_PIN_TASK_COUNT {
             pool.execute({
                 let one_processor = one_processor.clone();
                 move || {
@@ -254,14 +274,13 @@ fn entrypoint(c: &mut Criterion) {
     let threadpool_100_time = times.operation("vicinal/spawn/threadpool_100");
 
     g.bench_function("threadpool_100", |b| {
-        // Vicinal pool defaults to 2 threads per processor, so we match.
-        let pool = ThreadPool::new(2);
+        // Match the number of workers Vicinal assigns to the selected processor.
+        let pool = ThreadPool::new(THREADPOOL_WORKER_COUNT);
         let event_pool = EventPool::<u32>::new();
 
-        // Ensure the thread pool threads are pinned to the same processor as main().
-        // There is no guarantee on what thread each task gets scheduled on, so we
-        // spam a whole bunch of these to make it more likely we hit both threads.
-        for _ in 0..30 {
+        // Submit more pinning callbacks than workers because the pool does not guarantee
+        // which worker runs each callback.
+        for _ in 0..THREADPOOL_PIN_TASK_COUNT {
             pool.execute({
                 let one_processor = one_processor.clone();
                 move || {
@@ -273,7 +292,7 @@ fn entrypoint(c: &mut Criterion) {
         pool.join();
 
         b.iter_custom(|iterations| {
-            let mut rxs = Vec::with_capacity(100);
+            let mut rxs = Vec::with_capacity(TASK_BATCH_SIZE);
 
             let _alloc_span = threadpool_100_alloc
                 .measure_process()
@@ -282,7 +301,7 @@ fn entrypoint(c: &mut Criterion) {
             let start = Instant::now();
 
             for _ in 0..iterations {
-                for _ in 0..100 {
+                for _ in 0..TASK_BATCH_SIZE {
                     let (tx, rx) = event_pool.rent();
                     rxs.push(rx);
                     pool.execute(move || {
@@ -352,7 +371,7 @@ fn entrypoint(c: &mut Criterion) {
         let event_pool = EventPool::<()>::new();
 
         b.iter_custom(|iterations| {
-            let mut rxs = Vec::with_capacity(100);
+            let mut rxs = Vec::with_capacity(TASK_BATCH_SIZE);
 
             let _alloc_span = spawn_with_event_100_alloc
                 .measure_process()
@@ -363,7 +382,7 @@ fn entrypoint(c: &mut Criterion) {
             let start = Instant::now();
 
             for _ in 0..iterations {
-                for _ in 0..100 {
+                for _ in 0..TASK_BATCH_SIZE {
                     let (tx, rx) = event_pool.rent();
                     rxs.push(rx);
                     let _handle = scheduler.spawn(move || {
@@ -428,7 +447,7 @@ fn entrypoint(c: &mut Criterion) {
         let event_pool = EventPool::<()>::new();
 
         b.iter_custom(|iterations| {
-            let mut rxs = Vec::with_capacity(100);
+            let mut rxs = Vec::with_capacity(TASK_BATCH_SIZE);
 
             let _alloc_span = spawn_and_forget_100_alloc
                 .measure_process()
@@ -439,7 +458,7 @@ fn entrypoint(c: &mut Criterion) {
             let start = Instant::now();
 
             for _ in 0..iterations {
-                for _ in 0..100 {
+                for _ in 0..TASK_BATCH_SIZE {
                     let (tx, rx) = event_pool.rent();
                     rxs.push(rx);
                     scheduler.spawn_and_forget(move || {

--- a/packages/vicinal/docs/design.md
+++ b/packages/vicinal/docs/design.md
@@ -1,0 +1,29 @@
+# vicinal design
+
+`vicinal` executes synchronous tasks near the processor that submitted them. This keeps
+detached work close to the data and caches used by its caller.
+
+## Processor locality
+
+Each task is assigned to the current processor when it is spawned. Workers associated with
+that processor execute the task. Platforms without processor-pinning support retain worker
+pool behavior without the locality guarantee.
+
+Workers are created lazily because single-task latency on an otherwise idle pool is the
+primary optimization target.
+
+## Scheduling
+
+Regular and urgent work use separate priority classes. Workers prefer urgent work, but
+tasks within a class may execute in any order and urgent work does not preempt a task that
+is already running.
+
+Tasks with join handles return their output asynchronously. A task panic is captured and
+resumed when the handle is awaited. Fire-and-forget tasks discard their output and report
+panics through tracing.
+
+## Shutdown
+
+Dropping the pool signals its workers and waits for tasks that are already executing.
+Queued tasks may be abandoned. Callers that require completion await the corresponding
+join handles before dropping the pool.

--- a/packages/vicinal/docs/implementation.md
+++ b/packages/vicinal/docs/implementation.md
@@ -1,0 +1,30 @@
+# vicinal implementation
+
+User-visible behavior is defined in the package [design](design.md).
+
+The pool maintains a registry of state created on demand for processors that submit work.
+Each processor state owns its queues, wake and shutdown signals, task storage and result
+channels. Workers pinned to that processor consume only its state.
+
+## Task storage
+
+Each processor owns a heterogeneous object pool that routes task layouts to reusable
+slots. Allocation is serialized because the pool facade is not shareable between threads.
+The resulting owning handles can be queued, executed and released on worker threads
+without holding or revisiting the allocation lock.
+
+Task slot reservation happens while the allocation lock is held. Initialization and type
+erasure happen after the lock is released so moving or dropping caller-owned task state
+cannot poison shared allocator state. Workers obtain pinned access through the owning
+handle, execute the task and then release the individual slot for reuse.
+
+## Queue and worker lifecycle
+
+Normal and urgent queues are independent. A worker removes a task while holding only the
+corresponding queue lock, then executes it after releasing the lock. User task code
+therefore runs without any processor-state lock held.
+
+Worker threads are created once per active processor and tracked by the owning pool.
+Shutdown prevents new worker creation, wakes existing workers and joins every worker
+thread. Result channels use a separate typed pool because their layout and lifecycle do
+not require heterogeneous task storage.

--- a/packages/vicinal/src/processor_state.rs
+++ b/packages/vicinal/src/processor_state.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use event_listener::Event;
 use events_once::EventLake;
-use multitude::Arena;
+use plurality::MultiPool;
 
 use crate::ErasedTaskHandle;
 
@@ -36,11 +36,9 @@ pub(crate) struct ProcessorState {
 
     /// Backing storage for the task objects queued on this processor.
     ///
-    /// An arena is neither `Sync` nor cloneable, so the mutex is what lets every thread
-    /// spawning onto this processor share one arena. It is held for the duration of a single
-    /// allocation and released before the task is enqueued, so it never overlaps with either
-    /// queue lock and an allocation never delays a worker dequeuing work.
-    pub(crate) task_arena: Mutex<Arena>,
+    /// `MultiPool` is not `Sync`, so the mutex serializes allocation by scheduler threads.
+    /// Slot initialization, queueing, execution and release happen after this lock is released.
+    pub(crate) task_pool: Mutex<MultiPool>,
 
     /// Pool for storing oneshot channels used to return task results.
     pub(crate) result_channel_pool: EventLake,
@@ -57,7 +55,7 @@ impl ProcessorState {
             wake_event: Event::new(),
             shutdown_flag: AtomicBool::new(false),
             workers_spawned: AtomicBool::new(false),
-            task_arena: Mutex::new(Arena::new()),
+            task_pool: Mutex::new(MultiPool::new()),
             result_channel_pool: EventLake::new(),
             tasks_spawned: AtomicU64::new(0),
         }
@@ -86,7 +84,26 @@ impl ProcessorState {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::pin::Pin;
+    use std::sync::{Arc, Barrier};
+
     use super::*;
+    use crate::{VicinalTask, init_task};
+
+    /// Spans multiple allocation/release operations without making Miri runs expensive.
+    const CONCURRENT_TASK_COUNT: usize = 32;
+
+    /// Minimal task used to exercise cross-thread slot release.
+    struct NoopTask;
+
+    impl VicinalTask for NoopTask {
+        fn call(self: Pin<&mut Self>) {}
+    }
+
+    fn alloc_noop_task(state: &ProcessorState) -> ErasedTaskHandle {
+        let slot = state.task_pool.lock().unwrap().alloc_uninit_box();
+        init_task(slot, NoopTask)
+    }
 
     #[test]
     fn new_creates_empty_queues() {
@@ -128,5 +145,31 @@ mod tests {
         state.record_task_spawned();
 
         assert_eq!(state.get_tasks_spawned(), 3);
+    }
+
+    #[test]
+    fn task_slots_can_be_released_while_allocating() {
+        let state = Arc::new(ProcessorState::new());
+        let tasks = std::iter::repeat_with(|| alloc_noop_task(&state))
+            .take(CONCURRENT_TASK_COUNT)
+            .collect::<Vec<_>>();
+        let barrier = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            scope.spawn({
+                let barrier = Arc::clone(&barrier);
+                move || {
+                    barrier.wait();
+                    drop(tasks);
+                }
+            });
+
+            barrier.wait();
+            for _ in 0..CONCURRENT_TASK_COUNT {
+                drop(alloc_noop_task(&state));
+            }
+        });
+
+        assert!(state.task_pool.lock().unwrap().is_empty());
     }
 }

--- a/packages/vicinal/src/scheduler.rs
+++ b/packages/vicinal/src/scheduler.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use tracing::trace;
 
 use crate::metrics::CLOCK;
-use crate::{JoinHandle, NEVER_POISONED, PoolInner, alloc_task, wrap_task};
+use crate::{
+    ErasedTaskHandle, JoinHandle, NEVER_POISONED, PoolInner, ProcessorState, VicinalTask,
+    init_task, wrap_task,
+};
 
 /// A handle for spawning tasks on a [`Pool`][crate::Pool].
 ///
@@ -162,12 +165,7 @@ impl Scheduler {
         // Wrap the task to capture panics and send the result.
         let wrapped = wrap_task(task, sender, spawn_time);
 
-        // Move the task into this processor's arena and erase its type. The arena lock is
-        // released before any queue lock is taken, so allocation never blocks a dequeue.
-        let dyn_task = {
-            let arena = state.task_arena.lock().expect(NEVER_POISONED);
-            alloc_task(&arena, wrapped)
-        };
+        let dyn_task = allocate_task(state, wrapped);
 
         // Push to the appropriate queue.
         if urgent {
@@ -225,12 +223,7 @@ impl Scheduler {
         // Wrap the task to capture panics and log them.
         let wrapped = wrap_task_and_forget(task, spawn_time);
 
-        // Move the task into this processor's arena and erase its type. The arena lock is
-        // released before any queue lock is taken, so allocation never blocks a dequeue.
-        let dyn_task = {
-            let arena = state.task_arena.lock().expect(NEVER_POISONED);
-            alloc_task(&arena, wrapped)
-        };
+        let dyn_task = allocate_task(state, wrapped);
 
         // Push to the appropriate queue.
         if urgent {
@@ -265,6 +258,21 @@ impl Scheduler {
         // Notify one worker that work is available.
         state.wake_event.notify(1);
     }
+}
+
+/// Allocates and initializes a task without invoking task code under the pool lock.
+fn allocate_task<T: VicinalTask>(state: &ProcessorState, task: T) -> ErasedTaskHandle {
+    let slot = {
+        let pool = state.task_pool.lock().expect(NEVER_POISONED);
+        pool.try_alloc_uninit_box()
+    };
+
+    let slot = match slot {
+        Ok(slot) => slot,
+        Err(error) => panic!("task pool allocation failed: {error}"),
+    };
+
+    init_task(slot, task)
 }
 
 #[cfg(test)]

--- a/packages/vicinal/src/task.rs
+++ b/packages/vicinal/src/task.rs
@@ -1,14 +1,14 @@
 //! Task representation and the wrappers that adapt user-provided closures to it.
 
 use std::any::Any;
+use std::mem::MaybeUninit;
 use std::panic::{self, AssertUnwindSafe};
 use std::pin::Pin;
 
 use events_once::PooledSender;
 use fast_time::Instant;
-use multitude::dst::pointee;
-use multitude::{Arena, coerce};
 use pin_project::pin_project;
+use plurality::{Box as PoolBox, coerce};
 
 use crate::metrics::{CLOCK, EXECUTION_TIME_MS, SCHEDULING_DELAY_MS};
 
@@ -18,31 +18,36 @@ use crate::metrics::{CLOCK, EXECUTION_TIME_MS, SCHEDULING_DELAY_MS};
 /// loop knows about a task: it can run it exactly once, in place, without knowing the
 /// closure type or return type it was built from. The `Send` supertrait is what allows the
 /// erased form to travel from the spawning thread to the worker thread.
-///
-/// The `pointee` attribute supplies the pointer-metadata implementation that
-/// [`multitude::Box`] requires of its unsized targets. `pointee` is `ptr_meta`'s macro,
-/// re-exported by `multitude`, and it emits `::ptr_meta::*` paths unless told otherwise;
-/// the `crate` argument redirects those at `multitude`'s re-export so this package needs
-/// no direct dependency on `ptr_meta`. Depending on `ptr_meta` directly would be worse: the
-/// generated impls must target the exact `ptr_meta` instance `multitude` was built against,
-/// so a version skew would surface as an unrelated-looking trait mismatch.
-#[pointee(crate = ::multitude::dst)]
 pub(crate) trait VicinalTask: Send + 'static {
     fn call(self: Pin<&mut Self>);
 }
 
 /// Owning handle to a type-erased task, as stored in a processor's task queue.
 ///
-/// The handle owns its slice of the arena outright and keeps the backing storage alive on
-/// its own, so queueing, dequeuing and executing a task need no further contact with the
-/// arena or the lock that guards it.
-pub(crate) type ErasedTaskHandle = Pin<multitude::Box<dyn VicinalTask>>;
+/// The handle owns its pool slot, so queueing, dequeuing and executing a task need no further
+/// contact with the pool or the lock that guards allocation.
+pub(crate) type ErasedTaskHandle = PoolBox<dyn VicinalTask>;
 
-/// Moves `task` into the arena and erases its type.
-pub(crate) fn alloc_task(arena: &Arena, task: impl VicinalTask) -> ErasedTaskHandle {
-    let handle = arena.alloc_box(task);
+/// A reserved task slot that can be initialized after releasing the pool lock.
+pub(crate) type UninitTaskHandle<T> = PoolBox<MaybeUninit<T>>;
 
-    multitude::Box::into_pin(multitude::Box::unsize(handle, coerce!(dyn VicinalTask)))
+/// Initializes a reserved slot with `task` and erases its type.
+pub(crate) fn init_task<T: VicinalTask>(
+    mut handle: UninitTaskHandle<T>,
+    task: T,
+) -> ErasedTaskHandle {
+    {
+        let slot = handle.as_pin_mut();
+        // SAFETY: The uniquely owned slot is still uninitialized, so there is no pinned `T`
+        // that could be moved through this mutable reference. The task is written in place.
+        let slot = unsafe { Pin::get_unchecked_mut(slot) };
+        slot.write(task);
+    }
+
+    // SAFETY: The task was written into this slot immediately above.
+    let handle = unsafe { handle.assume_init() };
+
+    PoolBox::unsize(handle, coerce!(dyn VicinalTask))
 }
 
 /// Outcome of running a task to completion: either its return value or the payload of the
@@ -148,8 +153,64 @@ where
 mod tests {
     use events_once::EventLake;
     use futures::executor::block_on;
+    use plurality::MultiPool;
 
     use super::*;
+
+    /// Makes capacity growth observable after live tasks fill an initial chunk.
+    const TEST_CHUNK_SIZE: u32 = 2;
+
+    /// Uses a meaningfully different task layout without making the test expensive.
+    const LARGE_TASK_WORDS: usize = 8;
+
+    /// The reuse test deliberately exercises unrelated allocation layouts.
+    const EXPECTED_LAYOUT_COUNT: usize = 2;
+
+    /// A compact task used to exercise one internal layout pool.
+    struct SmallTask(u8);
+
+    impl VicinalTask for SmallTask {
+        fn call(self: Pin<&mut Self>) {
+            _ = std::hint::black_box(self.0);
+        }
+    }
+
+    /// A larger task used to exercise an independent internal layout pool.
+    struct LargeTask([u64; LARGE_TASK_WORDS]);
+
+    impl VicinalTask for LargeTask {
+        fn call(self: Pin<&mut Self>) {
+            _ = std::hint::black_box(self.0);
+        }
+    }
+
+    fn alloc_test_task<T: VicinalTask>(pool: &MultiPool, task: T) -> ErasedTaskHandle {
+        init_task(pool.alloc_uninit_box(), task)
+    }
+
+    #[test]
+    fn released_task_slots_are_reused_per_layout() {
+        let pool = MultiPool::builder().chunk_size(TEST_CHUNK_SIZE).build();
+        let small_held = alloc_test_task(&pool, SmallTask(u8::default()));
+        let small_released = alloc_test_task(&pool, SmallTask(u8::default()));
+        let large_held = alloc_test_task(&pool, LargeTask([u64::default(); LARGE_TASK_WORDS]));
+        let large_released = alloc_test_task(&pool, LargeTask([u64::default(); LARGE_TASK_WORDS]));
+
+        assert_eq!(pool.layouts(), EXPECTED_LAYOUT_COUNT);
+        assert_eq!(pool.capacity_of::<SmallTask>(), u64::from(TEST_CHUNK_SIZE));
+        assert_eq!(pool.capacity_of::<LargeTask>(), u64::from(TEST_CHUNK_SIZE));
+
+        drop((small_released, large_released));
+        let small_replacement = alloc_test_task(&pool, SmallTask(u8::default()));
+        let large_replacement =
+            alloc_test_task(&pool, LargeTask([u64::default(); LARGE_TASK_WORDS]));
+
+        assert_eq!(pool.capacity_of::<SmallTask>(), u64::from(TEST_CHUNK_SIZE));
+        assert_eq!(pool.capacity_of::<LargeTask>(), u64::from(TEST_CHUNK_SIZE));
+
+        drop((small_held, small_replacement, large_held, large_replacement));
+        assert!(pool.is_empty());
+    }
 
     #[test]
     fn wrap_task_sends_return_value() {

--- a/packages/vicinal/src/worker.rs
+++ b/packages/vicinal/src/worker.rs
@@ -55,13 +55,13 @@ impl<'a> WorkerCore<'a> {
 
         let task = self.urgent_queue.lock().expect(NEVER_POISONED).pop_front();
         if let Some(mut task) = task {
-            task.as_mut().call();
+            task.as_pin_mut().call();
             return IterationResult::ExecutedUrgent;
         }
 
         let task = self.regular_queue.lock().expect(NEVER_POISONED).pop_front();
         if let Some(mut task) = task {
-            task.as_mut().call();
+            task.as_pin_mut().call();
             return IterationResult::ExecutedRegular;
         }
 
@@ -75,10 +75,14 @@ mod tests {
     use std::pin::Pin;
     use std::sync::atomic::AtomicU32;
 
-    use multitude::Arena;
+    use plurality::MultiPool;
 
     use super::*;
-    use crate::{VicinalTask, alloc_task};
+    use crate::{VicinalTask, init_task};
+
+    fn alloc_task(pool: &MultiPool, task: impl VicinalTask) -> ErasedTaskHandle {
+        init_task(pool.alloc_uninit_box(), task)
+    }
 
     /// A simple task that increments a counter when called.
     struct CountingTask {
@@ -132,12 +136,12 @@ mod tests {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         COUNTER.store(0, Ordering::Relaxed);
 
-        let arena = Arena::new();
+        let pool = MultiPool::new();
         let urgent = Mutex::new(VecDeque::new());
         let regular = Mutex::new(VecDeque::new());
         let shutdown = AtomicBool::new(false);
 
-        let task = alloc_task(&arena, CountingTask::new(&COUNTER));
+        let task = alloc_task(&pool, CountingTask::new(&COUNTER));
         urgent.lock().unwrap().push_back(task);
 
         let core = WorkerCore::new(&urgent, &regular, &shutdown);
@@ -153,13 +157,13 @@ mod tests {
         URGENT_COUNTER.store(0, Ordering::Relaxed);
         REGULAR_COUNTER.store(0, Ordering::Relaxed);
 
-        let arena = Arena::new();
+        let pool = MultiPool::new();
         let urgent = Mutex::new(VecDeque::new());
         let regular = Mutex::new(VecDeque::new());
         let shutdown = AtomicBool::new(false);
 
-        let urgent_task = alloc_task(&arena, CountingTask::new(&URGENT_COUNTER));
-        let regular_task = alloc_task(&arena, CountingTask::new(&REGULAR_COUNTER));
+        let urgent_task = alloc_task(&pool, CountingTask::new(&URGENT_COUNTER));
+        let regular_task = alloc_task(&pool, CountingTask::new(&REGULAR_COUNTER));
         urgent.lock().unwrap().push_back(urgent_task);
         regular.lock().unwrap().push_back(regular_task);
 
@@ -176,12 +180,12 @@ mod tests {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         COUNTER.store(0, Ordering::Relaxed);
 
-        let arena = Arena::new();
+        let pool = MultiPool::new();
         let urgent = Mutex::new(VecDeque::new());
         let regular = Mutex::new(VecDeque::new());
         let shutdown = AtomicBool::new(false);
 
-        let task = alloc_task(&arena, CountingTask::new(&COUNTER));
+        let task = alloc_task(&pool, CountingTask::new(&COUNTER));
         regular.lock().unwrap().push_back(task);
 
         let core = WorkerCore::new(&urgent, &regular, &shutdown);
@@ -195,12 +199,12 @@ mod tests {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         COUNTER.store(0, Ordering::Relaxed);
 
-        let arena = Arena::new();
+        let pool = MultiPool::new();
         let urgent = Mutex::new(VecDeque::new());
         let regular = Mutex::new(VecDeque::new());
         let shutdown = AtomicBool::new(true);
 
-        let task = alloc_task(&arena, CountingTask::new(&COUNTER));
+        let task = alloc_task(&pool, CountingTask::new(&COUNTER));
         regular.lock().unwrap().push_back(task);
 
         let core = WorkerCore::new(&urgent, &regular, &shutdown);


### PR DESCRIPTION
[Copilot speaking]

`future_deque` and `vicinal` need reusable object slots rather than arena allocation, while `infinity_pool` is moving into maintenance-only mode. This migrates both packages to `plurality` and removes the workspace's remaining dependency on `multitude` and cross-package dependency surface for `infinity_pool`.

## Changes

- Use per-thread `plurality::MultiPool` storage for heterogeneous futures in `future_deque`, preserving stable pinned handles and separate local/thread-mobile capacity.
- Use per-processor `plurality::MultiPool` storage for `vicinal` tasks, reserving slots under the allocator lock and initializing caller-owned task state after releasing it.
- Upgrade `plurality` to 0.2.2, remove obsolete allocator dependencies, and update allocator guidance and package design/implementation documentation.
- Make allocator-sensitive benchmarks compare equivalent layouts and cover deterministic insertion and polling paths.

## Performance

Allocation counts are unchanged, including zero steady-state allocations in the churn scenarios. Deterministic instruction counts show pending-100 polling essentially unchanged (9,550 to 9,547 instructions). Populated `future_deque` insertion increases from 134 to 159 instructions; the remaining 25-instruction cost is heterogeneous `MultiPool` routing. Larger wall-clock workloads remain approximately flat to 7% slower, while the smallest insertion/churn scenarios are about 10-15% slower. `vicinal` shows no consistent regression.