### PR TITLE
bench-history: fix issue filing broken by an undefined label

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -47,8 +47,8 @@ concurrency:
   cancel-in-progress: true
 
 # Title of the rolling failure-alert issue, defined once and shared by the two jobs that
-# reference it: the `alert` job files it under this exact title (via the shared
-# gh-file-rolling-issue recipe), and the `resolve-alert` job matches on it to close that issue.
+# reference it: the `alert` job files it under this exact title (via Publish-RollingIssue),
+# and the `resolve-alert` job matches on it to close that issue.
 # The rolling-issue filing dedups solely by exact title, so this string is the alert's
 # identity; a single definition keeps the open and close paths from drifting apart.
 env:
@@ -317,7 +317,7 @@ jobs:
             ${{ steps.scratch.outputs.dir }}/report.json
           if-no-files-found: error
 
-      # The File step passes the title and labels to the gh-file-rolling-issue recipe as `gh`
+      # The File step passes the title and label to the gh-file-rolling-issue recipe as `gh`
       # flags, so this body needs NO YAML front matter - it is the pure issue body. That fixed
       # title is the dedup key that turns findings into one rolling issue.
       # The body carries the CONDENSED summary (not the full report) so it fits the issue
@@ -360,7 +360,7 @@ jobs:
           - **A defect to fix**: fix it as usual. A fixed finding self-clears on its own several runs after the fix, even without a blessing. This is **not** immediate: clearing it needs statistical evidence from multiple post-fix runs.
           '@
 
-          # The title and labels are NOT front matter here - the File step passes them to the
+          # The title and label are NOT front matter here - the File step passes them to the
           # gh-file-rolling-issue recipe as `gh` flags - so this file is the pure issue body.
           $parts = @(
             $summary
@@ -380,14 +380,16 @@ jobs:
       # only when findings exist; runs with none touch nothing. Filed over `gh` via the
       # shared gh-file-rolling-issue recipe (the workflow's one issue-filing path) rather
       # than a template action, so the body file can live in the runner temp dir, outside
-      # the repo checkout.
+      # the repo checkout. The label is one of the repository's standing labels: it is both
+      # applied on creation and the label the dedup search narrows to, and `gh issue create`
+      # fails outright on a label the repository does not define.
       - name: File rolling regression issue
         if: steps.notable.outputs.value == 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
-        run: just gh-file-rolling-issue 'Benchmark regressions detected' 'bench-history,regression' (Join-Path $env:SCRATCH_DIR 'issue-body.md')
+        run: just gh-file-rolling-issue 'Benchmark regressions detected' 'regression' (Join-Path $env:SCRATCH_DIR 'issue-body.md')
 
   alert:
     # Open a deduplicated issue whenever collection or analysis fails, so a broken
@@ -441,7 +443,7 @@ jobs:
 
           $url = Publish-RollingIssue `
             -Title $env:FAILURE_ISSUE_TITLE `
-            -Label 'bench-history,ci-failure' `
+            -Label 'ci-failure' `
             -BodyFile $bodyFile `
             -Verbose
           Write-Host "Failure alert issue: $url"

--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -378,18 +378,31 @@ jobs:
       # One rolling issue, updated rather than duplicated each run (the fixed title is
       # the dedup key), so a regression that persists does not spam new issues. Opened
       # only when findings exist; runs with none touch nothing. Filed over `gh` via the
-      # shared gh-file-rolling-issue recipe (the workflow's one issue-filing path) rather
-      # than a template action, so the body file can live in the runner temp dir, outside
-      # the repo checkout. The label is one of the repository's standing labels: it is both
-      # applied on creation and the label the dedup search narrows to, and `gh issue create`
-      # fails outright on a label the repository does not define.
+      # gh-file-rolling-issue recipe (a thin wrapper over the Publish-RollingIssue seam both of
+      # this workflow's issue paths share) rather than a template action, so the body file can
+      # live in the runner temp dir, outside the repo checkout. The label is one of the
+      # repository's standing labels: it is both applied on creation and the label the dedup
+      # search narrows to. `gh issue create` fails outright on a label the repository does not
+      # define, so the step reinstates it first.
       - name: File rolling regression issue
         if: steps.notable.outputs.value == 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
-        run: just gh-file-rolling-issue 'Benchmark regressions detected' 'regression' (Join-Path $env:SCRATCH_DIR 'issue-body.md')
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          # Ensure the standing label exists (idempotent) so `gh issue create` cannot fail on a
+          # missing label. --force also rewrites an existing label, so the color and description
+          # must stay the repository's canonical ones or every run would churn them.
+          $PSNativeCommandUseErrorActionPreference = $false
+          gh label create regression --color d73a4a --description "Performance/behavior regression" --force *> $null
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          just gh-file-rolling-issue 'Benchmark regressions detected' 'regression' (Join-Path $env:SCRATCH_DIR 'issue-body.md')
 
   alert:
     # Open a deduplicated issue whenever collection or analysis fails, so a broken
@@ -440,6 +453,13 @@ jobs:
           $body = $template -f $env:RUN_URL
           $bodyFile = Join-Path $env:RUNNER_TEMP 'bench-history-failure-issue.md'
           Set-Content -Path $bodyFile -Value $body -Encoding utf8
+
+          # Ensure the standing label exists (idempotent) so `gh issue create` cannot fail on a
+          # missing label. This label is shared with the per-run alerts that validation.yml and
+          # release.yml file, so its color and description are kept identical to the guard there.
+          $PSNativeCommandUseErrorActionPreference = $false
+          gh label create ci-failure --color B60205 --description "CI workflow failure" --force *> $null
+          $PSNativeCommandUseErrorActionPreference = $true
 
           $url = Publish-RollingIssue `
             -Title $env:FAILURE_ISSUE_TITLE `

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -389,9 +389,9 @@ gh-analyze-pr-bench-history dir base keydir:
 # a new one each run - so both the regression alert ('Benchmark regressions detected') and the
 # workflow-failure alert share Publish-RollingIssue with their own title/label; only the regression
 # path goes through this recipe, since the lightweight alert job skips the build-environment setup
-# `just` needs and imports the module directly. `label` is the single label applied on creation,
-# which must already exist in the repository. Needs GH_TOKEN in the environment (the workflow
-# supplies it).
+# `just` needs and imports the module directly. `label` is the single label applied on creation; it
+# must already exist in the repository, which the calling workflow step ensures. Needs GH_TOKEN in
+# the environment (the workflow supplies it).
 [group('automation')]
 [script]
 gh-file-rolling-issue title label body_file:

--- a/justfiles/just_automation.just
+++ b/justfiles/just_automation.just
@@ -387,8 +387,10 @@ gh-analyze-pr-bench-history dir base keydir:
 # from any path (--body-file), so it can live in the runner temp dir, outside the repo checkout.
 # The title is the dedup key - a persisting condition updates one rolling issue instead of opening
 # a new one each run - so both the regression alert ('Benchmark regressions detected') and the
-# workflow-failure alert route through here with their own title/label. `label` is the
-# comma-separated label list applied on creation. Needs GH_TOKEN in the environment (the workflow
+# workflow-failure alert share Publish-RollingIssue with their own title/label; only the regression
+# path goes through this recipe, since the lightweight alert job skips the build-environment setup
+# `just` needs and imports the module directly. `label` is the single label applied on creation,
+# which must already exist in the repository. Needs GH_TOKEN in the environment (the workflow
 # supplies it).
 [group('automation')]
 [script]
@@ -398,7 +400,7 @@ gh-file-rolling-issue title label body_file:
     $PSNativeCommandUseErrorActionPreference = $true
     Import-Module ./scripts/bench-history/BenchHistoryIssue.psm1 -Force
 
-    Write-Verbose "Filing or updating the rolling issue titled '{{title}}' (labels '{{label}}') from body file {{body_file}}." -Verbose
+    Write-Verbose "Filing or updating the rolling issue titled '{{title}}' (label '{{label}}') from body file {{body_file}}." -Verbose
     $url = Publish-RollingIssue `
         -Title '{{title}}' `
         -Label '{{label}}' `

--- a/scripts/bench-history/BenchHistoryIssue.Tests.ps1
+++ b/scripts/bench-history/BenchHistoryIssue.Tests.ps1
@@ -29,15 +29,15 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         }
 
         It 'returns that issue' {
-            $issue = Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history'
+            $issue = Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression'
             $issue.number | Should -Be 42
             $issue.url | Should -Be 'https://github.com/o/r/issues/42'
         }
 
         It 'narrows the list to the given label and open state' {
-            Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history' | Out-Null
+            Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression' | Out-Null
             Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
-                ($args -contains '--label') -and ($args -contains 'bench-history') -and
+                ($args -contains '--label') -and ($args -contains 'regression') -and
                 ($args -contains '--state') -and ($args -contains 'open')
             }
         }
@@ -52,7 +52,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         }
 
         It 'returns null' {
-            Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history' | Should -BeNullOrEmpty
+            Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression' | Should -BeNullOrEmpty
         }
     }
 
@@ -62,7 +62,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         }
 
         It 'returns null' {
-            Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history' | Should -BeNullOrEmpty
+            Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression' | Should -BeNullOrEmpty
         }
     }
 
@@ -73,7 +73,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         }
 
         It 'throws, surfacing the gh output' {
-            { Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history' } |
+            { Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression' } |
                 Should -Throw '*503*'
         }
     }
@@ -94,7 +94,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         }
 
         It 'ignores the stderr note and still parses the issue from stdout' {
-            $issue = Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history'
+            $issue = Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression'
             $issue.number | Should -Be 42
         }
     }
@@ -109,7 +109,7 @@ Describe 'Get-OpenIssueByTitle (mocked gh issue list)' {
         }
 
         It 'surfaces the stderr text in the thrown error' {
-            { Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'bench-history' } |
+            { Get-OpenIssueByTitle -Title 'Benchmark regressions detected' -Label 'regression' } |
                 Should -Throw '*rate limit exceeded*'
         }
     }
@@ -132,13 +132,13 @@ Describe 'Publish-RollingIssue (mocked gh)' {
         }
 
         It 'updates the existing issue instead of creating a duplicate' {
-            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history,regression' -BodyFile $script:BodyFile | Out-Null
+            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile | Out-Null
             Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter { $args[1] -eq 'edit' }
             Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter { $args[1] -eq 'create' } -Times 0 -Exactly
         }
 
         It 'edits the matched issue number and passes the body file' {
-            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history,regression' -BodyFile $script:BodyFile | Out-Null
+            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile | Out-Null
             Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
                 ($args[1] -eq 'edit') -and ($args -contains 42) -and
                 ($args -contains '--body-file') -and ($args -contains $script:BodyFile)
@@ -146,7 +146,7 @@ Describe 'Publish-RollingIssue (mocked gh)' {
         }
 
         It 'returns the existing issue url' {
-            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history,regression' -BodyFile $script:BodyFile |
+            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile |
                 Should -Be 'https://github.com/o/r/issues/42'
         }
     }
@@ -162,25 +162,25 @@ Describe 'Publish-RollingIssue (mocked gh)' {
             }
         }
 
-        It 'creates a new issue with the given title and full label list' {
-            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history,regression' -BodyFile $script:BodyFile | Out-Null
+        It 'creates a new issue with the given title and label' {
+            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile | Out-Null
             Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
                 ($args[1] -eq 'create') -and
                 ($args -contains '--title') -and ($args -contains 'Benchmark regressions detected') -and
-                ($args -contains '--label') -and ($args -contains 'bench-history,regression') -and
+                ($args -contains '--label') -and ($args -contains 'regression') -and
                 ($args -contains '--body-file') -and ($args -contains $script:BodyFile)
             }
         }
 
-        It 'narrows the dedup search to the first label only' {
-            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history,regression' -BodyFile $script:BodyFile | Out-Null
+        It 'narrows the dedup search to the same label it files under' {
+            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile | Out-Null
             Should -Invoke gh -ModuleName BenchHistoryIssue -ParameterFilter {
-                ($args[1] -eq 'list') -and ($args -contains '--label') -and ($args -contains 'bench-history')
+                ($args[1] -eq 'list') -and ($args -contains '--label') -and ($args -contains 'regression')
             }
         }
 
         It 'returns the created issue url' {
-            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history,regression' -BodyFile $script:BodyFile |
+            Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile |
                 Should -Be 'https://github.com/o/r/issues/99'
         }
     }
@@ -188,7 +188,7 @@ Describe 'Publish-RollingIssue (mocked gh)' {
     Context 'error handling' {
         It 'throws when the body file does not exist' {
             $missing = Join-Path ([System.IO.Path]::GetTempPath()) "bh-missing-$([guid]::NewGuid().ToString('n')).md"
-            { Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history' -BodyFile $missing } |
+            { Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $missing } |
                 Should -Throw '*does not exist*'
         }
 
@@ -200,7 +200,7 @@ Describe 'Publish-RollingIssue (mocked gh)' {
                     default { $global:LASTEXITCODE = 1; "unexpected: $args" }
                 }
             }
-            { Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history' -BodyFile $script:BodyFile } |
+            { Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile } |
                 Should -Throw '*could not create issue*'
         }
 
@@ -215,7 +215,7 @@ Describe 'Publish-RollingIssue (mocked gh)' {
                     default { $global:LASTEXITCODE = 1; "unexpected: $args" }
                 }
             }
-            { Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'bench-history' -BodyFile $script:BodyFile } |
+            { Publish-RollingIssue -Title 'Benchmark regressions detected' -Label 'regression' -BodyFile $script:BodyFile } |
                 Should -Throw '*could not edit issue*'
         }
     }

--- a/scripts/bench-history/BenchHistoryIssue.psm1
+++ b/scripts/bench-history/BenchHistoryIssue.psm1
@@ -117,8 +117,8 @@ function Publish-RollingIssue {
     # into the repo checkout. $Label is the single label applied on creation, and also the label the
     # dedup search is narrowed to, so the next run finds the filed issue instead of duplicating it.
     # It must already exist in the repository - `gh issue create` fails outright on an unknown label
-    # - so callers pass one of the repository's standing labels rather than inventing a
-    # workflow-specific one. Returns the issue URL.
+    # - so callers pass one of the repository's standing labels and reinstate it idempotently before
+    # calling rather than inventing a workflow-specific one. Returns the issue URL.
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string] $Title,

--- a/scripts/bench-history/BenchHistoryIssue.psm1
+++ b/scripts/bench-history/BenchHistoryIssue.psm1
@@ -73,16 +73,25 @@ function Invoke-GhCapture {
 
 function Get-OpenIssueByTitle {
     # Returns the first OPEN issue whose title equals $Title exactly, or $null when none matches.
-    # The list is narrowed to $Label so only a handful of issues come back, then the exact-title
-    # match is done client-side - the same list-then-match approach the workflow's `resolve-alert` job
-    # uses to find the failure-alert issue, which avoids the eventual-consistency lag of the GitHub
-    # search index that a `gh issue list --search`/`gh search issues` query would hit. Isolates the
-    # real `gh issue list` call so the tests can mock it.
+    # The list is narrowed to $Label, then the exact-title match is done client-side - the same
+    # list-then-match approach the workflow's `resolve-alert` job uses to find the failure-alert
+    # issue, which avoids the eventual-consistency lag of the GitHub search index that a
+    # `gh issue list --search`/`gh search issues` query would hit. Isolates the real
+    # `gh issue list` call so the tests can mock it.
+    #
+    # $Limit must stay well above the number of open issues the label can plausibly carry, because
+    # `gh` returns them newest-first: the rolling issue is updated in place rather than refiled, so
+    # it only ages relative to its label-mates, and anything past the limit is invisible here - a
+    # miss would silently file a duplicate. The standing labels these callers use (`ci-failure`,
+    # `regression`) are shared with the per-run failure issues that validation.yml and release.yml
+    # file and never auto-close, so a backlog is possible even though a healthy repository keeps
+    # only a handful open. `gh` pages internally to satisfy the limit and stops once the results
+    # are exhausted, so a generous ceiling costs a single request in the healthy case.
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string] $Title,
         [Parameter(Mandatory)][string] $Label,
-        [int] $Limit = 100
+        [int] $Limit = 1000
     )
 
     # Ask `gh` for the open issues carrying $Label as JSON; Invoke-GhCapture keeps stderr off
@@ -105,8 +114,11 @@ function Publish-RollingIssue {
     # body is updated in place (so a persisting condition never spams duplicates), otherwise a new
     # issue is created with $Label. The body is read by `gh` from $BodyFile, which may be any path
     # (for example the runner temp dir) - this is what frees the workflow from writing scratch files
-    # into the repo checkout. $Label is the comma-separated label list applied on creation; the
-    # dedup search is narrowed to the first of those labels. Returns the issue URL.
+    # into the repo checkout. $Label is the single label applied on creation, and also the label the
+    # dedup search is narrowed to, so the next run finds the filed issue instead of duplicating it.
+    # It must already exist in the repository - `gh issue create` fails outright on an unknown label
+    # - so callers pass one of the repository's standing labels rather than inventing a
+    # workflow-specific one. Returns the issue URL.
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string] $Title,
@@ -118,9 +130,8 @@ function Publish-RollingIssue {
         throw "Issue body file '$BodyFile' does not exist."
     }
 
-    $searchLabel = ($Label -split ',')[0].Trim()
-    Write-Verbose "Searching for an existing open issue titled '$Title' among issues labelled '$searchLabel' before filing, so a regression that persists across runs updates one rolling issue instead of opening a duplicate every run."
-    $existing = Get-OpenIssueByTitle -Title $Title -Label $searchLabel
+    Write-Verbose "Searching for an existing open issue titled '$Title' among issues labelled '$Label' before filing, so a regression that persists across runs updates one rolling issue instead of opening a duplicate every run."
+    $existing = Get-OpenIssueByTitle -Title $Title -Label $Label
 
     if ($existing) {
         Write-Verbose "Found open issue #$($existing.number) ($($existing.url)); updating its body from '$BodyFile' rather than creating a duplicate."
@@ -128,7 +139,7 @@ function Publish-RollingIssue {
         return $existing.url
     }
 
-    Write-Verbose "No open issue titled '$Title' found; creating a new one with labels '$Label' and body from '$BodyFile'."
+    Write-Verbose "No open issue titled '$Title' found; creating a new one with label '$Label' and body from '$BodyFile'."
     $output = Invoke-GhCapture -Arguments @('issue', 'create', '--title', $Title, '--label', $Label, '--body-file', $BodyFile)
 
     # `gh issue create` prints the new issue's URL on success; extract it (stderr is already kept
@@ -154,10 +165,11 @@ function Close-RollingIssue {
         [Parameter(Mandatory)][string] $Title,
         [Parameter(Mandatory)][string] $Label,
         [Parameter(Mandatory)][string] $Comment,
-        [int] $Limit = 100
+        [int] $Limit = 1000
     )
 
-    # `--limit` defeats the 30-result default so a backlog of historical duplicates all come back.
+    # `--limit` defeats the 30-result default so a backlog of historical duplicates all come back;
+    # see Get-OpenIssueByTitle for why the ceiling is generous rather than merely comfortable.
     $output = Invoke-GhCapture -RetryOnFailure -Arguments @(
         'issue', 'list', '--state', 'open', '--label', $Label, '--limit', $Limit, '--json', 'number,title'
     )


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The `Benchmark history` workflow failed on `main` ([run 34056419052](https://github.com/folo-rs/folo/actions/runs/34056419052)). Two jobs died on the same error:

```
gh issue create --title '...' --label bench-history,regression --body-file ...
  failed (exit 1): could not add label: 'bench-history' not found
```

Both issue-filing paths applied a leading `bench-history` label that the repository never defined. The repository has `regression` and `ci-failure`; `bench-history` was only ever referenced by the workflow. `gh issue create` rejects an unknown label outright, so `analyze` could not file the regression issue it had findings for, and `alert` could not file the failure notice about that.

## Changes

**The `bench-history` label is gone from the design.** Each issue now carries exactly one standing repository label — `regression` for the regression alert, `ci-failure` for the failure alert — which is also the label the dedup search narrows to.

`Publish-RollingIssue` correspondingly takes a single label rather than a comma-separated list whose first entry drove the search:

```
  before                                  after

  'bench-history,regression'              'regression'
   │                                       │
   ├─ [0] ──> gh issue list --label ─┐     ├──────> gh issue list --label
   │                                 │     │
   └─ all ──> gh issue create --label┘     └──────> gh issue create --label
```

**The lookup window is widened.** `regression` and `ci-failure` are shared with the per-run failure issues that `validation.yml` and `release.yml` file and never auto-close, so the rolling issue is no longer alone under its label. `gh` returns issues newest-first and the rolling issue is edited in place rather than refiled, so it only ages relative to its label-mates — a backlog could push it past the fetch limit, silently producing a duplicate on the open path and leaving a resolved alert open on the close path. The ceiling now sits far above any plausible backlog; `gh` pages internally and stops when results are exhausted, so the healthy case still costs one request.

**A missing label can no longer break the workflow.** Both filing paths reinstate their label idempotently before filing, the same guard `validation.yml` and `release.yml` already run. The color and description match the repository's canonical definitions, so `--force` restores a missing or drifted label without churning a healthy one.

## Note

That run did detect notable regressions — the issue simply never got filed. The next `main` run will file it.