### PR TITLE
cargo-release-plan: cache current manifest parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-plan"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ azure_identity = { version = "1.0.0", default-features = false }
 azure_storage_blob = { version = "1.0.0", default-features = false }
 base64 = { version = "0.23.1", default-features = false, features = ["std"] }
 cargo-freeze-deps = { version = "0.1.11", path = "packages/cargo-freeze-deps", default-features = false }
-cargo-release-plan = { version = "0.2.0", path = "packages/cargo-release-plan", default-features = false }
+cargo-release-plan = { version = "0.2.1", path = "packages/cargo-release-plan", default-features = false }
 cbh_analyze = { version = "=0.2.8", path = "packages/cbh_analyze", default-features = false }
 cbh_cli = { version = "=0.2.8", path = "packages/cbh_cli", default-features = false }
 cbh_codec = { version = "=0.2.8", path = "packages/cbh_codec", default-features = false }

--- a/packages/cargo-release-plan/Cargo.toml
+++ b/packages/cargo-release-plan/Cargo.toml
@@ -3,7 +3,7 @@
 name = "cargo-release-plan"
 description = "A Cargo subcommand that classifies publishable packages against their version anchors and applies increment plans"
 publish = true
-version = "0.2.0"
+version = "0.2.1"
 
 authors.workspace = true
 edition.workspace = true

--- a/packages/cargo-release-plan/docs/implementation.md
+++ b/packages/cargo-release-plan/docs/implementation.md
@@ -55,8 +55,11 @@ dependency relationships. Git-tracked manifests constrain that candidate set.
 The current model keeps both every tracked version target and the publishable
 `WorkPackage` projection used for classification. An untracked or ignored
 manifest found through a member glob can become neither a version target nor a
-release assessment. Historical workspaces cannot use Cargo without checking out
-each commit, so `SnapshotCache` reconstructs them from tracked manifests.
+release assessment. Each tracked current member manifest is loaded and parsed
+once per work-tree snapshot; its parsed document and derived package facts are
+shared by version-target construction, exact-dependency discovery, and the
+publishable projection. Historical workspaces cannot use Cargo without checking
+out each commit, so `SnapshotCache` reconstructs them from tracked manifests.
 
 The reconstruction starts from the root package and declared member patterns,
 then follows in-workspace path dependencies to a fixed point while honoring

--- a/packages/cargo-release-plan/src/manifest.rs
+++ b/packages/cargo-release-plan/src/manifest.rs
@@ -218,6 +218,15 @@ pub(crate) fn parse_package_manifest(
 ) -> Result<Option<PackageManifest>, AppError> {
     let path = Path::new(manifest_path);
     let doc = parse_document(path, content)?;
+    package_manifest_from_document(&doc, manifest_path, workspace)
+}
+
+/// Extracts package facts from an already parsed manifest document.
+pub(crate) fn package_manifest_from_document(
+    doc: &DocumentMut,
+    manifest_path: &str,
+    workspace: &WorkspaceInherit<'_>,
+) -> Result<Option<PackageManifest>, AppError> {
     // A manifest without a complete `[package]` identity is not something Cargo
     // would publish: it is either a virtual workspace root or a member whose
     // version is inherited from a root that does not declare one. Both are
@@ -249,16 +258,16 @@ pub(crate) fn parse_package_manifest(
     let directory = directory_of(manifest_path);
     let (resource_paths, inherited_resource_paths, auto_readme) =
         resource_paths(package, workspace);
-    let targets = target_discovery(&doc, package);
+    let targets = target_discovery(doc, package);
     Ok(Some(PackageManifest {
         name: name.to_string(),
         version,
         directory,
         packaging: packaging_from_package(package, workspace)?,
-        inherited: collect_inherited_keys(&doc),
+        inherited: collect_inherited_keys(doc),
         publish: publish_allowed(package, workspace),
-        path_dependencies: path_dependencies(&doc),
-        inherited_path_dependencies: inherited_path_dependencies(&doc, workspace),
+        path_dependencies: path_dependencies(doc),
+        inherited_path_dependencies: inherited_path_dependencies(doc, workspace),
         resource_paths,
         inherited_resource_paths,
         auto_readme,

--- a/packages/cargo-release-plan/src/metadata.rs
+++ b/packages/cargo-release-plan/src/metadata.rs
@@ -3,7 +3,7 @@
 // The design forbids resolving a full graph or compiling. `--no-deps` is the
 // only Cargo invocation used for classification.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -22,7 +22,7 @@ use crate::inherited::InheritedKeys;
 use crate::manifest::TargetDiscovery;
 use crate::manifest::{
     PackageManifest, PathCase, WorkspaceInherit, for_each_dependency_table,
-    for_each_dependency_table_with_context, parse_document, parse_package_manifest,
+    for_each_dependency_table_with_context, package_manifest_from_document, parse_document,
     workspace_relative_path,
 };
 #[cfg(test)]
@@ -214,6 +214,102 @@ struct MetadataDep {
     kind: Option<String>,
 }
 
+/// Parsed current manifests shared by every work-tree projection.
+///
+/// The root and selected member paths may overlap, so loading deduplicates by
+/// path before deriving package facts from the parsed documents.
+struct ManifestSnapshot {
+    documents: BTreeMap<PathBuf, DocumentMut>,
+    packages: BTreeMap<PathBuf, Option<PackageManifest>>,
+}
+
+impl ManifestSnapshot {
+    fn load(
+        metadata: &MetadataJson,
+        selected_member_ids: &HashSet<&str>,
+        workspace_root: &Path,
+    ) -> Result<Self, AppError> {
+        Self::load_with(
+            metadata,
+            selected_member_ids,
+            workspace_root,
+            |path| {
+                fs::read_to_string(path)
+                    .map_err(|error| ReadFileError::caused_by(path, error).into())
+            },
+            parse_document,
+        )
+    }
+
+    fn load_with(
+        metadata: &MetadataJson,
+        selected_member_ids: &HashSet<&str>,
+        workspace_root: &Path,
+        mut read: impl FnMut(&Path) -> Result<String, AppError>,
+        mut parse: impl FnMut(&Path, &str) -> Result<DocumentMut, AppError>,
+    ) -> Result<Self, AppError> {
+        let root_manifest_path = workspace_root.join("Cargo.toml");
+        let mut paths = BTreeSet::from([root_manifest_path.clone()]);
+        paths.extend(
+            metadata
+                .packages
+                .iter()
+                .filter(|package| selected_member_ids.contains(package.id.as_str()))
+                .map(|package| PathBuf::from(&package.manifest_path)),
+        );
+
+        let mut documents = BTreeMap::new();
+        for path in paths {
+            let text = read(&path)?;
+            documents.insert(path.clone(), parse(&path, &text)?);
+        }
+
+        let root_manifest = documents
+            .get(&root_manifest_path)
+            .expect("the root manifest path is always loaded into this snapshot");
+        let workspace = WorkspaceInherit::from_root(root_manifest);
+        let mut packages = BTreeMap::new();
+        for package in &metadata.packages {
+            if !selected_member_ids.contains(package.id.as_str()) {
+                continue;
+            }
+            let path = PathBuf::from(&package.manifest_path);
+            let document = documents
+                .get(&path)
+                .expect("every selected member manifest is loaded into this snapshot");
+            let git_manifest_path = workspace_relative_path(workspace_root, &path).expect(
+                "a selected manifest already matched a tracked path after this same conversion",
+            );
+            packages.insert(
+                path,
+                package_manifest_from_document(document, &git_manifest_path, &workspace)?,
+            );
+        }
+
+        Ok(Self {
+            documents,
+            packages,
+        })
+    }
+
+    fn root(&self, workspace_root: &Path) -> &DocumentMut {
+        self.document(&workspace_root.join("Cargo.toml"))
+    }
+
+    fn document(&self, path: &Path) -> &DocumentMut {
+        self.documents
+            .get(path)
+            .expect("the requested manifest belongs to this snapshot")
+    }
+
+    fn package(&self, path: &Path) -> Option<&PackageManifest> {
+        self.packages
+            .get(path)
+            .expect("the requested package manifest belongs to this snapshot")
+            .as_ref()
+    }
+}
+
 /// Git-tracked inputs that constrain Cargo's work-tree metadata.
 ///
 /// Cargo still supplies manifest normalization and dependency relationships,
@@ -361,25 +457,15 @@ fn work_tree_from_metadata(
         .filter(|package| cargo_member_ids.contains(package.id.as_str()))
         .filter_map(|package| library_crate_name(package).map(|lib| (package.name.as_str(), lib)))
         .collect();
-    let root_manifest_path = workspace_root.join("Cargo.toml");
-    let root_manifest = fs::read_to_string(&root_manifest_path)
-        .map_err(|error| ReadFileError::caused_by(&root_manifest_path, error))?;
-    let root_manifest = parse_document(&root_manifest_path, &root_manifest)?;
-    let workspace = WorkspaceInherit::from_root(&root_manifest);
+    let manifests = ManifestSnapshot::load(metadata, &selected_member_ids, &workspace_root)?;
+    let root_manifest = manifests.root(&workspace_root);
     let mut version_targets = Vec::new();
     for package in &metadata.packages {
         if !selected_member_ids.contains(package.id.as_str()) {
             continue;
         }
         let path = PathBuf::from(&package.manifest_path);
-        let manifest_text =
-            fs::read_to_string(&path).map_err(|error| ReadFileError::caused_by(&path, error))?;
-        let git_manifest_path = workspace_relative_path(&workspace_root, &path).expect(
-            "a selected manifest already matched a tracked path after this same conversion",
-        );
-        let Some(manifest) =
-            parse_package_manifest(&manifest_text, &git_manifest_path, &workspace)?
-        else {
+        let Some(manifest) = manifests.package(&path) else {
             continue;
         };
         let version = package.version.parse::<Version>().map_err(|error| {
@@ -401,7 +487,8 @@ fn work_tree_from_metadata(
         &selected_member_ids,
         &tracked_members_by_dir,
         &canonical_tracked_members_by_dir,
-        &root_manifest,
+        &manifests,
+        root_manifest,
         &workspace_root,
     )?;
     exact_dependencies.sort_by(|left, right| {
@@ -436,20 +523,13 @@ fn work_tree_from_metadata(
             continue;
         }
         let path = PathBuf::from(&package.manifest_path);
-        let manifest_text =
-            fs::read_to_string(&path).map_err(|error| ReadFileError::caused_by(&path, error))?;
-        let git_manifest_path = workspace_relative_path(&workspace_root, &path).expect(
-            "a selected manifest already matched a tracked path after this same conversion",
-        );
-        let Some(mut manifest) =
-            parse_package_manifest(&manifest_text, &git_manifest_path, &workspace)?
-        else {
+        let Some(mut manifest) = manifests.package(&path).cloned() else {
             continue;
         };
         if !manifest.publish {
             continue;
         }
-        let manifest_doc = parse_document(&path, &manifest_text)?;
+        let manifest_doc = manifests.document(&path);
         manifest.version = package.version.parse::<Version>().map_err(|error| {
             InvalidVersionError::caused_by(&package.name, &package.version, error)
         })?;
@@ -463,8 +543,8 @@ fn work_tree_from_metadata(
                 is_intra_workspace_released(
                     dep,
                     &tracked_members_by_dir,
-                    &manifest_doc,
-                    &root_manifest,
+                    manifest_doc,
+                    root_manifest,
                 )
             })
             .map(|dep| ReportedDep {
@@ -537,6 +617,7 @@ fn discover_exact_dependencies(
     selected_member_ids: &HashSet<&str>,
     tracked_members_by_dir: &BTreeMap<PathBuf, String>,
     canonical_tracked_members_by_dir: &BTreeMap<PathBuf, String>,
+    manifests: &ManifestSnapshot,
     workspace_manifest: &DocumentMut,
     workspace_root: &Path,
 ) -> Result<Vec<ExactDependency>, AppError> {
@@ -546,9 +627,7 @@ fn discover_exact_dependencies(
             continue;
         }
         let manifest_path = PathBuf::from(&package.manifest_path);
-        let text = fs::read_to_string(&manifest_path)
-            .map_err(|error| ReadFileError::caused_by(&manifest_path, error))?;
-        let manifest = parse_document(&manifest_path, &text)?;
+        let manifest = manifests.document(&manifest_path);
         let manifest_dir = manifest_path
             .parent()
             .expect("Cargo reports a manifest path with a parent directory");
@@ -1072,12 +1151,106 @@ pub(crate) fn dependents_of(packages: &[WorkPackage], name: &str) -> Vec<String>
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::cell::RefCell;
+
     use serde_json::json;
 
     use super::*;
 
     fn doc(text: &str) -> DocumentMut {
         parse_document(Path::new("Cargo.toml"), text).unwrap()
+    }
+
+    #[test]
+    fn manifest_snapshot_loads_and_parses_each_path_once() {
+        let workspace_root = Path::new("/workspace");
+        let root_path = workspace_root.join("Cargo.toml");
+        let member_path = workspace_root.join("packages/member/Cargo.toml");
+        let untracked_path = workspace_root.join("packages/untracked/Cargo.toml");
+        let metadata = MetadataJson {
+            packages: vec![
+                MetadataPackage {
+                    name: "root".to_string(),
+                    version: "0.1.0".to_string(),
+                    id: "root".to_string(),
+                    manifest_path: root_path.to_string_lossy().into_owned(),
+                    publish: None,
+                    dependencies: Vec::new(),
+                    targets: Vec::new(),
+                    metadata: Value::Null,
+                },
+                MetadataPackage {
+                    name: "member".to_string(),
+                    version: "0.1.0".to_string(),
+                    id: "member".to_string(),
+                    manifest_path: member_path.to_string_lossy().into_owned(),
+                    publish: None,
+                    dependencies: Vec::new(),
+                    targets: Vec::new(),
+                    metadata: Value::Null,
+                },
+                MetadataPackage {
+                    name: "untracked".to_string(),
+                    version: "0.1.0".to_string(),
+                    id: "untracked".to_string(),
+                    manifest_path: untracked_path.to_string_lossy().into_owned(),
+                    publish: None,
+                    dependencies: Vec::new(),
+                    targets: Vec::new(),
+                    metadata: Value::Null,
+                },
+            ],
+            workspace_members: vec![
+                "root".to_string(),
+                "member".to_string(),
+                "untracked".to_string(),
+            ],
+            workspace_root: workspace_root.to_string_lossy().into_owned(),
+            metadata: Value::Null,
+        };
+        let selected_member_ids = HashSet::from(["root", "member"]);
+        let reads = RefCell::new(BTreeMap::<PathBuf, usize>::new());
+        let parses = RefCell::new(BTreeMap::<PathBuf, usize>::new());
+
+        let snapshot = ManifestSnapshot::load_with(
+            &metadata,
+            &selected_member_ids,
+            workspace_root,
+            |path| {
+                let mut reads = reads.borrow_mut();
+                *reads.entry(path.to_path_buf()).or_default() += 1;
+                if path == root_path {
+                    Ok(
+                        "[workspace]\nmembers = [\"packages/member\"]\n\n[package]\nname = \"root\"\nversion = \"0.1.0\"\n"
+                            .to_string(),
+                    )
+                } else if path == member_path {
+                    Ok("[package]\nname = \"member\"\nversion = \"0.1.0\"\n".to_string())
+                } else {
+                    panic!("unselected manifest was read")
+                }
+            },
+            |path, text| {
+                let mut parses = parses.borrow_mut();
+                *parses.entry(path.to_path_buf()).or_default() += 1;
+                parse_document(path, text)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            reads.into_inner(),
+            BTreeMap::from([(root_path.clone(), 1), (member_path.clone(), 1)])
+        );
+        assert_eq!(
+            parses.into_inner(),
+            BTreeMap::from([(root_path.clone(), 1), (member_path.clone(), 1)])
+        );
+        assert_eq!(snapshot.package(&root_path).unwrap().name, "root");
+        assert_eq!(snapshot.package(&member_path).unwrap().name, "member");
+        assert!(snapshot.document(&member_path).get("package").is_some());
+        assert!(!snapshot.documents.contains_key(&untracked_path));
+        assert!(!snapshot.packages.contains_key(&untracked_path));
     }
 
     #[test]


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Current work-tree construction reread each tracked member manifest while deriving version targets, exact dependency edges, and publishable package data. The repeated filesystem access and TOML parsing scale unnecessarily with larger workspaces.

## Changes

Current workspace loading now builds one manifest snapshot keyed by manifest path. Root and selected tracked member paths are deduplicated, each document is loaded and parsed once, and the parsed document plus derived package facts are shared across version-target construction, exact-edge discovery, and publishable package construction.

Read and parse failures continue to stop loading with their original typed diagnostics. The cache retains Git-tracked-member selection, workspace inheritance, path and alias resolution, non-publishable targets, deterministic grouping, and apply behavior. Focused coverage asserts that selected paths are loaded and parsed once while unselected members are never loaded.

This internal performance improvement advances `cargo-release-plan` to `0.2.1`.