### PR TITLE
cargo-release-plan/all_the_time: fix Windows CI failures

### DIFF
--- a/packages/all_the_time/examples/all_the_time_readme.rs
+++ b/packages/all_the_time/examples/all_the_time_readme.rs
@@ -3,9 +3,9 @@
 //! This shows the recommended `iter_custom` pattern for tracking processor time,
 //! feeding the Criterion-chosen iteration count into each recorded span.
 //!
-//! Criterion is configured with a small measurement budget so the example runs
-//! quickly and deterministically as a smoke test; a real benchmark would use
-//! `Criterion::default()`.
+//! Criterion is configured with small measurement and statistical-analysis
+//! budgets so the example runs quickly as a smoke test; a real benchmark would
+//! use `Criterion::default()`.
 
 use std::hint::black_box;
 use std::time::{Duration, Instant};
@@ -18,9 +18,10 @@ fn main() {
     let operation = session.operation("my_operation");
 
     let mut criterion = Criterion::default()
-        .warm_up_time(Duration::from_millis(100))
-        .measurement_time(Duration::from_millis(500))
+        .warm_up_time(Duration::from_millis(10))
+        .measurement_time(Duration::from_millis(20))
         .sample_size(10)
+        .nresamples(2000)
         .without_plots();
     criterion.bench_function("my_operation", |b| {
         b.iter_custom(|iters| {

--- a/packages/cargo-release-plan/tests/integration/fixture.rs
+++ b/packages/cargo-release-plan/tests/integration/fixture.rs
@@ -4,6 +4,7 @@
 //! user settings.
 
 use std::fs;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -145,28 +146,60 @@ const HERMETIC_CONFIG: &[&str] = &[
     "core.autocrlf=false",
 ];
 
-/// Empty global configuration source understood by the platform's Git executable.
-#[cfg(windows)]
-const EMPTY_GIT_CONFIG: &str = "NUL";
-/// Empty global configuration source understood by the platform's Git executable.
-#[cfg(not(windows))]
-const EMPTY_GIT_CONFIG: &str = "/dev/null";
+/// A Git command that keeps its empty global configuration file alive.
+///
+/// Git for Windows on ARM64 rejects the `NUL` device as a configuration path, so
+/// every command receives a real empty file instead of a platform-specific null
+/// device. The owning temporary directory removes the file after the command is
+/// dropped.
+pub(crate) struct HermeticGit {
+    command: Command,
+    _global_config_dir: TempDir,
+}
+
+impl HermeticGit {
+    fn new() -> Self {
+        let global_config_dir = TempDir::new().unwrap();
+        let global_config = global_config_dir.path().join("config");
+        fs::write(&global_config, "").unwrap();
+
+        let mut command = Command::new("git");
+        command
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", global_config)
+            .env_remove("GIT_CONFIG")
+            .env_remove("GIT_CONFIG_COUNT")
+            .env_remove("GIT_CONFIG_PARAMETERS");
+        command.args(HERMETIC_CONFIG);
+
+        Self {
+            command,
+            _global_config_dir: global_config_dir,
+        }
+    }
+}
+
+impl Deref for HermeticGit {
+    type Target = Command;
+
+    fn deref(&self) -> &Self::Target {
+        &self.command
+    }
+}
+
+impl DerefMut for HermeticGit {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.command
+    }
+}
 
 /// A `git` command carrying the pinned configuration and no working directory.
 ///
 /// `Fixture::git` runs inside an existing fixture; a test that creates a
 /// repository somewhere else, such as a clone, needs the same settings without
 /// one.
-pub(crate) fn hermetic_git() -> Command {
-    let mut command = Command::new("git");
-    command
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", EMPTY_GIT_CONFIG)
-        .env_remove("GIT_CONFIG")
-        .env_remove("GIT_CONFIG_COUNT")
-        .env_remove("GIT_CONFIG_PARAMETERS");
-    command.args(HERMETIC_CONFIG);
-    command
+pub(crate) fn hermetic_git() -> HermeticGit {
+    HermeticGit::new()
 }
 
 #[cfg_attr(miri, ignore)] // Spawns git, which Miri cannot emulate.


### PR DESCRIPTION
[Copilot speaking]

Windows validation failed because Git on the ARM64 runner rejects `NUL` as `GIT_CONFIG_GLOBAL`, while the `all_the_time` README example spent most of its runtime performing Criterion's default statistical analysis and exceeded the example timeout.

## Changes

- Give every hermetic test Git command a real empty temporary global configuration file and retain its owner until the command completes, avoiding platform-specific null-device behavior.
- Preserve the documented Criterion `iter_custom` pattern while using smoke-test-sized warm-up, measurement, and resampling budgets, bringing the example runtime below one second.