### PR TITLE
dure: isolate supervisor tests from filesystem I/O

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -60,6 +60,12 @@ When there is a danger that a test may hang (e.g. it contains a `.wait()`,
 wrap the test body with a timeout. Do not implement custom watchdog timers —
 always use the existing watchdog from the `testing` package.
 
+Use `testing::with_watchdog_phases()` when a test has several identifiable
+blocking stages. Its initial label describes the work before the first report;
+call `WatchdogPhaseReporter::report()` immediately before each later operation
+that may block so a timeout identifies the latest stage. Keep
+`testing::with_watchdog()` for tests where one timeout label is sufficient.
+
 Watchdogs are automatically disabled during mutation testing (`MUTATION_TESTING=1`
 environment variable). A mutation that causes a test to hang should be fixed by
 either redesigning the test to catch the mutation without blocking (e.g. adding

--- a/packages/dure/docs/implementation.md
+++ b/packages/dure/docs/implementation.md
@@ -341,8 +341,12 @@ host drains independently of the app, so that hold is bounded.
 
 Installing the client slot releases the first-attach lifetime gate before the
 advisory attached flag is written to the session store. The store update happens
-after the attach lock is released, so durable filesystem I/O cannot hold up
-another attach or prevent an app that already exited from delivering its status.
+after both ownership locks are released, so durable filesystem I/O cannot hold
+up another attach or prevent an app that already exited from delivering its
+status. Each client-slot change assigns a generation to its advisory update.
+Store writes are serialized and discard generations older than the latest
+ownership state, so an update delayed by filesystem I/O cannot overwrite a newer
+attach or detach.
 
 Session teardown closes the pseudoconsole and joins the output pump before
 queueing the app's exit status, which is what orders the app's final output

--- a/packages/dure/docs/implementation.md
+++ b/packages/dure/docs/implementation.md
@@ -90,8 +90,10 @@ The PAL is sliced by responsibility, at a grain that tests can drive, not as a
 
 * **Session store** — create, read, list, and delete session records; allocate
   ids; provide the store root. The real implementation uses the per-user
-  LocalAppData known folder, subdirectory `dure`. The root is supplied by the
-  PAL so tests never touch the user's real store.
+  LocalAppData known folder, subdirectory `dure`. Coordination-focused unit
+  tests use shared in-memory records, while the session-store tests use an
+  isolated root to exercise filesystem durability without touching the user's
+  real store.
 * **Processes** — spawn a console-detached supervisor with job breakaway;
   identify it by pid and process creation time; report whether a job object would
   end this process along with its launcher; create a job with a chosen
@@ -336,6 +338,11 @@ ownership and applies each message under the client-slot lock, so a client
 displaced while its receive was in flight cannot reach the pseudoconsole
 afterwards. Pseudoconsole input lands in the console host's buffer, which the
 host drains independently of the app, so that hold is bounded.
+
+Installing the client slot releases the first-attach lifetime gate before the
+advisory attached flag is written to the session store. The store update happens
+after the attach lock is released, so durable filesystem I/O cannot hold up
+another attach or prevent an app that already exited from delivering its status.
 
 Session teardown closes the pseudoconsole and joins the output pump before
 queueing the app's exit status, which is what orders the app's final output

--- a/packages/dure/docs/implementation.md
+++ b/packages/dure/docs/implementation.md
@@ -39,9 +39,9 @@ so a client never reports a startup failure while leaving a live session behind.
 The startup channel stays open past that acknowledgement, as the supervisor's
 signal that `dure run` still intends to attach. An app that exits immediately
 would otherwise be torn down before the client finishes attaching, losing its
-output and exit status to the race. So once the app has exited, the supervisor
-holds the session open — listener included — until either a client has attached
-or the initiator has dropped the channel.
+output and exit status to the race. The supervisor's **first-attach lifetime
+gate** therefore keeps the exited app's session and listener available until
+either a client has attached or the initiator has dropped the channel.
 
 ## Platform gate
 
@@ -339,14 +339,14 @@ displaced while its receive was in flight cannot reach the pseudoconsole
 afterwards. Pseudoconsole input lands in the console host's buffer, which the
 host drains independently of the app, so that hold is bounded.
 
-Installing the client slot releases the first-attach lifetime gate before the
-advisory attached flag is written to the session store. The store update happens
-after both ownership locks are released, so durable filesystem I/O cannot hold
-up another attach or prevent an app that already exited from delivering its
-status. Each client-slot change assigns a generation to its advisory update.
-Store writes are serialized and discard generations older than the latest
-ownership state, so an update delayed by filesystem I/O cannot overwrite a newer
-attach or detach.
+Installing the client slot and signaling the first-attach lifetime gate let the
+supervisor finish delivering an already-exited app's output and status before
+the advisory attached flag is written to the session store. The store update
+happens after both ownership locks are released, so durable filesystem I/O
+cannot block that supervisor progress or another attach. Each client-slot change
+assigns a generation to its advisory update. Store writes are serialized and
+discard generations older than the latest ownership state, so an update delayed
+by filesystem I/O cannot overwrite a newer attach or detach.
 
 Session teardown closes the pseudoconsole and joins the output pump before
 queueing the app's exit status, which is what orders the app's final output

--- a/packages/dure/docs/implementation.md
+++ b/packages/dure/docs/implementation.md
@@ -345,8 +345,9 @@ the advisory attached flag is written to the session store. The store update
 happens after both ownership locks are released, so durable filesystem I/O
 cannot block that supervisor progress or another attach. Each client-slot change
 assigns a generation to its advisory update. Store writes are serialized and
-discard generations older than the latest ownership state, so an update delayed
-by filesystem I/O cannot overwrite a newer attach or detach.
+skip updates that are already stale when they reach that serialization boundary.
+If a write becomes stale inside filesystem I/O, the newer update follows it
+through the same boundary and establishes the final attached state.
 
 Session teardown closes the pseudoconsole and joins the output pump before
 queueing the app's exit status, which is what orders the app's final output

--- a/packages/dure/src/pal/transport/memory.rs
+++ b/packages/dure/src/pal/transport/memory.rs
@@ -19,8 +19,14 @@ struct ConnState {
     peer: ConnId,
     closed: bool,
     /// Sends on this connection block, standing in for a peer that has stopped
-    /// draining its pipe. Only `disconnect` releases them, as `CancelIoEx` does.
+    /// draining its pipe. Tests release them with `resume`; `disconnect` also
+    /// releases them, as `CancelIoEx` does.
     stalled: bool,
+    /// Senders parked on this connection's stalled predicate.
+    ///
+    /// Tests observe this under the connection map lock to prove that a
+    /// particular send reached the intended blocking boundary.
+    stalled_senders: usize,
 }
 
 struct ListenerState {
@@ -40,22 +46,12 @@ struct Inner {
     timeout_next_accept: AtomicBool,
     /// Makes the next timed receive report a timeout once its connection is idle.
     timeout_next_recv: AtomicBool,
-    /// Deterministic gate for tests that inspect behavior during a blocked send.
-    send_stall: Mutex<SendStall>,
-    send_stall_changed: Condvar,
     /// Guards the pending-connection predicate under `listener_state`. A
     /// `Condvar` may only ever be paired with one mutex, so the connection side
     /// has its own below.
     listener_cond: Condvar,
     /// Guards the queued-message and stalled predicates under `conns`.
     conn_cond: Condvar,
-}
-
-/// State of the deterministic send gate.
-#[derive(Debug, Default)]
-struct SendStall {
-    enabled: bool,
-    waiting: usize,
 }
 
 /// Thread-safe in-memory named-pipe stand-in.
@@ -82,8 +78,6 @@ impl MemoryTransport {
                 fail_next_send: AtomicBool::new(false),
                 timeout_next_accept: AtomicBool::new(false),
                 timeout_next_recv: AtomicBool::new(false),
-                send_stall: Mutex::new(SendStall::default()),
-                send_stall_changed: Condvar::new(),
                 listener_cond: Condvar::new(),
                 conn_cond: Condvar::new(),
             }),
@@ -97,51 +91,57 @@ impl MemoryTransport {
     /// Make sends on `conn` block until it is disconnected or resumed.
     pub(crate) fn stall(&self, conn: ConnId) {
         let mut conns = self.inner.conns.lock().expect("conn map lock");
-        if let Some(state) = conns.get_mut(&conn) {
-            state.stalled = true;
-        }
+        let state = conns
+            .get_mut(&conn)
+            .expect("tests only stall a live connection");
+        assert!(!state.stalled, "a connection cannot be stalled twice");
+        assert_eq!(
+            state.stalled_senders, 0,
+            "a connection cannot be rearmed before prior senders resume"
+        );
+        state.stalled = true;
         self.inner.conn_cond.notify_all();
     }
 
-    /// Let sends on `conn` proceed again, releasing whoever is blocked on it.
+    /// Let sends on `conn` proceed and wait until its old stall has drained.
+    ///
+    /// Draining the parked-sender count before returning makes the connection
+    /// safe to stall again without observing a sender from the previous stall.
     pub(crate) fn resume(&self, conn: ConnId) {
         let mut conns = self.inner.conns.lock().expect("conn map lock");
-        if let Some(state) = conns.get_mut(&conn) {
-            state.stalled = false;
-        }
+        let state = conns
+            .get_mut(&conn)
+            .expect("tests only resume a live connection");
+        assert!(state.stalled, "only a stalled connection can be resumed");
+        state.stalled = false;
         self.inner.conn_cond.notify_all();
-    }
-
-    /// Make sends block at the transport boundary until resumed.
-    pub(crate) fn stall_sends(&self) {
-        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
-        assert!(!stall.enabled);
-        stall.enabled = true;
-        self.inner.send_stall_changed.notify_all();
-    }
-
-    /// Block until a send has reached the deterministic send gate.
-    pub(crate) fn wait_for_stalled_send(&self) {
-        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
-        assert!(
-            stall.enabled,
-            "the send stall must be enabled before waiting"
-        );
-        while stall.waiting == 0 {
-            stall = self
-                .inner
-                .send_stall_changed
-                .wait(stall)
-                .expect("send-stall condvar");
+        loop {
+            let state = conns
+                .get(&conn)
+                .expect("connections remain addressable after disconnection");
+            if state.stalled_senders == 0 {
+                return;
+            }
+            conns = self.inner.conn_cond.wait(conns).expect("conn condvar");
         }
     }
 
-    /// Release sends waiting at the deterministic send gate.
-    pub(crate) fn resume_sends(&self) {
-        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
-        assert!(stall.enabled);
-        stall.enabled = false;
-        self.inner.send_stall_changed.notify_all();
+    /// Block until a send has parked on `conn`'s injected stall.
+    pub(crate) fn wait_for_stalled_send(&self, conn: ConnId) {
+        let mut conns = self.inner.conns.lock().expect("conn map lock");
+        loop {
+            let state = conns
+                .get(&conn)
+                .expect("tests only observe a live connection");
+            assert!(
+                state.stalled,
+                "the connection must be stalled before waiting"
+            );
+            if state.stalled_senders != 0 {
+                return;
+            }
+            conns = self.inner.conn_cond.wait(conns).expect("conn condvar");
+        }
     }
 
     pub(crate) fn startup_commit_count(&self) -> usize {
@@ -236,23 +236,6 @@ impl MemoryTransport {
             };
         }
     }
-
-    fn await_send_permission(&self) {
-        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
-        if !stall.enabled {
-            return;
-        }
-        stall.waiting = stall.waiting.checked_add(1).unwrap();
-        self.inner.send_stall_changed.notify_all();
-        while stall.enabled {
-            stall = self
-                .inner
-                .send_stall_changed
-                .wait(stall)
-                .expect("send-stall condvar");
-        }
-        stall.waiting = stall.waiting.checked_sub(1).unwrap();
-    }
 }
 
 impl Default for MemoryTransport {
@@ -308,6 +291,7 @@ impl Transport for MemoryTransport {
                     peer: client,
                     closed: false,
                     stalled: false,
+                    stalled_senders: 0,
                 },
             );
             conns.insert(
@@ -317,6 +301,7 @@ impl Transport for MemoryTransport {
                     peer: server,
                     closed: false,
                     stalled: false,
+                    stalled_senders: 0,
                 },
             );
         }
@@ -340,17 +325,30 @@ impl Transport for MemoryTransport {
         if self.inner.fail_next_send.swap(false, Ordering::SeqCst) {
             return Err(PalError::new(PalErrorKind::Other));
         }
-        self.await_send_permission();
         let mut conns = self.inner.conns.lock().expect("conn map lock");
+        let mut waiting = false;
         let peer = loop {
-            let Some(state) = conns.get(&conn) else {
+            let Some(state) = conns.get_mut(&conn) else {
                 return Err(PalError::new(PalErrorKind::NotFound));
             };
             if state.closed {
+                if waiting {
+                    state.stalled_senders = state.stalled_senders.checked_sub(1).unwrap();
+                    self.inner.conn_cond.notify_all();
+                }
                 return Err(PalError::new(PalErrorKind::NotFound));
             }
             if !state.stalled {
+                if waiting {
+                    state.stalled_senders = state.stalled_senders.checked_sub(1).unwrap();
+                    self.inner.conn_cond.notify_all();
+                }
                 break state.peer;
+            }
+            if !waiting {
+                state.stalled_senders = state.stalled_senders.checked_add(1).unwrap();
+                waiting = true;
+                self.inner.conn_cond.notify_all();
             }
             conns = self.inner.conn_cond.wait(conns).expect("conn condvar");
         };
@@ -448,23 +446,26 @@ mod tests {
     }
 
     #[test]
-    fn send_stall_reports_when_a_sender_is_parked() {
+    fn connection_send_stall_reports_each_rearmed_sender() {
         with_watchdog(|| {
             let transport = MemoryTransport::new();
             let listener = transport.listen("session").unwrap();
             let client = transport.connect("session", Duration::ZERO).unwrap();
             let server = transport.accept(listener).unwrap();
-            transport.stall_sends();
 
-            let sender = thread::spawn({
-                let transport = transport.clone();
-                move || transport.send(client, &Message::StartupErr)
-            });
+            for message in [Message::StartupErr, Message::StartupCommit] {
+                transport.stall(client);
+                let sender = thread::spawn({
+                    let transport = transport.clone();
+                    let message = message.clone();
+                    move || transport.send(client, &message)
+                });
 
-            transport.wait_for_stalled_send();
-            transport.resume_sends();
-            sender.join().unwrap().unwrap();
-            assert_eq!(transport.recv(server).unwrap(), Message::StartupErr);
+                transport.wait_for_stalled_send(client);
+                transport.resume(client);
+                sender.join().unwrap().unwrap();
+                assert_eq!(transport.recv(server).unwrap(), message);
+            }
         });
     }
 }

--- a/packages/dure/src/pal/transport/memory.rs
+++ b/packages/dure/src/pal/transport/memory.rs
@@ -123,6 +123,10 @@ impl MemoryTransport {
     /// Block until a send has reached the deterministic send gate.
     pub(crate) fn wait_for_stalled_send(&self) {
         let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
+        assert!(
+            stall.enabled,
+            "the send stall must be enabled before waiting"
+        );
         while stall.waiting == 0 {
             stall = self
                 .inner

--- a/packages/dure/src/pal/transport/memory.rs
+++ b/packages/dure/src/pal/transport/memory.rs
@@ -40,12 +40,22 @@ struct Inner {
     timeout_next_accept: AtomicBool,
     /// Makes the next timed receive report a timeout once its connection is idle.
     timeout_next_recv: AtomicBool,
+    /// Deterministic gate for tests that inspect behavior during a blocked send.
+    send_stall: Mutex<SendStall>,
+    send_stall_changed: Condvar,
     /// Guards the pending-connection predicate under `listener_state`. A
     /// `Condvar` may only ever be paired with one mutex, so the connection side
     /// has its own below.
     listener_cond: Condvar,
     /// Guards the queued-message and stalled predicates under `conns`.
     conn_cond: Condvar,
+}
+
+/// State of the deterministic send gate.
+#[derive(Debug, Default)]
+struct SendStall {
+    enabled: bool,
+    waiting: usize,
 }
 
 /// Thread-safe in-memory named-pipe stand-in.
@@ -72,6 +82,8 @@ impl MemoryTransport {
                 fail_next_send: AtomicBool::new(false),
                 timeout_next_accept: AtomicBool::new(false),
                 timeout_next_recv: AtomicBool::new(false),
+                send_stall: Mutex::new(SendStall::default()),
+                send_stall_changed: Condvar::new(),
                 listener_cond: Condvar::new(),
                 conn_cond: Condvar::new(),
             }),
@@ -98,6 +110,34 @@ impl MemoryTransport {
             state.stalled = false;
         }
         self.inner.conn_cond.notify_all();
+    }
+
+    /// Make sends block at the transport boundary until resumed.
+    pub(crate) fn stall_sends(&self) {
+        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
+        assert!(!stall.enabled);
+        stall.enabled = true;
+        self.inner.send_stall_changed.notify_all();
+    }
+
+    /// Block until a send has reached the deterministic send gate.
+    pub(crate) fn wait_for_stalled_send(&self) {
+        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
+        while stall.waiting == 0 {
+            stall = self
+                .inner
+                .send_stall_changed
+                .wait(stall)
+                .expect("send-stall condvar");
+        }
+    }
+
+    /// Release sends waiting at the deterministic send gate.
+    pub(crate) fn resume_sends(&self) {
+        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
+        assert!(stall.enabled);
+        stall.enabled = false;
+        self.inner.send_stall_changed.notify_all();
     }
 
     pub(crate) fn startup_commit_count(&self) -> usize {
@@ -192,6 +232,23 @@ impl MemoryTransport {
             };
         }
     }
+
+    fn await_send_permission(&self) {
+        let mut stall = self.inner.send_stall.lock().expect("send-stall lock");
+        if !stall.enabled {
+            return;
+        }
+        stall.waiting = stall.waiting.checked_add(1).unwrap();
+        self.inner.send_stall_changed.notify_all();
+        while stall.enabled {
+            stall = self
+                .inner
+                .send_stall_changed
+                .wait(stall)
+                .expect("send-stall condvar");
+        }
+        stall.waiting = stall.waiting.checked_sub(1).unwrap();
+    }
 }
 
 impl Default for MemoryTransport {
@@ -279,6 +336,7 @@ impl Transport for MemoryTransport {
         if self.inner.fail_next_send.swap(false, Ordering::SeqCst) {
             return Err(PalError::new(PalErrorKind::Other));
         }
+        self.await_send_permission();
         let mut conns = self.inner.conns.lock().expect("conn map lock");
         let peer = loop {
             let Some(state) = conns.get(&conn) else {
@@ -355,6 +413,10 @@ impl Transport for MemoryTransport {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::thread;
+
+    use testing::with_watchdog;
+
     use super::*;
 
     #[test]
@@ -379,5 +441,26 @@ mod tests {
         let error = transport.recv_timeout(client, Duration::ZERO).unwrap_err();
 
         assert_eq!(error.kind(), PalErrorKind::Timeout);
+    }
+
+    #[test]
+    fn send_stall_reports_when_a_sender_is_parked() {
+        with_watchdog(|| {
+            let transport = MemoryTransport::new();
+            let listener = transport.listen("session").unwrap();
+            let client = transport.connect("session", Duration::ZERO).unwrap();
+            let server = transport.accept(listener).unwrap();
+            transport.stall_sends();
+
+            let sender = thread::spawn({
+                let transport = transport.clone();
+                move || transport.send(client, &Message::StartupErr)
+            });
+
+            transport.wait_for_stalled_send();
+            transport.resume_sends();
+            sender.join().unwrap().unwrap();
+            assert_eq!(transport.recv(server).unwrap(), Message::StartupErr);
+        });
     }
 }

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -1331,6 +1331,8 @@ mod tests {
             processes
                 .expect_create_lifetime_job()
                 .returning(|| Ok(JobId(1)));
+            // Spawn fails before initialization constructs the session record,
+            // so this path never reads the system clock.
             processes
                 .expect_spawn_app()
                 .returning(|_| Err(PalError::new(PalErrorKind::Other)));

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -1,7 +1,7 @@
 //! Supervisor role: own the app, accept clients, last-connect-wins steal.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread;
 
@@ -257,6 +257,12 @@ struct Shared<T: Transport, C> {
     /// acknowledge in one order and install in another, letting an older
     /// attach displace a newer one.
     attach: Mutex<()>,
+    /// Monotonic identity of the latest client-slot ownership state.
+    ///
+    /// Advisory store updates carry the generation assigned under the client
+    /// slot, so an older update that waited for store I/O cannot overwrite a
+    /// newer attach or detach.
+    attached_generation: Arc<AtomicU64>,
     /// Output the app produced before anyone attached, kept for the first
     /// client. Taken under the client slot, which is what orders it ahead of
     /// the output that follows the attach.
@@ -335,6 +341,23 @@ impl<T: Transport, C> Shared<T, C> {
         self.client
             .lock()
             .expect("client slot is only copied or replaced, never held across a panic")
+    }
+
+    /// Advances the identity of the client-slot ownership state.
+    // A constant-return mutation makes later ownership updates indistinguishable.
+    // The deterministic stall test then waits for an update that is correctly
+    // discarded, and mutation watchdogs are disabled.
+    #[cfg_attr(test, mutants::skip)]
+    fn next_attached_generation(&self) -> u64 {
+        let previous = self
+            .attached_generation
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |generation| {
+                generation.checked_add(1)
+            })
+            .expect("the process cannot perform enough ownership changes to exhaust u64");
+        previous
+            .checked_add(1)
+            .expect("fetch_update only succeeds when the next generation exists")
     }
 
     /// Holds output produced before the first client attached.
@@ -416,6 +439,7 @@ where
     } = *initialized;
 
     let record_live = Arc::new(Mutex::new(true));
+    let attached_generation = Arc::new(AtomicU64::default());
     let shared = Arc::new(Shared {
         transport: transport.clone(),
         pty_host: pty_host.clone(),
@@ -423,6 +447,7 @@ where
         session_id,
         client: Mutex::new(None),
         attach: Mutex::new(()),
+        attached_generation: Arc::clone(&attached_generation),
         preamble: Mutex::new(Some(Vec::new())),
         first_attach: Mutex::new(FirstAttach::default()),
         first_attach_changed: Condvar::new(),
@@ -441,7 +466,12 @@ where
         }
     });
 
-    let store_flag = store_attached_flag(store, session_id, Arc::clone(&record_live));
+    let store_flag = store_attached_flag(
+        store,
+        session_id,
+        Arc::clone(&record_live),
+        attached_generation,
+    );
     thread::spawn({
         let shared = Arc::clone(&shared);
         let transport = transport.clone();
@@ -537,13 +567,14 @@ fn store_attached_flag<S: SessionStore + Clone>(
     store: &S,
     id: SessionId,
     record_live: Arc<Mutex<bool>>,
-) -> impl Fn(bool) + Clone + Send + 'static {
+    current_generation: Arc<AtomicU64>,
+) -> impl Fn(u64, bool) + Clone + Send + 'static {
     let store = store.clone();
-    move |attached: bool| {
+    move |generation: u64, attached: bool| {
         let live = record_live
             .lock()
             .expect("record_live is only set false at delete, never held across a panic");
-        if !*live {
+        if !*live || current_generation.load(Ordering::SeqCst) != generation {
             return;
         }
         if let Ok(Some(mut record)) = store.read(id) {
@@ -562,7 +593,7 @@ fn accept_loop<T, C>(
     shared: &Arc<Shared<T, C>>,
     transport: &T,
     listener: ListenerId,
-    set_attached: impl Fn(bool) + Clone + Send + 'static,
+    set_attached: impl Fn(u64, bool) + Clone + Send + 'static,
 ) where
     T: Transport + Clone,
     C: Pseudoconsole,
@@ -585,7 +616,7 @@ fn accept_loop<T, C>(
 // Blocking recv. A mutation that drops the disconnect path hangs unit tests
 // because watchdogs are disabled under cargo-mutants.
 #[cfg_attr(test, mutants::skip)]
-fn client_loop<T, C>(shared: &Shared<T, C>, conn: ConnId, set_attached: &impl Fn(bool))
+fn client_loop<T, C>(shared: &Shared<T, C>, conn: ConnId, set_attached: &impl Fn(u64, bool))
 where
     T: Transport + Clone,
     C: Pseudoconsole,
@@ -611,7 +642,7 @@ where
                 return;
             }
             let outbox = Outbox::start(shared.transport.clone(), conn);
-            let previous = {
+            let (previous, generation) = {
                 let mut slot = shared.client();
                 // Acknowledging under the client slot keeps `Attached` ahead of
                 // any `Output` on this connection, and installing in the same
@@ -639,10 +670,12 @@ where
                         outbox.send(message);
                     }
                 }
-                slot.replace(Client {
+                let previous = slot.replace(Client {
                     conn,
                     outbox: Arc::clone(&outbox),
-                })
+                });
+                let generation = shared.next_attached_generation();
+                (previous, generation)
             };
             // The client owns the slot now, so an app that already exited can
             // finish serving it. The advisory store update below may perform
@@ -677,7 +710,7 @@ where
             // stalled durable write must not prevent teardown or another client
             // from acquiring the attach lock.
             drop(_attach);
-            set_attached(true);
+            set_attached(generation, true);
         }
         _ => {
             shared.transport.disconnect(conn);
@@ -711,18 +744,21 @@ where
         }
         drop(slot);
     }
-    let departing = {
+    let (departing, generation) = {
         let mut slot = shared.client();
         if slot.as_ref().map(|client| client.conn) == Some(conn) {
             let departing = slot.take();
-            // Holding the slot so a replacement cannot publish attached=true
-            // before this disconnect publishes attached=false.
-            set_attached(false);
-            departing
+            let generation = shared.next_attached_generation();
+            (departing, Some(generation))
         } else {
-            None
+            (None, None)
         }
     };
+    if let Some(generation) = generation {
+        // Store I/O is serialized by generation rather than by the client slot.
+        // A stalled advisory write therefore cannot block ownership transfer.
+        set_attached(generation, false);
+    }
     if let Some(departing) = departing {
         // The peer is gone or misbehaving, so nothing still queued for it is
         // worth waiting on.
@@ -1766,6 +1802,7 @@ mod tests {
             session_id: SessionId::from_u32(1).unwrap(),
             client: Mutex::new(None),
             attach: Mutex::new(()),
+            attached_generation: Arc::new(AtomicU64::default()),
             preamble: Mutex::new(Some(Vec::new())),
             first_attach: Mutex::new(FirstAttach::default()),
             first_attach_changed: Condvar::new(),
@@ -1787,11 +1824,13 @@ mod tests {
     }
 
     /// Records every attached-flag publication in order.
-    fn attach_recorder() -> (Arc<Mutex<Vec<bool>>>, impl Fn(bool)) {
+    fn attach_recorder() -> (Arc<Mutex<Vec<bool>>>, impl Fn(u64, bool)) {
         let flags = Arc::new(Mutex::new(Vec::new()));
         let recorder = {
             let flags = Arc::clone(&flags);
-            move |attached: bool| flags.lock().expect("flag lock").push(attached)
+            move |_generation: u64, attached: bool| {
+                flags.lock().expect("flag lock").push(attached);
+            }
         };
         (flags, recorder)
     }
@@ -1831,7 +1870,7 @@ mod tests {
             let relay = thread::spawn({
                 let shared = Arc::clone(&shared);
                 move || {
-                    client_loop(&shared, supervisor, &|attached| {
+                    client_loop(&shared, supervisor, &|_generation, attached| {
                         attached_tx.send(attached).unwrap();
                     });
                 }
@@ -1855,6 +1894,101 @@ mod tests {
             phases.set("waiting for the client relay to stop");
             relay.join().unwrap();
             assert!(!attached_rx.recv().unwrap());
+        });
+    }
+
+    #[test]
+    fn a_stalled_detach_update_does_not_block_or_overwrite_a_steal() {
+        with_watchdog_phases("setting up the client relays", |phases| {
+            let transport = MemoryTransport::new();
+            let pty_host = MemoryPseudoconsole::new();
+            let shared = Arc::new(shared_session(&transport, &pty_host));
+            let store = MemorySessionStore::new();
+            let owner = ProcessIdentity::for_test(1);
+            let id = store.allocate_id(&owner).unwrap();
+            assert_eq!(id, shared.session_id);
+            store
+                .publish(&SessionRecord {
+                    id: id.get(),
+                    supervisor_pid: owner.pid,
+                    supervisor_creation_time: owner.creation_time,
+                    pipe_name: "pipe".to_string(),
+                    launch_directory: PathBuf::from("/work"),
+                    command: vec!["app.exe".to_string()],
+                    started_at_unix_ms: 1,
+                    attached: false,
+                })
+                .unwrap();
+            let record_live = Arc::new(Mutex::new(true));
+            let set_attached = store_attached_flag(
+                &store,
+                id,
+                record_live,
+                Arc::clone(&shared.attached_generation),
+            );
+            let (updated_tx, updated_rx) = mpsc::channel();
+            let observe_update = move |generation, attached| {
+                set_attached(generation, attached);
+                updated_tx.send(attached).unwrap();
+            };
+
+            let (first_supervisor, first_client) = connected_pair(&transport, "first");
+            let first_relay = thread::spawn({
+                let shared = Arc::clone(&shared);
+                let observe_update = observe_update.clone();
+                move || client_loop(&shared, first_supervisor, &observe_update)
+            });
+            transport
+                .send(first_client, &Message::Attach { cols: 80, rows: 24 })
+                .unwrap();
+            phases.set("waiting for the first attach acknowledgement");
+            assert!(matches!(
+                transport.recv(first_client).unwrap(),
+                Message::Attached { .. }
+            ));
+            phases.set("waiting for the first attached-flag update");
+            assert!(updated_rx.recv().unwrap());
+
+            store.stall_publishes();
+            transport.disconnect(first_client);
+            phases.set("waiting for the detached-flag update to stall");
+            store.wait_for_stalled_publish();
+
+            let (second_supervisor, second_client) = connected_pair(&transport, "second");
+            let second_relay = thread::spawn({
+                let shared = Arc::clone(&shared);
+                move || client_loop(&shared, second_supervisor, &observe_update)
+            });
+            transport
+                .send(
+                    second_client,
+                    &Message::Attach {
+                        cols: 100,
+                        rows: 30,
+                    },
+                )
+                .unwrap();
+            // The first relay is blocked in store I/O. Receiving this proves it
+            // released the client slot before publishing the advisory flag.
+            phases.set("waiting for the stealing attach acknowledgement");
+            assert!(matches!(
+                transport.recv(second_client).unwrap(),
+                Message::Attached { .. }
+            ));
+
+            store.resume_publishes();
+            phases.set("waiting for the stalled detach and newer attach updates");
+            let completed = [updated_rx.recv().unwrap(), updated_rx.recv().unwrap()];
+            assert!(completed.contains(&false));
+            assert!(completed.contains(&true));
+            first_relay.join().unwrap();
+            assert!(store.read(id).unwrap().unwrap().attached);
+
+            transport.disconnect(second_client);
+            phases.set("waiting for the final detach update");
+            assert!(!updated_rx.recv().unwrap());
+            second_relay.join().unwrap();
+            assert!(!store.read(id).unwrap().unwrap().attached);
         });
     }
 
@@ -1957,7 +2091,7 @@ mod tests {
             let shared = Arc::clone(&shared);
             let successor_outbox = Arc::clone(&successor_outbox);
             let displaced = Arc::clone(&displaced);
-            move |attached: bool| {
+            move |_generation: u64, attached: bool| {
                 if attached {
                     let previous = shared.client().replace(Client {
                         conn: successor,
@@ -2084,7 +2218,7 @@ mod tests {
     }
 
     #[test]
-    fn attached_flag_publishes_only_while_the_record_lives() {
+    fn attached_flag_publishes_only_the_current_generation_while_the_record_lives() {
         let store = MemorySessionStore::new();
         let id = store.allocate_id(&ProcessIdentity::for_test(1)).unwrap();
         store
@@ -2101,12 +2235,22 @@ mod tests {
             .unwrap();
 
         let record_live = Arc::new(Mutex::new(true));
-        let set_attached = store_attached_flag(&store, id, Arc::clone(&record_live));
-        set_attached(true);
+        let current_generation = Arc::new(AtomicU64::new(2));
+        let set_attached = store_attached_flag(
+            &store,
+            id,
+            Arc::clone(&record_live),
+            Arc::clone(&current_generation),
+        );
+        set_attached(1, true);
+        assert!(!store.read(id).unwrap().unwrap().attached);
+
+        set_attached(2, true);
         assert!(store.read(id).unwrap().unwrap().attached);
 
         *record_live.lock().expect("record_live lock") = false;
-        set_attached(false);
+        current_generation.store(3, Ordering::SeqCst);
+        set_attached(3, false);
         assert!(store.read(id).unwrap().unwrap().attached);
     }
 }

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -267,7 +267,9 @@ struct Shared<T: Transport, C> {
     /// client. Taken under the client slot, which is what orders it ahead of
     /// the output that follows the attach.
     preamble: Mutex<Option<Vec<u8>>>,
-    /// Gate that holds the session open until somebody has come for it.
+    /// The supervisor's first-attach lifetime gate.
+    ///
+    /// Holds an exited app's session open until somebody has come for it.
     first_attach: Mutex<FirstAttach>,
     first_attach_changed: Condvar,
     stopping: AtomicBool,
@@ -288,7 +290,7 @@ impl<T: Transport> Clone for Client<T> {
     }
 }
 
-/// Whether the session has been claimed, and whether anyone is still coming.
+/// State of the supervisor's first-attach lifetime gate.
 ///
 /// An app that exits immediately would otherwise be torn down before `dure run`
 /// finishes attaching, losing both its output and its exit status. The
@@ -677,9 +679,10 @@ where
                 let generation = shared.next_attached_generation();
                 (previous, generation)
             };
-            // The client owns the slot now, so an app that already exited can
-            // finish serving it. The advisory store update below may perform
-            // durable I/O and must not delay that lifetime signal.
+            // The client owns the slot now. Signaling the supervisor's
+            // first-attach lifetime gate lets it finish delivering an
+            // already-exited app's output and status before the advisory store
+            // update below can encounter durable I/O.
             shared.note_attached();
             if let Some(old) = previous {
                 // Queued rather than written here, so a client that stopped
@@ -806,7 +809,7 @@ mod tests {
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::thread;
 
-    use testing::{WatchdogPhases, with_watchdog_phases};
+    use testing::{WatchdogPhaseReporter, with_watchdog_phases};
 
     use super::*;
     use crate::durability::Durability;
@@ -820,6 +823,9 @@ mod tests {
     /// Arbitrary nonzero status the mock app exits with, so a test can tell a
     /// forwarded status from a defaulted one.
     const SAMPLE_APP_EXIT: i32 = 7;
+
+    /// Ordinary valid geometry for tests where resize behavior is out of scope.
+    const ORDINARY_ATTACH: Message = Message::Attach { cols: 80, rows: 24 };
 
     /// Shared stateful session store for supervisor unit tests.
     ///
@@ -898,18 +904,19 @@ mod tests {
 
     impl SessionStore for MemorySessionStore {
         fn root(&self) -> PathBuf {
-            PathBuf::new()
+            // Supervisor tests receive prepared paths and never query store path support.
+            panic!("supervisor tests do not query the session store root")
         }
 
         fn allocate_id(&self, owner: &ProcessIdentity) -> Result<SessionId, PalError> {
             let mut records = self.inner.records.lock().unwrap();
             let mut id = SessionId::MIN;
             while records.contains_key(&id) {
-                let raw = id
+                id = id
                     .get()
                     .checked_add(1)
+                    .and_then(SessionId::from_u32)
                     .ok_or_else(|| PalError::new(PalErrorKind::Other))?;
-                id = SessionId::from_u32(raw).ok_or_else(|| PalError::new(PalErrorKind::Other))?;
             }
             records.insert(id, StoredSession::Reserved { owner: *owner });
             Ok(id)
@@ -970,12 +977,14 @@ mod tests {
             Ok(())
         }
 
-        fn canonicalize(&self, path: &Path) -> Result<PathBuf, PalError> {
-            Ok(path.to_path_buf())
+        fn canonicalize(&self, _path: &Path) -> Result<PathBuf, PalError> {
+            // Supervisor tests receive prepared paths and never query store path support.
+            panic!("supervisor tests do not canonicalize paths through the session store")
         }
 
         fn current_dir(&self) -> Result<PathBuf, PalError> {
-            Ok(PathBuf::new())
+            // Supervisor tests receive prepared paths and never query store path support.
+            panic!("supervisor tests do not query the current directory")
         }
     }
 
@@ -983,11 +992,11 @@ mod tests {
     fn commit_startup(
         transport: &MemoryTransport,
         listener: ListenerId,
-        phases: &WatchdogPhases,
+        phase_reporter: &WatchdogPhaseReporter,
     ) -> (ConnId, SessionId, Durability) {
-        phases.set("waiting for the supervisor startup connection");
+        phase_reporter.report("waiting for the supervisor startup connection");
         let conn = transport.accept(listener).unwrap();
-        phases.set("waiting for the supervisor startup response");
+        phase_reporter.report("waiting for the supervisor startup response");
         let Message::StartupOk {
             session_id,
             durability,
@@ -1060,7 +1069,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn steal_displaces_first_client() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1085,36 +1094,26 @@ mod tests {
             });
 
             let (startup_conn, session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
             transport.disconnect(startup_conn);
 
             let pipe = transport.pipe_name("nonce");
             let first = transport.connect(&pipe, CONNECT_TIMEOUT).unwrap();
-            transport
-                .send(first, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            phases.set("waiting for the first attach acknowledgement");
+            transport.send(first, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the first attach acknowledgement");
             assert!(matches!(
                 transport.recv(first).unwrap(),
                 Message::Attached { session_id: id } if id == session_id
             ));
 
             let second = transport.connect(&pipe, CONNECT_TIMEOUT).unwrap();
-            transport
-                .send(
-                    second,
-                    &Message::Attach {
-                        cols: 100,
-                        rows: 30,
-                    },
-                )
-                .unwrap();
-            phases.set("waiting for the second attach acknowledgement");
+            transport.send(second, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the second attach acknowledgement");
             assert!(matches!(
                 transport.recv(second).unwrap(),
                 Message::Attached { .. }
             ));
-            phases.set("waiting for the displacement notice");
+            phase_reporter.report("waiting for the displacement notice");
             assert!(matches!(transport.recv(first).unwrap(), Message::Displaced));
 
             {
@@ -1122,7 +1121,7 @@ mod tests {
                 *lock.lock().expect("exit lock") = true;
                 cvar.notify_all();
             }
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
             assert!(store.list().unwrap().is_empty());
         });
@@ -1132,7 +1131,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn final_output_arrives_before_the_exit_status() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1157,16 +1156,14 @@ mod tests {
             });
 
             let (startup_conn, _session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
             transport.disconnect(startup_conn);
 
             let client = transport
                 .connect(&transport.pipe_name("nonce"), CONNECT_TIMEOUT)
                 .unwrap();
-            transport
-                .send(client, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            phases.set("waiting for the attach acknowledgement");
+            transport.send(client, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
@@ -1187,19 +1184,19 @@ mod tests {
                 cvar.notify_all();
             }
 
-            phases.set("waiting for final app output");
+            phase_reporter.report("waiting for final app output");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::Output(b"bye".to_vec())
             );
-            phases.set("waiting for the app exit status");
+            phase_reporter.report("waiting for the app exit status");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::AppExited {
                     status: SAMPLE_APP_EXIT
                 }
             );
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
         });
     }
@@ -1208,7 +1205,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn an_app_that_exits_before_anyone_attaches_still_reports_its_status() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1233,29 +1230,27 @@ mod tests {
             });
 
             let (startup_conn, _session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
 
             // The startup connection stays open, which is what holds the
             // session up for the attach that `dure run` is about to make.
             let client = transport
                 .connect(&transport.pipe_name("nonce"), CONNECT_TIMEOUT)
                 .unwrap();
-            transport
-                .send(client, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            phases.set("waiting for the attach acknowledgement");
+            transport.send(client, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
             ));
-            phases.set("waiting for the app exit status");
+            phase_reporter.report("waiting for the app exit status");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::AppExited {
                     status: SAMPLE_APP_EXIT
                 }
             );
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
             transport.disconnect(startup_conn);
         });
@@ -1265,7 +1260,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_stalled_attached_flag_does_not_delay_the_exit_status() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1275,6 +1270,9 @@ mod tests {
             let processes =
                 mock_processes_with_close_job(exit, Durability::Durable, AppWait::Reports, {
                     let store = store.clone();
+                    // Hold teardown after the first-attach lifetime gate opens
+                    // but before it claims the client slot and invalidates the
+                    // record, so the advisory write reaches its injected stall.
                     move |_| store.wait_for_stalled_publish()
                 });
 
@@ -1296,27 +1294,25 @@ mod tests {
             });
 
             let (startup_conn, _session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
             store.stall_publishes();
 
             let client = transport
                 .connect(&transport.pipe_name("nonce"), CONNECT_TIMEOUT)
                 .unwrap();
-            transport
-                .send(client, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            phases.set("waiting for the attach acknowledgement");
+            transport.send(client, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
             ));
 
-            phases.set("waiting for the attached-flag publication to stall");
+            phase_reporter.report("waiting for the attached-flag publication to stall");
             store.wait_for_stalled_publish();
             // Reaching the exit status proves both that the first-attach signal
             // preceded the advisory write and that teardown acquired the attach
             // lock while the write remained stalled.
-            phases.set("waiting for the app exit status");
+            phase_reporter.report("waiting for the app exit status");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::AppExited {
@@ -1326,7 +1322,7 @@ mod tests {
 
             store.resume_publishes();
             transport.disconnect(client);
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
             transport.disconnect(startup_conn);
             assert!(store.list().unwrap().is_empty());
@@ -1337,7 +1333,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_session_nobody_comes_for_ends_when_its_initiator_gives_up() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1362,10 +1358,10 @@ mod tests {
             });
 
             let (startup_conn, _session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
             // Nobody will ever attach, so the gate must open on this instead.
             transport.disconnect(startup_conn);
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
             assert!(store.list().unwrap().is_empty());
         });
@@ -1379,7 +1375,7 @@ mod tests {
     }
 
     fn assert_rejected_startup_rolls_back(rejection: RejectedStartup) {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1403,9 +1399,9 @@ mod tests {
                 }
             });
 
-            phases.set("waiting for the supervisor startup connection");
+            phase_reporter.report("waiting for the supervisor startup connection");
             let startup_conn = transport.accept(startup).unwrap();
-            phases.set("waiting for the supervisor startup response");
+            phase_reporter.report("waiting for the supervisor startup response");
             assert!(matches!(
                 transport.recv(startup_conn).unwrap(),
                 Message::StartupOk { .. }
@@ -1423,7 +1419,7 @@ mod tests {
                 RejectedStartup::Timeout => transport.timeout_next_recv(),
             }
 
-            phases.set("waiting for startup rollback");
+            phase_reporter.report("waiting for startup rollback");
             let error = supervisor.join().unwrap().unwrap_err();
             assert!(error.find_source::<StartupFailedError>().is_some());
             assert!(store.list().unwrap().is_empty());
@@ -1458,7 +1454,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn failure_to_send_startup_ok_rolls_back() {
-        with_watchdog_phases("running the rejected startup", |_phases| {
+        with_watchdog_phases("running the rejected startup", |_phase_reporter| {
             let transport = MemoryTransport::new();
             transport.fail_next_send();
             let pty = MemoryPseudoconsole::new();
@@ -1485,7 +1481,7 @@ mod tests {
 
     #[test]
     fn init_failure_sends_startup_err_and_closes_job() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1518,11 +1514,11 @@ mod tests {
                 }
             });
 
-            phases.set("waiting for the supervisor startup connection");
+            phase_reporter.report("waiting for the supervisor startup connection");
             let startup_conn = transport.accept(startup).unwrap();
-            phases.set("waiting for the startup error");
+            phase_reporter.report("waiting for the startup error");
             assert_eq!(transport.recv(startup_conn).unwrap(), Message::StartupErr);
-            phases.set("waiting for startup rollback");
+            phase_reporter.report("waiting for startup rollback");
             supervisor.join().unwrap().unwrap_err();
             assert!(store.list().unwrap().is_empty());
         });
@@ -1532,7 +1528,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_supervisor_that_cannot_outlive_its_launcher_says_so_on_the_startup_pipe() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
@@ -1561,7 +1557,7 @@ mod tests {
 
             // Only the client has a console to report this on.
             let (startup_conn, _session_id, durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
             assert_eq!(durability, Durability::TiedToLauncher);
             transport.disconnect(startup_conn);
             {
@@ -1569,7 +1565,7 @@ mod tests {
                 *lock.lock().expect("exit lock") = true;
                 cvar.notify_all();
             }
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             supervisor.join().unwrap().unwrap();
         });
     }
@@ -1578,7 +1574,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_wait_that_fails_still_takes_the_session_off_the_host() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
@@ -1604,7 +1600,7 @@ mod tests {
             });
 
             let (startup_conn, _session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
             assert_eq!(store.list().unwrap().len(), 1, "the session was published");
             transport.disconnect(startup_conn);
             {
@@ -1613,7 +1609,7 @@ mod tests {
                 cvar.notify_all();
             }
 
-            phases.set("waiting for failed-wait cleanup");
+            phase_reporter.report("waiting for failed-wait cleanup");
             supervisor.join().unwrap().unwrap_err();
             // The wait is the only thing that failed, so everything the session
             // put on the host is still the session's to take back.
@@ -1636,7 +1632,7 @@ mod tests {
     // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn output_produced_before_the_first_attach_reaches_that_client() {
-        with_watchdog_phases("setting up the supervisor", |phases| {
+        with_watchdog_phases("setting up the supervisor", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
             let store = MemorySessionStore::new();
@@ -1661,7 +1657,7 @@ mod tests {
             });
 
             let (startup_conn, _session_id, _durability) =
-                commit_startup(&transport, startup, &phases);
+                commit_startup(&transport, startup, &phase_reporter);
 
             // The app speaks before anyone has attached, which is the window
             // `dure run` spends spawning the supervisor and connecting to it.
@@ -1673,10 +1669,8 @@ mod tests {
             let client = transport
                 .connect(&transport.pipe_name("nonce"), CONNECT_TIMEOUT)
                 .unwrap();
-            transport
-                .send(client, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            phases.set("waiting for the attach acknowledgement");
+            transport.send(client, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
@@ -1694,7 +1688,7 @@ mod tests {
             // the failure is an assertion rather than a wait with no end.
             let mut received = Vec::new();
             loop {
-                phases.set("waiting for held output or the app exit status");
+                phase_reporter.report("waiting for held output or the app exit status");
                 match transport.recv(client).unwrap() {
                     Message::Output(bytes) => received.extend(bytes),
                     Message::AppExited { status } => {
@@ -1706,7 +1700,7 @@ mod tests {
             }
             assert_eq!(received, b"hello");
 
-            phases.set("waiting for supervisor shutdown");
+            phase_reporter.report("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
         });
     }
@@ -1842,9 +1836,7 @@ mod tests {
         let shared = shared_session(&transport, &pty_host);
         let (supervisor, client) = connected_pair(&transport, "pipe");
 
-        transport
-            .send(client, &Message::Attach { cols: 80, rows: 24 })
-            .unwrap();
+        transport.send(client, &ORDINARY_ATTACH).unwrap();
         transport.disconnect(client);
 
         let (flags, recorder) = attach_recorder();
@@ -1856,17 +1848,15 @@ mod tests {
 
     #[test]
     fn a_stalled_attach_acknowledgement_does_not_signal_attachment() {
-        with_watchdog_phases("setting up the client relay", |phases| {
+        with_watchdog_phases("setting up the client relay", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty_host = MemoryPseudoconsole::new();
             let shared = Arc::new(shared_session(&transport, &pty_host));
             let (supervisor, client) = connected_pair(&transport, "pipe");
 
             let (attached_tx, attached_rx) = mpsc::channel();
-            transport
-                .send(client, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            transport.stall_sends();
+            transport.send(client, &ORDINARY_ATTACH).unwrap();
+            transport.stall(supervisor);
             let relay = thread::spawn({
                 let shared = Arc::clone(&shared);
                 move || {
@@ -1876,22 +1866,22 @@ mod tests {
                 }
             });
 
-            phases.set("waiting for the attach acknowledgement to stall");
-            transport.wait_for_stalled_send();
+            phase_reporter.report("waiting for the attach acknowledgement to stall");
+            transport.wait_for_stalled_send(supervisor);
             assert!(!shared.first_attach().attached);
 
-            transport.resume_sends();
-            phases.set("waiting for the attach acknowledgement");
+            transport.resume(supervisor);
+            phase_reporter.report("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
             ));
-            phases.set("waiting for the attached-flag update");
+            phase_reporter.report("waiting for the attached-flag update");
             assert!(attached_rx.recv().unwrap());
             assert!(shared.first_attach().attached);
 
             transport.send(client, &Message::StartupErr).unwrap();
-            phases.set("waiting for the client relay to stop");
+            phase_reporter.report("waiting for the client relay to stop");
             relay.join().unwrap();
             assert!(!attached_rx.recv().unwrap());
         });
@@ -1899,7 +1889,7 @@ mod tests {
 
     #[test]
     fn a_stalled_detach_update_does_not_block_or_overwrite_a_steal() {
-        with_watchdog_phases("setting up the client relays", |phases| {
+        with_watchdog_phases("setting up the client relays", |phase_reporter| {
             let transport = MemoryTransport::new();
             let pty_host = MemoryPseudoconsole::new();
             let shared = Arc::new(shared_session(&transport, &pty_host));
@@ -1938,20 +1928,18 @@ mod tests {
                 let observe_update = observe_update.clone();
                 move || client_loop(&shared, first_supervisor, &observe_update)
             });
-            transport
-                .send(first_client, &Message::Attach { cols: 80, rows: 24 })
-                .unwrap();
-            phases.set("waiting for the first attach acknowledgement");
+            transport.send(first_client, &ORDINARY_ATTACH).unwrap();
+            phase_reporter.report("waiting for the first attach acknowledgement");
             assert!(matches!(
                 transport.recv(first_client).unwrap(),
                 Message::Attached { .. }
             ));
-            phases.set("waiting for the first attached-flag update");
+            phase_reporter.report("waiting for the first attached-flag update");
             assert!(updated_rx.recv().unwrap());
 
             store.stall_publishes();
             transport.disconnect(first_client);
-            phases.set("waiting for the detached-flag update to stall");
+            phase_reporter.report("waiting for the detached-flag update to stall");
             store.wait_for_stalled_publish();
 
             let (second_supervisor, second_client) = connected_pair(&transport, "second");
@@ -1959,25 +1947,17 @@ mod tests {
                 let shared = Arc::clone(&shared);
                 move || client_loop(&shared, second_supervisor, &observe_update)
             });
-            transport
-                .send(
-                    second_client,
-                    &Message::Attach {
-                        cols: 100,
-                        rows: 30,
-                    },
-                )
-                .unwrap();
+            transport.send(second_client, &ORDINARY_ATTACH).unwrap();
             // The first relay is blocked in store I/O. Receiving this proves it
             // released the client slot before publishing the advisory flag.
-            phases.set("waiting for the stealing attach acknowledgement");
+            phase_reporter.report("waiting for the stealing attach acknowledgement");
             assert!(matches!(
                 transport.recv(second_client).unwrap(),
                 Message::Attached { .. }
             ));
 
             store.resume_publishes();
-            phases.set("waiting for the stalled detach and newer attach updates");
+            phase_reporter.report("waiting for the stalled detach and newer attach updates");
             let completed = [updated_rx.recv().unwrap(), updated_rx.recv().unwrap()];
             assert!(completed.contains(&false));
             assert!(completed.contains(&true));
@@ -1985,7 +1965,7 @@ mod tests {
             assert!(store.read(id).unwrap().unwrap().attached);
 
             transport.disconnect(second_client);
-            phases.set("waiting for the final detach update");
+            phase_reporter.report("waiting for the final detach update");
             assert!(!updated_rx.recv().unwrap());
             second_relay.join().unwrap();
             assert!(!store.read(id).unwrap().unwrap().attached);
@@ -2002,9 +1982,7 @@ mod tests {
         // slot, so there is nothing left for a new client to be given.
         shared.stopping.store(true, Ordering::SeqCst);
 
-        transport
-            .send(client, &Message::Attach { cols: 80, rows: 24 })
-            .unwrap();
+        transport.send(client, &ORDINARY_ATTACH).unwrap();
 
         let (flags, recorder) = attach_recorder();
         client_loop(&shared, supervisor, &recorder);
@@ -2043,9 +2021,7 @@ mod tests {
         let shared = shared_session(&transport, &pty_host);
         let (supervisor, client) = connected_pair(&transport, "pipe");
 
-        transport
-            .send(client, &Message::Attach { cols: 80, rows: 24 })
-            .unwrap();
+        transport.send(client, &ORDINARY_ATTACH).unwrap();
         transport
             .send(
                 client,
@@ -2106,9 +2082,7 @@ mod tests {
             }
         };
 
-        transport
-            .send(client, &Message::Attach { cols: 80, rows: 24 })
-            .unwrap();
+        transport.send(client, &ORDINARY_ATTACH).unwrap();
         transport
             .send(client, &Message::Input(b"x".to_vec()))
             .unwrap();

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -804,11 +804,11 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::thread;
 
+    use memory_session_store::MemorySessionStore;
     use testing::{WatchdogPhaseReporter, with_watchdog_phases};
 
     use super::*;
@@ -818,7 +818,7 @@ mod tests {
     use crate::pal::pseudoconsole::MemoryPseudoconsole;
     use crate::pal::transport::MemoryTransport;
     use crate::protocol::{Message, encode, payload_len_ok};
-    use crate::session_record::{ProcessIdentity, StoredSession};
+    use crate::session_record::ProcessIdentity;
 
     /// Arbitrary nonzero status the mock app exits with, so a test can tell a
     /// forwarded status from a defaulted one.
@@ -826,167 +826,6 @@ mod tests {
 
     /// Ordinary valid geometry for tests where resize behavior is out of scope.
     const ORDINARY_ATTACH: Message = Message::Attach { cols: 80, rows: 24 };
-
-    /// Shared stateful session store for supervisor unit tests.
-    ///
-    /// Supervisor tests exercise synchronization among the process, transport,
-    /// pseudoconsole, and store boundaries. Keeping records in memory ensures a
-    /// filesystem flush cannot consume the watchdog intended to diagnose those
-    /// synchronization paths.
-    #[derive(Clone, Debug, Default)]
-    struct MemorySessionStore {
-        inner: Arc<MemorySessionStoreInner>,
-    }
-
-    /// Record state and deterministic publish-stall coordination.
-    #[derive(Debug, Default)]
-    struct MemorySessionStoreInner {
-        records: Mutex<BTreeMap<SessionId, StoredSession>>,
-        /// Injects a publication failure after id allocation.
-        fail_next_publish: AtomicBool,
-        publish_stall: Mutex<PublishStall>,
-        publish_stall_changed: Condvar,
-    }
-
-    /// Gate used to park store publications at a known point in a test.
-    #[derive(Debug, Default)]
-    struct PublishStall {
-        enabled: bool,
-        waiting: usize,
-    }
-
-    impl MemorySessionStore {
-        fn new() -> Self {
-            Self::default()
-        }
-
-        fn stall_publishes(&self) {
-            let mut stall = self.inner.publish_stall.lock().unwrap();
-            assert!(!stall.enabled);
-            stall.enabled = true;
-        }
-
-        fn fail_next_publish(&self) {
-            self.inner.fail_next_publish.store(true, Ordering::SeqCst);
-        }
-
-        fn wait_for_stalled_publish(&self) {
-            let mut stall = self.inner.publish_stall.lock().unwrap();
-            assert!(
-                stall.enabled,
-                "the publish stall must be enabled before waiting"
-            );
-            while stall.waiting == 0 {
-                stall = self.inner.publish_stall_changed.wait(stall).unwrap();
-            }
-        }
-
-        fn resume_publishes(&self) {
-            let mut stall = self.inner.publish_stall.lock().unwrap();
-            assert!(stall.enabled);
-            stall.enabled = false;
-            self.inner.publish_stall_changed.notify_all();
-        }
-
-        fn await_publish_permission(&self) {
-            let mut stall = self.inner.publish_stall.lock().unwrap();
-            if !stall.enabled {
-                return;
-            }
-            stall.waiting = stall.waiting.checked_add(1).unwrap();
-            self.inner.publish_stall_changed.notify_all();
-            while stall.enabled {
-                stall = self.inner.publish_stall_changed.wait(stall).unwrap();
-            }
-            stall.waiting = stall.waiting.checked_sub(1).unwrap();
-        }
-    }
-
-    impl SessionStore for MemorySessionStore {
-        fn root(&self) -> PathBuf {
-            // Supervisor tests receive prepared paths and never query store path support.
-            panic!("supervisor tests do not query the session store root")
-        }
-
-        fn allocate_id(&self, owner: &ProcessIdentity) -> Result<SessionId, PalError> {
-            let mut records = self.inner.records.lock().unwrap();
-            let mut id = SessionId::MIN;
-            while records.contains_key(&id) {
-                id = id
-                    .get()
-                    .checked_add(1)
-                    .and_then(SessionId::from_u32)
-                    .ok_or_else(|| PalError::new(PalErrorKind::Other))?;
-            }
-            records.insert(id, StoredSession::Reserved { owner: *owner });
-            Ok(id)
-        }
-
-        fn publish(&self, record: &SessionRecord) -> Result<(), PalError> {
-            if self.inner.fail_next_publish.swap(false, Ordering::SeqCst) {
-                return Err(PalError::new(PalErrorKind::Other));
-            }
-            self.await_publish_permission();
-            self.inner.records.lock().unwrap().insert(
-                record.session_id(),
-                StoredSession::Published(record.clone()),
-            );
-            Ok(())
-        }
-
-        fn read(&self, id: SessionId) -> Result<Option<SessionRecord>, PalError> {
-            let records = self.inner.records.lock().unwrap();
-            Ok(match records.get(&id) {
-                Some(StoredSession::Published(record)) => Some(record.clone()),
-                Some(StoredSession::Reserved { .. }) | None => None,
-            })
-        }
-
-        fn list(&self) -> Result<Vec<SessionRecord>, PalError> {
-            let records = self.inner.records.lock().unwrap();
-            Ok(records
-                .values()
-                .filter_map(|stored| match stored {
-                    StoredSession::Published(record) => Some(record.clone()),
-                    StoredSession::Reserved { .. } => None,
-                })
-                .collect())
-        }
-
-        fn list_reservations(&self) -> Result<Vec<(SessionId, ProcessIdentity)>, PalError> {
-            let records = self.inner.records.lock().unwrap();
-            Ok(records
-                .iter()
-                .filter_map(|(id, stored)| match stored {
-                    StoredSession::Reserved { owner } => Some((*id, *owner)),
-                    StoredSession::Published(_) => None,
-                })
-                .collect())
-        }
-
-        fn delete_owned_by(&self, id: SessionId, owner: &ProcessIdentity) -> Result<(), PalError> {
-            let mut records = self.inner.records.lock().unwrap();
-            let owned = match records.get(&id) {
-                Some(StoredSession::Reserved { owner: current }) => current == owner,
-                Some(StoredSession::Published(record)) => record.identity() == *owner,
-                None => false,
-            };
-            if owned {
-                records.remove(&id);
-            }
-            Ok(())
-        }
-
-        fn canonicalize(&self, _path: &Path) -> Result<PathBuf, PalError> {
-            // Supervisor tests receive prepared paths and never query store path support.
-            panic!("supervisor tests do not canonicalize paths through the session store")
-        }
-
-        fn current_dir(&self) -> Result<PathBuf, PalError> {
-            // Supervisor tests receive prepared paths and never query store path support.
-            panic!("supervisor tests do not query the current directory")
-        }
-    }
 
     /// Completes the client side of the startup commit handshake.
     fn commit_startup(
@@ -2227,4 +2066,6 @@ mod tests {
         set_attached(3, false);
         assert!(store.read(id).unwrap().unwrap().attached);
     }
+
+    mod memory_session_store;
 }

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -830,6 +830,10 @@ mod tests {
 
         fn wait_for_stalled_publish(&self) {
             let mut stall = self.inner.publish_stall.lock().unwrap();
+            assert!(
+                stall.enabled,
+                "the publish stall must be enabled before waiting"
+            );
             while stall.waiting == 0 {
                 stall = self.inner.publish_stall_changed.wait(stall).unwrap();
             }

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -529,6 +529,10 @@ where
     Ok(status)
 }
 
+// A mutation that skips a live record's update leaves the deterministic
+// store-stall test waiting for an operation that can never arrive, and
+// watchdogs are disabled under cargo-mutants.
+#[cfg_attr(test, mutants::skip)]
 fn store_attached_flag<S: SessionStore + Clone>(
     store: &S,
     id: SessionId,
@@ -640,6 +644,10 @@ where
                     outbox: Arc::clone(&outbox),
                 })
             };
+            // The client owns the slot now, so an app that already exited can
+            // finish serving it. The advisory store update below may perform
+            // durable I/O and must not delay that lifetime signal.
+            shared.note_attached();
             if let Some(old) = previous {
                 // Queued rather than written here, so a client that stopped
                 // reading cannot hold up the steal that is replacing it. The
@@ -665,8 +673,11 @@ where
             _ = shared
                 .pty_host
                 .resize(shared.pty, WindowSize { cols, rows });
+            // Store I/O is not part of the serialized ownership transfer. A
+            // stalled durable write must not prevent teardown or another client
+            // from acquiring the attach lock.
+            drop(_attach);
             set_attached(true);
-            shared.note_attached();
         }
         _ => {
             shared.transport.disconnect(conn);
@@ -754,32 +765,189 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::path::PathBuf;
-    use std::sync::{Arc, Condvar, Mutex};
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::thread;
 
-    use testing::with_watchdog;
+    use testing::{WatchdogPhases, with_watchdog_phases};
 
     use super::*;
     use crate::durability::Durability;
     use crate::pal::ids::{AppId, ConnId, JobId, ListenerId};
     use crate::pal::processes::MockProcesses;
     use crate::pal::pseudoconsole::MemoryPseudoconsole;
-    use crate::pal::session_store::FsSessionStore;
     use crate::pal::transport::MemoryTransport;
     use crate::protocol::{Message, encode, payload_len_ok};
-    use crate::session_record::ProcessIdentity;
+    use crate::session_record::{ProcessIdentity, StoredSession};
 
     /// Arbitrary nonzero status the mock app exits with, so a test can tell a
     /// forwarded status from a defaulted one.
     const SAMPLE_APP_EXIT: i32 = 7;
 
+    /// Shared stateful session store for supervisor unit tests.
+    ///
+    /// Supervisor tests exercise synchronization among the process, transport,
+    /// pseudoconsole, and store boundaries. Keeping records in memory ensures a
+    /// filesystem flush cannot consume the watchdog intended to diagnose those
+    /// synchronization paths.
+    #[derive(Clone, Debug, Default)]
+    struct MemorySessionStore {
+        inner: Arc<MemorySessionStoreInner>,
+    }
+
+    /// Record state and deterministic publish-stall coordination.
+    #[derive(Debug, Default)]
+    struct MemorySessionStoreInner {
+        records: Mutex<BTreeMap<SessionId, StoredSession>>,
+        /// Injects a publication failure after id allocation.
+        fail_next_publish: AtomicBool,
+        publish_stall: Mutex<PublishStall>,
+        publish_stall_changed: Condvar,
+    }
+
+    /// Gate used to park store publications at a known point in a test.
+    #[derive(Debug, Default)]
+    struct PublishStall {
+        enabled: bool,
+        waiting: usize,
+    }
+
+    impl MemorySessionStore {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn stall_publishes(&self) {
+            let mut stall = self.inner.publish_stall.lock().unwrap();
+            assert!(!stall.enabled);
+            stall.enabled = true;
+        }
+
+        fn fail_next_publish(&self) {
+            self.inner.fail_next_publish.store(true, Ordering::SeqCst);
+        }
+
+        fn wait_for_stalled_publish(&self) {
+            let mut stall = self.inner.publish_stall.lock().unwrap();
+            while stall.waiting == 0 {
+                stall = self.inner.publish_stall_changed.wait(stall).unwrap();
+            }
+        }
+
+        fn resume_publishes(&self) {
+            let mut stall = self.inner.publish_stall.lock().unwrap();
+            assert!(stall.enabled);
+            stall.enabled = false;
+            self.inner.publish_stall_changed.notify_all();
+        }
+
+        fn await_publish_permission(&self) {
+            let mut stall = self.inner.publish_stall.lock().unwrap();
+            if !stall.enabled {
+                return;
+            }
+            stall.waiting = stall.waiting.checked_add(1).unwrap();
+            self.inner.publish_stall_changed.notify_all();
+            while stall.enabled {
+                stall = self.inner.publish_stall_changed.wait(stall).unwrap();
+            }
+            stall.waiting = stall.waiting.checked_sub(1).unwrap();
+        }
+    }
+
+    impl SessionStore for MemorySessionStore {
+        fn root(&self) -> PathBuf {
+            PathBuf::new()
+        }
+
+        fn allocate_id(&self, owner: &ProcessIdentity) -> Result<SessionId, PalError> {
+            let mut records = self.inner.records.lock().unwrap();
+            let mut id = SessionId::MIN;
+            while records.contains_key(&id) {
+                let raw = id
+                    .get()
+                    .checked_add(1)
+                    .ok_or_else(|| PalError::new(PalErrorKind::Other))?;
+                id = SessionId::from_u32(raw).ok_or_else(|| PalError::new(PalErrorKind::Other))?;
+            }
+            records.insert(id, StoredSession::Reserved { owner: *owner });
+            Ok(id)
+        }
+
+        fn publish(&self, record: &SessionRecord) -> Result<(), PalError> {
+            if self.inner.fail_next_publish.swap(false, Ordering::SeqCst) {
+                return Err(PalError::new(PalErrorKind::Other));
+            }
+            self.await_publish_permission();
+            self.inner.records.lock().unwrap().insert(
+                record.session_id(),
+                StoredSession::Published(record.clone()),
+            );
+            Ok(())
+        }
+
+        fn read(&self, id: SessionId) -> Result<Option<SessionRecord>, PalError> {
+            let records = self.inner.records.lock().unwrap();
+            Ok(match records.get(&id) {
+                Some(StoredSession::Published(record)) => Some(record.clone()),
+                Some(StoredSession::Reserved { .. }) | None => None,
+            })
+        }
+
+        fn list(&self) -> Result<Vec<SessionRecord>, PalError> {
+            let records = self.inner.records.lock().unwrap();
+            Ok(records
+                .values()
+                .filter_map(|stored| match stored {
+                    StoredSession::Published(record) => Some(record.clone()),
+                    StoredSession::Reserved { .. } => None,
+                })
+                .collect())
+        }
+
+        fn list_reservations(&self) -> Result<Vec<(SessionId, ProcessIdentity)>, PalError> {
+            let records = self.inner.records.lock().unwrap();
+            Ok(records
+                .iter()
+                .filter_map(|(id, stored)| match stored {
+                    StoredSession::Reserved { owner } => Some((*id, *owner)),
+                    StoredSession::Published(_) => None,
+                })
+                .collect())
+        }
+
+        fn delete_owned_by(&self, id: SessionId, owner: &ProcessIdentity) -> Result<(), PalError> {
+            let mut records = self.inner.records.lock().unwrap();
+            let owned = match records.get(&id) {
+                Some(StoredSession::Reserved { owner: current }) => current == owner,
+                Some(StoredSession::Published(record)) => record.identity() == *owner,
+                None => false,
+            };
+            if owned {
+                records.remove(&id);
+            }
+            Ok(())
+        }
+
+        fn canonicalize(&self, path: &Path) -> Result<PathBuf, PalError> {
+            Ok(path.to_path_buf())
+        }
+
+        fn current_dir(&self) -> Result<PathBuf, PalError> {
+            Ok(PathBuf::new())
+        }
+    }
+
     /// Completes the client side of the startup commit handshake.
     fn commit_startup(
         transport: &MemoryTransport,
         listener: ListenerId,
+        phases: &WatchdogPhases,
     ) -> (ConnId, SessionId, Durability) {
+        phases.set("waiting for the supervisor startup connection");
         let conn = transport.accept(listener).unwrap();
+        phases.set("waiting for the supervisor startup response");
         let Message::StartupOk {
             session_id,
             durability,
@@ -809,6 +977,15 @@ mod tests {
         durability: Durability,
         wait: AppWait,
     ) -> MockProcesses {
+        mock_processes_with_close_job(exit, durability, wait, |_| {})
+    }
+
+    fn mock_processes_with_close_job(
+        exit: Arc<(Mutex<bool>, Condvar)>,
+        durability: Durability,
+        wait: AppWait,
+        close_job: impl Fn(JobId) + Send + Sync + 'static,
+    ) -> MockProcesses {
         let mut processes = MockProcesses::new();
         processes.expect_durability().returning(move || durability);
         processes
@@ -824,7 +1001,7 @@ mod tests {
         processes
             .expect_random_nonce()
             .returning(|| "nonce".to_string());
-        processes.expect_close_job().returning(|_| ());
+        processes.expect_close_job().returning(close_job);
         processes.expect_wait_app().returning(move |_| {
             let (lock, cvar) = &*exit;
             let mut done = lock.lock().expect("exit lock");
@@ -840,20 +1017,20 @@ mod tests {
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn steal_displaces_first_client() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let processes = mock_processes(Arc::clone(&exit));
 
             let startup = transport.listen("startup").unwrap();
             let supervisor = thread::spawn({
                 let transport = transport.clone();
+                let store = store.clone();
                 move || {
                     run_supervisor(
                         &processes,
@@ -867,7 +1044,8 @@ mod tests {
                 }
             });
 
-            let (startup_conn, session_id, _durability) = commit_startup(&transport, startup);
+            let (startup_conn, session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
             transport.disconnect(startup_conn);
 
             let pipe = transport.pipe_name("nonce");
@@ -875,6 +1053,7 @@ mod tests {
             transport
                 .send(first, &Message::Attach { cols: 80, rows: 24 })
                 .unwrap();
+            phases.set("waiting for the first attach acknowledgement");
             assert!(matches!(
                 transport.recv(first).unwrap(),
                 Message::Attached { session_id: id } if id == session_id
@@ -890,10 +1069,12 @@ mod tests {
                     },
                 )
                 .unwrap();
+            phases.set("waiting for the second attach acknowledgement");
             assert!(matches!(
                 transport.recv(second).unwrap(),
                 Message::Attached { .. }
             ));
+            phases.set("waiting for the displacement notice");
             assert!(matches!(transport.recv(first).unwrap(), Message::Displaced));
 
             {
@@ -901,21 +1082,20 @@ mod tests {
                 *lock.lock().expect("exit lock") = true;
                 cvar.notify_all();
             }
+            phases.set("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
-            let leftover = FsSessionStore::new(dir.path().to_path_buf());
-            assert!(leftover.list().unwrap().is_empty());
+            assert!(store.list().unwrap().is_empty());
         });
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn final_output_arrives_before_the_exit_status() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let processes = mock_processes(Arc::clone(&exit));
 
@@ -936,7 +1116,8 @@ mod tests {
                 }
             });
 
-            let (startup_conn, _session_id, _durability) = commit_startup(&transport, startup);
+            let (startup_conn, _session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
             transport.disconnect(startup_conn);
 
             let client = transport
@@ -945,6 +1126,7 @@ mod tests {
             transport
                 .send(client, &Message::Attach { cols: 80, rows: 24 })
                 .unwrap();
+            phases.set("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
@@ -965,29 +1147,31 @@ mod tests {
                 cvar.notify_all();
             }
 
+            phases.set("waiting for final app output");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::Output(b"bye".to_vec())
             );
+            phases.set("waiting for the app exit status");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::AppExited {
                     status: SAMPLE_APP_EXIT
                 }
             );
+            phases.set("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
         });
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn an_app_that_exits_before_anyone_attaches_still_reports_its_status() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             // The app is already gone by the time the supervisor waits on it.
             let exit = Arc::new((Mutex::new(true), Condvar::new()));
             let processes = mock_processes(Arc::clone(&exit));
@@ -1008,7 +1192,8 @@ mod tests {
                 }
             });
 
-            let (startup_conn, _session_id, _durability) = commit_startup(&transport, startup);
+            let (startup_conn, _session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
 
             // The startup connection stays open, which is what holds the
             // session up for the attach that `dure run` is about to make.
@@ -1018,36 +1203,45 @@ mod tests {
             transport
                 .send(client, &Message::Attach { cols: 80, rows: 24 })
                 .unwrap();
+            phases.set("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
             ));
+            phases.set("waiting for the app exit status");
             assert_eq!(
                 transport.recv(client).unwrap(),
                 Message::AppExited {
                     status: SAMPLE_APP_EXIT
                 }
             );
+            phases.set("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
             transport.disconnect(startup_conn);
         });
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
-    fn a_session_nobody_comes_for_ends_when_its_initiator_gives_up() {
-        with_watchdog(|| {
+    fn a_stalled_attached_flag_does_not_delay_the_exit_status() {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
+            // The app is already gone, so attaching must immediately release
+            // the supervisor to report its status.
             let exit = Arc::new((Mutex::new(true), Condvar::new()));
-            let processes = mock_processes(Arc::clone(&exit));
+            let processes =
+                mock_processes_with_close_job(exit, Durability::Durable, AppWait::Reports, {
+                    let store = store.clone();
+                    move |_| store.wait_for_stalled_publish()
+                });
 
             let startup = transport.listen("startup").unwrap();
             let supervisor = thread::spawn({
                 let transport = transport.clone();
+                let store = store.clone();
                 move || {
                     run_supervisor(
                         &processes,
@@ -1061,13 +1255,79 @@ mod tests {
                 }
             });
 
-            let (startup_conn, _session_id, _durability) = commit_startup(&transport, startup);
+            let (startup_conn, _session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
+            store.stall_publishes();
+
+            let client = transport
+                .connect(&transport.pipe_name("nonce"), CONNECT_TIMEOUT)
+                .unwrap();
+            transport
+                .send(client, &Message::Attach { cols: 80, rows: 24 })
+                .unwrap();
+            phases.set("waiting for the attach acknowledgement");
+            assert!(matches!(
+                transport.recv(client).unwrap(),
+                Message::Attached { .. }
+            ));
+
+            phases.set("waiting for the attached-flag publication to stall");
+            store.wait_for_stalled_publish();
+            // Reaching the exit status proves both that the first-attach signal
+            // preceded the advisory write and that teardown acquired the attach
+            // lock while the write remained stalled.
+            phases.set("waiting for the app exit status");
+            assert_eq!(
+                transport.recv(client).unwrap(),
+                Message::AppExited {
+                    status: SAMPLE_APP_EXIT
+                }
+            );
+
+            store.resume_publishes();
+            transport.disconnect(client);
+            phases.set("waiting for supervisor shutdown");
+            assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
+            transport.disconnect(startup_conn);
+            assert!(store.list().unwrap().is_empty());
+        });
+    }
+
+    #[test]
+    // Building the session record reads the real system clock.
+    #[cfg_attr(miri, ignore)]
+    fn a_session_nobody_comes_for_ends_when_its_initiator_gives_up() {
+        with_watchdog_phases("setting up the supervisor", |phases| {
+            let transport = MemoryTransport::new();
+            let pty = MemoryPseudoconsole::new();
+            let store = MemorySessionStore::new();
+            let exit = Arc::new((Mutex::new(true), Condvar::new()));
+            let processes = mock_processes(Arc::clone(&exit));
+
+            let startup = transport.listen("startup").unwrap();
+            let supervisor = thread::spawn({
+                let transport = transport.clone();
+                let store = store.clone();
+                move || {
+                    run_supervisor(
+                        &processes,
+                        &store,
+                        &transport,
+                        &pty,
+                        "startup",
+                        PathBuf::from("/work"),
+                        vec!["app.exe".to_string()],
+                    )
+                }
+            });
+
+            let (startup_conn, _session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
             // Nobody will ever attach, so the gate must open on this instead.
             transport.disconnect(startup_conn);
-
+            phases.set("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
-            let leftover = FsSessionStore::new(dir.path().to_path_buf());
-            assert!(leftover.list().unwrap().is_empty());
+            assert!(store.list().unwrap().is_empty());
         });
     }
 
@@ -1079,11 +1339,10 @@ mod tests {
     }
 
     fn assert_rejected_startup_rolls_back(rejection: RejectedStartup) {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let exit = Arc::new((Mutex::new(true), Condvar::new()));
             let processes = mock_processes(exit);
 
@@ -1104,7 +1363,9 @@ mod tests {
                 }
             });
 
+            phases.set("waiting for the supervisor startup connection");
             let startup_conn = transport.accept(startup).unwrap();
+            phases.set("waiting for the supervisor startup response");
             assert!(matches!(
                 transport.recv(startup_conn).unwrap(),
                 Message::StartupOk { .. }
@@ -1122,6 +1383,7 @@ mod tests {
                 RejectedStartup::Timeout => transport.timeout_next_recv(),
             }
 
+            phases.set("waiting for startup rollback");
             let error = supervisor.join().unwrap().unwrap_err();
             assert!(error.find_source::<StartupFailedError>().is_some());
             assert!(store.list().unwrap().is_empty());
@@ -1132,36 +1394,35 @@ mod tests {
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_session_without_startup_commit_is_rolled_back() {
         assert_rejected_startup_rolls_back(RejectedStartup::Disconnect);
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_session_with_an_invalid_startup_commit_is_rolled_back() {
         assert_rejected_startup_rolls_back(RejectedStartup::Message(Message::StartupErr));
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_startup_commit_timeout_is_rolled_back() {
         assert_rejected_startup_rolls_back(RejectedStartup::Timeout);
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn failure_to_send_startup_ok_rolls_back() {
-        with_watchdog(|| {
+        with_watchdog_phases("running the rejected startup", |_phases| {
             let transport = MemoryTransport::new();
             transport.fail_next_send();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let exit = Arc::new((Mutex::new(true), Condvar::new()));
             let processes = mock_processes(exit);
 
@@ -1183,14 +1444,11 @@ mod tests {
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
-    #[cfg_attr(miri, ignore)]
     fn init_failure_sends_startup_err_and_closes_job() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let mut processes = MockProcesses::new();
             processes
                 .expect_durability()
@@ -1220,23 +1478,25 @@ mod tests {
                 }
             });
 
+            phases.set("waiting for the supervisor startup connection");
             let startup_conn = transport.accept(startup).unwrap();
+            phases.set("waiting for the startup error");
             assert_eq!(transport.recv(startup_conn).unwrap(), Message::StartupErr);
+            phases.set("waiting for startup rollback");
             supervisor.join().unwrap().unwrap_err();
             assert!(store.list().unwrap().is_empty());
         });
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_supervisor_that_cannot_outlive_its_launcher_says_so_on_the_startup_pipe() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let processes = mock_processes_with(
                 Arc::clone(&exit),
                 Durability::TiedToLauncher,
@@ -1260,7 +1520,8 @@ mod tests {
             });
 
             // Only the client has a console to report this on.
-            let (startup_conn, _session_id, durability) = commit_startup(&transport, startup);
+            let (startup_conn, _session_id, durability) =
+                commit_startup(&transport, startup, &phases);
             assert_eq!(durability, Durability::TiedToLauncher);
             transport.disconnect(startup_conn);
             {
@@ -1268,20 +1529,20 @@ mod tests {
                 *lock.lock().expect("exit lock") = true;
                 cvar.notify_all();
             }
+            phases.set("waiting for supervisor shutdown");
             supervisor.join().unwrap().unwrap();
         });
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_wait_that_fails_still_takes_the_session_off_the_host() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let processes =
                 mock_processes_with(Arc::clone(&exit), Durability::Durable, AppWait::Fails);
 
@@ -1302,7 +1563,8 @@ mod tests {
                 }
             });
 
-            let (startup_conn, _session_id, _durability) = commit_startup(&transport, startup);
+            let (startup_conn, _session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
             assert_eq!(store.list().unwrap().len(), 1, "the session was published");
             transport.disconnect(startup_conn);
             {
@@ -1311,6 +1573,7 @@ mod tests {
                 cvar.notify_all();
             }
 
+            phases.set("waiting for failed-wait cleanup");
             supervisor.join().unwrap().unwrap_err();
             // The wait is the only thing that failed, so everything the session
             // put on the host is still the session's to take back.
@@ -1330,14 +1593,13 @@ mod tests {
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn output_produced_before_the_first_attach_reaches_that_client() {
-        with_watchdog(|| {
+        with_watchdog_phases("setting up the supervisor", |phases| {
             let transport = MemoryTransport::new();
             let pty = MemoryPseudoconsole::new();
-            let dir = tempfile::TempDir::new().unwrap();
-            let store = FsSessionStore::new(dir.path().to_path_buf());
+            let store = MemorySessionStore::new();
             let exit = Arc::new((Mutex::new(false), Condvar::new()));
             let processes = mock_processes(Arc::clone(&exit));
 
@@ -1358,7 +1620,8 @@ mod tests {
                 }
             });
 
-            let (startup_conn, _session_id, _durability) = commit_startup(&transport, startup);
+            let (startup_conn, _session_id, _durability) =
+                commit_startup(&transport, startup, &phases);
 
             // The app speaks before anyone has attached, which is the window
             // `dure run` spends spawning the supervisor and connecting to it.
@@ -1373,6 +1636,7 @@ mod tests {
             transport
                 .send(client, &Message::Attach { cols: 80, rows: 24 })
                 .unwrap();
+            phases.set("waiting for the attach acknowledgement");
             assert!(matches!(
                 transport.recv(client).unwrap(),
                 Message::Attached { .. }
@@ -1390,6 +1654,7 @@ mod tests {
             // the failure is an assertion rather than a wait with no end.
             let mut received = Vec::new();
             loop {
+                phases.set("waiting for held output or the app exit status");
                 match transport.recv(client).unwrap() {
                     Message::Output(bytes) => received.extend(bytes),
                     Message::AppExited { status } => {
@@ -1401,6 +1666,7 @@ mod tests {
             }
             assert_eq!(received, b"hello");
 
+            phases.set("waiting for supervisor shutdown");
             assert_eq!(supervisor.join().unwrap().unwrap(), SAMPLE_APP_EXIT);
         });
     }
@@ -1543,6 +1809,49 @@ mod tests {
 
         assert!(client_conn(&shared).is_none());
         assert!(flags.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_stalled_attach_acknowledgement_does_not_signal_attachment() {
+        with_watchdog_phases("setting up the client relay", |phases| {
+            let transport = MemoryTransport::new();
+            let pty_host = MemoryPseudoconsole::new();
+            let shared = Arc::new(shared_session(&transport, &pty_host));
+            let (supervisor, client) = connected_pair(&transport, "pipe");
+
+            let (attached_tx, attached_rx) = mpsc::channel();
+            transport
+                .send(client, &Message::Attach { cols: 80, rows: 24 })
+                .unwrap();
+            transport.stall_sends();
+            let relay = thread::spawn({
+                let shared = Arc::clone(&shared);
+                move || {
+                    client_loop(&shared, supervisor, &|attached| {
+                        attached_tx.send(attached).unwrap();
+                    });
+                }
+            });
+
+            phases.set("waiting for the attach acknowledgement to stall");
+            transport.wait_for_stalled_send();
+            assert!(!shared.first_attach().attached);
+
+            transport.resume_sends();
+            phases.set("waiting for the attach acknowledgement");
+            assert!(matches!(
+                transport.recv(client).unwrap(),
+                Message::Attached { .. }
+            ));
+            phases.set("waiting for the attached-flag update");
+            assert!(attached_rx.recv().unwrap());
+            assert!(shared.first_attach().attached);
+
+            transport.send(client, &Message::StartupErr).unwrap();
+            phases.set("waiting for the client relay to stop");
+            relay.join().unwrap();
+            assert!(!attached_rx.recv().unwrap());
+        });
     }
 
     #[test]
@@ -1731,28 +2040,15 @@ mod tests {
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
+    // Building the session record reads the real system clock.
     #[cfg_attr(miri, ignore)]
     fn a_failure_after_id_allocation_releases_the_id() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let store = FsSessionStore::new(dir.path().to_path_buf());
+        let store = MemorySessionStore::new();
+        store.fail_next_publish();
         let transport = MemoryTransport::new();
         let pty = MemoryPseudoconsole::new();
-        let mut processes = MockProcesses::new();
-        processes
-            .expect_durability()
-            .returning(|| Durability::Durable);
-        processes
-            .expect_create_lifetime_job()
-            .returning(|| Ok(JobId(1)));
-        processes.expect_spawn_app().returning(|_| Ok(AppId(1)));
-        processes
-            .expect_random_nonce()
-            .returning(|| "nonce".to_string());
-        processes
-            .expect_current_identity()
-            .returning(|| Err(PalError::new(PalErrorKind::Other)));
-        processes.expect_close_job().returning(|_| ());
+        let exit = Arc::new((Mutex::new(true), Condvar::new()));
+        let processes = mock_processes(exit);
 
         {
             let mut guard = InitGuard {
@@ -1776,19 +2072,16 @@ mod tests {
                 vec!["app.exe".to_string()],
             )
             .err()
-            .expect("identity lookup fails");
-            assert!(error.find_source::<StartupFailedError>().is_some());
+            .expect("record publication fails");
+            assert!(error.find_source::<StoreError>().is_some());
         }
 
-        assert!(!dir.path().join("1.json").exists());
+        assert!(store.list_reservations().unwrap().is_empty());
     }
 
     #[test]
-    // Talks to the real operating system: the session store is a real directory.
-    #[cfg_attr(miri, ignore)]
     fn attached_flag_publishes_only_while_the_record_lives() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let store = FsSessionStore::new(dir.path().to_path_buf());
+        let store = MemorySessionStore::new();
         let id = store.allocate_id(&ProcessIdentity::for_test(1)).unwrap();
         store
             .publish(&SessionRecord {

--- a/packages/dure/src/supervisor/tests/memory_session_store.rs
+++ b/packages/dure/src/supervisor/tests/memory_session_store.rs
@@ -1,0 +1,174 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! In-memory session store for supervisor unit tests.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+use crate::pal::error::{PalError, PalErrorKind};
+use crate::pal::session_store::SessionStore;
+use crate::session_id::SessionId;
+use crate::session_record::{ProcessIdentity, SessionRecord, StoredSession};
+
+/// Shared stateful session store for supervisor unit tests.
+///
+/// Supervisor tests exercise synchronization among the process, transport,
+/// pseudoconsole, and store boundaries. Keeping records in memory ensures a
+/// filesystem flush cannot consume the watchdog intended to diagnose those
+/// synchronization paths.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MemorySessionStore {
+    inner: Arc<MemorySessionStoreInner>,
+}
+
+/// Record state and deterministic publish-stall coordination.
+#[derive(Debug, Default)]
+struct MemorySessionStoreInner {
+    records: Mutex<BTreeMap<SessionId, StoredSession>>,
+    /// Injects a publication failure after id allocation.
+    fail_next_publish: AtomicBool,
+    publish_stall: Mutex<PublishStall>,
+    publish_stall_changed: Condvar,
+}
+
+/// Gate used to park store publications at a known point in a test.
+#[derive(Debug, Default)]
+struct PublishStall {
+    enabled: bool,
+    waiting: usize,
+}
+
+impl MemorySessionStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn stall_publishes(&self) {
+        let mut stall = self.inner.publish_stall.lock().unwrap();
+        assert!(!stall.enabled);
+        stall.enabled = true;
+    }
+
+    pub(crate) fn fail_next_publish(&self) {
+        self.inner.fail_next_publish.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn wait_for_stalled_publish(&self) {
+        let mut stall = self.inner.publish_stall.lock().unwrap();
+        assert!(
+            stall.enabled,
+            "the publish stall must be enabled before waiting"
+        );
+        while stall.waiting == 0 {
+            stall = self.inner.publish_stall_changed.wait(stall).unwrap();
+        }
+    }
+
+    pub(crate) fn resume_publishes(&self) {
+        let mut stall = self.inner.publish_stall.lock().unwrap();
+        assert!(stall.enabled);
+        stall.enabled = false;
+        self.inner.publish_stall_changed.notify_all();
+    }
+
+    fn await_publish_permission(&self) {
+        let mut stall = self.inner.publish_stall.lock().unwrap();
+        if !stall.enabled {
+            return;
+        }
+        stall.waiting = stall.waiting.checked_add(1).unwrap();
+        self.inner.publish_stall_changed.notify_all();
+        while stall.enabled {
+            stall = self.inner.publish_stall_changed.wait(stall).unwrap();
+        }
+        stall.waiting = stall.waiting.checked_sub(1).unwrap();
+    }
+}
+
+impl SessionStore for MemorySessionStore {
+    fn root(&self) -> PathBuf {
+        // Supervisor tests receive prepared paths and never query store path support.
+        panic!("supervisor tests do not query the session store root")
+    }
+
+    fn allocate_id(&self, owner: &ProcessIdentity) -> Result<SessionId, PalError> {
+        let mut records = self.inner.records.lock().unwrap();
+        let mut id = SessionId::MIN;
+        while records.contains_key(&id) {
+            id = id
+                .get()
+                .checked_add(1)
+                .and_then(SessionId::from_u32)
+                .ok_or_else(|| PalError::new(PalErrorKind::Other))?;
+        }
+        records.insert(id, StoredSession::Reserved { owner: *owner });
+        Ok(id)
+    }
+
+    fn publish(&self, record: &SessionRecord) -> Result<(), PalError> {
+        if self.inner.fail_next_publish.swap(false, Ordering::SeqCst) {
+            return Err(PalError::new(PalErrorKind::Other));
+        }
+        self.await_publish_permission();
+        self.inner.records.lock().unwrap().insert(
+            record.session_id(),
+            StoredSession::Published(record.clone()),
+        );
+        Ok(())
+    }
+
+    fn read(&self, id: SessionId) -> Result<Option<SessionRecord>, PalError> {
+        let records = self.inner.records.lock().unwrap();
+        Ok(match records.get(&id) {
+            Some(StoredSession::Published(record)) => Some(record.clone()),
+            Some(StoredSession::Reserved { .. }) | None => None,
+        })
+    }
+
+    fn list(&self) -> Result<Vec<SessionRecord>, PalError> {
+        let records = self.inner.records.lock().unwrap();
+        Ok(records
+            .values()
+            .filter_map(|stored| match stored {
+                StoredSession::Published(record) => Some(record.clone()),
+                StoredSession::Reserved { .. } => None,
+            })
+            .collect())
+    }
+
+    fn list_reservations(&self) -> Result<Vec<(SessionId, ProcessIdentity)>, PalError> {
+        let records = self.inner.records.lock().unwrap();
+        Ok(records
+            .iter()
+            .filter_map(|(id, stored)| match stored {
+                StoredSession::Reserved { owner } => Some((*id, *owner)),
+                StoredSession::Published(_) => None,
+            })
+            .collect())
+    }
+
+    fn delete_owned_by(&self, id: SessionId, owner: &ProcessIdentity) -> Result<(), PalError> {
+        let mut records = self.inner.records.lock().unwrap();
+        let owned = match records.get(&id) {
+            Some(StoredSession::Reserved { owner: current }) => current == owner,
+            Some(StoredSession::Published(record)) => record.identity() == *owner,
+            None => false,
+        };
+        if owned {
+            records.remove(&id);
+        }
+        Ok(())
+    }
+
+    fn canonicalize(&self, _path: &Path) -> Result<PathBuf, PalError> {
+        // Supervisor tests receive prepared paths and never query store path support.
+        panic!("supervisor tests do not canonicalize paths through the session store")
+    }
+
+    fn current_dir(&self) -> Result<PathBuf, PalError> {
+        // Supervisor tests receive prepared paths and never query store path support.
+        panic!("supervisor tests do not query the current directory")
+    }
+}

--- a/packages/dure/src/supervisor/tests/memory_session_store.rs
+++ b/packages/dure/src/supervisor/tests/memory_session_store.rs
@@ -48,6 +48,10 @@ impl MemorySessionStore {
     pub(crate) fn stall_publishes(&self) {
         let mut stall = self.inner.publish_stall.lock().unwrap();
         assert!(!stall.enabled);
+        assert_eq!(
+            stall.waiting, 0,
+            "the publish stall cannot be rearmed before prior publishers resume"
+        );
         stall.enabled = true;
     }
 
@@ -71,6 +75,9 @@ impl MemorySessionStore {
         assert!(stall.enabled);
         stall.enabled = false;
         self.inner.publish_stall_changed.notify_all();
+        while stall.waiting != 0 {
+            stall = self.inner.publish_stall_changed.wait(stall).unwrap();
+        }
     }
 
     fn await_publish_permission(&self) {
@@ -84,6 +91,7 @@ impl MemorySessionStore {
             stall = self.inner.publish_stall_changed.wait(stall).unwrap();
         }
         stall.waiting = stall.waiting.checked_sub(1).unwrap();
+        self.inner.publish_stall_changed.notify_all();
     }
 }
 
@@ -170,5 +178,54 @@ impl SessionStore for MemorySessionStore {
     fn current_dir(&self) -> Result<PathBuf, PalError> {
         // Supervisor tests receive prepared paths and never query store path support.
         panic!("supervisor tests do not query the current directory")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use testing::with_watchdog_phases;
+
+    use super::*;
+
+    #[test]
+    fn publish_stall_reports_each_rearmed_publisher() {
+        with_watchdog_phases("setting up the store", |phase_reporter| {
+            let store = MemorySessionStore::new();
+            let owner = ProcessIdentity::for_test(1);
+            let id = store.allocate_id(&owner).unwrap();
+            let mut publishers = Vec::new();
+
+            for attached in [true, false] {
+                store.stall_publishes();
+                let publisher = thread::spawn({
+                    let store = store.clone();
+                    move || {
+                        store.publish(&SessionRecord {
+                            id: id.get(),
+                            supervisor_pid: owner.pid,
+                            supervisor_creation_time: owner.creation_time,
+                            pipe_name: "pipe".to_string(),
+                            launch_directory: PathBuf::from("/work"),
+                            command: vec!["app.exe".to_string()],
+                            started_at_unix_ms: 1,
+                            attached,
+                        })
+                    }
+                });
+
+                phase_reporter.report("waiting for the publisher to stall");
+                store.wait_for_stalled_publish();
+                store.resume_publishes();
+                // Joining after both cycles makes rearming depend on
+                // `resume_publishes()` draining the previous waiter.
+                publishers.push(publisher);
+            }
+
+            for publisher in publishers {
+                publisher.join().unwrap().unwrap();
+            }
+        });
     }
 }

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -20,7 +20,7 @@ pub use drop_waker::{DropOnWakerRelease, drop_waker};
 pub use float::f64_diff_abs;
 pub use reentrant_waker::ReentrantWakerData;
 pub use wake_action_waker::wake_action_waker;
-pub use watchdog::{WatchdogPhases, with_watchdog, with_watchdog_phases};
+pub use watchdog::{WatchdogPhaseReporter, with_watchdog, with_watchdog_phases};
 
 #[cfg(windows)]
 mod windows;

--- a/packages/testing/src/lib.rs
+++ b/packages/testing/src/lib.rs
@@ -20,7 +20,7 @@ pub use drop_waker::{DropOnWakerRelease, drop_waker};
 pub use float::f64_diff_abs;
 pub use reentrant_waker::ReentrantWakerData;
 pub use wake_action_waker::wake_action_waker;
-pub use watchdog::with_watchdog;
+pub use watchdog::{WatchdogPhases, with_watchdog, with_watchdog_phases};
 
 #[cfg(windows)]
 mod windows;

--- a/packages/testing/src/watchdog.rs
+++ b/packages/testing/src/watchdog.rs
@@ -2,6 +2,24 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+/// Reports the operation a watchdog-protected test is about to block on.
+///
+/// [`with_watchdog_phases()`] includes the most recently reported phase in its
+/// timeout panic, so a synchronization failure identifies the operation that did
+/// not complete.
+#[derive(Clone, Debug)]
+pub struct WatchdogPhases {
+    phase_tx: mpsc::Sender<&'static str>,
+}
+
+impl WatchdogPhases {
+    /// Replaces the phase shown if the test times out.
+    pub fn set(&self, phase: &'static str) {
+        // The receiver only disappears after the watchdog has already ended the test.
+        _ = self.phase_tx.send(phase);
+    }
+}
+
 /// Runs a test with a timeout to prevent infinite hangs.
 ///
 /// This function wraps a test closure with a timeout mechanism. The closure runs
@@ -39,6 +57,44 @@ where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
 {
+    run_with_watchdog(test_fn, |timeout| {
+        format!("Test exceeded {}-second timeout", timeout.as_secs())
+    })
+}
+
+/// Runs a test with a timeout that reports the last active phase.
+///
+/// Call [`WatchdogPhases::set()`] immediately before each potentially blocking
+/// operation. If the closure exceeds the timeout, the panic identifies the last
+/// phase it entered.
+///
+/// # Panics
+///
+/// Panics on the calling thread if the wrapped closure does not complete within
+/// the timeout. Mutation testing disables the timeout.
+pub fn with_watchdog_phases<F, R>(initial_phase: &'static str, test_fn: F) -> R
+where
+    F: FnOnce(WatchdogPhases) -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (phase_tx, phase_rx) = mpsc::channel();
+    run_with_watchdog(
+        move || test_fn(WatchdogPhases { phase_tx }),
+        move |timeout| {
+            let phase = phase_rx.try_iter().last().unwrap_or(initial_phase);
+            format!(
+                "Test exceeded {}-second timeout during phase: {phase}",
+                timeout.as_secs()
+            )
+        },
+    )
+}
+
+fn run_with_watchdog<F, R>(test_fn: F, timeout_message: impl FnOnce(Duration) -> String) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
     // Check if we are running under mutation testing.
     if std::env::var("MUTATION_TESTING").as_deref() == Ok("1") {
         // Under mutation testing, disable the watchdog to allow hanging mutations.
@@ -71,7 +127,7 @@ where
         }
         Err(mpsc::RecvTimeoutError::Timeout) => {
             // Test timed out - this indicates the test is hanging
-            panic!("Test exceeded {}-second timeout", timeout.as_secs());
+            panic!("{}", timeout_message(timeout));
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             // Thread panicked, join it to get the panic
@@ -86,7 +142,13 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use static_assertions::assert_impl_all;
+
     use super::*;
+
+    assert_impl_all!(WatchdogPhases: RefUnwindSafe, UnwindSafe);
 
     #[test]
     fn watchdog_allows_fast_tests() {
@@ -100,6 +162,15 @@ mod tests {
     #[test]
     fn watchdog_returns_correct_value() {
         let result = with_watchdog(|| "hello world");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn phased_watchdog_returns_correct_value() {
+        let result = with_watchdog_phases("starting", |phases| {
+            phases.set("finishing");
+            "hello world"
+        });
         assert_eq!(result, "hello world");
     }
 }

--- a/packages/testing/src/watchdog.rs
+++ b/packages/testing/src/watchdog.rs
@@ -80,13 +80,19 @@ where
     let (phase_tx, phase_rx) = mpsc::channel();
     run_with_watchdog(
         move || test_fn(WatchdogPhases { phase_tx }),
-        move |timeout| {
-            let phase = phase_rx.try_iter().last().unwrap_or(initial_phase);
-            format!(
-                "Test exceeded {}-second timeout during phase: {phase}",
-                timeout.as_secs()
-            )
-        },
+        move |timeout| phased_timeout_message(initial_phase, &phase_rx, timeout),
+    )
+}
+
+fn phased_timeout_message(
+    initial_phase: &'static str,
+    phase_rx: &mpsc::Receiver<&'static str>,
+    timeout: Duration,
+) -> String {
+    let phase = phase_rx.try_iter().last().unwrap_or(initial_phase);
+    format!(
+        "Test exceeded {}-second timeout during phase: {phase}",
+        timeout.as_secs()
     )
 }
 
@@ -172,5 +178,25 @@ mod tests {
             "hello world"
         });
         assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn phased_timeout_reports_the_initial_phase_before_any_update() {
+        let (_phase_tx, phase_rx) = mpsc::channel();
+        let message = phased_timeout_message("initial phase", &phase_rx, Duration::ZERO);
+        assert!(message.contains("initial phase"));
+    }
+
+    #[test]
+    fn phased_timeout_reports_the_latest_phase() {
+        let (phase_tx, phase_rx) = mpsc::channel();
+        phase_tx.send("earlier phase").unwrap();
+        phase_tx.send("latest phase").unwrap();
+
+        let message = phased_timeout_message("initial phase", &phase_rx, Duration::ZERO);
+
+        assert!(message.contains("latest phase"));
+        assert!(!message.contains("earlier phase"));
+        assert!(!message.contains("initial phase"));
     }
 }

--- a/packages/testing/src/watchdog.rs
+++ b/packages/testing/src/watchdog.rs
@@ -8,13 +8,15 @@ use std::time::Duration;
 /// timeout panic, so a synchronization failure identifies the operation that did
 /// not complete.
 #[derive(Clone, Debug)]
-pub struct WatchdogPhases {
+pub struct WatchdogPhaseReporter {
     phase_tx: mpsc::Sender<&'static str>,
 }
 
-impl WatchdogPhases {
-    /// Replaces the phase shown if the test times out.
-    pub fn set(&self, phase: &'static str) {
+impl WatchdogPhaseReporter {
+    /// Reports the next operation that may block.
+    ///
+    /// The latest reported phase replaces the timeout label.
+    pub fn report(&self, phase: &'static str) {
         // The receiver only disappears after the watchdog has already ended the test.
         _ = self.phase_tx.send(phase);
     }
@@ -39,8 +41,9 @@ impl WatchdogPhases {
 /// # Panics
 ///
 /// Panics on the calling thread if the wrapped closure does not complete within
-/// the timeout. When mutation testing is enabled (`MUTATION_TESTING=1`) the
-/// watchdog is disabled and the closure runs directly, so no timeout panic occurs.
+/// the timeout. A panic raised by the wrapped closure is propagated to the calling
+/// thread. When mutation testing is enabled (`MUTATION_TESTING=1`) the watchdog is
+/// disabled and the closure runs directly, so no timeout panic occurs.
 ///
 /// # Example
 ///
@@ -64,22 +67,24 @@ where
 
 /// Runs a test with a timeout that reports the last active phase.
 ///
-/// Call [`WatchdogPhases::set()`] immediately before each potentially blocking
-/// operation. If the closure exceeds the timeout, the panic identifies the last
-/// phase it entered.
+/// `initial_phase` is the timeout label until the closure reports another
+/// potentially blocking operation through [`WatchdogPhaseReporter::report()`].
+/// Each report replaces the label, so a timeout identifies the latest operation
+/// the test entered.
 ///
 /// # Panics
 ///
 /// Panics on the calling thread if the wrapped closure does not complete within
-/// the timeout. Mutation testing disables the timeout.
+/// the timeout. A panic raised by the wrapped closure is propagated to the calling
+/// thread. Mutation testing disables the timeout.
 pub fn with_watchdog_phases<F, R>(initial_phase: &'static str, test_fn: F) -> R
 where
-    F: FnOnce(WatchdogPhases) -> R + Send + 'static,
+    F: FnOnce(WatchdogPhaseReporter) -> R + Send + 'static,
     R: Send + 'static,
 {
     let (phase_tx, phase_rx) = mpsc::channel();
     run_with_watchdog(
-        move || test_fn(WatchdogPhases { phase_tx }),
+        move || test_fn(WatchdogPhaseReporter { phase_tx }),
         move |timeout| phased_timeout_message(initial_phase, &phase_rx, timeout),
     )
 }
@@ -154,7 +159,7 @@ mod tests {
 
     use super::*;
 
-    assert_impl_all!(WatchdogPhases: RefUnwindSafe, UnwindSafe);
+    assert_impl_all!(WatchdogPhaseReporter: RefUnwindSafe, UnwindSafe);
 
     #[test]
     fn watchdog_allows_fast_tests() {
@@ -173,8 +178,8 @@ mod tests {
 
     #[test]
     fn phased_watchdog_returns_correct_value() {
-        let result = with_watchdog_phases("starting", |phases| {
-            phases.set("finishing");
+        let result = with_watchdog_phases("starting", |phase_reporter| {
+            phase_reporter.report("finishing");
             "hello world"
         });
         assert_eq!(result, "hello world");


### PR DESCRIPTION
[Copilot speaking]

The supervisor synchronization tests used the durable filesystem session store, allowing Windows flush and write-through operations to consume watchdog time and obscure actual synchronization failures.

This change gives the supervisor tests a shared in-memory session store while retaining filesystem durability coverage in the session-store tests. Client-slot changes now assign generations to advisory attached-state updates, which run outside both ownership locks and discard stale writes so delayed filesystem I/O cannot overwrite newer attach or detach state. Deterministic transport/store stall coverage verifies the ordering, and phase-aware watchdog diagnostics identify the blocking operation when a supervisor test times out.

Closes #517