### PR TITLE
dure: bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "dure-test-helper",

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.1.1"
+version = "0.1.2"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
[Copilot speaking]

A `dure` fix has landed since the latest published release, while crates.io still serves version 0.1.1.

Bump the crate and workspace lockfile to 0.1.2 so the release automation can publish the corrected version.