### PR TITLE
dure: Use positional session IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "dure-test-helper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dure-test-helper",

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.1.2"
+version = "0.1.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.1.3"
+version = "0.2.0"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/dure/README.md
+++ b/packages/dure/README.md
@@ -19,14 +19,14 @@ cargo binstall dure
 
 ```text
 dure run -- <command> [args...]
-dure resume [--id <id>]
+dure resume [<id>]
 dure list
 dure kill --id <id>
 ```
 
 `run` always starts a new session in the current directory and attaches immediately.
 `resume` attaches to an existing live session (auto-detect by launch directory, or
-`--id`). Closing the foreground `dure` process detaches; the supervisor and app
-keep running. A new attach displaces any older client.
+an explicit `<id>` argument). Closing the foreground `dure` process detaches; the
+supervisor and app keep running. A new attach displaces any older client.
 
 See `docs/design.md` for the full contract.

--- a/packages/dure/README.md
+++ b/packages/dure/README.md
@@ -21,7 +21,7 @@ cargo binstall dure
 dure run -- <command> [args...]
 dure resume [<id>]
 dure list
-dure kill --id <id>
+dure kill <id>
 ```
 
 `run` always starts a new session in the current directory and attaches immediately.

--- a/packages/dure/docs/design.md
+++ b/packages/dure/docs/design.md
@@ -77,8 +77,7 @@ an attach failure identifies the session and notes that it may still be running,
 so `list`, `resume`, and `kill` remain available.
 
 `dure resume` attaches using auto-detect. `dure resume <id>` attaches to that
-live session and skips auto-detect. The hidden `--id <id>` spelling is accepted
-as a compatibility alias.
+live session and skips auto-detect.
 
 `dure list` prints live sessions: id, whether a client is currently attached,
 supervisor pid, how long the session has been running, launch directory, and
@@ -87,9 +86,9 @@ reuse of its numeric process id by another process does not keep the record live
 Attached means the supervisor still has a client connection; a hung client may
 still appear attached. Resume steals anyway.
 
-`dure kill --id <id>` abruptly terminates the supervisor process for that
-session. The app and its ordinary descendants die with it. `--id` is required;
-kill does not auto-detect. Kill targets the recorded supervisor process directly
+`dure kill <id>` abruptly terminates the supervisor process for that session.
+The app and its ordinary descendants die with it. An id is required; kill does
+not auto-detect. Kill targets the recorded supervisor process directly
 instead of using the session connection, so it still works when that connection
 is wedged. An attached client, if any, sees the relay end. Killing a missing or
 already-dead id is a failure after stale-record cleanup.
@@ -144,7 +143,7 @@ last is the one left holding the session.
 A session is live while the same supervisor process is still running. A record
 is dropped only when that process is gone. If the supervisor is running but
 does not accept a connection within a bounded wait, resume fails and the
-session stays listed; `dure kill --id` still reaches it.
+session stays listed; `dure kill <id>` still reaches it.
 
 While detached, the app's console stays open. Input is not closed (end of stdin
 would terminate many apps). Output is drained and discarded so the app cannot

--- a/packages/dure/docs/design.md
+++ b/packages/dure/docs/design.md
@@ -76,8 +76,9 @@ leaves no live session behind. Once the supervisor and client confirm startup,
 an attach failure identifies the session and notes that it may still be running,
 so `list`, `resume`, and `kill` remain available.
 
-`dure resume` attaches using auto-detect. `dure resume --id <id>` attaches to
-that live session and skips auto-detect.
+`dure resume` attaches using auto-detect. `dure resume <id>` attaches to that
+live session and skips auto-detect. The hidden `--id <id>` spelling is accepted
+as a compatibility alias.
 
 `dure list` prints live sessions: id, whether a client is currently attached,
 supervisor pid, how long the session has been running, launch directory, and
@@ -99,14 +100,14 @@ Each session records the canonical absolute path of the directory from which
 `dure run` was invoked (the launch directory). The app later changing its own
 working directory does not change that record.
 
-`dure resume` with no `--id`:
+`dure resume` with no id:
 
 * If there is no live session, it fails.
 * If exactly one live session has a launch directory equal to the current
   directory, it attaches to that session.
 * Otherwise it prints the live session list and reads a session id from the
   terminal. Unreadable stdin, empty input, or a non-terminal stdin is a failure;
-  the caller uses `--id` instead.
+  the caller passes the session id as an argument instead.
 
 If several live sessions share the current directory, that is not a unique
 match; the command lists and asks. It does not pick arbitrarily.
@@ -183,14 +184,14 @@ unavailable.
 
 `dure` writes diagnostics to stderr only while it is not attached. Before
 attach, `run` and `resume` print the session id so the user can `kill` or
-`resume --id` later. After attach, the funnel is exclusive. A displaced client
+`resume <id>` later. After attach, the funnel is exclusive. A displaced client
 writes one diagnostic once its relay has ended and exits with a failure status.
 When the app exits, an attached client receives the app's remaining output
 before the exit status, then exits with that status.
 
 Attaching (`run`, `resume`) requires a console. `list` and `kill` do not. The
 resume id prompt additionally requires a terminal stdin; without one, `resume`
-without `--id` fails.
+without an id fails.
 
 A console is the Windows console-host API: handles, modes, and window size. A
 terminal is the visible emulator (Windows Terminal, an SSH client) that renders

--- a/packages/dure/docs/implementation.md
+++ b/packages/dure/docs/implementation.md
@@ -307,7 +307,7 @@ and inside a permissive job nested in one that forbids it.
 The supervisor listens for a new client even while it is busy reading and
 writing the current one. Steal does not depend on the old connection still being
 healthy. Connect attempts time out. A supervisor whose recorded process identity
-is still alive but never accepts stays listed; resume fails and `kill --id`
+is still alive but never accepts stays listed; resume fails and `kill <id>`
 still targets it.
 
 ```mermaid
@@ -324,7 +324,7 @@ stateDiagram-v2
   end note
 ```
 
-`dure kill --id` opens the recorded pid, verifies the process creation time and
+`dure kill <id>` opens the recorded pid, verifies the process creation time and
 running state, and terminates that process handle, then waits for the process to
 signal before reporting success. It never needs the session connection.
 

--- a/packages/dure/src/cli.rs
+++ b/packages/dure/src/cli.rs
@@ -51,16 +51,12 @@ enum CliCommand {
     Resume {
         /// Session id to attach to, skipping auto-detect.
         id: Option<NonZero<u32>>,
-        /// Hidden compatibility spelling for the session id.
-        #[arg(long = "id", value_name = "ID", hide = true, conflicts_with = "id")]
-        legacy_id: Option<NonZero<u32>>,
     },
     /// Print live sessions.
     List,
     /// Abruptly terminate the supervisor for a session.
     Kill {
         /// Session id to kill. Required; kill does not auto-detect.
-        #[arg(long)]
         id: NonZero<u32>,
     },
     /// Hidden supervisor process started by `dure run`.
@@ -127,8 +123,8 @@ impl Cli {
     pub fn into_input(self) -> RunInput {
         let command = match self.command {
             CliCommand::Run { command } => Command::Run { command },
-            CliCommand::Resume { id, legacy_id } => Command::Resume {
-                id: id.or(legacy_id).map(SessionId::new),
+            CliCommand::Resume { id } => Command::Resume {
+                id: id.map(SessionId::new),
             },
             CliCommand::List => Command::List,
             CliCommand::Kill { id } => Command::Kill {
@@ -190,19 +186,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_resume_with_legacy_id_option() {
-        let input = parse(&["resume", "--id", "3"]);
-        assert_eq!(
-            input.command,
-            Command::Resume {
-                id: SessionId::from_u32(3),
-            }
-        );
-    }
-
-    #[test]
-    fn parse_resume_rejects_duplicate_id() {
-        Cli::from_args(&["dure"], &["resume", "3", "--id", "4"]).unwrap_err();
+    fn parse_resume_rejects_id_option() {
+        Cli::from_args(&["dure"], &["resume", "--id", "3"]).unwrap_err();
     }
 
     #[test]
@@ -221,13 +206,26 @@ mod tests {
     #[test]
     fn parse_kill_requires_id() {
         Cli::from_args(&["dure"], &["kill"]).unwrap_err();
-        let input = parse(&["kill", "--id", "2"]);
+        let input = parse(&["kill", "2"]);
         assert_eq!(
             input.command,
             Command::Kill {
                 id: SessionId::from_u32(2).unwrap(),
             }
         );
+    }
+
+    #[test]
+    fn parse_kill_rejects_id_option() {
+        Cli::from_args(&["dure"], &["kill", "--id", "2"]).unwrap_err();
+    }
+
+    #[test]
+    fn kill_help_shows_positional_id() {
+        let err = Cli::from_args(&["dure"], &["kill", "--help"]).unwrap_err();
+        assert!(err.status.is_ok());
+        assert!(err.output.contains("<ID>"));
+        assert!(!err.output.contains("--id"));
     }
 
     #[test]

--- a/packages/dure/src/cli.rs
+++ b/packages/dure/src/cli.rs
@@ -50,8 +50,10 @@ enum CliCommand {
     /// Attach to a live session.
     Resume {
         /// Session id to attach to, skipping auto-detect.
-        #[arg(long)]
         id: Option<NonZero<u32>>,
+        /// Hidden compatibility spelling for the session id.
+        #[arg(long = "id", value_name = "ID", hide = true, conflicts_with = "id")]
+        legacy_id: Option<NonZero<u32>>,
     },
     /// Print live sessions.
     List,
@@ -125,8 +127,8 @@ impl Cli {
     pub fn into_input(self) -> RunInput {
         let command = match self.command {
             CliCommand::Run { command } => Command::Run { command },
-            CliCommand::Resume { id } => Command::Resume {
-                id: id.map(SessionId::new),
+            CliCommand::Resume { id, legacy_id } => Command::Resume {
+                id: id.or(legacy_id).map(SessionId::new),
             },
             CliCommand::List => Command::List,
             CliCommand::Kill { id } => Command::Kill {
@@ -177,7 +179,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_resume_with_id() {
+    fn parse_resume_with_positional_id() {
+        let input = parse(&["resume", "3"]);
+        assert_eq!(
+            input.command,
+            Command::Resume {
+                id: SessionId::from_u32(3),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_resume_with_legacy_id_option() {
         let input = parse(&["resume", "--id", "3"]);
         assert_eq!(
             input.command,
@@ -185,6 +198,19 @@ mod tests {
                 id: SessionId::from_u32(3),
             }
         );
+    }
+
+    #[test]
+    fn parse_resume_rejects_duplicate_id() {
+        Cli::from_args(&["dure"], &["resume", "3", "--id", "4"]).unwrap_err();
+    }
+
+    #[test]
+    fn resume_help_shows_positional_id() {
+        let err = Cli::from_args(&["dure"], &["resume", "--help"]).unwrap_err();
+        assert!(err.status.is_ok());
+        assert!(err.output.contains("[ID]"));
+        assert!(!err.output.contains("--id"));
     }
 
     #[test]

--- a/packages/dure/src/commands/kill.rs
+++ b/packages/dure/src/commands/kill.rs
@@ -1,4 +1,4 @@
-//! `dure kill --id`.
+//! `dure kill`.
 
 use ohno::AppError;
 

--- a/packages/dure/src/errors.rs
+++ b/packages/dure/src/errors.rs
@@ -118,7 +118,7 @@ pub(crate) struct StoreError;
 
 /// Resume without an id needs a terminal stdin to prompt for one.
 #[ohno::error]
-#[display("Cannot prompt for a session id without a terminal stdin; pass the id as an argument")]
+#[display("Cannot prompt for a session id without a terminal stdin; run `dure resume <id>`")]
 pub(crate) struct PromptFailedError;
 
 /// This client was displaced by a newer attach.

--- a/packages/dure/src/errors.rs
+++ b/packages/dure/src/errors.rs
@@ -116,9 +116,9 @@ pub(crate) struct CanonicalizeError {
 #[display("Session store error")]
 pub(crate) struct StoreError;
 
-/// Resume without `--id` needs a terminal stdin to prompt for a session id.
+/// Resume without an id needs a terminal stdin to prompt for one.
 #[ohno::error]
-#[display("Cannot prompt for a session id without a terminal stdin; use --id")]
+#[display("Cannot prompt for a session id without a terminal stdin; pass the id as an argument")]
 pub(crate) struct PromptFailedError;
 
 /// This client was displaced by a newer attach.

--- a/packages/dure/tests/cli.rs
+++ b/packages/dure/tests/cli.rs
@@ -44,14 +44,13 @@ fn list_empty_store() {
 // Talks to the real operating system: runs the built binary as a child process.
 #[cfg_attr(miri, ignore)]
 #[test]
-fn kill_missing_id_fails() {
+fn kill_missing_session_fails() {
     let dir = TempDir::new().unwrap();
     let output = dure()
         .args([
             "--store-root",
             dir.path().to_str().expect("temp path is unicode"),
             "kill",
-            "--id",
             "1",
         ])
         .output()


### PR DESCRIPTION
[Copilot speaking]

Explicit session selection currently requires the verbose `--id` option. This makes the CLI more concise and consistent by treating session IDs as command arguments.

`dure resume [<id>]` now accepts an optional positional ID while preserving no-argument auto-detection, and `dure kill <id>` requires its ID positionally. The old `--id` forms are removed as a deliberate breaking change. User guidance and diagnostics use the new syntax, and `dure` is versioned as 0.2.0 to trigger the corresponding release.