### PR TITLE
events_once: make destructor cleanup callback-safe

### DIFF
--- a/packages/events_once/AGENTS.md
+++ b/packages/events_once/AGENTS.md
@@ -74,7 +74,7 @@ and its models, so the table below identifies every row that exists:
 | `poll` | `pending_first`, `pending_repeat`, `disconnected` | boxed | local, sync | every row (6) |
 | `into_value` | `pending`, `ready`, `disconnected` | boxed | local, sync | every row (6) |
 | `is_ready` | `pending`, `ready`, `disconnected` | boxed | local, sync | none |
-| `cancel` | `sender_first_bound`, `sender_first_awaiting`, `receiver_first_bound` | boxed, embedded, pooled, raw_pooled, lake, raw_lake | local, sync | every row (36) |
+| `cancel` | `sender_first_bound`, `sender_first_awaiting`, `receiver_first_bound`, `receiver_first_awaiting` | boxed, embedded, pooled, raw_pooled, lake, raw_lake | local, sync | every row (48) |
 
 The `oneshot` leaves are an external reference point for the same lifecycle; they
 live in the same group so Criterion reports them alongside our own numbers.

--- a/packages/events_once/benches/events_once_ops.rs
+++ b/packages/events_once/benches/events_once_ops.rs
@@ -1057,7 +1057,7 @@ fn is_ready(c: &mut Criterion) {
 // or the caller's embedded place - is returned from the measured closure so that its
 // own teardown stays outside the measured region.
 //
-// Three start states are measured per storage and model:
+// Four start states are measured per storage and model:
 //
 // - `sender_first_bound`: the receiver never polled, so there is no waker to consume.
 // - `sender_first_awaiting`: the receiver parked a waker, which the sender consumes and
@@ -1065,6 +1065,9 @@ fn is_ready(c: &mut Criterion) {
 //   `src/core/state.rs` and described in `docs/implementation.md`.
 // - `receiver_first_bound`: the receiver is dropped before polling, which makes the
 //   sender the endpoint that releases the storage.
+// - `receiver_first_awaiting`: the receiver is dropped after parking a waker, so receiver
+//   cancellation includes the waker cleanup and state handoff before the sender releases
+//   the storage.
 fn cancel(c: &mut Criterion) {
     let mut g = c.benchmark_group("events_once_ops/cancel");
 
@@ -1104,6 +1107,18 @@ fn cancel(c: &mut Criterion) {
         sync_boxed_bound,
         receiver_first
     );
+    bench_cancel_boxed!(
+        g,
+        "local/boxed/receiver_first_awaiting",
+        local_boxed_awaiting,
+        receiver_first
+    );
+    bench_cancel_boxed!(
+        g,
+        "sync/boxed/receiver_first_awaiting",
+        sync_boxed_awaiting,
+        receiver_first
+    );
 
     bench_cancel_owned!(
         g,
@@ -1139,6 +1154,18 @@ fn cancel(c: &mut Criterion) {
         g,
         "sync/embedded/receiver_first_bound",
         sync_embedded_bound,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "local/embedded/receiver_first_awaiting",
+        local_embedded_awaiting,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "sync/embedded/receiver_first_awaiting",
+        sync_embedded_awaiting,
         receiver_first
     );
 
@@ -1178,6 +1205,18 @@ fn cancel(c: &mut Criterion) {
         sync_pooled_bound,
         receiver_first
     );
+    bench_cancel_owned!(
+        g,
+        "local/pooled/receiver_first_awaiting",
+        local_pooled_awaiting,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "sync/pooled/receiver_first_awaiting",
+        sync_pooled_awaiting,
+        receiver_first
+    );
 
     bench_cancel_owned!(
         g,
@@ -1213,6 +1252,18 @@ fn cancel(c: &mut Criterion) {
         g,
         "sync/raw_pooled/receiver_first_bound",
         sync_raw_pooled_bound,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "local/raw_pooled/receiver_first_awaiting",
+        local_raw_pooled_awaiting,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "sync/raw_pooled/receiver_first_awaiting",
+        sync_raw_pooled_awaiting,
         receiver_first
     );
 
@@ -1252,6 +1303,18 @@ fn cancel(c: &mut Criterion) {
         sync_lake_bound,
         receiver_first
     );
+    bench_cancel_owned!(
+        g,
+        "local/lake/receiver_first_awaiting",
+        local_lake_awaiting,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "sync/lake/receiver_first_awaiting",
+        sync_lake_awaiting,
+        receiver_first
+    );
 
     bench_cancel_owned!(
         g,
@@ -1287,6 +1350,18 @@ fn cancel(c: &mut Criterion) {
         g,
         "sync/raw_lake/receiver_first_bound",
         sync_raw_lake_bound,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "local/raw_lake/receiver_first_awaiting",
+        local_raw_lake_awaiting,
+        receiver_first
+    );
+    bench_cancel_owned!(
+        g,
+        "sync/raw_lake/receiver_first_awaiting",
+        sync_raw_lake_awaiting,
         receiver_first
     );
 

--- a/packages/events_once/benches/events_once_ops_cg.rs
+++ b/packages/events_once/benches/events_once_ops_cg.rs
@@ -856,7 +856,7 @@ mod linux {
     // handle, or the caller's embedded place - is returned from the measured region so
     // that its own teardown stays untimed.
     //
-    // Three start states are measured per storage and model:
+    // Four start states are measured per storage and model:
     //
     // - `sender_first_bound`: the receiver never polled, so there is no waker to consume.
     // - `sender_first_awaiting`: the receiver parked a waker, which the sender consumes
@@ -868,6 +868,9 @@ mod linux {
     //   in `docs/implementation.md` ("The state machine is the single source of truth").
     // - `receiver_first_bound`: the receiver is dropped before polling, which makes the
     //   sender the endpoint that releases the storage.
+    // - `receiver_first_awaiting`: the receiver is dropped after parking a waker, so
+    //   receiver cancellation includes the waker cleanup and state handoff before the
+    //   sender releases the storage.
 
     #[library_benchmark]
     #[bench::bound(local_boxed_bound())]
@@ -912,6 +915,22 @@ mod linux {
     #[library_benchmark]
     #[bench::bound(sync_boxed_bound())]
     fn cancel_sync_boxed_receiver_first_bound(input: SyncBoxedEndpoints) {
+        let (sender, receiver) = input;
+        drop(receiver);
+        drop(sender);
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(local_boxed_awaiting())]
+    fn cancel_local_boxed_receiver_first_awaiting(input: LocalBoxedEndpoints) {
+        let (sender, receiver) = input;
+        drop(receiver);
+        drop(sender);
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(sync_boxed_awaiting())]
+    fn cancel_sync_boxed_receiver_first_awaiting(input: SyncBoxedEndpoints) {
         let (sender, receiver) = input;
         drop(receiver);
         drop(sender);
@@ -975,6 +994,28 @@ mod linux {
     #[library_benchmark]
     #[bench::bound(sync_embedded_bound())]
     fn cancel_sync_embedded_receiver_first_bound(
+        input: (SyncEmbeddedStorage, SyncEmbeddedEndpoints),
+    ) -> SyncEmbeddedStorage {
+        let (place, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        place
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(local_embedded_awaiting())]
+    fn cancel_local_embedded_receiver_first_awaiting(
+        input: (LocalEmbeddedStorage, LocalEmbeddedEndpoints),
+    ) -> LocalEmbeddedStorage {
+        let (place, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        place
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(sync_embedded_awaiting())]
+    fn cancel_sync_embedded_receiver_first_awaiting(
         input: (SyncEmbeddedStorage, SyncEmbeddedEndpoints),
     ) -> SyncEmbeddedStorage {
         let (place, (sender, receiver)) = input;
@@ -1050,6 +1091,28 @@ mod linux {
     }
 
     #[library_benchmark]
+    #[bench::awaiting(local_pooled_awaiting())]
+    fn cancel_local_pooled_receiver_first_awaiting(
+        input: (LocalEventPool<i32>, LocalPooledEndpoints),
+    ) -> LocalEventPool<i32> {
+        let (pool, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        pool
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(sync_pooled_awaiting())]
+    fn cancel_sync_pooled_receiver_first_awaiting(
+        input: (EventPool<i32>, SyncPooledEndpoints),
+    ) -> EventPool<i32> {
+        let (pool, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        pool
+    }
+
+    #[library_benchmark]
     #[bench::bound(local_raw_pooled_bound())]
     fn cancel_local_raw_pooled_sender_first_bound(
         input: (LocalRawPool, LocalRawPooledEndpoints),
@@ -1107,6 +1170,28 @@ mod linux {
     #[library_benchmark]
     #[bench::bound(sync_raw_pooled_bound())]
     fn cancel_sync_raw_pooled_receiver_first_bound(
+        input: (SyncRawPool, SyncRawPooledEndpoints),
+    ) -> SyncRawPool {
+        let (pool, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        pool
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(local_raw_pooled_awaiting())]
+    fn cancel_local_raw_pooled_receiver_first_awaiting(
+        input: (LocalRawPool, LocalRawPooledEndpoints),
+    ) -> LocalRawPool {
+        let (pool, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        pool
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(sync_raw_pooled_awaiting())]
+    fn cancel_sync_raw_pooled_receiver_first_awaiting(
         input: (SyncRawPool, SyncRawPooledEndpoints),
     ) -> SyncRawPool {
         let (pool, (sender, receiver)) = input;
@@ -1178,6 +1263,28 @@ mod linux {
     }
 
     #[library_benchmark]
+    #[bench::awaiting(local_lake_awaiting())]
+    fn cancel_local_lake_receiver_first_awaiting(
+        input: (LocalEventLake, LocalPooledEndpoints),
+    ) -> LocalEventLake {
+        let (lake, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        lake
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(sync_lake_awaiting())]
+    fn cancel_sync_lake_receiver_first_awaiting(
+        input: (EventLake, SyncPooledEndpoints),
+    ) -> EventLake {
+        let (lake, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        lake
+    }
+
+    #[library_benchmark]
     #[bench::bound(local_raw_lake_bound())]
     fn cancel_local_raw_lake_sender_first_bound(
         input: (RawLocalEventLake, LocalRawPooledEndpoints),
@@ -1235,6 +1342,28 @@ mod linux {
     #[library_benchmark]
     #[bench::bound(sync_raw_lake_bound())]
     fn cancel_sync_raw_lake_receiver_first_bound(
+        input: (RawEventLake, SyncRawPooledEndpoints),
+    ) -> RawEventLake {
+        let (lake, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        lake
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(local_raw_lake_awaiting())]
+    fn cancel_local_raw_lake_receiver_first_awaiting(
+        input: (RawLocalEventLake, LocalRawPooledEndpoints),
+    ) -> RawLocalEventLake {
+        let (lake, (sender, receiver)) = input;
+        drop(receiver);
+        drop(sender);
+        lake
+    }
+
+    #[library_benchmark]
+    #[bench::awaiting(sync_raw_lake_awaiting())]
+    fn cancel_sync_raw_lake_receiver_first_awaiting(
         input: (RawEventLake, SyncRawPooledEndpoints),
     ) -> RawEventLake {
         let (lake, (sender, receiver)) = input;
@@ -1324,36 +1453,48 @@ mod linux {
             cancel_sync_boxed_sender_first_awaiting,
             cancel_local_boxed_receiver_first_bound,
             cancel_sync_boxed_receiver_first_bound,
+            cancel_local_boxed_receiver_first_awaiting,
+            cancel_sync_boxed_receiver_first_awaiting,
             cancel_local_embedded_sender_first_bound,
             cancel_sync_embedded_sender_first_bound,
             cancel_local_embedded_sender_first_awaiting,
             cancel_sync_embedded_sender_first_awaiting,
             cancel_local_embedded_receiver_first_bound,
             cancel_sync_embedded_receiver_first_bound,
+            cancel_local_embedded_receiver_first_awaiting,
+            cancel_sync_embedded_receiver_first_awaiting,
             cancel_local_pooled_sender_first_bound,
             cancel_sync_pooled_sender_first_bound,
             cancel_local_pooled_sender_first_awaiting,
             cancel_sync_pooled_sender_first_awaiting,
             cancel_local_pooled_receiver_first_bound,
             cancel_sync_pooled_receiver_first_bound,
+            cancel_local_pooled_receiver_first_awaiting,
+            cancel_sync_pooled_receiver_first_awaiting,
             cancel_local_raw_pooled_sender_first_bound,
             cancel_sync_raw_pooled_sender_first_bound,
             cancel_local_raw_pooled_sender_first_awaiting,
             cancel_sync_raw_pooled_sender_first_awaiting,
             cancel_local_raw_pooled_receiver_first_bound,
             cancel_sync_raw_pooled_receiver_first_bound,
+            cancel_local_raw_pooled_receiver_first_awaiting,
+            cancel_sync_raw_pooled_receiver_first_awaiting,
             cancel_local_lake_sender_first_bound,
             cancel_sync_lake_sender_first_bound,
             cancel_local_lake_sender_first_awaiting,
             cancel_sync_lake_sender_first_awaiting,
             cancel_local_lake_receiver_first_bound,
             cancel_sync_lake_receiver_first_bound,
+            cancel_local_lake_receiver_first_awaiting,
+            cancel_sync_lake_receiver_first_awaiting,
             cancel_local_raw_lake_sender_first_bound,
             cancel_sync_raw_lake_sender_first_bound,
             cancel_local_raw_lake_sender_first_awaiting,
             cancel_sync_raw_lake_sender_first_awaiting,
             cancel_local_raw_lake_receiver_first_bound,
             cancel_sync_raw_lake_receiver_first_bound,
+            cancel_local_raw_lake_receiver_first_awaiting,
+            cancel_sync_raw_lake_receiver_first_awaiting,
         ]
     );
 }

--- a/packages/events_once/docs/design.md
+++ b/packages/events_once/docs/design.md
@@ -63,9 +63,12 @@ obtained through any other construction path.
 Waker cloning, waking and destruction, together with payload destruction, are callback
 boundaries because they can execute caller code. Before invoking one, an event completes the
 observable state transition that led to it and releases every borrow or lock that callback code
-could re-enter.
+could re-enter. It also completes endpoint and storage cleanup that must survive if the callback
+unwinds, so catching a callback panic through an unwind-safe endpoint leaves pooled storage
+available for reuse.
 
 A waker cloned while a receiver is being polled may send through or drop the corresponding
 sender. A registered waker that runs while an event completes or is cancelled may poll the
 receiver to completion or drop either endpoint. These operations observe the state published
-before the callback.
+before the callback. A destructor for a discarded payload or registered waker may likewise use
+the event's pool or lake and drop a surviving endpoint.

--- a/packages/events_once/docs/implementation.md
+++ b/packages/events_once/docs/implementation.md
@@ -40,6 +40,19 @@ Two properties of the state machine matter beyond the event implementations them
   as the result of the transition it performed. No endpoint may derive that right from an
   observation it made earlier, because the other endpoint may act in between.
 
+## User destructors are callback boundaries
+
+Waker vtable operations and payload destruction may reenter the event or storage owner and may
+unwind. The state machine therefore finishes the observable transition and releases any borrow or
+lock before invoking them. When an endpoint is ending its lifecycle, it first transfers or
+completes storage cleanup, while temporarily owning any waker or payload whose destructor must be
+deferred. A panic from that destructor can then propagate without stranding a rented slot.
+
+Terminal value extraction is separate from receiver cancellation. The extraction path handles only
+stable terminal states and remains inline with the normal receiver flow. Synchronized cancellation
+contains the callback-bearing state handoff and storage release in a cold, out-of-line helper, so
+completed-receiver destruction does not inherit the cancellation state machine.
+
 ## Unsafe reference ownership and the release boundary
 
 The endpoint reference is the package's central unsafe abstraction, so its obligations are

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -17,9 +17,9 @@ use std::task::Waker;
 #[cfg(debug_assertions)]
 use crate::{BacktraceType, capture_backtrace};
 use crate::{
-    BoxedLocalReceiver, BoxedLocalRef, BoxedLocalSender, Disconnected, EVENT_AWAITING, EVENT_BOUND,
-    EVENT_DISCONNECTED, EVENT_SET, EmbeddedLocalEvent, LocalReceiverCore, LocalSenderCore,
-    PtrLocalRef, RawLocalReceiver, RawLocalSender,
+    BoxedLocalReceiver, BoxedLocalRef, BoxedLocalSender, Cancellation, Disconnected,
+    EVENT_AWAITING, EVENT_BOUND, EVENT_DISCONNECTED, EVENT_SET, EmbeddedLocalEvent,
+    LocalReceiverCore, LocalSenderCore, PtrLocalRef, RawLocalReceiver, RawLocalSender,
 };
 
 /// Coordinates delivery of a `T` at most once from a sender to a receiver on the same thread.
@@ -35,6 +35,10 @@ use crate::{
 /// is likewise user-supplied code. Such a callback may operate on the sender endpoint of the event
 /// being polled: it may send a value and it may drop the sender. The poll observes the resulting
 /// state.
+///
+/// Destruction of a registered waker or discarded payload may also run arbitrary user code. The
+/// event completes any endpoint and storage cleanup that must survive unwinding before invoking
+/// such a destructor.
 pub struct LocalEvent<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: Cell<u8>,
@@ -496,7 +500,7 @@ impl<T: 'static> LocalEvent<T> {
     /// caller to close, so two obligations follow: every user-controlled callback (waker clone,
     /// drop or wake) must have finished before entry, and the caller must release the event on
     /// return without any further state-driven cleanup. Otherwise a callback that unwinds into
-    /// receiver cleanup reaches `final_poll()`, which trusts `EVENT_SET` and would read the
+    /// receiver cancellation reaches `cancel()`, which trusts `EVENT_SET` and would read the
     /// moved-out payload a second time. Ref: docs/callback-safety.md.
     #[must_use]
     fn poll_set(&self) -> T {
@@ -663,8 +667,46 @@ impl<T: 'static> LocalEvent<T> {
         matches!(self.state.get(), EVENT_SET | EVENT_DISCONNECTED)
     }
 
-    /// Attempts to obtain the value from the event, if one has been sent, while indicating
-    /// that no further polls will be performed by the receiver.
+    /// Extracts the terminal result after the receiver has observed a completed event.
+    ///
+    /// The receiver owns event cleanup after either result.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the event is not in a terminal state.
+    // Callgrind and disassembly show that terminal extraction must remain inline with
+    // `into_value()` to keep cancellation machinery off that hot path.
+    #[inline]
+    pub(crate) fn take_result(event_cell: &UnsafeCell<Self>) -> Result<T, Disconnected> {
+        // SAFETY: The event reference contract guarantees shared access through this outer
+        // UnsafeCell for as long as the receiver still owns its endpoint reference.
+        let event = unsafe { &*event_cell.get() };
+
+        let previous_state = event.state.replace(EVENT_DISCONNECTED);
+
+        match previous_state {
+            EVENT_SET => {
+                // SAFETY: EVENT_SET guarantees that the payload cell is initialized, and this
+                // terminal transition gives the receiver exclusive extraction rights.
+                let value_cell_maybe = unsafe { event.value.get().as_mut() };
+                // SAFETY: UnsafeCell pointer is never null.
+                let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
+
+                // SAFETY: The state guarantee above proves the cell is initialized.
+                Ok(unsafe { value_cell.assume_init_read() })
+            }
+            EVENT_DISCONNECTED => Err(Disconnected),
+            // Defensive: the caller must have observed a terminal state.
+            _ => {
+                unreachable!(
+                    "unreachable {} state on terminal result extraction: {previous_state}",
+                    type_name::<Self>()
+                );
+            }
+        }
+    }
+
+    /// Cancels the receiver, returning the final event observation and any deferred callback.
     ///
     /// Returns `Ok(None)` if the sender has not yet sent a value. In this case, the sender will
     /// eventually clean up the event.
@@ -676,23 +718,19 @@ impl<T: 'static> LocalEvent<T> {
     /// See [`set()`][Self::set] for why the event arrives as an `&UnsafeCell<Self>`; here it is
     /// the waker's destructor rather than `wake()` that may release the event storage.
     #[inline]
-    pub(crate) fn final_poll(event_cell: &UnsafeCell<Self>) -> Result<Option<T>, Disconnected> {
+    pub(crate) fn cancel(event_cell: &UnsafeCell<Self>) -> Cancellation<T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
         let event = unsafe { &*event_cell.get() };
 
-        // If we are still awaiting, the receiver (the caller) owns the stored waker and must
-        // destroy it before disconnecting. We revert to EVENT_BOUND *before* dropping the waker
-        // so that a reentrant sender drop triggered by the waker's destructor observes a live,
-        // non-terminal event and defers cleanup, rather than deallocating the storage we are
-        // about to read from again. Only once the waker is gone do we read the resulting state
-        // and transition to EVENT_DISCONNECTED.
+        // If we are still awaiting, the receiver owns the stored waker. Move it out before
+        // disconnecting, but defer its destruction to the receiver core so no user code runs until
+        // the state transition and any storage release have completed.
         //
-        // This mirrors the sync `Event::final_poll`, which reverts AWAITING -> BOUND before
-        // destroying the awaiter, and follows docs/callback-safety.md ("No callbacks under
-        // borrows of shared state"; symmetric handoff vs. cleanup ordering).
-        if event.state.get() == EVENT_AWAITING {
+        // This mirrors the sync `Event::cancel`, which also reverts AWAITING -> BOUND before
+        // extracting the awaiter. Ref: docs/callback-safety.md.
+        let awaiter = if event.state.get() == EVENT_AWAITING {
             event.state.set(EVENT_BOUND);
 
             // SAFETY: The only other potential references to the field are other short-lived
@@ -702,27 +740,22 @@ impl<T: 'static> LocalEvent<T> {
             // SAFETY: UnsafeCell pointer is never null.
             let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
 
-            // We drop the waker and consider the field uninitialized again.
+            // We extract the waker and consider the field uninitialized again.
             // SAFETY: We were in EVENT_AWAITING which guarantees there is a waker in there.
-            unsafe {
-                awaiter_cell.assume_init_drop();
-            }
-        }
+            Some(unsafe { awaiter_cell.assume_init_read() })
+        } else {
+            None
+        };
 
-        // Re-read the state: a reentrant sender drop during the waker's destructor above may
-        // have advanced us from EVENT_BOUND to EVENT_DISCONNECTED. In this single-threaded
-        // design the reentrant sender is the only actor that could have changed the state while
-        // we were dropping the waker.
         let previous_state = event.state.get();
 
         // We can immediately set this because this is a single-threaded event, so there cannot
         // be any race condition causing us issues with the receiver seeing this too early.
         event.state.set(EVENT_DISCONNECTED);
 
-        match previous_state {
+        let result = match previous_state {
             EVENT_BOUND => {
-                // The sender had not yet set any value (nor did a reentrant sender drop
-                // disconnect while we dropped the waker). It will clean up the event later.
+                // The sender had not yet set any value. It will clean up the event later.
                 Ok(None)
             }
             EVENT_SET => {
@@ -745,9 +778,7 @@ impl<T: 'static> LocalEvent<T> {
                 Ok(Some(value))
             }
             EVENT_DISCONNECTED => {
-                // The receiver is the last endpoint remaining, so it will clean up. This also
-                // covers the case where a reentrant sender drop disconnected while we dropped
-                // the waker above: the sender observed EVENT_BOUND and deferred cleanup to us.
+                // The receiver is the last endpoint remaining, so it will clean up.
                 Err(Disconnected)
             }
             // Defensive: state machine guarantees this is unreachable, since we already handled
@@ -758,6 +789,11 @@ impl<T: 'static> LocalEvent<T> {
                     type_name::<Self>()
                 );
             }
+        };
+
+        Cancellation {
+            result,
+            _awaiter: awaiter,
         }
     }
 }

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -698,10 +698,7 @@ impl<T: 'static> LocalEvent<T> {
             EVENT_DISCONNECTED => Err(Disconnected),
             // Defensive: the caller must have observed a terminal state.
             _ => {
-                unreachable!(
-                    "unreachable {} state on terminal result extraction: {previous_state}",
-                    type_name::<Self>()
-                );
+                unreachable!("invalid {} state: {previous_state}", type_name::<Self>());
             }
         }
     }

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -303,9 +303,12 @@ impl<T: 'static> LocalEvent<T> {
     /// strongly protected by the aliasing model for the whole call, which makes such a release
     /// undefined behavior, whereas references derived from an `UnsafeCell` carry no protector and
     /// may dangle. The event is therefore not touched after the callback runs.
+    ///
+    /// Returns the payload to the caller if the receiver has already disconnected. The caller
+    /// owns cleanup in that case and must release the event before dropping the payload.
     /// Ref: docs/callback-safety.md.
     #[inline]
-    pub(crate) fn set(event_cell: &UnsafeCell<Self>, value: T) -> Result<(), Disconnected> {
+    pub(crate) fn set(event_cell: &UnsafeCell<Self>, value: T) -> Result<(), T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
@@ -374,7 +377,8 @@ impl<T: 'static> LocalEvent<T> {
             }
             EVENT_DISCONNECTED => {
                 // The receiver has already disconnected, so we can clean up the event now.
-                // We have to first drop the value that we inserted into the event, though.
+                // Move the value back to the sender core so it can release the event before the
+                // payload destructor invokes user code.
 
                 // SAFETY: The only other potential references to the field are other short-lived
                 // references in this type, which cannot exist at the moment because
@@ -383,14 +387,12 @@ impl<T: 'static> LocalEvent<T> {
                 // SAFETY: UnsafeCell pointer is never null.
                 let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
 
-                // We drop the value and consider the cell uninitialized.
+                // We extract the value and consider the cell uninitialized.
                 //
                 // SAFETY: We were in EVENT_SET which guarantees there is a value in there.
-                unsafe {
-                    value_cell.assume_init_drop();
-                }
+                let value = unsafe { value_cell.assume_init_read() };
 
-                Err(Disconnected)
+                Err(value)
             }
             // Defensive: state machine guarantees this is unreachable.
             _ => {

--- a/packages/events_once/src/core/local/tests/reentrancy.rs
+++ b/packages/events_once/src/core/local/tests/reentrancy.rs
@@ -112,11 +112,11 @@ fn boxed_sender_drop_with_reentrant_waker_observes_disconnected() {
     });
 }
 
-// Regression test for cancellation through a reentrant waker destructor. `final_poll` returns
-// the event to BOUND while the receiver retains cleanup ownership, then drops the stored waker.
-// Its destructor drops the sender, which publishes DISCONNECTED and defers cleanup to the
-// receiver. Ref: docs/callback-safety.md. This runs under Miri so an ordering regression that
-// accesses released storage is detected.
+// Regression test for cancellation through a reentrant waker destructor. `cancel` extracts the
+// stored waker and publishes DISCONNECTED before deferring its destruction. The waker destructor
+// drops the sender, which observes the disconnection and performs the sole cleanup. Ref:
+// docs/callback-safety.md. This runs under Miri so an ordering regression that accesses released
+// storage is detected.
 #[test]
 fn boxed_receiver_cancel_with_sender_dropping_waker_preserves_storage() {
     let (sender, receiver) = LocalEvent::<i32>::boxed();
@@ -136,8 +136,8 @@ fn boxed_receiver_cancel_with_sender_dropping_waker_preserves_storage() {
     drop(waker);
     assert!(!sender_dropped.get());
 
-    // Dropping the receiver releases the stored waker. Its destructor drops the sender, which
-    // publishes DISCONNECTED and leaves the receiver to perform the sole cleanup.
+    // Dropping the receiver publishes DISCONNECTED before releasing the stored waker. Its
+    // destructor drops the sender, which observes the disconnection and performs the sole cleanup.
     drop(receiver);
 
     assert!(sender_dropped.get(), "{REENTRANCY_REQUIRED}");

--- a/packages/events_once/src/core/local_endpoints_nice.rs
+++ b/packages/events_once/src/core/local_endpoints_nice.rs
@@ -1,9 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
 //!
-//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
-//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
-//! impact in this package".
+//! Hot-path forwarders are inlined so this API layer does not interrupt the
+//! generic core's inlining chain. Ref: `packages/events_once/AGENTS.md`,
+//! "`#[inline]` annotations have outsized impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};

--- a/packages/events_once/src/core/local_endpoints_nice.rs
+++ b/packages/events_once/src/core/local_endpoints_nice.rs
@@ -1,5 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
+//!
+//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
+//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
+//! impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -34,6 +38,7 @@ impl<T: 'static> BoxedLocalSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -58,9 +63,11 @@ impl<T: 'static> fmt::Debug for BoxedLocalSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including re-entering related user state or dropping a surviving
+/// endpoint. Before each callback, the event publishes the resulting state and completes any
+/// endpoint or storage cleanup that must survive unwinding.
 pub struct BoxedLocalReceiver<T: 'static> {
     inner: LocalReceiverCore<BoxedLocalRef<T>, T>,
 }
@@ -85,6 +92,7 @@ impl<T: 'static> BoxedLocalReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -137,6 +145,7 @@ impl<T: 'static> BoxedLocalReceiver<T> {
 impl<T: 'static> Future for BoxedLocalReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
@@ -175,6 +184,7 @@ impl<T: 'static> RawLocalSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -200,9 +210,11 @@ impl<T: 'static> fmt::Debug for RawLocalSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including re-entering related user state or dropping a surviving
+/// endpoint. Before each callback, the event publishes the resulting state and completes any
+/// endpoint or storage cleanup that must survive unwinding.
 pub struct RawLocalReceiver<T: 'static> {
     inner: LocalReceiverCore<PtrLocalRef<T>, T>,
 }
@@ -225,6 +237,7 @@ impl<T: 'static> RawLocalReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -282,6 +295,7 @@ impl<T: 'static> RawLocalReceiver<T> {
 impl<T: 'static> Future for RawLocalReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/packages/events_once/src/core/local_receiver.rs
+++ b/packages/events_once/src/core/local_receiver.rs
@@ -93,17 +93,16 @@ where
                 Err(IntoValueError::Pending(self))
             }
             EVENT_SET | EVENT_DISCONNECTED => {
-                // The event has completed - consume self and
-                // let final_poll decide which endpoint performs the cleanup.
+                // The event has completed - consume self and extract its terminal result.
                 let mut this = ManuallyDrop::new(self);
                 let event_ref = this.event_ref.take().expect(
                     "event_ref was proven present above and neither the state inspection nor \
                      wrapping self in ManuallyDrop can clear it",
                 );
 
-                match LocalEvent::final_poll(&event_ref) {
-                    Ok(Some(value)) => {
-                        // SAFETY: `final_poll` returning a value means the state machine made
+                match LocalEvent::take_result(&event_ref) {
+                    Ok(value) => {
+                        // SAFETY: `take_result` returning a value means the state machine made
                         // the receiver the last endpoint and assigned it cleanup ownership. We
                         // do not access the event after this call - the receiver is consumed
                         // and its reference goes out of scope.
@@ -111,18 +110,11 @@ where
                             event_ref.release_event();
                         }
 
+                        drop(event_ref);
                         Ok(value)
                     }
-                    Ok(None) => {
-                        // Defensive: state machine guarantees final_poll
-                        // always returns Some or Err when the event has completed.
-                        unreachable!(
-                            "{} reported no result on value extraction from a terminal state",
-                            type_name::<LocalEvent<T>>()
-                        )
-                    }
                     Err(Disconnected) => {
-                        // SAFETY: `final_poll` reporting disconnection means the state machine
+                        // SAFETY: `take_result` reporting disconnection means the state machine
                         // made the receiver the last endpoint and assigned it cleanup ownership.
                         // We do not access the event after this call - the receiver is consumed
                         // and its reference goes out of scope.
@@ -130,6 +122,7 @@ where
                             event_ref.release_event();
                         }
 
+                        drop(event_ref);
                         Err(IntoValueError::Disconnected)
                     }
                 }
@@ -201,26 +194,25 @@ where
     #[inline]
     fn drop(&mut self) {
         if let Some(event_ref) = self.event_ref.take() {
-            match LocalEvent::final_poll(&event_ref) {
-                Ok(None) => {
-                    // Nothing for us to do - the sender was still connected and had not
-                    // sent any value, so it will perform the cleanup on its own.
-                }
-                _ => {
-                    // Either a value was waiting for us or the sender has disconnected. Both
-                    // outcomes leave the receiver as the last endpoint, so we release the event.
-                    // A value delivered here is intentionally discarded with the match
-                    // temporary - nobody is left to receive it.
+            let cancellation = LocalEvent::cancel(&event_ref);
+            let release_event = !matches!(&cancellation.result, Ok(None));
 
-                    // SAFETY: `final_poll` returned a terminal outcome, which is how the state
-                    // machine assigns cleanup ownership to the receiver. The receiver is being
-                    // dropped and its reference goes out of scope, so nothing accesses the event
-                    // after this call.
-                    unsafe {
-                        event_ref.release_event();
-                    }
+            if release_event {
+                // Either a value was waiting for us or the sender has disconnected. Both outcomes
+                // leave the receiver as the last endpoint, so we release the event.
+                //
+                // SAFETY: `cancel` returned a terminal outcome, which is how the state machine
+                // assigns cleanup ownership to the receiver. The receiver is being dropped and its
+                // reference goes out of scope, so nothing accesses the event after this call.
+                unsafe {
+                    event_ref.release_event();
                 }
             }
+
+            // Endpoint bookkeeping and any owned storage release must complete before destructors
+            // for the discarded payload or extracted waker invoke user code.
+            drop(event_ref);
+            drop(cancellation);
         }
     }
 }

--- a/packages/events_once/src/core/local_sender.rs
+++ b/packages/events_once/src/core/local_sender.rs
@@ -35,23 +35,30 @@ where
     /// there is a receiver waiting.
     #[inline]
     pub(crate) fn send(self, value: T) {
-        // The drop logic is different before/after set(), so we switch to manual drop here.
-        let mut this = ManuallyDrop::new(self);
+        // The drop logic is different before/after set(), so we prevent the sender destructor
+        // from running and move its reference into an ordinary local. The local is still dropped
+        // if a waker callback unwinds out of `set()`.
+        let this = ManuallyDrop::new(self);
 
-        if LocalEvent::set(&this.event_ref, value) == Err(Disconnected) {
+        // SAFETY: `this` will never be dropped, so reading its event reference transfers that
+        // field into `event_ref` exactly once. The marker field needs no destruction.
+        let event_ref = unsafe { ptr::read(&raw const this.event_ref) };
+
+        if let Err(value) = LocalEvent::set(&event_ref, value) {
             // SAFETY: `set()` reported that the receiver had already disconnected, which is the
             // transition that grants this sender sole cleanup responsibility, and we do not
             // access the event afterwards.
             unsafe {
-                this.event_ref.release_event();
+                event_ref.release_event();
             }
+
+            // Release all event-owned resources before payload destruction invokes user code.
+            drop(event_ref);
+            drop(value);
+            return;
         }
 
-        // SAFETY: The field contains a valid object of the right type. We avoid a double-drop
-        // via ManuallyDrop above. We consume `self` so nothing further can happen.
-        unsafe {
-            ptr::drop_in_place(&raw mut this.event_ref);
-        }
+        drop(event_ref);
     }
 }
 

--- a/packages/events_once/src/core/state.rs
+++ b/packages/events_once/src/core/state.rs
@@ -56,12 +56,14 @@
 //! party permitted to release the event, and no endpoint may access the event after the
 //! transition that transferred cleanup ownership to the other endpoint.
 //!
-//! # Callback publication order
+//! # Callback boundary order
 //!
-//! Completing or cancelling an event runs user-supplied waker callbacks that may reenter the
-//! event, including polling the receiver and dropping the last endpoint. The terminal state is
-//! therefore always published before such a callback runs, so a reentrant caller observes a
-//! terminal state rather than the transient `signaling` state. See `docs/callback-safety.md`.
+//! Cloning, waking or dropping a waker and dropping a payload can execute user code that reenters
+//! the event or its storage owner and can unwind. Before invoking one of these callbacks, an
+//! operation completes the observable state transition, releases every borrow or lock the callback
+//! can reenter, and completes any endpoint or storage handoff that unwinding would otherwise skip.
+//! User-owned values are moved into temporary ownership when their destruction must be deferred
+//! past that handoff. See `docs/callback-safety.md`.
 //!
 //! # The signaling state
 //!
@@ -80,6 +82,21 @@
 //! This compresses a read-and-write into one atomic instruction. The single-threaded variant
 //! cannot benefit from the encoding (a non-atomic `Cell` `+= 1` lowers to a separate load + add
 //! + store), so it transitions directly to the target state instead.
+
+use std::task::Waker;
+
+use crate::Disconnected;
+
+/// Carries a receiver's cancellation outcome and any waker deferred past state handoff.
+///
+/// Receiver cancellation extracts the registered waker without destroying it, publishes the
+/// disconnection, and then lets the receiver core release any storage it owns before this value is
+/// dropped. The payload and waker may both invoke user code from their destructors, so keeping them
+/// together makes their deferred ownership explicit.
+pub(crate) struct Cancellation<T> {
+    pub(crate) result: Result<Option<T>, Disconnected>,
+    pub(crate) _awaiter: Option<Waker>,
+}
 
 pub(crate) const EVENT_BOUND: u8 = 0;
 pub(crate) const EVENT_SET: u8 = 1;

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -324,10 +324,10 @@ where
 
     /// Sets the value of the event and notifies the receiver's awaiter, if there is one.
     ///
-    /// Returns `Err` if the receiver has already disconnected and the caller must clean up the
-    /// event now.
+    /// Returns the payload to the caller if the receiver has already disconnected. The caller
+    /// owns cleanup in that case and must release the event before dropping the payload.
     #[inline]
-    pub(crate) fn set(event_cell: &UnsafeCell<Self>, value: T) -> Result<(), Disconnected> {
+    pub(crate) fn set(event_cell: &UnsafeCell<Self>, value: T) -> Result<(), T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
@@ -417,15 +417,14 @@ where
             }
             EVENT_DISCONNECTED => {
                 // The receiver has already been dropped, so we need to clean up the event.
-                // We have to first drop the value that we inserted into the event, though.
+                // Move the value back to the sender core so it can release the event before the
+                // payload destructor invokes user code.
 
                 // SAFETY: The receiver is gone - there is nobody else who might be touching
                 // the event anymore, we are essentially in a single-threaded mode now.
                 // We also just inserted the value, so it must still be there because we never
                 // entered a state where the receiver had the permission to extract the value.
-                unsafe {
-                    event.destroy_value();
-                }
+                let value = unsafe { event.take_value() };
 
                 // Before it is safe to destroy the event, we need to synchronize with whatever
                 // writes the receiver may have done into its state (e.g. it may have removed
@@ -433,7 +432,7 @@ where
                 atomic::fence(atomic::Ordering::Acquire);
 
                 // The sender (the caller) needs to clean up the event.
-                Err(Disconnected)
+                Err(value)
             }
             // Defensive: state machine guarantees this is unreachable.
             _ => {
@@ -983,22 +982,20 @@ where
         }
     }
 
-    /// Drops the payload stored in `value`, leaving that cell uninitialized.
+    /// Extracts the payload stored in `value`, leaving that cell uninitialized.
     ///
     /// # Safety
     ///
     /// The caller must have acquired the synchronization block for `value` and `value` must hold
     /// an initialized payload.
-    unsafe fn destroy_value(&self) {
+    unsafe fn take_value(&self) -> T {
         // SAFETY: Forwarding guarantees from the caller.
         let value_cell_maybe = unsafe { self.value.get().as_mut() };
         // SAFETY: UnsafeCell pointer is never null.
         let value_cell = unsafe { value_cell_maybe.unwrap_unchecked() };
 
         // SAFETY: Forwarding guarantees from the caller.
-        unsafe {
-            value_cell.assume_init_drop();
-        }
+        unsafe { value_cell.assume_init_read() }
     }
 }
 

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -886,10 +886,7 @@ where
             EVENT_DISCONNECTED => Err(Disconnected),
             // Defensive: the caller must have observed a terminal state.
             _ => {
-                unreachable!(
-                    "unreachable {} state on terminal result extraction: {previous_state}",
-                    type_name::<Self>()
-                );
+                unreachable!("invalid {} state: {previous_state}", type_name::<Self>());
             }
         }
     }

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -21,7 +21,7 @@ use crate::NEVER_POISONED;
 #[cfg(debug_assertions)]
 use crate::{BacktraceType, capture_backtrace};
 use crate::{
-    BoxedReceiver, BoxedRef, BoxedSender, Disconnected, EVENT_AWAITING, EVENT_BOUND,
+    BoxedReceiver, BoxedRef, BoxedSender, Cancellation, Disconnected, EVENT_AWAITING, EVENT_BOUND,
     EVENT_DISCONNECTED, EVENT_SET, EVENT_SIGNALING, EmbeddedEvent, PtrRef, RawReceiver, RawSender,
     ReceiverCore, SenderCore,
 };
@@ -39,6 +39,10 @@ use crate::{
 /// is likewise user-supplied code. Such a callback may operate on the sender endpoint of the event
 /// being polled: it may send a value and it may drop the sender. The poll observes the resulting
 /// state.
+///
+/// Destruction of a registered waker or discarded payload may also run arbitrary user code. The
+/// event completes any endpoint and storage cleanup that must survive unwinding before invoking
+/// such a destructor.
 pub struct Event<T> {
     /// The logical state of the event; see constants in `state.rs`.
     pub(crate) state: AtomicU8,
@@ -94,8 +98,8 @@ pub struct Event<T> {
 //   and leave another endpoint waiting for a transition that will not come.
 // * User-controlled code that can unwind - waker clones, wakes, waker drops and payload drops -
 //   therefore always runs where state and storage agree, so a caught panic leaves an event that
-//   the remaining endpoint can still complete or clean up. The worst outcome is that the event
-//   storage is leaked, which is safe. The unwinding regression tests exercise this.
+//   the remaining endpoint can still complete or clean up. The unwinding regression tests exercise
+//   this.
 impl<T: Send + 'static> UnwindSafe for Event<T> {}
 impl<T: Send + 'static> RefUnwindSafe for Event<T> {}
 
@@ -845,8 +849,52 @@ where
         )
     }
 
-    /// Attempts to obtain the value from the event, if one has been sent, while indicating
-    /// that no further polls will be performed by the receiver.
+    /// Extracts the terminal result after the receiver has observed a completed event.
+    ///
+    /// The receiver owns event cleanup after either result.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the event is not in a terminal state.
+    // Callgrind and disassembly show that terminal extraction must remain inline with
+    // `into_value()` to keep cancellation machinery off that hot path.
+    #[inline]
+    pub(crate) fn take_result(event_cell: &UnsafeCell<Self>) -> Result<T, Disconnected> {
+        // SAFETY: The event reference contract guarantees shared access through this outer
+        // UnsafeCell for as long as the receiver still owns its endpoint reference.
+        let event = unsafe { &*event_cell.get() };
+
+        #[cfg(debug_assertions)]
+        event
+            .backtrace
+            .lock()
+            .expect(NEVER_POISONED)
+            .replace(capture_backtrace());
+
+        // Terminal states are stable, so no sender can race this exchange. AcqRel both acquires
+        // the sender's payload/disconnection writes and publishes receiver cleanup.
+        let previous_state = event
+            .state
+            .swap(EVENT_DISCONNECTED, atomic::Ordering::AcqRel);
+
+        match previous_state {
+            EVENT_SET => {
+                // SAFETY: EVENT_SET guarantees that the payload is initialized and that this
+                // receiver acquired its synchronization block through the exchange above.
+                Ok(unsafe { event.take_value() })
+            }
+            EVENT_DISCONNECTED => Err(Disconnected),
+            // Defensive: the caller must have observed a terminal state.
+            _ => {
+                unreachable!(
+                    "unreachable {} state on terminal result extraction: {previous_state}",
+                    type_name::<Self>()
+                );
+            }
+        }
+    }
+
+    /// Cancels the receiver, returning the final event observation and any deferred callback.
     ///
     /// Returns `Ok(None)` if the sender has not yet sent a value. In this case, the sender will
     /// eventually clean up the event.
@@ -855,7 +903,7 @@ where
     /// Returns `Err` if the sender has already disconnected without sending a value.
     /// In both of these cases, the receiver must clean up the event now.
     #[inline]
-    pub(crate) fn final_poll(event_cell: &UnsafeCell<Self>) -> Result<Option<T>, Disconnected> {
+    pub(crate) fn cancel(event_cell: &UnsafeCell<Self>) -> Cancellation<T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
@@ -870,13 +918,12 @@ where
             .expect(NEVER_POISONED)
             .replace(capture_backtrace());
 
-        // The receiver (who is calling this) may still own the waker if the waker has not
-        // been used. If this is the case, we need to destroy the waker before proceeding.
-        // This is only the case if we are in the AWAITING state - in all other states, we
-        // either do not have a waker or the sender will destroy it.
+        // The receiver may still own the waker if the waker has not been used. If this is the case,
+        // move it out and defer its destruction until the state handoff and any storage release
+        // have completed.
         // We implement this check by attempting to revert ourselves back to the BOUND state.
-        // If successful, we know we were in AWAITING and can destroy the waker.
-        if event
+        // If successful, we know we were in AWAITING and can extract the waker.
+        let awaiter = if event
             .state
             .compare_exchange(
                 EVENT_AWAITING,
@@ -889,10 +936,10 @@ where
             // SAFETY: The `awaiter` is guaranteed to be present because we just came from
             // `EVENT_AWAITING`. The sender will only touch the awaiter in `EVENT_SIGNALING`,
             // which never entered. Therefore, we are the only one who can touch the awaiter now.
-            unsafe {
-                event.destroy_awaiter();
-            }
-        }
+            Some(unsafe { event.take_awaiter() })
+        } else {
+            None
+        };
 
         // We must transition the event into DISCONNECTED, but we cannot do so while the
         // sender is in the middle of a SIGNALING transition — writing DISCONNECTED via swap
@@ -929,7 +976,7 @@ where
             }
         };
 
-        match previous_state {
+        let result = match previous_state {
             EVENT_BOUND => {
                 // The sender had not yet set any value. It will clean up the event later.
                 Ok(None)
@@ -961,7 +1008,28 @@ where
                     type_name::<Self>()
                 );
             }
+        };
+
+        Cancellation {
+            result,
+            _awaiter: awaiter,
         }
+    }
+
+    /// Extracts the waker registered in `awaiter`, leaving that cell uninitialized.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have acquired the synchronization block for `awaiter` and `awaiter` must
+    /// hold an initialized waker.
+    unsafe fn take_awaiter(&self) -> Waker {
+        // SAFETY: Forwarding guarantees from the caller.
+        let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
+        // SAFETY: UnsafeCell pointer is never null.
+        let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
+
+        // SAFETY: Forwarding guarantees from the caller.
+        unsafe { awaiter_cell.assume_init_read() }
     }
 
     /// Drops the waker registered in `awaiter`, leaving that cell uninitialized.
@@ -972,14 +1040,7 @@ where
     /// hold an initialized waker.
     unsafe fn destroy_awaiter(&self) {
         // SAFETY: Forwarding guarantees from the caller.
-        let awaiter_cell_maybe = unsafe { self.awaiter.get().as_mut() };
-        // SAFETY: UnsafeCell pointer is never null.
-        let awaiter_cell = unsafe { awaiter_cell_maybe.unwrap_unchecked() };
-
-        // SAFETY: Forwarding guarantees from the caller.
-        unsafe {
-            awaiter_cell.assume_init_drop();
-        }
+        drop(unsafe { self.take_awaiter() });
     }
 
     /// Extracts the payload stored in `value`, leaving that cell uninitialized.

--- a/packages/events_once/src/core/sync/tests/races.rs
+++ b/packages/events_once/src/core/sync/tests/races.rs
@@ -171,17 +171,17 @@ fn boxed_poll_awaiting_races_sender_disconnect() {
     });
 }
 
-// This test verifies that `final_poll` correctly handles the case where the sender is
-// mid-SIGNALING when the receiver is dropped. The fix uses a CAS loop in `final_poll`
+// This test verifies that `cancel` correctly handles the case where the sender is
+// mid-SIGNALING when the receiver is dropped. The cancellation CAS loop
 // that spins on SIGNALING, so the receiver waits for the sender to finish before writing
-// DISCONNECTED. The receiver-drop must happen on a separate thread because `final_poll`
+// DISCONNECTED. The receiver-drop must happen on a separate thread because `cancel`
 // will spin until the sender completes, and the sender is blocked on the hook barrier.
 #[test]
-// The receiver's `final_poll` spins while the event is in SIGNALING, and here the sender only
+// The receiver's `cancel` spins while the event is in SIGNALING, and here the sender only
 // leaves SIGNALING once the test releases its barrier. Miri's interpreter makes such a
 // cross-thread spin extremely slow, so this scenario is reserved for native runs.
 #[cfg_attr(miri, ignore)]
-fn boxed_final_poll_races_sender_signaling() {
+fn boxed_cancel_races_sender_signaling() {
     with_watchdog(|| {
         let BarrierHook {
             entered,
@@ -208,7 +208,7 @@ fn boxed_final_poll_races_sender_signaling() {
             // Wait for the hook to fire (sender is in SIGNALING).
             entered.wait();
 
-            // Drop the receiver on a separate thread. final_poll
+            // Drop the receiver on a separate thread. cancel
             // will spin on SIGNALING until the sender completes
             // its transition, so we cannot block this thread — we
             // need it to release the sender via proceed.wait().
@@ -217,7 +217,7 @@ fn boxed_final_poll_races_sender_signaling() {
             });
 
             // Release the sender so it can complete its transition
-            // from SIGNALING -> SET. This unblocks final_poll's
+            // from SIGNALING -> SET. This unblocks cancel's
             // spin, which then sees SET and reads the value.
             proceed.wait();
 

--- a/packages/events_once/src/core/sync/tests/reentrancy.rs
+++ b/packages/events_once/src/core/sync/tests/reentrancy.rs
@@ -186,9 +186,9 @@ fn boxed_receiver_cancel_with_sender_dropping_waker_preserves_storage() {
     drop(waker);
     assert!(!sender_dropped.get());
 
-    // Dropping the receiver cancels the wait. `final_poll` returns the event to BOUND before
-    // dropping the stored waker, whose destructor drops the sender. The sender publishes
-    // DISCONNECTED and leaves the receiver to perform the sole cleanup.
+    // Dropping the receiver cancels the wait. `cancel` extracts the stored waker and publishes
+    // DISCONNECTED before deferring its destruction. The waker destructor drops the sender, which
+    // observes the disconnection and performs the sole cleanup.
     drop(receiver);
 
     assert!(sender_dropped.get(), "{REENTRANCY_REQUIRED}");
@@ -198,7 +198,7 @@ fn boxed_receiver_cancel_with_sender_dropping_waker_preserves_storage() {
 /// a terminal state.
 ///
 /// The reentrancy tests below release this from inside a sender operation, where dropping the
-/// receiver re-enters `Event::final_poll`. That call spins while the event is in the
+/// receiver re-enters `Event::cancel`. That call spins while the event is in the
 /// transient `EVENT_SIGNALING` state, and the sender that would leave that state is the very
 /// operation blocked in this destructor - so a regression in terminal-state publication would
 /// hang the test instead of failing it. Checking readiness first turns that regression into a

--- a/packages/events_once/src/core/sync_endpoints_nice.rs
+++ b/packages/events_once/src/core/sync_endpoints_nice.rs
@@ -1,5 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
+//!
+//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
+//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
+//! impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -32,6 +36,7 @@ impl<T: Send + 'static> BoxedSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -56,9 +61,11 @@ impl<T: Send + 'static> fmt::Debug for BoxedSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including re-entering related user state or dropping a surviving
+/// endpoint. Before each callback, the event publishes the resulting state and completes any
+/// endpoint or storage cleanup that must survive unwinding.
 pub struct BoxedReceiver<T: Send + 'static> {
     inner: ReceiverCore<BoxedRef<T>, T>,
 }
@@ -83,6 +90,7 @@ impl<T: Send + 'static> BoxedReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -135,6 +143,7 @@ impl<T: Send + 'static> BoxedReceiver<T> {
 impl<T: Send + 'static> Future for BoxedReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
@@ -173,6 +182,7 @@ impl<T: Send + 'static> RawSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -198,9 +208,11 @@ impl<T: Send + 'static> fmt::Debug for RawSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including re-entering related user state or dropping a surviving
+/// endpoint. Before each callback, the event publishes the resulting state and completes any
+/// endpoint or storage cleanup that must survive unwinding.
 pub struct RawReceiver<T: Send + 'static> {
     inner: ReceiverCore<PtrRef<T>, T>,
 }
@@ -223,6 +235,7 @@ impl<T: Send + 'static> RawReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -280,6 +293,7 @@ impl<T: Send + 'static> RawReceiver<T> {
 impl<T: Send + 'static> Future for RawReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/packages/events_once/src/core/sync_endpoints_nice.rs
+++ b/packages/events_once/src/core/sync_endpoints_nice.rs
@@ -1,9 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
 //!
-//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
-//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
-//! impact in this package".
+//! Hot-path forwarders are inlined so this API layer does not interrupt the
+//! generic core's inlining chain. Ref: `packages/events_once/AGENTS.md`,
+//! "`#[inline]` annotations have outsized impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};

--- a/packages/events_once/src/core/sync_receiver.rs
+++ b/packages/events_once/src/core/sync_receiver.rs
@@ -106,17 +106,16 @@ where
                 Err(IntoValueError::Pending(self))
             }
             EVENT_SET | EVENT_DISCONNECTED => {
-                // The event has completed - consume self and
-                // let final_poll decide which endpoint performs the cleanup.
+                // The event has completed - consume self and extract its terminal result.
                 let mut this = ManuallyDrop::new(self);
                 let event_ref = this.event_ref.take().expect(
                     "event_ref was proven present above and neither the state inspection nor \
                      wrapping self in ManuallyDrop can clear it",
                 );
 
-                match Event::final_poll(&event_ref) {
-                    Ok(Some(value)) => {
-                        // SAFETY: `final_poll` returning a value means the state machine made
+                match Event::take_result(&event_ref) {
+                    Ok(value) => {
+                        // SAFETY: `take_result` returning a value means the state machine made
                         // the receiver the last endpoint and assigned it cleanup ownership. We
                         // do not access the event after this call - the receiver is consumed
                         // and its reference goes out of scope.
@@ -124,15 +123,11 @@ where
                             event_ref.release_event();
                         }
 
+                        drop(event_ref);
                         Ok(value)
                     }
-                    // Defensive: state machine guarantees final_poll
-                    // always returns Some or Err when the event has completed.
-                    Ok(None) => {
-                        unreachable!("final_poll returned None")
-                    }
                     Err(Disconnected) => {
-                        // SAFETY: `final_poll` reporting disconnection means the state machine
+                        // SAFETY: `take_result` reporting disconnection means the state machine
                         // made the receiver the last endpoint and assigned it cleanup ownership.
                         // We do not access the event after this call - the receiver is consumed
                         // and its reference goes out of scope.
@@ -140,6 +135,7 @@ where
                             event_ref.release_event();
                         }
 
+                        drop(event_ref);
                         Err(IntoValueError::Disconnected)
                     }
                 }
@@ -198,6 +194,41 @@ where
     }
 }
 
+/// Cancels a receiver that still owns an endpoint reference.
+///
+/// This path invokes user destructors and may release storage, while completed receivers only need
+/// to observe that their reference is absent. Keeping cancellation out of line preserves that
+/// common drop path through the public endpoint wrappers.
+// Callgrind and disassembly show that permitting inlining pulls this callback-heavy state machine
+// into generic receiver drop glue and regresses completed-event lifecycles.
+#[cold]
+#[inline(never)]
+fn cancel_receiver<E, T>(event_ref: E)
+where
+    E: EventRef<T>,
+    T: Send + 'static,
+{
+    let cancellation = Event::cancel(&event_ref);
+    let release_event = !matches!(&cancellation.result, Ok(None));
+
+    if release_event {
+        // Either a value was waiting for us or the sender has disconnected. Both outcomes leave
+        // the receiver as the last endpoint, so we release the event.
+        //
+        // SAFETY: `cancel` returned a terminal outcome, which is how the state machine assigns
+        // cleanup ownership to the receiver. The receiver is being dropped and its reference goes
+        // out of scope, so nothing accesses the event after this call.
+        unsafe {
+            event_ref.release_event();
+        }
+    }
+
+    // Endpoint bookkeeping and any owned storage release must complete before destructors for the
+    // discarded payload or extracted waker invoke user code.
+    drop(event_ref);
+    drop(cancellation);
+}
+
 impl<E, T> Drop for ReceiverCore<E, T>
 where
     E: EventRef<T>,
@@ -206,26 +237,7 @@ where
     #[inline]
     fn drop(&mut self) {
         if let Some(event_ref) = self.event_ref.take() {
-            match Event::final_poll(&event_ref) {
-                Ok(None) => {
-                    // Nothing for us to do - the sender was still connected and had not
-                    // sent any value, so it will perform the cleanup on its own.
-                }
-                _ => {
-                    // Either a value was waiting for us or the sender has disconnected. Both
-                    // outcomes leave the receiver as the last endpoint, so we release the event.
-                    // A value delivered here is intentionally discarded with the match
-                    // temporary - nobody is left to receive it.
-
-                    // SAFETY: `final_poll` returned a terminal outcome, which is how the state
-                    // machine assigns cleanup ownership to the receiver. The receiver is being
-                    // dropped and its reference goes out of scope, so nothing accesses the event
-                    // after this call.
-                    unsafe {
-                        event_ref.release_event();
-                    }
-                }
-            }
+            cancel_receiver(event_ref);
         }
     }
 }

--- a/packages/events_once/src/core/sync_sender.rs
+++ b/packages/events_once/src/core/sync_sender.rs
@@ -43,25 +43,32 @@ where
     /// there is a receiver waiting.
     #[inline]
     pub(crate) fn send(self, value: T) {
-        // The drop logic is different before/after set(), so we switch to manual drop here.
-        let mut this = ManuallyDrop::new(self);
+        // The drop logic is different before/after set(), so we prevent the sender destructor
+        // from running and move its reference into an ordinary local. The local is still dropped
+        // if a waker callback unwinds out of `set()`.
+        let this = ManuallyDrop::new(self);
 
-        if Event::set(&this.event_ref, value) == Err(Disconnected) {
+        // SAFETY: `this` will never be dropped, so reading its event reference transfers that
+        // field into `event_ref` exactly once. The marker fields need no destruction.
+        let event_ref = unsafe { ptr::read(&raw const this.event_ref) };
+
+        if let Err(value) = Event::set(&event_ref, value) {
             // The other endpoint has disconnected, so we need to clean up the event.
 
             // SAFETY: `set` reporting disconnection is how the state machine assigns cleanup
             // ownership to the sender, which by then is the last endpoint. The sender is
             // consumed here, so nothing accesses the event after this call.
             unsafe {
-                this.event_ref.release_event();
+                event_ref.release_event();
             }
+
+            // Release all event-owned resources before payload destruction invokes user code.
+            drop(event_ref);
+            drop(value);
+            return;
         }
 
-        // SAFETY: The field contains a valid object of the right type. We avoid a double-drop
-        // via ManuallyDrop above. We consume `self` so nothing further can happen.
-        unsafe {
-            ptr::drop_in_place(&raw mut this.event_ref);
-        }
+        drop(event_ref);
     }
 }
 

--- a/packages/events_once/src/lake/local.rs
+++ b/packages/events_once/src/lake/local.rs
@@ -204,7 +204,11 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
-    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
+    use crate::{
+        PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+        assert_receiver_waker_panic_handoff_releases_event,
+        assert_unread_payload_panic_releases_event,
+    };
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -222,7 +226,29 @@ mod tests {
 
         assert_disconnected_send_payload_panic_releases_event(
             || lake.rent::<PanickingPayload>(),
-            |sender, value| sender.send(value),
+            PooledLocalSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn receiver_waker_panic_handoff_releases_event() {
+        let lake = LocalEventLake::new();
+
+        assert_receiver_waker_panic_handoff_releases_event(
+            || lake.rent::<i32>(),
+            PooledLocalSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn unread_payload_panic_releases_event() {
+        let lake = LocalEventLake::new();
+
+        assert_unread_payload_panic_releases_event(
+            || lake.rent::<PanickingPayload>(),
+            PooledLocalSender::send,
             || lake.is_empty(),
         );
     }

--- a/packages/events_once/src/lake/local.rs
+++ b/packages/events_once/src/lake/local.rs
@@ -204,6 +204,7 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
+    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -214,6 +215,17 @@ mod tests {
     assert_impl_all!(
         LocalEventLake: UnwindSafe, RefUnwindSafe
     );
+
+    #[test]
+    fn disconnected_send_payload_panic_releases_event() {
+        let lake = LocalEventLake::new();
+
+        assert_disconnected_send_payload_panic_releases_event(
+            || lake.rent::<PanickingPayload>(),
+            |sender, value| sender.send(value),
+            || lake.is_empty(),
+        );
+    }
 
     #[test]
     fn len() {

--- a/packages/events_once/src/lake/raw_local.rs
+++ b/packages/events_once/src/lake/raw_local.rs
@@ -245,6 +245,7 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
+    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -254,6 +255,18 @@ mod tests {
     assert_impl_all!(
         RawLocalEventLake: UnwindSafe, RefUnwindSafe
     );
+
+    #[test]
+    fn disconnected_send_payload_panic_releases_event() {
+        let lake = RawLocalEventLake::new();
+
+        assert_disconnected_send_payload_panic_releases_event(
+            // SAFETY: The lake remains alive until the helper consumes both endpoints.
+            || unsafe { lake.rent::<PanickingPayload>() },
+            |sender, value| sender.send(value),
+            || lake.is_empty(),
+        );
+    }
 
     #[test]
     fn len() {

--- a/packages/events_once/src/lake/raw_local.rs
+++ b/packages/events_once/src/lake/raw_local.rs
@@ -245,7 +245,11 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
-    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
+    use crate::{
+        PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+        assert_receiver_waker_panic_handoff_releases_event,
+        assert_unread_payload_panic_releases_event,
+    };
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -263,7 +267,31 @@ mod tests {
         assert_disconnected_send_payload_panic_releases_event(
             // SAFETY: The lake remains alive until the helper consumes both endpoints.
             || unsafe { lake.rent::<PanickingPayload>() },
-            |sender, value| sender.send(value),
+            RawLocalPooledSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn receiver_waker_panic_handoff_releases_event() {
+        let lake = RawLocalEventLake::new();
+
+        assert_receiver_waker_panic_handoff_releases_event(
+            // SAFETY: The lake remains alive until the helper consumes both endpoints.
+            || unsafe { lake.rent::<i32>() },
+            RawLocalPooledSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn unread_payload_panic_releases_event() {
+        let lake = RawLocalEventLake::new();
+
+        assert_unread_payload_panic_releases_event(
+            // SAFETY: The lake remains alive until the helper consumes both endpoints.
+            || unsafe { lake.rent::<PanickingPayload>() },
+            RawLocalPooledSender::send,
             || lake.is_empty(),
         );
     }

--- a/packages/events_once/src/lake/raw_sync.rs
+++ b/packages/events_once/src/lake/raw_sync.rs
@@ -266,7 +266,11 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
-    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
+    use crate::{
+        PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+        assert_receiver_waker_panic_handoff_releases_event,
+        assert_unread_payload_panic_releases_event,
+    };
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -284,7 +288,31 @@ mod tests {
         assert_disconnected_send_payload_panic_releases_event(
             // SAFETY: The lake remains alive until the helper consumes both endpoints.
             || unsafe { lake.rent::<PanickingPayload>() },
-            |sender, value| sender.send(value),
+            RawPooledSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn receiver_waker_panic_handoff_releases_event() {
+        let lake = RawEventLake::new();
+
+        assert_receiver_waker_panic_handoff_releases_event(
+            // SAFETY: The lake remains alive until the helper consumes both endpoints.
+            || unsafe { lake.rent::<i32>() },
+            RawPooledSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn unread_payload_panic_releases_event() {
+        let lake = RawEventLake::new();
+
+        assert_unread_payload_panic_releases_event(
+            // SAFETY: The lake remains alive until the helper consumes both endpoints.
+            || unsafe { lake.rent::<PanickingPayload>() },
+            RawPooledSender::send,
             || lake.is_empty(),
         );
     }

--- a/packages/events_once/src/lake/raw_sync.rs
+++ b/packages/events_once/src/lake/raw_sync.rs
@@ -266,6 +266,7 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
+    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -275,6 +276,18 @@ mod tests {
     assert_impl_all!(
         RawEventLake: UnwindSafe, RefUnwindSafe
     );
+
+    #[test]
+    fn disconnected_send_payload_panic_releases_event() {
+        let lake = RawEventLake::new();
+
+        assert_disconnected_send_payload_panic_releases_event(
+            // SAFETY: The lake remains alive until the helper consumes both endpoints.
+            || unsafe { lake.rent::<PanickingPayload>() },
+            |sender, value| sender.send(value),
+            || lake.is_empty(),
+        );
+    }
 
     #[test]
     fn concurrent_same_type_rentals_are_usable_across_threads() {

--- a/packages/events_once/src/lake/sync.rs
+++ b/packages/events_once/src/lake/sync.rs
@@ -202,7 +202,11 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
-    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
+    use crate::{
+        PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+        assert_receiver_waker_panic_handoff_releases_event,
+        assert_unread_payload_panic_releases_event,
+    };
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -219,7 +223,29 @@ mod tests {
 
         assert_disconnected_send_payload_panic_releases_event(
             || lake.rent::<PanickingPayload>(),
-            |sender, value| sender.send(value),
+            PooledSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn receiver_waker_panic_handoff_releases_event() {
+        let lake = EventLake::new();
+
+        assert_receiver_waker_panic_handoff_releases_event(
+            || lake.rent::<i32>(),
+            PooledSender::send,
+            || lake.is_empty(),
+        );
+    }
+
+    #[test]
+    fn unread_payload_panic_releases_event() {
+        let lake = EventLake::new();
+
+        assert_unread_payload_panic_releases_event(
+            || lake.rent::<PanickingPayload>(),
+            PooledSender::send,
             || lake.is_empty(),
         );
     }

--- a/packages/events_once/src/lake/sync.rs
+++ b/packages/events_once/src/lake/sync.rs
@@ -202,6 +202,7 @@ mod tests {
     use super::*;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
+    use crate::{PanickingPayload, assert_disconnected_send_payload_panic_releases_event};
 
     /// Compatible event representations must share the same internal layout pool.
     const EXPECTED_COMPATIBLE_LAYOUT_COUNT: usize = 1;
@@ -211,6 +212,17 @@ mod tests {
     assert_impl_all!(
         EventLake: UnwindSafe, RefUnwindSafe
     );
+
+    #[test]
+    fn disconnected_send_payload_panic_releases_event() {
+        let lake = EventLake::new();
+
+        assert_disconnected_send_payload_panic_releases_event(
+            || lake.rent::<PanickingPayload>(),
+            |sender, value| sender.send(value),
+            || lake.is_empty(),
+        );
+    }
 
     #[test]
     fn concurrent_same_type_rentals_are_usable_across_threads() {

--- a/packages/events_once/src/lib.rs
+++ b/packages/events_once/src/lib.rs
@@ -301,7 +301,7 @@ mod core;
 mod disconnected;
 mod lake;
 mod pool;
-#[cfg(all(test, debug_assertions))]
+#[cfg(test)]
 mod reentrancy;
 
 pub use core::*;
@@ -312,5 +312,5 @@ pub(crate) use constants::{EVENT_COUNT_FITS_IN_USIZE, NEVER_POISONED};
 pub use disconnected::*;
 pub use lake::*;
 pub use pool::*;
-#[cfg(all(test, debug_assertions))]
+#[cfg(test)]
 pub(crate) use reentrancy::*;

--- a/packages/events_once/src/pool/local.rs
+++ b/packages/events_once/src/pool/local.rs
@@ -204,6 +204,8 @@ mod tests {
     use crate::assert_inspect_awaiters_is_reentrant;
     use crate::{
         Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+        assert_receiver_waker_panic_handoff_releases_event,
+        assert_unread_payload_panic_releases_event,
     };
 
     // The payload is itself thread-safe, so the pool is what confines this to one thread.
@@ -219,7 +221,29 @@ mod tests {
 
         assert_disconnected_send_payload_panic_releases_event(
             || pool.rent(),
-            |sender, value| sender.send(value),
+            PooledLocalSender::send,
+            || pool.is_empty(),
+        );
+    }
+
+    #[test]
+    fn receiver_waker_panic_handoff_releases_event() {
+        let pool = LocalEventPool::<i32>::new();
+
+        assert_receiver_waker_panic_handoff_releases_event(
+            || pool.rent(),
+            PooledLocalSender::send,
+            || pool.is_empty(),
+        );
+    }
+
+    #[test]
+    fn unread_payload_panic_releases_event() {
+        let pool = LocalEventPool::<PanickingPayload>::new();
+
+        assert_unread_payload_panic_releases_event(
+            || pool.rent(),
+            PooledLocalSender::send,
             || pool.is_empty(),
         );
     }

--- a/packages/events_once/src/pool/local.rs
+++ b/packages/events_once/src/pool/local.rs
@@ -200,9 +200,11 @@ mod tests {
     use testing::assert_panics_with;
 
     use super::*;
-    use crate::Disconnected;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
+    use crate::{
+        Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+    };
 
     // The payload is itself thread-safe, so the pool is what confines this to one thread.
     assert_not_impl_any!(LocalEventPool<u32>: Send, Sync);
@@ -210,6 +212,17 @@ mod tests {
     // The payload satisfies only the bound that the pool's API requires (`'static`) and is
     // neither `UnwindSafe` nor `RefUnwindSafe`, so both traits come from the pool itself.
     assert_impl_all!(LocalEventPool<Rc<RefCell<u32>>>: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn disconnected_send_payload_panic_releases_event() {
+        let pool = LocalEventPool::<PanickingPayload>::new();
+
+        assert_disconnected_send_payload_panic_releases_event(
+            || pool.rent(),
+            |sender, value| sender.send(value),
+            || pool.is_empty(),
+        );
+    }
 
     #[test]
     fn len() {

--- a/packages/events_once/src/pool/local_endpoints_nice.rs
+++ b/packages/events_once/src/pool/local_endpoints_nice.rs
@@ -1,9 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
 //!
-//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
-//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
-//! impact in this package".
+//! Hot-path forwarders are inlined so this API layer does not interrupt the
+//! generic core's inlining chain. Ref: `packages/events_once/AGENTS.md`,
+//! "`#[inline]` annotations have outsized impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};

--- a/packages/events_once/src/pool/local_endpoints_nice.rs
+++ b/packages/events_once/src/pool/local_endpoints_nice.rs
@@ -1,5 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
+//!
+//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
+//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
+//! impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -31,6 +35,7 @@ impl<T: 'static> PooledLocalSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -54,9 +59,11 @@ impl<T: 'static> fmt::Debug for PooledLocalSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including using the event's pool or lake. Before each callback, the
+/// event publishes the resulting state and completes any endpoint or storage cleanup that must
+/// survive unwinding.
 pub struct PooledLocalReceiver<T: 'static> {
     inner: LocalReceiverCore<PooledLocalRef<T>, T>,
 }
@@ -79,6 +86,7 @@ impl<T: 'static> PooledLocalReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -132,6 +140,7 @@ impl<T: 'static> PooledLocalReceiver<T> {
 impl<T: 'static> Future for PooledLocalReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/packages/events_once/src/pool/raw_local.rs
+++ b/packages/events_once/src/pool/raw_local.rs
@@ -250,6 +250,8 @@ mod tests {
     use crate::assert_inspect_awaiters_is_reentrant;
     use crate::{
         Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+        assert_receiver_waker_panic_handoff_releases_event,
+        assert_unread_payload_panic_releases_event,
     };
 
     // The payload is itself thread-safe, so the pool is what confines this to one thread.
@@ -266,7 +268,31 @@ mod tests {
         assert_disconnected_send_payload_panic_releases_event(
             // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
             || unsafe { pool.as_ref().rent() },
-            |sender, value| sender.send(value),
+            RawLocalPooledSender::send,
+            || pool.is_empty(),
+        );
+    }
+
+    #[test]
+    fn receiver_waker_panic_handoff_releases_event() {
+        let pool = Box::pin(RawLocalEventPool::<i32>::new());
+
+        assert_receiver_waker_panic_handoff_releases_event(
+            // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
+            || unsafe { pool.as_ref().rent() },
+            RawLocalPooledSender::send,
+            || pool.is_empty(),
+        );
+    }
+
+    #[test]
+    fn unread_payload_panic_releases_event() {
+        let pool = Box::pin(RawLocalEventPool::<PanickingPayload>::new());
+
+        assert_unread_payload_panic_releases_event(
+            // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
+            || unsafe { pool.as_ref().rent() },
+            RawLocalPooledSender::send,
             || pool.is_empty(),
         );
     }

--- a/packages/events_once/src/pool/raw_local.rs
+++ b/packages/events_once/src/pool/raw_local.rs
@@ -246,9 +246,11 @@ mod tests {
     use testing::assert_panics_with;
 
     use super::*;
-    use crate::Disconnected;
     #[cfg(debug_assertions)]
     use crate::assert_inspect_awaiters_is_reentrant;
+    use crate::{
+        Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+    };
 
     // The payload is itself thread-safe, so the pool is what confines this to one thread.
     assert_not_impl_any!(RawLocalEventPool<u32>: Send, Sync);
@@ -256,6 +258,18 @@ mod tests {
     // The payload satisfies only the bound that the pool's API requires (`'static`) and is
     // neither `UnwindSafe` nor `RefUnwindSafe`, so both traits come from the pool itself.
     assert_impl_all!(RawLocalEventPool<Rc<RefCell<u32>>>: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn disconnected_send_payload_panic_releases_event() {
+        let pool = Box::pin(RawLocalEventPool::<PanickingPayload>::new());
+
+        assert_disconnected_send_payload_panic_releases_event(
+            // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
+            || unsafe { pool.as_ref().rent() },
+            |sender, value| sender.send(value),
+            || pool.is_empty(),
+        );
+    }
 
     #[test]
     fn len() {

--- a/packages/events_once/src/pool/raw_local_endpoints_nice.rs
+++ b/packages/events_once/src/pool/raw_local_endpoints_nice.rs
@@ -1,9 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
 //!
-//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
-//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
-//! impact in this package".
+//! Hot-path forwarders are inlined so this API layer does not interrupt the
+//! generic core's inlining chain. Ref: `packages/events_once/AGENTS.md`,
+//! "`#[inline]` annotations have outsized impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -15,7 +15,8 @@ use crate::{Disconnected, IntoValueError, LocalReceiverCore, LocalSenderCore, Ra
 
 /// Delivers a single value to the receiver connected to the same event.
 ///
-/// This kind of endpoint is used for events stored in a raw single-threaded event pool or event lake.
+/// This kind of endpoint is used for events stored in a raw single-threaded event pool or event
+/// lake.
 pub struct RawLocalPooledSender<T: 'static> {
     inner: LocalSenderCore<RawLocalPooledRef<T>, T>,
 }
@@ -54,7 +55,8 @@ impl<T: 'static> fmt::Debug for RawLocalPooledSender<T> {
 ///
 /// Awaiting the receiver will yield either the payload of type `T` or a [`Disconnected`] error.
 ///
-/// This kind of endpoint is used for events stored in a raw single-threaded event pool or event lake.
+/// This kind of endpoint is used for events stored in a raw single-threaded event pool or event
+/// lake.
 ///
 /// # Reentrancy
 ///

--- a/packages/events_once/src/pool/raw_local_endpoints_nice.rs
+++ b/packages/events_once/src/pool/raw_local_endpoints_nice.rs
@@ -1,5 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
+//!
+//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
+//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
+//! impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -31,6 +35,7 @@ impl<T: 'static> RawLocalPooledSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -54,9 +59,11 @@ impl<T: 'static> fmt::Debug for RawLocalPooledSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including using the event's pool or lake. Before each callback, the
+/// event publishes the resulting state and completes any endpoint or storage cleanup that must
+/// survive unwinding.
 pub struct RawLocalPooledReceiver<T: 'static> {
     inner: LocalReceiverCore<RawLocalPooledRef<T>, T>,
 }
@@ -79,6 +86,7 @@ impl<T: 'static> RawLocalPooledReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -136,6 +144,7 @@ impl<T: 'static> RawLocalPooledReceiver<T> {
 impl<T: 'static> Future for RawLocalPooledReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/packages/events_once/src/pool/raw_sync/tests.rs
+++ b/packages/events_once/src/pool/raw_sync/tests.rs
@@ -12,15 +12,29 @@ use testing::assert_panics_with;
 use testing::with_watchdog;
 
 use super::*;
-use crate::Disconnected;
 #[cfg(debug_assertions)]
 use crate::assert_inspect_awaiters_is_reentrant;
+use crate::{
+    Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+};
 
 // The payload satisfies only the bound that the pool's API requires (`Send`) and lacks every
 // trait asserted here, so each of them is supplied by the pool's own synchronization and
 // storage rather than inherited from the payload. A trait object payload also has to preserve
 // the thread-safety traits (regression test for #142).
 assert_impl_all!(RawEventPool<Box<dyn Send>>: Send, Sync, UnwindSafe, RefUnwindSafe);
+
+#[test]
+fn disconnected_send_payload_panic_releases_event() {
+    let pool = Box::pin(RawEventPool::<PanickingPayload>::new());
+
+    assert_disconnected_send_payload_panic_releases_event(
+        // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
+        || unsafe { pool.as_ref().rent() },
+        |sender, value| sender.send(value),
+        || pool.is_empty(),
+    );
+}
 
 mod concurrency;
 mod diagnostics;

--- a/packages/events_once/src/pool/raw_sync/tests.rs
+++ b/packages/events_once/src/pool/raw_sync/tests.rs
@@ -16,6 +16,7 @@ use super::*;
 use crate::assert_inspect_awaiters_is_reentrant;
 use crate::{
     Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+    assert_receiver_waker_panic_handoff_releases_event, assert_unread_payload_panic_releases_event,
 };
 
 // The payload satisfies only the bound that the pool's API requires (`Send`) and lacks every
@@ -31,7 +32,31 @@ fn disconnected_send_payload_panic_releases_event() {
     assert_disconnected_send_payload_panic_releases_event(
         // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
         || unsafe { pool.as_ref().rent() },
-        |sender, value| sender.send(value),
+        RawPooledSender::send,
+        || pool.is_empty(),
+    );
+}
+
+#[test]
+fn receiver_waker_panic_handoff_releases_event() {
+    let pool = Box::pin(RawEventPool::<i32>::new());
+
+    assert_receiver_waker_panic_handoff_releases_event(
+        // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
+        || unsafe { pool.as_ref().rent() },
+        RawPooledSender::send,
+        || pool.is_empty(),
+    );
+}
+
+#[test]
+fn unread_payload_panic_releases_event() {
+    let pool = Box::pin(RawEventPool::<PanickingPayload>::new());
+
+    assert_unread_payload_panic_releases_event(
+        // SAFETY: The pool remains pinned and alive until the helper consumes both endpoints.
+        || unsafe { pool.as_ref().rent() },
+        RawPooledSender::send,
         || pool.is_empty(),
     );
 }

--- a/packages/events_once/src/pool/raw_sync/tests.rs
+++ b/packages/events_once/src/pool/raw_sync/tests.rs
@@ -15,8 +15,12 @@ use super::*;
 #[cfg(debug_assertions)]
 use crate::assert_inspect_awaiters_is_reentrant;
 use crate::{
-    Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
-    assert_receiver_waker_panic_handoff_releases_event, assert_unread_payload_panic_releases_event,
+    Disconnected,
+    PanickingPayload,
+    // Shared helpers keep callback-safety regression coverage consistent across containers.
+    assert_disconnected_send_payload_panic_releases_event,
+    assert_receiver_waker_panic_handoff_releases_event,
+    assert_unread_payload_panic_releases_event,
 };
 
 // The payload satisfies only the bound that the pool's API requires (`Send`) and lacks every

--- a/packages/events_once/src/pool/raw_sync_endpoints_nice.rs
+++ b/packages/events_once/src/pool/raw_sync_endpoints_nice.rs
@@ -1,9 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
 //!
-//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
-//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
-//! impact in this package".
+//! Hot-path forwarders are inlined so this API layer does not interrupt the
+//! generic core's inlining chain. Ref: `packages/events_once/AGENTS.md`,
+//! "`#[inline]` annotations have outsized impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};

--- a/packages/events_once/src/pool/raw_sync_endpoints_nice.rs
+++ b/packages/events_once/src/pool/raw_sync_endpoints_nice.rs
@@ -1,5 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
+//!
+//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
+//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
+//! impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -28,6 +32,7 @@ impl<T: Send + 'static> RawPooledSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -51,9 +56,11 @@ impl<T: Send + 'static> fmt::Debug for RawPooledSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including using the event's pool or lake. Before each callback, the
+/// event publishes the resulting state and completes any endpoint or storage cleanup that must
+/// survive unwinding.
 pub struct RawPooledReceiver<T: Send + 'static> {
     inner: ReceiverCore<RawPooledRef<T>, T>,
 }
@@ -76,6 +83,7 @@ impl<T: Send + 'static> RawPooledReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -133,6 +141,7 @@ impl<T: Send + 'static> RawPooledReceiver<T> {
 impl<T: Send + 'static> Future for RawPooledReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/packages/events_once/src/pool/sync/tests.rs
+++ b/packages/events_once/src/pool/sync/tests.rs
@@ -16,6 +16,7 @@ use super::*;
 use crate::assert_inspect_awaiters_is_reentrant;
 use crate::{
     Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+    assert_receiver_waker_panic_handoff_releases_event, assert_unread_payload_panic_releases_event,
 };
 
 // The payload satisfies only the bound that the pool's API requires (`Send`) and lacks every
@@ -30,7 +31,29 @@ fn disconnected_send_payload_panic_releases_event() {
 
     assert_disconnected_send_payload_panic_releases_event(
         || pool.rent(),
-        |sender, value| sender.send(value),
+        PooledSender::send,
+        || pool.is_empty(),
+    );
+}
+
+#[test]
+fn receiver_waker_panic_handoff_releases_event() {
+    let pool = EventPool::<i32>::new();
+
+    assert_receiver_waker_panic_handoff_releases_event(
+        || pool.rent(),
+        PooledSender::send,
+        || pool.is_empty(),
+    );
+}
+
+#[test]
+fn unread_payload_panic_releases_event() {
+    let pool = EventPool::<PanickingPayload>::new();
+
+    assert_unread_payload_panic_releases_event(
+        || pool.rent(),
+        PooledSender::send,
         || pool.is_empty(),
     );
 }

--- a/packages/events_once/src/pool/sync/tests.rs
+++ b/packages/events_once/src/pool/sync/tests.rs
@@ -15,8 +15,12 @@ use super::*;
 #[cfg(debug_assertions)]
 use crate::assert_inspect_awaiters_is_reentrant;
 use crate::{
-    Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
-    assert_receiver_waker_panic_handoff_releases_event, assert_unread_payload_panic_releases_event,
+    Disconnected,
+    PanickingPayload,
+    // Shared helpers keep callback-safety regression coverage consistent across containers.
+    assert_disconnected_send_payload_panic_releases_event,
+    assert_receiver_waker_panic_handoff_releases_event,
+    assert_unread_payload_panic_releases_event,
 };
 
 // The payload satisfies only the bound that the pool's API requires (`Send`) and lacks every

--- a/packages/events_once/src/pool/sync/tests.rs
+++ b/packages/events_once/src/pool/sync/tests.rs
@@ -12,15 +12,28 @@ use testing::assert_panics_with;
 use testing::with_watchdog;
 
 use super::*;
-use crate::Disconnected;
 #[cfg(debug_assertions)]
 use crate::assert_inspect_awaiters_is_reentrant;
+use crate::{
+    Disconnected, PanickingPayload, assert_disconnected_send_payload_panic_releases_event,
+};
 
 // The payload satisfies only the bound that the pool's API requires (`Send`) and lacks every
 // trait asserted here, so each of them is supplied by the pool's own synchronization and
 // storage rather than inherited from the payload. A trait object payload also has to preserve
 // the thread-safety traits (regression test for #142).
 assert_impl_all!(EventPool<Box<dyn Send>>: Send, Sync, UnwindSafe, RefUnwindSafe);
+
+#[test]
+fn disconnected_send_payload_panic_releases_event() {
+    let pool = EventPool::<PanickingPayload>::new();
+
+    assert_disconnected_send_payload_panic_releases_event(
+        || pool.rent(),
+        |sender, value| sender.send(value),
+        || pool.is_empty(),
+    );
+}
 
 mod concurrency;
 mod diagnostics;

--- a/packages/events_once/src/pool/sync_endpoints_nice.rs
+++ b/packages/events_once/src/pool/sync_endpoints_nice.rs
@@ -1,9 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
 //!
-//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
-//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
-//! impact in this package".
+//! Hot-path forwarders are inlined so this API layer does not interrupt the
+//! generic core's inlining chain. Ref: `packages/events_once/AGENTS.md`,
+//! "`#[inline]` annotations have outsized impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};

--- a/packages/events_once/src/pool/sync_endpoints_nice.rs
+++ b/packages/events_once/src/pool/sync_endpoints_nice.rs
@@ -1,5 +1,9 @@
 //! This simply wraps the core endpoints with a nicer API surface that eliminates
 //! the outer generic type parameter, leaving only the inner T of the payload.
+//!
+//! Hot-path forwarders are inlined so this API layer does not interrupt the generic core's
+//! inlining chain. Ref: `packages/events_once/AGENTS.md`, "`#[inline]` annotations have outsized
+//! impact in this package".
 
 use std::any::type_name;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -30,6 +34,7 @@ impl<T: Send + 'static> PooledSender<T> {
     ///
     /// This method consumes the sender and always succeeds, regardless of whether
     /// there is a receiver waiting.
+    #[inline]
     pub fn send(self, value: T) {
         self.inner.send(value);
     }
@@ -53,9 +58,11 @@ impl<T: Send + 'static> fmt::Debug for PooledSender<T> {
 /// # Reentrancy
 ///
 /// Cloning a waker during polling may synchronously send through or drop the sender. Waking or
-/// dropping a registered waker during completion or cancellation may synchronously poll this
-/// receiver to completion or drop an endpoint. The event publishes the resulting state before
-/// each callback.
+/// dropping a registered waker during completion may synchronously poll this receiver to completion
+/// or drop an endpoint. Destruction of a registered waker or discarded payload during cancellation
+/// may run arbitrary user code, including using the event's pool or lake. Before each callback, the
+/// event publishes the resulting state and completes any endpoint or storage cleanup that must
+/// survive unwinding.
 pub struct PooledReceiver<T: Send + 'static> {
     inner: ReceiverCore<PooledRef<T>, T>,
 }
@@ -78,6 +85,7 @@ impl<T: Send + 'static> PooledReceiver<T> {
     /// # Panics
     ///
     /// Panics if called after `poll()` has returned `Ready`.
+    #[inline]
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.inner.is_ready()
@@ -131,6 +139,7 @@ impl<T: Send + 'static> PooledReceiver<T> {
 impl<T: Send + 'static> Future for PooledReceiver<T> {
     type Output = Result<T, Disconnected>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/packages/events_once/src/reentrancy.rs
+++ b/packages/events_once/src/reentrancy.rs
@@ -1,14 +1,28 @@
+#[cfg(debug_assertions)]
 use std::backtrace::Backtrace;
+#[cfg(debug_assertions)]
 use std::cell::Cell;
+#[cfg(test)]
+use std::future::Future;
+#[cfg(test)]
+use std::pin::Pin;
+#[cfg(test)]
+use std::task::{self, Poll};
 
 #[cfg(test)]
-use testing::assert_panics;
+use testing::{assert_panics, clone_action_waker_panicking_on_clone_release};
+
+/// Arbitrary test payload; event lifecycle logic treats its value as opaque.
+#[cfg(test)]
+const TEST_PAYLOAD: i32 = 42;
 
 /// The closure that an `inspect_awaiters()` method calls once per awaited event.
+#[cfg(debug_assertions)]
 type AwaiterInspector<'a> = dyn FnMut(&Backtrace) + 'a;
 
 /// Calls the `inspect_awaiters()` method of the object under test, passing it the provided
 /// closure.
+#[cfg(debug_assertions)]
 type InspectAwaiters<'a> = dyn Fn(&mut AwaiterInspector<'_>) + 'a;
 
 /// Asserts that the `inspect_awaiters()` method of an event pool or event lake tolerates a
@@ -21,6 +35,7 @@ type InspectAwaiters<'a> = dyn Fn(&mut AwaiterInspector<'_>) + 'a;
 /// it receives. `rent_and_drop` must rent an event from the same object and immediately drop
 /// both of its endpoints, returning the event to the object.
 #[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(debug_assertions)]
 pub(crate) fn assert_inspect_awaiters_is_reentrant(
     inspect: &InspectAwaiters<'_>,
     rent_and_drop: &dyn Fn(),
@@ -81,5 +96,54 @@ pub(crate) fn assert_disconnected_send_payload_panic_releases_event<S, R>(
     assert!(
         is_empty(),
         "the event must be returned before the payload destructor unwinds"
+    );
+}
+
+/// Asserts that receiver cancellation completes its handoff before dropping a stored waker.
+#[cfg(test)]
+pub(crate) fn assert_receiver_waker_panic_handoff_releases_event<S, R>(
+    rent: impl FnOnce() -> (S, R),
+    send: impl FnOnce(S, i32),
+    is_empty: impl FnOnce() -> bool,
+) where
+    R: Future + Unpin,
+{
+    let (sender, mut receiver) = rent();
+
+    // SAFETY: The payload is not `Send`, and this helper keeps the waker on one thread.
+    let (waker, cloned) = unsafe { clone_action_waker_panicking_on_clone_release(|| {}) };
+
+    let mut cx = task::Context::from_waker(&waker);
+    assert!(matches!(
+        Pin::new(&mut receiver).poll(&mut cx),
+        Poll::Pending
+    ));
+    assert!(cloned.get(), "the receiver must register a waker clone");
+    drop(waker);
+
+    assert_panics(|| drop(receiver));
+
+    send(sender, TEST_PAYLOAD);
+    assert!(
+        is_empty(),
+        "the sender must observe receiver disconnection and return the event"
+    );
+}
+
+/// Asserts that receiver teardown returns event storage before dropping an unread payload.
+#[cfg(test)]
+pub(crate) fn assert_unread_payload_panic_releases_event<S, R>(
+    rent: impl FnOnce() -> (S, R),
+    send: impl FnOnce(S, PanickingPayload),
+    is_empty: impl FnOnce() -> bool,
+) {
+    let (sender, receiver) = rent();
+    send(sender, PanickingPayload);
+
+    assert_panics(|| drop(receiver));
+
+    assert!(
+        is_empty(),
+        "the event must be returned before the unread payload destructor unwinds"
     );
 }

--- a/packages/events_once/src/reentrancy.rs
+++ b/packages/events_once/src/reentrancy.rs
@@ -1,6 +1,9 @@
 use std::backtrace::Backtrace;
 use std::cell::Cell;
 
+#[cfg(test)]
+use testing::assert_panics;
+
 /// The closure that an `inspect_awaiters()` method calls once per awaited event.
 type AwaiterInspector<'a> = dyn FnMut(&Backtrace) + 'a;
 
@@ -50,4 +53,33 @@ pub(crate) fn assert_inspect_awaiters_is_reentrant(
     // The nested inspection observes the same awaited events as the outer one because the event
     // that `rent_and_drop` rents is never awaited and therefore never inspected.
     assert_eq!(nested_calls.get(), outer_calls.get());
+}
+
+/// A payload whose destructor unwinds after a disconnected send rejects it.
+#[cfg(test)]
+pub(crate) struct PanickingPayload;
+
+#[cfg(test)]
+impl Drop for PanickingPayload {
+    fn drop(&mut self) {
+        panic!("payload destructor");
+    }
+}
+
+/// Asserts that a disconnected send returns event storage before dropping its payload.
+#[cfg(test)]
+pub(crate) fn assert_disconnected_send_payload_panic_releases_event<S, R>(
+    rent: impl FnOnce() -> (S, R),
+    send: impl FnOnce(S, PanickingPayload),
+    is_empty: impl FnOnce() -> bool,
+) {
+    let (sender, receiver) = rent();
+    drop(receiver);
+
+    assert_panics(|| send(sender, PanickingPayload));
+
+    assert!(
+        is_empty(),
+        "the event must be returned before the payload destructor unwinds"
+    );
 }


### PR DESCRIPTION
[Copilot speaking]

## Motivation

`events_once` treats waker operations as user-code callback boundaries, but endpoint teardown and disconnected sends could still destroy caller-provided payloads or stored wakers before reusable event storage was returned. If such a destructor panicked and the caller caught the unwind, a managed or raw pool/lake slot could remain checked out despite the endpoint types' unwind-safety contract.

## Changes

Receiver cancellation and disconnected sends now finish their observable state transition, release re-enterable borrows or locks, and complete or transfer endpoint and storage cleanup before destroying user-owned payloads or wakers. This applies consistently to local and synchronized events across boxed, embedded, managed pooled, raw pooled, lake, and raw lake storage.

The receiver cancellation state machines extract callback-bearing values into deferred cleanup ownership. Synchronized cancellation remains isolated in a cold, out-of-line helper, while terminal value extraction uses a separate callback-free path. Concrete receiver documentation and pool/lake rental APIs now expose the same canonical reentrancy contract.

Instruction-level coverage now includes receiver-first awaiting cancellation for every storage strategy. Primary pooled lifecycle counts remain unchanged at 88 local and 140 synchronized instructions, and sender/polling hot paths are preserved. Synchronized pending `into_value` increases from 44 to 51 instructions; synchronized terminal extraction improves, while cancellation intentionally pays the additional cleanup-safety cost.