### PR TITLE
nm: address review feedback without performance regressions

### DIFF
--- a/docs/impl-crate-split.md
+++ b/docs/impl-crate-split.md
@@ -492,15 +492,15 @@ The second worked example. Concrete files to study:
   explicit `pub use nm_otel_impl::{Publisher, PublisherBuilder};`.
 - `packages/nm_otel/tests/nm_otel_reexports.rs` — re-export smoke test.
 - `packages/nm_otel_impl/Cargo.toml` — impl manifest with `[lib] doc = false`,
-  the `private-test-util` feature gating
-  `Publisher::run_one_iteration_with_report`, the `nm_otel` dev-dep for the
-  doctest cycle, and the `nm_impl` dev-dep with
+  the `private-test-util` feature gating one-iteration publisher drivers and
+  histogram delta test state, the `nm_otel` dev-dep for the doctest cycle, and
+  the `nm_impl` dev-dep with
   `features = ["private-test-util"]` so the impl-hosted benches can build
   input reports via `Report::fake`. Both `[[bench]]` entries declare
   `required-features = ["private-test-util"]`.
 - `packages/nm_otel_impl/src/lib.rs` — `#![doc(hidden)]` root that re-exports
-  the public-API subset for the shell crate plus `EventState` for the
-  alloc-tracking integration test.
+  the public-API subset for the shell crate plus feature-gated `EventState` for
+  the alloc-tracking integration test.
 - `packages/nm_otel_impl/README.md` — "do not depend on this directly" notice.
 - `release-plz.toml` — `version_group = "nm_otel"` entries for `nm_otel` and
   `nm_otel_impl`.
@@ -584,4 +584,3 @@ deferring their documentation. Concrete files to study:
   to every crate in the family: each `cbh_*` package is pinned `=0.0.3` in
   `[workspace.dependencies]` and shares `version_group = "cargo-bench-history"`
   with the CLI, so the published set can never drift to mismatched versions.
-

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -57,5 +57,15 @@ name = "nm_push_bulk"
 harness = false
 
 [[bench]]
+name = "nm_rendering"
+harness = false
+required-features = ["private-test-util"]
+
+[[bench]]
+name = "nm_rendering_cg"
+harness = false
+required-features = ["private-test-util"]
+
+[[bench]]
 name = "nm_performance_cg"
 harness = false

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -27,13 +27,13 @@ private-test-util = []
 
 [dependencies]
 fast_time = { workspace = true }
-new_zealand = { workspace = true }
 num-traits = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
 many_cpus = { path = "../many_cpus" }
 mutants = { workspace = true }
+new_zealand = { path = "../new_zealand" }
 # `nm` is a development dependency so doctests, examples, and benchmarks can write
 # `use nm::Event;` exactly as user code would, matching the documentation rendered for `nm`.
 nm = { path = "../nm" }

--- a/packages/nm_impl/benches/nm_rendering.rs
+++ b/packages/nm_impl/benches/nm_rendering.rs
@@ -51,10 +51,10 @@ struct ByteCounter {
 }
 
 impl Write for ByteCounter {
-    fn write_str(&mut self, value: &str) -> fmt::Result {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
         self.bytes = self
             .bytes
-            .checked_add(value.len())
+            .checked_add(s.len())
             .expect("formatted histogram output fits in usize");
         Ok(())
     }

--- a/packages/nm_impl/benches/nm_rendering.rs
+++ b/packages/nm_impl/benches/nm_rendering.rs
@@ -1,0 +1,102 @@
+//! Benchmarks for human-readable nm histogram rendering.
+//!
+//! Paired with `nm_rendering_cg.rs`, which measures the same low- and high-cardinality
+//! histograms under Callgrind. Rendering writes to a counting sink so output allocation does not
+//! obscure formatter work.
+
+#![allow(missing_docs, reason = "Benchmark code does not expose a public API.")]
+
+use std::fmt::{self, Write};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nm::{Histogram, Magnitude};
+
+criterion_group!(benches, entrypoint);
+criterion_main!(benches);
+
+fn entrypoint(c: &mut Criterion) {
+    let low = make_histogram(LOW_CARDINALITY_BUCKET_BOUNDS);
+    let high = make_histogram(HIGH_CARDINALITY_BUCKET_BOUNDS);
+    let mut group = c.benchmark_group("nm_rendering/histogram");
+
+    group.bench_function("low", |b| {
+        b.iter(|| black_box(render(black_box(&low))));
+    });
+    group.bench_function("high", |b| {
+        b.iter(|| black_box(render(black_box(&high))));
+    });
+
+    group.finish();
+}
+
+fn make_histogram(bucket_bounds: &'static [Magnitude]) -> Histogram {
+    Histogram::fake(
+        bucket_bounds,
+        vec![OBSERVATIONS_PER_BUCKET; bucket_bounds.len()],
+        OBSERVATIONS_PER_BUCKET,
+    )
+}
+
+fn render(histogram: &Histogram) -> usize {
+    let mut output = ByteCounter::default();
+    write!(&mut output, "{histogram}").expect("the counting sink accepts all formatted output");
+    output.bytes
+}
+
+/// Counts formatted bytes without allocating output storage.
+#[derive(Debug, Default)]
+struct ByteCounter {
+    bytes: usize,
+}
+
+impl Write for ByteCounter {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.bytes = self
+            .bytes
+            .checked_add(value.len())
+            .expect("formatted histogram output fits in usize");
+        Ok(())
+    }
+}
+
+/// Represents a compact histogram used for ordinary event reporting.
+const LOW_CARDINALITY_BUCKET_BOUNDS: &[Magnitude] = &[1, 10, 50, 100, 500, 1_000, 5_000];
+
+/// Exposes how rendering scales at the upper end of configured bucket cardinality.
+const HIGH_CARDINALITY_BUCKET_BOUNDS: &[Magnitude] = &[
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1_024,
+    2_048,
+    4_096,
+    8_192,
+    16_384,
+    32_768,
+    65_536,
+    131_072,
+    262_144,
+    524_288,
+    1_048_576,
+    2_097_152,
+    4_194_304,
+    8_388_608,
+    16_777_216,
+    33_554_432,
+    67_108_864,
+    134_217_728,
+    268_435_456,
+    536_870_912,
+    1_073_741_824,
+];
+
+/// Produces a full-width bar for every bucket without approaching arithmetic limits.
+const OBSERVATIONS_PER_BUCKET: u64 = 100;

--- a/packages/nm_impl/benches/nm_rendering_cg.rs
+++ b/packages/nm_impl/benches/nm_rendering_cg.rs
@@ -84,10 +84,10 @@ mod linux {
     }
 
     impl Write for ByteCounter {
-        fn write_str(&mut self, value: &str) -> fmt::Result {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
             self.bytes = self
                 .bytes
-                .checked_add(value.len())
+                .checked_add(s.len())
                 .expect("formatted histogram output fits in usize");
             Ok(())
         }

--- a/packages/nm_impl/benches/nm_rendering_cg.rs
+++ b/packages/nm_impl/benches/nm_rendering_cg.rs
@@ -1,0 +1,136 @@
+//! Callgrind benchmarks for human-readable nm histogram rendering.
+//!
+//! Paired with `nm_rendering.rs`, which covers the same low- and high-cardinality histograms
+//! under wall-clock measurement. Rendering writes to a counting sink so output allocation does
+//! not obscure formatter work.
+
+#![allow(missing_docs, reason = "Benchmark code does not expose a public API.")]
+#![cfg_attr(
+    target_os = "linux",
+    expect(
+        clippy::exit,
+        clippy::missing_docs_in_private_items,
+        unused_qualifications,
+        reason = "These lints originate in Gungraun macro expansion and cannot be addressed in \
+                  this benchmark."
+    )
+)]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Gungraun requires Valgrind, which is available only on Linux.
+}
+
+#[cfg(target_os = "linux")]
+use gungraun::{Callgrind, CallgrindMetrics, LibraryBenchmarkConfig, main};
+#[cfg(target_os = "linux")]
+pub use linux::*;
+
+#[cfg(target_os = "linux")]
+main!(
+    config = LibraryBenchmarkConfig::default().tool(
+        Callgrind::default()
+            .args(["--branch-sim=yes", "--collect-bus=yes"])
+            .format([CallgrindMetrics::Default, CallgrindMetrics::BranchSim]),
+    ),
+    library_benchmark_groups = histogram
+);
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::fmt::{self, Write};
+    use std::hint::black_box;
+
+    use gungraun::prelude::*;
+    use nm::{Histogram, Magnitude};
+
+    #[library_benchmark]
+    #[bench::default(make_histogram(LOW_CARDINALITY_BUCKET_BOUNDS))]
+    fn histogram_low(histogram: Histogram) -> (Histogram, usize) {
+        let bytes = render(black_box(&histogram));
+        (histogram, black_box(bytes))
+    }
+
+    #[library_benchmark]
+    #[bench::default(make_histogram(HIGH_CARDINALITY_BUCKET_BOUNDS))]
+    fn histogram_high(histogram: Histogram) -> (Histogram, usize) {
+        let bytes = render(black_box(&histogram));
+        (histogram, black_box(bytes))
+    }
+
+    library_benchmark_group!(
+        name = histogram,
+        benchmarks = [histogram_low, histogram_high]
+    );
+
+    fn make_histogram(bucket_bounds: &'static [Magnitude]) -> Histogram {
+        Histogram::fake(
+            bucket_bounds,
+            vec![OBSERVATIONS_PER_BUCKET; bucket_bounds.len()],
+            OBSERVATIONS_PER_BUCKET,
+        )
+    }
+
+    fn render(histogram: &Histogram) -> usize {
+        let mut output = ByteCounter::default();
+        write!(&mut output, "{histogram}").expect("the counting sink accepts all formatted output");
+        output.bytes
+    }
+
+    /// Counts formatted bytes without allocating output storage.
+    #[derive(Debug, Default)]
+    struct ByteCounter {
+        bytes: usize,
+    }
+
+    impl Write for ByteCounter {
+        fn write_str(&mut self, value: &str) -> fmt::Result {
+            self.bytes = self
+                .bytes
+                .checked_add(value.len())
+                .expect("formatted histogram output fits in usize");
+            Ok(())
+        }
+    }
+
+    /// Represents a compact histogram used for ordinary event reporting.
+    const LOW_CARDINALITY_BUCKET_BOUNDS: &[Magnitude] = &[1, 10, 50, 100, 500, 1_000, 5_000];
+
+    /// Exposes how rendering scales at the upper end of configured bucket cardinality.
+    const HIGH_CARDINALITY_BUCKET_BOUNDS: &[Magnitude] = &[
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
+        1_024,
+        2_048,
+        4_096,
+        8_192,
+        16_384,
+        32_768,
+        65_536,
+        131_072,
+        262_144,
+        524_288,
+        1_048_576,
+        2_097_152,
+        4_194_304,
+        8_388_608,
+        16_777_216,
+        33_554_432,
+        67_108_864,
+        134_217_728,
+        268_435_456,
+        536_870_912,
+        1_073_741_824,
+    ];
+
+    /// Produces a full-width bar for every bucket without approaching arithmetic limits.
+    const OBSERVATIONS_PER_BUCKET: u64 = 100;
+}

--- a/packages/nm_impl/src/event.rs
+++ b/packages/nm_impl/src/event.rs
@@ -255,7 +255,6 @@ where
     ///
     /// Only the whole number part of the duration is used; fractional milliseconds are ignored.
     /// Values outside the i64 range are not guaranteed to be correctly represented.
-    #[inline]
     pub fn observe_millis(&self, duration: Duration) {
         #[expect(
             clippy::cast_possible_truncation,
@@ -275,7 +274,6 @@ where
     /// # Reentrancy
     ///
     /// The measured function may observe this event or any other event.
-    #[inline]
     pub fn observe_duration_millis<F, R>(&self, f: F) -> R
     where
         F: FnOnce() -> R,

--- a/packages/nm_impl/src/reports.rs
+++ b/packages/nm_impl/src/reports.rs
@@ -2,8 +2,6 @@ use std::fmt::{self, Display, Write};
 use std::num::NonZero;
 use std::{cmp, iter};
 
-use new_zealand::nz;
-
 use crate::{
     EventName, GLOBAL_REGISTRY, GlobalEventRegistry, HashMap, Magnitude, ObservationBagSnapshot,
 };
@@ -510,71 +508,63 @@ const TARGET_HISTOGRAM_BAR_WIDTH_CHARS: u64 = 50;
 /// Ensures that a nonempty histogram remains renderable when its largest bucket is small.
 const MIN_OBSERVATIONS_PER_BAR_CHAR: u64 = 1;
 
-/// Pre-allocated string of histogram bar characters to avoid allocation during rendering.
-/// We make this longer than the typical bar width to handle cases where quantization causes
-/// the bar to exceed the target width.
-const HISTOGRAM_BAR_CHARS: &str =
-    "∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎";
+/// Uses the conventional textual representation for an unbounded upper range.
+const PLUS_INFINITY_BOUND_LABEL: &str = "+inf";
 
-const HISTOGRAM_BAR_CHARS_LEN_BYTES: NonZero<usize> = nz!(HISTOGRAM_BAR_CHARS.len());
+/// Makes relative bucket counts easy to compare in a Unicode-capable terminal.
+const HISTOGRAM_BAR_CHAR: char = '∎';
 
-/// UTF-8 width of each histogram bar character.
-const BYTES_PER_HISTOGRAM_BAR_CHAR: NonZero<usize> = nz!('∎'.len_utf8());
+fn decimal_width(value: u64) -> usize {
+    let width = value
+        .checked_ilog10()
+        .unwrap_or(0)
+        .checked_add(1)
+        .expect("a u64 decimal width fits in u32");
+    usize::try_from(width).expect("a u64 decimal width fits in usize")
+}
+
+fn magnitude_width(value: Magnitude) -> usize {
+    decimal_width(value.unsigned_abs())
+        .checked_add(usize::from(value.is_negative()))
+        .expect("an i64 decimal width fits in usize")
+}
 
 impl Display for Histogram {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let buckets = self.buckets().collect::<Vec<_>>();
+        let (widest_upper_bound, widest_count) = self.buckets().fold(
+            (0, 0),
+            |(upper_bound_width, count_width), (magnitude, count)| {
+                let magnitude_width = if magnitude == Magnitude::MAX {
+                    PLUS_INFINITY_BOUND_LABEL.len()
+                } else {
+                    magnitude_width(magnitude)
+                };
 
-        let mut count_str = String::new();
-
-        let widest_count = buckets.iter().fold(0, |current, &(_, count)| {
-            count_str.clear();
-            write!(&mut count_str, "{count}").expect("writing to a String is infallible");
-            cmp::max(current, count_str.len())
-        });
-
-        let mut upper_bound_str = String::new();
-
-        let widest_upper_bound = buckets.iter().fold(0, |current, &(magnitude, _)| {
-            upper_bound_str.clear();
-
-            if magnitude == Magnitude::MAX {
-                upper_bound_str.push_str("+inf");
-            } else {
-                write!(&mut upper_bound_str, "{magnitude}")
-                    .expect("writing to a String is infallible");
-            }
-
-            cmp::max(current, upper_bound_str.len())
-        });
+                (
+                    cmp::max(upper_bound_width, magnitude_width),
+                    cmp::max(count_width, decimal_width(count)),
+                )
+            },
+        );
 
         let histogram_scale = HistogramScale::new(self);
 
-        for (magnitude, count) in buckets {
-            upper_bound_str.clear();
-
+        for (magnitude, count) in self.buckets() {
             if magnitude == Magnitude::MAX {
-                upper_bound_str.push_str("+inf");
+                write!(
+                    f,
+                    "value <= {PLUS_INFINITY_BOUND_LABEL:>widest_upper_bound$} \
+                     [ {count:>widest_count$} ]: "
+                )?;
             } else {
-                write!(&mut upper_bound_str, "{magnitude}")?;
+                write!(
+                    f,
+                    "value <= {magnitude:>widest_upper_bound$} \
+                     [ {count:>widest_count$} ]: "
+                )?;
             }
 
-            let padding_needed = widest_upper_bound.saturating_sub(upper_bound_str.len());
-            for _ in 0..padding_needed {
-                upper_bound_str.insert(0, ' ');
-            }
-
-            count_str.clear();
-            write!(&mut count_str, "{count}")?;
-
-            let padding_needed = widest_count.saturating_sub(count_str.len());
-            for _ in 0..padding_needed {
-                count_str.insert(0, ' ');
-            }
-
-            write!(f, "value <= {upper_bound_str} [ {count_str} ]: ")?;
             histogram_scale.write_bar(count, f)?;
-
             writeln!(f)?;
         }
 
@@ -616,34 +606,8 @@ impl HistogramScale {
             .checked_div(self.observations_per_char.get())
             .expect("the observations-per-character divisor is nonzero");
 
-        let chars_in_constant = HISTOGRAM_BAR_CHARS_LEN_BYTES
-            .get()
-            .checked_div(BYTES_PER_HISTOGRAM_BAR_CHAR.get())
-            .expect("the histogram bar character width is nonzero");
-        let chars_in_constant = u64::try_from(chars_in_constant)
-            .expect("Rust does not support pointer widths greater than 64 bits");
-
-        let mut remaining = histogram_bar_width;
-
-        while remaining > 0 {
-            let chunk_char_count = NonZero::new(remaining.min(chars_in_constant))
-                .expect("the loop condition and nonempty bar constant guarantee a nonzero chunk");
-            let chunk_char_count_usize = usize::try_from(chunk_char_count.get())
-                .expect("the chunk is bounded by the bar constant's usize character count");
-
-            let byte_end = chunk_char_count_usize
-                .checked_mul(BYTES_PER_HISTOGRAM_BAR_CHAR.get())
-                .expect("the chunk is bounded by the bar constant's byte length");
-
-            #[expect(
-                clippy::string_slice,
-                reason = "The end is a multiple of the known UTF-8 character width."
-            )]
-            f.write_str(&HISTOGRAM_BAR_CHARS[..byte_end])?;
-
-            remaining = remaining
-                .checked_sub(chunk_char_count.get())
-                .expect("the chunk is no larger than the remaining width");
+        for _ in 0..histogram_bar_width {
+            f.write_char(HISTOGRAM_BAR_CHAR)?;
         }
 
         Ok(())
@@ -739,6 +703,13 @@ mod tests {
         for line in output.lines() {
             assert!(line.len() < max_line_bytes);
         }
+    }
+
+    #[test]
+    fn histogram_magnitude_width_accounts_for_digits_and_sign() {
+        // Multiple digits and opposite signs make both parts of the width observable.
+        assert_eq!(magnitude_width(12_345), 5);
+        assert_eq!(magnitude_width(-12_345), 6);
     }
 
     #[test]
@@ -1137,15 +1108,6 @@ mod tests {
             output,
             "∎".repeat(usize::try_from(TARGET_HISTOGRAM_BAR_WIDTH_CHARS).unwrap() - 1)
         );
-    }
-
-    #[test]
-    fn histogram_char_byte_count_is_correct() {
-        assert_eq!("∎".len(), BYTES_PER_HISTOGRAM_BAR_CHAR.get());
-
-        let expected_chars = HISTOGRAM_BAR_CHARS.chars().count();
-        let expected_bytes = expected_chars * BYTES_PER_HISTOGRAM_BAR_CHAR.get();
-        assert_eq!(HISTOGRAM_BAR_CHARS.len(), expected_bytes);
     }
 
     #[test]

--- a/packages/nm_impl/src/reports.rs
+++ b/packages/nm_impl/src/reports.rs
@@ -511,6 +511,21 @@ const MIN_OBSERVATIONS_PER_BAR_CHAR: u64 = 1;
 /// Uses the conventional textual representation for an unbounded upper range.
 const PLUS_INFINITY_BOUND_LABEL: &str = "+inf";
 
+/// A chunk exceeds the target bar width so ordinary bars require one writer call.
+///
+/// Low- and high-cardinality rendering benchmarks show that per-glyph writer calls materially
+/// increase instruction counts, so the formatter retains this allocation-free specialization.
+const HISTOGRAM_BAR_CHUNK: &str = concat!(
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+    "∎∎∎∎∎∎∎∎",
+);
+
 /// Makes relative bucket counts easy to compare in a Unicode-capable terminal.
 const HISTOGRAM_BAR_CHAR: char = '∎';
 
@@ -605,10 +620,28 @@ impl HistogramScale {
         let histogram_bar_width = count
             .checked_div(self.observations_per_char.get())
             .expect("the observations-per-character divisor is nonzero");
+        let mut remaining_width = usize::try_from(histogram_bar_width)
+            .expect("histogram scaling keeps bar widths within the usize range");
+        let bytes_per_char = HISTOGRAM_BAR_CHAR.len_utf8();
+        let chars_per_chunk = HISTOGRAM_BAR_CHUNK
+            .len()
+            .checked_div(bytes_per_char)
+            .expect("the histogram bar character width is nonzero");
 
-        for _ in 0..histogram_bar_width {
-            f.write_char(HISTOGRAM_BAR_CHAR)?;
+        while remaining_width >= chars_per_chunk {
+            f.write_str(HISTOGRAM_BAR_CHUNK)?;
+            remaining_width = remaining_width
+                .checked_sub(chars_per_chunk)
+                .expect("the written chunk is no wider than the remaining bar");
         }
+
+        let remaining_bytes = remaining_width
+            .checked_mul(bytes_per_char)
+            .expect("the remainder is bounded by the histogram chunk");
+        let remainder = HISTOGRAM_BAR_CHUNK
+            .get(..remaining_bytes)
+            .expect("the remainder ends at a histogram character boundary");
+        f.write_str(remainder)?;
 
         Ok(())
     }
@@ -1032,6 +1065,20 @@ mod tests {
             output,
             "∎".repeat(usize::try_from(TARGET_HISTOGRAM_BAR_WIDTH_CHARS + 1).unwrap())
         );
+    }
+
+    #[test]
+    fn histogram_scale_bar_spans_chunks() {
+        let histogram_scale = HistogramScale {
+            observations_per_char: NonZero::new(1).unwrap(),
+        };
+        // One extra character exercises both the full-chunk and remainder writes.
+        let count = u64::try_from(HISTOGRAM_BAR_CHUNK.chars().count()).unwrap() + 1;
+        let mut output = String::new();
+
+        histogram_scale.write_bar(count, &mut output).unwrap();
+
+        assert_eq!(output, "∎".repeat(usize::try_from(count).unwrap()));
     }
 
     #[test]

--- a/packages/nm_otel/docs/implementation.md
+++ b/packages/nm_otel/docs/implementation.md
@@ -12,6 +12,11 @@ The two crates form one library and are versioned together. `nm_otel_impl` is no
 API or documentation owner; architectural changes in that partition are described here, and
 user-visible changes are described in [the design document](design.md).
 
+Production collection remains private to the publisher. The implementation crate's
+`private-test-util` feature exposes a separately named one-iteration driver, pre-built report
+driver, and histogram delta state only to in-workspace tests and benchmarks. The shell does not
+forward this feature.
+
 ## Recording pipeline
 
 On each publisher interval, the implementation obtains an aggregated report from `nm`, associates
@@ -30,6 +35,18 @@ The instrument names, including the underscore shift that keeps companion-shaped
 apart, are derived at that point rather than per export. Once the event and histogram
 configuration is established, the steady-state histogram path looks up this state, computes
 deltas, and records them without allocating.
+
+### Delta discontinuities and limits
+
+OpenTelemetry counters accept only nonnegative increments. If an upstream cumulative count or
+bucket total decreases, the publisher treats it as a discontinuity: it records no increment for
+that collection and replaces the retained baseline. Later increases are measured from the
+replacement baseline instead of being suppressed until they exceed the old value.
+
+Converting non-cumulative histogram buckets into cumulative `u64` values clamps totals at
+`u64::MAX`. The counter representation cannot encode a larger value, and wrapping would fabricate
+a smaller total and a false discontinuity. Iterator indexing is not metric arithmetic and remains
+checked as a structural invariant.
 
 Both the delta state and the instrument cache are keyed by event name and hashed with the
 standard library's `HashDoS`-resistant default rather than a faster non-cryptographic hasher.

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -18,7 +18,15 @@ all-features = true
 # development dependencies appear unused.
 # Ignore them here to silence false positives.
 [package.metadata.cargo-udeps.ignore]
-development = ["criterion", "gungraun", "many_cpus", "nm_otel", "par_bench"]
+development = [
+    "alloc_tracker",
+    "criterion",
+    "gungraun",
+    "many_cpus",
+    "new_zealand",
+    "nm_otel",
+    "par_bench",
+]
 
 [lib]
 # nm_otel_impl exists only to host the implementation of `nm_otel` and to expose
@@ -69,6 +77,10 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time
 # Gungraun drives Valgrind-based Callgrind benchmarks; Linux-only.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 gungraun = { workspace = true, features = ["default"] }
+
+[[test]]
+name = "nm_otel_histogram_deltas_alloc"
+required-features = ["private-test-util"]
 
 [[test]]
 name = "nm_otel_publish_forever"

--- a/packages/nm_otel_impl/README.md
+++ b/packages/nm_otel_impl/README.md
@@ -10,6 +10,8 @@ to reach internal items that are not part of the `nm_otel` API. See the
 [`nm_otel` implementation guide] for the package architecture.
 
 Only the items re-exported by `nm_otel` are part of its public API contract.
+Internal test and benchmark helpers are available only through the `private-test-util`
+feature, which the `nm_otel` shell does not forward.
 
 [`nm_otel` implementation guide]:
     https://github.com/folo-rs/folo/blob/main/packages/nm_otel/docs/implementation.md

--- a/packages/nm_otel_impl/benches/nm_otel_export.rs
+++ b/packages/nm_otel_impl/benches/nm_otel_export.rs
@@ -9,6 +9,7 @@
 
 use std::cell::RefCell;
 use std::hint::black_box;
+use std::iter;
 
 use alloc_tracker::{Allocator, Session as AllocSession};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -16,7 +17,7 @@ use many_cpus::SystemHardware;
 use new_zealand::nz;
 use nm::{EventMetrics, Histogram, Magnitude, Report};
 use nm_otel::Publisher;
-use nm_otel_impl::create_test_provider;
+use nm_otel_impl::{EventState, create_test_provider};
 use par_bench::{ResourceUsageExt, Run, ThreadPool};
 use tick::Clock;
 
@@ -89,6 +90,7 @@ criterion_main!(benches);
 
 fn entrypoint(c: &mut Criterion) {
     benchmark_bucket_cardinality(c);
+    benchmark_delta_computation(c);
     benchmark_multi_event_allocations(c);
 }
 
@@ -113,6 +115,27 @@ fn benchmark_bucket_cardinality(c: &mut Criterion) {
         b.iter_batched_ref(
             setup_high_bucket_cardinality_positive_delta,
             run_export,
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn benchmark_delta_computation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nm_otel_export/delta");
+
+    group.bench_function("low_bucket_cardinality_positive_delta", |b| {
+        b.iter_batched_ref(
+            || setup_delta(LOW_CARDINALITY_BUCKET_BOUNDS),
+            run_delta,
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("high_bucket_cardinality_positive_delta", |b| {
+        b.iter_batched_ref(
+            || setup_delta(HIGH_CARDINALITY_BUCKET_BOUNDS),
+            run_delta,
             BatchSize::SmallInput,
         );
     });
@@ -256,4 +279,54 @@ fn setup_high_bucket_cardinality_positive_delta() -> ExportInputs {
 fn run_export(inputs: &mut ExportInputs) {
     let (publisher, report) = inputs;
     publisher.run_one_iteration_with_report(black_box(report));
+}
+
+/// Carries warm delta state and the next collection's non-cumulative bucket counts.
+#[derive(Debug)]
+struct DeltaInputs {
+    state: EventState,
+    bucket_bounds: &'static [Magnitude],
+    counts: Vec<u64>,
+}
+
+fn setup_delta(bucket_bounds: &'static [Magnitude]) -> DeltaInputs {
+    let mut state = EventState::default();
+    let bucket_count = bucket_bounds
+        .len()
+        .checked_add(1)
+        .expect("the benchmark bucket count fits in usize");
+    let initial_counts = vec![WARM_PER_BUCKET_COUNT; bucket_count];
+    _ = state
+        .histogram_deltas(
+            bucket_bounds
+                .iter()
+                .copied()
+                .chain(iter::once(Magnitude::MAX)),
+            initial_counts,
+        )
+        .count();
+
+    DeltaInputs {
+        state,
+        bucket_bounds,
+        counts: vec![POSITIVE_DELTA_PER_BUCKET_COUNT; bucket_count],
+    }
+}
+
+fn run_delta(inputs: &mut DeltaInputs) {
+    let DeltaInputs {
+        state,
+        bucket_bounds,
+        counts,
+    } = inputs;
+
+    for delta in state.histogram_deltas(
+        bucket_bounds
+            .iter()
+            .copied()
+            .chain(iter::once(Magnitude::MAX)),
+        black_box(counts).iter().copied(),
+    ) {
+        black_box(delta);
+    }
 }

--- a/packages/nm_otel_impl/benches/nm_otel_export_cg.rs
+++ b/packages/nm_otel_impl/benches/nm_otel_export_cg.rs
@@ -37,17 +37,18 @@ main!(
             .args(["--branch-sim=yes", "--collect-bus=yes"])
             .format([CallgrindMetrics::Default, CallgrindMetrics::BranchSim]),
     ),
-    library_benchmark_groups = export
+    library_benchmark_groups = [export, delta]
 );
 
 #[cfg(target_os = "linux")]
 mod linux {
     use std::hint::black_box;
+    use std::iter;
 
     use gungraun::prelude::*;
     use nm::{EventMetrics, Histogram, Magnitude, Report};
     use nm_otel::Publisher;
-    use nm_otel_impl::create_test_provider;
+    use nm_otel_impl::{EventState, create_test_provider};
     use tick::Clock;
 
     // A stable synthetic name avoids introducing registry-dependent setup.
@@ -196,6 +197,18 @@ mod linux {
         run_export(inputs)
     }
 
+    #[library_benchmark]
+    #[bench::default(setup_delta(LOW_CARDINALITY_BUCKET_BOUNDS))]
+    fn delta_low_bucket_cardinality_positive_delta(inputs: DeltaInputs) -> DeltaInputs {
+        run_delta(inputs)
+    }
+
+    #[library_benchmark]
+    #[bench::default(setup_delta(HIGH_CARDINALITY_BUCKET_BOUNDS))]
+    fn delta_high_bucket_cardinality_positive_delta(inputs: DeltaInputs) -> DeltaInputs {
+        run_delta(inputs)
+    }
+
     library_benchmark_group!(
         name = export,
         benchmarks = [
@@ -204,4 +217,58 @@ mod linux {
             export_high_bucket_cardinality_positive_delta
         ]
     );
+
+    library_benchmark_group!(
+        name = delta,
+        benchmarks = [
+            delta_low_bucket_cardinality_positive_delta,
+            delta_high_bucket_cardinality_positive_delta
+        ]
+    );
+
+    /// Carries warm delta state and the next collection's non-cumulative bucket counts.
+    #[derive(Debug)]
+    struct DeltaInputs {
+        state: EventState,
+        bucket_bounds: &'static [Magnitude],
+        counts: Vec<u64>,
+    }
+
+    fn setup_delta(bucket_bounds: &'static [Magnitude]) -> DeltaInputs {
+        let mut state = EventState::default();
+        let bucket_count = bucket_bounds
+            .len()
+            .checked_add(1)
+            .expect("the benchmark bucket count fits in usize");
+        let initial_counts = vec![WARM_PER_BUCKET_COUNT; bucket_count];
+        _ = state
+            .histogram_deltas(
+                bucket_bounds
+                    .iter()
+                    .copied()
+                    .chain(iter::once(Magnitude::MAX)),
+                initial_counts,
+            )
+            .count();
+
+        DeltaInputs {
+            state,
+            bucket_bounds,
+            counts: vec![POSITIVE_DELTA_PER_BUCKET_COUNT; bucket_count],
+        }
+    }
+
+    fn run_delta(mut inputs: DeltaInputs) -> DeltaInputs {
+        for delta in inputs.state.histogram_deltas(
+            inputs
+                .bucket_bounds
+                .iter()
+                .copied()
+                .chain(iter::once(Magnitude::MAX)),
+            black_box(&inputs.counts).iter().copied(),
+        ) {
+            black_box(delta);
+        }
+        inputs
+    }
 }

--- a/packages/nm_otel_impl/src/lib.rs
+++ b/packages/nm_otel_impl/src/lib.rs
@@ -25,7 +25,9 @@ mod state;
 mod test_metric_reader;
 
 pub use publisher::*;
-pub use state::*;
+#[cfg(any(test, feature = "private-test-util"))]
+#[doc(hidden)]
+pub use state::EventState;
 #[cfg(any(test, feature = "private-test-util"))]
 #[doc(hidden)]
 pub use test_metric_reader::*;

--- a/packages/nm_otel_impl/src/publisher.rs
+++ b/packages/nm_otel_impl/src/publisher.rs
@@ -267,16 +267,22 @@ impl Publisher {
         }
     }
 
-    /// Collects and publishes metrics once.
+    fn run_one_iteration(&mut self) {
+        let report = Report::collect();
+        self.export(&report);
+    }
+
+    /// Collects and publishes metrics once for an in-workspace test.
     ///
     /// # Panics
     ///
     /// Panics if nm report collection finds incompatible configurations for the same event, or
     /// if the collection contains a different histogram bucket count from a previous collection.
+    #[cfg(any(test, feature = "private-test-util"))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[doc(hidden)]
-    pub fn run_one_iteration(&mut self) {
-        let report = Report::collect();
-        self.export(&report);
+    pub fn run_one_iteration_for_test(&mut self) {
+        self.run_one_iteration();
     }
 
     /// Publishes the supplied report once.

--- a/packages/nm_otel_impl/src/state.rs
+++ b/packages/nm_otel_impl/src/state.rs
@@ -30,7 +30,7 @@ pub(crate) struct CollectionState {
     hasher: RandomState,
 
     /// Previous state per event name.
-    events: HashTable<(EventName, EventState)>,
+    events: HashTable<(EventName, EventDeltaState)>,
 }
 
 impl CollectionState {
@@ -43,7 +43,7 @@ impl CollectionState {
     }
 
     /// Gets or creates the state for an event.
-    pub(crate) fn event_state(&mut self, name: &EventName) -> &mut EventState {
+    pub(crate) fn event_state(&mut self, name: &EventName) -> &mut EventDeltaState {
         let hash = self.hasher.hash_one(name);
         let hasher = &self.hasher;
         // The three closures fed to `entry()`:
@@ -63,7 +63,7 @@ impl CollectionState {
                 // name is seen. Every later export for the same name takes the occupied branch
                 // above and performs no clone.
                 &mut vacant
-                    .insert((name.clone(), EventState::default()))
+                    .insert((name.clone(), EventDeltaState::default()))
                     .into_mut()
                     .1
             }
@@ -71,7 +71,7 @@ impl CollectionState {
     }
 }
 
-/// Previous cumulative state for a single event, used to derive per-collection deltas.
+/// Retains one event's cumulative values to derive per-collection deltas.
 ///
 /// nm reports counter-type metrics (the occurrence count and each histogram bucket) as
 /// running cumulative totals, but OpenTelemetry counters are fed deltas. This type retains
@@ -79,7 +79,7 @@ impl CollectionState {
 /// subtract them and publish only the increment. It holds no gauge-type state, because sum
 /// is exported as an absolute value and needs no history.
 #[derive(Debug, Default)]
-pub struct EventState {
+pub(crate) struct EventDeltaState {
     /// Previous cumulative count.
     pub(crate) count: u64,
 
@@ -88,11 +88,14 @@ pub struct EventState {
     pub(crate) histogram_buckets: Vec<u64>,
 }
 
-impl EventState {
+impl EventDeltaState {
     /// Computes the delta for the count metric.
     ///
     /// Returns the delta and updates internal state.
     pub(crate) fn count_delta(&mut self, current: u64) -> u64 {
+        // A counter decrease is a discontinuity: counters cannot accept a negative increment,
+        // so publish zero and replace the baseline to measure later growth from the new value.
+        // Ref: packages/nm_otel/docs/implementation.md, "Delta discontinuities and limits".
         let delta = current.saturating_sub(self.count);
         self.count = current;
         delta
@@ -124,7 +127,7 @@ impl EventState {
     /// fixed for the lifetime of an event. The check fires either when an extra bucket
     /// is yielded beyond the established length, or when the source iterator is exhausted
     /// before all established buckets have been visited.
-    pub fn histogram_deltas<'a>(
+    pub(crate) fn histogram_deltas<'a>(
         &'a mut self,
         magnitudes: impl IntoIterator<Item = Magnitude> + 'a,
         non_cumulative_counts: impl IntoIterator<Item = u64> + 'a,
@@ -150,13 +153,39 @@ impl EventState {
     }
 }
 
+/// Exposes histogram delta state to in-workspace allocation tests.
+///
+/// The production exporter owns [`EventDeltaState`] privately. This facade exists only when
+/// `private-test-util` is active so integration tests can measure the same streaming operation
+/// without making its callback-capable iterator part of the normal implementation-crate surface.
+#[cfg(any(test, feature = "private-test-util"))]
+#[doc(hidden)]
+#[derive(Debug, Default)]
+pub struct EventState {
+    inner: EventDeltaState,
+}
+
+#[cfg(any(test, feature = "private-test-util"))]
+impl EventState {
+    /// Computes streaming cumulative histogram values and deltas.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    pub fn histogram_deltas<'a>(
+        &'a mut self,
+        magnitudes: impl IntoIterator<Item = Magnitude> + 'a,
+        non_cumulative_counts: impl IntoIterator<Item = u64> + 'a,
+    ) -> impl Iterator<Item = (Magnitude, u64, u64)> + 'a {
+        self.inner
+            .histogram_deltas(magnitudes, non_cumulative_counts)
+    }
+}
+
 /// Running cumulative bucket total before any observation has been folded in.
 const INITIAL_CUMULATIVE: u64 = 0;
 
 /// Index of the first histogram bucket.
 const FIRST_BUCKET_INDEX: usize = 0;
 
-/// Streaming iterator returned by [`EventState::histogram_deltas`].
+/// Streams histogram deltas while updating retained bucket state.
 ///
 /// On the first call `buckets` starts empty and is grown lazily as items are yielded.
 /// On subsequent calls `buckets` already has the established length and we index into
@@ -184,6 +213,9 @@ where
             return None;
         };
 
+        // Clamp a cumulative total that exceeds the u64 counter range. Wrapping would fabricate
+        // a smaller total and a false reset that OpenTelemetry cannot represent meaningfully.
+        // Ref: packages/nm_otel/docs/implementation.md, "Delta discontinuities and limits".
         self.running_cumulative = self.running_cumulative.saturating_add(non_cumulative);
 
         let previous = if self.first_call {
@@ -200,6 +232,8 @@ where
             previous
         };
 
+        // Apply the same discontinuity policy as the event count. The new cumulative value is
+        // stored below, so later growth is measured from the replacement baseline.
         let delta = self.running_cumulative.saturating_sub(previous);
 
         #[expect(
@@ -210,7 +244,10 @@ where
         {
             self.buckets[self.index] = self.running_cumulative;
         }
-        self.index = self.index.saturating_add(1);
+        self.index = self
+            .index
+            .checked_add(1)
+            .expect("a Vec cannot contain more than usize::MAX histogram buckets");
 
         Some((magnitude, self.running_cumulative, delta))
     }
@@ -239,7 +276,7 @@ mod tests {
 
     #[test]
     fn event_state_count_delta_first_collection() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
         let delta = state.count_delta(100);
         assert_eq!(delta, 100);
         assert_eq!(state.count, 100);
@@ -247,7 +284,7 @@ mod tests {
 
     #[test]
     fn event_state_count_delta_subsequent_collections() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
 
         let first_delta = state.count_delta(100);
         assert_eq!(first_delta, 100);
@@ -262,6 +299,15 @@ mod tests {
         assert_eq!(later_increase_delta, 50);
     }
 
+    #[test]
+    fn event_state_count_delta_replaces_a_decreased_baseline() {
+        let mut state = EventDeltaState::default();
+
+        assert_eq!(state.count_delta(100), 100);
+        assert_eq!(state.count_delta(40), 0);
+        assert_eq!(state.count_delta(45), 5);
+    }
+
     // `Iterator::eq` against a finite expected array is the bounded-consumption pattern
     // we use throughout these tests: it calls `self.next()` at most `expected.len() + 1`
     // times and returns `false` on the first value mismatch. That makes it self-bounded
@@ -273,7 +319,7 @@ mod tests {
 
     #[test]
     fn event_state_histogram_deltas_first_collection() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
 
         let magnitudes = [10, 50, 100, Magnitude::MAX];
         let non_cumulative = [5, 12, 8, 2];
@@ -299,7 +345,7 @@ mod tests {
 
     #[test]
     fn event_state_histogram_deltas_subsequent_collections() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
 
         let magnitudes = [10, 50, 100, Magnitude::MAX];
 
@@ -334,6 +380,42 @@ mod tests {
     }
 
     #[test]
+    fn event_state_histogram_deltas_replace_decreased_baselines() {
+        let mut state = EventDeltaState::default();
+        let magnitudes = [10, Magnitude::MAX];
+
+        assert!(
+            state
+                .histogram_deltas(magnitudes, [5, 10])
+                .eq([(10, 5, 5), (Magnitude::MAX, 15, 15)])
+        );
+        assert!(
+            state
+                .histogram_deltas(magnitudes, [2, 3])
+                .eq([(10, 2, 0), (Magnitude::MAX, 5, 0)])
+        );
+        assert!(
+            state
+                .histogram_deltas(magnitudes, [3, 4])
+                .eq([(10, 3, 1), (Magnitude::MAX, 7, 2)])
+        );
+    }
+
+    #[test]
+    fn event_state_histogram_cumulative_values_saturate() {
+        let mut state = EventDeltaState::default();
+
+        assert!(
+            state
+                .histogram_deltas([10, Magnitude::MAX], [u64::MAX, 1])
+                .eq([
+                    (10, u64::MAX, u64::MAX),
+                    (Magnitude::MAX, u64::MAX, u64::MAX),
+                ])
+        );
+    }
+
+    #[test]
     fn collection_state_creates_event_state_on_demand() {
         let mut state = CollectionState::new();
 
@@ -364,7 +446,7 @@ mod tests {
         // enough events to force multiple grows and then reads every entry back to
         // verify the rehash closure produces hashes consistent with the lookup-time
         // hashing — otherwise entries would land in the wrong buckets after a grow
-        // and the reads would return fresh `EventState::default()` values instead of
+        // and the reads would return fresh `EventDeltaState::default()` values instead of
         // the values we wrote.
         //
         // A freshly constructed `HashTable` starts with no heap capacity, so this count
@@ -375,7 +457,7 @@ mod tests {
         let mut state = CollectionState::new();
 
         for i in 0..NUM_EVENTS {
-            // Use distinguishable non-zero values so a re-defaulted `EventState` (count = 0)
+            // Use distinguishable non-zero values so a re-defaulted `EventDeltaState` (count = 0)
             // would be detectable.
             state.event_state(&format!("growth_event_{i}").into()).count =
                 i.saturating_mul(7).saturating_add(1);
@@ -392,7 +474,7 @@ mod tests {
 
     #[test]
     fn event_state_histogram_deltas_same_bucket_count_works() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
 
         let magnitudes = [10, 50, 100];
 
@@ -430,7 +512,7 @@ mod tests {
 
     #[test]
     fn event_state_histogram_deltas_bucket_count_mismatch_panics() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
 
         // First call establishes three buckets.
         let first_magnitudes = [10, 50, 100];
@@ -458,7 +540,7 @@ mod tests {
 
     #[test]
     fn event_state_histogram_deltas_fewer_buckets_panics() {
-        let mut state = EventState::default();
+        let mut state = EventDeltaState::default();
 
         // First call establishes three buckets.
         let first_magnitudes = [10, 50, 100];

--- a/packages/nm_otel_impl/tests/nm_otel_run_one_iteration.rs
+++ b/packages/nm_otel_impl/tests/nm_otel_run_one_iteration.rs
@@ -40,7 +40,7 @@ fn run_one_iteration_exports_recorded_events() {
         .clock(Clock::new_frozen())
         .build();
 
-    publisher.run_one_iteration();
+    publisher.run_one_iteration_for_test();
     let metrics = reader.collect();
 
     assert_eq!(

--- a/packages/nm_otel_impl/tests/nm_otel_run_one_iteration_deltas.rs
+++ b/packages/nm_otel_impl/tests/nm_otel_run_one_iteration_deltas.rs
@@ -41,7 +41,7 @@ fn run_one_iteration_computes_deltas_across_collections() {
         .clock(Clock::new_frozen())
         .build();
 
-    publisher.run_one_iteration();
+    publisher.run_one_iteration_for_test();
     let metrics = reader.collect();
     assert_eq!(
         find_u64_sum(&metrics, EVENT_NAME),
@@ -54,7 +54,7 @@ fn run_one_iteration_computes_deltas_across_collections() {
             .observe(ADDITIONAL_MAGNITUDE);
     });
 
-    publisher.run_one_iteration();
+    publisher.run_one_iteration_for_test();
     let metrics = reader.collect();
     assert_eq!(
         find_u64_sum(&metrics, EVENT_NAME),


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Additional review feedback identified undocumented delta edge-case semantics, test-only APIs exposed to consumers, unsupported inline hints, and unnecessary allocation and complexity in histogram rendering. This PR resolves those findings while preserving performance across the `nm` package family.

## Changes

- Defines and tests OpenTelemetry delta behavior for counter resets, bucket decreases, cumulative overflow, and iterator indexing.
- Confines delta-state and one-iteration publication helpers to the existing `private-test-util` boundary instead of exposing implementation-shaped APIs in production builds.
- Simplifies histogram rendering by avoiding bucket collection and temporary strings, using dynamic formatter alignment, and retaining only a benchmark-justified allocation-free chunked write.
- Removes unsupported inline hints from nontrivial duration-observation methods.
- Adds low- and high-cardinality Criterion and Callgrind coverage for histogram rendering and deterministic OpenTelemetry delta computation.

## Performance impact

Low-cardinality histogram rendering decreases from 11,503 to 5,533 simulated instructions, and high-cardinality rendering decreases from 48,180 to 24,534. Wall-clock measurements improve by approximately 54% and 50%, respectively. OpenTelemetry production export instruction counts are unchanged, while duration observation and direct delta measurements remain within the benchmark noise threshold.