### PR TITLE
cbh_storage: cover Azure upload retry error paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-bench-history"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bench-history-faker"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "folo_utils",
  "mimalloc",
@@ -586,7 +586,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbh_analyze"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyspawn",
  "cbh_command",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cbh_command",
  "cbh_model",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_codec"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "alloc_tracker",
  "cbh_model",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_command"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cbh_model",
  "mutants",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_config"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cbh_command",
  "mutants",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_detect"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyspawn",
  "cbh_model",
@@ -675,14 +675,14 @@ dependencies = [
 
 [[package]]
 name = "cbh_diag"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "mutants",
 ]
 
 [[package]]
 name = "cbh_engines"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_git"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cbh_model",
  "futures",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_model"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "criterion",
  "jiff",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_probe"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cbh_git",
  "cbh_model",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_render"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cbh_detect",
  "cbh_model",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_stats"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "criterion",
  "mutants",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_storage"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,20 +29,20 @@ azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
 cargo-freeze-deps = { version = "0.1.9", path = "packages/cargo-freeze-deps", default-features = false }
 cargo-release-plan = { version = "0.1.3", path = "packages/cargo-release-plan", default-features = false }
-cbh_analyze = { version = "=0.2.5", path = "packages/cbh_analyze", default-features = false }
-cbh_cli = { version = "=0.2.5", path = "packages/cbh_cli", default-features = false }
-cbh_codec = { version = "=0.2.5", path = "packages/cbh_codec", default-features = false }
-cbh_command = { version = "=0.2.5", path = "packages/cbh_command", default-features = false }
-cbh_config = { version = "=0.2.5", path = "packages/cbh_config", default-features = false }
-cbh_detect = { version = "=0.2.5", path = "packages/cbh_detect", default-features = false }
-cbh_diag = { version = "=0.2.5", path = "packages/cbh_diag", default-features = false }
-cbh_engines = { version = "=0.2.5", path = "packages/cbh_engines", default-features = false }
-cbh_git = { version = "=0.2.5", path = "packages/cbh_git", default-features = false }
-cbh_model = { version = "=0.2.5", path = "packages/cbh_model", default-features = false }
-cbh_probe = { version = "=0.2.5", path = "packages/cbh_probe", default-features = false }
-cbh_render = { version = "=0.2.5", path = "packages/cbh_render", default-features = false }
-cbh_stats = { version = "=0.2.5", path = "packages/cbh_stats", default-features = false }
-cbh_storage = { version = "=0.2.5", path = "packages/cbh_storage", default-features = false }
+cbh_analyze = { version = "=0.2.6", path = "packages/cbh_analyze", default-features = false }
+cbh_cli = { version = "=0.2.6", path = "packages/cbh_cli", default-features = false }
+cbh_codec = { version = "=0.2.6", path = "packages/cbh_codec", default-features = false }
+cbh_command = { version = "=0.2.6", path = "packages/cbh_command", default-features = false }
+cbh_config = { version = "=0.2.6", path = "packages/cbh_config", default-features = false }
+cbh_detect = { version = "=0.2.6", path = "packages/cbh_detect", default-features = false }
+cbh_diag = { version = "=0.2.6", path = "packages/cbh_diag", default-features = false }
+cbh_engines = { version = "=0.2.6", path = "packages/cbh_engines", default-features = false }
+cbh_git = { version = "=0.2.6", path = "packages/cbh_git", default-features = false }
+cbh_model = { version = "=0.2.6", path = "packages/cbh_model", default-features = false }
+cbh_probe = { version = "=0.2.6", path = "packages/cbh_probe", default-features = false }
+cbh_render = { version = "=0.2.6", path = "packages/cbh_render", default-features = false }
+cbh_stats = { version = "=0.2.6", path = "packages/cbh_stats", default-features = false }
+cbh_storage = { version = "=0.2.6", path = "packages/cbh_storage", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
 colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }

--- a/packages/cargo-bench-history-faker/Cargo.toml
+++ b/packages/cargo-bench-history-faker/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cargo-bench-history-faker"
 description = "Unsupported synthetic benchmark-output generator for validating cargo-bench-history end to end; no stable API or CLI"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-bench-history"
 description = "A Cargo tool that maintains a long-lived history of benchmark results and analyzes it for trends"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_analyze/Cargo.toml
+++ b/packages/cbh_analyze/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_analyze"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_cli/Cargo.toml
+++ b/packages/cbh_cli/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_cli"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_codec/Cargo.toml
+++ b/packages/cbh_codec/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_codec"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_command/Cargo.toml
+++ b/packages/cbh_command/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_command"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_config/Cargo.toml
+++ b/packages/cbh_config/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_config"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_detect/Cargo.toml
+++ b/packages/cbh_detect/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_detect"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_diag/Cargo.toml
+++ b/packages/cbh_diag/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_diag"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_engines/Cargo.toml
+++ b/packages/cbh_engines/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_engines"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_git/Cargo.toml
+++ b/packages/cbh_git/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_git"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_model/Cargo.toml
+++ b/packages/cbh_model/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_model"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_probe/Cargo.toml
+++ b/packages/cbh_probe/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_probe"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_render/Cargo.toml
+++ b/packages/cbh_render/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_render"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_stats/Cargo.toml
+++ b/packages/cbh_stats/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_stats"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_storage/Cargo.toml
+++ b/packages/cbh_storage/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_storage"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.5"
+version = "0.2.6"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_storage/src/azure.rs
+++ b/packages/cbh_storage/src/azure.rs
@@ -1039,6 +1039,34 @@ mod tests {
         }
     }
 
+    /// An HTTP client that returns `BlobAlreadyExists` for an upload and rejects
+    /// any ownership probe.
+    ///
+    /// It verifies that non-conditional upload modes keep the collision as an
+    /// operation error without inspecting the existing object.
+    #[derive(Debug)]
+    struct NonConditionalCollisionHttpClient;
+
+    #[async_trait::async_trait]
+    impl HttpClient for NonConditionalCollisionHttpClient {
+        async fn execute_request(
+            &self,
+            request: &azure_core::http::Request,
+        ) -> azure_core::Result<azure_core::http::AsyncRawResponse> {
+            assert_eq!(request.method(), Method::Put);
+            let mut headers = Headers::new();
+            headers.insert(
+                "x-ms-error-code",
+                StorageErrorCode::BlobAlreadyExists.as_ref(),
+            );
+            Ok(azure_core::http::AsyncRawResponse::from_bytes(
+                StatusCode::Conflict,
+                headers,
+                azure_core::Bytes::new(),
+            ))
+        }
+    }
+
     /// An HTTP client that answers every request with `404 Not Found`, standing
     /// in for a blob (or container) that does not exist. The status is outside
     /// the SDK's retry set, so the request is issued exactly once and the test
@@ -1060,9 +1088,9 @@ mod tests {
         }
     }
 
-    /// The result exposed by a simulated conditional-create ownership probe.
+    /// A conditional-create response sequence exposed by the fake HTTP client.
     #[derive(Clone, Copy, Debug)]
-    enum CollisionProbe {
+    enum ConditionalCreateScenario {
         /// The object was committed by this upload before its collision response.
         ThisUpload,
         /// The first request committed but lost its response, so its retry collides.
@@ -1073,36 +1101,42 @@ mod tests {
         NoIdentity,
         /// Inspecting the colliding object fails.
         Failure,
+        /// Container creation succeeds but the retried blob upload fails.
+        ContainerRetryFailure,
     }
 
-    /// An HTTP client that models a conditional-create response sequence and its
-    /// ownership probe.
+    /// An HTTP client that models conditional-create response sequences.
     ///
-    /// Uploads normally return `BlobAlreadyExists`. The retry scenario first
-    /// returns a retryable transport error and then the collision. A subsequent
-    /// properties request exposes the configured identity outcome or a probe
-    /// failure.
+    /// Collision scenarios expose the configured identity outcome through a
+    /// subsequent properties request. Retry scenarios model either a lost response
+    /// or on-demand container creation without real network access.
     #[derive(Debug)]
-    struct ConditionalCreateCollisionHttpClient {
-        probe: CollisionProbe,
+    struct ConditionalCreateHttpClient {
+        scenario: ConditionalCreateScenario,
         create_ids: futures::lock::Mutex<Vec<String>>,
+        container_create_count: futures::lock::Mutex<usize>,
     }
 
-    impl ConditionalCreateCollisionHttpClient {
-        fn new(probe: CollisionProbe) -> Self {
+    impl ConditionalCreateHttpClient {
+        fn new(scenario: ConditionalCreateScenario) -> Self {
             Self {
-                probe,
+                scenario,
                 create_ids: futures::lock::Mutex::new(Vec::new()),
+                container_create_count: futures::lock::Mutex::new(0),
             }
         }
 
         async fn create_ids(&self) -> Vec<String> {
             self.create_ids.lock().await.clone()
         }
+
+        async fn container_create_count(&self) -> usize {
+            *self.container_create_count.lock().await
+        }
     }
 
     #[async_trait::async_trait]
-    impl HttpClient for ConditionalCreateCollisionHttpClient {
+    impl HttpClient for ConditionalCreateHttpClient {
         async fn execute_request(
             &self,
             request: &azure_core::http::Request,
@@ -1110,6 +1144,24 @@ mod tests {
             let metadata_header = format!("x-ms-meta-{CONDITIONAL_CREATE_ID_METADATA_KEY}");
             match request.method() {
                 Method::Put => {
+                    let is_container_create = request
+                        .url()
+                        .query_pairs()
+                        .any(|(name, value)| name == "restype" && value == "container");
+                    if is_container_create {
+                        assert!(matches!(
+                            self.scenario,
+                            ConditionalCreateScenario::ContainerRetryFailure
+                        ));
+                        let mut container_create_count = self.container_create_count.lock().await;
+                        *container_create_count = container_create_count.checked_add(1).unwrap();
+                        return Ok(azure_core::http::AsyncRawResponse::from_bytes(
+                            StatusCode::Created,
+                            Headers::new(),
+                            azure_core::Bytes::new(),
+                        ));
+                    }
+
                     let create_id = request
                         .headers()
                         .iter()
@@ -1128,11 +1180,39 @@ mod tests {
                         create_ids.push(create_id);
                         create_ids.len()
                     };
-                    if matches!(self.probe, CollisionProbe::RetriedThisUpload) && attempt_count == 1
+                    if matches!(self.scenario, ConditionalCreateScenario::RetriedThisUpload)
+                        && attempt_count == 1
                     {
                         return Err(azure_core::Error::with_message(
                             ErrorKind::Io,
                             "the first upload response was lost after commit",
+                        ));
+                    }
+                    if matches!(
+                        self.scenario,
+                        ConditionalCreateScenario::ContainerRetryFailure
+                    ) {
+                        if attempt_count == 1 {
+                            let mut headers = Headers::new();
+                            headers.insert(
+                                "x-ms-error-code",
+                                StorageErrorCode::ContainerNotFound.as_ref(),
+                            );
+                            return Ok(azure_core::http::AsyncRawResponse::from_bytes(
+                                StatusCode::NotFound,
+                                headers,
+                                azure_core::Bytes::new(),
+                            ));
+                        }
+                        let mut headers = Headers::new();
+                        headers.insert(
+                            "x-ms-error-code",
+                            StorageErrorCode::AuthorizationPermissionMismatch.as_ref(),
+                        );
+                        return Ok(azure_core::http::AsyncRawResponse::from_bytes(
+                            StatusCode::Forbidden,
+                            headers,
+                            azure_core::Bytes::new(),
                         ));
                     }
 
@@ -1148,8 +1228,8 @@ mod tests {
                     ))
                 }
                 Method::Head => {
-                    let create_id = match self.probe {
-                        CollisionProbe::ThisUpload => {
+                    let create_id = match self.scenario {
+                        ConditionalCreateScenario::ThisUpload => {
                             let Some(create_id) = self.create_ids.lock().await.last().cloned()
                             else {
                                 return Err(azure_core::Error::with_message(
@@ -1159,7 +1239,7 @@ mod tests {
                             };
                             Some(create_id)
                         }
-                        CollisionProbe::RetriedThisUpload => {
+                        ConditionalCreateScenario::RetriedThisUpload => {
                             let create_ids = self.create_ids.lock().await;
                             let [first, second] = create_ids.as_slice() else {
                                 return Err(azure_core::Error::with_message(
@@ -1175,14 +1255,17 @@ mod tests {
                             }
                             Some(first.clone())
                         }
-                        CollisionProbe::OtherUpload => Some("other-upload".to_owned()),
-                        CollisionProbe::NoIdentity => None,
-                        CollisionProbe::Failure => {
+                        ConditionalCreateScenario::OtherUpload => Some("other-upload".to_owned()),
+                        ConditionalCreateScenario::NoIdentity => None,
+                        ConditionalCreateScenario::Failure => {
                             return Ok(azure_core::http::AsyncRawResponse::from_bytes(
                                 StatusCode::NotFound,
                                 Headers::new(),
                                 azure_core::Bytes::new(),
                             ));
+                        }
+                        ConditionalCreateScenario::ContainerRetryFailure => {
+                            panic!("the failed upload must not probe object ownership")
                         }
                     };
                     let mut headers = Headers::new();
@@ -1237,7 +1320,7 @@ mod tests {
     /// immediately through the injected HTTP client.
     fn retrying_collision_blob_client(
         key: &str,
-        http_client: Arc<ConditionalCreateCollisionHttpClient>,
+        http_client: Arc<ConditionalCreateHttpClient>,
     ) -> BlobClient {
         let options = BlobClientOptions {
             client_options: ClientOptions {
@@ -1401,8 +1484,8 @@ mod tests {
             "history",
             None,
             fake_credential(),
-            Arc::new(ConditionalCreateCollisionHttpClient::new(
-                CollisionProbe::ThisUpload,
+            Arc::new(ConditionalCreateHttpClient::new(
+                ConditionalCreateScenario::ThisUpload,
             )),
         )
         .unwrap();
@@ -1417,8 +1500,8 @@ mod tests {
     )]
     async fn conditional_create_accepts_a_collision_from_its_own_retried_upload() {
         let key = "v1/proj/object.json";
-        let http_client = Arc::new(ConditionalCreateCollisionHttpClient::new(
-            CollisionProbe::RetriedThisUpload,
+        let http_client = Arc::new(ConditionalCreateHttpClient::new(
+            ConditionalCreateScenario::RetriedThisUpload,
         ));
         let client = retrying_collision_blob_client(key, Arc::clone(&http_client));
         let mode = UploadMode::conditional_create();
@@ -1443,13 +1526,16 @@ mod tests {
     )]
     async fn conditional_create_rejects_collisions_not_owned_by_this_upload() {
         let key = "v1/proj/object.json";
-        for probe in [CollisionProbe::OtherUpload, CollisionProbe::NoIdentity] {
+        for scenario in [
+            ConditionalCreateScenario::OtherUpload,
+            ConditionalCreateScenario::NoIdentity,
+        ] {
             let storage = AzureBlobStorage::from_parts(
                 "acct",
                 "history",
                 None,
                 fake_credential(),
-                Arc::new(ConditionalCreateCollisionHttpClient::new(probe)),
+                Arc::new(ConditionalCreateHttpClient::new(scenario)),
             )
             .unwrap();
 
@@ -1475,8 +1561,8 @@ mod tests {
             "history",
             None,
             fake_credential(),
-            Arc::new(ConditionalCreateCollisionHttpClient::new(
-                CollisionProbe::Failure,
+            Arc::new(ConditionalCreateHttpClient::new(
+                ConditionalCreateScenario::Failure,
             )),
         )
         .unwrap();
@@ -1489,6 +1575,69 @@ mod tests {
         assert!(operation.operation.contains("verify"));
         let source = error.find_source::<azure_core::Error>().unwrap();
         assert_eq!(source.http_status(), Some(StatusCode::NotFound));
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        miri,
+        ignore = "drives the Azure SDK request pipeline, which Miri cannot run"
+    )]
+    async fn conditional_create_failure_after_container_creation_is_an_operation_error() {
+        let key = "v1/proj/object.json";
+        let http_client = Arc::new(ConditionalCreateHttpClient::new(
+            ConditionalCreateScenario::ContainerRetryFailure,
+        ));
+        let storage_http_client = Arc::clone(&http_client);
+        let storage = AzureBlobStorage::from_parts(
+            "acct",
+            "history",
+            None,
+            fake_credential(),
+            storage_http_client,
+        )
+        .unwrap();
+
+        let error = storage.put(key, b"body").await.unwrap_err();
+
+        assert_azure_upload_operation(&error, key);
+        assert!(error.find_source::<ObjectAlreadyExistsError>().is_none());
+        let source = error.find_source::<azure_core::Error>().unwrap();
+        assert_eq!(source.http_status(), Some(StatusCode::Forbidden));
+        let create_ids = http_client.create_ids().await;
+        assert!(matches!(
+            create_ids.as_slice(),
+            [first, second] if first == second
+        ));
+        assert_eq!(http_client.container_create_count().await, 1);
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        miri,
+        ignore = "drives the Azure SDK request pipeline, which Miri cannot run"
+    )]
+    async fn overwrite_upload_failure_is_an_operation_error() {
+        let key = "v1/proj/object.json";
+        let storage = AzureBlobStorage::from_parts(
+            "acct",
+            "history",
+            None,
+            fake_credential(),
+            Arc::new(NonConditionalCollisionHttpClient),
+        )
+        .unwrap();
+        let client = storage.blob_client(key).unwrap();
+
+        let error = storage
+            .upload_with_retry(&client, b"body", key, UploadMode::Overwrite)
+            .await
+            .unwrap_err();
+
+        assert_azure_upload_operation(&error, key);
+        assert_eq!(error.already_existing_key(), None);
+        assert!(error.find_source::<ObjectAlreadyExistsError>().is_none());
+        let source = error.find_source::<azure_core::Error>().unwrap();
+        assert_eq!(source.http_status(), Some(StatusCode::Conflict));
     }
 
     // =======================================================================


### PR DESCRIPTION
[Copilot speaking]

#533 merged with a Codecov patch-coverage failure because two newly added Azure upload error branches were not exercised. This follow-up adds focused fake-transport regressions for those paths without changing production behavior.

The tests model an upload that encounters a missing container, creates it, and then fails its second conditional-create attempt while retaining the same request identity. They also verify that `BlobAlreadyExists` from a non-conditional overwrite remains an Azure operation error and never triggers an ownership probe.

The shared `cargo-bench-history` version group moves to `0.2.6` so the shipped `cbh_storage` regression coverage is released consistently.