### PR TITLE
release: ship only consumer build inputs and catch up versions

### DIFF
--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -47,7 +47,9 @@ On Windows, the module scopes `CARGO_TARGET_DIR` for direct `cargo-semver-checks
 `release-plz update` invocations to a stable, workspace-specific directory beneath the user
 temporary directory. This keeps the SemVer tool's nested placeholder builds independent of
 checkout depth without changing target-directory behavior for unrelated Cargo commands or
-non-Windows validation.
+non-Windows validation. The override can be reassessed when
+[cargo-semver-checks issue #1725](https://github.com/obi1kenobi/cargo-semver-checks/issues/1725)
+shortens the generated paths upstream.
 
 ## Merge-blocking result
 

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -43,6 +43,12 @@ analyzed incompletely several times in review — once per release state that re
 checked as an outcome, where an incomplete analysis fails whatever form it takes. A scenario
 passes either by refusing to generate a plan or by generating one that holds every property.
 
+On Windows, the module scopes `CARGO_TARGET_DIR` for direct `cargo-semver-checks` and
+`release-plz update` invocations to a stable, workspace-specific directory beneath the user
+temporary directory. This keeps the SemVer tool's nested placeholder builds independent of
+checkout depth without changing target-directory behavior for unrelated Cargo commands or
+non-Windows validation.
+
 ## Merge-blocking result
 
 The `required-checks` job is the intended single ruleset target. Its `needs` graph contains

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,16 @@ must be `path = "../foo"` references.
 `Cargo.toml`; taking a dev-dependency on another workspace crate; deciding
 whether to enable default features.
 
+### [docs/packaging.md](docs/packaging.md)
+
+What a published crate archive contains: the `include` allow-list every
+publishable package declares, the compile-time inputs that justify shipping a
+file outside `src/`, and the inputs Cargo adds regardless.
+
+**Open this when**: adding a publishable package; changing what a package ships;
+embedding a file into the crate at compile time; wondering whether a README,
+diagram, or design document belongs in the archive.
+
 ### [docs/feature-flags.md](docs/feature-flags.md)
 
 Conditional compilation: gating test-only code with `#[cfg(test)]`, gating

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "all_the_time"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "alloc_tracker",
  "cpu-time",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "alloc_tracker"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "all_the_time",
  "criterion",
@@ -209,7 +209,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "awaiter_set"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "criterion",
  "futures",
@@ -448,7 +448,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-bench-history"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bench-history-faker"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "folo_utils",
  "mimalloc",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-detect-package"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "clap",
  "mimalloc",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-freeze-deps"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "mimalloc",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-plan"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "criterion",
@@ -586,7 +586,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbh_analyze"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyspawn",
  "cbh_command",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cbh_command",
  "cbh_model",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_codec"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alloc_tracker",
  "cbh_model",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_command"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cbh_model",
  "mutants",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cbh_command",
  "mutants",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_detect"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyspawn",
  "cbh_model",
@@ -675,14 +675,14 @@ dependencies = [
 
 [[package]]
 name = "cbh_diag"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "mutants",
 ]
 
 [[package]]
 name = "cbh_engines"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_git"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cbh_model",
  "futures",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_model"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "criterion",
  "jiff",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_probe"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cbh_git",
  "cbh_model",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_render"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cbh_detect",
  "cbh_model",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_stats"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "criterion",
  "mutants",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_storage"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -915,7 +915,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "cpulist"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "itertools 0.15.0",
  "new_zealand",
@@ -1206,7 +1206,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "dure-test-helper",
@@ -1266,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "events"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "alloc_tracker",
  "awaiter_set",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "events_once"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "criterion",
  "futures",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "fast_time"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "criterion",
  "gungraun",
@@ -1377,7 +1377,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "folo_ffi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "mutants",
  "static_assertions",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "folo_utils"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "mutants",
  "serde",
@@ -1443,7 +1443,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "future_deque"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "infinity_pool"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "alloc_tracker",
  "criterion",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "linked"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "criterion",
  "gungraun",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "linked_macros"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "linked_macros_impl",
  "proc-macro2",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "linked_macros_impl"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2228,7 +2228,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "many_cpus"
-version = "2.4.17"
+version = "2.4.18"
 dependencies = [
  "many_cpus_impl",
  "new_zealand",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "many_cpus_benchmarking"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "cpulist",
  "criterion",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "many_cpus_impl"
-version = "2.4.17"
+version = "2.4.18"
 dependencies = [
  "cpulist",
  "criterion",
@@ -2369,11 +2369,11 @@ checksum = "add0ac067452ff1aca8c5002111bd6b1c895baee6e45fcbc44e0193aea17be56"
 
 [[package]]
 name = "new_zealand"
-version = "1.0.8"
+version = "1.0.9"
 
 [[package]]
 name = "nm"
-version = "0.1.46"
+version = "0.1.47"
 dependencies = [
  "nm_impl",
  "static_assertions",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "nm_impl"
-version = "0.1.46"
+version = "0.1.47"
 dependencies = [
  "criterion",
  "fast_time",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "nm_otel"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "nm",
  "nm_otel_impl",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "nm_otel_impl"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "alloc_tracker",
  "criterion",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "par_bench"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -2883,7 +2883,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3057,7 +3057,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "region_cached"
-version = "1.0.32"
+version = "1.0.33"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "region_local"
-version = "1.0.32"
+version = "1.0.33"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3185,7 +3185,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3242,7 +3242,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3603,7 +3603,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4166,7 +4166,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vicinal"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -4341,7 +4341,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,54 +9,60 @@ license = "MIT"
 repository = "https://github.com/folo-rs/folo"
 rust-version = "1.95"
 
+# The default published archive for every publishable package. A package that embeds a file
+# outside `src/` at compile time overrides this with its own list, because inheritance replaces
+# the value rather than extending it.
+# Ref: docs/packaging.md.
+include = ["src/**/*"]
+
 [workspace.dependencies]
-all_the_time = { version = "0.6.3", path = "packages/all_the_time", default-features = false }
-alloc_tracker = { version = "0.7.3", path = "packages/alloc_tracker", default-features = false }
+all_the_time = { version = "0.6.4", path = "packages/all_the_time", default-features = false }
+alloc_tracker = { version = "0.7.4", path = "packages/alloc_tracker", default-features = false }
 anyspawn = { version = "0.8.0", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
-awaiter_set = { version = "0.1.12", path = "packages/awaiter_set", default-features = false }
+awaiter_set = { version = "0.1.13", path = "packages/awaiter_set", default-features = false }
 axum = { version = "0.8.0", default-features = false }
 azure_core = { version = "1.0.0", default-features = false }
 azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
-cargo-freeze-deps = { version = "0.1.8", path = "packages/cargo-freeze-deps", default-features = false }
-cargo-release-plan = { version = "0.1.2", path = "packages/cargo-release-plan", default-features = false }
-cbh_analyze = { version = "=0.2.3", path = "packages/cbh_analyze", default-features = false }
-cbh_cli = { version = "=0.2.3", path = "packages/cbh_cli", default-features = false }
-cbh_codec = { version = "=0.2.3", path = "packages/cbh_codec", default-features = false }
-cbh_command = { version = "=0.2.3", path = "packages/cbh_command", default-features = false }
-cbh_config = { version = "=0.2.3", path = "packages/cbh_config", default-features = false }
-cbh_detect = { version = "=0.2.3", path = "packages/cbh_detect", default-features = false }
-cbh_diag = { version = "=0.2.3", path = "packages/cbh_diag", default-features = false }
-cbh_engines = { version = "=0.2.3", path = "packages/cbh_engines", default-features = false }
-cbh_git = { version = "=0.2.3", path = "packages/cbh_git", default-features = false }
-cbh_model = { version = "=0.2.3", path = "packages/cbh_model", default-features = false }
-cbh_probe = { version = "=0.2.3", path = "packages/cbh_probe", default-features = false }
-cbh_render = { version = "=0.2.3", path = "packages/cbh_render", default-features = false }
-cbh_stats = { version = "=0.2.3", path = "packages/cbh_stats", default-features = false }
-cbh_storage = { version = "=0.2.3", path = "packages/cbh_storage", default-features = false }
+cargo-freeze-deps = { version = "0.1.9", path = "packages/cargo-freeze-deps", default-features = false }
+cargo-release-plan = { version = "0.1.3", path = "packages/cargo-release-plan", default-features = false }
+cbh_analyze = { version = "=0.2.4", path = "packages/cbh_analyze", default-features = false }
+cbh_cli = { version = "=0.2.4", path = "packages/cbh_cli", default-features = false }
+cbh_codec = { version = "=0.2.4", path = "packages/cbh_codec", default-features = false }
+cbh_command = { version = "=0.2.4", path = "packages/cbh_command", default-features = false }
+cbh_config = { version = "=0.2.4", path = "packages/cbh_config", default-features = false }
+cbh_detect = { version = "=0.2.4", path = "packages/cbh_detect", default-features = false }
+cbh_diag = { version = "=0.2.4", path = "packages/cbh_diag", default-features = false }
+cbh_engines = { version = "=0.2.4", path = "packages/cbh_engines", default-features = false }
+cbh_git = { version = "=0.2.4", path = "packages/cbh_git", default-features = false }
+cbh_model = { version = "=0.2.4", path = "packages/cbh_model", default-features = false }
+cbh_probe = { version = "=0.2.4", path = "packages/cbh_probe", default-features = false }
+cbh_render = { version = "=0.2.4", path = "packages/cbh_render", default-features = false }
+cbh_stats = { version = "=0.2.4", path = "packages/cbh_stats", default-features = false }
+cbh_storage = { version = "=0.2.4", path = "packages/cbh_storage", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
 colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }
-cpulist = { version = "1.1.8", path = "packages/cpulist", default-features = false }
+cpulist = { version = "1.1.9", path = "packages/cpulist", default-features = false }
 criterion = { version = "0.8.2", default-features = false }
 deranged = { version = "0.5.2", default-features = false }
 derive_more = { version = "2.0.0", default-features = false }
 event-listener = { version = "5.4.0", default-features = false, features = [
     "std",
 ] }
-events = { version = "0.7.14", path = "packages/events", default-features = false }
-events_once = { version = "0.5.35", path = "packages/events_once", default-features = false }
+events = { version = "0.7.15", path = "packages/events", default-features = false }
+events_once = { version = "0.5.36", path = "packages/events_once", default-features = false }
 fake_headers = { version = "0.0.5", default-features = false }
-fast_time = { version = "0.1.28", path = "packages/fast_time", default-features = false }
+fast_time = { version = "0.1.29", path = "packages/fast_time", default-features = false }
 flate2 = { version = "1.1.9", default-features = false }
 foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
-folo_ffi = { version = "0.1.16", path = "packages/folo_ffi", default-features = false }
-folo_utils = { version = "0.1.12", path = "packages/folo_utils", default-features = false }
+folo_ffi = { version = "0.1.17", path = "packages/folo_ffi", default-features = false }
+folo_utils = { version = "0.1.13", path = "packages/folo_utils", default-features = false }
 frozen-collections = { version = "0.9.1", default-features = false }
-future_deque = { version = "0.1.18", path = "packages/future_deque", default-features = false }
+future_deque = { version = "0.1.19", path = "packages/future_deque", default-features = false }
 futures = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-core = { version = "0.3.32", default-features = false }
 # Keep this version in lockstep with `GUNGRAUN_RUNNER_VERSION` in `constants.env` (which the
@@ -78,20 +84,20 @@ itertools = { version = "0.15.0", default-features = false, features = [
 ] }
 jiff = { version = "0.2.28", default-features = false, features = ["std"] }
 libc = { version = "0.2.172", default-features = false }
-linked = { version = "1.0.20", path = "packages/linked", default-features = false }
-linked_macros = { version = "=1.0.20", path = "packages/linked_macros", default-features = false }
-linked_macros_impl = { version = "=1.0.20", path = "packages/linked_macros_impl", default-features = false }
-many_cpus = { version = "2.4.17", path = "packages/many_cpus", default-features = false }
-many_cpus_impl = { version = "=2.4.17", path = "packages/many_cpus_impl", default-features = false }
+linked = { version = "1.0.21", path = "packages/linked", default-features = false }
+linked_macros = { version = "=1.0.21", path = "packages/linked_macros", default-features = false }
+linked_macros_impl = { version = "=1.0.21", path = "packages/linked_macros_impl", default-features = false }
+many_cpus = { version = "2.4.18", path = "packages/many_cpus", default-features = false }
+many_cpus_impl = { version = "=2.4.18", path = "packages/many_cpus_impl", default-features = false }
 mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.15.0", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
 negative-impl = { version = "0.1.0", default-features = false }
-new_zealand = { version = "1.0.8", path = "packages/new_zealand", default-features = false }
-nm = { version = "0.1.46", path = "packages/nm", default-features = false }
-nm_impl = { version = "=0.1.46", path = "packages/nm_impl", default-features = false }
-nm_otel = { version = "0.4.18", path = "packages/nm_otel", default-features = false }
-nm_otel_impl = { version = "=0.4.18", path = "packages/nm_otel_impl", default-features = false }
+new_zealand = { version = "1.0.9", path = "packages/new_zealand", default-features = false }
+nm = { version = "0.1.47", path = "packages/nm", default-features = false }
+nm_impl = { version = "=0.1.47", path = "packages/nm_impl", default-features = false }
+nm_otel = { version = "0.4.19", path = "packages/nm_otel", default-features = false }
+nm_otel_impl = { version = "=0.4.19", path = "packages/nm_otel_impl", default-features = false }
 nonempty = { version = "0.12.0", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
@@ -139,7 +145,7 @@ toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.12", default-features = false }
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 trybuild = { version = "1.0.0", default-features = false }
-vicinal = { version = "0.1.37", path = "packages/vicinal", default-features = false }
+vicinal = { version = "0.1.38", path = "packages/vicinal", default-features = false }
 windows = { version = "0.62.0", default-features = false, features = ["std"] }
 
 # Cargo packages that form one logical unit belong to one version group, and the

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,69 @@
+# Packaging
+
+This chapter covers what a published crate archive contains: the `include`
+allow-list every publishable package declares, and the inputs Cargo adds on its
+own.
+
+## Only what a consumer compiles ships
+
+A published archive exists so a consumer can build the crate and read its
+rendered API documentation. Every publishable package therefore declares an
+`include` allow-list rather than an `exclude` deny-list, so a file added later
+stays out of the archive until someone lists it deliberately.
+
+The default allow-list is the source tree alone, declared once in
+`[workspace.package]` and inherited by each publishable package:
+
+```toml
+# Workspace Cargo.toml
+[workspace.package]
+include = [
+    "src/**/*",
+]
+```
+
+```toml
+# Package Cargo.toml
+include.workspace = true
+```
+
+A `publish = false` package inherits nothing here, because it is never packaged.
+
+Tests, benchmarks, examples, books, and `AGENTS.md` stay in git. They are inputs
+to developing the crate, not to consuming it.
+
+Design and implementation documents stay in git as well. They are maintainer
+documents, not user-facing documentation (see [design.md](design.md) and
+[implementation.md](implementation.md)), and they link to repository-root
+chapters that no archive carries, so a packaged copy could not be followed to a
+complete picture anyway.
+
+## Compile-time inputs are the exception
+
+A file outside `src/` ships when the crate embeds it at compile time, because
+the packaged crate cannot build without it. Such a package declares its own
+`include` instead of inheriting, because inheritance replaces the workspace
+value rather than extending it, so the list repeats `src/**/*` alongside the
+extra pattern. Add the narrowest pattern that covers those files, and say in a
+comment why they ship.
+
+The cases in this workspace are the Mermaid diagrams embedded into rendered
+documentation with `simple_mermaid::mermaid!`, and the fixture files
+`cbh_engines` embeds with `include_str!` under its `private-test-util` feature.
+A published feature that cannot compile is a defect, so the files its code
+embeds ship with it.
+
+## What Cargo adds regardless
+
+Cargo packs `Cargo.toml`, a generated `Cargo.lock`, and the README it detects in
+the package directory whether or not `include` names them. Listing the README
+would only imply that the list controls it. For the full set of inputs Cargo
+adds outside ordinary package rules, see
+[`packages/cargo-release-plan/docs/design.md`](../packages/cargo-release-plan/docs/design.md),
+"Where Cargo adds content".
+
+## Changing an allow-list is a released-content change
+
+Editing `include` changes which files the archive carries, so it changes
+released content and requires a version increment like any other such change.
+See [git-workflow.md](git-workflow.md) and the `increment-versions` skill.

--- a/justfiles/just_release.just
+++ b/justfiles/just_release.just
@@ -9,8 +9,9 @@ prepare-release: verify-semver-checks && check-never-published
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
+    Import-Module "{{ justfile_directory() }}/scripts/release/ReleasePlan.psm1" -Force
     Write-Verbose "Bumping versions and changelogs via 'release-plz update'" -Verbose
-    release-plz update
+    Invoke-ReleasePlzUpdate
 
 # Preflight for `just prepare-release`: proves that `cargo semver-checks` can actually run on
 # this machine before `release-plz update` starts trusting it. release-plz runs
@@ -31,30 +32,8 @@ verify-semver-checks:
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
-    # A tiny published crate that builds quickly, keeping this preflight cheap. Its own API is
-    # irrelevant here - it is only a vehicle for exercising the rustdoc build+parse path that
-    # release-plz relies on.
-    $package = "folo_utils"
-
-    Write-Verbose "Verifying that cargo-semver-checks can run (canary package '$package', compared against its own HEAD)" -Verbose
-
-    try {
-        cargo semver-checks --baseline-rev HEAD -p $package
-    }
-    catch {
-        Write-Host ""
-        Write-Host "ERROR: cargo-semver-checks failed to run on the canary package '$package' (see the error above)." -ForegroundColor Red
-        Write-Host ""
-        Write-Host "This most likely means the installed cargo-semver-checks is too old for the current" -ForegroundColor Red
-        Write-Host "toolchain's rustdoc JSON format (look for an 'unsupported rustdoc format' message above)." -ForegroundColor Red
-        Write-Host "release-plz silently treats a cargo-semver-checks *failure* as 'no breaking changes', so" -ForegroundColor Red
-        Write-Host "releasing now could ship an undetected breaking change. The release has been aborted before" -ForegroundColor Red
-        Write-Host "any versions or changelogs were touched." -ForegroundColor Red
-        Write-Host ""
-        Write-Host "Fix: update the tool with 'cargo install cargo-semver-checks --locked' (or 'just install-tools')" -ForegroundColor Red
-        Write-Host "and re-run 'just prepare-release'." -ForegroundColor Red
-        exit 1
-    }
+    Import-Module "{{ justfile_directory() }}/scripts/release/ReleasePlan.psm1" -Force
+    Invoke-VerifySemverCheck
 
 # Verifies the checked-in Cargo.lock is consistent with the workspace manifests, WITHOUT
 # modifying it. `cargo metadata --locked` resolves the dependency graph against the committed

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -2,10 +2,11 @@
 name = "all_the_time"
 description = "Processor time tracking utilities for benchmarks and performance analysis"
 publish = true
-version = "0.6.3"
+version = "0.6.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/alloc_tracker/Cargo.toml
+++ b/packages/alloc_tracker/Cargo.toml
@@ -2,10 +2,11 @@
 name = "alloc_tracker"
 description = "Memory allocation tracking utilities for benchmarks and performance analysis"
 publish = true
-version = "0.7.3"
+version = "0.7.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/awaiter_set/Cargo.toml
+++ b/packages/awaiter_set/Cargo.toml
@@ -2,13 +2,17 @@
 name = "awaiter_set"
 description = "Zero-allocation awaiter tracking for async synchronization primitives"
 publish = true
-version = "0.1.12"
+version = "0.1.13"
 
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+# The diagram is embedded into the rendered documentation at compile time.
+# Ref: docs/packaging.md.
+include = ["src/**/*", "docs/diagrams/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/cargo-bench-history-faker/Cargo.toml
+++ b/packages/cargo-bench-history-faker/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cargo-bench-history-faker"
 description = "Unsupported synthetic benchmark-output generator for validating cargo-bench-history end to end; no stable API or CLI"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -3,10 +3,11 @@
 name = "cargo-bench-history"
 description = "A Cargo tool that maintains a long-lived history of benchmark results and analyzes it for trends"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -3,10 +3,11 @@
 name = "cargo-detect-package"
 description = "A Cargo tool to detect the package that a file belongs to, passing the package name to a subcommand"
 publish = true
-version = "1.0.29"
+version = "1.0.30"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -3,10 +3,11 @@
 name = "cargo-freeze-deps"
 description = "A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file to their literal values"
 publish = true
-version = "0.1.8"
+version = "0.1.9"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cargo-release-plan/Cargo.toml
+++ b/packages/cargo-release-plan/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-release-plan"
 description = "A Cargo subcommand that classifies publishable packages against their version anchors and applies increment plans"
 publish = true
-version = "0.1.2"
+version = "0.1.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-release-plan/src/command.rs
+++ b/packages/cargo-release-plan/src/command.rs
@@ -113,6 +113,19 @@ fn failure_status(status: ExitStatus) -> String {
         .map_or_else(|| "signal".to_string(), |code| code.to_string())
 }
 
+/// Directory passed to `Command::current_dir`.
+///
+/// `Path::parent()` of a relative file such as `Cargo.toml` is the empty path.
+/// `Command::current_dir` rejects that empty path (Windows `ERROR_INVALID_NAME`,
+/// Unix `chdir("")`), so use the process current directory instead.
+fn subprocess_cwd(cwd: &Path) -> &Path {
+    if cwd.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        cwd
+    }
+}
+
 // Mutations of the spawn arguments cannot be caught without asserting on a real
 // child process, which is impractical in unit tests.
 #[cfg_attr(test, mutants::skip)]
@@ -136,7 +149,7 @@ fn spawn(
     // variable settles it.
     Command::new(program)
         .args(args)
-        .current_dir(cwd)
+        .current_dir(subprocess_cwd(cwd))
         .env("CARGO_TERM_COLOR", "never")
         .env("LC_ALL", "C")
         .output()
@@ -151,6 +164,13 @@ mod tests {
 
     use super::*;
     use crate::CommandSpawnError;
+
+    #[test]
+    fn empty_cwd_uses_process_current_directory() {
+        assert_eq!(subprocess_cwd(Path::new("")), Path::new("."));
+        assert_eq!(subprocess_cwd(Path::new(".")), Path::new("."));
+        assert_eq!(subprocess_cwd(Path::new("packages")), Path::new("packages"));
+    }
 
     #[cfg_attr(miri, ignore)] // Process spawn uses host APIs Miri cannot emulate.
     #[test]

--- a/packages/cbh_analyze/Cargo.toml
+++ b/packages/cbh_analyze/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_analyze"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_cli/Cargo.toml
+++ b/packages/cbh_cli/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_cli"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_codec/Cargo.toml
+++ b/packages/cbh_codec/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_codec"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_command/Cargo.toml
+++ b/packages/cbh_command/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_command"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_config/Cargo.toml
+++ b/packages/cbh_config/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_config"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_detect/Cargo.toml
+++ b/packages/cbh_detect/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_detect"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_diag/Cargo.toml
+++ b/packages/cbh_diag/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_diag"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_engines/Cargo.toml
+++ b/packages/cbh_engines/Cargo.toml
@@ -4,13 +4,18 @@
 name = "cbh_engines"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+# The fixtures are embedded by `src/testing.rs` at compile time under the
+# `private-test-util` feature, which cannot compile without them.
+# Ref: docs/packaging.md.
+include = ["src/**/*", "tests/fixtures/**/*"]
 
 # Baseline of external types intentionally exposed in the public API. Any new
 # external type must be reviewed and added explicitly.

--- a/packages/cbh_git/Cargo.toml
+++ b/packages/cbh_git/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_git"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_model/Cargo.toml
+++ b/packages/cbh_model/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_model"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_probe/Cargo.toml
+++ b/packages/cbh_probe/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_probe"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_render/Cargo.toml
+++ b/packages/cbh_render/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_render"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_stats/Cargo.toml
+++ b/packages/cbh_stats/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_stats"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cbh_storage/Cargo.toml
+++ b/packages/cbh_storage/Cargo.toml
@@ -4,10 +4,11 @@
 name = "cbh_storage"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/cpulist/Cargo.toml
+++ b/packages/cpulist/Cargo.toml
@@ -2,10 +2,11 @@
 name = "cpulist"
 description = "Parse and emit the Linux 'cpulist' data format used to list processors, memory regions and similar entities"
 publish = true
-version = "1.1.8"
+version = "1.1.9"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,18 +2,14 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-
-# Only what builds the source, plus the landing page crates.io renders. The guides under `docs/`
-# are written for maintainers of this repository and link to repository-root documents that no
-# crate archive carries, so a packaged copy could not be followed to a complete picture anyway.
-include = ["Cargo.toml", "README.md", "src/**/*"]
 
 # `dure` is a command-line tool; its Rust API exists only so the in-package binary and the
 # integration tests can reach the crate, so the crate root carries

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -2,10 +2,11 @@
 name = "events"
 description = "Async manual-reset and auto-reset event primitives"
 publish = true
-version = "0.7.14"
+version = "0.7.15"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/events_once/Cargo.toml
+++ b/packages/events_once/Cargo.toml
@@ -2,10 +2,11 @@
 name = "events_once"
 description = "Efficient oneshot events (channels) with support for single-threaded events, object embedding, event pools and event lakes"
 publish = true
-version = "0.5.35"
+version = "0.5.36"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/fast_time/Cargo.toml
+++ b/packages/fast_time/Cargo.toml
@@ -2,10 +2,11 @@
 name = "fast_time"
 description = "An efficient low-precision timestamp source suitable for high-frequency querying"
 publish = true
-version = "0.1.28"
+version = "0.1.29"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/folo_ffi/Cargo.toml
+++ b/packages/folo_ffi/Cargo.toml
@@ -2,10 +2,11 @@
 name = "folo_ffi"
 description = "Utilities for working with FFI logic; exists for internal use in Folo packages; no stable API surface"
 publish = true
-version = "0.1.16"
+version = "0.1.17"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/folo_utils/Cargo.toml
+++ b/packages/folo_utils/Cargo.toml
@@ -2,10 +2,11 @@
 name = "folo_utils"
 description = "Utilities for internal use in Folo packages; no stable API surface"
 publish = true
-version = "0.1.12"
+version = "0.1.13"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/future_deque/Cargo.toml
+++ b/packages/future_deque/Cargo.toml
@@ -2,10 +2,11 @@
 name = "future_deque"
 description = "Deque collections for managing groups of futures"
 publish = true
-version = "0.1.18"
+version = "0.1.19"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/infinity_pool/Cargo.toml
+++ b/packages/infinity_pool/Cargo.toml
@@ -2,10 +2,11 @@
 name = "infinity_pool"
 description = "Offers object pooling capabilities both thread-safe and single threaded, both lifetime-managed and manual, both typed and untyped"
 publish = true
-version = "0.8.25"
+version = "0.8.26"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/linked/Cargo.toml
+++ b/packages/linked/Cargo.toml
@@ -2,13 +2,17 @@
 name = "linked"
 description = "Create families of linked objects that can collaborate across threads while being internally single-threaded"
 publish = true
-version = "1.0.20"
+version = "1.0.21"
 
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+# The diagrams are embedded into the rendered documentation at compile time.
+# Ref: docs/packaging.md.
+include = ["src/**/*", "doc/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/linked_macros/Cargo.toml
+++ b/packages/linked_macros/Cargo.toml
@@ -2,10 +2,11 @@
 name = "linked_macros"
 description = "Internal dependency of the 'linked' package - do not reference directly"
 publish = true
-version = "1.0.20"
+version = "1.0.21"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/linked_macros_impl/Cargo.toml
+++ b/packages/linked_macros_impl/Cargo.toml
@@ -2,10 +2,11 @@
 name = "linked_macros_impl"
 description = "Internal dependency of the 'linked_macros' package - do not reference directly"
 publish = true
-version = "1.0.20"
+version = "1.0.21"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/many_cpus/Cargo.toml
+++ b/packages/many_cpus/Cargo.toml
@@ -2,10 +2,11 @@
 name = "many_cpus"
 description = "Efficiently schedule work and inspect the hardware environment on many-processor systems"
 publish = true
-version = "2.4.17"
+version = "2.4.18"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/many_cpus_benchmarking/Cargo.toml
+++ b/packages/many_cpus_benchmarking/Cargo.toml
@@ -2,10 +2,11 @@
 name = "many_cpus_benchmarking"
 description = "Criterion benchmark harness to easily compare different processor configurations"
 publish = true
-version = "0.2.8"
+version = "0.2.9"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -2,10 +2,11 @@
 name = "many_cpus_impl"
 description = "Implementation crate for many_cpus - do not reference directly"
 publish = true
-version = "2.4.17"
+version = "2.4.18"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/new_zealand/Cargo.toml
+++ b/packages/new_zealand/Cargo.toml
@@ -2,10 +2,11 @@
 name = "new_zealand"
 description = "Utilities for working with non-zero integers"
 publish = true
-version = "1.0.8"
+version = "1.0.9"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/nm/Cargo.toml
+++ b/packages/nm/Cargo.toml
@@ -2,10 +2,11 @@
 name = "nm"
 description = "Minimalistic high-performance metrics collection in highly concurrent environments"
 publish = true
-version = "0.1.46"
+version = "0.1.47"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -2,10 +2,11 @@
 name = "nm_impl"
 description = "Implementation crate for nm; do not depend on it directly"
 publish = true
-version = "0.1.46"
+version = "0.1.47"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -2,10 +2,11 @@
 name = "nm_otel"
 description = "OpenTelemetry bridge for nm metrics"
 publish = true
-version = "0.4.18"
+version = "0.4.19"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -2,10 +2,11 @@
 name = "nm_otel_impl"
 description = "Implementation crate for nm_otel; do not depend on it directly"
 publish = true
-version = "0.4.18"
+version = "0.4.19"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/par_bench/Cargo.toml
+++ b/packages/par_bench/Cargo.toml
@@ -2,10 +2,11 @@
 name = "par_bench"
 description = "Mechanisms for multithreaded benchmarking, designed for integration with Criterion or a similar benchmark framework"
 publish = true
-version = "0.2.53"
+version = "0.2.54"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/packages/region_cached/Cargo.toml
+++ b/packages/region_cached/Cargo.toml
@@ -2,13 +2,17 @@
 name = "region_cached"
 description = "Adds a logical layer of caching between processor L3 cache and main memory"
 publish = true
-version = "1.0.32"
+version = "1.0.33"
 
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+# The diagrams are embedded into the rendered documentation at compile time.
+# Ref: docs/packaging.md.
+include = ["src/**/*", "doc/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/region_local/Cargo.toml
+++ b/packages/region_local/Cargo.toml
@@ -2,13 +2,17 @@
 name = "region_local"
 description = "Isolated variable storage per memory region, similar to `thread_local_rc!`"
 publish = true
-version = "1.0.32"
+version = "1.0.33"
 
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+# The diagrams are embedded into the rendered documentation at compile time.
+# Ref: docs/packaging.md.
+include = ["src/**/*", "doc/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/vicinal/Cargo.toml
+++ b/packages/vicinal/Cargo.toml
@@ -2,10 +2,11 @@
 name = "vicinal"
 description = "Processor-local worker pool that schedules tasks in the vicinity of the caller"
 publish = true
-version = "0.1.37"
+version = "0.1.38"
 
 authors.workspace = true
 edition.workspace = true
+include.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/scripts/release/ReleasePlan.Tests.ps1
+++ b/scripts/release/ReleasePlan.Tests.ps1
@@ -328,6 +328,141 @@ Describe 'Assert-SemverCheckExitCode' {
     }
 }
 
+Describe 'cargo-semver-checks target directory' {
+    It 'creates a stable workspace-specific path under the temporary root' {
+        InModuleScope ReleasePlan {
+            $tempRoot = Join-Path $TestDrive 'temp'
+            $firstWorkspace = Join-Path $TestDrive 'first-workspace'
+            $secondWorkspace = Join-Path $TestDrive 'second-workspace'
+
+            $first = Get-SemverCheckTargetDirectory `
+                -WorkspaceRoot $firstWorkspace `
+                -TempRoot $tempRoot
+            $firstAgain = Get-SemverCheckTargetDirectory `
+                -WorkspaceRoot $firstWorkspace `
+                -TempRoot $tempRoot
+            $second = Get-SemverCheckTargetDirectory `
+                -WorkspaceRoot $secondWorkspace `
+                -TempRoot $tempRoot
+
+            Split-Path -Parent $first | Should -BeExactly ([IO.Path]::GetFullPath($tempRoot))
+            $first | Should -BeExactly $firstAgain
+            $first | Should -Not -BeExactly $second
+        }
+    }
+
+    It 'preserves a configured target directory when it is shorter' {
+        InModuleScope ReleasePlan {
+            $previous = [Environment]::GetEnvironmentVariable(
+                'CARGO_TARGET_DIR',
+                'Process'
+            )
+            $configured = Join-Path $TestDrive 't'
+            try {
+                [Environment]::SetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    $configured,
+                    'Process'
+                )
+                $actual = Get-SemverCheckTargetDirectory `
+                    -WorkspaceRoot (Join-Path $TestDrive 'workspace') `
+                    -TempRoot (Join-Path $TestDrive 'deliberately-long-temporary-root')
+
+                $actual | Should -BeExactly ([IO.Path]::GetFullPath($configured))
+            } finally {
+                [Environment]::SetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    $previous,
+                    'Process'
+                )
+            }
+        }
+    }
+
+    It 'scopes the target directory to the SemVer command and restores the environment' {
+        InModuleScope ReleasePlan {
+            $previous = [Environment]::GetEnvironmentVariable(
+                'CARGO_TARGET_DIR',
+                'Process'
+            )
+            $target = Join-Path $TestDrive 'short-target'
+            $script:observedTarget = $null
+            try {
+                [Environment]::SetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    'original-target',
+                    'Process'
+                )
+                Invoke-WithSemverCheckTargetDirectory `
+                    -Action {
+                        $script:observedTarget = $env:CARGO_TARGET_DIR
+                    } `
+                    -TargetDirectory $target
+
+                $script:observedTarget | Should -BeExactly $target
+                $env:CARGO_TARGET_DIR | Should -BeExactly 'original-target'
+            } finally {
+                [Environment]::SetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    $previous,
+                    'Process'
+                )
+            }
+        }
+    }
+
+    It 'restores an absent target directory when the SemVer command fails' {
+        InModuleScope ReleasePlan {
+            $previous = [Environment]::GetEnvironmentVariable(
+                'CARGO_TARGET_DIR',
+                'Process'
+            )
+            try {
+                [Environment]::SetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    $null,
+                    'Process'
+                )
+                {
+                    Invoke-WithSemverCheckTargetDirectory `
+                        -Action { throw 'expected failure' } `
+                        -TargetDirectory (Join-Path $TestDrive 'short-target')
+                } | Should -Throw '*expected failure*'
+
+                [Environment]::GetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    'Process'
+                ) | Should -BeNullOrEmpty
+            } finally {
+                [Environment]::SetEnvironmentVariable(
+                    'CARGO_TARGET_DIR',
+                    $previous,
+                    'Process'
+                )
+            }
+        }
+    }
+
+    It 'scopes the target directory around release-plz update' {
+        InModuleScope ReleasePlan {
+            $target = Join-Path $TestDrive 'short-target'
+            $script:observedArgument = $null
+            $script:observedTarget = $null
+
+            Invoke-ReleasePlzUpdate `
+                -TargetDirectory $target `
+                -ReleasePlz {
+                    param([string[]] $Argument)
+                    $script:observedArgument = @($Argument)
+                    $script:observedTarget = $env:CARGO_TARGET_DIR
+                }
+
+            $script:observedArgument | Should -Be @('update')
+            $script:observedTarget | Should -BeExactly $target
+        }
+    }
+}
+
 Describe 'Invoke-ReleaseReport' {
     It 'runs SemVer checks only for the explicit report targets' {
         $outDir = Join-Path $TestDrive 'collect'

--- a/scripts/release/ReleasePlan.psm1
+++ b/scripts/release/ReleasePlan.psm1
@@ -262,6 +262,157 @@ function Get-SemverCheckCargoArgument {
     return $argument
 }
 
+function Get-SemverCheckTargetDirectory {
+    # cargo-semver-checks nests generated placeholder workspaces below Cargo's target directory.
+    # Keep the Windows target root independent of the checkout depth so MSVC tools do not encounter
+    # the legacy MAX_PATH boundary. A workspace-specific name avoids collisions between worktrees.
+    # Reassess this override when cargo-semver-checks shortens those generated paths:
+    # https://github.com/obi1kenobi/cargo-semver-checks/issues/1725
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string] $WorkspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path,
+        [string] $TempRoot = [IO.Path]::GetTempPath()
+    )
+
+    $workspacePath = [IO.Path]::GetFullPath($WorkspaceRoot)
+    $hash = [Security.Cryptography.SHA256]::HashData(
+        [Text.Encoding]::UTF8.GetBytes($workspacePath)
+    )
+    # Local cache names need collision resistance, not a full cryptographic identity; preserving
+    # path budget is the purpose of this directory.
+    $workspaceIdLength = 16
+    $workspaceId = [Convert]::ToHexString($hash).Substring(0, $workspaceIdLength).ToLowerInvariant()
+    $candidate = Join-Path ([IO.Path]::GetFullPath($TempRoot)) "fsc-$workspaceId"
+
+    $configured = [Environment]::GetEnvironmentVariable('CARGO_TARGET_DIR', 'Process')
+    if (-not [string]::IsNullOrWhiteSpace($configured)) {
+        $configuredPath = [IO.Path]::GetFullPath($configured)
+        if ($configuredPath.Length -lt $candidate.Length) {
+            return $configuredPath
+        }
+    }
+    return $candidate
+}
+
+function Invoke-WithSemverCheckTargetDirectory {
+    # Scopes the short target directory to commands that run cargo-semver-checks. Other Cargo
+    # commands keep the workspace target directory and its normal cache behavior.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][scriptblock] $Action,
+        [AllowNull()][string] $TargetDirectory
+    )
+
+    if (-not $PSBoundParameters.ContainsKey('TargetDirectory') -and $IsWindows) {
+        $TargetDirectory = Get-SemverCheckTargetDirectory
+    }
+    if ([string]::IsNullOrWhiteSpace($TargetDirectory)) {
+        & $Action
+        return
+    }
+
+    $previousTargetDirectory =
+        [Environment]::GetEnvironmentVariable('CARGO_TARGET_DIR', 'Process')
+    try {
+        Write-Verbose (
+            "Using CARGO_TARGET_DIR=$TargetDirectory for cargo-semver-checks because its " +
+            'generated build paths can exceed the Windows path limit.'
+        ) -Verbose
+        [Environment]::SetEnvironmentVariable(
+            'CARGO_TARGET_DIR',
+            $TargetDirectory,
+            'Process'
+        )
+        & $Action
+    } finally {
+        [Environment]::SetEnvironmentVariable(
+            'CARGO_TARGET_DIR',
+            $previousTargetDirectory,
+            'Process'
+        )
+    }
+}
+
+function Invoke-SemverCheckCargo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string[]] $Argument,
+        [scriptblock] $Cargo = { param([string[]] $CargoArgument) & cargo @CargoArgument },
+        [AllowNull()][string] $TargetDirectory
+    )
+
+    $action = { & $Cargo $Argument }
+    if ($PSBoundParameters.ContainsKey('TargetDirectory')) {
+        Invoke-WithSemverCheckTargetDirectory `
+            -Action $action `
+            -TargetDirectory $TargetDirectory
+    } else {
+        Invoke-WithSemverCheckTargetDirectory -Action $action
+    }
+}
+
+function Invoke-VerifySemverCheck {
+    # Proves the installed tool can build rustdoc JSON before release decisions trust its output.
+    [CmdletBinding()]
+    param(
+        [scriptblock] $Cargo = { param([string[]] $Argument) & cargo @Argument }
+    )
+
+    # A tiny published crate keeps the canary cheap; its API is irrelevant because both sides use
+    # the same revision.
+    $package = 'folo_utils'
+    Write-Verbose (
+        "Verifying that cargo-semver-checks can run (canary package '$package', " +
+        'compared against its own HEAD).'
+    ) -Verbose
+
+    try {
+        Invoke-SemverCheckCargo `
+            -Argument @('semver-checks', '--baseline-rev', 'HEAD', '-p', $package) `
+            -Cargo $Cargo
+    } catch {
+        Write-Host ''
+        Write-Host (
+            "ERROR: cargo-semver-checks failed to run on the canary package '$package' " +
+            '(see the error above).'
+        ) -ForegroundColor Red
+        Write-Host ''
+        Write-Host (
+            'A broken cargo-semver-checks must not be interpreted as an absence of ' +
+            'breaking changes.'
+        ) -ForegroundColor Red
+        Write-Host (
+            "Update the tool with 'cargo install cargo-semver-checks --locked' " +
+            "(or 'just install-tools'), then re-run the command."
+        ) -ForegroundColor Red
+        throw
+    }
+}
+
+function Invoke-ReleasePlzUpdate {
+    # release-plz invokes cargo-semver-checks internally, so it must share the same Windows path
+    # mitigation as direct checks.
+    [CmdletBinding()]
+    param(
+        [scriptblock] $ReleasePlz = {
+            param([string[]] $Argument)
+            & release-plz @Argument
+        },
+        [AllowNull()][string] $TargetDirectory
+    )
+
+    $argument = @('update')
+    $action = { & $ReleasePlz $argument }
+    if ($PSBoundParameters.ContainsKey('TargetDirectory')) {
+        Invoke-WithSemverCheckTargetDirectory `
+            -Action $action `
+            -TargetDirectory $TargetDirectory
+    } else {
+        Invoke-WithSemverCheckTargetDirectory -Action $action
+    }
+}
+
 function Assert-SemverCheckExitCode {
     # Both completed cargo-semver-checks outcomes are retained as evidence because a finding exit
     # still means the comparison ran successfully and produced the log the skill needs.
@@ -324,7 +475,8 @@ function Invoke-ReleaseReport {
     # restores the caller's native-command error behavior.
     $PSNativeCommandUseErrorActionPreference = $false
     try {
-        & $Cargo $argument 2>&1 | Tee-Object -FilePath $logPath
+        Invoke-SemverCheckCargo -Argument $argument -Cargo $Cargo 2>&1 |
+            Tee-Object -FilePath $logPath
         $exitCode = $LASTEXITCODE
     } finally {
         $PSNativeCommandUseErrorActionPreference = $previousPreference
@@ -348,7 +500,7 @@ function Invoke-SemverCheck {
 
     $argument = Get-SemverCheckCargoArgument -Package $targets
     Write-Verbose "Running cargo $($argument -join ' ')" -Verbose
-    & $Cargo $argument
+    Invoke-SemverCheckCargo -Argument $argument -Cargo $Cargo
 }
 
 function Invoke-ExpandReleasePlan {
@@ -1687,6 +1839,8 @@ function New-ReleasePlanFile {
 
 Export-ModuleMember -Function `
     Invoke-ValidateVersions, `
+    Invoke-VerifySemverCheck, `
+    Invoke-ReleasePlzUpdate, `
     Invoke-ReleaseReport, `
     Invoke-SemverCheck, `
     Get-ReleasePlanAnalysisBatchJson, `


### PR DESCRIPTION
[Copilot speaking]

Publishable crates now ship only what a consumer compiles. The default allow-list is declared once in `[workspace.package]` as `include = ["src/**/*"]` and inherited with `include.workspace = true`; Cargo adds `Cargo.toml`, a generated `Cargo.lock`, and the README it detects on its own, so naming those would only imply the list controls them. Tests, benchmarks, examples, books, `AGENTS.md`, and design and implementation documents stay in git — the latter are maintainer documents that link to repository-root chapters no archive carries.

Five packages declare their own list instead of inheriting, because inheritance replaces the value rather than extending it and each embeds a file outside `src/` at compile time: the Mermaid diagrams rendered into documentation by `linked`, `region_cached`, `region_local`, and `awaiter_set`, and the fixtures `cbh_engines` embeds under its `private-test-util` feature, which could not otherwise compile from the published archive. `docs/packaging.md` records this policy.

This pull request is the catch-up increment: every publishable package takes a patch bump, and each version group stays aligned, so `validate-versions` is clean. The changes are packaging-only; `cargo-semver-checks` required no higher floor.

On Windows, repository-owned SemVer checks and `release-plz update` use a short, workspace-specific Cargo target directory beneath the user temporary directory. This keeps cargo-semver-checks' generated placeholder builds below legacy tool path limits without changing unrelated Cargo commands or non-Windows validation. The override can be reassessed when [cargo-semver-checks issue #1725](https://github.com/obi1kenobi/cargo-semver-checks/issues/1725) shortens those generated paths upstream.

`cargo-release-plan` treats an empty subprocess working directory as the process current directory, so the default relative `Cargo.toml` path works on Windows and Unix.