### PR TITLE
cbh_detect: fail fast on invalid regime search budgets

### DIFF
--- a/packages/cbh_detect/src/detect/branch.rs
+++ b/packages/cbh_detect/src/detect/branch.rs
@@ -314,6 +314,12 @@ fn select_regime(series: &Series) -> RegimeSelection {
         .collect();
 
     let search_alpha = regime_search_alpha(selector.len());
+    // Check the calibration before recursive segmentation because a broader-than-budget chance
+    // level can make every candidate eligible and drive prohibitively expensive searches.
+    debug_assert!(
+        search_alpha <= noise_gates::MAX_BRANCH_REGIME_CHANCE_LEVEL,
+        "one regime search cannot consume more than the complete search budget",
+    );
     let mut boundaries = Vec::new();
     collect_supported_boundaries(series.kind, &selector, 0, search_alpha, &mut boundaries);
     extend_current_regime(series.kind, &selector, search_alpha, &mut boundaries);


### PR DESCRIPTION
[Copilot speaking]

A mutation that widened the regime-search chance level could make recursive segmentation perform enough unnecessary statistical work to time out on Linux, turning a catchable defect into an unreliable mutation result.

This adds a caller-side debug invariant before recursive segmentation to ensure one search never exceeds the complete chance-level budget. Invalid calibrations now fail immediately in test and mutation profiles without changing release behavior.