### PR TITLE
cargo-bench-history: present change points as nearby estimates

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -323,8 +323,9 @@ jobs:
       # The body carries the CONDENSED summary (not the full report) so it fits the issue
       # limit, followed by a link to the attached full reports and a footer with two parts:
       # a minimal "Issue lifecycle" summary (refreshed only on runs that still have findings,
-      # never auto-closed) and a "What do I do?" section pointing at `examine` and the
-      # bless-an-intentional-change vs. fix-a-defect decision - see the File step.
+      # never auto-closed) and a "What do I do?" section pointing at `examine` to narrow a
+      # change-point estimate, then the bless-an-intentional-change vs. fix-a-defect
+      # decision - see the File step.
       - name: Compose regression issue
         if: steps.notable.outputs.value == 'true'
         shell: pwsh
@@ -349,7 +350,7 @@ jobs:
 
           **What do I do?**
 
-          First, see exactly how the series moved over time. Copy the benchmark id and metric from the finding above and run:
+          A change-point location is an estimate: the change occurred somewhere near the named commit, not necessarily at it. Use `cargo bench-history examine <filters>` to narrow down on the specific commit where the change occurred. Copy the benchmark id, metric, and discriminant filters from the finding above and run:
 
           `cargo bench-history examine --benchmark <id> --metric <name>`
 

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -350,9 +350,9 @@ jobs:
 
           **What do I do?**
 
-          A change-point location is an estimate: the change occurred somewhere near the named commit, not necessarily at it. Use `cargo bench-history examine <filters>` to narrow down on the specific commit where the change occurred. Copy the benchmark id, metric, and discriminant filters from the finding above and run:
+          A change-point location is an estimate: the change occurred somewhere near the named commit, not necessarily at it. Use `cargo bench-history examine` to narrow down on the specific commit where the change occurred. Copy the benchmark id, metric, and discriminant filters from the finding above and run:
 
-          `cargo bench-history examine --benchmark <id> --metric <name>`
+          `cargo bench-history examine --benchmark <id> --metric <name> --engine <engine> --target-triple <triple> --machine-key <key>`
 
           Then decide what the change is:
 

--- a/packages/cargo-bench-history-figures/src/figures/reporting.rs
+++ b/packages/cargo-bench-history-figures/src/figures/reporting.rs
@@ -366,8 +366,8 @@ fn finding_annotated() -> String {
     writeln!(
         markdown,
         "| `{detail}` | The detail: direction, the detector that produced the finding, \
-         the baseline and latest representative values, and the commit the change is \
-         attributed to. |"
+         the baseline and latest representative values, and a commit somewhere near \
+         the change. |"
     )
     .expect("writing to a String never fails");
     markdown.push_str(

--- a/packages/cargo-bench-history-figures/src/glossary.rs
+++ b/packages/cargo-bench-history-figures/src/glossary.rs
@@ -77,8 +77,8 @@ pub const TERMS: &[Term] = &[
     },
     Term {
         phrase: "change point",
-        definition: "The commit where a series stops holding one level and starts \
-                     holding another.",
+        definition: "An estimated location near which a series stops holding one \
+                     level and starts holding another.",
         formal_name: "",
         chapter: "detection.md",
     },

--- a/packages/cargo-bench-history-figures/src/verdict.rs
+++ b/packages/cargo-bench-history-figures/src/verdict.rs
@@ -30,14 +30,15 @@ fn history_reported(finding: &Finding, reading: &str) -> String {
         FindingMethod::BranchExcursion => "branch excursion",
     };
 
-    // A change point names the commit the new level starts at, which is a claim about
-    // where something happened. A drift belongs to its whole window rather than one commit,
-    // so it names the range it accumulated over. Rendering a drift as a single commit would
-    // invite the reader to go looking at one commit's diff, which is exactly the wrong thing
-    // to do with one.
+    // A change point names a commit somewhere near the split, because the detector
+    // estimates a regime boundary and cannot always identify the first commit that
+    // introduced the new level. A drift belongs to its whole window rather than one
+    // commit, so it names the range it accumulated over. Rendering a drift as a
+    // single commit would invite the reader to go looking at one commit's diff, which
+    // is exactly the wrong thing to do with one.
     let attribution = match (finding.method, finding.commit.as_deref()) {
         (_, None) => "across the analyzed window".to_owned(),
-        (FindingMethod::ChangePoint, Some(commit)) => format!("first seen at `{commit}`"),
+        (FindingMethod::ChangePoint, Some(commit)) => format!("somewhere near `{commit}`"),
         (FindingMethod::Drift, Some(commit)) => match finding.window_start_commit.as_deref() {
             Some(start) => format!("accumulated from `{start}` to `{commit}`"),
             None => format!("accumulated across the window ending at `{commit}`"),
@@ -159,6 +160,7 @@ mod tests {
 
         assert!(fragment.contains("Reported."));
         assert!(fragment.contains("% via"));
+        assert!(fragment.contains("somewhere near"));
         assert!(fragment.contains("Because the level changed."));
     }
 
@@ -178,7 +180,7 @@ mod tests {
         assert!(fragment.contains("excess beyond its nearest edge"));
         assert!(!fragment.contains('%'));
         assert!(!fragment.contains("via change point"));
-        assert!(!fragment.contains("first seen"));
+        assert!(!fragment.contains("somewhere near"));
         assert!(!fragment.contains("the level moved"));
     }
 

--- a/packages/cargo-bench-history/book/src/appendix/detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/detection.md
@@ -58,8 +58,10 @@ The step detector works in three moves.
 3. **Size.** Each side's median becomes its level, and the difference between them is the
    move. Medians rather than averages, so one outlier cannot invent a step or hide one.
 
-The change is attributed to **the first commit of the after-side** — the earliest commit that
-already shows the new level.
+The report names a commit **somewhere near** the split — the detector's best estimate of where
+the new level begins, not a guarantee of the first commit that introduced it. Use
+[`examine`](../commands/examine.md) to inspect the series and narrow the location if a
+specific commit can be identified.
 
 > The split search's own chance level is not used as evidence. It only locates the boundary.
 > The rank comparison decides whether the regimes differ, and the correction below makes that

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-clean-step.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-clean-step.md
@@ -1,4 +1,4 @@
-> **Reported.** A regression of +29.57% via change point, first seen at `commit10`.
+> **Reported.** A regression of +29.57% via change point, somewhere near `commit10`.
 >
 > The level moved from 100.4 to 130.1.
 >

--- a/packages/cargo-bench-history/book/src/appendix/generated/detection-multi-step.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/detection-multi-step.md
@@ -1,4 +1,4 @@
-> **Reported.** A regression of +54.07% via change point, first seen at `commit15`.
+> **Reported.** A regression of +54.07% via change point, somewhere near `commit15`.
 >
 > The level moved from 102.2 to 157.4.
 >

--- a/packages/cargo-bench-history/book/src/appendix/generated/glossary-table.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/glossary-table.md
@@ -4,7 +4,7 @@
 | blessing | A recorded decision to treat a change as accepted, so earlier measurements no longer influence analysis. |  | [Reconstruction](reconstruction.md) |
 | census | The report's account of how many series it judged, and why it did not judge the rest. |  | [Reporting](reporting.md) |
 | chance level | How often pure chance alone would produce a pattern at least this strong. | p-value | [Detection](detection.md) |
-| change point | The commit where a series stops holding one level and starts holding another. |  | [Detection](detection.md) |
+| change point | An estimated location near which a series stops holding one level and starts holding another. |  | [Detection](detection.md) |
 | comparison-base lag | A branch comparison made against base data from several commits back. |  | [Reporting](reporting.md) |
 | confidence interval | A range the benchmark engine reports alongside a measurement to say how precisely it pinned it down. |  | [Noise gates](gates.md) |
 | detector | The procedure that examines one series for one shape of change: a change point, a drift, or a branch comparison. |  | [Detection](detection.md) |

--- a/packages/cargo-bench-history/book/src/appendix/generated/reporting-finding-annotated.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/reporting-finding-annotated.md
@@ -3,7 +3,7 @@ A finding, as the text report prints it:
 ```text
 http_parse/case
   +29.57% wall_time
-    regression via change point · 100.4 → 130.1 · @ commit10
+    regression via change point · 100.4 → 130.1 · somewhere near commit10
  135 ┤           ╭─╮╭─╮╭╮           
  126 ┤         ╭─╯ ╰╯ ╰╯╰─          
  116 ┤         │                    
@@ -15,5 +15,5 @@ http_parse/case
 |---|---|
 | `http_parse/case` | The benchmark identity: every benchmark-ID segment joined by `/`. This slash-rendered identity is the string accepted by [`examine`](../commands/examine.md) and matched by the benchmark-ID prefix supplied to [`bless`](../commands/bless.md). |
 | `+29.57% wall_time` | The headline: the move as a percentage of the baseline, and the metric kind that moved. Findings are ranked by the magnitude of that percentage. |
-| `regression via change point · 100.4 → 130.1 · @ commit10` | The detail: direction, the detector that produced the finding, the baseline and latest representative values, and the commit the change is attributed to. |
+| `regression via change point · 100.4 → 130.1 · somewhere near commit10` | The detail: direction, the detector that produced the finding, the baseline and latest representative values, and a commit somewhere near the change. |
 | the lines below it | The chart: the series drawn against topology, one column per commit. |

--- a/packages/cargo-bench-history/book/src/appendix/generated/reporting-text.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/reporting-text.md
@@ -11,7 +11,7 @@ criterion/x86_64-unknown-linux-gnu/a1b2c3d4
 
 http_parse/case
   +29.57% wall_time
-    regression via change point · 100.4 → 130.1 · @ commit10
+    regression via change point · 100.4 → 130.1 · somewhere near commit10
  135 ┤           ╭─╮╭─╮╭╮           
  126 ┤         ╭─╯ ╰╯ ╰╯╰─          
  116 ┤         │                    

--- a/packages/cargo-bench-history/book/src/appendix/generated/terms-detection.md
+++ b/packages/cargo-bench-history/book/src/appendix/generated/terms-detection.md
@@ -1,7 +1,7 @@
 | Term | What it means |
 |---|---|
 | **chance level** | How often pure chance alone would produce a pattern at least this strong. |
-| **change point** | The commit where a series stops holding one level and starts holding another. |
+| **change point** | An estimated location near which a series stops holding one level and starts holding another. |
 | **detector** | The procedure that examines one series for one shape of change: a change point, a drift, or a branch comparison. |
 | **drift** | A series that moves steadily in one direction rather than stepping between levels. |
 | **level** | The value a series sits at over a stretch of commits, ignoring run-to-run scatter. |

--- a/packages/cargo-bench-history/book/src/appendix/insights.md
+++ b/packages/cargo-bench-history/book/src/appendix/insights.md
@@ -16,7 +16,7 @@ flowchart TD
     F["A finding"] --> Q0{"Which mode<br/>produced the report?"}
     Q0 -->|"branch"| BR["It compares your tip<br/>to the base"]
     Q0 -->|"history"| Q1{"Which method?"}
-    Q1 -->|"change point"| CP["It names a commit"]
+    Q1 -->|"change point"| CP["It names a nearby commit"]
     Q1 -->|"drift"| DR["It names a window"]
     CP --> Q2{"Did anything else move<br/>at the same commit?"}
     Q2 -->|"many series"| SHARED["Look for a shared cause:<br/>code or environment"]
@@ -34,14 +34,14 @@ which mode ran.
 
 ### A change point
 
-The finding names the **first commit that already shows the new level**. That is not
-necessarily the commit that caused it — if collection is sparse, the cause is somewhere in the
-gap before it.
+The finding names a commit **somewhere near** the change, not the exact first commit that
+introduced the new level. A specific causal commit is not always identifiable; if collection
+is sparse, the cause is somewhere in the gap before the named commit.
 
 1. **Look at the series.** `cargo bench-history examine --benchmark <qualified-id> --metric <name>`
    prints every stored point. Both values come from the finding. The chart in the report is a
    summary; this is the data.
-2. **Check whether the attributed commit has a neighbor gap.** If the previous observation is
+2. **Check whether the named commit has a neighbor gap.** If the previous observation is
    twenty commits back, your suspect list is those twenty commits, not one.
 3. **Check what else moved.** Many simultaneous steps suggest a shared cause, not a specific
    one. The cause may be shared code such as an allocator, runtime or dependency, or an

--- a/packages/cargo-bench-history/book/src/commands/analyze.md
+++ b/packages/cargo-bench-history/book/src/commands/analyze.md
@@ -57,9 +57,9 @@ See [Analysis](../concepts/analysis.md) for what each mode detects.
 
 ## Output
 
-Each finding names the benchmark and metric, quantifies the move, attributes it to a commit,
-and draws a compact, topology-accurate chart — one column per first-parent commit, so a commit
-with no measurement is a gap rather than being collapsed away. History
+Each finding names the benchmark and metric, quantifies the move, names a commit somewhere
+near the change, and draws a compact, topology-accurate chart — one column per first-parent
+commit, so a commit with no measurement is a gap rather than being collapsed away. History
 mode charts the full selected series, keeping a trailing gap up to the analyzed tip when a
 benchmark has not been measured on the most recent commits. Branch mode charts the comparison
 baseline followed by the recent per-commit tail ending at the tip, keeping the one commit

--- a/packages/cargo-bench-history/book/src/concepts/analysis.md
+++ b/packages/cargo-bench-history/book/src/concepts/analysis.md
@@ -12,7 +12,7 @@ History mode evaluates two finding methods for each series, and the resulting fi
 ranked together by descending relative move:
 
 1. **Change-point (step)** — the primary finding. A single most-likely level shift is located,
-   attributing the change to the commit at the start of the after-regime. Persistence is built
+   and the report names a commit somewhere near that split. Persistence is built
    in, so a single-commit blip cannot trip it.
 2. **Monotonic drift** — a separate finding type for slow trends, established by a trend test
    and sized by an outlier-resistant slope.

--- a/packages/cargo-bench-history/docs/DESIGN.md
+++ b/packages/cargo-bench-history/docs/DESIGN.md
@@ -4,8 +4,8 @@ A Cargo subcommand that maintains a **long-lived history** of benchmark results 
 analyzes that history for trends that snapshot / "previous run" tools cannot see:
 
 * slow incremental drift (a scenario that got 30 % slower over a year, 1 % at a time);
-* step changes attributable to a specific commit, visible only in hindsight once the
-  noise averages out;
+* step changes whose approximate location in history becomes visible only in hindsight
+  once the noise averages out;
 * regressions distinguished from measurement jitter by engine-aware statistics rather
   than a single noisy neighbour.
 
@@ -870,10 +870,10 @@ move:
 
 1. **Change-point (step)** — the primary finding. A single most-likely level shift is
    located with the **Pettitt** nonparametric change-point test, splitting the series into
-   a before regime and an after regime; the change is attributed to the commit at the start
-   of the after regime, answering "what changed, and after which commit". Persistence is
-   built in — both regimes must contain a minimum number of points — so a single-commit
-   blip cannot trip it.
+   a before regime and an after regime. The report names a commit somewhere near that
+   split, as an estimate of where the new level begins rather than a claim that that
+   commit introduced it. Persistence is built in — both regimes must contain a minimum
+   number of points — so a single-commit blip cannot trip it.
 2. **Monotonic drift** — a separate finding type for slow trends. A **Mann–Kendall** trend
    test establishes that a monotonic trend exists and a robust **Theil–Sen** slope
    estimates its magnitude.
@@ -1310,7 +1310,8 @@ tallies. JSON keeps full precision and omits the per-commit series (a charting c
 human reports draw from internally, not data a consumer reconstructs); the text and
 Markdown values round to four significant figures. A consumer keys off a top-level
 "notable" flag (post or stay silent) and reads each finding's direction, magnitude, and
-attribution.
+associated commit. A change-point finding's commit is an estimate of where the new level
+begins, not a claim that that commit introduced it.
 
 Every format also states what the analysis **judged** (§8.9): a coverage tally in the header of
 all three, prose qualifying a silent verdict where there are no findings, and, in JSON, a

--- a/packages/cbh_detect/src/detect/findings.rs
+++ b/packages/cbh_detect/src/detect/findings.rs
@@ -521,15 +521,17 @@ pub struct Finding {
     /// excess relative to the nearest range edge, matching
     /// [`BranchExcursion::relative_excess`].
     pub relative_delta: f64,
-    /// Commit the change is attributed to, if known. For a change point this is the
-    /// first commit of the new level; for a branch comparison it is the context
-    /// commit; for a drift it is the newest commit the trend reached (paired with
-    /// [`window_start_commit`](Self::window_start_commit) to name the accumulation
-    /// range, since a drift belongs to the whole window rather than one commit).
+    /// Commit associated with the finding, if known. For a change point this is the
+    /// detector's estimate of where the new level begins — somewhere near the true
+    /// first commit of that level, which cannot always be identified. For a branch
+    /// comparison it is the context commit; for a drift it is the newest commit the
+    /// trend reached (paired with [`window_start_commit`](Self::window_start_commit)
+    /// to name the accumulation range, since a drift belongs to the whole window
+    /// rather than one commit).
     pub commit: Option<String>,
     /// The oldest commit of a drift's accumulation window, so the report can name the
     /// range the trend accrued over. `Some` only for a drift finding; `None` for a
-    /// change point or branch comparison, which are attributed to a single commit.
+    /// change point or branch comparison.
     pub window_start_commit: Option<String>,
     /// Abbreviated commit of the blessing that re-baselined this series, if any.
     pub blessed_at: Option<String>,

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -331,8 +331,10 @@ struct JsonFinding<'a> {
     /// the signed excess relative to the nearest range edge, matching
     /// [`BranchExcursion::relative_excess`].
     relative_delta: f64,
-    /// Commit the change is attributed to, if known. For a drift this is the newest
-    /// commit the trend reached; `window_start` names where it began.
+    /// Commit associated with the finding, if known. For a change point this is the
+    /// detector's estimate of where the new level begins, not a claim that that commit
+    /// introduced it. For a drift this is the newest commit the trend reached;
+    /// `window_start` names where it began.
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<&'a str>,
     /// The oldest commit of a drift's accumulation window, present only for a drift, so
@@ -790,10 +792,11 @@ fn runs_with_span(runs: usize, span: Option<(&str, &str)>) -> String {
 }
 
 /// The plain-text detail body shared by the text and Markdown reports: the
-/// direction, detector, the `baseline → latest` move, and the commit it is attributed
-/// to. A drift belongs to its whole window rather than one commit, so it names the
-/// range it accumulated over (`from … to …`) instead of a single commit. Carries no
-/// styling and no leading indent; each format applies its own.
+/// direction, detector, the `baseline → latest` move, and the commit associated with
+/// it. A change point names a commit somewhere near the split; a drift belongs to its
+/// whole window rather than one commit, so it names the range it accumulated over
+/// (`from … to …`). Carries no styling and no leading indent; each format applies
+/// its own.
 fn detail_text(finding: &Finding) -> String {
     if let Some(branch) = &finding.branch {
         return format!(
@@ -876,16 +879,22 @@ fn previous_regime_text(finding: &Finding) -> Option<String> {
     ))
 }
 
-/// The commit(s) a finding is attributed to, for the detail body. A change point or
-/// branch comparison names one commit (`@ <commit>`); a drift names the range it
-/// accumulated over (`accumulated <oldest> → <newest>`), because no single commit is
-/// responsible — [`examine`](../commands/examine.md) is where to see the shape within
-/// it.
+/// The commit(s) a finding is associated with, for the detail body.
+///
+/// A change point names a commit somewhere near the detected split, because the split
+/// search estimates a regime boundary and cannot always identify the first commit that
+/// introduced the new level. A branch comparison names the context commit
+/// (`@ <commit>`). A drift names the range it accumulated over
+/// (`accumulated <oldest> → <newest>`), because no single commit is responsible.
 fn attribution_text(finding: &Finding) -> String {
     let commit = finding.commit.as_deref().unwrap_or("unknown");
-    match finding.window_start_commit.as_deref() {
-        Some(start) => format!("accumulated {start} → {commit}"),
-        None => format!("@ {commit}"),
+    match finding.method {
+        FindingMethod::ChangePoint => format!("somewhere near {commit}"),
+        FindingMethod::Drift => match finding.window_start_commit.as_deref() {
+            Some(start) => format!("accumulated {start} → {commit}"),
+            None => format!("accumulated ending at {commit}"),
+        },
+        FindingMethod::BranchExcursion => format!("@ {commit}"),
     }
 }
 
@@ -3907,11 +3916,13 @@ mod tests {
     }
 
     #[test]
-    fn attribution_text_names_a_commit_or_a_drift_range() {
-        // A change point (no window start) is attributed to its single commit.
-        assert_eq!(attribution_text(&regression()), "@ deadbee");
+    fn attribution_text_names_a_nearby_commit_or_a_drift_range() {
+        // A change point names an estimated location, not the exact first commit.
+        assert_eq!(attribution_text(&regression()), "somewhere near deadbee");
         // A drift names the whole range it accumulated over, not one commit.
         assert_eq!(attribution_text(&drift()), "accumulated f00dcafe → deadbee");
+        // A branch comparison names the context commit itself.
+        assert_eq!(attribution_text(&branch_regression(true)), "@ deadbee");
     }
 
     fn darwin_set() -> DiscriminantSet {

--- a/packages/cbh_render/src/report.rs
+++ b/packages/cbh_render/src/report.rs
@@ -886,15 +886,17 @@ fn previous_regime_text(finding: &Finding) -> Option<String> {
 /// introduced the new level. A branch comparison names the context commit
 /// (`@ <commit>`). A drift names the range it accumulated over
 /// (`accumulated <oldest> → <newest>`), because no single commit is responsible.
+/// A missing commit is attributed across the analyzed window, matching the book
+/// fragments, rather than naming a placeholder.
 fn attribution_text(finding: &Finding) -> String {
-    let commit = finding.commit.as_deref().unwrap_or("unknown");
-    match finding.method {
-        FindingMethod::ChangePoint => format!("somewhere near {commit}"),
-        FindingMethod::Drift => match finding.window_start_commit.as_deref() {
+    match (finding.method, finding.commit.as_deref()) {
+        (_, None) => "across the analyzed window".to_owned(),
+        (FindingMethod::ChangePoint, Some(commit)) => format!("somewhere near {commit}"),
+        (FindingMethod::Drift, Some(commit)) => match finding.window_start_commit.as_deref() {
             Some(start) => format!("accumulated {start} → {commit}"),
             None => format!("accumulated ending at {commit}"),
         },
-        FindingMethod::BranchExcursion => format!("@ {commit}"),
+        (FindingMethod::BranchExcursion, Some(commit)) => format!("@ {commit}"),
     }
 }
 
@@ -3921,8 +3923,31 @@ mod tests {
         assert_eq!(attribution_text(&regression()), "somewhere near deadbee");
         // A drift names the whole range it accumulated over, not one commit.
         assert_eq!(attribution_text(&drift()), "accumulated f00dcafe → deadbee");
+        let mut drift_without_start = drift();
+        drift_without_start.window_start_commit = None;
+        assert_eq!(
+            attribution_text(&drift_without_start),
+            "accumulated ending at deadbee"
+        );
         // A branch comparison names the context commit itself.
         assert_eq!(attribution_text(&branch_regression(true)), "@ deadbee");
+        // A series point may lack commit metadata; do not invent a placeholder name.
+        let mut unattributed = regression();
+        unattributed.commit = None;
+        assert_eq!(
+            attribution_text(&unattributed),
+            "across the analyzed window"
+        );
+        unattributed.method = FindingMethod::Drift;
+        assert_eq!(
+            attribution_text(&unattributed),
+            "across the analyzed window"
+        );
+        unattributed.method = FindingMethod::BranchExcursion;
+        assert_eq!(
+            attribution_text(&unattributed),
+            "across the analyzed window"
+        );
     }
 
     fn darwin_set() -> DiscriminantSet {


### PR DESCRIPTION
[Copilot speaking]

Change-point detection cannot always name the first commit that introduced a new level, but analysis reports presented that commit as `@ <commit>`, which reads as a causal attribution.

Reports now say `somewhere near <commit>` for change points. Branch comparisons still use `@ <commit>` because that is the exact context commit. Drift still uses `accumulated A → B`. Generated GitHub issues state that the named commit is an estimate and tell people to use `cargo bench-history examine <filters>` to narrow the location themselves.

JSON still carries a `commit` field; that remains an estimate of the split, not a promise of the first causal commit.