### PR TITLE
Scheduled validation: make manual checks independent of repair policy

### DIFF
--- a/.github/prompts/setup-scheduled-remediation.prompt.md
+++ b/.github/prompts/setup-scheduled-remediation.prompt.md
@@ -7,6 +7,13 @@ create, enable or run an automation,
 reset repair state, change billing identity or accept repository configuration
 implicitly. Preserve existing worker sessions, worktrees, claims and counters.
 
+This installation procedure is not required for manually requested GitHub checks.
+For those requests, follow `docs\scheduled-validation.md`, **Running checks manually**:
+use **Scheduled verification** on `main` with the requested crate and check ID.
+Do not require policy edits, repair allowlists, Local enrollment or model/billing
+setup just to run a check. Manual diagnostics do not update coverage or repair issues;
+run-level issue reporting retains its separate `rollout.reporting_enabled` authorization.
+
 The supported phase is **hosted evidence intake only**, with compatibility for
 registered repair recovery and bounded continuation. AI triage and new repair
 admission are not implemented. Report `ai-triage-unavailable` even when all policy

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -65,6 +65,14 @@ reporting disabled. Local triage is not dispatched and new repair admission is r
 The operator approves enrollment, scope and operating settings; installing or reconciling
 either automation does not activate them.
 
+Manual **Run workflow** requests authorize fresh checks independently of automatic
+execution or AI repair settings. Targeted checks accept workspace crates rather than
+repair allowlists. Their results remain diagnostics: they cannot update authoritative
+main coverage or confirm a repair. Issue reporting requires its own existing
+authorization and may publish run-level intake for manual failures, never repair
+closure. The [manual instructions](../../docs/scheduled-validation.md#running-checks-manually)
+describe the inputs and supported checks.
+
 ### Scheduled evidence
 
 Complete coverage is evidence for an immutable source and check contract, not merely a green

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -13,10 +13,10 @@ below are UTC. Local App timers are separate and use their verified installation
 
 | Workflow | What starts it | Responsibility and downstream calls |
 |---|---|---|
-| `scheduled-validation.yml` / **Scheduled validation** | Daily `schedule` at 02:41 (`41 2 * * *`), or authorized `workflow_dispatch` on `main`. | Plans immutable full-main scope and checks reusable coverage. Calls `deep-checks.yml` only when execution is authorized and needed. `force` bypasses coverage reuse, not execution authorization; `canary` permits an explicit read-only execution check. |
+| `scheduled-validation.yml` / **Scheduled validation** | Daily `schedule` at 02:41 (`41 2 * * *`), or `workflow_dispatch` on `main`. | Plans the immutable full-main suite. Automatic execution requires policy authorization and may reuse coverage. Manual execution always runs fresh checks without consulting coverage or repair settings. |
 | `deep-checks.yml` / **Deep checks** | **Only `workflow_call`**, from `scheduled-validation.yml`, `scheduled-verify.yml`, or `validation.yml`. No timer, push trigger or manual entry point. | Reusable matrix execution of the caller's declared scope. Its jobs and artifacts belong to the calling run; it does not file issues or start a separate reporting chain. |
 | `scheduled-report.yml` / **Scheduled reporting** | `workflow_run: completed` for **Scheduled validation** and **Scheduled verification** on `main`, regardless of conclusion. No timer or `workflow_dispatch`. | Validates the originating attempt, collects evidence and files/updates run-level failure intake; also maintains coverage and applicable authoritative confirmation. Does not perform AI triage or directly create diagnosed problem issues. Uses trusted default-branch code; writes require reporting authorization. Recover by rerunning the existing reporter run, not by rerunning deep checks. |
-| `scheduled-verify.yml` / **Scheduled verification** | Each `push` to `main`, or authorized `workflow_dispatch` with an explicit immutable source and scope. | The cheap planner selects pending registered merged repairs, or explicit diagnostics. Calls `deep-checks.yml` only for selected authorized work; no pending repair is a normal no-work outcome. Completion triggers `scheduled-report.yml`. |
+| `scheduled-verify.yml` / **Scheduled verification** | Each `push` to `main`, or `workflow_dispatch` on `main` with check IDs, crate names and an optional source SHA. | The cheap planner selects pending registered merged repairs for authorized automatic execution, or fresh manual diagnostics without repair prerequisites. No pending repair is a normal automatic no-work outcome. Completion triggers `scheduled-report.yml`. |
 | `scheduled-health.yml` / **Scheduled health** | `schedule` at minute 11 every third hour (`11 */3 * * *`), or `workflow_dispatch` on `main`. | Read-only observation of scheduler, reporter, coverage and separate Local triage/repair health. Writes a summary/artifact and signals failure; does not call deep checks, file a finding for every red run, or trigger the reporter. |
 | `validation.yml` / **Validation** | `push` to `main`; PRs targeting `main` on `opened`, `synchronize`, `reopened`, `edited`, or `ready_for_review`; merge-queue `merge_group` events for `main`. | Ordinary merge validation and the managed-repair gate. Calls `deep-checks.yml` for relevant registered repair scope, not the entire scheduled suite. Results feed `required-checks`; this workflow does not trigger scheduled issue reporting. |
 | `pr-bench-history.yml` / **PR Benchmark history** | PRs targeting `main` on `opened`, `synchronize`, or `reopened`. | Independent advisory benchmark workflow; excludes managed repairs from production-backed collection. It neither calls deep checks nor triggers scheduled issue reporting. |
@@ -159,6 +159,32 @@ their plan, result and raw evidence, not just a job conclusion.
 Before reuse, the planner also checks the execution API for unreported failures, active work and
 newer attempts on the same main commit. The asynchronous reporter's durable index cannot conceal
 those observations, and skipped work does not refresh the coverage timestamp.
+Manual diagnostic attempts are excluded from this reuse decision; they cannot
+invalidate automatic coverage even while their reporting is pending.
+
+### Manual checks
+
+The planner recognizes manual requests by GitHub's `workflow_dispatch` event.
+Both entry points require **Use workflow from** to select `main`; an incorrect
+selection fails explicitly rather than skipping the plan job. The checked-out event
+SHA pins the controller. In targeted verification, a blank source selects that same
+immutable commit; an explicit full SHA is resolved through GitHub before execution
+and can identify a branch or PR commit without becoming controller code.
+
+The unprepared planner validates literal crate names and catalog combinations in
+PowerShell without bootstrapping Rust or inspecting repair permission. Execution
+uses the existing Cargo workspace metadata and package selection at the candidate
+source to reject unknown crates. The reporter reconstructs the same catalog and
+validates exact-source, contract and run-attempt evidence without a repair allowlist.
+
+The reporter distinguishes diagnostics using the API-validated originating event,
+not a plan field. Manual results bypass coverage and repair record discovery,
+confirmation and mutations, including full-workspace manual runs. With no write
+authorization they also bypass run-intake issue discovery and retain artifacts only.
+When both `-Apply` and `rollout.reporting_enabled` authorize issue writes, manual
+results can use the existing run-intake publication and recovery path. This does
+not authorize coverage or repair mutations. Invalid or incomplete results remain
+visible; successful intake of failures does not turn the source check green.
 
 ### Evidence decoding
 
@@ -355,7 +381,7 @@ The selected checks execute against the actual combined candidate. Their uncondi
 Metadata-only corrections retrigger through the PR `edited` event or a rerun at the same head.
 The worker and PR records carry the same bounded causal explanation and bind the current enrolled
 executor. Main confirmation uses the merged commit rather than the original pre-squash head.
-Both full-main reporting and dedicated verification can confirm the live merged registration;
+Both automatic full-main reporting and automatic dedicated verification can confirm the live merged registration;
 arrival order does not strand a problem in `needs-human`.
 An unexplained pass does not disable the gate for an existing registered repair PR. Local intake
 still refuses fresh admission of that disposition; the current worker can finish its causal repair
@@ -405,10 +431,11 @@ Safe installation defaults disable hosted execution/reporting and both Local rol
 and leave repair allowlists unconfigured. Disabled hosted execution means automatic
 recurring deep coverage is off; it is not proof that PR validation covers it.
 Setup preserves those settings.
-Manual read-only execution uses the existing `canary` dispatch input to exercise hosted execution
-without changing recurring authorization; explicit verification similarly validates approved
-diagnostic scope, not problem resolution by itself. Neither action is part of merely installing the
-Local automations.
+Manual **Run workflow** requests run fresh checks without changing recurring
+authorization or requiring repair package approval. Their diagnostics are separate
+from main coverage and repair confirmation. Issue reporting remains independently
+authorized, including on-demand run-level intake. See [Manual checks](#manual-checks).
+Running checks is not part of installing or reconciling Local automations.
 
 The default-branch controller, workflows, policy and their helpers form one installed contract.
 When neither policy nor controller is installed there, Validation runs its shallow checks

--- a/.github/workflows/scheduled-report.yml
+++ b/.github/workflows/scheduled-report.yml
@@ -50,9 +50,10 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           Import-Module ./scripts/setup/RustToolchain.psm1 -Force
           Install-RustupToolchain -Channel (Get-PinnedRustChannel) -InstallProfile minimal
-      - name: Reconcile durable evidence under reviewed operating policy
+      - name: Collect results and report automatic runs under reviewed policy
         # The reporting switch authorizes writes independently of execution and Local admission.
         # Downloaded replay evidence remains data and cannot select controller code or policy.
+        # Manual requests retain artifacts by default; authorized writes target run intake only.
         # Ref: .github/workflows/implementation.md#serialized-reporting.
         # Ref: .github/workflows/implementation.md#operating-policy.
         shell: pwsh

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -4,15 +4,6 @@ on:
   schedule:
     - cron: 41 2 * * *
   workflow_dispatch:
-    inputs:
-      force:
-        description: Force fresh full evidence even when unchanged main is covered
-        type: boolean
-        default: false
-      canary:
-        description: Explicit read-only execution check without enabling recurring execution
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -25,9 +16,9 @@ concurrency:
 
 jobs:
   plan:
-    # Recurring scope is fixed before any checker starts and only for this repository's main.
+    # The planner rejects a non-main workflow selection with instructions rather than skipping.
     # Ref: .github/workflows/implementation.md#immutable-execution.
-    if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    if: github.repository == 'folo-rs/folo'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,7 +38,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
-      - name: Decide whether complete coverage is reusable
+      - name: Plan fresh manual checks or reusable automatic checks
         # Reuse requires compatible full success and no unsettled/newer failure; skips do not
         # renew success age or imply authorization to run the personal repair worker.
         # Ref: .github/workflows/implementation.md#complete-evidence-and-reuse.
@@ -55,13 +46,11 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          FORCE_RECHECK: ${{ inputs.force || false }}
-          EXECUTION_CANARY: ${{ inputs.canary || false }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          ./scripts/scheduled/Invoke-ScheduledPlan.ps1 -Force:($env:FORCE_RECHECK -eq 'true') -Canary:($env:EXECUTION_CANARY -eq 'true')
+          ./scripts/scheduled/Invoke-ScheduledPlan.ps1
       - name: Preserve expected scope even when checks are not run
         # Reporting must distinguish an intentional skip from incomplete evidence.
         # Ref: .github/workflows/implementation.md#complete-evidence-and-reuse.

--- a/.github/workflows/scheduled-verify.yml
+++ b/.github/workflows/scheduled-verify.yml
@@ -8,15 +8,15 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: Immutable main commit to confirm (not the original pre-squash PR head)
-        required: true
+        description: Full commit SHA to test (main, branch or PR); leave blank for current main. Keep Use workflow from set to main.
+        required: false
         type: string
       check_ids:
-        description: Comma-separated catalog check IDs
+        description: Check IDs, separated by commas (for example miri-ubuntu-latest); see docs/scheduled-validation.md
         required: true
         type: string
       packages:
-        description: Comma-separated approved packages
+        description: Crate names, separated by commas (for example cpulist)
         required: true
         type: string
 
@@ -25,9 +25,10 @@ permissions:
 
 jobs:
   plan:
-    # Confirmation scope comes from live merged registrations or explicit approved diagnostics.
+    # Automatic confirmation uses live registrations; manual requests need no repair permission.
+    # A non-main workflow selection fails in the planner instead of silently skipping.
     # Ref: .github/workflows/implementation.md#managed-repair-gate.
-    if: github.repository == 'folo-rs/folo' && github.ref == 'refs/heads/main'
+    if: github.repository == 'folo-rs/folo'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,9 +48,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
-      - name: Validate explicit immutable confirmation scope
-        # A diagnostic selection alone cannot close an incident; live registration is authoritative.
-        # Ref: .github/workflows/implementation.md#managed-repair-gate.
+      - name: Select requested checks or pending merged repairs
+        # Manual diagnostics never update repair records or shared main coverage.
+        # Ref: .github/workflows/implementation.md#manual-checks.
         id: plan
         shell: pwsh
         env:
@@ -70,7 +71,7 @@ jobs:
           if-no-files-found: error
           retention-days: 30
   checks:
-    # Do not invent global work when confirmation has no selected incident scope.
+    # Do not run the workspace when automatic confirmation has no pending repair.
     # Ref: .github/workflows/implementation.md#serialized-reporting.
     needs: plan
     if: needs.plan.outputs.run == 'true'

--- a/docs/scheduled-validation.md
+++ b/docs/scheduled-validation.md
@@ -44,6 +44,57 @@ for mutation quality and reviewed skip criteria. The shared versioned contracts 
 reviewed defaults live under `scripts/scheduled/`; policy is not inferred from App UI
 state.
 
+## Running checks manually
+
+Manual checks require only permission to run GitHub Actions in this repository.
+They do not require changes to `scripts/scheduled/policy.json`, repair package
+allowlists, Local App enrollment, Copilot models or billing, or enabled timers.
+Clicking **Run workflow** requests fresh execution, even if the same source has
+already passed automatic validation.
+
+To run Miri on `cpulist`:
+
+1. Open the repository's **Actions** tab and select **Scheduled verification**.
+2. Click **Run workflow** and keep **Use workflow from** set to **main**.
+3. Leave **source_sha** blank to test the immutable main commit selected for this
+   run. Alternatively, enter a full commit SHA available in this repository,
+   including a branch or PR commit.
+4. Enter **miri-ubuntu-latest** in **check_ids** and **cpulist** in **packages**.
+5. Click **Run workflow**. The run summary identifies the tested commit; the
+   **Deep checks** jobs show execution results and retain raw evidence artifacts.
+
+The optional source SHA selects code to test, not workflow or reporting code.
+The workflow and reporter use `main`. Selecting another branch under **Use workflow
+from** fails with instructions to use the source SHA instead.
+
+For other checks, use the following IDs. Enter exact crate names from the tested
+workspace, separated by commas; spaces around commas are accepted. Every requested
+crate must be covered by a selected check. Unknown checks, incompatible selections
+and unknown crates fail rather than silently becoming successful empty runs.
+Crate membership is checked by Cargo at the tested source, not by a repair allowlist.
+
+| Check | Supported IDs |
+|---|---|
+| Miri | `miri-ubuntu-latest`, `miri-windows-latest`, `miri-ubuntu-24.04-arm`, `miri-windows-11-arm` |
+| Mutation testing | `mutants-ubuntu-latest-1` through `mutants-ubuntu-latest-8`, or `mutants-windows-latest-1` through `mutants-windows-latest-8`; each ID runs one shard |
+| Careful checking | `careful-ubuntu-latest`, `careful-windows-latest` |
+| Many-seed Miri | `miri-many-events_once-1` through `miri-many-events_once-4`; `miri-many-events-1` through `miri-many-events-2`; `miri-many-awaiter_set-1` through `miri-many-awaiter_set-2`; `miri-many-nm_impl-1` through `miri-many-nm_impl-2`; each ID runs only its named crate |
+
+To run the entire deep suite on main, select **Scheduled validation**, keep
+**Use workflow from** set to **main**, and click **Run workflow**. There is no
+additional permission checkbox or cache override.
+
+Manual runs do not update shared main coverage or confirm or close repair issues.
+With the checked-in defaults, **Scheduled reporting** retains `report.json` and
+downloaded evidence in its report artifact without reading or writing issues.
+Failed checks remain failed in the originating run; missing or invalid evidence
+also fails the report. When an operator separately enables
+`rollout.reporting_enabled` in `scripts/scheduled/policy.json`, the reporter's
+existing `-Apply` invocation also permits run-level failure intake for manual
+results. This supports on-demand reporting without waiting for the timer, but
+still cannot change repair issues or shared coverage. Neither running a check nor
+reporting its failure authorizes AI repairs.
+
 ## Problems and triage
 
 These are the requirements for a downstream AI triage consumer. Hosted intake

--- a/scripts/scheduled/Invoke-ScheduledPlan.ps1
+++ b/scripts/scheduled/Invoke-ScheduledPlan.ps1
@@ -6,9 +6,9 @@ triggering event, shared across three workflows.
 .DESCRIPTION
 `-Mode` selects the triggering context: `validation` for ordinary validation.yml PR/merge-group
 events (deciding whether the candidate is a managed repair and, if so, which packages/checks it
-must confirm), `verify` for scheduled-verify.yml's post-merge confirmation pass, and `scheduled` for
-scheduled-validation.yml's full periodic run. `-Canary` permits explicit read-only execution while
-recurring execution is disabled; `-Force` bypasses coverage reuse, not execution authorization.
+must confirm), `verify` for scheduled-verify.yml's targeted checks, and `scheduled` for
+scheduled-validation.yml's full run. A workflow_dispatch event requests fresh read-only checks
+independently of automatic execution, issue reporting and Local repair settings.
 All three delegate to `Invoke-ScheduledPlanning` in ScheduledWorkflow.psm1, which is the
 actual decision logic; this wrapper only resolves the triggering event from `-EventPath` and writes
 `plan.json` plus the `GITHUB_OUTPUT` values (`run`, `managed`, `matrix`, ...) the calling workflow's
@@ -21,14 +21,11 @@ later steps and matrix job read. See
 param(
     [ValidateSet('scheduled', 'validation', 'verify')][string] $Mode = 'scheduled',
     [string] $EventPath = $env:GITHUB_EVENT_PATH,
-    [string] $OutputDirectory = '.scheduled-plan',
-    [switch] $Force,
-    [switch] $Canary
+    [string] $OutputDirectory = '.scheduled-plan'
 )
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 $VerbosePreference = 'Continue'
 Import-Module (Join-Path $PSScriptRoot 'ScheduledWorkflow.psm1') -Force
-Invoke-ScheduledPlanning -Mode $Mode -EventPath $EventPath -OutputDirectory $OutputDirectory `
-    -Force:$Force -Canary:$Canary
+Invoke-ScheduledPlanning -Mode $Mode -EventPath $EventPath -OutputDirectory $OutputDirectory

--- a/scripts/scheduled/Invoke-ScheduledReport.ps1
+++ b/scripts/scheduled/Invoke-ScheduledReport.ps1
@@ -11,7 +11,10 @@ influenced by candidate content; see
 `Invoke-ScheduledReporting` (ScheduledGitHub.psm1), which downloads and validates the originating
 run's job/step inventory and plan/result artifacts, preserves failure evidence for AI triage,
 and (only with `-Apply`, gated further by `policy.rollout.reporting_enabled`) writes run-level
-issues. It never creates diagnosed problem issues. `-Apply` is the switch
+issues. Manual runs retain diagnostic artifacts without consulting issue state by default.
+Separately authorized issue reporting also permits run-level intake for manual runs, but they
+never consult or change coverage or problem issues.
+It never creates diagnosed problem issues. `-Apply` is the switch
 between the workflow's dry-run/report-only path and the path with side effects; the reporting run's
 `queue: max` concurrency means a superseded or failed attempt must be recovered explicitly, not
 silently reattempted (../../docs/scheduled-validation.md#health-recovery-and-rollback). An

--- a/scripts/scheduled/ScheduledEntryPoints.Tests.ps1
+++ b/scripts/scheduled/ScheduledEntryPoints.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
     $script:entryRoot = Join-Path $TestDrive 'entrypoints'
     New-Item -ItemType Directory -Path $entryRoot | Out-Null
     Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'Invoke-ScheduledCheck.ps1'),
+        (Join-Path $PSScriptRoot 'Invoke-ScheduledPlan.ps1'),
         (Join-Path $PSScriptRoot 'Invoke-ScheduledHealth.ps1'),
         (Join-Path $PSScriptRoot 'Invoke-ScheduledReport.ps1') -Destination $entryRoot
     @'
@@ -31,6 +32,13 @@ function Invoke-ScheduledReporting {
 }
 Export-ModuleMember -Function Get-ScheduledGitHubHealth, Invoke-ScheduledReporting
 '@ | Set-Content -LiteralPath (Join-Path $entryRoot 'ScheduledGitHub.psm1')
+    @'
+function Invoke-ScheduledPlanning {
+    param($Mode, $EventPath, $OutputDirectory)
+    @{ mode = $Mode; event_path = $EventPath; output_directory = $OutputDirectory } | ConvertTo-Json -Compress
+}
+Export-ModuleMember -Function Invoke-ScheduledPlanning
+'@ | Set-Content -LiteralPath (Join-Path $entryRoot 'ScheduledWorkflow.psm1')
 
     function Invoke-EntryPointFixture {
         param([string] $Name, [string] $Outcome, [string[]] $Arguments = @())
@@ -63,6 +71,19 @@ Export-ModuleMember -Function Get-ScheduledGitHubHealth, Invoke-ScheduledReporti
 }
 
 Describe 'Hosted entrypoint exit contracts' {
+    It 'invokes the planner without extra permission switches for <Mode>' -TestCases @(
+        @{ Mode = 'verify' }, @{ Mode = 'scheduled' }, @{ Mode = 'validation' }
+    ) {
+        param($Mode)
+        $result = Invoke-EntryPointFixture -Name 'Invoke-ScheduledPlan.ps1' -Outcome $Mode `
+            -Arguments @('-Mode', $Mode, '-EventPath', 'event.json', '-OutputDirectory', 'output')
+        $result.code | Should -Be 0
+        $result.stderr | Should -BeNullOrEmpty
+        $result.stdout | Should -Match ('"mode":"' + $Mode + '"')
+        $result.stdout | Should -Match '"event_path":"event.json"'
+        $result.stdout | Should -Match '"output_directory":"output"'
+    }
+
     It 'distinguishes captured execution failures from reporting failure: <Outcome>' -TestCases @(
         @{ Outcome = 'passed'; Code = 0 }
         @{ Outcome = 'not-run'; Code = 0 }

--- a/scripts/scheduled/ScheduledExecution.Tests.ps1
+++ b/scripts/scheduled/ScheduledExecution.Tests.ps1
@@ -1033,6 +1033,29 @@ Describe 'Miri and careful evidence' {
 }
 
 Describe 'Cargo test target scope' {
+    It 'validates cpulist and rejects unknown crate names using the tested workspace metadata' {
+        $path = New-Output
+        & cargo metadata --manifest-path (Join-Path $script:root 'Cargo.toml') --format-version=1 --no-deps --locked |
+            Set-Content -LiteralPath (Join-Path $path 'metadata.stdout')
+        $LASTEXITCODE | Should -Be 0
+        $check = New-Check 'miri'
+        $check.packages = @('cpulist')
+        $scopes = @(& (Get-Module ScheduledExecution) {
+                param($Check, $Path)
+                Get-ScheduledTestScope -Check $Check -OutputDirectory $Path
+            } $check $path)
+        $scopes.Count | Should -BeGreaterThan 0
+        @($scopes.package | Sort-Object -Unique) | Should -Be @('cpulist')
+        foreach ($kind in @('miri', 'careful')) {
+            $check.kind = $kind
+            $check.packages = @('not-a-workspace-crate')
+            { & (Get-Module ScheduledExecution) {
+                    param($Check, $Path)
+                    Get-ScheduledTestScope -Check $Check -OutputDirectory $Path
+                } $check $path } | Should -Throw -ExceptionType ([FormatException])
+        }
+    }
+
     It 'enumerates ordinary lib/bin/integration targets and skips disabled and non-test targets' {
         $check = New-Check 'miri'
         $check.packages = @()

--- a/scripts/scheduled/ScheduledGitHub.Tests.ps1
+++ b/scripts/scheduled/ScheduledGitHub.Tests.ps1
@@ -382,6 +382,153 @@ Describe 'Archive extraction boundaries' {
                 Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Method -in @('POST', 'PATCH') }
                 Test-Path -LiteralPath (Join-Path $caseRoot 'report\report.json') | Should -BeTrue
             }
+            Describe 'Manual diagnostics with the checked-in policy' {
+                BeforeEach {
+                    $script:apiPolicy = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'policy.json') -Raw |
+                        ConvertFrom-Json -AsHashtable
+                    $apiRun.name = 'Scheduled verification'
+                    $apiRun.path = '.github/workflows/scheduled-verify.yml'
+                    $apiRun.event = 'workflow_dispatch'
+                    @{
+                        action = 'completed'; workflow_run = $apiRun
+                        repository = @{ id = 850321188; full_name = 'folo-rs/folo'; default_branch = 'main' }
+                    } | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath $eventFile
+                    $apiPlan.manifest = Get-ScheduledCheckManifest -SourceSha ('b' * 40) -ControllerSha ('a' * 40) `
+                        -ContractDigest ('c' * 64) -Scope confirmation -Packages cpulist -CheckIds miri-ubuntu-latest
+                    $apiPlan.confirmations = @()
+                    $apiPlan | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath (Join-Path $planRoot 'plan.json')
+                    Mock Get-ScheduledOwnedIssue { throw 'Unrelated repair or coverage state must not be read.' }
+                    Mock Get-ScheduledTrustedConfirmation { throw 'A diagnostic is not repair confirmation.' }
+                    Mock Merge-ScheduledCoverage { throw 'A diagnostic cannot change main coverage.' }
+                    Mock Sync-ScheduledIssue { throw 'A diagnostic cannot change repair or coverage issues.' }
+                }
+
+                It 'accepts cpulist Miri evidence for the exact candidate without issue or repair authority' {
+                    $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'manual') -Apply
+                    $report.problems | Should -BeNullOrEmpty
+                    $report.status | Should -Be passed
+                    $report.diagnostic | Should -BeTrue
+                    $report.applied | Should -BeFalse
+                    $report.writes_authorized | Should -BeFalse
+                    $report.ContainsKey('coverage') | Should -BeFalse
+                    $report.manifest.source_sha | Should -BeExactly ('b' * 40)
+                    $report.results.Count | Should -Be 1
+                    $report.results[0].actual_scope.packages | Should -Be @('cpulist')
+                    $saved = Get-Content -LiteralPath (Join-Path $caseRoot 'manual\report.json') -Raw | ConvertFrom-Json
+                    $saved.manifest.source_sha | Should -BeExactly ('b' * 40)
+                    $saved.results[0].outcome | Should -Be passed
+                    Should -Invoke Get-ScheduledCheckResult -Times 1
+                    Should -Invoke Get-ScheduledOwnedIssue -Times 0
+                    Should -Invoke Get-ScheduledTrustedConfirmation -Times 0
+                    Should -Invoke Sync-ScheduledRunIntake -Times 0
+                    Should -Invoke Restore-ScheduledRunPublicationState -Times 0
+                    Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -like '*/issues*' }
+                    Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Method -in @('POST', 'PATCH') }
+                }
+
+                It 'retains full manual evidence without creating or invalidating a main coverage receipt' {
+                    $apiRun.name = 'Scheduled validation'; $apiRun.path = '.github/workflows/scheduled-validation.yml'
+                    @{
+                        action = 'completed'; workflow_run = $apiRun
+                        repository = @{ id = 850321188; full_name = 'folo-rs/folo'; default_branch = 'main' }
+                    } | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath $eventFile
+                    $apiPlan.manifest = $expectedManifest
+                    $apiPlan | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath (Join-Path $planRoot 'plan.json')
+                    $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'full-manual') -Apply
+                    $report.status | Should -Be passed
+                    $report.results.Count | Should -Be 32
+                    $report.ContainsKey('coverage') | Should -BeFalse
+                    Should -Invoke Merge-ScheduledCoverage -Times 0
+                    Should -Invoke Sync-ScheduledIssue -Times 0
+                }
+
+                It 'retains failing check evidence without attempting issue publication' {
+                    Mock Get-ScheduledCheckResult {
+                        param($Check, $RunContext)
+                        $result = $RunContext.Clone()
+                        $result.schema_version = 1; $result.check_id = $Check.id; $result.actual_scope = $Check
+                        $result.outcome = 'findings'; $result.summary = 'Miri reported undefined behavior.'
+                        return $result
+                    }
+                    $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'failed-manual') -Apply
+                    $report.status | Should -Be reported
+                    $report.results[0].outcome | Should -Be findings
+                    $report.jobs.Count | Should -Be 1
+                    $report.actions | Should -BeNullOrEmpty
+                    Should -Invoke Sync-ScheduledRunIntake -Times 0
+                }
+
+                It 'keeps on-demand run intake available only with separately authorized writes' {
+                    $apiPolicy.rollout.reporting_enabled = $true
+                    Mock Assert-ScheduledWriteController {}
+                    Mock Get-ScheduledArtifact { throw [IO.IOException]::new('Missing check artifact.') } `
+                        -ParameterFilter { $Name -like 'scheduled-result-*' }
+                    $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'authorized') -Apply
+                    $report.status | Should -Be reported
+                    $report.applied | Should -BeTrue
+                    $report.run_intake.requires_triage | Should -BeTrue
+                    $report.ContainsKey('coverage') | Should -BeFalse
+                    Should -Invoke Assert-ScheduledWriteController -Times 1
+                    Should -Invoke Restore-ScheduledRunPublicationState -Times 1
+                    Should -Invoke Sync-ScheduledRunIntake -Times 1 -ParameterFilter { $Apply }
+                    Should -Invoke Get-ScheduledOwnedIssue -Times 0
+                    Should -Invoke Get-ScheduledTrustedConfirmation -Times 0
+                    Should -Invoke Merge-ScheduledCoverage -Times 0
+                    Should -Invoke Sync-ScheduledIssue -Times 0
+                }
+
+                It 'does not read issue state when reporting is enabled but Apply is absent' {
+                    $apiPolicy.rollout.reporting_enabled = $true
+                    Mock Get-ScheduledArtifact { throw [IO.IOException]::new('Missing check artifact.') } `
+                        -ParameterFilter { $Name -like 'scheduled-result-*' }
+                    $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'no-apply')
+                    $report.status | Should -Be incomplete
+                    $report.applied | Should -BeFalse
+                    $report.writes_authorized | Should -BeFalse
+                    $report.jobs.Count | Should -Be 1
+                    $report.problems.Count | Should -BeGreaterThan 0
+                    Should -Invoke Sync-ScheduledRunIntake -Times 0
+                    Should -Invoke Restore-ScheduledRunPublicationState -Times 0
+                    Should -Invoke Get-ScheduledOwnedIssue -Times 0
+                    Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -like '*/issues*' }
+                }
+
+                It 'reports incomplete evidence for <Damage> rather than accepting a manual exception' -TestCases @(
+                    @{ Damage = 'skipped' }, @{ Damage = 'confirmation' }, @{ Damage = 'contract' },
+                    @{ Damage = 'unknown-check' }, @{ Damage = 'empty-packages' },
+                    @{ Damage = 'stale-source' }, @{ Damage = 'missing-artifact' }
+                ) {
+                    param($Damage)
+                    switch ($Damage) {
+                        'skipped' { $apiPlan.decision.run = $false }
+                        'confirmation' { $apiPlan.confirmations = @(@{ finding_id = 'f' * 64 }) }
+                        'contract' { $apiPlan.manifest.check_contract_digest = 'd' * 64 }
+                        'unknown-check' { $apiPlan.manifest.checks[0].id = 'unknown' }
+                        'empty-packages' { $apiPlan.manifest.checks[0].packages = @() }
+                        'stale-source' {
+                            Mock Get-ScheduledCheckResult {
+                                param($Check, $RunContext)
+                                $result = $RunContext.Clone()
+                                $result.schema_version = 1; $result.check_id = $Check.id; $result.actual_scope = $Check
+                                $result.source_sha = 'd' * 40; $result.outcome = 'passed'
+                                return $result
+                            }
+                        }
+                        'missing-artifact' {
+                            Mock Get-ScheduledArtifact { throw [IO.IOException]::new('Missing check artifact.') } `
+                                -ParameterFilter { $Name -like 'scheduled-result-*' }
+                        }
+                    }
+                    $apiPlan | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath (Join-Path $planRoot 'plan.json')
+                    $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot $Damage) -Apply
+                    $report.status | Should -Be incomplete
+                    $report.problems.Count | Should -BeGreaterThan 0
+                    $report.actions | Should -BeNullOrEmpty
+                    $report.ContainsKey('coverage') | Should -BeFalse
+                    Test-Path -LiteralPath (Join-Path $caseRoot "$Damage\report.json") | Should -BeTrue
+                    Should -Invoke Sync-ScheduledRunIntake -Times 0
+                }
+            }
             It 'normalizes relative report paths before supplying artifact roots to the parser' {
                 $relativeOutput = [IO.Path]::GetRelativePath((Get-Location).Path, (Join-Path $caseRoot 'relative-output'))
                 $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile $relativeOutput
@@ -389,6 +536,16 @@ Describe 'Archive extraction boundaries' {
                 Should -Invoke Get-ScheduledArtifact -Times 1 -ParameterFilter {
                     $Name -like 'scheduled-plan-*' -and [IO.Path]::IsPathFullyQualified($OutputDirectory)
                 }
+            }
+            It 'rejects ambiguous authoritative coverage for automatic reporting' {
+                Mock Sync-ScheduledIssue { throw 'Ambiguous coverage must not be published.' }
+                Mock Get-ScheduledOwnedIssue { @(@{ number = 1 }, @{ number = 2 }) } `
+                    -ParameterFilter { $Label -ceq 'scheduled-coverage' }
+                $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'ambiguous')
+                $report.status | Should -Be incomplete
+                $report.problems.Count | Should -BeGreaterThan 0
+                Should -Invoke Sync-ScheduledIssue -Times 0
+                Should -Invoke Get-ScheduledArtifact -Times 0
             }
             It 'serializes a setup-only failure through the real Rust intake contract' {
                 $apiRun.conclusion = 'failure'

--- a/scripts/scheduled/ScheduledGitHub.psm1
+++ b/scripts/scheduled/ScheduledGitHub.psm1
@@ -443,16 +443,20 @@ function Invoke-ScheduledReporting {
         $run = Invoke-ScheduledGitHubApi "repos/$Repository/actions/runs/$($eventRun.id)/attempts/$($eventRun.run_attempt)"
         $workflow = Invoke-ScheduledGitHubApi "repos/$Repository/actions/workflows/$($run.workflow_id)"
         Assert-ScheduledReportingRun -WorkflowEvent $workflowEvent -Run $run -Workflow $workflow -Policy $policy
+        # Authorization comes from the API-validated event, never an artifact-supplied flag.
+        # Manual checks do not depend on, or modify, retained repair/coverage state.
+        # Ref: ../../.github/workflows/implementation.md#manual-checks.
+        $diagnostic = $run.event -ceq 'workflow_dispatch'
+        $applyWrites = $Apply -and $policy.rollout.reporting_enabled
         $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
         $checkoutSha = (& git -C $root rev-parse HEAD).Trim()
         $defaultRef = Invoke-ScheduledGitHubApi "repos/$Repository/git/ref/heads/main"
-        if ($Apply -and $policy.rollout.reporting_enabled) {
+        if ($applyWrites) {
             Assert-ScheduledWriteController -Policy $policy -CheckoutSha $checkoutSha -DefaultSha $defaultRef.object.sha
         }
         if (-not (Test-ScheduledGitHubAncestor $Repository $run.head_sha $defaultRef.object.sha)) {
             throw [FormatException]::new('Originating controller is not on default-branch ancestry.')
         }
-        $applyWrites = $Apply -and $policy.rollout.reporting_enabled
         $report.writes_authorized = [bool]$applyWrites
         if ($applyWrites) {
             Restore-ScheduledRunPublicationState -Policy $policy -Run $run -OutputDirectory $OutputDirectory
@@ -476,11 +480,16 @@ function Invoke-ScheduledReporting {
             run_started_at = $run.run_started_at
         }
         $contractDigest = Get-ScheduledContractDigest -Root $root
-        $coverageIssues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-coverage)
-        if ($coverageIssues.Count -gt 1) { throw [FormatException]::new('More than one reporter-owned coverage issue exists.') }
-        $coverageIssue = if ($coverageIssues.Count -eq 1) { $coverageIssues[0] } else { $null }
-        $coverage = if ($null -ne $coverageIssue) { Read-ScheduledRecord -Text $coverageIssue.body -Kind coverage } else { $null }
-        $issues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-finding)
+        $coverageIssue = $null
+        $coverage = $null
+        $issues = @()
+        if (-not $diagnostic) {
+            $coverageIssues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-coverage)
+            if ($coverageIssues.Count -gt 1) { throw [FormatException]::new('More than one reporter-owned coverage issue exists.') }
+            $coverageIssue = if ($coverageIssues.Count -eq 1) { $coverageIssues[0] } else { $null }
+            $coverage = if ($null -ne $coverageIssue) { Read-ScheduledRecord -Text $coverageIssue.body -Kind coverage } else { $null }
+            $issues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-finding)
+        }
         $index = @{}
         $ambiguous = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
         foreach ($issue in $issues) {
@@ -532,21 +541,21 @@ function Invoke-ScheduledReporting {
                 $plan.manifest.check_contract_digest -cne $contractDigest -or
                 $plan.manifest.scope -cne $scope) { throw [FormatException]::new('Plan identity or contract is incompatible.') }
             Assert-ScheduledSha $plan.manifest.source_sha
-            if (-not (& $isAncestor $plan.manifest.source_sha $run.head_sha) -or
+            if ((-not $diagnostic -and -not (& $isAncestor $plan.manifest.source_sha $run.head_sha)) -or
                 ($scope -ceq 'full' -and $plan.manifest.source_sha -cne $run.head_sha)) {
                 throw [FormatException]::new('Planned source is not the authoritative main candidate.')
             }
             $packages = @()
             $checkIds = @()
             if ($plan.decision.run -isnot [bool]) { throw [FormatException]::new('Plan decision is malformed.') }
+            if ($diagnostic -and -not $plan.decision.run) {
+                throw [FormatException]::new('A manual request must run fresh checks, not skip execution.')
+            }
             # No-work verification retains the unselected catalog. Package-specific many-seed
             # entries are not a global package selection when no confirmation was admitted.
             if ($scope -ceq 'confirmation' -and $plan.decision.run) {
-                $packages = @($plan.manifest.checks.packages | Sort-Object -Unique)
+                $packages = @($plan.manifest.checks | ForEach-Object { $_.packages } | Sort-Object -Unique)
                 $checkIds = @($plan.manifest.checks.id)
-                foreach ($packageName in $packages) {
-                    if ($packageName -cnotin $policy.repair.allowed_packages) { throw [FormatException]::new('Unapproved confirmation package.') }
-                }
                 if ($packages.Count -eq 0 -and $plan.decision.run) { throw [FormatException]::new('Confirmation has no package scope.') }
             }
             $manifest = Get-ScheduledCheckManifest -SourceSha $plan.manifest.source_sha -ControllerSha $run.head_sha `
@@ -557,6 +566,9 @@ function Invoke-ScheduledReporting {
             if ($plan.ContainsKey('confirmations')) {
                 if ($plan.confirmations -isnot [array]) { throw [FormatException]::new('Plan confirmations must be an array.') }
                 $confirmations = @($plan.confirmations)
+            }
+            if ($diagnostic -and $confirmations.Count -gt 0) {
+                throw [FormatException]::new('Manual checks cannot declare repair confirmations.')
             }
             if (-not $plan.ContainsKey('planned_at')) { throw [FormatException]::new('Plan has no planning timestamp.') }
             $plannedAt = [datetimeoffset]$plan.planned_at
@@ -602,7 +614,7 @@ function Invoke-ScheduledReporting {
         }
         $context.evidence_complete = $verdict.complete -and $report.problems.Count -eq 0
         $executionEvidenceComplete = $context.evidence_complete
-        if (-not $skipped) {
+        if (-not $skipped -and -not $diagnostic) {
             $confirmedScope = @{}
             foreach ($declaration in $confirmations) {
                 try {
@@ -665,13 +677,29 @@ function Invoke-ScheduledReporting {
         }
         $intakeGaps = @($report.problems)
         if (-not $skipped) { $intakeGaps += $verdict.problems }
-        $intake = Sync-ScheduledRunIntake -Policy $policy -Run $run -Plan $validatedPlan `
-            -Manifest $manifest -Results $results -Jobs $jobEvidence.jobs `
-            -EvidenceGaps $intakeGaps -Skipped:$skipped `
-            -Artifacts $artifacts -TransientPaths (@($OutputDirectory, $downloadRoot) + $jobEvidence.transient_paths) `
-            -OutputDirectory $OutputDirectory -Api $api -Apply:$applyWrites
-        $report.actions += $intake.actions
-        $report.run_intake = $intake
+        if (-not $diagnostic -or $applyWrites) {
+            $intake = Sync-ScheduledRunIntake -Policy $policy -Run $run -Plan $validatedPlan `
+                -Manifest $manifest -Results $results -Jobs $jobEvidence.jobs `
+                -EvidenceGaps $intakeGaps -Skipped:$skipped `
+                -Artifacts $artifacts -TransientPaths (@($OutputDirectory, $downloadRoot) + $jobEvidence.transient_paths) `
+                -OutputDirectory $OutputDirectory -Api $api -Apply:$applyWrites
+            $report.actions += $intake.actions
+            $report.run_intake = $intake
+        }
+        if ($diagnostic) {
+            # Preserve exact-source diagnostics without proposing main coverage or repair closure.
+            # Separately authorized run-level intake remains available for on-demand reporting.
+            $report.diagnostic = $true
+            $report.manifest = $manifest
+            $report.results = $results
+            $report.jobs = $jobEvidence.jobs
+            $report.problems = $intakeGaps
+            $report.applied = [bool]$applyWrites
+            $report.status = if ($applyWrites -and $intake.requires_triage) { 'reported' }
+                elseif (-not $context.evidence_complete) { 'incomplete' }
+                elseif ($verdict.successful) { 'passed' } else { 'reported' }
+            return $report
+        }
         $nextCoverage = Merge-ScheduledCoverage -Coverage $coverage -Manifest $manifest -Results $results `
             -Context $context -IsAncestor $isAncestor -Skipped:$skipped
         $nextCoverage.repository_id = $policy.repository_id

--- a/scripts/scheduled/ScheduledPlan.Tests.ps1
+++ b/scripts/scheduled/ScheduledPlan.Tests.ps1
@@ -103,9 +103,8 @@ Describe 'Unchanged main decisions' {
         $decision.run | Should -BeFalse
         $decision.receipt.completed_at | Should -Be $receipt.completed_at
     }
-    It 'reruns missing forced stale future or partial evidence' {
+    It 'reruns missing stale future or partial evidence' {
         (Get-ScheduledRunDecision -Manifest $manifest -Coverage $null -Now $now).run | Should -BeTrue
-        (Get-ScheduledRunDecision -Manifest $manifest -Coverage $coverage -Now $now -Force).run | Should -BeTrue
         foreach ($completed in @('2026-09-01T12:00:00Z', '2026-09-09T12:00:00Z')) {
             $receipt.completed_at = $completed
             (Get-ScheduledRunDecision -Manifest $manifest -Coverage $coverage -Now $now).run | Should -BeTrue

--- a/scripts/scheduled/ScheduledPlan.psm1
+++ b/scripts/scheduled/ScheduledPlan.psm1
@@ -24,6 +24,11 @@ function Get-ScheduledCheckManifest {
 
     Assert-ScheduledSha $SourceSha
     Assert-ScheduledSha $ControllerSha
+    foreach ($packageName in $Packages) {
+        if ($packageName -cnotmatch '^[A-Za-z0-9_][A-Za-z0-9_-]*$') {
+            throw [ArgumentException]::new("Enter a crate name, not a Cargo package pattern or option: '$packageName'.")
+        }
+    }
     $checks = @()
     foreach ($platform in @('ubuntu-latest', 'windows-latest', 'ubuntu-24.04-arm', 'windows-11-arm')) {
         $checks += @{
@@ -62,9 +67,16 @@ function Get-ScheduledCheckManifest {
     if ($CheckIds.Count -gt 0) {
         if ($Scope -eq 'full') { throw 'A partial selection cannot claim full coverage.' }
         foreach ($id in $CheckIds) {
-            if ($id -cnotin @($checks.id)) { throw "Unknown scheduled check: $id" }
+            if ($id -cnotin @($checks.id)) {
+                throw [ArgumentException]::new("Check '$id' is unknown or does not support the selected crates. See docs/scheduled-validation.md#running-checks-manually.")
+            }
         }
         $checks = @($checks | Where-Object { $_.id -cin $CheckIds })
+    }
+    foreach ($packageName in $Packages) {
+        if ($packageName -cnotin @($checks.packages)) {
+            throw [ArgumentException]::new("No selected check runs crate '$packageName'. Select a compatible check for every requested crate.")
+        }
     }
     if ($Scope -eq 'full' -and $Packages.Count -gt 0) { throw 'Full coverage requires the workspace.' }
     return @{
@@ -163,12 +175,10 @@ function Get-ScheduledRunDecision {
         [Parameter(Mandatory)][hashtable] $Manifest,
         [AllowNull()][hashtable] $Coverage,
         [Parameter(Mandatory)][datetimeoffset] $Now,
-        [int] $MaxAgeDays = 7,
-        [switch] $Force
+        [int] $MaxAgeDays = 7
     )
 
     $reason = 'no-compatible-complete-success'
-    if ($Force) { return @{ run = $true; reason = 'forced'; receipt = $null } }
     if ($null -ne $Coverage -and $Coverage.ContainsKey('schema_version') -and
         $Coverage.schema_version -eq 1 -and $Coverage.ContainsKey('invalidation') -and
         $Coverage.ContainsKey('receipt') -and $null -ne $Coverage.receipt) {

--- a/scripts/scheduled/ScheduledValidation.Tests.ps1
+++ b/scripts/scheduled/ScheduledValidation.Tests.ps1
@@ -219,6 +219,16 @@ Describe 'Hosted planning authorization' {
             $plan.manifest.checks[0].packages | Should -Be @('cpulist', 'events')
         }
 
+        It 'uses the captured main commit when an API dispatch omits the optional source field' {
+            $manualEvent.inputs.Remove('source_sha')
+            $manualEvent | ConvertTo-Json -Depth 10 | Set-Content $eventPath
+            $plan = Invoke-ScheduledPlanning -Mode verify -EventPath $eventPath `
+                -OutputDirectory (Join-Path $TestDrive 'plan')
+            $plan.decision.run | Should -BeTrue
+            $plan.manifest.source_sha | Should -BeExactly ('a' * 40)
+            Should -Invoke Invoke-ScheduledReadApi -ModuleName ScheduledWorkflow -Times 0
+        }
+
         It 'rejects invalid or incompatible requested names <Packages> / <Checks>' -TestCases @(
             @{ Packages = ''; Checks = 'miri-ubuntu-latest' },
             @{ Packages = 'cpulist'; Checks = '' },

--- a/scripts/scheduled/ScheduledValidation.Tests.ps1
+++ b/scripts/scheduled/ScheduledValidation.Tests.ps1
@@ -1,6 +1,6 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 # Protects fixed local validation depth and the hosted validation graph without executing any
-# checker. Planner tests isolate GitHub reads so disabled execution, explicit canaries and
+# checker. Planner tests isolate GitHub reads so disabled execution, manual requests and
 # managed repair gates remain independent of ordinary shallow CI.
 # Ref: ../../.github/workflows/design.md#shallow-and-deep-validation.
 BeforeAll {
@@ -13,6 +13,8 @@ BeforeAll {
     foreach ($match in [regex]::Matches($jobDefinitions, '(?ms)^  ([\w-]+):\r?\n(.*?)(?=^  [\w-]+:|\z)')) {
         $jobs[$match.Groups[1].Value] = $match.Groups[2].Value
     }
+    Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1') -Force
+    Import-Module (Join-Path $PSScriptRoot 'ScheduledPlan.psm1') -Force
     Import-Module (Join-Path $PSScriptRoot 'ScheduledWorkflow.psm1') -Force
 }
 
@@ -81,12 +83,16 @@ Describe 'Shallow hosted validation with managed deep evidence' {
 Describe 'Hosted planning authorization' {
     BeforeEach {
         $savedEnvironment = @{}
-        foreach ($name in @('GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT', 'GITHUB_RUN_NUMBER', 'GITHUB_OUTPUT')) {
+        foreach ($name in @('GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT', 'GITHUB_RUN_NUMBER', 'GITHUB_OUTPUT',
+                'GITHUB_REF', 'GITHUB_EVENT_NAME', 'GITHUB_STEP_SUMMARY')) {
             $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
         }
         $env:GITHUB_RUN_ID = '10'
         $env:GITHUB_RUN_ATTEMPT = '1'
         $env:GITHUB_RUN_NUMBER = '5'
+        $env:GITHUB_REF = 'refs/heads/main'
+        $env:GITHUB_EVENT_NAME = 'schedule'
+        $env:GITHUB_STEP_SUMMARY = Join-Path $TestDrive 'summary.md'
         $env:GITHUB_OUTPUT = Join-Path $TestDrive 'outputs'
         Set-Content -LiteralPath $env:GITHUB_OUTPUT -Value '' -NoNewline
         $eventPath = Join-Path $TestDrive 'event.json'
@@ -104,21 +110,145 @@ Describe 'Hosted planning authorization' {
         }
     }
 
-    It 'does not authorize recurring execution merely because a recheck is forced' {
+    It 'keeps recurring execution disabled with the checked-in policy' {
         $plan = Invoke-ScheduledPlanning -Mode scheduled -EventPath $eventPath `
-            -OutputDirectory (Join-Path $TestDrive 'plan') -Now '2026-09-08T12:00:00Z' -Force
+            -OutputDirectory (Join-Path $TestDrive 'plan') -Now '2026-09-08T12:00:00Z'
         $plan.decision.run | Should -BeFalse
-        $plan.canary | Should -BeFalse
         Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 0 -Exactly
     }
 
-    It 'retains explicit read-only canary execution while recurring execution is disabled' {
+    It 'runs fresh full manual checks without any rollout or cache prerequisite' {
+        $env:GITHUB_EVENT_NAME = 'workflow_dispatch'
+        Mock Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow { throw 'Unrelated broken coverage index.' }
         $plan = Invoke-ScheduledPlanning -Mode scheduled -EventPath $eventPath `
-            -OutputDirectory (Join-Path $TestDrive 'plan') -Now '2026-09-08T12:00:00Z' -Canary -Force
+            -OutputDirectory (Join-Path $TestDrive 'plan') -Now '2026-09-08T12:00:00Z'
         $plan.decision.run | Should -BeTrue
-        $plan.canary | Should -BeTrue
         $plan.manifest.scope | Should -Be full
-        Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 1 -Exactly
+        $plan.manifest.checks.Count | Should -Be 32
+        $plan.confirmations | Should -BeNullOrEmpty
+        $plan.repairs | Should -BeNullOrEmpty
+        Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 0 -Exactly
+    }
+
+    It 'retains automatic unchanged-source reuse when recurring execution is enabled' {
+        $script:enabledPolicy = Get-ScheduledPolicy
+        $enabledPolicy.rollout.hosted_execution_enabled = $true
+        Mock Get-ScheduledPolicy -ModuleName ScheduledWorkflow { $enabledPolicy }
+        $manifest = Get-ScheduledCheckManifest -SourceSha ('a' * 40) -ControllerSha ('a' * 40) -ContractDigest ('c' * 64)
+        $script:automaticCoverage = @{
+            schema_version = 1; invalidation = $null
+            receipt = @{
+                source_sha = 'a' * 40; check_contract_digest = 'c' * 64; scope = 'full'
+                complete = $true; successful = $true; manifest = $manifest
+                run_id = 9; run_attempt = 1; run_number = 4; completed_at = '2026-09-08T11:00:00Z'
+            }
+        }
+        Mock Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow { $automaticCoverage }
+        Mock Invoke-ScheduledReadApi -ModuleName ScheduledWorkflow { @(@{ workflow_runs = @() }) }
+        $plan = Invoke-ScheduledPlanning -Mode scheduled -EventPath $eventPath `
+            -OutputDirectory (Join-Path $TestDrive 'plan') -Now '2026-09-08T12:00:00Z'
+        $plan.decision.run | Should -BeFalse
+        $plan.decision.reason | Should -Be not-run-unchanged
+        Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 1
+    }
+
+    It 'fails a non-main workflow selection instead of silently skipping <Mode>' -TestCases @(
+        @{ Mode = 'scheduled' }, @{ Mode = 'verify' }
+    ) {
+        param($Mode)
+        $env:GITHUB_EVENT_NAME = 'workflow_dispatch'
+        $env:GITHUB_REF = 'refs/heads/topic'
+        $rejectedPlan = Join-Path $TestDrive "rejected-$Mode"
+        { Invoke-ScheduledPlanning -Mode $Mode -EventPath $eventPath `
+                -OutputDirectory $rejectedPlan } | Should -Throw
+        Test-Path -LiteralPath $rejectedPlan | Should -BeFalse
+    }
+
+    Describe 'Manual crate checks with the actual default policy' {
+        BeforeEach {
+            $env:GITHUB_EVENT_NAME = 'workflow_dispatch'
+            $script:manualEvent = @{
+                repository = @{ id = 850321188 }
+                inputs = @{ source_sha = ''; check_ids = 'miri-ubuntu-latest'; packages = 'cpulist' }
+            }
+            $policy = Get-ScheduledPolicy
+            $policy.repair.allowed_packages | Should -BeNullOrEmpty
+            $policy.local.allowed_packages | Should -BeNullOrEmpty
+            $policy.local.enrolled_machine_id | Should -BeNullOrEmpty
+            $policy.rollout.hosted_execution_enabled | Should -BeFalse
+            $policy.rollout.reporting_enabled | Should -BeFalse
+            @($policy.rollout.prerequisites.Values | Where-Object { $_ }).Count | Should -Be 0
+        }
+
+        It 'plans cpulist Miri at <Source> independently of repair permissions' -TestCases @(
+            @{ Source = ''; Expected = 'a' * 40 },
+            @{ Source = 'a' * 40; Expected = 'a' * 40 },
+            @{ Source = 'b' * 40; Expected = 'b' * 40 }
+        ) {
+            param($Source, $Expected)
+            $manualEvent.inputs.source_sha = $Source
+            $manualEvent | ConvertTo-Json -Depth 10 | Set-Content $eventPath
+            Mock Invoke-ScheduledReadApi -ModuleName ScheduledWorkflow {
+                param($Endpoint)
+                @{ sha = ($Endpoint -split '/')[-1] }
+            }
+            $plan = Invoke-ScheduledPlanning -Mode verify -EventPath $eventPath `
+                -OutputDirectory (Join-Path $TestDrive 'plan')
+            $plan.decision.run | Should -BeTrue
+            $plan.manifest.source_sha | Should -BeExactly $Expected
+            $plan.manifest.controller_sha | Should -BeExactly ('a' * 40)
+            $plan.manifest.scope | Should -Be confirmation
+            @($plan.manifest.checks.id) | Should -Be @('miri-ubuntu-latest')
+            $plan.manifest.checks[0].packages | Should -Be @('cpulist')
+            $plan.managed | Should -BeFalse
+            $plan.confirmations | Should -BeNullOrEmpty
+            $plan.repairs | Should -BeNullOrEmpty
+            Get-Content -LiteralPath $env:GITHUB_OUTPUT | Should -Contain 'run=true'
+            Get-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Raw | Should -Match $Expected
+            Should -Invoke Get-ScheduledConfirmationScope -ModuleName ScheduledWorkflow -Times 0
+            Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 0
+        }
+
+        It 'accepts spaces around comma-separated names' {
+            $manualEvent.inputs.packages = ' cpulist , events '
+            $manualEvent.inputs.check_ids = ' miri-ubuntu-latest , careful-windows-latest '
+            $manualEvent | ConvertTo-Json -Depth 10 | Set-Content $eventPath
+            $plan = Invoke-ScheduledPlanning -Mode verify -EventPath $eventPath `
+                -OutputDirectory (Join-Path $TestDrive 'plan')
+            $plan.manifest.checks.Count | Should -Be 2
+            $plan.manifest.checks[0].packages | Should -Be @('cpulist', 'events')
+        }
+
+        It 'rejects invalid or incompatible requested names <Packages> / <Checks>' -TestCases @(
+            @{ Packages = ''; Checks = 'miri-ubuntu-latest' },
+            @{ Packages = 'cpulist'; Checks = '' },
+            @{ Packages = 'cpulist,'; Checks = 'miri-ubuntu-latest' },
+            @{ Packages = 'cpulist'; Checks = 'miri-ubuntu-latest, ' },
+            @{ Packages = '*'; Checks = 'miri-ubuntu-latest' },
+            @{ Packages = '--workspace'; Checks = 'mutants-ubuntu-latest-1' },
+            @{ Packages = 'cpulist'; Checks = 'miri' },
+            @{ Packages = 'cpulist'; Checks = 'miri-many-events-1' },
+            @{ Packages = 'events,cpulist'; Checks = 'miri-many-events-1' }
+        ) {
+            param($Packages, $Checks)
+            $manualEvent.inputs.packages = $Packages
+            $manualEvent.inputs.check_ids = $Checks
+            $manualEvent | ConvertTo-Json -Depth 10 | Set-Content $eventPath
+            { Invoke-ScheduledPlanning -Mode verify -EventPath $eventPath `
+                    -OutputDirectory (Join-Path $TestDrive 'plan') } | Should -Throw
+            Get-Content -LiteralPath $env:GITHUB_OUTPUT | Should -Not -Contain 'run=true'
+        }
+
+        It 'rejects a symbolic or unresolved source before starting checks' -TestCases @(
+            @{ Source = 'main' }, @{ Source = 'd' * 40 }
+        ) {
+            param($Source)
+            $manualEvent.inputs.source_sha = $Source
+            $manualEvent | ConvertTo-Json -Depth 10 | Set-Content $eventPath
+            Mock Invoke-ScheduledReadApi -ModuleName ScheduledWorkflow { @{ sha = 'e' * 40 } }
+            { Invoke-ScheduledPlanning -Mode verify -EventPath $eventPath `
+                    -OutputDirectory (Join-Path $TestDrive 'plan') } | Should -Throw
+        }
     }
 
     It 'keeps automatic merged repair confirmation disabled' {

--- a/scripts/scheduled/ScheduledWorkflow.Tests.ps1
+++ b/scripts/scheduled/ScheduledWorkflow.Tests.ps1
@@ -7,6 +7,19 @@ BeforeAll {
     Import-Module (Join-Path $PSScriptRoot 'ScheduledWorkflow.psm1') -Force
 }
 Describe 'Repair gate orchestration' {
+    It 'wires manual requests without redundant checkboxes or a silent branch skip' {
+        $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+        foreach ($name in @('scheduled-validation.yml', 'scheduled-verify.yml')) {
+            $workflow = Get-Content -LiteralPath (Join-Path $root ".github\workflows\$name") -Raw
+            $workflow | Should -Match '(?m)^  workflow_dispatch:\r?$'
+            $workflow | Should -Match "(?m)^    if: github.repository == 'folo-rs/folo'\r?$"
+            $workflow | Should -Not -Match 'EXECUTION_CANARY|FORCE_RECHECK|inputs\.canary|inputs\.force'
+            $workflow | Should -Match 'ref: \$\{\{ github.sha \}\}'
+            $workflow | Should -Match '(?m)^          ./scripts/scheduled/Invoke-ScheduledPlan.ps1'
+            $workflow | Should -Match '(?m)^          include-hidden-files: true\r?$'
+        }
+    }
+
     It 'serializes reporting without replacing pending events' {
         $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
         $workflow = Get-Content -LiteralPath (Join-Path $root '.github\workflows\scheduled-report.yml') -Raw
@@ -49,6 +62,7 @@ Describe 'Repair gate orchestration' {
                 param($Status, $Conclusion, $Attempt, $Id, $Reason)
                 $execution = @{
                     id = $Id; run_attempt = $Attempt; head_sha = 'a' * 40; head_branch = 'main'
+                    event = 'schedule'
                     status = $Status; conclusion = $Conclusion; updated_at = '2026-09-08T11:00:00Z'
                 }
                 Mock Invoke-ScheduledReadApi { @(@{ workflow_runs = @($execution) }) }
@@ -61,6 +75,21 @@ Describe 'Repair gate orchestration' {
         It 'ignores its own planning run without refreshing or invalidating prior coverage' {
             InModuleScope ScheduledWorkflow {
                 Mock Invoke-ScheduledReadApi { @(@{ workflow_runs = @(@{ id = 30 }) }) }
+                Get-ScheduledCoverageRunRisk -Policy @{ repository = 'folo-rs/folo' } `
+                    -Receipt @{ run_id = 10; run_attempt = 1; source_sha = 'a' * 40; completed_at = '2026-09-08T10:00:00Z' } `
+                    -CurrentRunId 30 -CurrentRunAttempt 1 | Should -BeNullOrEmpty
+                Should -Invoke Invoke-ScheduledReadApi -Times 2 -Exactly
+            }
+        }
+
+        It 'ignores manual failures and unfinished diagnostics when reusing automatic coverage' {
+            InModuleScope ScheduledWorkflow {
+                Mock Invoke-ScheduledReadApi {
+                    @(@{ workflow_runs = @(
+                        @{ id = 20; event = 'workflow_dispatch'; status = 'completed'; conclusion = 'failure' },
+                        @{ id = 21; event = 'workflow_dispatch'; status = 'in_progress' }
+                    ) })
+                }
                 Get-ScheduledCoverageRunRisk -Policy @{ repository = 'folo-rs/folo' } `
                     -Receipt @{ run_id = 10; run_attempt = 1; source_sha = 'a' * 40; completed_at = '2026-09-08T10:00:00Z' } `
                     -CurrentRunId 30 -CurrentRunAttempt 1 | Should -BeNullOrEmpty

--- a/scripts/scheduled/ScheduledWorkflow.psm1
+++ b/scripts/scheduled/ScheduledWorkflow.psm1
@@ -50,6 +50,10 @@ function Get-ScheduledCoverageRunRisk {
         $pages = Invoke-ScheduledReadApi "repos/$($Policy.repository)/actions/workflows/$workflow/runs?head_sha=$($Receipt.source_sha)&branch=main&per_page=100" -Paginate
         foreach ($execution in @($pages | ForEach-Object { $_.workflow_runs })) {
             if ($execution.id -eq $CurrentRunId) { continue }
+            # Manual diagnostics have no authority over automatic main coverage, including
+            # while their reporter is pending.
+            # Ref: ../../.github/workflows/implementation.md#manual-checks.
+            if ($execution.event -ceq 'workflow_dispatch') { continue }
             if ($execution.head_sha -cne $Receipt.source_sha -or $execution.head_branch -cne 'main') {
                 throw 'Execution API returned an incompatible coverage candidate.'
             }
@@ -107,13 +111,15 @@ function Invoke-ScheduledPlanning {
         [Parameter(Mandatory)][ValidateSet('scheduled', 'validation', 'verify')][string] $Mode,
         [Parameter(Mandatory)][string] $EventPath,
         [Parameter(Mandatory)][string] $OutputDirectory,
-        [datetimeoffset] $Now = [datetimeoffset]::UtcNow,
-        [switch] $Force,
-        [switch] $Canary
+        [datetimeoffset] $Now = [datetimeoffset]::UtcNow
     )
     $workflowEvent = Get-Content -LiteralPath $EventPath -Raw | ConvertFrom-Json -AsHashtable
     $policy = Get-ScheduledPolicy
     if ($workflowEvent.repository.id -ne $policy.repository_id) { throw 'Wrong repository for scheduled controller.' }
+    if ($Mode -ne 'validation' -and $env:GITHUB_REF -cne 'refs/heads/main') {
+        throw 'Select main under Use workflow from. To test another commit, enter its full SHA in Scheduled verification.'
+    }
+    $diagnostic = $env:GITHUB_EVENT_NAME -ceq 'workflow_dispatch'
     $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
     $controllerSha = (& git -C $root rev-parse HEAD).Trim()
     $contractDigest = Get-ScheduledContractDigest -Root $root
@@ -183,19 +189,19 @@ function Invoke-ScheduledPlanning {
         }
     } elseif ($Mode -eq 'verify') {
         $scope = 'confirmation'
-        if ($workflowEvent.ContainsKey('inputs')) {
-            $sourceSha = $workflowEvent.inputs.source_sha
-            Assert-ScheduledSha $sourceSha
-            # Manual selection is diagnostic evidence, not authority to close an incident.
-            $comparison = Invoke-ScheduledReadApi "repos/$($policy.repository)/compare/${sourceSha}...${controllerSha}"
-            if ($comparison.status -cnotin @('identical', 'ahead')) {
-                throw 'Confirmation source must be on the trusted main ancestry.'
+        if ($diagnostic) {
+            if (-not [string]::IsNullOrWhiteSpace($workflowEvent.inputs.source_sha)) {
+                $sourceSha = $workflowEvent.inputs.source_sha.Trim()
+                Assert-ScheduledSha $sourceSha
+                # Only tested bytes may come from a branch/PR; controller code remains on main.
+                # Ref: ../../.github/workflows/implementation.md#manual-checks.
+                $commit = Invoke-ScheduledReadApi "repos/$($policy.repository)/commits/$sourceSha"
+                if ($commit.sha -cne $sourceSha) { throw 'GitHub did not resolve the requested source commit.' }
             }
-            $checkIds = @($workflowEvent.inputs.check_ids -split ',' | Where-Object { $_ })
-            $packages = @($workflowEvent.inputs.packages -split ',' | Where-Object { $_ })
-            if ($checkIds.Count -eq 0 -or $packages.Count -eq 0) { throw 'Verification requires explicit check and package scope.' }
-            foreach ($packageName in $packages) {
-                if ($packageName -cnotin $policy.repair.allowed_packages) { throw "Unapproved verification package: $packageName" }
+            $checkIds = @($workflowEvent.inputs.check_ids -split ',' | ForEach-Object { $_.Trim() })
+            $packages = @($workflowEvent.inputs.packages -split ',' | ForEach-Object { $_.Trim() })
+            if ('' -cin $checkIds -or '' -cin $packages) {
+                throw 'Enter check IDs and crate names separated by commas, without empty entries.'
             }
             $run = $true
             $reason = 'explicit-verification'
@@ -217,10 +223,16 @@ function Invoke-ScheduledPlanning {
     $manifest = Get-ScheduledCheckManifest -SourceSha $sourceSha -ControllerSha $controllerSha `
         -ContractDigest $contractDigest -Scope $scope -Packages $packages -CheckIds $checkIds
     if ($Mode -eq 'scheduled') {
-        if ($policy.rollout.hosted_execution_enabled -or $Canary) {
+        if ($diagnostic) {
+            # Run workflow is the authorization for fresh read-only checks, not a cache lookup
+            # or permission for issue writes/repairs.
+            # Ref: ../../.github/workflows/implementation.md#manual-checks.
+            $run = $true
+            $reason = 'manual-checks'
+        } elseif ($policy.rollout.hosted_execution_enabled) {
             $coverage = Get-ScheduledCoverageIndex -Policy $policy
             $decision = Get-ScheduledRunDecision -Manifest $manifest -Coverage $coverage `
-                -Now $Now -MaxAgeDays $policy.coverage.max_age_days -Force:$Force
+                -Now $Now -MaxAgeDays $policy.coverage.max_age_days
             $run = $decision.run
             $reason = $decision.reason
             $receipt = $decision.receipt
@@ -237,7 +249,7 @@ function Invoke-ScheduledPlanning {
     }
     $plan = @{
         schema_version = 1; manifest = $manifest; decision = @{ run = $run; reason = $reason; receipt = $receipt }
-        managed = $managed; repairs = $repairs; confirmations = $confirmations; canary = [bool]$Canary
+        managed = $managed; repairs = $repairs; confirmations = $confirmations
         release_base_sha = $releaseBaseSha
         run_id = [long]$env:GITHUB_RUN_ID; run_attempt = [int]$env:GITHUB_RUN_ATTEMPT
         run_number = [long]$env:GITHUB_RUN_NUMBER; planned_at = $Now.ToString('o')
@@ -254,6 +266,15 @@ function Invoke-ScheduledPlanning {
             "source_sha=$sourceSha"
             "controller_sha=$controllerSha"
         ) | Add-Content -LiteralPath $env:GITHUB_OUTPUT
+    }
+    if ($diagnostic -and $env:GITHUB_STEP_SUMMARY) {
+        @(
+            '## Manual checks'
+            ''
+            "Tested commit: ``$sourceSha``."
+            ''
+            'Fresh execution requested. These results do not update shared main coverage or confirm a repair.'
+        ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
     }
     Write-Verbose "Planning $Mode source=$sourceSha contract=${contractDigest}: run=$run because $reason."
     return $plan

--- a/scripts/scheduled/ScheduledWorkflow.psm1
+++ b/scripts/scheduled/ScheduledWorkflow.psm1
@@ -190,7 +190,8 @@ function Invoke-ScheduledPlanning {
     } elseif ($Mode -eq 'verify') {
         $scope = 'confirmation'
         if ($diagnostic) {
-            if (-not [string]::IsNullOrWhiteSpace($workflowEvent.inputs.source_sha)) {
+            if ($workflowEvent.inputs.ContainsKey('source_sha') -and
+                -not [string]::IsNullOrWhiteSpace($workflowEvent.inputs.source_sha)) {
                 $sourceSha = $workflowEvent.inputs.source_sha.Trim()
                 Assert-ScheduledSha $sourceSha
                 # Only tested bytes may come from a branch/PR; controller code remains on main.


### PR DESCRIPTION
[Copilot speaking]

Manually requesting a read-only check must not require authorization for AI source repairs. Running Miri on a crate such as `cpulist` should work with the checked-in policy, without a configuration PR, repair package approval, Local App enrollment, model or billing setup, or enabling automatic execution.

**Scheduled verification** accepts supported check IDs and exact workspace crate names independently of repair allowlists. A blank source SHA tests the immutable main commit selected for that run; an optional full SHA can select a branch or PR commit while the workflow and reporter remain on main. The run summary identifies the tested commit. Invalid names, incompatible crate/check selections and incorrect workflow-branch selections fail explicitly. **Scheduled validation** also runs fresh when manually requested, without redundant permission or cache-override checkboxes.

Manual results do not read or modify repair registrations or shared main coverage, and cannot block automatic coverage reuse while awaiting reporting. With default settings, reporting preserves diagnostic artifacts without accessing issues. The existing reporting switch, together with `-Apply`, still permits on-demand run-level failure intake and its publication recovery; it never permits manual results to confirm repairs or change coverage. Automatic execution remains disabled by default, unchanged-source reuse remains available for authorized automatic runs, and managed repair safeguards and the unavailable AI-triage handoff remain enforced.

The operator instructions and setup prompt explain the exact manual workflow inputs and keep test execution separate from Local repair setup.

## Version/release plan

No released-content or crate-version changes. All publishable packages remain unchanged relative to their release anchors. There are no dependent or version-group movements, retained pending increments, or first-publication packages in this PR.