### PR TITLE
Raise workspace MSRV and adopt Rust 1.95 APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Sander Saares <sander@saares.eu>"]
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/folo-rs/folo"
-rust-version = "1.93.1"
+rust-version = "1.95"
 
 [workspace.dependencies]
 all_the_time = { version = "0.6.2", path = "packages/all_the_time", default-features = false }

--- a/TODO.md
+++ b/TODO.md
@@ -4,26 +4,6 @@ Tracking notes for follow-up work that is intentionally deferred. Each entry
 should describe the task, the trigger condition that makes it actionable, and
 links to the relevant code.
 
-## Migrate to stable `std::hint::cold_path()` (requires MSRV 1.95+)
-
-`packages/nm_impl/src/observations.rs` defines a private `cold_path()` helper as a
-workaround for `std::hint::cold_path()` being unavailable at the workspace MSRV.
-
-The intrinsic stabilized in Rust 1.95. The workspace toolchain
-(`rust-toolchain.toml`) is at 1.96.1, but the workspace MSRV is 1.93.1, so
-`std::hint::cold_path()` cannot yet be used without raising `nm`'s MSRV.
-
-Once the workspace MSRV (or just `nm`'s package MSRV) is raised to 1.95 or
-later:
-
-1. Delete the private `fn cold_path()` helper from
-   `packages/nm_impl/src/observations.rs`.
-2. Replace each call site (`cold_path();`) with `std::hint::cold_path();`.
-3. Verify with `just package=nm_impl bench-cg` that Callgrind numbers remain at
-   or better than the stable-helper baseline. The stdlib version uses an
-   LLVM intrinsic and should be at least as effective as the
-   `#[cold] #[inline(never)] fn` workaround.
-
 ## Reorder bench-history object-key segments to `triple/machine/engine`
 
 `cargo-bench-history` keys stored objects as

--- a/constants.env
+++ b/constants.env
@@ -1,5 +1,5 @@
 # used for testing, ensures the MSRV promise is kept; must match Cargo.toml [workspace.package].rust-version
-RUST_MSRV=1.93.1
+RUST_MSRV=1.95
 # used for coverage, formatting, miri and extended analysis. Pinned to a specific
 # nightly for reproducibility: with a floating `nightly` the toolchain rolls forward
 # underneath a cached target/miri, and the newer cargo-miri then rejects the run-stub

--- a/docs/unsafe-code.md
+++ b/docs/unsafe-code.md
@@ -17,8 +17,8 @@ claims, they must specifically explain how we satisfy the safety requirements of
 the function we are calling (e.g. by referencing an assertion, a type invariant,
 earlier logic or other mechanism).
 
-When creating a reference from a raw pointer (`unsafe { &*ptr }`,
-`unsafe { &mut *ptr }`, `NonNull::as_ref`, `NonNull::as_mut`, etc.), the safety
+When creating a reference from a raw pointer (`as_ref_unchecked`,
+`as_mut_unchecked`, `NonNull::as_ref`, `NonNull::as_mut`, etc.), the safety
 comment must address BOTH:
 
 1. **Validity** — the pointer is non-null, properly aligned, points to an
@@ -35,6 +35,11 @@ strict and equally easy to violate, especially when constructing references from
 raw pointers stored across function calls or threads. Justify aliasing by
 referencing locks held, single-threaded ownership, `!Send`/`!Sync` markers,
 scope-bounded borrows, atomic-only access, or other concrete mechanisms.
+
+Prefer the named `as_ref_unchecked` and `as_mut_unchecked` methods over the
+equivalent `&*ptr` and `&mut *ptr` expressions. The named methods make the
+raw-pointer-to-reference conversion explicit without changing its safety
+requirements.
 
 Safety comments are also required in examples and doctests that use `unsafe`
 blocks.

--- a/packages/alloc_tracker/src/allocator.rs
+++ b/packages/alloc_tracker/src/allocator.rs
@@ -74,7 +74,7 @@ pub(crate) fn get_or_init_thread_counters() -> &'static PerThreadCounters {
     TLS_COUNTER_PTR.with(|cell| {
         if let Some(ptr) = cell.get() {
             // SAFETY: pointer originates from Arc stored in REGISTRY which retains ownership for program lifetime.
-            return unsafe { &**ptr };
+            return unsafe { (*ptr).as_ref_unchecked() };
         }
 
         TLS_INIT_GUARD.set(true);
@@ -88,7 +88,7 @@ pub(crate) fn get_or_init_thread_counters() -> &'static PerThreadCounters {
         TLS_INIT_GUARD.set(false);
 
         // SAFETY: pointer obtained from Arc::as_ptr for Arc stored in REGISTRY; lifetime extends for program duration.
-        unsafe { &*ptr }
+        unsafe { ptr.as_ref_unchecked() }
     })
 }
 

--- a/packages/awaiter_set/src/awaiter.rs
+++ b/packages/awaiter_set/src/awaiter.rs
@@ -188,7 +188,7 @@ impl Awaiter {
         // for as long as `self` does. Aliasing — the caller of this `unsafe` function
         // guarantees that access is serialized and that no other reference to this
         // awaiter's `Inner` is live for the duration of the returned borrow.
-        unsafe { &mut *self.inner.get() }
+        unsafe { self.inner.get().as_mut_unchecked() }
     }
 
     /// Returns a shared reference to the internal state.
@@ -204,7 +204,7 @@ impl Awaiter {
         // for as long as `self` does. Aliasing — the caller of this `unsafe` function
         // guarantees that access is serialized and that no `&mut Inner` to this
         // awaiter's interior is live for the duration of the returned borrow.
-        unsafe { &*self.inner.get() }
+        unsafe { self.inner.get().as_ref_unchecked() }
     }
 }
 

--- a/packages/awaiter_set/src/set.rs
+++ b/packages/awaiter_set/src/set.rs
@@ -220,7 +220,7 @@ impl AwaiterSet {
             // scope; and the tail awaiter is a distinct object from `awaiter` (which
             // is being newly inserted), so the existing `&mut Awaiter` borrow does
             // not alias.
-            let tail = unsafe { &*self.tail };
+            let tail = unsafe { self.tail.as_ref_unchecked() };
             // SAFETY: Access is serialized by the caller's lock; no other reference
             // to `tail`'s `Inner` is live (we hold only `&Awaiter` to it here).
             unsafe { tail.inner_mut() }.next = ptr;
@@ -347,7 +347,7 @@ impl AwaiterSet {
         // `&self`-only; access to its `Inner` is gated by this `&mut self` lock
         // scope; the owning future is asleep (it is a registered waiter), so no
         // `&mut Awaiter` to it is live elsewhere.
-        let head = unsafe { &*self.head };
+        let head = unsafe { self.head.as_ref_unchecked() };
         // SAFETY: Access is serialized by this `&mut self` lock scope; we hold
         // only `&Awaiter` and no `&mut Inner` is live.
         let head_generation = unsafe { head.inner_ref() }.generation;
@@ -371,7 +371,7 @@ impl AwaiterSet {
         // valid `Awaiter` currently in the set. Aliasing — `Awaiter`'s public API
         // is `&self`-only; access to its `Inner` is gated by this `&mut self` lock
         // scope; the owning future is asleep, so no `&mut Awaiter` to it is live.
-        let awaiter = unsafe { &*ptr };
+        let awaiter = unsafe { ptr.as_ref_unchecked() };
         // SAFETY: Access is serialized by this `&mut self` lock scope; we hold only
         // `&Awaiter` and no `&mut Inner` is live.
         let inner = unsafe { awaiter.inner_ref() };
@@ -450,7 +450,7 @@ impl AwaiterSet {
             // access to its `Inner` is gated by this `&mut self` lock scope; and
             // `prev` is a distinct awaiter from the one being unlinked, so no
             // `&mut Awaiter` borrow held elsewhere in this call aliases.
-            let prev = unsafe { &*prev };
+            let prev = unsafe { prev.as_ref_unchecked() };
             // SAFETY: Access is serialized by the caller's lock; no other reference
             // to `prev`'s `Inner` is live (we hold only `&Awaiter` to it here).
             unsafe { prev.inner_mut() }.next = next;
@@ -465,7 +465,7 @@ impl AwaiterSet {
             // access to its `Inner` is gated by this `&mut self` lock scope; and
             // `next` is a distinct awaiter from the one being unlinked, so no
             // `&mut Awaiter` borrow held elsewhere in this call aliases.
-            let next = unsafe { &*next };
+            let next = unsafe { next.as_ref_unchecked() };
             // SAFETY: Access is serialized by the caller's lock; no other reference
             // to `next`'s `Inner` is live (we hold only `&Awaiter` to it here).
             unsafe { next.inner_mut() }.prev = prev;

--- a/packages/cargo-bench-history-figures/src/figures/pipeline.rs
+++ b/packages/cargo-bench-history-figures/src/figures/pipeline.rs
@@ -1045,11 +1045,7 @@ mod tests {
             .collect();
 
         assert!(
-            positions.windows(2).all(|pair| {
-                pair.first()
-                    .zip(pair.get(1))
-                    .is_none_or(|(from, to)| from <= to)
-            }),
+            positions.array_windows::<2>().all(|[from, to]| from <= to),
             "{positions:?}"
         );
     }

--- a/packages/cargo-bench-history-figures/src/styles/plot.rs
+++ b/packages/cargo-bench-history-figures/src/styles/plot.rs
@@ -401,11 +401,8 @@ impl Plot {
             .map(|observation| (coord::of(observation.position), observation.value))
             .collect();
 
-        live.windows(2)
-            .filter_map(|window| {
-                let (Some(&from), Some(&to)) = (window.first(), window.get(1)) else {
-                    return None;
-                };
+        live.array_windows::<2>()
+            .filter_map(|&[from, to]| {
                 // Consecutive commits only. A commit that carries no observation must read
                 // as a hole, and a line drawn straight across one would assert a
                 // trajectory through commits nothing was ever measured at — the exact

--- a/packages/cargo-bench-history-stress/src/scenario.rs
+++ b/packages/cargo-bench-history-stress/src/scenario.rs
@@ -494,8 +494,8 @@ mod tests {
         let series: Vec<f64> = (0..s.commits)
             .map(|i| s.main_clean_value(5, 0, i))
             .collect();
-        for pair in series.windows(2) {
-            assert!(pair[1] > pair[0], "expected rising drift, got {series:?}");
+        for [previous, current] in series.array_windows::<2>() {
+            assert!(current > previous, "expected rising drift, got {series:?}");
         }
         let base = s.base_value(5, 0);
         assert!(close(series[0], base));
@@ -610,9 +610,9 @@ mod tests {
         assert_eq!(FEATURE_COMMIT_SPACING_SECONDS, 3_600);
 
         // main is oldest-first, ends at the anchor, starts a year before it.
-        for pair in main.windows(2) {
+        for [previous, current] in main.array_windows::<2>() {
             assert!(
-                pair[1] > pair[0],
+                current > previous,
                 "main commits must be strictly increasing"
             );
         }
@@ -620,9 +620,9 @@ mod tests {
         assert_eq!(main[main.len() - 1].as_second(), anchor.as_second());
 
         // feature commits all follow the anchor, evenly spaced and increasing.
-        for pair in feature.windows(2) {
+        for [previous, current] in feature.array_windows::<2>() {
             assert!(
-                pair[1] > pair[0],
+                current > previous,
                 "feature commits must be strictly increasing"
             );
         }

--- a/packages/cargo-release-plan/src/diff.rs
+++ b/packages/cargo-release-plan/src/diff.rs
@@ -226,16 +226,19 @@ fn changed_regions<'a>(
                 new_index = new_index.saturating_add(1);
             }
             Edit::Delete | Edit::Insert => {
-                if !open {
-                    regions.push(ChangedRegion {
+                let region = if open {
+                    regions
+                        .last_mut()
+                        .expect("an open region was created by a previous edit")
+                } else {
+                    open = true;
+                    regions.push_mut(ChangedRegion {
                         old_start: old_index,
                         old_end: old_index,
                         new_start: new_index,
                         new_end: new_index,
-                    });
-                    open = true;
-                }
-                let region = regions.last_mut().expect("a region was just opened");
+                    })
+                };
                 if matches!(edit, Edit::Delete) {
                     old_index = old_index.saturating_add(1);
                     region.old_end = old_index;

--- a/packages/cbh_stats/src/selection/permutation.rs
+++ b/packages/cbh_stats/src/selection/permutation.rs
@@ -480,11 +480,10 @@ fn scatter_key(index: usize) -> u64 {
 }
 
 fn next_permutation(values: &mut [usize]) -> bool {
-    let Some(pivot) = values.windows(2).rposition(|pair| {
-        pair.first()
-            .zip(pair.last())
-            .is_some_and(|(left, right)| left < right)
-    }) else {
+    let Some(pivot) = values
+        .array_windows::<2>()
+        .rposition(|[left, right]| left < right)
+    else {
         values.reverse();
         return false;
     };

--- a/packages/dure/src/pal/transport/windows.rs
+++ b/packages/dure/src/pal/transport/windows.rs
@@ -215,7 +215,7 @@ fn current_user_sid_string() -> Result<String, PalError> {
     {
         // SAFETY: `buf` holds a TOKEN_USER written by GetTokenInformation. No
         // other exclusive borrow of `buf` exists. `User.Sid` points into `buf`.
-        let user = unsafe { &*buf.as_ptr().cast::<TOKEN_USER>() };
+        let user = unsafe { buf.as_ptr().cast::<TOKEN_USER>().as_ref_unchecked() };
         // SAFETY: `user.User.Sid` is a valid SID inside `buf`. On success
         // `sid_str` is a LocalAlloc string we own.
         unsafe { ConvertSidToStringSidW(user.User.Sid, &raw mut sid_str) }

--- a/packages/dure/src/supervisor.rs
+++ b/packages/dure/src/supervisor.rs
@@ -353,13 +353,13 @@ impl<T: Transport, C> Shared<T, C> {
     fn next_attached_generation(&self) -> u64 {
         let previous = self
             .attached_generation
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |generation| {
+            .try_update(Ordering::SeqCst, Ordering::SeqCst, |generation| {
                 generation.checked_add(1)
             })
             .expect("the process cannot perform enough ownership changes to exhaust u64");
         previous
             .checked_add(1)
-            .expect("fetch_update only succeeds when the next generation exists")
+            .expect("try_update only succeeds when the next generation exists")
     }
 
     /// Holds output produced before the first client attached.

--- a/packages/events/src/auto.rs
+++ b/packages/events/src/auto.rs
@@ -177,7 +177,7 @@ impl EventInner {
         // poll/drop path, which is single-threaded (one future is polled by one task at a
         // time) and has not constructed `&mut Awaiter` here. Other threads access the
         // awaiter only via `AwaiterSet`, which uses `&Awaiter`.
-        let awaiter_ref = unsafe { &*awaiter };
+        let awaiter_ref = unsafe { awaiter.as_ref_unchecked() };
         if awaiter_ref.take_notification() {
             return Poll::Ready(());
         }
@@ -231,7 +231,7 @@ impl EventInner {
         // `Awaiter` reference via `AwaiterSet`); the awaiter is owned by a single future
         // polled by a single task (so no other poll/drop path runs concurrently); and
         // our prior `awaiter_ref` borrow is no longer in use past this point.
-        let awaiter_mut = unsafe { &mut *awaiter };
+        let awaiter_mut = unsafe { awaiter.as_mut_unchecked() };
         // SAFETY: The awaiter is pinned inside the owning future.
         let awaiter_mut = unsafe { Pin::new_unchecked(awaiter_mut) };
         // SAFETY: We hold the mutex; the awaiter is pinned.
@@ -248,7 +248,7 @@ impl EventInner {
         // poll/drop path, which is single-threaded (one future is polled by one task at a
         // time) and has not constructed `&mut Awaiter` here. Other threads access the
         // awaiter only via `AwaiterSet`, which uses `&Awaiter`.
-        let awaiter_ref = unsafe { &*awaiter };
+        let awaiter_ref = unsafe { awaiter.as_ref_unchecked() };
         if !awaiter_ref.is_registered() {
             return;
         }
@@ -276,7 +276,7 @@ impl EventInner {
             // by a single future polled by a single task (so no other poll/drop path
             // runs concurrently); and our prior `awaiter_ref` borrow is no longer in
             // use past this point.
-            let awaiter_mut = unsafe { &mut *awaiter };
+            let awaiter_mut = unsafe { awaiter.as_mut_unchecked() };
             // SAFETY: The awaiter is pinned inside the owning future.
             let awaiter_mut = unsafe { Pin::new_unchecked(awaiter_mut) };
             // SAFETY: We hold the mutex.

--- a/packages/events/src/local_auto.rs
+++ b/packages/events/src/local_auto.rs
@@ -118,7 +118,7 @@ impl Inner {
             // excludes other threads, and the borrow is scoped to this block, ending
             // before the captured waker is invoked; a reentrant `set()` therefore
             // cannot observe an aliasing `&mut`.
-            let state = unsafe { &mut *state_ptr };
+            let state = unsafe { state_ptr.as_mut_unchecked() };
 
             match state {
                 InnerState::Set => None,
@@ -144,7 +144,7 @@ impl Inner {
         // outlives this borrow. Aliasing — `Inner: !Send` excludes other threads, and
         // this function runs no user code while the borrow is live, so no nested or
         // reentrant access can construct an aliasing reference.
-        let state = unsafe { &mut *self.state.get() };
+        let state = unsafe { self.state.get().as_mut_unchecked() };
         if matches!(state, InnerState::Set) {
             *state = InnerState::Unset(AwaiterSet::new());
             true
@@ -166,7 +166,7 @@ impl Inner {
         // borrow is held only while invoking internal `&mut AwaiterSet` methods (no
         // user code runs), so no nested or reentrant access can construct an aliasing
         // reference.
-        let state = unsafe { &mut *self.state.get() };
+        let state = unsafe { self.state.get().as_mut_unchecked() };
 
         match state {
             InnerState::Set => {
@@ -211,7 +211,7 @@ impl Inner {
             // and the borrow is scoped to the `let waker = match state { ... }` chain,
             // ending before `wake()` is invoked; a reentrant call therefore cannot
             // observe an aliasing `&mut`.
-            let state = unsafe { &mut *self.state.get() };
+            let state = unsafe { self.state.get().as_mut_unchecked() };
             let waker = match state {
                 InnerState::Unset(waiters) => match waiters.notify_one() {
                     Some(w) => Some(w),
@@ -233,7 +233,7 @@ impl Inner {
             // outlives this borrow. Aliasing — `Inner: !Send` excludes other threads,
             // and the borrow is held only while invoking `AwaiterSet::unregister`,
             // which runs no user code.
-            let state = unsafe { &mut *self.state.get() };
+            let state = unsafe { self.state.get().as_mut_unchecked() };
             match state {
                 InnerState::Unset(waiters) => {
                     // SAFETY: Single-threaded, awaiter is registered in

--- a/packages/events/src/local_manual.rs
+++ b/packages/events/src/local_manual.rs
@@ -126,7 +126,7 @@ impl Inner {
             // that outlives this borrow. Aliasing — `Inner: !Send` excludes other
             // threads, and the borrow is held only while invoking
             // `AwaiterSet::advance_generation`, which runs no user code.
-            let waiters = unsafe { &mut *self.waiters.get() };
+            let waiters = unsafe { self.waiters.get().as_mut_unchecked() };
             waiters.advance_generation();
         }
 
@@ -144,7 +144,7 @@ impl Inner {
                 // threads, and the borrow is scoped to this block, ending before
                 // `wake()` is invoked; a reentrant call therefore cannot observe an
                 // aliasing `&mut`.
-                let waiters = unsafe { &mut *self.waiters.get() };
+                let waiters = unsafe { self.waiters.get().as_mut_unchecked() };
                 waiters.notify_one_prior_generation()
             };
 
@@ -182,7 +182,7 @@ impl Inner {
         // outlives this borrow. Aliasing — `Inner: !Send` excludes other threads, and
         // the borrow is held only while invoking `AwaiterSet::register`, which runs no
         // user code.
-        let waiters = unsafe { &mut *self.waiters.get() };
+        let waiters = unsafe { self.waiters.get().as_mut_unchecked() };
         // SAFETY: Single-threaded.
         unsafe {
             waiters.register(awaiter.as_mut(), waker);
@@ -200,7 +200,7 @@ impl Inner {
             // outlives this borrow. Aliasing — `Inner: !Send` excludes other threads,
             // and the borrow is held only while invoking `AwaiterSet::unregister`,
             // which runs no user code.
-            let waiters = unsafe { &mut *self.waiters.get() };
+            let waiters = unsafe { self.waiters.get().as_mut_unchecked() };
             // SAFETY: Single-threaded.
             unsafe {
                 waiters.unregister(awaiter.as_mut());

--- a/packages/events/src/manual.rs
+++ b/packages/events/src/manual.rs
@@ -165,7 +165,7 @@ impl EventInner {
         // poll/drop path, which is single-threaded (one future is polled by one task at a
         // time) and has not constructed `&mut Awaiter` here. Other threads access the
         // awaiter only via `AwaiterSet`, which uses `&Awaiter`.
-        let awaiter_ref = unsafe { &*awaiter };
+        let awaiter_ref = unsafe { awaiter.as_ref_unchecked() };
         if awaiter_ref.take_notification() {
             return Poll::Ready(());
         }
@@ -215,7 +215,7 @@ impl EventInner {
         // `Awaiter` reference via `AwaiterSet`); the awaiter is owned by a single future
         // polled by a single task (so no other poll/drop path runs concurrently); and
         // our prior `awaiter_ref` borrows are no longer in use past this point.
-        let awaiter_mut = unsafe { &mut *awaiter };
+        let awaiter_mut = unsafe { awaiter.as_mut_unchecked() };
         // SAFETY: The awaiter is pinned inside the owning future.
         let awaiter_mut = unsafe { Pin::new_unchecked(awaiter_mut) };
         // SAFETY: We hold the mutex.
@@ -233,7 +233,7 @@ impl EventInner {
         // poll/drop path, which is single-threaded (one future is polled by one task at a
         // time) and has not constructed `&mut Awaiter` here. Other threads access the
         // awaiter only via `AwaiterSet`, which uses `&Awaiter`.
-        let awaiter_ref = unsafe { &*awaiter };
+        let awaiter_ref = unsafe { awaiter.as_ref_unchecked() };
         if !awaiter_ref.is_registered() {
             return;
         }
@@ -245,7 +245,7 @@ impl EventInner {
         // `Awaiter` reference via `AwaiterSet`); the awaiter is owned by a single future
         // polled by a single task (so no other poll/drop path runs concurrently); and
         // our prior `awaiter_ref` borrow is no longer in use past this point.
-        let awaiter_mut = unsafe { &mut *awaiter };
+        let awaiter_mut = unsafe { awaiter.as_mut_unchecked() };
         // SAFETY: The awaiter is pinned inside the owning future.
         let awaiter_mut = unsafe { Pin::new_unchecked(awaiter_mut) };
         // SAFETY: We hold the mutex.

--- a/packages/events/src/test_helpers.rs
+++ b/packages/events/src/test_helpers.rs
@@ -56,7 +56,7 @@ fn atomic_wake_by_ref_fn(data: *const ()) {
     // contract on `waker()`). Aliasing — the type only exposes `&self` methods backed
     // by atomics, so unbounded `&AtomicWakeTracker` references may coexist; no
     // `&mut AtomicWakeTracker` is ever constructed by this type's API.
-    let this = unsafe { &*(data as *const AtomicWakeTracker) };
+    let this = unsafe { (data as *const AtomicWakeTracker).as_ref_unchecked() };
     this.woken.store(true, Ordering::Relaxed);
 }
 

--- a/packages/events_once/src/core/local.rs
+++ b/packages/events_once/src/core/local.rs
@@ -266,7 +266,7 @@ impl<T: 'static> LocalEvent<T> {
 
         // SAFETY: The same caller guarantee excludes an exclusive reference while this shared
         // reference exists, and the event outlives this function call.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         NonNull::from(&event.backtrace)
     }
@@ -290,7 +290,7 @@ impl<T: 'static> LocalEvent<T> {
         // SAFETY: The cell's pointer is always valid and points to an initialized event because
         // the caller is still an endpoint of it. We only ever create shared references to the
         // event through this cell, so no exclusive reference can alias this one.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         let mut backtrace = event.backtrace.borrow_mut();
 
@@ -316,7 +316,7 @@ impl<T: 'static> LocalEvent<T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         let value_cell = event.value.get();
 
@@ -608,7 +608,7 @@ impl<T: 'static> LocalEvent<T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         let previous_state = event.state.get();
 
@@ -680,7 +680,7 @@ impl<T: 'static> LocalEvent<T> {
     pub(crate) fn take_result(event_cell: &UnsafeCell<Self>) -> Result<T, Disconnected> {
         // SAFETY: The event reference contract guarantees shared access through this outer
         // UnsafeCell for as long as the receiver still owns its endpoint reference.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         let previous_state = event.state.replace(EVENT_DISCONNECTED);
 
@@ -719,7 +719,7 @@ impl<T: 'static> LocalEvent<T> {
         // SAFETY: We only ever create shared references to the event, so no aliasing conflicts.
         // The event lives until both sender and receiver are dropped or inert, so we know it must
         // still exist because something was able to call this method.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         // If we are still awaiting, the receiver owns the stored waker. Move it out before
         // disconnecting, but defer its destruction to the receiver core so no user code runs until

--- a/packages/events_once/src/core/local/tests.rs
+++ b/packages/events_once/src/core/local/tests.rs
@@ -49,7 +49,7 @@ fn placed<T: 'static>() -> (
 fn placed_event<T: 'static>(place: &EmbeddedLocalEvent<T>) -> &LocalEvent<T> {
     // SAFETY: The container is only ever accessed through shared references, matching the
     // access that the endpoints make, and the pointer of an `UnsafeCell` is never null.
-    let event = unsafe { &*place.inner.get() };
+    let event = unsafe { place.inner.get().as_ref_unchecked() };
 
     // SAFETY: The caller obtained this container from `placed()`, which initialized an event
     // into it. Releasing an event does not deinitialize the storage.

--- a/packages/events_once/src/core/local_receiver.rs
+++ b/packages/events_once/src/core/local_receiver.rs
@@ -44,7 +44,7 @@ where
         // it, which includes the returned reference. Aliasing: the same contract limits all
         // access to shared references, and the event manages its interior fields itself, so no
         // exclusive reference to the event can exist.
-        unsafe { &*event_ref.get() }
+        unsafe { event_ref.get().as_ref_unchecked() }
     }
 
     /// Checks whether the event has completed, in which case reception can finish immediately.

--- a/packages/events_once/src/core/sync.rs
+++ b/packages/events_once/src/core/sync.rs
@@ -295,7 +295,7 @@ where
 
         // SAFETY: The same caller guarantee excludes an exclusive reference while this shared
         // reference exists, and the event outlives this function call.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         NonNull::from(&event.backtrace)
     }
@@ -319,7 +319,7 @@ where
         // SAFETY: The cell's pointer is always valid and points to an initialized event because
         // the caller is still an endpoint of it. We only ever create shared references to the
         // event through this cell, so no exclusive reference can alias this one.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         let mut backtrace = event.backtrace.lock().expect(NEVER_POISONED);
 
@@ -862,7 +862,7 @@ where
     pub(crate) fn take_result(event_cell: &UnsafeCell<Self>) -> Result<T, Disconnected> {
         // SAFETY: The event reference contract guarantees shared access through this outer
         // UnsafeCell for as long as the receiver still owns its endpoint reference.
-        let event = unsafe { &*event_cell.get() };
+        let event = unsafe { event_cell.get().as_ref_unchecked() };
 
         #[cfg(debug_assertions)]
         event

--- a/packages/events_once/src/core/sync_receiver.rs
+++ b/packages/events_once/src/core/sync_receiver.rs
@@ -57,7 +57,7 @@ where
         // access it, which includes the returned reference. Aliasing: the same contract limits
         // all access to shared references, and the event synchronizes its interior fields
         // itself, so no exclusive reference to the event can exist.
-        unsafe { &*event_ref.get() }
+        unsafe { event_ref.get().as_ref_unchecked() }
     }
 
     /// Checks whether the event has completed, in which case reception can finish immediately.

--- a/packages/events_once/src/lake/raw_local.rs
+++ b/packages/events_once/src/lake/raw_local.rs
@@ -113,7 +113,7 @@ impl RawLocalEventLake {
         // SAFETY: The cell holds a live, initialized `Core` per the above. We only ever create
         // shared references to its contents, never `&mut Core`, so no conflicting exclusive
         // reference can exist concurrently.
-        unsafe { &*core_cell.get() }
+        unsafe { core_cell.get().as_ref_unchecked() }
     }
 
     /// Rents an event from the lake, returning its endpoints.

--- a/packages/events_once/src/lake/raw_sync.rs
+++ b/packages/events_once/src/lake/raw_sync.rs
@@ -114,7 +114,7 @@ impl RawEventLake {
         // SAFETY: The cell holds a live, initialized `Core` per the above. We only ever create
         // shared references to its contents, never `&mut Core`, so no conflicting exclusive
         // reference can exist concurrently.
-        unsafe { &*core_cell.get() }
+        unsafe { core_cell.get().as_ref_unchecked() }
     }
 
     /// Rents an event from the lake, returning its endpoints.

--- a/packages/events_once/src/lib.rs
+++ b/packages/events_once/src/lib.rs
@@ -294,6 +294,10 @@
 //!
 //! [1]: https://crates.io/crates/oneshot
 
+#[allow(
+    clippy::unnecessary_safety_comment,
+    reason = "the safety comment belongs to the preceding doctest's unsafe block"
+)]
 #[cfg(debug_assertions)]
 mod backtrace;
 mod constants;

--- a/packages/events_once/src/pool/local_state.rs
+++ b/packages/events_once/src/pool/local_state.rs
@@ -68,7 +68,7 @@ pub(crate) fn initialize_local_event<T: 'static>(
 
     // SAFETY: `MaybeUninit` and `UnsafeCell` are transparent wrappers, so both nestings describe
     // the same storage. No reference to the uninitialized slot remains from the owner above.
-    let place = unsafe { &mut *place };
+    let place = unsafe { place.as_mut_unchecked() };
 
     LocalEvent::new_in_inner(place);
 

--- a/packages/events_once/src/pool/raw_local.rs
+++ b/packages/events_once/src/pool/raw_local.rs
@@ -127,7 +127,7 @@ impl<T: 'static> RawLocalEventPool<T> {
         // references. Endpoints retain an event pointer and, in debug builds, a pointer to the
         // registry rather than the core. `LocalPoolState` allocates through shared references,
         // while the registry mediates its mutation through its own `RefCell`.
-        unsafe { &*core_cell.get() }
+        unsafe { core_cell.get().as_ref_unchecked() }
     }
 
     /// Rents an event from the pool, returning its endpoints.

--- a/packages/events_once/src/pool/raw_sync.rs
+++ b/packages/events_once/src/pool/raw_sync.rs
@@ -128,7 +128,7 @@ impl<T: Send + 'static> RawEventPool<T> {
         // references. Endpoints retain an event pointer and, in debug builds, a pointer to the
         // registry rather than the core. Mutation of the state and registry is synchronized by
         // their own mutexes.
-        unsafe { &*core_cell.get() }
+        unsafe { core_cell.get().as_ref_unchecked() }
     }
 
     /// Rents an event from the pool, returning its endpoints.

--- a/packages/events_once/src/pool/state.rs
+++ b/packages/events_once/src/pool/state.rs
@@ -66,7 +66,7 @@ pub(crate) fn initialize_event<T: Send + 'static>(
 
     // SAFETY: `MaybeUninit` and `UnsafeCell` are transparent wrappers, so both nestings describe
     // the same storage. No reference to the uninitialized slot remains from the owner above.
-    let place = unsafe { &mut *place };
+    let place = unsafe { place.as_mut_unchecked() };
 
     Event::new_in_inner(place);
 

--- a/packages/fast_time/src/clock.rs
+++ b/packages/fast_time/src/clock.rs
@@ -57,8 +57,8 @@ use crate::pal::{Platform, PlatformFacade, TimeSource, TimeSourceFacade};
 /// }
 ///
 /// // All durations should be monotonically increasing
-/// for window in durations.windows(2) {
-///     assert!(window[1] >= window[0]);
+/// for [earlier, later] in durations.array_windows::<2>() {
+///     assert!(later >= earlier);
 /// }
 /// ```
 ///

--- a/packages/fast_time/src/pal.rs
+++ b/packages/fast_time/src/pal.rs
@@ -4,15 +4,19 @@ mod facade;
 pub(crate) use abstractions::*;
 pub(crate) use facade::*;
 
-#[cfg(all(target_os = "linux", not(miri)))]
-mod linux;
-#[cfg(all(target_os = "linux", not(miri)))]
-pub(crate) use linux::*;
-
-#[cfg(all(windows, not(miri)))]
-mod windows;
-#[cfg(all(windows, not(miri)))]
-pub(crate) use windows::*;
+std::cfg_select! {
+    all(target_os = "linux", not(miri)) => {
+        mod linux;
+        pub(crate) use linux::*;
+    }
+    all(windows, not(miri)) => {
+        mod windows;
+        pub(crate) use windows::*;
+    }
+    _ => {
+        pub(crate) use rust::*;
+    }
+}
 
 #[cfg(test)]
 mod mock;
@@ -21,5 +25,3 @@ pub(crate) use mock::*;
 
 // We do not cfg(miri) this simply because that disables IDE editor support, which is annoying.
 mod rust;
-#[cfg(any(miri, not(any(target_os = "linux", windows))))]
-pub(crate) use rust::*;

--- a/packages/future_deque/src/future_deque_core.rs
+++ b/packages/future_deque/src/future_deque_core.rs
@@ -1459,7 +1459,7 @@ mod tests {
             // clone
             |data| {
                 // SAFETY: data is a valid *const Arc<AtomicBool> from Box::into_raw.
-                let flag = unsafe { &*(data as *const Arc<AtomicBool>) };
+                let flag = unsafe { (data as *const Arc<AtomicBool>).as_ref_unchecked() };
                 let cloned = Box::new(Arc::clone(flag));
                 RawWaker::new(Box::into_raw(cloned) as *const (), &VTABLE)
             },
@@ -1472,7 +1472,7 @@ mod tests {
             // wake_by_ref
             |data| {
                 // SAFETY: data is a valid *const Arc<AtomicBool> from Box::into_raw.
-                let flag = unsafe { &*(data as *const Arc<AtomicBool>) };
+                let flag = unsafe { (data as *const Arc<AtomicBool>).as_ref_unchecked() };
                 flag.store(true, Ordering::Release);
             },
             // drop
@@ -1529,7 +1529,7 @@ mod tests {
             // clone
             |data| {
                 // SAFETY: data is a valid *const Arc<AtomicUsize> from Box::into_raw.
-                let counter = unsafe { &*(data as *const Arc<AtomicUsize>) };
+                let counter = unsafe { (data as *const Arc<AtomicUsize>).as_ref_unchecked() };
                 let cloned = Box::new(Arc::clone(counter));
                 RawWaker::new(Box::into_raw(cloned) as *const (), &VTABLE)
             },
@@ -1542,7 +1542,7 @@ mod tests {
             // wake_by_ref
             |data| {
                 // SAFETY: data is a valid *const Arc<AtomicUsize> from Box::into_raw.
-                let counter = unsafe { &*(data as *const Arc<AtomicUsize>) };
+                let counter = unsafe { (data as *const Arc<AtomicUsize>).as_ref_unchecked() };
                 counter.fetch_add(1, Ordering::Relaxed);
             },
             // drop

--- a/packages/future_deque/src/waker_meta.rs
+++ b/packages/future_deque/src/waker_meta.rs
@@ -88,7 +88,7 @@ pub(crate) fn create_waker_meta(shared_parent: &Arc<Mutex<Waker>>) -> MetaPtr {
 /// Creates a [`Waker`] from a metadata pointer, incrementing the refcount.
 pub(crate) fn make_waker(meta: MetaPtr) -> Waker {
     // SAFETY: The metadata is valid (refcount > 0 guarantees it has not been removed).
-    let meta_ref = unsafe { &*meta.0 };
+    let meta_ref = unsafe { meta.0.as_ref_unchecked() };
     meta_ref.ref_count.fetch_add(1, Ordering::Relaxed);
 
     // SAFETY: The vtable functions correctly match the data pointer layout.
@@ -104,7 +104,7 @@ pub(crate) fn make_waker(meta: MetaPtr) -> Waker {
 #[cfg_attr(test, mutants::skip)]
 pub(crate) fn check_activated(meta: MetaPtr) -> bool {
     // SAFETY: The metadata is valid (refcount > 0 guarantees it has not been removed).
-    let meta_ref = unsafe { &*meta.0 };
+    let meta_ref = unsafe { meta.0.as_ref_unchecked() };
     meta_ref.activated.swap(0, Ordering::AcqRel) != 0
 }
 
@@ -119,7 +119,9 @@ pub(crate) fn check_activated(meta: MetaPtr) -> bool {
 #[cfg_attr(test, mutants::skip)]
 pub(crate) fn release_ref(meta: MetaPtr) {
     // SAFETY: The metadata is valid (refcount > 0 guarantees it has not been removed).
-    let previous = unsafe { &*meta.0 }.ref_count.fetch_sub(1, Ordering::AcqRel);
+    let previous = unsafe { meta.0.as_ref_unchecked() }
+        .ref_count
+        .fetch_sub(1, Ordering::AcqRel);
 
     if previous == 1 {
         let ptr = NonNull::new(meta.0.cast_mut())
@@ -138,7 +140,7 @@ pub(crate) fn release_ref(meta: MetaPtr) {
 unsafe fn clone_raw_waker(data: *const ()) -> RawWaker {
     // SAFETY: The data pointer is a valid WakerMeta pointer (guaranteed by
     // construction in make_waker and create_waker_meta).
-    let meta = unsafe { &*(data as *const WakerMeta) };
+    let meta = unsafe { (data as *const WakerMeta).as_ref_unchecked() };
     meta.ref_count.fetch_add(1, Ordering::Relaxed);
     RawWaker::new(data, &WAKER_VTABLE)
 }
@@ -158,7 +160,7 @@ unsafe fn wake_raw_waker(data: *const ()) {
 
 unsafe fn wake_by_ref_raw_waker(data: *const ()) {
     // SAFETY: The data pointer is a valid WakerMeta pointer.
-    let meta = unsafe { &*(data as *const WakerMeta) };
+    let meta = unsafe { (data as *const WakerMeta).as_ref_unchecked() };
 
     // Only wake the parent if we are the first to set the activation flag.
     // If it was already set, the parent was already woken by a prior activation.

--- a/packages/infinity_pool/src/opaque/slab_layout.rs
+++ b/packages/infinity_pool/src/opaque/slab_layout.rs
@@ -52,13 +52,8 @@ impl SlabLayout {
             .extend(object_layout)
             .expect("layout extension cannot fail for valid layouts with reasonable sizes");
 
-        // Calculate the layout for the entire slab (array of slot layouts).
-        //
-        // We cannot use Layout::array() because that requires us to name a type.
-        // Therefore, we just perform the necessary calculations manually.
-        //
-        // Layout::pad_to_align() ensures the size is a multiple of alignment,
-        // which is exactly what we need for proper array element spacing.
+        // Padding the slot first makes its stored size equal the array stride reported by
+        // `Layout::repeat()`.
         let slot_layout = slot_layout.pad_to_align();
 
         let capacity = determine_capacity(
@@ -66,13 +61,9 @@ impl SlabLayout {
                 .expect("slot layout size is non-zero because object layout size is non-zero"),
         );
 
-        let total_size = slot_layout
-            .size()
-            .checked_mul(capacity.get())
+        let (slot_array_layout, _) = slot_layout
+            .repeat(capacity.get())
             .expect("the resulting slab size would be greater than virtual memory - can only be the result of invalid math");
-
-        let slot_array_layout = Layout::from_size_align(total_size, slot_layout.align())
-            .expect("slab layout calculation cannot fail for valid slot layouts");
 
         Self {
             capacity,

--- a/packages/many_cpus_impl/src/pal.rs
+++ b/packages/many_cpus_impl/src/pal.rs
@@ -7,15 +7,19 @@ pub(crate) use abstractions::*;
 mod facade;
 pub(crate) use facade::*;
 
-#[cfg(all(target_os = "linux", not(miri)))]
-mod linux;
-#[cfg(all(target_os = "linux", not(miri)))]
-pub(crate) use linux::*;
-
-#[cfg(all(windows, not(miri)))]
-mod windows;
-#[cfg(all(windows, not(miri)))]
-pub use windows::*;
+std::cfg_select! {
+    all(target_os = "linux", not(miri)) => {
+        mod linux;
+        pub(crate) use linux::*;
+    }
+    all(windows, not(miri)) => {
+        mod windows;
+        pub use windows::*;
+    }
+    _ => {
+        pub(crate) use fallback::*;
+    }
+}
 
 // The fallback module is compiled in test mode on all platforms, under Miri, and as the primary
 // implementation on unsupported platforms. However, we only glob-import it when it is the primary
@@ -24,6 +28,3 @@ pub use windows::*;
 // platform-specific implementation.
 #[cfg(any(test, miri, not(any(target_os = "linux", windows))))]
 pub(crate) mod fallback;
-
-#[cfg(any(miri, not(any(target_os = "linux", windows))))]
-pub(crate) use fallback::*;

--- a/packages/nm_impl/src/event_builder.rs
+++ b/packages/nm_impl/src/event_builder.rs
@@ -113,13 +113,11 @@ where
     /// that exceed the user-defined buckets.
     #[must_use]
     pub fn histogram(self, buckets: &'static [Magnitude]) -> Self {
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "Each window guarantees both indexed elements are in bounds."
-        )]
-        {
-            assert!(buckets.windows(2).all(|w| w[0] < w[1]));
-        }
+        assert!(
+            buckets
+                .array_windows::<2>()
+                .all(|[lower, upper]| lower < upper)
+        );
         assert!(!buckets.contains(&Magnitude::MAX));
 
         Self {

--- a/packages/nm_impl/src/observations.rs
+++ b/packages/nm_impl/src/observations.rs
@@ -1,26 +1,9 @@
 use std::cell::Cell;
+use std::hint::cold_path;
 use std::iter;
 use std::sync::atomic::{self, AtomicI64, AtomicU64};
 
 use crate::Magnitude;
-
-/// Hints to the compiler that the calling branch is unlikely to be taken.
-///
-/// LLVM propagates the `#[cold]` attribute from the called function to the call
-/// site, biasing branch prediction and code layout so that the hot fall-through
-/// path is laid out in straight-line fashion. The cold branch target is moved
-/// to a far section to reduce icache pressure on the hot path.
-///
-/// Marked `#[inline(never)]` so the call is preserved at the call site even
-/// though the body is empty. If LLVM inlined the empty body away, the cold
-/// marker would vanish along with it and the surrounding branch would lose
-/// its cold biasing.
-///
-/// This is a temporary workaround until `std::hint::cold_path()` is
-/// stabilized. See `TODO.md` at the workspace root for the migration note.
-#[cold]
-#[inline(never)]
-fn cold_path() {}
 
 /// Computes the running-total and running-sum increments for a batch observation.
 ///

--- a/packages/nm_impl/src/reports.rs
+++ b/packages/nm_impl/src/reports.rs
@@ -478,17 +478,11 @@ impl Histogram {
     ) -> Self {
         assert_eq!(bucket_counts.len(), bucket_upper_bounds.len());
 
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "Windows guarantee that both indexed elements are in bounds."
-        )]
-        {
-            assert!(
-                bucket_upper_bounds
-                    .windows(2)
-                    .all(|window| window[0] < window[1])
-            );
-        }
+        assert!(
+            bucket_upper_bounds
+                .array_windows::<2>()
+                .all(|[lower, upper]| lower < upper)
+        );
 
         assert!(!bucket_upper_bounds.contains(&Magnitude::MAX));
 

--- a/packages/testing/src/reentrant_waker.rs
+++ b/packages/testing/src/reentrant_waker.rs
@@ -80,7 +80,7 @@ fn wake_by_ref_fn(data: *const ()) {
     // `waker()` requires the caller hold no `&mut ReentrantWakerData` while
     // any waker (or clone) created from it may be invoked, so this `&` borrow
     // does not alias with any `&mut` elsewhere.
-    let this = unsafe { &*(data.cast::<ReentrantWakerData>()) };
+    let this = unsafe { data.cast::<ReentrantWakerData>().as_ref_unchecked() };
     this.was_woken.set(true);
     (this.action)();
 }


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The workspace can raise its supported Rust floor from 1.93.1 to 1.95 and replace compatibility and manual patterns with standard APIs guaranteed by that floor.

## Changes

- Declares Rust 1.95 as the workspace MSRV and removes the obsolete `cold_path` compatibility tracking item.
- Uses `std::hint::cold_path` and adopts the verified Rust 1.94 and 1.95 opportunities: fixed-size `array_windows`, `AtomicU64::try_update`, `Layout::repeat`, `Vec::push_mut`, and `cfg_select!`.
- Replaces all 56 eligible raw-pointer `&*` and `&mut *` reference constructions with explicit `as_ref_unchecked` and `as_mut_unchecked` calls, while preserving their validity and aliasing proofs.
- Records the explicit raw-pointer methods as the workspace convention.
- Preserves a required doctest safety proof with a narrowly reasoned allowance for a Rust 1.95 Clippy false positive that associates it with a later module declaration.