### PR TITLE
benchmark history: Enable all Cargo features

### DIFF
--- a/.github/workflows/bench-history-backfill.yml
+++ b/.github/workflows/bench-history-backfill.yml
@@ -115,10 +115,11 @@ jobs:
           Import-Module ./scripts/bench-history/AzureFederation.psm1 -Force
           Set-AzureFederationEnv -ConstantsPath constants.env -EnvFilePath $env:GITHUB_ENV | Out-Null
 
-      # The recipe resolves the commit range, measures only the commits this runner's own machine
-      # partition is missing, and appends them under the runner's real hardware fingerprint (no fixed
-      # machine key). BACKFILL_TO_COMMIT is empty on a scheduled run; it is passed through the
-      # environment so an untrusted dispatch input is never spliced into a shell command line here.
+      # The recipe resolves the commit range, measures all Cargo features for only the commits this
+      # runner's own machine partition is missing, and appends them under the runner's real hardware
+      # fingerprint (no fixed machine key). BACKFILL_TO_COMMIT is empty on a scheduled run; it is
+      # passed through the environment so an untrusted dispatch input is never spliced into a shell
+      # command line here.
       - name: Backfill benchmark history
         shell: pwsh
         env:

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -2,9 +2,9 @@ name: Benchmark history
 
 # Per-commit collection of the workspace's benchmark results into the long-lived Azure
 # history store (account folohistory, baked into .cargo/bench_history.toml; see also
-# infra/azure-bench-history-prod/). Each push to `main` benchmarks the whole workspace
-# EXCEPT the slow, special-purpose `benchmarks` package, on the x86_64 Linux and Windows
-# runners, and appends the results keyed by the pushed commit. Over time this builds the
+# infra/azure-bench-history-prod/). Each push to `main` benchmarks the whole workspace with all
+# Cargo features enabled EXCEPT the slow, special-purpose `benchmarks` package, on the x86_64 Linux
+# and Windows runners, and appends the results keyed by the pushed commit. Over time this builds the
 # performance history that `cargo-bench-history analyze` reads to spot regressions.
 #
 # Runs per-push rather than on a nightly schedule: a nightly run re-benchmarks an unchanged

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -224,6 +224,12 @@ ARM and macOS are only nominally supported — they must pass tests (see the Pla
 section) but their performance is not tracked — so benchmarking them would spend runner
 minutes producing series no one reads.
 
+Every selected package is benchmarked with all Cargo features enabled. This makes Cargo include
+benchmark targets guarded by `required-features` and builds each selected package in its
+all-features configuration. The push, PR, re-collection and nightly-backfill paths all obtain this
+feature selection from the same command builder, so a stored point is never made incomparable by
+one path using narrower feature coverage.
+
 Even with those defences, a single day of a badly degraded runner can still leave one commit's
 data point corrupted. Collection is therefore also manually re-runnable against a specific
 historical commit: a `workflow_dispatch` with a `recollect_commit_id` re-measures just that

--- a/.github/workflows/pr-bench-history.yml
+++ b/.github/workflows/pr-bench-history.yml
@@ -2,13 +2,13 @@ name: PR Benchmark history
 
 # Per-push benchmark feedback on pull requests: the PR counterpart of bench-history.yml. Where that
 # workflow collects on every push to `main` and files a rolling ISSUE about long-range trends, this
-# one runs on every push to a PR branch, benchmarks only the packages the PR impacts (the changed
-# packages plus their dependents, cargo-delta scoped), compares the PR head's benchmark level
-# against `main` in BRANCH mode, and posts/updates a rolling PR COMMENT with the findings. PR-head
-# points are written into the SAME prod Azure store as the `main` baseline (branch-mode comparison
-# reads a single backend); PR commits are
-# topologically branch-unique, so they never enter `main`'s history analysis. Findings are advisory:
-# they never gate the merge, only inform. See .github/workflows/design.md (Benchmark history).
+# one runs on every push to a PR branch, benchmarks all Cargo features of only the packages the PR
+# impacts (the changed packages plus their dependents, cargo-delta scoped), compares the PR head's
+# benchmark level against `main` in BRANCH mode, and posts/updates a rolling PR COMMENT with the
+# findings. PR-head points are written into the SAME prod Azure store as the `main` baseline
+# (branch-mode comparison reads a single backend); PR commits are topologically branch-unique, so
+# they never enter `main`'s history analysis. Findings are advisory: they never gate the merge, only
+# inform. See .github/workflows/design.md (Benchmark history).
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -6,26 +6,26 @@
 # thin wrappers over the tool, free of local-developer conveniences.
 
 # Collects the whole workspace's benchmark history (excluding the slow, special-purpose
-# `benchmarks` package) into the prod Azure store, keyed by the current commit. The machine
-# partition for every engine is the runner's OWN auto-detected hardware fingerprint,
-# NOT a fixed key: the GitHub-hosted runner pool is heterogeneous, and pinning every runner onto one
-# shared series just mixes incomparable machines and jitters daily. Letting each runner stamp
-# its real fingerprint splits the data into one clean series per hardware type; the analyze job is
-# fed the exact fingerprints collected this run (see gh-analyze-bench-history) so it surveys only
-# those series. Every engine is partitioned this way — even Callgrind and the allocation/time
-# counters, whose simulated figures still vary across microarchitectures as libraries dispatch to
-# different code paths. `--best-of 3` counteracts the same runner noise from the other direction: the
-# suite runs three times and each metric keeps its minimum sample, since benchmark interference
-# on a shared runner is one-sided (it only ever makes a case slower) and the runs are spaced far
-# enough apart in time that a transient slowdown is unlikely to hit every one. This roughly
-# triples the wall-clock benchmark portion of the collect job (see bench-history.yml's
-# `timeout-minutes`). `--verbose` makes the collect log spell out the resolved machine key and the
-# fingerprint components behind it, so a key change (a runner hardware shift) is debuggable from the
-# log alone. `--skip-existing` makes a re-run on an unchanged commit a no-op append (each
-# already-stored object is skipped, not overwritten), so a re-triggered run of an
-# already-collected commit never bumps the cache-invalidation marker the `analyze` job's
-# read-through cache depends on - a re-run of the same commit is not "better" data, so there is
-# nothing to replace.
+# `benchmarks` package) with every selected package's Cargo features enabled, so targets guarded by
+# `required-features` are included. Results go into the prod Azure store, keyed by the current
+# commit. The machine partition for every engine is the runner's OWN auto-detected hardware
+# fingerprint, NOT a fixed key: the GitHub-hosted runner pool is heterogeneous, and pinning every
+# runner onto one shared series just mixes incomparable machines and jitters daily. Letting each
+# runner stamp its real fingerprint splits the data into one clean series per hardware type; the
+# analyze job is fed the exact fingerprints collected this run (see gh-analyze-bench-history) so it
+# surveys only those series. Every engine is partitioned this way — even Callgrind and the
+# allocation/time counters, whose simulated figures still vary across microarchitectures as
+# libraries dispatch to different code paths. `--best-of 3` counteracts the same runner noise from
+# the other direction: the suite runs three times and each metric keeps its minimum sample, since
+# benchmark interference on a shared runner is one-sided (it only ever makes a case slower) and the
+# runs are spaced far enough apart in time that a transient slowdown is unlikely to hit every one.
+# This roughly triples the wall-clock benchmark portion of the collect job (see
+# bench-history.yml's `timeout-minutes`). `--verbose` makes the collect log spell out the resolved
+# machine key and the fingerprint components behind it, so a key change (a runner hardware shift)
+# is debuggable from the log alone. `--skip-existing` makes a re-run on an unchanged commit a no-op
+# append (each already-stored object is skipped, not overwritten), so a re-triggered run of the
+# same commit never bumps the cache-invalidation marker the `analyze` job's read-through cache
+# depends on - a re-run of the same commit is not "better" data, so there is nothing to replace.
 #
 # RECOLLECT MODE. When the environment variable `RECOLLECT_COMMIT_ID` is set (the bench-history.yml
 # `collect` job wires it from the optional `recollect_commit_id` workflow_dispatch input), this
@@ -84,11 +84,12 @@ gh-collect-bench-history:
 # and it is safe because branch-mode `analyze` only ever flags a series that has a data point at the
 # branch-unique head commit, i.e. exactly the packages collected here (see
 # gh-analyze-pr-bench-history and .github/workflows/design.md). Everything else is identical to the
-# push-to-main collect: each runner stamps its OWN real hardware fingerprint (no fixed key), so PR
-# wall-clock series live on the same per-machine-key partitions as main's baseline, `--best-of 3`
-# sheds one-sided runner jitter, `--verbose` logs the resolved key and its components, and
-# `--skip-existing` makes a re-run of the same head SHA a no-op append. There is no recollect mode on
-# PRs (that repairs main's permanent history); the scope decision lives in
+# push-to-main collect: all Cargo features are enabled so required-feature targets run, each runner
+# stamps its OWN real hardware fingerprint (no fixed key), so PR wall-clock series live on the same
+# per-machine-key partitions as main's baseline, `--best-of 3` sheds one-sided runner jitter,
+# `--verbose` logs the resolved key and its components, and `--skip-existing` makes a re-run of the
+# same head SHA a no-op append. There is no recollect mode on PRs (that repairs main's permanent
+# history); the scope decision lives in
 # scripts/bench-history/BenchHistoryCollect.psm1 (Pester-tested via `just test-scripts`), so this is
 # a thin import + call. `packages` must be non-empty - the workflow only invokes this recipe when
 # the delta produced at least one benchmarkable package, and an empty scope would wrongly fall back
@@ -140,12 +141,12 @@ gh-collect-pr-bench-history packages:
 # oldest first-parent commit reachable from that end and newer than 14 days, since older points have
 # no comparison value against current tips. An EMPTY argument vector means no commit is eligible yet
 # (every commit is still inside the quarantine), which is a successful no-op rather than a failure.
-# The scope, `--best-of 3` and `--verbose` are the same ones gh-collect-bench-history uses - a point
-# measured with a narrower scope or a lower best-of would not be comparable to its pushed neighbours,
-# and would still count as recorded and never be revisited. `--ignore-errors` walks past a commit
-# that fails to build instead of abandoning the rest of the window; there is no `--overwrite` (an
-# existing point is exactly what should be skipped) and no `--machine-key` (each runner stamps its
-# own real hardware fingerprint).
+# The package scope, `--all-features`, `--best-of 3` and `--verbose` are the same ones
+# gh-collect-bench-history uses - a point measured with different feature coverage, a narrower scope
+# or a lower best-of would not be comparable to its pushed neighbours, and would still count as
+# recorded and never be revisited. `--ignore-errors` walks past a commit that fails to build instead
+# of abandoning the rest of the window; there is no `--overwrite` (an existing point is exactly what
+# should be skipped) and no `--machine-key` (each runner stamps its own real hardware fingerprint).
 #
 # Each commit is built with the toolchain it pins, but the RUSTFLAGS below come from HEAD's
 # constants.env, so a commit older than the newest change to them is measured slightly differently

--- a/scripts/bench-history/BenchHistoryCollect.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryCollect.Tests.ps1
@@ -19,6 +19,7 @@ BeforeAll {
     $script:Scope = @(
         '--workspace',
         '--exclude', 'benchmarks',
+        '--all-features',
         '--best-of', '3',
         '--verbose'
     )
@@ -109,6 +110,7 @@ Describe 'Get-BenchHistoryCollectCommand' {
                 'collect',
                 '--package', 'nm',
                 '--package', 'many_cpus',
+                '--all-features',
                 '--best-of', '3',
                 '--verbose',
                 '--skip-existing'
@@ -126,6 +128,7 @@ Describe 'Get-BenchHistoryCollectCommand' {
             $result | Should -Be @(
                 'collect',
                 '--package', 'nm',
+                '--all-features',
                 '--best-of', '3',
                 '--verbose',
                 '--skip-existing'
@@ -135,6 +138,11 @@ Describe 'Get-BenchHistoryCollectCommand' {
         It 'treats an all-blank package list as no scope (whole workspace)' {
             $result = Get-BenchHistoryCollectCommand -RecollectCommitId '' -Package @('', '  ')
             $result | Should -Be (@('collect') + $script:Scope + @('--skip-existing'))
+        }
+
+        It 'enables all features so Cargo runs required-feature benchmark targets' {
+            $result = Get-BenchHistoryCollectCommand -Package 'nm_otel_impl'
+            $result | Should -Contain '--all-features'
         }
     }
 }
@@ -324,5 +332,3 @@ Describe 'Select-BenchmarkablePackage' {
             Should -Be @('Benchmarks', 'nm')
     }
 }
-
-

--- a/scripts/bench-history/BenchHistoryCollect.psm1
+++ b/scripts/bench-history/BenchHistoryCollect.psm1
@@ -22,7 +22,9 @@
 #
 # Collection scope is orthogonal to the mode: with no explicit package list the whole workspace is
 # benched except the special-purpose `benchmarks` crate (the push-to-main default); the PR workflow
-# instead passes the delta-affected packages so it benches only what the PR impacts.
+# instead passes the delta-affected packages so it benches only what the PR impacts. Every selected
+# package is benched with all Cargo features enabled, so Cargo includes targets guarded by
+# `required-features` and builds each package in its all-features configuration.
 # Select-BenchmarkablePackage is the shared helper that drops `benchmarks` from a delta-affected set
 # before both the scope decision and the "is there anything to bench at all" gate.
 #
@@ -84,9 +86,10 @@ function Select-BenchmarkablePackage {
 }
 
 function Get-BenchHistoryScopeArgument {
-    # Builds the scope + noise-reduction flags EVERY benchmark-history run shares, so a `collect` and
-    # a `backfill` can never measure the same commit differently. `collect` and `backfill` flatten the
-    # same clap arg groups, so this array applies verbatim to either subcommand.
+    # Builds the scope + feature-selection + noise-reduction flags EVERY benchmark-history run
+    # shares, so a `collect` and a `backfill` can never measure the same commit differently.
+    # `collect` and `backfill` flatten the same clap arg groups, so this array applies verbatim to
+    # either subcommand.
     #
     # $Package selects the collection scope. When empty (the push-to-main and nightly-backfill
     # default), the whole workspace is benched except the excluded `benchmarks` crate (`--workspace
@@ -94,13 +97,16 @@ function Get-BenchHistoryScopeArgument {
     # packages), the run is scoped to exactly those packages (`--package <name>` each); the caller is
     # expected to have already dropped `benchmarks` via Select-BenchmarkablePackage.
     #
+    # `--all-features` ensures Cargo runs benchmark targets guarded by `required-features` and
+    # compiles feature-gated code paths into every selected package's benchmarks.
+    #
     # Each runner stamps its results with its OWN real hardware fingerprint, so a heterogeneous
-    # GitHub runner pool splits into one clean wall-clock series per
-    # hardware type instead of one jittery series mixing incomparable machines. `--best-of 3` keeps
-    # each metric's minimum across three runs to shed one-sided runner jitter - a point taken at a
-    # lower best-of would sit systematically higher than its neighbours and manufacture a step change
-    # in the series. `--verbose` makes the log spell out the resolved machine key and the fingerprint
-    # components behind it, so a key change is debuggable from the log alone.
+    # GitHub runner pool splits into one clean wall-clock series per hardware type instead of one
+    # jittery series mixing incomparable machines. `--best-of 3` keeps each metric's minimum across
+    # three runs to shed one-sided runner jitter - a point taken at a lower best-of would sit
+    # systematically higher than its neighbours and manufacture a step change in the series.
+    # `--verbose` makes the log spell out the resolved machine key and the fingerprint components
+    # behind it, so a key change is debuggable from the log alone.
     [CmdletBinding()]
     [OutputType([string[]])]
     param(
@@ -124,6 +130,7 @@ function Get-BenchHistoryScopeArgument {
     }
 
     return $selection + @(
+        '--all-features',
         '--best-of', '3',
         '--verbose'
     )


### PR DESCRIPTION
[Copilot speaking]

Benchmark-history collection currently uses default Cargo features, so Cargo silently skips benchmark targets guarded by `required-features`. This leaves the `par_bench_overhead`, `par_bench_basic`, `nm_otel_export`, and `nm_otel_export_cg` targets out of the stored performance history.

All benchmark-history collection modes now obtain `--all-features` from the shared command builder. Push, pull request, re-collection, and nightly backfill runs therefore use the same feature coverage and remain comparable, with the workflow documentation and command-builder tests reflecting that contract.