### PR TITLE
Cover const functions during runtime tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "all_the_time"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "alloc_tracker",
  "cpu-time",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "alloc_tracker"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "all_the_time",
  "criterion",
@@ -209,7 +209,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "awaiter_set"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "criterion",
  "futures",
@@ -448,7 +448,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-bench-history"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bench-history-faker"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "folo_utils",
  "mimalloc",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-detect-package"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "clap",
  "mimalloc",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-freeze-deps"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "mimalloc",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-plan"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "criterion",
@@ -586,7 +586,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbh_analyze"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyspawn",
  "cbh_command",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "cbh_command",
  "cbh_model",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_codec"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alloc_tracker",
  "cbh_model",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_command"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "cbh_model",
  "mutants",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_config"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "cbh_command",
  "mutants",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_detect"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyspawn",
  "cbh_model",
@@ -675,14 +675,14 @@ dependencies = [
 
 [[package]]
 name = "cbh_diag"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "mutants",
 ]
 
 [[package]]
 name = "cbh_engines"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_git"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "cbh_model",
  "futures",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_model"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "criterion",
  "jiff",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_probe"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "cbh_git",
  "cbh_model",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_render"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "cbh_detect",
  "cbh_model",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_stats"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "criterion",
  "mutants",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "cbh_storage"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -915,7 +915,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dure"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "dure-test-helper",
@@ -1266,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "events"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "alloc_tracker",
  "awaiter_set",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "events_once"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "criterion",
  "futures",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "fast_time"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "criterion",
  "gungraun",
@@ -1443,7 +1443,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "future_deque"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "infinity_pool"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "alloc_tracker",
  "criterion",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "linked"
-version = "1.0.21"
+version = "1.0.22"
 dependencies = [
  "criterion",
  "gungraun",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "linked_macros"
-version = "1.0.21"
+version = "1.0.22"
 dependencies = [
  "linked_macros_impl",
  "proc-macro2",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "linked_macros_impl"
-version = "1.0.21"
+version = "1.0.22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2228,7 +2228,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "many_cpus"
-version = "2.4.18"
+version = "2.4.19"
 dependencies = [
  "many_cpus_impl",
  "new_zealand",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "many_cpus_benchmarking"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "cpulist",
  "criterion",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "many_cpus_impl"
-version = "2.4.18"
+version = "2.4.19"
 dependencies = [
  "cpulist",
  "criterion",
@@ -2373,7 +2373,7 @@ version = "1.0.9"
 
 [[package]]
 name = "nm"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "nm_impl",
  "static_assertions",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "nm_impl"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "criterion",
  "fast_time",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "nm_otel"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "nm",
  "nm_otel_impl",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "nm_otel_impl"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "alloc_tracker",
  "criterion",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "par_bench"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -2883,7 +2883,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3057,7 +3057,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "region_cached"
-version = "1.0.33"
+version = "1.0.34"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "region_local"
-version = "1.0.33"
+version = "1.0.34"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3185,7 +3185,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3242,7 +3242,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3603,7 +3603,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4166,7 +4166,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vicinal"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "all_the_time",
  "alloc_tracker",
@@ -4341,7 +4341,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,33 +16,33 @@ rust-version = "1.95"
 include = ["src/**/*"]
 
 [workspace.dependencies]
-all_the_time = { version = "0.6.4", path = "packages/all_the_time", default-features = false }
-alloc_tracker = { version = "0.7.4", path = "packages/alloc_tracker", default-features = false }
+all_the_time = { version = "0.6.5", path = "packages/all_the_time", default-features = false }
+alloc_tracker = { version = "0.7.5", path = "packages/alloc_tracker", default-features = false }
 anyspawn = { version = "0.8.0", default-features = false }
 arc-swap = { version = "1.7.0", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
-awaiter_set = { version = "0.1.13", path = "packages/awaiter_set", default-features = false }
+awaiter_set = { version = "0.1.14", path = "packages/awaiter_set", default-features = false }
 axum = { version = "0.8.0", default-features = false }
 azure_core = { version = "1.0.0", default-features = false }
 azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
-cargo-freeze-deps = { version = "0.1.9", path = "packages/cargo-freeze-deps", default-features = false }
-cargo-release-plan = { version = "0.1.3", path = "packages/cargo-release-plan", default-features = false }
-cbh_analyze = { version = "=0.2.6", path = "packages/cbh_analyze", default-features = false }
-cbh_cli = { version = "=0.2.6", path = "packages/cbh_cli", default-features = false }
-cbh_codec = { version = "=0.2.6", path = "packages/cbh_codec", default-features = false }
-cbh_command = { version = "=0.2.6", path = "packages/cbh_command", default-features = false }
-cbh_config = { version = "=0.2.6", path = "packages/cbh_config", default-features = false }
-cbh_detect = { version = "=0.2.6", path = "packages/cbh_detect", default-features = false }
-cbh_diag = { version = "=0.2.6", path = "packages/cbh_diag", default-features = false }
-cbh_engines = { version = "=0.2.6", path = "packages/cbh_engines", default-features = false }
-cbh_git = { version = "=0.2.6", path = "packages/cbh_git", default-features = false }
-cbh_model = { version = "=0.2.6", path = "packages/cbh_model", default-features = false }
-cbh_probe = { version = "=0.2.6", path = "packages/cbh_probe", default-features = false }
-cbh_render = { version = "=0.2.6", path = "packages/cbh_render", default-features = false }
-cbh_stats = { version = "=0.2.6", path = "packages/cbh_stats", default-features = false }
-cbh_storage = { version = "=0.2.6", path = "packages/cbh_storage", default-features = false }
+cargo-freeze-deps = { version = "0.1.10", path = "packages/cargo-freeze-deps", default-features = false }
+cargo-release-plan = { version = "0.1.4", path = "packages/cargo-release-plan", default-features = false }
+cbh_analyze = { version = "=0.2.7", path = "packages/cbh_analyze", default-features = false }
+cbh_cli = { version = "=0.2.7", path = "packages/cbh_cli", default-features = false }
+cbh_codec = { version = "=0.2.7", path = "packages/cbh_codec", default-features = false }
+cbh_command = { version = "=0.2.7", path = "packages/cbh_command", default-features = false }
+cbh_config = { version = "=0.2.7", path = "packages/cbh_config", default-features = false }
+cbh_detect = { version = "=0.2.7", path = "packages/cbh_detect", default-features = false }
+cbh_diag = { version = "=0.2.7", path = "packages/cbh_diag", default-features = false }
+cbh_engines = { version = "=0.2.7", path = "packages/cbh_engines", default-features = false }
+cbh_git = { version = "=0.2.7", path = "packages/cbh_git", default-features = false }
+cbh_model = { version = "=0.2.7", path = "packages/cbh_model", default-features = false }
+cbh_probe = { version = "=0.2.7", path = "packages/cbh_probe", default-features = false }
+cbh_render = { version = "=0.2.7", path = "packages/cbh_render", default-features = false }
+cbh_stats = { version = "=0.2.7", path = "packages/cbh_stats", default-features = false }
+cbh_storage = { version = "=0.2.7", path = "packages/cbh_storage", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["default"] }
 colored = { version = "3.1.1", default-features = false }
 cpu-time = { version = "1.0.0", default-features = false }
@@ -53,16 +53,16 @@ derive_more = { version = "2.0.0", default-features = false }
 event-listener = { version = "5.4.0", default-features = false, features = [
     "std",
 ] }
-events = { version = "0.7.15", path = "packages/events", default-features = false }
-events_once = { version = "0.5.36", path = "packages/events_once", default-features = false }
+events = { version = "0.7.16", path = "packages/events", default-features = false }
+events_once = { version = "0.5.37", path = "packages/events_once", default-features = false }
 fake_headers = { version = "0.0.5", default-features = false }
-fast_time = { version = "0.1.29", path = "packages/fast_time", default-features = false }
+fast_time = { version = "0.1.30", path = "packages/fast_time", default-features = false }
 flate2 = { version = "1.1.9", default-features = false }
 foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
 folo_ffi = { version = "0.1.17", path = "packages/folo_ffi", default-features = false }
 folo_utils = { version = "0.1.13", path = "packages/folo_utils", default-features = false }
 frozen-collections = { version = "0.9.1", default-features = false }
-future_deque = { version = "0.1.19", path = "packages/future_deque", default-features = false }
+future_deque = { version = "0.1.20", path = "packages/future_deque", default-features = false }
 futures = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-core = { version = "0.3.32", default-features = false }
 # Keep this version in lockstep with `GUNGRAUN_RUNNER_VERSION` in `constants.env` (which the
@@ -84,20 +84,20 @@ itertools = { version = "0.15.0", default-features = false, features = [
 ] }
 jiff = { version = "0.2.28", default-features = false, features = ["std"] }
 libc = { version = "0.2.172", default-features = false }
-linked = { version = "1.0.21", path = "packages/linked", default-features = false }
-linked_macros = { version = "=1.0.21", path = "packages/linked_macros", default-features = false }
-linked_macros_impl = { version = "=1.0.21", path = "packages/linked_macros_impl", default-features = false }
-many_cpus = { version = "2.4.18", path = "packages/many_cpus", default-features = false }
-many_cpus_impl = { version = "=2.4.18", path = "packages/many_cpus_impl", default-features = false }
+linked = { version = "1.0.22", path = "packages/linked", default-features = false }
+linked_macros = { version = "=1.0.22", path = "packages/linked_macros", default-features = false }
+linked_macros_impl = { version = "=1.0.22", path = "packages/linked_macros_impl", default-features = false }
+many_cpus = { version = "2.4.19", path = "packages/many_cpus", default-features = false }
+many_cpus_impl = { version = "=2.4.19", path = "packages/many_cpus_impl", default-features = false }
 mimalloc = { version = "0.1.52", default-features = false }
 mockall = { version = "0.15.0", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
 negative-impl = { version = "0.1.0", default-features = false }
 new_zealand = { version = "1.0.9", path = "packages/new_zealand", default-features = false }
-nm = { version = "0.1.47", path = "packages/nm", default-features = false }
-nm_impl = { version = "=0.1.47", path = "packages/nm_impl", default-features = false }
-nm_otel = { version = "0.4.19", path = "packages/nm_otel", default-features = false }
-nm_otel_impl = { version = "=0.4.19", path = "packages/nm_otel_impl", default-features = false }
+nm = { version = "0.1.48", path = "packages/nm", default-features = false }
+nm_impl = { version = "=0.1.48", path = "packages/nm_impl", default-features = false }
+nm_otel = { version = "0.4.20", path = "packages/nm_otel", default-features = false }
+nm_otel_impl = { version = "=0.4.20", path = "packages/nm_otel_impl", default-features = false }
 nonempty = { version = "0.12.0", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
@@ -145,7 +145,7 @@ toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.12", default-features = false }
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 trybuild = { version = "1.0.0", default-features = false }
-vicinal = { version = "0.1.38", path = "packages/vicinal", default-features = false }
+vicinal = { version = "0.1.39", path = "packages/vicinal", default-features = false }
 windows = { version = "0.62.0", default-features = false, features = ["std"] }
 
 # Cargo packages that form one logical unit belong to one version group, and the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -215,12 +215,11 @@ covered by tests. For example:
   (anything `#[cfg(test)]`) need to be excluded. Integration tests in `tests/`
   are automatically excluded, though — no need to worry about those.
 * Defensive branches that can never be reached due to defense in depth layering.
-* Code that is only ever executed in a const context, as const context is not
-  covered in coverage measurements.
 * When code has no API contract to test (e.g. `fmt::Debug` implementations which
   may contractually write anything).
-* Facade types whose only purpose is to redirect calls to either a real or mock
-  implementation — not worth testing.
+* Facade pass-through methods whose only purpose is to redirect calls to either a
+  real or mock implementation. Const facade constructors remain instrumented and
+  are called at runtime as described below.
 
 To exclude code from coverage measurement, mark it with
 `#[cfg_attr(coverage_nightly, coverage(off))]`. This also requires
@@ -233,3 +232,37 @@ known gaps rather than trying to restructure the code to work around them.
 
 When excluding code for any other reason than "it is test code", leave a comment
 to explain why.
+
+### Cover const functions at runtime
+
+Coverage instrumentation cannot observe compile-time evaluation. A `const fn`
+that production code and behavioral tests only use in constants or static
+initializers therefore appears uncovered even though the compiler evaluates it.
+
+Add a focused test that calls the function in a non-const expression and passes
+the result through `std::hint::black_box()`. The test supplies the runtime
+context; the optimization barrier prevents the compiler from discarding the
+call or replacing it with a precomputed value:
+
+```rust
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::hint::black_box;
+
+    use super::*;
+
+    #[test]
+    fn constructor_executes_at_runtime() {
+        _ = black_box(Widget::new());
+    }
+}
+```
+
+Passing an already initialized `const` or `static` item to `black_box()` does not
+execute the const function and therefore does not generate coverage. When one
+const function consumes the result of another, pass each call through
+`black_box()` before passing the intermediate value onward. This makes both
+runtime calls explicit and prevents either from being folded away. Do not
+exclude a function from coverage merely because its production callers evaluate
+it in a const context.

--- a/packages/all_the_time/Cargo.toml
+++ b/packages/all_the_time/Cargo.toml
@@ -2,7 +2,7 @@
 name = "all_the_time"
 description = "Processor time tracking utilities for benchmarks and performance analysis"
 publish = true
-version = "0.6.4"
+version = "0.6.5"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/alloc_tracker/Cargo.toml
+++ b/packages/alloc_tracker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alloc_tracker"
 description = "Memory allocation tracking utilities for benchmarks and performance analysis"
 publish = true
-version = "0.7.4"
+version = "0.7.5"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/alloc_tracker/src/allocator.rs
+++ b/packages/alloc_tracker/src/allocator.rs
@@ -102,8 +102,6 @@ impl Allocator<std::alloc::System> {
     /// allocations without changing the underlying allocation strategy.
     #[must_use]
     #[inline]
-    // Only ever executed in const context, which is not covered by coverage measurement.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub const fn system() -> Self {
         Self {
             inner: std::alloc::System,
@@ -118,8 +116,6 @@ impl<A: GlobalAlloc> Allocator<A> {
     /// as the underlying allocator, with the addition of allocation tracking capabilities.
     #[must_use]
     #[inline]
-    // Only ever executed in const context, which is not covered by coverage measurement.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub const fn new(allocator: A) -> Self {
         Self { inner: allocator }
     }
@@ -203,6 +199,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for Allocator<A> {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
     use std::panic::{RefUnwindSafe, UnwindSafe};
     use std::{ptr, thread};
 
@@ -268,6 +265,11 @@ mod tests {
         unsafe fn realloc(&self, _ptr: *mut u8, _layout: Layout, _new_size: usize) -> *mut u8 {
             ptr::null_mut()
         }
+    }
+
+    #[test]
+    fn system_constructor_executes_at_runtime() {
+        _ = black_box(Allocator::system());
     }
 
     /// An arbitrary layout, large enough that a real allocation is unlikely to be optimized away.

--- a/packages/awaiter_set/Cargo.toml
+++ b/packages/awaiter_set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "awaiter_set"
 description = "Zero-allocation awaiter tracking for async synchronization primitives"
 publish = true
-version = "0.1.13"
+version = "0.1.14"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-bench-history-faker/Cargo.toml
+++ b/packages/cargo-bench-history-faker/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cargo-bench-history-faker"
 description = "Unsupported synthetic benchmark-output generator for validating cargo-bench-history end to end; no stable API or CLI"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-bench-history/Cargo.toml
+++ b/packages/cargo-bench-history/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-bench-history"
 description = "A Cargo tool that maintains a long-lived history of benchmark results and analyzes it for trends"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-detect-package/Cargo.toml
+++ b/packages/cargo-detect-package/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-detect-package"
 description = "A Cargo tool to detect the package that a file belongs to, passing the package name to a subcommand"
 publish = true
-version = "1.0.30"
+version = "1.0.31"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-detect-package/src/pal/filesystem/facade.rs
+++ b/packages/cargo-detect-package/src/pal/filesystem/facade.rs
@@ -42,17 +42,19 @@ impl fmt::Debug for FilesystemFacade {
 /// Static instance of the real filesystem for production use.
 static BUILD_TARGET_FILESYSTEM: BuildTargetFilesystem = BuildTargetFilesystem;
 
-// Facade types are trivial pass-through layers - not worth testing.
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg_attr(test, mutants::skip)]
 impl FilesystemFacade {
     /// Creates a facade using the real filesystem.
+    // A default-return mutation recurses through `Default::default()` instead of failing cleanly.
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) const fn target() -> Self {
         Self::Target(&BUILD_TARGET_FILESYSTEM)
     }
 
     /// Creates a facade wrapping a mock filesystem (test builds only).
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn from_mock(mock: MockFilesystem) -> Self {
         Self::Mock(Arc::new(mock))
     }
@@ -117,5 +119,21 @@ impl Filesystem for FilesystemFacade {
 impl Default for FilesystemFacade {
     fn default() -> Self {
         Self::target()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::hint::black_box;
+
+    use super::*;
+
+    #[test]
+    fn target_constructor_executes_at_runtime() {
+        assert!(matches!(
+            black_box(FilesystemFacade::target()),
+            FilesystemFacade::Target(_)
+        ));
     }
 }

--- a/packages/cargo-freeze-deps/Cargo.toml
+++ b/packages/cargo-freeze-deps/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-freeze-deps"
 description = "A Cargo subcommand that freezes all floating dependency versions in a Cargo.toml file to their literal values"
 publish = true
-version = "0.1.9"
+version = "0.1.10"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-release-plan/Cargo.toml
+++ b/packages/cargo-release-plan/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-release-plan"
 description = "A Cargo subcommand that classifies publishable packages against their version anchors and applies increment plans"
 publish = true
-version = "0.1.3"
+version = "0.1.4"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_analyze/Cargo.toml
+++ b/packages/cbh_analyze/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_analyze"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_cli/Cargo.toml
+++ b/packages/cbh_cli/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_cli"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_codec/Cargo.toml
+++ b/packages/cbh_codec/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_codec"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_command/Cargo.toml
+++ b/packages/cbh_command/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_command"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_config/Cargo.toml
+++ b/packages/cbh_config/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_config"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_detect/Cargo.toml
+++ b/packages/cbh_detect/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_detect"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_diag/Cargo.toml
+++ b/packages/cbh_diag/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_diag"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_engines/Cargo.toml
+++ b/packages/cbh_engines/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_engines"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_git/Cargo.toml
+++ b/packages/cbh_git/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_git"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_model/Cargo.toml
+++ b/packages/cbh_model/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_model"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_probe/Cargo.toml
+++ b/packages/cbh_probe/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_probe"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_render/Cargo.toml
+++ b/packages/cbh_render/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_render"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_stats/Cargo.toml
+++ b/packages/cbh_stats/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_stats"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cbh_storage/Cargo.toml
+++ b/packages/cbh_storage/Cargo.toml
@@ -4,7 +4,7 @@
 name = "cbh_storage"
 description = "Implementation crate for cargo-bench-history - do not reference directly"
 publish = true
-version = "0.2.6"
+version = "0.2.7"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/dure/Cargo.toml
+++ b/packages/dure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dure"
 description = "Detachable Windows console sessions that outlive the terminal"
 publish = true
-version = "0.2.4"
+version = "0.2.5"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/dure/src/pal/local_console/facade.rs
+++ b/packages/dure/src/pal/local_console/facade.rs
@@ -36,14 +36,15 @@ impl fmt::Debug for LocalConsoleFacade {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg_attr(test, mutants::skip)]
 impl LocalConsoleFacade {
     pub(crate) const fn target() -> Self {
         Self::Target(&TARGET)
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn from_mock(mock: MockLocalConsole) -> Self {
         Self::Mock(Arc::new(mock))
     }
@@ -128,7 +129,17 @@ impl LocalConsole for LocalConsoleFacade {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
+
     use super::*;
+
+    #[test]
+    fn target_constructor_executes_at_runtime() {
+        assert!(matches!(
+            black_box(LocalConsoleFacade::target()),
+            LocalConsoleFacade::Target(_)
+        ));
+    }
 
     #[test]
     fn from_mock_dispatches_has_console() {

--- a/packages/dure/src/pal/processes/facade.rs
+++ b/packages/dure/src/pal/processes/facade.rs
@@ -39,14 +39,15 @@ impl fmt::Debug for ProcessesFacade {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg_attr(test, mutants::skip)]
 impl ProcessesFacade {
     pub(crate) const fn target() -> Self {
         Self::Target(&TARGET)
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn from_mock(mock: MockProcesses) -> Self {
         Self::Mock(Arc::new(mock))
     }
@@ -155,9 +156,19 @@ impl Processes for ProcessesFacade {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
+
     use super::*;
     use crate::pal::processes::ProcessLiveness;
     use crate::session_record::ProcessIdentity;
+
+    #[test]
+    fn target_constructor_executes_at_runtime() {
+        assert!(matches!(
+            black_box(ProcessesFacade::target()),
+            ProcessesFacade::Target(_)
+        ));
+    }
 
     #[test]
     fn from_mock_dispatches_probe() {

--- a/packages/dure/src/pal/pseudoconsole/facade.rs
+++ b/packages/dure/src/pal/pseudoconsole/facade.rs
@@ -33,14 +33,15 @@ impl fmt::Debug for PseudoconsoleFacade {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg_attr(test, mutants::skip)]
 impl PseudoconsoleFacade {
     pub(crate) const fn target() -> Self {
         Self::Target(&TARGET)
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn from_memory(pty: MemoryPseudoconsole) -> Self {
         Self::Memory(pty)
     }
@@ -101,7 +102,17 @@ impl Pseudoconsole for PseudoconsoleFacade {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
+
     use super::*;
+
+    #[test]
+    fn target_constructor_executes_at_runtime() {
+        assert!(matches!(
+            black_box(PseudoconsoleFacade::target()),
+            PseudoconsoleFacade::Target(_)
+        ));
+    }
 
     #[test]
     fn from_memory_creates_pty() {

--- a/packages/dure/src/pal/transport/facade.rs
+++ b/packages/dure/src/pal/transport/facade.rs
@@ -35,14 +35,15 @@ impl fmt::Debug for TransportFacade {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg_attr(test, mutants::skip)]
 impl TransportFacade {
     pub(crate) const fn target() -> Self {
         Self::Target(&TARGET)
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn from_memory(transport: MemoryTransport) -> Self {
         Self::Memory(transport)
     }
@@ -135,7 +136,17 @@ impl Transport for TransportFacade {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
+
     use super::*;
+
+    #[test]
+    fn target_constructor_executes_at_runtime() {
+        assert!(matches!(
+            black_box(TransportFacade::target()),
+            TransportFacade::Target(_)
+        ));
+    }
 
     #[test]
     fn from_memory_dispatches_pipe_name() {

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -2,7 +2,7 @@
 name = "events"
 description = "Async manual-reset and auto-reset event primitives"
 publish = true
-version = "0.7.15"
+version = "0.7.16"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/events_once/Cargo.toml
+++ b/packages/events_once/Cargo.toml
@@ -2,7 +2,7 @@
 name = "events_once"
 description = "Efficient oneshot events (channels) with support for single-threaded events, object embedding, event pools and event lakes"
 publish = true
-version = "0.5.36"
+version = "0.5.37"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/fast_time/Cargo.toml
+++ b/packages/fast_time/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fast_time"
 description = "An efficient low-precision timestamp source suitable for high-frequency querying"
 publish = true
-version = "0.1.29"
+version = "0.1.30"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/fast_time/src/pal/linux/bindings/facade.rs
+++ b/packages/fast_time/src/pal/linux/bindings/facade.rs
@@ -1,6 +1,3 @@
-// Facade types are trivial pass-through layers - not worth testing.
-#![cfg_attr(coverage_nightly, coverage(off))]
-
 use std::fmt::Debug;
 #[cfg(test)]
 use std::sync::Arc;
@@ -24,6 +21,8 @@ impl BindingsFacade {
     }
 }
 
+// Facade types are trivial pass-through layers - not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl Bindings for BindingsFacade {
     #[inline]
     fn clock_gettime_nanos(&self) -> u64 {
@@ -44,6 +43,8 @@ impl Bindings for BindingsFacade {
     }
 }
 
+// Facade types are trivial pass-through layers - not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl From<&'static BuildTargetBindings> for BindingsFacade {
     fn from(bindings: &'static BuildTargetBindings) -> Self {
         Self::Real(bindings)
@@ -51,6 +52,8 @@ impl From<&'static BuildTargetBindings> for BindingsFacade {
 }
 
 #[cfg(test)]
+// Facade types are trivial pass-through layers - not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl From<MockBindings> for BindingsFacade {
     fn from(bindings: MockBindings) -> Self {
         Self::Mock(Arc::new(bindings))

--- a/packages/fast_time/src/pal/linux/platform.rs
+++ b/packages/fast_time/src/pal/linux/platform.rs
@@ -12,8 +12,6 @@ pub(crate) struct BuildTargetPlatform {
 }
 
 impl BuildTargetPlatform {
-    // Only executed in const context.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) const fn new(bindings: BindingsFacade) -> Self {
         Self { bindings }
     }
@@ -30,9 +28,18 @@ impl Platform for BuildTargetPlatform {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
     use std::panic::{RefUnwindSafe, UnwindSafe};
 
     use super::*;
 
     static_assertions::assert_impl_all!(BuildTargetPlatform: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn constructors_execute_at_runtime() {
+        let bindings = black_box(BindingsFacade::real());
+        let platform = black_box(BuildTargetPlatform::new(bindings));
+
+        assert!(matches!(platform.bindings, BindingsFacade::Real(_)));
+    }
 }

--- a/packages/fast_time/src/pal/windows/bindings/facade.rs
+++ b/packages/fast_time/src/pal/windows/bindings/facade.rs
@@ -1,6 +1,3 @@
-// Facade types are trivial pass-through layers - not worth testing.
-#![cfg_attr(coverage_nightly, coverage(off))]
-
 use std::fmt::Debug;
 #[cfg(test)]
 use std::sync::Arc;
@@ -25,6 +22,8 @@ impl BindingsFacade {
     }
 }
 
+// Facade types are trivial pass-through layers - not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl Bindings for BindingsFacade {
     #[inline]
     fn get_tick_count_64(&self) -> u64 {
@@ -45,6 +44,8 @@ impl Bindings for BindingsFacade {
     }
 }
 
+// Facade types are trivial pass-through layers - not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl From<&'static BuildTargetBindings> for BindingsFacade {
     fn from(bindings: &'static BuildTargetBindings) -> Self {
         Self::Real(bindings)
@@ -52,6 +53,8 @@ impl From<&'static BuildTargetBindings> for BindingsFacade {
 }
 
 #[cfg(test)]
+// Facade types are trivial pass-through layers - not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl From<MockBindings> for BindingsFacade {
     fn from(bindings: MockBindings) -> Self {
         Self::Mock(Arc::new(bindings))

--- a/packages/fast_time/src/pal/windows/platform.rs
+++ b/packages/fast_time/src/pal/windows/platform.rs
@@ -12,8 +12,6 @@ pub(crate) struct BuildTargetPlatform {
 }
 
 impl BuildTargetPlatform {
-    // Only executed in const context.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) const fn new(bindings: BindingsFacade) -> Self {
         Self { bindings }
     }
@@ -30,9 +28,18 @@ impl Platform for BuildTargetPlatform {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
     use std::panic::{RefUnwindSafe, UnwindSafe};
 
     use super::*;
 
     static_assertions::assert_impl_all!(BuildTargetPlatform: UnwindSafe, RefUnwindSafe);
+
+    #[test]
+    fn constructors_execute_at_runtime() {
+        let bindings = black_box(BindingsFacade::real());
+        let platform = black_box(BuildTargetPlatform::new(bindings));
+
+        assert!(matches!(platform.bindings, BindingsFacade::Real(_)));
+    }
 }

--- a/packages/future_deque/Cargo.toml
+++ b/packages/future_deque/Cargo.toml
@@ -2,7 +2,7 @@
 name = "future_deque"
 description = "Deque collections for managing groups of futures"
 publish = true
-version = "0.1.19"
+version = "0.1.20"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/infinity_pool/Cargo.toml
+++ b/packages/infinity_pool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "infinity_pool"
 description = "Offers object pooling capabilities both thread-safe and single threaded, both lifetime-managed and manual, both typed and untyped"
 publish = true
-version = "0.8.26"
+version = "0.8.27"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/linked/Cargo.toml
+++ b/packages/linked/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linked"
 description = "Create families of linked objects that can collaborate across threads while being internally single-threaded"
 publish = true
-version = "1.0.21"
+version = "1.0.22"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/linked/src/static_instance_per_thread.rs
+++ b/packages/linked/src/static_instance_per_thread.rs
@@ -27,9 +27,6 @@ where
     /// Note: this function exists to serve the inner workings of the
     /// `linked::thread_local_rc!` macro and should not be used directly.
     /// It is not part of the public API and may be removed or changed at any time.
-    // Only ever called in const context by macros. Coverage instrumentation
-    // cannot detect const context execution.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     #[doc(hidden)]
     #[must_use]
     pub const fn new(get_storage: fn() -> &'static LocalKey<Rc<T>>) -> Self {
@@ -294,7 +291,9 @@ macro_rules! thread_local_rc {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::Cell;
+    use std::hint::black_box;
     use std::panic::{RefUnwindSafe, UnwindSafe};
+    use std::rc::Rc;
     use std::thread;
 
     use static_assertions::assert_impl_all;
@@ -325,6 +324,17 @@ mod tests {
             self.local_value
                 .set(self.local_value.get().saturating_add(1));
         }
+    }
+
+    #[test]
+    fn constructor_executes_at_runtime() {
+        thread_local! {
+            static CACHE: Rc<TokenCache> = Rc::new(TokenCache::new(1000));
+        }
+
+        let instance = black_box(StaticInstancePerThread::new(|| &CACHE));
+
+        instance.with(|cache| assert_eq!(cache.value(), 1000));
     }
 
     #[test]

--- a/packages/linked/src/static_instance_per_thread_sync.rs
+++ b/packages/linked/src/static_instance_per_thread_sync.rs
@@ -309,7 +309,9 @@ macro_rules! thread_local_arc {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
     use std::panic::{RefUnwindSafe, UnwindSafe};
+    use std::sync::Arc;
     use std::sync::atomic::{self, AtomicUsize};
     use std::thread;
 
@@ -341,6 +343,17 @@ mod tests {
         fn increment(&self) {
             self.local_value.fetch_add(1, atomic::Ordering::Relaxed);
         }
+    }
+
+    #[test]
+    fn constructor_executes_at_runtime() {
+        thread_local! {
+            static CACHE: Arc<TokenCache> = Arc::new(TokenCache::new(1000));
+        }
+
+        let instance = black_box(StaticInstancePerThreadSync::new(|| &CACHE));
+
+        instance.with(|cache| assert_eq!(cache.value(), 1000));
     }
 
     #[test]

--- a/packages/linked/src/static_instances.rs
+++ b/packages/linked/src/static_instances.rs
@@ -44,9 +44,6 @@ where
     /// This function exists to serve the inner workings of the
     /// `linked::instances!` macro and should not be used directly.
     /// It is not part of the public API and may be removed or changed at any time.
-    // Only ever called in const context by macros. Coverage instrumentation
-    // cannot detect const context execution.
-    #[cfg_attr(coverage_nightly, coverage(off))]
     #[doc(hidden)]
     #[must_use]
     pub const fn new(
@@ -330,6 +327,7 @@ pub fn __private_clear_linked_variables_local() {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::any::TypeId;
+    use std::hint::black_box;
     use std::panic::{RefUnwindSafe, UnwindSafe};
     use std::rc::Rc;
     use std::sync::{Arc, Mutex};
@@ -365,6 +363,17 @@ mod tests {
             let mut writer = self.value.lock().unwrap();
             *writer = writer.saturating_add(1);
         }
+    }
+
+    #[test]
+    fn constructor_executes_at_runtime() {
+        struct Key;
+
+        let instances = black_box(StaticInstances::new(TypeId::of::<Key>, || {
+            TokenCache::new(42)
+        }));
+
+        assert_eq!(instances.get().value(), 42);
     }
 
     #[test]

--- a/packages/linked_macros/Cargo.toml
+++ b/packages/linked_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linked_macros"
 description = "Internal dependency of the 'linked' package - do not reference directly"
 publish = true
-version = "1.0.21"
+version = "1.0.22"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/linked_macros_impl/Cargo.toml
+++ b/packages/linked_macros_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linked_macros_impl"
 description = "Internal dependency of the 'linked_macros' package - do not reference directly"
 publish = true
-version = "1.0.21"
+version = "1.0.22"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus/Cargo.toml
+++ b/packages/many_cpus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "many_cpus"
 description = "Efficiently schedule work and inspect the hardware environment on many-processor systems"
 publish = true
-version = "2.4.18"
+version = "2.4.19"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus_benchmarking/Cargo.toml
+++ b/packages/many_cpus_benchmarking/Cargo.toml
@@ -2,7 +2,7 @@
 name = "many_cpus_benchmarking"
 description = "Criterion benchmark harness to easily compare different processor configurations"
 publish = true
-version = "0.2.9"
+version = "0.2.10"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus_impl/Cargo.toml
+++ b/packages/many_cpus_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "many_cpus_impl"
 description = "Implementation crate for many_cpus - do not reference directly"
 publish = true
-version = "2.4.18"
+version = "2.4.19"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/many_cpus_impl/src/pal/linux/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/linux/bindings/facade.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(coverage_nightly, coverage(off))]
-
 use std::fmt::Debug;
 use std::io;
 use std::num::NonZero;
@@ -25,11 +23,15 @@ impl BindingsFacade {
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) fn from_mock(mock: MockBindings) -> Self {
         Self::Mock(Arc::new(mock))
     }
 }
 
+// Facade pass-through logic is not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl Bindings for BindingsFacade {
     fn sched_setaffinity_current(&self, mask: &CpuMask) -> Result<(), io::Error> {
         match self {

--- a/packages/many_cpus_impl/src/pal/linux/filesystem/facade.rs
+++ b/packages/many_cpus_impl/src/pal/linux/filesystem/facade.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(coverage_nightly, coverage(off))]
-
 use std::fmt::Debug;
 #[cfg(test)]
 use std::sync::Arc;
@@ -23,11 +21,15 @@ impl FilesystemFacade {
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) fn from_mock(mock: MockFilesystem) -> Self {
         Self::Mock(Arc::new(mock))
     }
 }
 
+// Facade pass-through logic is not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl Filesystem for FilesystemFacade {
     fn get_cpuinfo_contents(&self) -> String {
         match self {

--- a/packages/many_cpus_impl/src/pal/linux/platform.rs
+++ b/packages/many_cpus_impl/src/pal/linux/platform.rs
@@ -848,6 +848,7 @@ mod tests {
         reason = "we need not worry in tests"
     )]
     use std::fmt::Write;
+    use std::hint::black_box;
     use std::sync::Barrier;
     use std::{io, thread};
 
@@ -871,6 +872,16 @@ mod tests {
 
     /// Speed of the processors in `GIANT_MACHINE_PROCESSORS`, which the tests do not care about.
     const GIANT_MACHINE_BOGOMIPS: [f64; 5] = [2000.0; 5];
+
+    #[test]
+    fn constructors_execute_at_runtime() {
+        let bindings = black_box(BindingsFacade::target());
+        let filesystem = black_box(FilesystemFacade::target());
+        let platform = black_box(BuildTargetPlatform::new(bindings, filesystem));
+
+        assert!(matches!(platform.bindings, BindingsFacade::Target(_)));
+        assert!(matches!(platform.fs, FilesystemFacade::Target(_)));
+    }
 
     #[test]
     fn get_all_processors_smoke_test() {

--- a/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
+++ b/packages/many_cpus_impl/src/pal/windows/bindings/facade.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(coverage_nightly, coverage(off))]
-
 use std::fmt::Debug;
 #[cfg(test)]
 use std::sync::Arc;
@@ -30,11 +28,15 @@ impl BindingsFacade {
     }
 
     #[cfg(test)]
+    // Facade pass-through logic is not worth testing.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) fn from_mock(mock: MockBindings) -> Self {
         Self::Mock(Arc::new(mock))
     }
 }
 
+// Facade pass-through logic is not worth testing.
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl Bindings for BindingsFacade {
     fn get_active_processor_count(&self, group_number: u16) -> u32 {
         match self {

--- a/packages/many_cpus_impl/src/pal/windows/platform.rs
+++ b/packages/many_cpus_impl/src/pal/windows/platform.rs
@@ -896,6 +896,7 @@ fn check_logical_processor_info_result(
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::hint::black_box;
     use std::mem::offset_of;
     use std::sync::Arc;
 
@@ -914,6 +915,14 @@ mod tests {
     use crate::pal::windows::{MockBindings, ProcessorIndexInGroup};
 
     const PROCESSOR_TIME_CLOSE_ENOUGH: f64 = 0.01;
+
+    #[test]
+    fn constructors_execute_at_runtime() {
+        let bindings = black_box(BindingsFacade::target());
+        let platform = black_box(BuildTargetPlatform::new(bindings));
+
+        assert!(matches!(platform.bindings, BindingsFacade::Target(_)));
+    }
 
     #[test]
     fn get_all_processors_smoke_test() {

--- a/packages/nm/Cargo.toml
+++ b/packages/nm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm"
 description = "Minimalistic high-performance metrics collection in highly concurrent environments"
 publish = true
-version = "0.1.47"
+version = "0.1.48"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_impl/Cargo.toml
+++ b/packages/nm_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm_impl"
 description = "Implementation crate for nm; do not depend on it directly"
 publish = true
-version = "0.1.47"
+version = "0.1.48"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_otel/Cargo.toml
+++ b/packages/nm_otel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm_otel"
 description = "OpenTelemetry bridge for nm metrics"
 publish = true
-version = "0.4.19"
+version = "0.4.20"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/nm_otel_impl/Cargo.toml
+++ b/packages/nm_otel_impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nm_otel_impl"
 description = "Implementation crate for nm_otel; do not depend on it directly"
 publish = true
-version = "0.4.19"
+version = "0.4.20"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/par_bench/Cargo.toml
+++ b/packages/par_bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "par_bench"
 description = "Mechanisms for multithreaded benchmarking, designed for integration with Criterion or a similar benchmark framework"
 publish = true
-version = "0.2.54"
+version = "0.2.55"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/region_cached/Cargo.toml
+++ b/packages/region_cached/Cargo.toml
@@ -2,7 +2,7 @@
 name = "region_cached"
 description = "Adds a logical layer of caching between processor L3 cache and main memory"
 publish = true
-version = "1.0.33"
+version = "1.0.34"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/region_local/Cargo.toml
+++ b/packages/region_local/Cargo.toml
@@ -2,7 +2,7 @@
 name = "region_local"
 description = "Isolated variable storage per memory region, similar to `thread_local_rc!`"
 publish = true
-version = "1.0.33"
+version = "1.0.34"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/vicinal/Cargo.toml
+++ b/packages/vicinal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vicinal"
 description = "Processor-local worker pool that schedules tasks in the vicinity of the caller"
 publish = true
-version = "0.1.38"
+version = "0.1.39"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
[Copilot speaking]

Const functions invoked only in const contexts disappear from LLVM runtime coverage, leaving tested behavior looking uncovered. This change ensures every workspace `const fn` executes under coverage on its supported platforms without weakening its const usability.

- Invoke const constructors from non-const tests and pass their results through `std::hint::black_box()` so the calls cannot be replaced with precomputed constants.
- Narrow broad PAL facade coverage exclusions so constructors remain instrumented while pass-through and mock-only code stays excluded.
- Document the convention, including nested const calls and why wrapping an already initialized const item does not execute its initializer.
- Apply the affected packages' patch releases and refresh workspace dependency requirements and `Cargo.lock`.