### PR TITLE
Upgrade workspace dependencies and package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "all_the_time"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "alloc_tracker",
  "cpu-time",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "alloc_tracker"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "all_the_time",
  "criterion",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyspawn"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394d31a3ddd26884b4080469dbda9b7b8df45641764f1f23206ddeb177b18a09"
+checksum = "3e77076dc007ba89c131f16caa365e39d98a528f9095d33e8d5dca776cd8e0dd"
 dependencies = [
  "futures-channel",
  "thread_aware",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -207,7 +207,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "awaiter_set"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "criterion",
  "futures",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -446,7 +446,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-bench-history"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bench-history-faker"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "folo_utils",
  "mimalloc",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-detect-package"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "clap",
  "mimalloc",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-freeze-deps"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "mimalloc",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-plan"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "criterion",
@@ -584,7 +584,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbh_analyze"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyspawn",
  "cbh_command",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cbh_command",
  "cbh_model",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_codec"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "alloc_tracker",
  "cbh_model",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_command"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cbh_model",
  "mutants",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_config"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cbh_command",
  "mutants",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_detect"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyspawn",
  "cbh_model",
@@ -673,14 +673,14 @@ dependencies = [
 
 [[package]]
 name = "cbh_diag"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "mutants",
 ]
 
 [[package]]
 name = "cbh_engines"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_git"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cbh_model",
  "futures",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_model"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "jiff",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_probe"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cbh_git",
  "cbh_model",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_render"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cbh_detect",
  "cbh_model",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_stats"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "mutants",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_storage"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
  "compression-core",
  "flate2",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "const-random"
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "cpulist"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "itertools 0.15.0",
  "new_zealand",
@@ -1204,7 +1204,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "dure-test-helper",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "events"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "alloc_tracker",
  "awaiter_set",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "events_once"
-version = "0.5.34"
+version = "0.5.35"
 dependencies = [
  "criterion",
  "futures",
@@ -1333,6 +1333,16 @@ dependencies = [
 [[package]]
 name = "fast_time"
 version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f47559135cddc2c472ba58e45bc466afd016ccc1602a90ccb364c92d765ee7"
+dependencies = [
+ "libc",
+ "windows",
+]
+
+[[package]]
+name = "fast_time"
+version = "0.1.28"
 dependencies = [
  "criterion",
  "gungraun",
@@ -1374,7 +1384,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "folo_ffi"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "mutants",
  "static_assertions",
@@ -1382,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "folo_utils"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "mutants",
  "serde",
@@ -1440,7 +1450,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "future_deque"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -1605,9 +1615,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1716,9 +1726,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "http"
@@ -1939,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1965,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "infinity_pool"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "alloc_tracker",
  "criterion",
@@ -2144,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "linked"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "criterion",
  "gungraun",
@@ -2162,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "linked_macros"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "linked_macros_impl",
  "proc-macro2",
@@ -2170,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "linked_macros_impl"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2225,7 +2235,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "many_cpus"
-version = "2.4.16"
+version = "2.4.17"
 dependencies = [
  "many_cpus_impl",
  "new_zealand",
@@ -2235,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "many_cpus_benchmarking"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "cpulist",
  "criterion",
@@ -2251,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "many_cpus_impl"
-version = "2.4.16"
+version = "2.4.17"
 dependencies = [
  "cpulist",
  "criterion",
@@ -2323,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -2366,27 +2376,46 @@ checksum = "add0ac067452ff1aca8c5002111bd6b1c895baee6e45fcbc44e0193aea17be56"
 
 [[package]]
 name = "new_zealand"
-version = "1.0.7"
+version = "1.0.8"
 
 [[package]]
 name = "nm"
 version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b02df290014878652b07696856ced9cbdc517b2ca4d57752d1a39c7a39515"
 dependencies = [
- "nm_impl",
+ "nm_impl 0.1.45",
+]
+
+[[package]]
+name = "nm"
+version = "0.1.46"
+dependencies = [
+ "nm_impl 0.1.46",
  "static_assertions",
 ]
 
 [[package]]
 name = "nm_impl"
 version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b27a3189e39c8052db6fb1d3b61d75ce036442a15170c81520cf334e1523886e"
+dependencies = [
+ "fast_time 0.1.27",
+ "num-traits",
+]
+
+[[package]]
+name = "nm_impl"
+version = "0.1.46"
 dependencies = [
  "criterion",
- "fast_time",
+ "fast_time 0.1.28",
  "gungraun",
  "many_cpus",
  "mutants",
  "new_zealand",
- "nm",
+ "nm 0.1.46",
  "num-traits",
  "par_bench",
  "static_assertions",
@@ -2395,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "nm_otel"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
- "nm",
+ "nm 0.1.46",
  "nm_otel_impl",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
@@ -2408,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "nm_otel_impl"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "alloc_tracker",
  "criterion",
@@ -2418,8 +2447,8 @@ dependencies = [
  "many_cpus",
  "mutants",
  "new_zealand",
- "nm",
- "nm_impl",
+ "nm 0.1.46",
+ "nm_impl 0.1.46",
  "nm_otel",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2484,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "ohno"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4665329d9a246af05b488837c3736801fedbec2ef3a1b1484fde1bc47550cf63"
+checksum = "c6f03365c20a62c82c5da4cd93abf43cec7115c7d9f84a55ea827e2b56d704a5"
 dependencies = [
  "ohno_macros",
  "typeid",
@@ -2494,9 +2523,18 @@ dependencies = [
 
 [[package]]
 name = "ohno_macros"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565bae93429e274bfbb568535b43dd6458538908014e44faec44dddfafcb5fd3"
+checksum = "2a4ce72614cf218523160501f1c275d718c80083697d62d54186e41512429ba9"
+dependencies = [
+ "ohno_macros_impl",
+]
+
+[[package]]
+name = "ohno_macros_impl"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a2711e52bb0de91b2d6a3c60636bac1827fb109003e235ed827dc9021287d0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2586,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "par_bench"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -2778,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2788,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
@@ -3045,7 +3083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "region_cached"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3067,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "region_local"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3274,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "3.8.7"
+version = "3.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61e66d981128945ef7253d1dcaff636423acfebdee22cd2d8dfd4eb89e4d134"
+checksum = "5d5f8ca67c4f6208caf824037a6a9df0211b4e0937fccc4f543441f294d04511"
 dependencies = [
  "saa",
  "sdd",
@@ -3493,9 +3531,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -3642,32 +3680,33 @@ dependencies = [
 
 [[package]]
 name = "thread_aware"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1d62dcaf3eec4b3d50494a244af37d0e169c37075ccfe02144ad98e86c6901"
+checksum = "1a51b2adee4e72d04bbdb051253a511e04e70fbffd00721bbd9e57bc45c2b29a"
 dependencies = [
+ "nm 0.1.45",
  "thread_aware_macros",
 ]
 
 [[package]]
 name = "thread_aware_macros"
-version = "0.7.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fbb45e1618e4517c4150b20f530af858985eb57f93ed9f22e4df661008b8c52"
+checksum = "2953cbdb8e54f9dc7d08613dedd330e3845330bfb1a0e55714e44b49a044eb80"
 dependencies = [
- "syn 2.0.119",
+ "syn 3.0.4",
  "thread_aware_macros_impl",
 ]
 
 [[package]]
 name = "thread_aware_macros_impl"
-version = "0.7.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe31f85f6362328b8db3ed92ae1d65ca828ed1edb9690d9715c5b0c104c4642d"
+checksum = "4271b41bf3fab1350360754e90a11bb7f661bce00aae8038b83be25030de9642"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3690,9 +3729,9 @@ dependencies = [
 
 [[package]]
 name = "tick"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac1a2e273c0e12c23b85ed62b9e7ae46342ed73a4082f95ed28cdbd807b1fce"
+checksum = "cf8b890df44ed42f77de97f2aa630091bf96fac578ca2a93953e8aee926ebcba"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3826,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4153,19 +4192,19 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vicinal"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
  "criterion",
  "event-listener",
  "events_once",
- "fast_time",
+ "fast_time 0.1.28",
  "futures",
  "many_cpus",
  "mutants",
  "new_zealand",
- "nm",
+ "nm 0.1.46",
  "pin-project",
  "plurality",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,16 +1332,6 @@ dependencies = [
 
 [[package]]
 name = "fast_time"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f47559135cddc2c472ba58e45bc466afd016ccc1602a90ccb364c92d765ee7"
-dependencies = [
- "libc",
- "windows",
-]
-
-[[package]]
-name = "fast_time"
 version = "0.1.28"
 dependencies = [
  "criterion",
@@ -2380,29 +2370,10 @@ version = "1.0.8"
 
 [[package]]
 name = "nm"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537b02df290014878652b07696856ced9cbdc517b2ca4d57752d1a39c7a39515"
-dependencies = [
- "nm_impl 0.1.45",
-]
-
-[[package]]
-name = "nm"
 version = "0.1.46"
 dependencies = [
- "nm_impl 0.1.46",
+ "nm_impl",
  "static_assertions",
-]
-
-[[package]]
-name = "nm_impl"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27a3189e39c8052db6fb1d3b61d75ce036442a15170c81520cf334e1523886e"
-dependencies = [
- "fast_time 0.1.27",
- "num-traits",
 ]
 
 [[package]]
@@ -2410,12 +2381,12 @@ name = "nm_impl"
 version = "0.1.46"
 dependencies = [
  "criterion",
- "fast_time 0.1.28",
+ "fast_time",
  "gungraun",
  "many_cpus",
  "mutants",
  "new_zealand",
- "nm 0.1.46",
+ "nm",
  "num-traits",
  "par_bench",
  "static_assertions",
@@ -2426,7 +2397,7 @@ dependencies = [
 name = "nm_otel"
 version = "0.4.18"
 dependencies = [
- "nm 0.1.46",
+ "nm",
  "nm_otel_impl",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
@@ -2447,8 +2418,8 @@ dependencies = [
  "many_cpus",
  "mutants",
  "new_zealand",
- "nm 0.1.46",
- "nm_impl 0.1.46",
+ "nm",
+ "nm_impl",
  "nm_otel",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3684,7 +3655,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a51b2adee4e72d04bbdb051253a511e04e70fbffd00721bbd9e57bc45c2b29a"
 dependencies = [
- "nm 0.1.45",
+ "nm",
  "thread_aware_macros",
 ]
 
@@ -4199,12 +4170,12 @@ dependencies = [
  "criterion",
  "event-listener",
  "events_once",
- "fast_time 0.1.28",
+ "fast_time",
  "futures",
  "many_cpus",
  "mutants",
  "new_zealand",
- "nm 0.1.46",
+ "nm",
  "pin-project",
  "plurality",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,19 @@ repository = "https://github.com/folo-rs/folo"
 rust-version = "1.95"
 
 [workspace.dependencies]
-all_the_time = { version = "0.6.2", path = "packages/all_the_time", default-features = false }
-alloc_tracker = { version = "0.7.1", path = "packages/alloc_tracker", default-features = false }
+all_the_time = { version = "0.6.3", path = "packages/all_the_time", default-features = false }
+alloc_tracker = { version = "0.7.2", path = "packages/alloc_tracker", default-features = false }
 anyspawn = { version = "0.8.0", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
-awaiter_set = { version = "0.1.11", path = "packages/awaiter_set", default-features = false }
+awaiter_set = { version = "0.1.12", path = "packages/awaiter_set", default-features = false }
 axum = { version = "0.8.0", default-features = false }
 azure_core = { version = "1.0.0", default-features = false }
 azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
-cargo-freeze-deps = { version = "0.1.7", path = "packages/cargo-freeze-deps", default-features = false }
-cargo-release-plan = { version = "0.1.1", path = "packages/cargo-release-plan", default-features = false }
+cargo-freeze-deps = { version = "0.1.8", path = "packages/cargo-freeze-deps", default-features = false }
+cargo-release-plan = { version = "0.1.2", path = "packages/cargo-release-plan", default-features = false }
 cbh_analyze = { version = "=0.2.3", path = "packages/cbh_analyze", default-features = false }
 cbh_cli = { version = "=0.2.3", path = "packages/cbh_cli", default-features = false }
 cbh_codec = { version = "=0.2.3", path = "packages/cbh_codec", default-features = false }
@@ -40,23 +40,23 @@ cbh_storage = { version = "=0.2.3", path = "packages/cbh_storage", default-featu
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
 colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }
-cpulist = { version = "1.1.7", path = "packages/cpulist", default-features = false }
+cpulist = { version = "1.1.8", path = "packages/cpulist", default-features = false }
 criterion = { version = "0.8.2", default-features = false }
 deranged = { version = "0.5.2", default-features = false }
 derive_more = { version = "2.0.0", default-features = false }
 event-listener = { version = "5.4.0", default-features = false, features = [
     "std",
 ] }
-events = { version = "0.7.13", path = "packages/events", default-features = false }
-events_once = { version = "0.5.34", path = "packages/events_once", default-features = false }
+events = { version = "0.7.14", path = "packages/events", default-features = false }
+events_once = { version = "0.5.35", path = "packages/events_once", default-features = false }
 fake_headers = { version = "0.0.5", default-features = false }
-fast_time = { version = "0.1.27", path = "packages/fast_time", default-features = false }
+fast_time = { version = "0.1.28", path = "packages/fast_time", default-features = false }
 flate2 = { version = "1.1.9", default-features = false }
 foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
-folo_ffi = { version = "0.1.15", path = "packages/folo_ffi", default-features = false }
-folo_utils = { version = "0.1.10", path = "packages/folo_utils", default-features = false }
+folo_ffi = { version = "0.1.16", path = "packages/folo_ffi", default-features = false }
+folo_utils = { version = "0.1.11", path = "packages/folo_utils", default-features = false }
 frozen-collections = { version = "0.9.1", default-features = false }
-future_deque = { version = "0.1.17", path = "packages/future_deque", default-features = false }
+future_deque = { version = "0.1.18", path = "packages/future_deque", default-features = false }
 futures = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-core = { version = "0.3.32", default-features = false }
 # Keep this version in lockstep with `GUNGRAUN_RUNNER_VERSION` in `constants.env` (which the
@@ -78,19 +78,19 @@ itertools = { version = "0.15.0", default-features = false, features = [
 ] }
 jiff = { version = "0.2.28", default-features = false, features = ["std"] }
 libc = { version = "0.2.172", default-features = false }
-linked = { version = "1.0.19", path = "packages/linked", default-features = false }
+linked = { version = "1.0.20", path = "packages/linked", default-features = false }
 linked_macros = { version = "=1.0.20", path = "packages/linked_macros", default-features = false }
 linked_macros_impl = { version = "=1.0.20", path = "packages/linked_macros_impl", default-features = false }
-many_cpus = { version = "2.4.16", path = "packages/many_cpus", default-features = false }
+many_cpus = { version = "2.4.17", path = "packages/many_cpus", default-features = false }
 many_cpus_impl = { version = "=2.4.17", path = "packages/many_cpus_impl", default-features = false }
 mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.15.0", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
 negative-impl = { version = "0.1.0", default-features = false }
-new_zealand = { version = "1.0.7", path = "packages/new_zealand", default-features = false }
-nm = { version = "0.1.45", path = "packages/nm", default-features = false }
+new_zealand = { version = "1.0.8", path = "packages/new_zealand", default-features = false }
+nm = { version = "0.1.46", path = "packages/nm", default-features = false }
 nm_impl = { version = "=0.1.46", path = "packages/nm_impl", default-features = false }
-nm_otel = { version = "0.4.17", path = "packages/nm_otel", default-features = false }
+nm_otel = { version = "0.4.18", path = "packages/nm_otel", default-features = false }
 nm_otel_impl = { version = "=0.4.18", path = "packages/nm_otel_impl", default-features = false }
 nonempty = { version = "0.12.0", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
@@ -139,7 +139,7 @@ toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.12", default-features = false }
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 trybuild = { version = "1.0.0", default-features = false }
-vicinal = { version = "0.1.36", path = "packages/vicinal", default-features = false }
+vicinal = { version = "0.1.37", path = "packages/vicinal", default-features = false }
 windows = { version = "0.62.0", default-features = false, features = ["std"] }
 
 # Cargo packages that form one logical unit belong to one version group, and the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,12 @@ trybuild = { version = "1.0.0", default-features = false }
 vicinal = { version = "0.1.37", path = "packages/vicinal", default-features = false }
 windows = { version = "0.62.0", default-features = false, features = ["std"] }
 
+[patch.crates-io]
+# `thread_aware` depends on a compatible published version of this package. Resolve that transitive
+# requirement to the workspace package so Cargo package selectors remain unambiguous.
+# Registry and path packages remain distinct identities even when their names and versions match.
+nm = { path = "packages/nm" }
+
 # Cargo packages that form one logical unit belong to one version group, and the
 # members of a version group must share a version. cargo-release-plan expands an
 # increment across every member of a version group and rewrites intra-workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.95"
 [workspace.dependencies]
 all_the_time = { version = "0.6.2", path = "packages/all_the_time", default-features = false }
 alloc_tracker = { version = "0.7.1", path = "packages/alloc_tracker", default-features = false }
-anyspawn = { version = "0.7.0", default-features = false }
+anyspawn = { version = "0.8.0", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
 awaiter_set = { version = "0.1.11", path = "packages/awaiter_set", default-features = false }
@@ -23,20 +23,20 @@ azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
 cargo-freeze-deps = { version = "0.1.7", path = "packages/cargo-freeze-deps", default-features = false }
 cargo-release-plan = { version = "0.1.1", path = "packages/cargo-release-plan", default-features = false }
-cbh_analyze = { version = "=0.2.2", path = "packages/cbh_analyze", default-features = false }
-cbh_cli = { version = "=0.2.2", path = "packages/cbh_cli", default-features = false }
-cbh_codec = { version = "=0.2.2", path = "packages/cbh_codec", default-features = false }
-cbh_command = { version = "=0.2.2", path = "packages/cbh_command", default-features = false }
-cbh_config = { version = "=0.2.2", path = "packages/cbh_config", default-features = false }
-cbh_detect = { version = "=0.2.2", path = "packages/cbh_detect", default-features = false }
-cbh_diag = { version = "=0.2.2", path = "packages/cbh_diag", default-features = false }
-cbh_engines = { version = "=0.2.2", path = "packages/cbh_engines", default-features = false }
-cbh_git = { version = "=0.2.2", path = "packages/cbh_git", default-features = false }
-cbh_model = { version = "=0.2.2", path = "packages/cbh_model", default-features = false }
-cbh_probe = { version = "=0.2.2", path = "packages/cbh_probe", default-features = false }
-cbh_render = { version = "=0.2.2", path = "packages/cbh_render", default-features = false }
-cbh_stats = { version = "=0.2.2", path = "packages/cbh_stats", default-features = false }
-cbh_storage = { version = "=0.2.2", path = "packages/cbh_storage", default-features = false }
+cbh_analyze = { version = "=0.2.3", path = "packages/cbh_analyze", default-features = false }
+cbh_cli = { version = "=0.2.3", path = "packages/cbh_cli", default-features = false }
+cbh_codec = { version = "=0.2.3", path = "packages/cbh_codec", default-features = false }
+cbh_command = { version = "=0.2.3", path = "packages/cbh_command", default-features = false }
+cbh_config = { version = "=0.2.3", path = "packages/cbh_config", default-features = false }
+cbh_detect = { version = "=0.2.3", path = "packages/cbh_detect", default-features = false }
+cbh_diag = { version = "=0.2.3", path = "packages/cbh_diag", default-features = false }
+cbh_engines = { version = "=0.2.3", path = "packages/cbh_engines", default-features = false }
+cbh_git = { version = "=0.2.3", path = "packages/cbh_git", default-features = false }
+cbh_model = { version = "=0.2.3", path = "packages/cbh_model", default-features = false }
+cbh_probe = { version = "=0.2.3", path = "packages/cbh_probe", default-features = false }
+cbh_render = { version = "=0.2.3", path = "packages/cbh_render", default-features = false }
+cbh_stats = { version = "=0.2.3", path = "packages/cbh_stats", default-features = false }
+cbh_storage = { version = "=0.2.3", path = "packages/cbh_storage", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
 colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }
@@ -79,23 +79,23 @@ itertools = { version = "0.15.0", default-features = false, features = [
 jiff = { version = "0.2.28", default-features = false, features = ["std"] }
 libc = { version = "0.2.172", default-features = false }
 linked = { version = "1.0.19", path = "packages/linked", default-features = false }
-linked_macros = { version = "=1.0.19", path = "packages/linked_macros", default-features = false }
-linked_macros_impl = { version = "=1.0.19", path = "packages/linked_macros_impl", default-features = false }
+linked_macros = { version = "=1.0.20", path = "packages/linked_macros", default-features = false }
+linked_macros_impl = { version = "=1.0.20", path = "packages/linked_macros_impl", default-features = false }
 many_cpus = { version = "2.4.16", path = "packages/many_cpus", default-features = false }
-many_cpus_impl = { version = "=2.4.16", path = "packages/many_cpus_impl", default-features = false }
+many_cpus_impl = { version = "=2.4.17", path = "packages/many_cpus_impl", default-features = false }
 mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.15.0", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
 negative-impl = { version = "0.1.0", default-features = false }
 new_zealand = { version = "1.0.7", path = "packages/new_zealand", default-features = false }
 nm = { version = "0.1.45", path = "packages/nm", default-features = false }
-nm_impl = { version = "=0.1.45", path = "packages/nm_impl", default-features = false }
+nm_impl = { version = "=0.1.46", path = "packages/nm_impl", default-features = false }
 nm_otel = { version = "0.4.17", path = "packages/nm_otel", default-features = false }
-nm_otel_impl = { version = "=0.4.17", path = "packages/nm_otel_impl", default-features = false }
+nm_otel_impl = { version = "=0.4.18", path = "packages/nm_otel_impl", default-features = false }
 nonempty = { version = "0.12.0", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
-ohno = { version = "0.4.0", default-features = false }
+ohno = { version = "0.5.0", default-features = false }
 oneshot = { version = "0.2.1", default-features = false, features = [
     "std",
     "async",
@@ -131,9 +131,9 @@ smallvec = { version = "1.15.0", default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
 syn = { version = "3.0.3", default-features = false }
 tempfile = { version = "3.20.0", default-features = false }
-thread_aware = { version = "0.9.0", default-features = false }
+thread_aware = { version = "0.11.0", default-features = false }
 threadpool = { version = "1.8.1", default-features = false }
-tick = { version = "0.5.0", default-features = false }
+tick = { version = "0.6.0", default-features = false }
 tokio = { version = "1.49.0", default-features = false }
 toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.12", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,12 +142,6 @@ trybuild = { version = "1.0.0", default-features = false }
 vicinal = { version = "0.1.37", path = "packages/vicinal", default-features = false }
 windows = { version = "0.62.0", default-features = false, features = ["std"] }
 
-[patch.crates-io]
-# `thread_aware` depends on a compatible published version of this package. Resolve that transitive
-# requirement to the workspace package so Cargo package selectors remain unambiguous.
-# Registry and path packages remain distinct identities even when their names and versions match.
-nm = { path = "packages/nm" }
-
 # Cargo packages that form one logical unit belong to one version group, and the
 # members of a version group must share a version. cargo-release-plan expands an
 # increment across every member of a version group and rewrites intra-workspace
@@ -399,6 +393,12 @@ useless_let_if_seq = "warn"
 verbose_bit_mask = "warn"
 volatile_composites = "warn"
 while_float = "warn"
+
+[patch.crates-io]
+# `thread_aware` depends on a compatible published version of this package. Resolve that transitive
+# requirement to the workspace package so Cargo package selectors remain unambiguous.
+# Registry and path packages remain distinct identities even when their names and versions match.
+nm = { path = "packages/nm" }
 
 [profile.release]
 # This ensures we have high quality data with proper stack traces when profiling.

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -2,7 +2,7 @@
 name = "all_the_time"
 description = "Processor time tracking utilities for benchmarks and performance analysis"
 publish = true
-version = "0.6.2"
+version = "0.6.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/alloc_tracker/Cargo.toml
+++ b/packages/alloc_tracker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alloc_tracker"
 description = "Memory allocation tracking utilities for benchmarks and performance analysis"
 publish = true
-version = "0.7.1"
+version = "0.7.2"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/awaiter_set/Cargo.toml
+++ b/packages/awaiter_set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "awaiter_set"
 description = "Zero-allocation awaiter tracking for async synchronization primitives"
 publish = true
-version = "0.1.11"
+version = "0.1.12"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-bench-history-faker/Cargo.toml
+++ b/packages/cargo-bench-history-faker/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cargo-bench-history-faker"
 description = "Unsupported synthetic benchmark-output generator for validating cargo-bench-history end to end; no stable API or CLI"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-bench-history"
 description = "A Cargo tool that maintains a long-lived history of benchmark results and analyzes it for trends"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-detect-package"
 description = "A Cargo tool to detect the package that a file belongs to, passing the package name to a subcommand"
 publish = true
-version = "1.0.28"
+version = "1.0.29"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-freeze-deps"
 description = "A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file to their literal values"
 publish = true
-version = "0.1.7"
+version = "0.1.8"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-release-plan/Cargo.toml
+++ b/packages/cargo-release-plan/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-release-plan"
 description = "A Cargo subcommand that classifies publishable packages against their version anchors and applies increment plans"
 publish = true
-version = "0.1.1"
+version = "0.1.2"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_analyze/Cargo.toml
+++ b/packages/cbh_analyze/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_analyze"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_analyze/src/error.rs
+++ b/packages/cbh_analyze/src/error.rs
@@ -4,6 +4,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use cbh_config::ConfigError;
 use cbh_storage::StorageError;
+use ohno::OhnoCore;
 
 /// An error from an `analyze`-family command (`analyze`, `list`, `prune`,
 /// `examine`, `bless`, `unbless`).
@@ -11,7 +12,7 @@ use cbh_storage::StorageError;
 /// It is transparent: it renders exactly the message of the failure it carries
 /// and adds nothing of its own, so converting one into the binary's
 /// [`AppError`](ohno::AppError) leaves the message a user sees unchanged.
-#[ohno::error]
+#[derive(ohno::Error)]
 #[no_constructors]
 #[from(ConfigError, StorageError, NoOutputSelectedError)]
 #[from(
@@ -37,14 +38,16 @@ use cbh_storage::StorageError;
 )]
 #[from(WorkingTreeProbeFailedError, CommitterTimeFailedError)]
 #[from(DefaultBranchProbeFailedError, ToolchainProbeFailedError)]
-pub struct AnalyzeError;
+pub struct AnalyzeError {
+    #[error]
+    core: OhnoCore,
+}
 
-// Every error type in this file holds an OhnoCore field containing
-// Arc<dyn Error + Send + Sync>, which is !UnwindSafe because Arc requires
-// T: RefUnwindSafe and trait objects are !RefUnwindSafe. However, ohno error types are
-// immutable after construction — no &self method mutates internal state — so observing
-// them through a shared reference during unwind is harmless. That is the reasoning the
-// manual impls following each type below rest on.
+// Every error type in this file holds an OhnoCore field containing Arc<dyn Error + Send + Sync>,
+// which is !UnwindSafe because Arc requires T: RefUnwindSafe and trait objects are
+// !RefUnwindSafe. However, ohno error types are immutable after construction — no &self method
+// mutates internal state — so observing them through a shared reference during unwind is
+// harmless. That is the reasoning the manual impls following each type below rest on.
 impl UnwindSafe for AnalyzeError {}
 impl RefUnwindSafe for AnalyzeError {}
 

--- a/packages/cbh_cli/Cargo.toml
+++ b/packages/cbh_cli/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_cli"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_codec/Cargo.toml
+++ b/packages/cbh_codec/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_codec"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_command/Cargo.toml
+++ b/packages/cbh_command/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_command"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_config/Cargo.toml
+++ b/packages/cbh_config/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_config"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_config/src/error.rs
+++ b/packages/cbh_config/src/error.rs
@@ -3,19 +3,24 @@
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::path::PathBuf;
 
+use ohno::OhnoCore;
+
 /// Loading configuration or resolving a configured option failed.
 ///
 /// The error preserves the concrete failure and any underlying I/O or TOML
 /// error in its source chain.
-#[ohno::error]
+#[derive(ohno::Error)]
 #[no_constructors]
 #[from(ReadConfigError, ParseConfigError, SelectionEnvironmentRequiredError)]
-pub struct ConfigError;
+pub struct ConfigError {
+    #[error]
+    core: OhnoCore,
+}
 
-// The #[ohno::error] macro injects an OhnoCore field containing Arc<dyn Error + Send + Sync>,
-// which is !UnwindSafe because Arc requires T: RefUnwindSafe and trait objects are !RefUnwindSafe.
-// However, ohno error types are immutable after construction — no &self method mutates internal
-// state — so observing them through a shared reference during unwind is harmless.
+// The OhnoCore field contains Arc<dyn Error + Send + Sync>, which is !UnwindSafe because Arc
+// requires T: RefUnwindSafe and trait objects are !RefUnwindSafe. However, ohno error types are
+// immutable after construction — no &self method mutates internal state — so observing them
+// through a shared reference during unwind is harmless.
 impl UnwindSafe for ConfigError {}
 impl RefUnwindSafe for ConfigError {}
 

--- a/packages/cbh_detect/Cargo.toml
+++ b/packages/cbh_detect/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_detect"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_diag/Cargo.toml
+++ b/packages/cbh_diag/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_diag"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_engines/Cargo.toml
+++ b/packages/cbh_engines/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_engines"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_engines/src/bench/all_the_time.rs
+++ b/packages/cbh_engines/src/bench/all_the_time.rs
@@ -16,15 +16,19 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use cbh_model::{BenchmarkId, BenchmarkResult, Metric, MetricKind};
 use nonempty::NonEmpty;
+use ohno::OhnoCore;
 use serde::Deserialize;
 
 /// Parsing an `all_the_time` operation file failed.
 ///
 /// The underlying failure is retained in the source chain.
-#[ohno::error]
+#[derive(ohno::Error)]
 #[no_constructors]
 #[from(AllTheTimeJsonError)]
-pub struct AllTheTimeParseError;
+pub struct AllTheTimeParseError {
+    #[error]
+    core: OhnoCore,
+}
 
 /// An `all_the_time` operation file was malformed.
 #[ohno::error]
@@ -32,10 +36,10 @@ pub struct AllTheTimeParseError;
 #[from(serde_json::Error)]
 struct AllTheTimeJsonError;
 
-// The #[ohno::error] macro injects an OhnoCore field containing Arc<dyn Error + Send + Sync>,
-// which is !UnwindSafe because Arc requires T: RefUnwindSafe and trait objects are !RefUnwindSafe.
-// However, ohno error types are immutable after construction — no &self method mutates internal
-// state — so observing them through a shared reference during unwind is harmless.
+// The OhnoCore field contains Arc<dyn Error + Send + Sync>, which is !UnwindSafe because Arc
+// requires T: RefUnwindSafe and trait objects are !RefUnwindSafe. However, ohno error types are
+// immutable after construction — no &self method mutates internal state — so observing them
+// through a shared reference during unwind is harmless.
 impl UnwindSafe for AllTheTimeParseError {}
 impl RefUnwindSafe for AllTheTimeParseError {}
 impl UnwindSafe for AllTheTimeJsonError {}

--- a/packages/cbh_engines/src/bench/alloc_tracker.rs
+++ b/packages/cbh_engines/src/bench/alloc_tracker.rs
@@ -23,15 +23,19 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use cbh_model::{BenchmarkId, BenchmarkResult, Metric, MetricKind};
 use nonempty::NonEmpty;
+use ohno::OhnoCore;
 use serde::Deserialize;
 
 /// Parsing an `alloc_tracker` operation file failed.
 ///
 /// The underlying failure is retained in the source chain.
-#[ohno::error]
+#[derive(ohno::Error)]
 #[no_constructors]
 #[from(AllocTrackerJsonError)]
-pub struct AllocTrackerParseError;
+pub struct AllocTrackerParseError {
+    #[error]
+    core: OhnoCore,
+}
 
 /// An `alloc_tracker` operation file was malformed.
 #[ohno::error]
@@ -39,10 +43,10 @@ pub struct AllocTrackerParseError;
 #[from(serde_json::Error)]
 struct AllocTrackerJsonError;
 
-// The #[ohno::error] macro injects an OhnoCore field containing Arc<dyn Error + Send + Sync>,
-// which is !UnwindSafe because Arc requires T: RefUnwindSafe and trait objects are !RefUnwindSafe.
-// However, ohno error types are immutable after construction — no &self method mutates internal
-// state — so observing them through a shared reference during unwind is harmless.
+// The OhnoCore field contains Arc<dyn Error + Send + Sync>, which is !UnwindSafe because Arc
+// requires T: RefUnwindSafe and trait objects are !RefUnwindSafe. However, ohno error types are
+// immutable after construction — no &self method mutates internal state — so observing them
+// through a shared reference during unwind is harmless.
 impl UnwindSafe for AllocTrackerParseError {}
 impl RefUnwindSafe for AllocTrackerParseError {}
 impl UnwindSafe for AllocTrackerJsonError {}

--- a/packages/cbh_engines/src/bench/callgrind.rs
+++ b/packages/cbh_engines/src/bench/callgrind.rs
@@ -11,6 +11,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use cbh_model::{BenchmarkId, BenchmarkResult, Metric, MetricKind};
 use nonempty::NonEmpty;
+use ohno::OhnoCore;
 use serde::Deserialize;
 
 /// The Gungraun summary schema version this parser understands.
@@ -20,10 +21,13 @@ const SUPPORTED_VERSION: &str = "6";
 ///
 /// The error retains the concrete parsing failure in its source chain and
 /// displays that failure without adding aggregate-level wording.
-#[ohno::error]
+#[derive(ohno::Error)]
 #[no_constructors]
 #[from(CallgrindJsonError, UnsupportedCallgrindVersionError)]
-pub struct CallgrindParseError;
+pub struct CallgrindParseError {
+    #[error]
+    core: OhnoCore,
+}
 
 /// A Callgrind `summary.json` document was malformed.
 ///
@@ -47,10 +51,10 @@ struct UnsupportedCallgrindVersionError {
     supported_version: String,
 }
 
-// The #[ohno::error] macro injects an OhnoCore field containing Arc<dyn Error + Send + Sync>,
-// which is !UnwindSafe because Arc requires T: RefUnwindSafe and trait objects are !RefUnwindSafe.
-// However, ohno error types are immutable after construction — no &self method mutates internal
-// state — so observing them through a shared reference during unwind is harmless.
+// The OhnoCore field contains Arc<dyn Error + Send + Sync>, which is !UnwindSafe because Arc
+// requires T: RefUnwindSafe and trait objects are !RefUnwindSafe. However, ohno error types are
+// immutable after construction — no &self method mutates internal state — so observing them
+// through a shared reference during unwind is harmless.
 impl UnwindSafe for CallgrindParseError {}
 impl RefUnwindSafe for CallgrindParseError {}
 impl UnwindSafe for CallgrindJsonError {}

--- a/packages/cbh_engines/src/bench/criterion.rs
+++ b/packages/cbh_engines/src/bench/criterion.rs
@@ -12,16 +12,20 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use cbh_model::{BenchmarkId, BenchmarkResult, Metric, MetricKind};
 use nonempty::NonEmpty;
+use ohno::OhnoCore;
 use serde::Deserialize;
 
 /// An error encountered while parsing a Criterion result case.
 ///
 /// The error retains the concrete document failure in its source chain and
 /// displays that failure without adding aggregate-level wording.
-#[ohno::error]
+#[derive(ohno::Error)]
 #[no_constructors]
 #[from(BenchmarkParseError, EstimatesParseError)]
-pub struct CriterionParseError;
+pub struct CriterionParseError {
+    #[error]
+    core: OhnoCore,
+}
 
 /// Criterion's `benchmark.json` was malformed.
 ///
@@ -39,10 +43,10 @@ struct BenchmarkParseError;
 #[from(serde_json::Error)]
 struct EstimatesParseError;
 
-// The #[ohno::error] macro injects an OhnoCore field containing Arc<dyn Error + Send + Sync>,
-// which is !UnwindSafe because Arc requires T: RefUnwindSafe and trait objects are !RefUnwindSafe.
-// However, ohno error types are immutable after construction — no &self method mutates internal
-// state — so observing them through a shared reference during unwind is harmless.
+// The OhnoCore field contains Arc<dyn Error + Send + Sync>, which is !UnwindSafe because Arc
+// requires T: RefUnwindSafe and trait objects are !RefUnwindSafe. However, ohno error types are
+// immutable after construction — no &self method mutates internal state — so observing them
+// through a shared reference during unwind is harmless.
 impl UnwindSafe for CriterionParseError {}
 impl RefUnwindSafe for CriterionParseError {}
 impl UnwindSafe for BenchmarkParseError {}

--- a/packages/cbh_git/Cargo.toml
+++ b/packages/cbh_git/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_git"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_model/Cargo.toml
+++ b/packages/cbh_model/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_model"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_model/src/aggregate.rs
+++ b/packages/cbh_model/src/aggregate.rs
@@ -15,6 +15,8 @@
 use std::collections::HashMap;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
+use ohno::OhnoCore;
+
 use crate::{BenchmarkId, BenchmarkResult, MetricKind, MetricList};
 
 /// The best-of-N reduction: combined results plus per-metric provenance.
@@ -49,16 +51,17 @@ pub struct Selection {
 /// that each metric has exactly one sample per run to minimize over. A missing or
 /// extra case or metric in any run is a hard error rather than something to paper
 /// over, because it means the runs did not exercise the same work.
-#[ohno::error]
-#[derive(Clone)]
+#[derive(Clone, ohno::Error)]
 #[no_constructors]
 #[from(MissingCaseError, MissingMetricError)]
-pub struct AggregateError;
+pub struct AggregateError {
+    #[error]
+    core: OhnoCore,
+}
 
-// `#[ohno::error]` injects `OhnoCore`, which blocks automatic unwind-safety trait
-// inference. All ohno error types in this module expose no mutation, so unwinding
-// cannot reveal a partially mutated value. Introducing mutation or interior mutability
-// requires re-evaluating every manual impl below.
+// `OhnoCore` blocks automatic unwind-safety trait inference. All ohno error types in this
+// module expose no mutation, so unwinding cannot reveal a partially mutated value.
+// Introducing mutation or interior mutability requires re-evaluating every manual impl below.
 impl UnwindSafe for AggregateError {}
 impl RefUnwindSafe for AggregateError {}
 

--- a/packages/cbh_model/src/benchmark_id.rs
+++ b/packages/cbh_model/src/benchmark_id.rs
@@ -5,6 +5,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::str::FromStr;
 
 use nonempty::NonEmpty;
+use ohno::OhnoCore;
 use serde::{Deserialize, Serialize};
 
 /// Stable identity of a benchmark series.
@@ -127,16 +128,17 @@ impl From<BenchmarkIdPrefix> for String {
 }
 
 /// Error returned when a [`BenchmarkIdPrefix`] is constructed from an empty value.
-#[ohno::error]
-#[derive(Clone)]
+#[derive(Clone, ohno::Error)]
 #[no_constructors]
 #[from(EmptyBenchmarkIdPrefixValueError)]
-pub struct EmptyBenchmarkIdPrefix;
+pub struct EmptyBenchmarkIdPrefix {
+    #[error]
+    core: OhnoCore,
+}
 
-// `#[ohno::error]` injects `OhnoCore`, which blocks automatic unwind-safety trait
-// inference. All ohno error types in this module expose no mutation, so unwinding
-// cannot reveal a partially mutated value. Introducing mutation or interior mutability
-// requires re-evaluating every manual impl below.
+// `OhnoCore` blocks automatic unwind-safety trait inference. All ohno error types in this
+// module expose no mutation, so unwinding cannot reveal a partially mutated value.
+// Introducing mutation or interior mutability requires re-evaluating every manual impl below.
 impl UnwindSafe for EmptyBenchmarkIdPrefix {}
 impl RefUnwindSafe for EmptyBenchmarkIdPrefix {}
 

--- a/packages/cbh_probe/Cargo.toml
+++ b/packages/cbh_probe/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_probe"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_render/Cargo.toml
+++ b/packages/cbh_render/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_render"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_stats/Cargo.toml
+++ b/packages/cbh_stats/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_stats"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_storage/Cargo.toml
+++ b/packages/cbh_storage/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_storage"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.2"
+version = "0.2.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cpulist/Cargo.toml
+++ b/packages/cpulist/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cpulist"
 description = "Parse and emit the Linux 'cpulist' data format used to list processors, memory regions and similar entities"
 publish = true
-version = "1.1.7"
+version = "1.1.8"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.2.0"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -2,7 +2,7 @@
 name = "events"
 description = "Async manual-reset and auto-reset event primitives"
 publish = true
-version = "0.7.13"
+version = "0.7.14"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/events_once/Cargo.toml
+++ b/packages/events_once/Cargo.toml
@@ -2,7 +2,7 @@
 name = "events_once"
 description = "Efficient oneshot events (channels) with support for single-threaded events, object embedding, event pools and event lakes"
 publish = true
-version = "0.5.34"
+version = "0.5.35"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/fast_time/Cargo.toml
+++ b/packages/fast_time/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fast_time"
 description = "An efficient low-precision timestamp source suitable for high-frequency querying"
 publish = true
-version = "0.1.27"
+version = "0.1.28"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/folo_ffi/Cargo.toml
+++ b/packages/folo_ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "folo_ffi"
 description = "Utilities for working with FFI logic; exists for internal use in Folo packages; no stable API surface"
 publish = true
-version = "0.1.15"
+version = "0.1.16"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/folo_utils/Cargo.toml
+++ b/packages/folo_utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "folo_utils"
 description = "Utilities for internal use in Folo packages; no stable API surface"
 publish = true
-version = "0.1.10"
+version = "0.1.11"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/future_deque/Cargo.toml
+++ b/packages/future_deque/Cargo.toml
@@ -2,7 +2,7 @@
 name = "future_deque"
 description = "Deque collections for managing groups of futures"
 publish = true
-version = "0.1.17"
+version = "0.1.18"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/infinity_pool/Cargo.toml
+++ b/packages/infinity_pool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "infinity_pool"
 description = "Offers object pooling capabilities both thread-safe and single threaded, both lifetime-managed and manual, both typed and untyped"
 publish = true
-version = "0.8.24"
+version = "0.8.25"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/linked/Cargo.toml
+++ b/packages/linked/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linked"
 description = "Create families of linked objects that can collaborate across threads while being internally single-threaded"
 publish = true
-version = "1.0.19"
+version = "1.0.20"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/linked_macros/Cargo.toml
+++ b/packages/linked_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linked_macros"
 description = "Internal dependency of the 'linked' package - do not reference directly"
 publish = true
-version = "1.0.19"
+version = "1.0.20"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/linked_macros_impl/Cargo.toml
+++ b/packages/linked_macros_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linked_macros_impl"
 description = "Internal dependency of the 'linked_macros' package - do not reference directly"
 publish = true
-version = "1.0.19"
+version = "1.0.20"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus/Cargo.toml
+++ b/packages/many_cpus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "many_cpus"
 description = "Efficiently schedule work and inspect the hardware environment on many-processor systems"
 publish = true
-version = "2.4.16"
+version = "2.4.17"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus_benchmarking/Cargo.toml
+++ b/packages/many_cpus_benchmarking/Cargo.toml
@@ -2,7 +2,7 @@
 name = "many_cpus_benchmarking"
 description = "Criterion benchmark harness to easily compare different processor configurations"
 publish = true
-version = "0.2.7"
+version = "0.2.8"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "many_cpus_impl"
 description = "Implementation crate for many_cpus - do not reference directly"
 publish = true
-version = "2.4.16"
+version = "2.4.17"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/new_zealand/Cargo.toml
+++ b/packages/new_zealand/Cargo.toml
@@ -2,7 +2,7 @@
 name = "new_zealand"
 description = "Utilities for working with non-zero integers"
 publish = true
-version = "1.0.7"
+version = "1.0.8"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm/Cargo.toml
+++ b/packages/nm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm"
 description = "Minimalistic high-performance metrics collection in highly concurrent environments"
 publish = true
-version = "0.1.45"
+version = "0.1.46"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm_impl"
 description = "Implementation crate for nm; do not depend on it directly"
 publish = true
-version = "0.1.45"
+version = "0.1.46"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm_otel"
 description = "OpenTelemetry bridge for nm metrics"
 publish = true
-version = "0.4.17"
+version = "0.4.18"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm_otel_impl"
 description = "Implementation crate for nm_otel; do not depend on it directly"
 publish = true
-version = "0.4.17"
+version = "0.4.18"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -17,10 +17,7 @@ all-features = true
 # external type must be reviewed and added explicitly.
 # Ref: docs/external-types.md.
 [package.metadata.cargo_check_external_types]
-allowed_external_types = [
-    "opentelemetry::metrics::meter::MeterProvider",
-    "tick::clock::Clock",
-]
+allowed_external_types = ["opentelemetry::metrics::meter::MeterProvider", "tick::clock::Clock"]
 
 # These dev-dependencies are consumed only by test and benchmark targets that require
 # `private-test-util`. When udeps runs without `--all-features`, the targets are skipped, so the

--- a/packages/par_bench/Cargo.toml
+++ b/packages/par_bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "par_bench"
 description = "Mechanisms for multithreaded benchmarking, designed for integration with Criterion or a similar benchmark framework"
 publish = true
-version = "0.2.52"
+version = "0.2.53"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/region_cached/Cargo.toml
+++ b/packages/region_cached/Cargo.toml
@@ -2,7 +2,7 @@
 name = "region_cached"
 description = "Adds a logical layer of caching between processor L3 cache and main memory"
 publish = true
-version = "1.0.31"
+version = "1.0.32"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/region_local/Cargo.toml
+++ b/packages/region_local/Cargo.toml
@@ -2,7 +2,7 @@
 name = "region_local"
 description = "Isolated variable storage per memory region, similar to `thread_local_rc!`"
 publish = true
-version = "1.0.31"
+version = "1.0.32"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/vicinal/Cargo.toml
+++ b/packages/vicinal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vicinal"
 description = "Processor-local worker pool that schedules tasks in the vicinity of the caller"
 publish = true
-version = "0.1.36"
+version = "0.1.37"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
[Copilot speaking]

The workspace should build, test, and publish against current dependency releases supported by Rust 1.95. This release preparation also advances every publishable package because workspace dependency and MSRV changes affect their released content.

## Changes

- Resolves compatible direct and transitive dependencies to their latest Rust 1.95-compatible versions.
- Raises dependency floors across breaking compatibility buckets for `anyspawn` 0.8, `ohno` 0.5, `thread_aware` 0.11, and `tick` 0.6.
- Adapts aggregate error declarations to `ohno` 0.5 by using explicit `OhnoCore` fields where generated constructors remain disabled.
- Applies patch releases to all publishable workspace packages while preserving version groups and exact internal dependency pins.