### PR TITLE
cargo-delta: preserve analysis errors when worktree cleanup fails

### DIFF
--- a/docs/cargo-delta.md
+++ b/docs/cargo-delta.md
@@ -42,6 +42,14 @@ The comparison anchor depends on the environment:
 Command-level validation, fetch policy mechanics and cargo-delta parameter wiring live in
 `scripts/build/Delta.psm1`.
 
+## Baseline worktree lifetime
+
+Baseline analysis uses a temporary Git worktree without switching the caller's checkout.
+Worktree removal is attempted only after successful creation, even when analysis fails.
+An analysis failure is preserved when removal succeeds; a removal failure is surfaced even
+when analysis succeeds. If both fail, an aggregate exception retains both original exceptions,
+with the analysis failure first.
+
 ## Local usage
 
 ```bash

--- a/scripts/build/Delta.Tests.ps1
+++ b/scripts/build/Delta.Tests.ps1
@@ -5,8 +5,12 @@
 # against realistic `cargo delta run` JSON (including the "nothing affected" and
 # malformed-but-tolerated shapes that must not throw under strict mode), Get-DeltaOutput against
 # the three CI step outputs it produces, and Get-DeltaWorkflowOutput against workflow branching.
-# Invoke-CargoDelta drives real cargo/git, so the full path is covered by the recipes running in CI
-# rather than unit-tested here.
+# Invoke-CargoDelta error paths use simulated cargo/git failures to cover worktree lifetime and
+# error preservation without relying on filesystem locks or timing.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
 
 BeforeAll {
     Import-Module (Join-Path $PSScriptRoot 'Delta.psm1') -Force
@@ -93,6 +97,97 @@ Describe 'Invoke-CargoDelta baseline revision validation' {
     }
 }
 
+
+Describe 'Invoke-CargoDelta worktree cleanup' {
+    It 'handles <Scenario>' -TestCases @(
+        @{ Scenario = 'success'; FailureStage = ''; CleanupFails = $false }
+        @{ Scenario = 'current analysis failure'; FailureStage = 'current'; CleanupFails = $false }
+        @{ Scenario = 'creation failure'; FailureStage = 'creation'; CleanupFails = $false }
+        @{ Scenario = 'baseline analysis failure'; FailureStage = 'baseline'; CleanupFails = $false }
+        @{ Scenario = 'analysis and cleanup failure'; FailureStage = 'baseline'; CleanupFails = $true }
+        @{ Scenario = 'cleanup-only failure'; FailureStage = ''; CleanupFails = $true }
+    ) {
+        param($FailureStage, $CleanupFails)
+
+        InModuleScope Delta -Parameters @{ FailureStage = $FailureStage; CleanupFails = $CleanupFails } {
+            param($FailureStage, $CleanupFails)
+
+            $state = @{ AnalysisCount = 0; Worktree = $null }
+            $operationException = [InvalidOperationException]::new('Operation canary')
+            $cleanupException = [IO.IOException]::new('Cleanup canary')
+            Mock git {
+                if ($args[0] -eq 'rev-parse') { return 'resolved-baseline' }
+                if ($args[0] -eq 'worktree' -and $args[1] -eq 'add') {
+                    $state.Worktree = $args[3]
+                    if ($FailureStage -eq 'creation') { throw $operationException }
+                    New-Item -ItemType Directory -Path $state.Worktree | Out-Null
+                    return
+                }
+                if ($args[0] -eq 'worktree' -and $args[1] -eq 'remove') {
+                    $args[2] | Should -Be $state.Worktree
+                    $args[3] | Should -Be '--force'
+                    if ($CleanupFails) { throw $cleanupException }
+                    Remove-Item -LiteralPath $state.Worktree -Recurse -Force
+                    return
+                }
+                throw "Unexpected git call: $($args -join ' ')"
+            }
+            Mock cargo {
+                if ($args[0] -eq 'delta' -and $args[3] -eq 'analyze') {
+                    $state.AnalysisCount++
+                    if (($state.AnalysisCount -eq 1 -and $FailureStage -eq 'current') -or
+                        ($state.AnalysisCount -eq 2 -and $FailureStage -eq 'baseline')) {
+                        throw $operationException
+                    }
+                    return '{}'
+                }
+                if ($args[0] -eq 'delta' -and $args[3] -eq 'run') {
+                    return '{"Affected":["present","removed"]}'
+                }
+                throw "Unexpected cargo call: $($args -join ' ')"
+            }
+            Mock Get-WorkspacePackage { return @('present') }
+
+            $originalLocation = (Get-Location).Path
+            $failure = $null
+            $result = @()
+            try {
+                $result = @(Invoke-CargoDelta -ConfigPath 'test-config' -SkipFetch)
+            } catch {
+                $failure = $_
+            }
+
+            if ($FailureStage -eq 'baseline' -and $CleanupFails) {
+                $failure.Exception | Should -BeOfType ([AggregateException])
+                $failure.Exception.InnerExceptions.Count | Should -Be 2
+                [object]::ReferenceEquals($failure.Exception.InnerExceptions[0], $operationException) |
+                    Should -BeTrue
+                [object]::ReferenceEquals($failure.Exception.InnerExceptions[1], $cleanupException) |
+                    Should -BeTrue
+            } elseif ($FailureStage -ne '') {
+                [object]::ReferenceEquals($failure.Exception, $operationException) | Should -BeTrue
+            } elseif ($CleanupFails) {
+                [object]::ReferenceEquals($failure.Exception, $cleanupException) | Should -BeTrue
+            } else {
+                $failure | Should -BeNullOrEmpty
+                $result | Should -Be @('present')
+            }
+
+            (Get-Location).Path | Should -Be $originalLocation
+            $created = $FailureStage -notin @('current', 'creation')
+            Should -Invoke git -Times ([int] $created) -Exactly -ParameterFilter {
+                $args[0] -eq 'worktree' -and $args[1] -eq 'remove'
+            }
+            $succeeded = $FailureStage -eq '' -and -not $CleanupFails
+            Should -Invoke cargo -Times ([int] $succeeded) -Exactly -ParameterFilter {
+                $args[0] -eq 'delta' -and $args[3] -eq 'run'
+            }
+            if ($null -ne $state.Worktree) {
+                Test-Path -LiteralPath (Split-Path $state.Worktree -Parent) | Should -BeFalse
+            }
+        }
+    }
+}
 
 Describe 'Select-ExistingPackage' {
     It 'drops packages that no longer exist in the workspace' {

--- a/scripts/build/Delta.psm1
+++ b/scripts/build/Delta.psm1
@@ -11,6 +11,8 @@
 # parsing, and CI output shaping.
 
 Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
 
 function Read-DeltaAffectedPackage {
     # Parses the JSON emitted by `cargo delta run` and returns its list of affected package names
@@ -203,6 +205,7 @@ function Invoke-CargoDelta {
         # Use a git worktree to analyze the baseline revision without switching branches.
         $worktreeDir = Join-Path $tempDir 'main-worktree'
         git worktree add --quiet $worktreeDir $resolvedBaselineRevision | Out-Null
+        $analysisError = $null
         try {
             Write-Host "Analyzing baseline revision ($BaselineRevision)..."
             Push-Location $worktreeDir
@@ -212,8 +215,20 @@ function Invoke-CargoDelta {
             } finally {
                 Pop-Location
             }
+        } catch {
+            $analysisError = $_
+            throw
         } finally {
-            git worktree remove $worktreeDir --force | Out-Null
+            # Cleanup must not hide the analysis failure that prompted it.
+            # See docs/cargo-delta.md, "Baseline worktree lifetime".
+            try {
+                git worktree remove $worktreeDir --force | Out-Null
+            } catch {
+                if ($null -eq $analysisError) { throw }
+                throw [AggregateException]::new(
+                    "Delta baseline analysis and cleanup of '$worktreeDir' both failed.",
+                    [Exception[]] @($analysisError.Exception, $_.Exception))
+            }
         }
 
         Write-Host 'Computing delta...'


### PR DESCRIPTION
[Copilot speaking]

A baseline analysis failure must remain diagnosable even when removing its temporary worktree also fails. Cargo-delta retains both original exceptions in an aggregate exception, with the analysis failure first.

Analysis-only and cleanup-only failures propagate unchanged, and worktree removal is attempted only after successful creation. Deterministic command-failure coverage protects these paths without relying on filesystem locks or timing.

## Version/release plan

No released-content or version changes. This change affects repository automation and its documentation only.

Fixes #548