### PR TITLE
dure: Fix resumed terminal resize handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "dure-test-helper",

--- a/packages/dure-test-helper/src/lib.rs
+++ b/packages/dure-test-helper/src/lib.rs
@@ -13,6 +13,8 @@
 
 mod locate;
 mod non_ascii;
+mod terminal_input;
 
 pub use locate::binary_path;
 pub use non_ascii::SAMPLE_NON_ASCII_TEXT;
+pub use terminal_input::*;

--- a/packages/dure-test-helper/src/main.rs
+++ b/packages/dure-test-helper/src/main.rs
@@ -12,6 +12,13 @@ use std::io::{self, IsTerminal, Read, Write};
 #[cfg(windows)]
 use std::{env, fs, process};
 
+/// Enables terminal focus, basic mouse, and SGR mouse reporting.
+///
+/// These are the protocols represented by `SAMPLE_TERMINAL_INPUT`, so the
+/// helper negotiates them before asking the test terminal to send the sample.
+#[cfg(windows)]
+const ENABLE_TERMINAL_INPUT: &str = "\x1b[?1004h\x1b[?1000h\x1b[?1006h";
+
 /// The helper serves Windows integration tests only, so on other platforms the
 /// binary is an empty stub, matching `dure` itself
 /// (`dure/docs/implementation.md`, "Platform gate").
@@ -38,6 +45,30 @@ fn main() {
             wait_for_resize();
             print_console_size();
         }
+        Some("report-size-after-input-and-resize") => {
+            print_console_size();
+            wait_for_key_then_flush_input();
+            println!("{}", dure_test_helper::RESIZE_READY);
+            io::stdout().flush().expect("flush stdout");
+            wait_for_resize();
+            print_console_size();
+        }
+        Some("verify-terminal-input") => {
+            enable_vt_input();
+            println!(
+                "{ENABLE_TERMINAL_INPUT}{}",
+                dure_test_helper::TERMINAL_INPUT_READY
+            );
+            io::stdout().flush().expect("flush stdout");
+            let expected = dure_test_helper::SAMPLE_TERMINAL_INPUT;
+            let mut actual = vec![0_u8; expected.len()];
+            io::stdin()
+                .read_exact(&mut actual)
+                .expect("read terminal input sample");
+            assert_eq!(actual, expected, "terminal input sample");
+            println!("{}", dure_test_helper::TERMINAL_INPUT_OK);
+            io::stdout().flush().expect("flush stdout");
+        }
         Some("exit") => {
             process::exit(exit_code(&args));
         }
@@ -59,7 +90,8 @@ fn main() {
         _ => {
             eprintln!(
                 "usage: dure-test-helper echo-line | print-and-wait | exit [code] | \
-                 has-console | print-non-ascii | report-size-after-resize | wait-has-console | \
+                 has-console | print-non-ascii | report-size-after-input-and-resize | \
+                 report-size-after-resize | verify-terminal-input | wait-has-console | \
                  wait-exit [code]"
             );
             process::exit(2);
@@ -80,6 +112,56 @@ fn exit_code(args: &[String]) -> i32 {
 fn wait_for_byte() {
     let mut buf = [0_u8; 1];
     _ = io::stdin().read(&mut buf);
+}
+
+/// Configures the helper to receive terminal reports as VT bytes.
+#[cfg(windows)]
+fn enable_vt_input() {
+    use windows::Win32::System::Console::{
+        CONSOLE_MODE, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
+        ENABLE_VIRTUAL_TERMINAL_INPUT, GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE,
+        SetConsoleMode,
+    };
+
+    // SAFETY: asks for this process's own standard input handle.
+    let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) }.expect("std input handle");
+    let mut mode = CONSOLE_MODE::default();
+    // SAFETY: `handle` is this process's console input and `mode` outlives the call.
+    unsafe { GetConsoleMode(handle, &raw mut mode) }.expect("console input mode");
+    let vt_mode = CONSOLE_MODE(
+        (mode.0 & !(ENABLE_ECHO_INPUT.0 | ENABLE_LINE_INPUT.0 | ENABLE_PROCESSED_INPUT.0))
+            | ENABLE_VIRTUAL_TERMINAL_INPUT.0,
+    );
+    // SAFETY: `handle` remains this process's live console input handle, and
+    // `vt_mode` combines documented input flags.
+    unsafe { SetConsoleMode(handle, vt_mode) }.expect("enable VT input");
+}
+
+/// Waits for a key record, then removes every record queued before readiness.
+#[cfg(windows)]
+fn wait_for_key_then_flush_input() {
+    use windows::Win32::System::Console::{
+        FlushConsoleInputBuffer, GetStdHandle, INPUT_RECORD, KEY_EVENT, ReadConsoleInputW,
+        STD_INPUT_HANDLE,
+    };
+
+    // SAFETY: asks for this process's own standard input handle.
+    let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) }.expect("std input handle");
+    loop {
+        let mut records = [INPUT_RECORD::default()];
+        let mut read = 0_u32;
+        // SAFETY: `records` is exclusive and outlives the call.
+        unsafe { ReadConsoleInputW(handle, &mut records, &raw mut read) }
+            .expect("read console input");
+        let record = records
+            .first()
+            .expect("the fixed input-record buffer has one element");
+        if read != 0 && u32::from(record.EventType) == KEY_EVENT {
+            break;
+        }
+    }
+    // SAFETY: `handle` remains this process's live console input handle.
+    unsafe { FlushConsoleInputBuffer(handle) }.expect("flush console input");
 }
 
 /// Blocks until the app's console reports a resize.

--- a/packages/dure-test-helper/src/terminal_input.rs
+++ b/packages/dure-test-helper/src/terminal_input.rs
@@ -1,0 +1,14 @@
+/// Sample VT input containing focus-in and an SGR mouse-button event.
+///
+/// The coordinates are arbitrary distinct values so a rearranged or truncated
+/// sequence cannot accidentally match the fixture.
+pub const SAMPLE_TERMINAL_INPUT: &[u8] = b"\x1b[I\x1b[<0;5;7M";
+
+/// Marker printed after the helper has enabled and is ready for terminal input.
+pub const TERMINAL_INPUT_READY: &str = "terminal-input-ready";
+
+/// Marker printed after the helper receives the sample input unchanged.
+pub const TERMINAL_INPUT_OK: &str = "terminal-input-ok";
+
+/// Marker printed after the helper has discarded pre-existing input records.
+pub const RESIZE_READY: &str = "resize-ready";

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.2.3"
+version = "0.2.4"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/dure/docs/console.md
+++ b/packages/dure/docs/console.md
@@ -99,8 +99,9 @@ echoed locally, buffered until a newline, or turned into a Ctrl+C signal for the
 client. `ENABLE_VIRTUAL_TERMINAL_INPUT` is set so the console encodes keys that
 are not characters — arrows, function keys, modifier chords — as the VT
 sequences an app already knows how to read, which is why no per-key mapping
-exists anywhere in this crate. `ENABLE_WINDOW_INPUT` is set so window changes
-arrive as records rather than being dropped.
+exists anywhere in this crate. `ENABLE_WINDOW_INPUT` is cleared so window
+changes do not enter the byte reader's queue; size is observed independently,
+as described under [Window size](#window-size).
 
 On output, `ENABLE_VIRTUAL_TERMINAL_PROCESSING`, `ENABLE_PROCESSED_OUTPUT`, and
 `ENABLE_WRAP_AT_EOL_OUTPUT` are set so the local console host renders the
@@ -139,42 +140,46 @@ received.
 
 ### Reading input
 
-Reading resizes is the one place the client cannot simply read bytes. Window
-changes are console *input records*, not VT input, so an ordinary read on stdin
-neither reports them nor returns while one is queued ahead of it. The client
-therefore inspects the record queue before every read: it reports a leading
-window-size record as a resize, waits for the handle to signal when nothing is
-pending, inspects again because a resize can arrive during the wait, and only
-reads bytes when the queue starts with a key.
+One blocking `ReadFile` path owns the console input queue. Under VT input mode,
+the console host exposes keys and terminal reports that have a VT representation
+through that byte stream. This includes mouse and focus reports when the app has
+negotiated them and the local console presents them as VT input. The relay does
+not inspect, classify, or consume individual input records.
 
-The same inspection drops leading records that are neither a resize nor a key —
-focus, menu, and mouse events — which would otherwise sit at the head of the
-queue and keep the read from ever returning. Discarding them is what excludes
-mouse reporting from pass-through. That discard runs before every read, so it
-uses fixed stack storage and allocates nothing.
+Window changes have no VT byte representation. They are deliberately kept out
+of the input queue and observed through the console's current size instead.
+Keeping those mechanisms independent avoids a check-then-read race in which a
+window record can arrive after the queue is inspected and be consumed without
+being reported by `ReadFile`.
 
 A blocking read outlives the relay unless something ends it, and a console
 handed back while a read is still outstanding would take the next thing the user
 types. The relay therefore cancels the read and joins its thread before handing
 the console back. The reader waits on the console input handle and a dedicated
-cancellation event together. Cancellation signals that event instead of adding
-a console input record, so it cannot race with queue inspection and leave a
-discardable record in front of a blocking byte read. Some key records produce no
-bytes and leave that read waiting; cancellation also cancels any such read. A
-sticky cancellation flag and a published read-active flag close the handoff
-between those two paths: a read starts only after checking the sticky flag, and
-the canceller retries for a bounded scheduler handoff and waits for an accepted
-cancellation to retire the read. If either step fails, the relay reports that
-failure without joining a reader it cannot prove was woken; the command can then
-leave instead of waiting indefinitely.
+cancellation event together. Some input records produce no bytes and leave that
+read waiting; cancellation also cancels any such read. A sticky cancellation
+flag and a published read-active flag close the handoff between those two paths:
+a read starts only after checking the sticky flag, and the canceller retries for
+a bounded scheduler handoff and waits for an accepted cancellation to retire
+the read. If either step fails, the relay reports that failure without joining a
+reader it cannot prove was woken; the command can then leave instead of waiting
+indefinitely.
 
 ### Window size
 
 Size travels on the same connection as bytes but as its own message, because it
 is console state rather than console content: the attach message carries the
-size the client starts with, and a resize message carries each later change.
-Both end at the pseudoconsole's resize, which is what makes the app observe a
-console resize rather than receive bytes describing one.
+size the client starts with, and a dedicated watcher samples the attached
+console at a short fixed cadence. It sends a resize message only when the
+observed size differs from the last size sent. Both messages end at the
+pseudoconsole's resize, which is what makes the app observe a console resize
+rather than receive bytes describing one.
+
+Size observation is state convergence rather than event forwarding. Several
+changes within one polling interval may collapse to the latest geometry, and
+ordering against input bytes is not defined. Neither distinction changes the
+app's result: it receives the current geometry shortly after the terminal
+settles, and a missed observation is corrected by the next sample.
 
 The attach size is applied only once the connection owns the client slot. The
 app redraws in response to a size change, and that redraw belongs to the client
@@ -183,7 +188,8 @@ client's screen. Until the first attach the pseudoconsole runs at a default
 geometry, which exists only so the app has some size during the window between
 spawn and attach.
 
-A resize failure is ignored on both paths. It means the pseudoconsole is already
-gone, which the app wait and the output pump observe on their own and act on by
-ending the relay; treating it as an error here would only report the same fact
-twice, and earlier than the paths that can act on it.
+A watcher stops if a size observation fails or the connection can no longer
+accept a resize. The input reader and receive loop own relay lifetime, so this
+secondary observer does not race them to decide how the relay ends. A
+pseudoconsole resize failure is likewise ignored: the app wait and output pump
+observe that teardown and end the session through the paths that own it.

--- a/packages/dure/docs/design.md
+++ b/packages/dure/docs/design.md
@@ -254,13 +254,13 @@ deciding what either of them means.
 
 **Window size.** The app always sees the size of the terminal it is currently
 being viewed through. The attaching client's size is applied to the app's
-console before the relay starts, and a resize while attached is carried through
-as it happens, so an app that redraws on resize reflows immediately. A resize is
-therefore not a detach-and-resume affair; it works in the middle of a live
-session. While no client is attached the console keeps the size the last client
-gave it, and the next attach replaces it. This is what makes a session portable
-between terminals: resuming from a differently sized window is a resize, not a
-broken layout.
+console before the relay starts, and a resize while attached converges to the
+new size within a short interval, so an app that redraws on resize reflows
+promptly. A resize is therefore not a detach-and-resume affair; it works in the
+middle of a live session. While no client is attached the console keeps the size
+the last client gave it, and the next attach replaces it. This is what makes a
+session portable between terminals: resuming from a differently sized window is
+a resize, not a broken layout.
 
 **Keyboard.** Keys arrive at the app the way the terminal sent them, including
 the ones that are sequences rather than characters — arrows, function keys, Home
@@ -272,10 +272,11 @@ movement, colors and styling, the alternate screen buffer, scroll regions, and
 window-title sequences all reach the terminal unchanged. `dure` does not parse,
 rewrite, or filter this stream.
 
-Mouse reporting is deliberately not carried, and neither are console events that
-describe the window rather than the user's input, such as focus changes and menu
-activity. An app that would use the mouse in the user's terminal does not get it
-under `dure`.
+Mouse and focus reports are carried when the app enables their terminal
+protocols and the local terminal stack provides them as VT input. The
+byte-transparent relay handles those bytes without per-protocol support. Console
+events with no byte representation, such as menu activity, are not carried;
+window size is handled separately as described above.
 
 Everything in this section follows from the relay being byte-transparent and
 size-aware; none of it is per-application support, so an app that works in the

--- a/packages/dure/src/attach/mod.rs
+++ b/packages/dure/src/attach/mod.rs
@@ -8,15 +8,17 @@ mod tests;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::thread;
 
 use ohno::AppError;
 
-use crate::constants::CONNECT_TIMEOUT;
+use crate::constants::{CONNECT_TIMEOUT, SIZE_POLL_INTERVAL};
 use crate::output::note_line;
 use crate::pal::error::{PalError, PalErrorKind};
 use crate::pal::ids::{ConnId, RelayLeaseId};
-use crate::pal::local_console::{ConsoleInput, LocalConsole};
+use crate::pal::local_console::LocalConsole;
+use crate::pal::pseudoconsole::WindowSize;
 use crate::pal::transport::Transport;
 use crate::protocol::Message;
 use crate::{
@@ -116,7 +118,7 @@ where
         }
     }
 
-    relay(transport, console, conn)
+    relay(transport, console, conn, size)
 }
 
 /// The local console, taken over for one relay and owed back.
@@ -160,15 +162,25 @@ impl<C: LocalConsole> Drop for ConsoleLease<'_, C> {
     }
 }
 
-fn relay<T, C>(transport: &T, console: &C, conn: ConnId) -> Result<Outcome, AppError>
+fn relay<T, C>(
+    transport: &T,
+    console: &C,
+    conn: ConnId,
+    initial_size: WindowSize,
+) -> Result<Outcome, AppError>
 where
     T: Transport + Clone + Send + Sync + 'static,
     C: LocalConsole + Clone + Send + Sync + 'static,
 {
     let input_failed = Arc::new(AtomicBool::new(false));
     let reader = spawn_input_reader(transport, console, conn, &input_failed);
+    let (size_watcher_stop, size_watcher_stop_rx) = mpsc::channel();
+    let size_watcher =
+        spawn_size_watcher(transport, console, conn, initial_size, size_watcher_stop_rx);
 
     let outcome = receive_until_relay_ends(transport, console, conn);
+    drop(size_watcher_stop);
+    _ = size_watcher.join();
     // Read before the reader is cancelled: a reader that failed set this flag
     // and then disconnected, which is what ended the receive above, while a
     // reader cancelled from here reports the same disconnect for a reason that
@@ -220,13 +232,8 @@ where
         move || {
             loop {
                 match console.read_input() {
-                    Ok(ConsoleInput::Bytes(bytes)) => {
+                    Ok(bytes) => {
                         if transport.send(conn, &Message::Input(bytes)).is_err() {
-                            break;
-                        }
-                    }
-                    Ok(ConsoleInput::Resize(size)) => {
-                        if transport.send(conn, &Message::Resize { size }).is_err() {
                             break;
                         }
                     }
@@ -235,6 +242,54 @@ where
                         transport.disconnect(conn);
                         break;
                     }
+                }
+            }
+        }
+    })
+}
+
+fn poll_size_once<T, C>(
+    transport: &T,
+    console: &C,
+    conn: ConnId,
+    last_size: &mut WindowSize,
+) -> Result<(), PalError>
+where
+    T: Transport,
+    C: LocalConsole,
+{
+    let size = console.window_size()?;
+    if size == *last_size {
+        return Ok(());
+    }
+    transport.send(conn, &Message::Resize { size })?;
+    *last_size = size;
+    Ok(())
+}
+
+// The cadence loop relies on elapsed real time. Its instantaneous work is
+// covered through `poll_size_once` instead of making tests wait.
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(test, mutants::skip)]
+fn spawn_size_watcher<T, C>(
+    transport: &T,
+    console: &C,
+    conn: ConnId,
+    initial_size: WindowSize,
+    stop: Receiver<()>,
+) -> thread::JoinHandle<()>
+where
+    T: Transport + Clone + Send + Sync + 'static,
+    C: LocalConsole + Clone + Send + Sync + 'static,
+{
+    thread::spawn({
+        let transport = transport.clone();
+        let console = console.clone();
+        move || {
+            let mut last_size = initial_size;
+            while stop.recv_timeout(SIZE_POLL_INTERVAL) == Err(RecvTimeoutError::Timeout) {
+                if poll_size_once(&transport, &console, conn, &mut last_size).is_err() {
+                    break;
                 }
             }
         }

--- a/packages/dure/src/attach/tests.rs
+++ b/packages/dure/src/attach/tests.rs
@@ -34,12 +34,12 @@ struct ConsoleScript {
 
 #[derive(Debug, Default)]
 struct ScriptState {
-    input: VecDeque<Result<ConsoleInput, PalErrorKind>>,
+    input: VecDeque<Result<Vec<u8>, PalErrorKind>>,
     cancelled: bool,
 }
 
 impl ConsoleScript {
-    fn new(input: Vec<Result<ConsoleInput, PalErrorKind>>) -> Self {
+    fn new(input: Vec<Result<Vec<u8>, PalErrorKind>>) -> Self {
         Self {
             state: Mutex::new(ScriptState {
                 input: input.into(),
@@ -49,7 +49,7 @@ impl ConsoleScript {
         }
     }
 
-    fn read(&self) -> Result<ConsoleInput, PalError> {
+    fn read(&self) -> Result<Vec<u8>, PalError> {
         let mut state = self.state.lock().unwrap();
         loop {
             if state.cancelled {
@@ -78,7 +78,7 @@ struct TestConsole {
     window_size: Result<(), PalErrorKind>,
     write_output: Result<(), PalErrorKind>,
     cancel_input: Result<(), PalErrorKind>,
-    input: Vec<Result<ConsoleInput, PalErrorKind>>,
+    input: Vec<Result<Vec<u8>, PalErrorKind>>,
     hand_backs: Arc<AtomicUsize>,
 }
 
@@ -543,27 +543,96 @@ fn the_console_can_be_taken_over_again_after_a_relay() {
 
 #[test]
 fn console_input_is_forwarded_to_the_supervisor() {
-    let resize = WindowSize::new(10, 20).expect("a fixture size is not empty");
     let console = TestConsole {
-        input: vec![
-            Ok(ConsoleInput::Bytes(b"hi".to_vec())),
-            Ok(ConsoleInput::Resize(resize)),
-        ],
+        input: vec![Ok(b"hi".to_vec())],
         ..TestConsole::new()
     };
-    let outcome = attach_to_scripted_supervisor(console, move |transport, conn| {
+    let outcome = attach_to_scripted_supervisor(console, |transport, conn| {
         assert!(matches!(
             transport.recv(conn),
             Ok(Message::Input(bytes)) if bytes == b"hi"
-        ));
-        assert!(matches!(
-            transport.recv(conn),
-            Ok(Message::Resize { size }) if size == resize
         ));
         _ = transport.send(conn, &Message::AppExited { status: 0 });
     })
     .unwrap();
     assert!(matches!(outcome, Outcome::AppExit(0)));
+}
+
+#[test]
+fn a_changed_console_size_is_forwarded_to_the_supervisor() {
+    let changed = WindowSize::new(100, 50).expect("a fixture size is not empty");
+    let (transport, client, supervisor) = connected_transport();
+    let mut console = MockLocalConsole::new();
+    console.expect_window_size().returning(move || Ok(changed));
+    let mut last_size = SAMPLE_SIZE;
+
+    poll_size_once(&transport, &console, client, &mut last_size).unwrap();
+
+    assert_eq!(last_size, changed);
+    assert!(matches!(
+        transport.recv_timeout(supervisor, Duration::ZERO),
+        Ok(Message::Resize { size }) if size == changed
+    ));
+}
+
+#[test]
+fn an_unchanged_console_size_is_not_forwarded() {
+    let (transport, client, supervisor) = connected_transport();
+    let mut console = MockLocalConsole::new();
+    console.expect_window_size().returning(|| Ok(SAMPLE_SIZE));
+    let mut last_size = SAMPLE_SIZE;
+
+    poll_size_once(&transport, &console, client, &mut last_size).unwrap();
+
+    assert_eq!(last_size, SAMPLE_SIZE);
+    transport.expire_next_recv("poll");
+    assert!(matches!(
+        transport.recv_timeout(supervisor, Duration::ZERO),
+        Err(error) if error.kind() == PalErrorKind::Timeout
+    ));
+}
+
+#[test]
+fn a_console_size_read_failure_is_returned() {
+    let (transport, client, supervisor) = connected_transport();
+    let mut console = MockLocalConsole::new();
+    console
+        .expect_window_size()
+        .returning(|| Err(PalError::new(PalErrorKind::Other)));
+    let mut last_size = SAMPLE_SIZE;
+
+    let result = poll_size_once(&transport, &console, client, &mut last_size);
+
+    assert!(result.is_err());
+    assert_eq!(last_size, SAMPLE_SIZE);
+    transport.expire_next_recv("poll");
+    assert!(matches!(
+        transport.recv_timeout(supervisor, Duration::ZERO),
+        Err(error) if error.kind() == PalErrorKind::Timeout
+    ));
+}
+
+#[test]
+fn a_console_size_send_failure_is_returned() {
+    let changed = WindowSize::new(100, 50).expect("a fixture size is not empty");
+    let (transport, client, supervisor) = connected_transport();
+    transport.disconnect(supervisor);
+    let mut console = MockLocalConsole::new();
+    console.expect_window_size().returning(move || Ok(changed));
+    let mut last_size = SAMPLE_SIZE;
+
+    let result = poll_size_once(&transport, &console, client, &mut last_size);
+
+    assert!(result.is_err());
+    assert_eq!(last_size, SAMPLE_SIZE);
+}
+
+fn connected_transport() -> (MemoryTransport, ConnId, ConnId) {
+    let transport = MemoryTransport::new();
+    let listener = transport.listen("poll").unwrap();
+    let client = transport.connect("poll", Duration::ZERO).unwrap();
+    let supervisor = transport.accept(listener).unwrap();
+    (transport, client, supervisor)
 }
 
 #[test]
@@ -580,29 +649,24 @@ fn console_input_failure_makes_the_relay_fail() {
 
 #[test]
 fn failed_input_sends_stop_the_reader() {
-    for input in [
-        ConsoleInput::Bytes(b"input".to_vec()),
-        ConsoleInput::Resize(SAMPLE_SIZE),
-    ] {
-        with_watchdog(move || {
-            let transport = MemoryTransport::new();
-            let listener = transport.listen("pipe").unwrap();
-            let client = transport.connect("pipe", Duration::ZERO).unwrap();
-            let supervisor = transport.accept(listener).unwrap();
-            transport.disconnect(supervisor);
-            let console = TestConsole {
-                input: vec![Ok(input)],
-                ..TestConsole::new()
-            }
-            .build();
-            let input_failed = Arc::new(AtomicBool::new(false));
+    with_watchdog(|| {
+        let transport = MemoryTransport::new();
+        let listener = transport.listen("pipe").unwrap();
+        let client = transport.connect("pipe", Duration::ZERO).unwrap();
+        let supervisor = transport.accept(listener).unwrap();
+        transport.disconnect(supervisor);
+        let console = TestConsole {
+            input: vec![Ok(b"input".to_vec())],
+            ..TestConsole::new()
+        }
+        .build();
+        let input_failed = Arc::new(AtomicBool::new(false));
 
-            spawn_input_reader(&transport, &console, client, &input_failed)
-                .join()
-                .unwrap();
-            assert!(!input_failed.load(Ordering::SeqCst));
-        });
-    }
+        spawn_input_reader(&transport, &console, client, &input_failed)
+            .join()
+            .unwrap();
+        assert!(!input_failed.load(Ordering::SeqCst));
+    });
 }
 
 #[test]

--- a/packages/dure/src/constants.rs
+++ b/packages/dure/src/constants.rs
@@ -20,6 +20,13 @@ pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Ref: docs/implementation.md, "Process split".
 pub(crate) const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Cadence at which an attached client reconciles its console size.
+///
+/// A window drag should reach the app without a perceptible pause, while
+/// querying one local console property at this cadence has negligible cost.
+/// Ref: docs/console.md, "Window size".
+pub(crate) const SIZE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
 /// Bound on how long `terminate` waits for a killed process to become signaled.
 ///
 /// `TerminateProcess` only initiates termination; the process object signals

--- a/packages/dure/src/pal/local_console/abstractions.rs
+++ b/packages/dure/src/pal/local_console/abstractions.rs
@@ -6,22 +6,6 @@ use crate::pal::error::PalError;
 use crate::pal::ids::RelayLeaseId;
 use crate::pal::pseudoconsole::WindowSize;
 
-/// One console event observed while a client is attached.
-///
-/// The relay reads these for the whole life of the attached session, not just
-/// during the handshake. Keys that are not characters — arrows, function keys,
-/// modifier chords — are encoded by the console as VT sequences, so they arrive
-/// in the same byte stream as typed text; a window change is the one event that
-/// is not bytes at all.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum ConsoleInput {
-    /// The forwarded input byte stream, relayed as
-    /// [`crate::protocol::Message::Input`].
-    Bytes(Vec<u8>),
-    /// Window size changed; forward as [`crate::protocol::Message::Resize`].
-    Resize(WindowSize),
-}
-
 /// Detect a console, take it over for a relay, and exchange bytes.
 ///
 /// Ref: docs/implementation.md, "PAL slicing"; docs/console.md.
@@ -56,8 +40,8 @@ pub(crate) trait LocalConsole: Send + Sync + fmt::Debug + 'static {
     /// Current console size.
     fn window_size(&self) -> Result<WindowSize, PalError>;
 
-    /// Blocking read of console input bytes or a window-size change.
-    fn read_input(&self) -> Result<ConsoleInput, PalError>;
+    /// Blocking read of console input bytes.
+    fn read_input(&self) -> Result<Vec<u8>, PalError>;
 
     /// Wake a blocked [`LocalConsole::read_input`] so its reader can stop.
     ///

--- a/packages/dure/src/pal/local_console/facade.rs
+++ b/packages/dure/src/pal/local_console/facade.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 
 use crate::pal::error::PalError;
 use crate::pal::ids::RelayLeaseId;
+use crate::pal::local_console::LocalConsole;
 #[cfg(test)]
 use crate::pal::local_console::MockLocalConsole;
 use crate::pal::local_console::windows::BuildTargetConsole;
-use crate::pal::local_console::{ConsoleInput, LocalConsole};
 use crate::pal::pseudoconsole::WindowSize;
 
 /// Dispatches console operations to the real PAL or a test mock.
@@ -92,7 +92,7 @@ impl LocalConsole for LocalConsoleFacade {
         }
     }
 
-    fn read_input(&self) -> Result<ConsoleInput, PalError> {
+    fn read_input(&self) -> Result<Vec<u8>, PalError> {
         match self {
             Self::Target(inner) => inner.read_input(),
             #[cfg(test)]

--- a/packages/dure/src/pal/local_console/windows.rs
+++ b/packages/dure/src/pal/local_console/windows.rs
@@ -13,9 +13,8 @@ use windows::Win32::System::Console::{
     ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_PROCESSED_OUTPUT,
     ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING, ENABLE_WINDOW_INPUT,
     ENABLE_WRAP_AT_EOL_OUTPUT, GetConsoleCP, GetConsoleMode, GetConsoleOutputCP,
-    GetConsoleScreenBufferInfo, GetStdHandle, INPUT_RECORD, KEY_EVENT, PeekConsoleInputW,
-    ReadConsoleInputW, STD_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetConsoleCP,
-    SetConsoleCtrlHandler, SetConsoleMode, SetConsoleOutputCP, WINDOW_BUFFER_SIZE_EVENT,
+    GetConsoleScreenBufferInfo, GetStdHandle, STD_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    SetConsoleCP, SetConsoleCtrlHandler, SetConsoleMode, SetConsoleOutputCP,
 };
 use windows::Win32::System::IO::CancelIoEx;
 use windows::Win32::System::Threading::{CreateEventW, INFINITE, SetEvent, WaitForMultipleObjects};
@@ -23,7 +22,7 @@ use windows::core::{BOOL, HRESULT};
 
 use crate::pal::error::{PalError, PalErrorKind};
 use crate::pal::ids::RelayLeaseId;
-use crate::pal::local_console::{ConsoleInput, LocalConsole};
+use crate::pal::local_console::LocalConsole;
 use crate::pal::pseudoconsole::WindowSize;
 use crate::pal::raw_handle::RawHandle;
 
@@ -34,14 +33,6 @@ pub(crate) struct BuildTargetConsole;
 /// One console `ReadFile` burst. Larger than a typical key or CSI sequence;
 /// `ReadFile` may return less. Not a protocol bound.
 const INPUT_READ_BUF: usize = 4096;
-
-/// Input records inspected per `PeekConsoleInputW` call.
-///
-/// Bounds how many leading records one pass can classify and discard; the queue
-/// is re-inspected until it starts with a key, so a smaller batch costs extra
-/// passes rather than losing events. It also sizes the stack buffer the discard
-/// path reads into, which is why the discard path allocates nothing.
-const PEEK_INPUT_RECORDS: usize = 16;
 
 /// Wait result for the input handle, which follows cancellation in the wait set.
 const WAIT_INPUT: WAIT_EVENT = WAIT_EVENT(WAIT_OBJECT_0.0 + 1);
@@ -287,86 +278,6 @@ fn read_window_size(output: HANDLE) -> Result<WindowSize, PalError> {
     .ok_or_else(|| PalError::new(PalErrorKind::Other))
 }
 
-fn event_kind(record: &INPUT_RECORD) -> u32 {
-    u32::from(record.EventType)
-}
-
-fn peek_input(handle: HANDLE) -> Result<([INPUT_RECORD; PEEK_INPUT_RECORDS], usize), PalError> {
-    let mut peek = [INPUT_RECORD::default(); PEEK_INPUT_RECORDS];
-    let mut count = 0_u32;
-    // SAFETY: `handle` is stdin; `peek` is exclusive for this call.
-    unsafe { PeekConsoleInputW(handle, &mut peek, &raw mut count) }
-        .map_err(|error| PalError::with_source(PalErrorKind::Other, error))?;
-    Ok((peek, count as usize))
-}
-
-/// Reads and throws away `count` leading records.
-///
-/// `count` is always a prefix of one peek, so the records fit on the stack and
-/// this path — which runs before every blocking read — allocates nothing.
-fn consume_records(handle: HANDLE, count: usize) -> Result<(), PalError> {
-    if count == 0 {
-        return Ok(());
-    }
-    let mut discarded = [INPUT_RECORD::default(); PEEK_INPUT_RECORDS];
-    let discarded = discarded
-        .get_mut(..count)
-        .ok_or_else(|| PalError::new(PalErrorKind::Other))?;
-    let mut read = 0_u32;
-    // SAFETY: `discarded` is exclusive and exactly `count` records long.
-    unsafe { ReadConsoleInputW(handle, discarded, &raw mut read) }
-        .map_err(|error| PalError::with_source(PalErrorKind::Other, error))?;
-    Ok(())
-}
-
-/// Consumes leading `WINDOW_BUFFER_SIZE_EVENT` records so a later `ReadFile`
-/// is not blocked behind them. Window changes are console input records, not
-/// VT bytes, which is why attach cannot learn resizes from `ReadFile` alone.
-/// Ref: docs/console.md, "Window size".
-fn take_leading_resize(handle: HANDLE) -> Result<Option<WindowSize>, PalError> {
-    let (peek, count) = peek_input(handle)?;
-    let leading_resizes = peek
-        .iter()
-        .take(count)
-        .take_while(|record| event_kind(record) == WINDOW_BUFFER_SIZE_EVENT)
-        .count();
-    if leading_resizes == 0 {
-        return Ok(None);
-    }
-    consume_records(handle, leading_resizes)?;
-    let output = std_handle(STD_OUTPUT_HANDLE)?;
-    read_window_size(output).map(Some)
-}
-
-/// Drops focus/menu/mouse records so they cannot hide a later resize or key.
-/// This is what excludes mouse reporting from pass-through.
-/// Ref: docs/console.md, "Window size".
-fn discard_leading_noise(handle: HANDLE) -> Result<bool, PalError> {
-    let (peek, count) = peek_input(handle)?;
-    let leading_noise = peek
-        .iter()
-        .take(count)
-        .take_while(|record| {
-            let kind = event_kind(record);
-            kind != WINDOW_BUFFER_SIZE_EVENT && kind != KEY_EVENT
-        })
-        .count();
-    if leading_noise == 0 {
-        return Ok(false);
-    }
-    consume_records(handle, leading_noise)?;
-    Ok(true)
-}
-
-/// Whether a queued record exists and, if so, whether it is a key.
-fn leading_record_is_key(handle: HANDLE) -> Result<Option<bool>, PalError> {
-    let (peek, count) = peek_input(handle)?;
-    Ok(peek
-        .first()
-        .filter(|_record| count != 0)
-        .map(|record| event_kind(record) == KEY_EVENT))
-}
-
 /// Puts both console directions into the relay's modes, recording each success.
 ///
 /// Ref: docs/console.md, "Modes".
@@ -379,12 +290,15 @@ fn take_over_console(
     out_mode: CONSOLE_MODE,
 ) -> Result<(), PalError> {
     // Disable cooked input so keystrokes reach the app immediately. Enable
-    // VT input for CSI sequences and window-input so resizes appear as
-    // `WINDOW_BUFFER_SIZE_EVENT` records rather than being dropped.
+    // VT input for CSI sequences, while leaving size observation to the
+    // independent poller so `ReadFile` owns the input queue without races.
     let raw_in = CONSOLE_MODE(
-        (in_mode.0 & !(ENABLE_ECHO_INPUT.0 | ENABLE_LINE_INPUT.0 | ENABLE_PROCESSED_INPUT.0))
-            | ENABLE_VIRTUAL_TERMINAL_INPUT.0
-            | ENABLE_WINDOW_INPUT.0,
+        (in_mode.0
+            & !(ENABLE_ECHO_INPUT.0
+                | ENABLE_LINE_INPUT.0
+                | ENABLE_PROCESSED_INPUT.0
+                | ENABLE_WINDOW_INPUT.0))
+            | ENABLE_VIRTUAL_TERMINAL_INPUT.0,
     );
     // VT processing plus wrap so the local console host renders the same
     // sequences the app writes through its pseudoconsole.
@@ -520,56 +434,40 @@ impl LocalConsole for BuildTargetConsole {
         read_window_size(std_handle(STD_OUTPUT_HANDLE)?)
     }
 
-    fn read_input(&self) -> Result<ConsoleInput, PalError> {
+    fn read_input(&self) -> Result<Vec<u8>, PalError> {
         let handle = std_handle(STD_INPUT_HANDLE)?;
         let cancel_event = active_cancel_event()?;
-        loop {
-            // Cancellation is a separate kernel event rather than a console
-            // input record, so it cannot land between queue inspection and
-            // `ReadFile` and become a record that blocks that read.
-            // SAFETY: both handles remain live across this wait. The lease owns
-            // the input handle, and `cancel_event` keeps the event alive.
-            let wait = unsafe {
-                WaitForMultipleObjects(&[cancel_event.as_handle(), handle], false, INFINITE)
-            };
-            if wait == WAIT_OBJECT_0 {
-                return Err(PalError::new(PalErrorKind::Disconnected));
-            }
-            if wait != WAIT_INPUT {
-                return Err(PalError::new(PalErrorKind::Other));
-            }
-            if let Some(size) = take_leading_resize(handle)? {
-                return Ok(ConsoleInput::Resize(size));
-            }
-            if discard_leading_noise(handle)? {
-                continue;
-            }
-            match leading_record_is_key(handle)? {
-                Some(true) | None => {}
-                Some(false) => continue,
-            }
-            if !cancel_event.begin_read() {
-                return Err(PalError::new(PalErrorKind::Disconnected));
-            }
-            let mut buf = vec![0_u8; INPUT_READ_BUF];
-            let mut transferred = 0_u32;
-            // SAFETY: `handle` is stdin; `buf` is exclusive for this call.
-            let read = unsafe {
-                ReadFile(
-                    handle,
-                    Some(buf.as_mut_slice()),
-                    Some(&raw mut transferred),
-                    None,
-                )
-            };
-            cancel_event.end_read();
-            read.map_err(|error| PalError::with_source(PalErrorKind::Disconnected, error))?;
-            if transferred == 0 {
-                return Err(PalError::new(PalErrorKind::Disconnected));
-            }
-            buf.truncate(transferred as usize);
-            return Ok(ConsoleInput::Bytes(buf));
+        // SAFETY: both handles remain live across this wait. The lease owns
+        // the input handle, and `cancel_event` keeps the event alive.
+        let wait =
+            unsafe { WaitForMultipleObjects(&[cancel_event.as_handle(), handle], false, INFINITE) };
+        if wait == WAIT_OBJECT_0 {
+            return Err(PalError::new(PalErrorKind::Disconnected));
         }
+        if wait != WAIT_INPUT {
+            return Err(PalError::new(PalErrorKind::Other));
+        }
+        if !cancel_event.begin_read() {
+            return Err(PalError::new(PalErrorKind::Disconnected));
+        }
+        let mut buf = vec![0_u8; INPUT_READ_BUF];
+        let mut transferred = 0_u32;
+        // SAFETY: `handle` is stdin; `buf` is exclusive for this call.
+        let read = unsafe {
+            ReadFile(
+                handle,
+                Some(buf.as_mut_slice()),
+                Some(&raw mut transferred),
+                None,
+            )
+        };
+        cancel_event.end_read();
+        read.map_err(|error| PalError::with_source(PalErrorKind::Disconnected, error))?;
+        if transferred == 0 {
+            return Err(PalError::new(PalErrorKind::Disconnected));
+        }
+        buf.truncate(transferred as usize);
+        Ok(buf)
     }
 
     fn cancel_input(&self) -> Result<(), PalError> {

--- a/packages/dure/tests/fixture/mod.rs
+++ b/packages/dure/tests/fixture/mod.rs
@@ -54,8 +54,12 @@ pub(crate) enum Scenario {
     PrintAndWait,
     /// Prints text no ASCII-only path can carry, then exits.
     PrintNonAscii,
+    /// Reports its size after an input-synchronized resize.
+    ReportSizeAfterInputAndResize,
     /// Reports its console size, waits for a resize, then reports it again.
     ReportSizeAfterResize,
+    /// Enables focus and mouse reporting, then verifies a sample input.
+    VerifyTerminalInput,
     /// Waits for input, then reports whether it has a console.
     WaitThenReportConsole,
     /// Waits for input, then exits with `SAMPLE_NONZERO_EXIT`.
@@ -68,7 +72,11 @@ impl Scenario {
             Self::EchoLine => vec!["echo-line".to_string()],
             Self::PrintAndWait => vec!["print-and-wait".to_string()],
             Self::PrintNonAscii => vec!["print-non-ascii".to_string()],
+            Self::ReportSizeAfterInputAndResize => {
+                vec!["report-size-after-input-and-resize".to_string()]
+            }
             Self::ReportSizeAfterResize => vec!["report-size-after-resize".to_string()],
+            Self::VerifyTerminalInput => vec!["verify-terminal-input".to_string()],
             Self::WaitThenReportConsole => vec!["wait-has-console".to_string()],
             Self::WaitThenExit => {
                 vec!["wait-exit".to_string(), SAMPLE_NONZERO_EXIT.to_string()]

--- a/packages/dure/tests/windows.rs
+++ b/packages/dure/tests/windows.rs
@@ -14,7 +14,10 @@ use std::fs;
 use std::sync::mpsc::Receiver;
 
 use dure::test_support::ConsoleProcess;
-use dure_test_helper::SAMPLE_NON_ASCII_TEXT;
+use dure_test_helper::{
+    RESIZE_READY, SAMPLE_NON_ASCII_TEXT, SAMPLE_TERMINAL_INPUT, TERMINAL_INPUT_OK,
+    TERMINAL_INPUT_READY,
+};
 use tempfile::TempDir;
 use testing::with_watchdog;
 
@@ -29,6 +32,11 @@ use fixture::{
 const ESC: char = '\u{1b}';
 /// Terminator the pseudoconsole uses for its window-title sequences.
 const BEL: char = '\u{7}';
+
+/// Geometry that differs from the harness default in both dimensions.
+///
+/// The dimensions are distinct so swapping them cannot accidentally pass.
+const DISTINCT_RESIZED_SIZE: (u16, u16) = (91, 37);
 
 /// Strip the control sequences a pseudoconsole typically injects around app text.
 ///
@@ -297,8 +305,39 @@ fn relayed_input_keeps_non_ascii_text_intact() {
 
 #[cfg_attr(miri, ignore)]
 #[test]
-fn the_app_is_given_the_attaching_terminal_size_and_told_when_it_changes() {
+fn relayed_input_carries_focus_and_mouse_vt_sequences() {
     with_watchdog(|| {
+        let dir = TempDir::new().unwrap();
+        let client = DureCommand::run(dir.path(), Scenario::VerifyTerminalInput).spawn(dir.path());
+        let mut watching = Console::watching(&client);
+        _ = watching.until(TERMINAL_INPUT_READY);
+
+        client.write_input(SAMPLE_TERMINAL_INPUT);
+        let output = watching.rest();
+        let status = client.wait();
+
+        assert_eq!(status, 0, "client output: {output:?}");
+        assert!(
+            output.contains(TERMINAL_INPUT_OK),
+            "focus and mouse VT input must reach the app unchanged, got {output:?}"
+        );
+    });
+}
+
+#[cfg_attr(miri, ignore)]
+#[test]
+fn the_app_is_given_the_attaching_terminal_size_and_told_when_it_changes() {
+    assert_resize_reaches_app(None);
+}
+
+#[cfg_attr(miri, ignore)]
+#[test]
+fn keyboard_input_does_not_hide_a_later_resize() {
+    assert_resize_reaches_app(Some(b"x"));
+}
+
+fn assert_resize_reaches_app(input_before_resize: Option<&'static [u8]>) {
+    with_watchdog(move || {
         let dir = TempDir::new().unwrap();
         let client =
             DureCommand::run(dir.path(), Scenario::ReportSizeAfterResize).spawn(dir.path());
@@ -313,6 +352,9 @@ fn the_app_is_given_the_attaching_terminal_size_and_told_when_it_changes() {
         // one. Deliberately smaller in one dimension and larger in the other,
         // so a report that swapped them would not match either.
         let resized = (attach_size.0.saturating_add(11), 17_u16);
+        if let Some(input) = input_before_resize {
+            client.write_input(input);
+        }
         client.resize(resized.0, resized.1);
         // The helper waits for the app console's resize event, so its second
         // report cannot race a separately injected input record.
@@ -324,6 +366,36 @@ fn the_app_is_given_the_attaching_terminal_size_and_told_when_it_changes() {
             last_reported_size(&output),
             Some(resized),
             "a live resize must reach the app, got {output:?}"
+        );
+    });
+}
+
+#[cfg_attr(miri, ignore)]
+#[test]
+fn a_resumed_session_receives_later_terminal_resizes() {
+    with_watchdog(|| {
+        let store = TempDir::new().unwrap();
+        let launch = TempDir::new().unwrap();
+        let original = DureCommand::run(store.path(), Scenario::ReportSizeAfterInputAndResize)
+            .spawn(launch.path());
+        let mut watching_original = Console::watching(&original);
+        _ = watching_original.until("size:");
+        drop(original);
+
+        let resumed = DureCommand::resume(store.path()).spawn(launch.path());
+        let mut watching_resumed = Console::watching(&resumed);
+        resumed.write_input(b"x");
+        _ = watching_resumed.until(RESIZE_READY);
+
+        resumed.resize(DISTINCT_RESIZED_SIZE.0, DISTINCT_RESIZED_SIZE.1);
+        let output = watching_resumed.rest();
+        let status = resumed.wait();
+
+        assert_eq!(status, 0, "resumed client output: {output:?}");
+        assert_eq!(
+            last_reported_size(&output),
+            Some(DISTINCT_RESIZED_SIZE),
+            "a resize after resume must reach the app, got {output:?}"
         );
     });
 }


### PR DESCRIPTION
[Copilot speaking]

Resumed clients could stop forwarding terminal resize changes because the Windows client mixed console-record inspection with blocking byte reads. A resize record could arrive after inspection and then be consumed by `ReadFile` without ever reaching the app.

This makes `ReadFile` the sole console-input owner and observes terminal size independently every 250 ms on a promptly stoppable watcher thread. The watcher sends resize messages only when the current geometry changes, so resize delivery converges reliably without coupling it to keyboard input ordering.

The terminal pass-through contract now also reflects the verified behavior for negotiated mouse and focus VT input. Regression coverage exercises keyboard input before resize, resize after detach and resume, and focus/mouse VT sequences. The `dure` version is incremented to 0.2.4.