### PR TITLE
CI: enable nightly deep validation and failure reporting

### DIFF
--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -65,10 +65,11 @@ Hosted checks and reporting can operate without Local automation. Disabling sche
 execution does not alter the local recipes or insert deep checks into ordinary CI;
 it leaves automatic recurring deep coverage disabled.
 
-Installation is not authorization to run or publish. Safe defaults leave hosted execution and
-reporting disabled. Local triage is not dispatched and new repair admission is rejected.
-The operator approves enrollment, scope and operating settings; installing or reconciling
-either automation does not activate them.
+The reviewed policy authorizes nightly full checks and failure reporting independently of
+Local readiness. Hosted reporting creates missing reporting labels when publishing, retaining
+operator-managed metadata on existing labels. Local triage is not dispatched and new repair
+admission is rejected; operators handle failure intake manually. Installing or reconciling
+a Local automation does not activate it or change hosted authorization.
 
 Manual **Run workflow** requests authorize fresh checks independently of automatic
 execution or AI repair settings. Targeted checks accept workspace crates rather than
@@ -85,6 +86,10 @@ workflow or an empty defect list. Compatible full successes can be reused for un
 within the reviewed maximum age. A skip preserves the age of that success; a newer failed or
 incomplete attempt invalidates it. Setup failures are execution problems, not a defect in each
 package that setup prevented from running.
+Missing initial coverage remains unavailable, not a passing baseline. Nightly planning
+freshness belongs to automatic full checks; unrelated selected plans cannot refresh it.
+An intentionally inactive, unenrolled Local executor is not an expected hosted-health component,
+while enrolled executors still require fresh successful heartbeats.
 Actual Actions jobs and steps are inventoried independently of checker artifacts.
 Failed jobs retain bounded log excerpts, original-log references and explicit
 capture gaps. Run evidence is paginated into durable issue comments rather than

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -300,6 +300,15 @@ before any checker result exists. Both reporting utilities are built from the
 trusted controller with its pinned toolchain and separate per-platform target
 directories, never from a candidate checkout or artifact.
 
+The per-run publication journal also fences creation of the shared coverage issue.
+Its `coverage_creation` intent is persisted after label bootstrap but before the
+issue POST, even when clean run intake itself remains in `prepared` state.
+An uncertain create is reconciled by its returned issue number when available, or
+by the unique reporter-owned coverage record. Without a confirmed matching record,
+the reporter retains the fence instead of posting a duplicate. A fresh reporter
+attempt restores this same journal; repeating run intake preserves the coverage
+intent. Unique label names remain independently retryable before this issue fence.
+
 #### Run-level failure intake
 
 Inventory actual Actions jobs and steps as well as the declared manifest: failed checkout,

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -195,6 +195,23 @@ those observations, and skipped work does not refresh the coverage timestamp.
 Manual diagnostic attempts are excluded from this reuse decision; they cannot
 invalidate automatic coverage even while their reporting is pending.
 
+### Reporting label bootstrap
+
+The issue-write adapters establish only the labels required by the publication they are
+about to perform: `scheduled-run-failure` for new run intake, `scheduled-coverage` and
+`scheduled-health` for the shared coverage issue. Both `-Apply` and
+`rollout.reporting_enabled` must authorize writes before any label lookup or creation.
+The existing reporter `issues: write` permission covers this boundary. Manual diagnostics
+never access repair or shared coverage records merely to establish their run-intake label.
+
+Paginated lookup preserves existing label spelling, color and description. Before a
+missing-label POST, the reporter persists intent in `label-<name>.json` in its report
+artifact. A read of that unique name confirms creation even after a raced or lost POST
+response; it never overwrites operator metadata. An unsuccessful confirming read fails
+publication explicitly. GitHub's unique label names permit lookup-based recovery without
+restoring this label journal as a precondition, unlike uncertain issue/page writes.
+PowerShell owns these GitHub/process operations; structured run evidence remains in Rust.
+
 ### Manual checks
 
 The planner recognizes manual requests by GitHub's `workflow_dispatch` event.
@@ -456,7 +473,6 @@ The serialized names are compatibility details. Their mapping to operating behav
 | `rollout.reporting_enabled` | Authorizes the reporter's issue writes independently of execution and local admission. |
 | `rollout.prerequisites.execution_canary`, `reporting_canary`, `native_app_canary` | Recorded operator verification of execution, reporting and actual native App capabilities. |
 | `rollout.prerequisites.benchmark_exclusion`, `azure_policy` | Recorded authorization and installation of managed-publication credential safeguards. |
-| `rollout.phase` | Descriptive compatibility metadata, not authorization to execute, report or admit work. |
 | `local.mode` | Repair admission selection: `observe` and `paused` do not dispatch repairs; `repair` also requires matching persisted executor mode, enrollment, approved scope, profile and budgets. It does not authorize triage. |
 | Planning reason or health status `staged` | Deliberately disabled hosted operation, not proof of coverage. |
 
@@ -466,10 +482,12 @@ profile, and distinguish disabled/observe/paused behavior from active admission.
 The new-admission capability boundary is not a policy switch: enabling any of those
 settings cannot bypass the unavailable AI-triage handoff.
 
-Safe installation defaults disable hosted execution/reporting and both Local roles,
-and leave repair allowlists unconfigured. Disabled hosted execution means automatic
-recurring deep coverage is off; it is not proof that PR validation covers it.
-Setup preserves those settings.
+The checked-in policy enables hosted execution and reporting, keeps Local in `observe`
+without enrollment, and leaves repair allowlists unconfigured. Recorded canary and
+publication-safeguard assertions remain false; they are not prerequisites for hosted
+checks or run intake. Local setup preserves these independent settings. Explicitly disabling
+hosted execution turns off automatic recurring coverage; it is not proof that ordinary
+PR validation covers it.
 Manual **Run workflow** requests run fresh checks without changing recurring
 authorization or requiring repair package approval. Their diagnostics are separate
 from main coverage and repair confirmation. Issue reporting remains independently
@@ -495,8 +513,14 @@ coverage and separate triage/repair availability. They distinguish fresh evidenc
 scan, deliberately disabled/paused operation and unavailable systems. No component claims to
 monitor its own total outage; the operator runbook is in the
 [deep validation chapter](../../docs/scheduled-validation.md#health-recovery-and-rollback).
-The reporter retains the actual validated planning timestamp rather than substituting run
-completion time. Hosted health uses read-only permissions and persists its component report as
+The reporter retains the actual validated planning timestamp for automatic Full deep validation,
+rather than substituting run completion time or advancing it from Selected deep validation.
+Only the full workflow's planning identity is accepted by hosted and Local health readers.
+An unenrolled Local executor in observe/paused mode has disabled health, with no requirement
+to discover a Local health comment. Enrollment or repair mode makes its heartbeat expected;
+stale or failed observations remain unhealthy even when admissions are paused.
+Missing baseline coverage remains unavailable and does not prevent observing reporter failures.
+Hosted health uses read-only permissions and persists its component report as
 an artifact and step summary before signaling failure. The shared coverage/health issue contains
 separate hosted coverage and role-specific personal executor health records. Triage health
 tracks unprocessed run evidence and completed analysis; repair health tracks actionable

--- a/.github/workflows/scheduled-report.yml
+++ b/.github/workflows/scheduled-report.yml
@@ -52,10 +52,11 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           Import-Module ./scripts/setup/RustToolchain.psm1 -Force
           Install-RustupToolchain -Channel (Get-PinnedRustChannel) -InstallProfile minimal
-      - name: Collect results and report automatic runs under reviewed policy
+      - name: Collect results and publish authorized run intake
         # The reporting switch authorizes writes independently of execution and Local admission.
         # Downloaded replay evidence remains data and cannot select controller code or policy.
-        # Manual requests retain artifacts by default; authorized writes target run intake only.
+        # Authorized manual failures publish run intake only, never coverage or repair state.
+        # Required labels are bootstrapped under the same issue-write authorization.
         # Ref: .github/workflows/implementation.md#serialized-reporting.
         # Ref: .github/workflows/implementation.md#operating-policy.
         shell: pwsh

--- a/docs/scheduled-validation.md
+++ b/docs/scheduled-validation.md
@@ -815,6 +815,12 @@ publication. Pending issue/page writes are reconciled against GitHub rather than
 blindly repeated. Missing recovery artifacts or an unresolved write with no visible
 result block the rerun and require operator reconciliation; deleting the journal
 is not a retry mechanism.
+The same journal carries shared coverage-issue creation separately from run intake.
+A clean run's `prepared` intake state does not authorize repeating an uncertain
+coverage POST. Recovery reads the known issue number, or searches for the owned
+coverage record, and requires matching persisted evidence. If that outcome remains
+unknown, retain the journal and reconcile the issue before retrying; do not create
+a replacement coverage issue.
 An incomplete report can have partial side effects: `writes_authorized` records
 whether writes were permitted, while `applied` becomes true only when reconciliation
 finishes. The journal and actual GitHub state determine recovery, not `applied: false`.

--- a/docs/scheduled-validation.md
+++ b/docs/scheduled-validation.md
@@ -44,6 +44,27 @@ for mutation quality and reviewed skip criteria. The shared versioned contracts 
 reviewed defaults live under `scripts/scheduled/`; policy is not inferred from App UI
 state.
 
+## Nightly operation
+
+The reviewed policy enables hosted execution and issue reporting. Once merged into
+`main`, **Full deep validation** plans the complete Miri, many-seed Miri, mutation-testing
+and careful-checking suite daily at **02:41 UTC**. Compatible complete successes for
+unchanged source can be reused for up to seven days; skipped checks never renew
+that evidence's age. Missing baseline coverage remains explicitly unavailable until
+an automatic full run supplies complete successful evidence.
+
+Failures produce **Deep validation failed** issues with durable run evidence.
+Until AI triage is implemented, the operator reads these issues, diagnoses failures
+and handles any corrections manually. No Local installation or per-checker manual
+pilot is required for hosted operation. Local mode remains `observe`, with no enrolled
+executor or active new-repair admission; the App's saved automation is not enabled.
+The recorded pilot assertions remain separate from hosted authorization and do not
+claim execution, reporting or native-App capabilities have been proved.
+
+Required reporting labels are created automatically when an authorized reporter
+first needs them. Existing label metadata is preserved. There is no manual label
+setup step, additional permission, or dependency on the Local App.
+
 ## Running checks manually
 
 The workflow names describe their scope. **Standard validation** handles ordinary
@@ -91,15 +112,15 @@ To run the entire deep suite on main, select **Full deep validation**, keep
 additional permission checkbox or cache override.
 
 Manual runs do not update shared main coverage or confirm or close repair issues.
-With the checked-in defaults, **Scheduled reporting** retains `report.json` and
-downloaded evidence in its report artifact without reading or writing issues.
+With the checked-in reporting authorization, **Scheduled reporting** can create
+run-level intake issues for manual failures as well as automatic failures.
+It also retains `report.json` and downloaded evidence in its report artifact.
 Failed checks remain failed in the originating run; missing or invalid evidence
-also fails the report. When an operator separately enables
-`rollout.reporting_enabled` in `scripts/scheduled/policy.json`, the reporter's
-existing `-Apply` invocation also permits run-level failure intake for manual
-results. This supports on-demand reporting without waiting for the timer, but
-still cannot change repair issues or shared coverage. Neither running a check nor
-reporting its failure authorizes AI repairs.
+remains explicit. If reporting authorization is disabled, or the reporter is
+invoked without `-Apply`, manual diagnostics retain artifacts without reading or
+writing issues or labels. Authorized manual publication bootstraps only its
+run-intake label, not shared coverage or Local health records. Neither running a
+check nor reporting its failure authorizes AI repairs.
 
 ## Problems and triage
 
@@ -323,10 +344,10 @@ Managed repair PRs additionally run the relevant deep checks needed to prove the
 
 Hosted execution, issue reporting, Local triage and repair admission are independently
 authorized. Hosted checks and reporting can run with both Local roles disabled.
-Safe installation defaults disable hosted execution/reporting, leave both Local
-roles disabled and repair allowlists unconfigured. Disabled scheduled execution
+The reviewed defaults enable hosted execution/reporting, leave Local roles
+inactive and repair allowlists unconfigured. Explicitly disabled scheduled execution
 means no automatic recurring deep coverage; it does not move deep checks into PR
-validation. Installation or profile reconciliation does not activate anything. The
+validation. Local installation or profile reconciliation does not change authorization. The
 [operating policy](../.github/workflows/implementation.md#operating-policy)
 defines the exact configuration mapping and readiness requirements.
 
@@ -733,12 +754,19 @@ The local executor's separate health record identifies triage and repair compone
 by role as well as repository name, numeric ID and executor ID. An absent/duplicate issue or
 ambiguous comment ownership blocks registration rather than creating a replacement.
 That issue's reporter-owned `coverage` record exposes
-`last_plan.planned_at` separately from `receipt.completed_at`. Successful skips may
-advance planning history but never renew full-success age.
+`last_plan.planned_at` separately from `receipt.completed_at`. Only automatic
+**Full deep validation** plans advance this planning history. Successful full-scope
+reuse may advance planning history but never renew full-success age; selected
+confirmation plans on main pushes and manual diagnostics cannot conceal a stopped
+nightly schedule.
 Hosted planning freshness uses `coverage.expected_plan_gap_hours`, not the local
 polling cadence. Deliberately disabled hosted operation is reported separately from
 an enabled scheduler that has stopped producing plans. Disabled operation does not
 establish recent coverage.
+An unenrolled Local executor in `observe` or `paused` mode is shown as **disabled**,
+not as a hosted failure. An enrolled executor still owes a current successful
+heartbeat, including while admissions are paused. Disabled Local operation never
+makes absent baseline coverage, stale hosted planning or failed reporting healthy.
 
 | Condition | Recovery |
 |---|---|
@@ -790,6 +818,11 @@ is not a retry mechanism.
 An incomplete report can have partial side effects: `writes_authorized` records
 whether writes were permitted, while `applied` becomes true only when reconciliation
 finishes. The journal and actual GitHub state determine recovery, not `applied: false`.
+Label creation has its own `label-<name>.json` intent journal in the report artifact.
+A lost or raced create response is reconciled by reading the unique label name;
+the reporter never overwrites existing metadata or assumes a failed API call succeeded.
+Label names are unique on GitHub, so retries can look up that identity without
+requiring a Local registration or repeating an uncertain issue creation.
 
 Confirm that the new attempt completes successfully and that its expected
 run-intake/coverage updates and reporting health are reconciled. Until then, retain

--- a/scripts/scheduled/Invoke-ScheduledHealth.ps1
+++ b/scripts/scheduled/Invoke-ScheduledHealth.ps1
@@ -6,7 +6,7 @@ Publishes the executor's rolling health surface for `scheduled-health.yml`.
 Reads the reporter-owned coverage/health issue and recent workflow runs through
 `Get-ScheduledGitHubHealth` (ScheduledGitHub.psm1) and reports a single combined status so an
 operator (or the same `scheduled-intake` skill) can distinguish "healthy", "staged" (hosted
-execution/reporting deliberately disabled while local admission proceeds) and genuine failure
+execution/reporting deliberately disabled), inactive Local operation and genuine failure
 without inferring it from silence. The component table is duplicated into the job's
 `GITHUB_STEP_SUMMARY` purely for human visibility in the Actions UI; the authoritative JSON is
 `health.json` in `-OutputDirectory`. A non-healthy, non-staged status fails the job so a broken

--- a/scripts/scheduled/LocalInbox.Tests.ps1
+++ b/scripts/scheduled/LocalInbox.Tests.ps1
@@ -205,7 +205,8 @@ Describe 'GitHub pagination and validated intake' {
             $result.deferred.issue_number | Should -Be 1
             $result.eligible.Count | Should -Be 0
             $result.blocked_conditions | Should -Contain ai-triage-unavailable
-            $result.blocked_conditions | Should -Contain hosted-staged
+            $result.blocked_conditions | Should -Contain github-schedule-disabled
+            $result.blocked_conditions | Should -Contain hosted-planning-evidence-missing
             $result.blocked_conditions | Should -Contain missing-or-invalid-evidence
             Should -Invoke Invoke-ScheduledApi -Exactly 1 -ParameterFilter {
                 $Endpoint -eq 'repos/folo-rs/folo/actions/runs/17/attempts/1'
@@ -221,14 +222,20 @@ Describe 'GitHub pagination and validated intake' {
                 -StateRoot $script:fixtureRoot } | Should -Throw
         }
     }
-    It 'preserves hosted coverage health independently of unavailable repair admission' {
+    It 'accepts only full hosted planning independently of unavailable repair admission' -TestCases @(
+        @{ Workflow = 'full-deep-validation.yml'; Accepted = $true }
+        @{ Workflow = 'selected-deep-validation.yml'; Accepted = $false }
+    ) {
+        param($Workflow, $Accepted)
         $policyPath = Join-Path $TestDrive 'coverage-policy.json'
         $policy = Get-ScheduledPolicy
         $policy.rollout.hosted_execution_enabled = $true
         $policy | ConvertTo-Json -Depth 40 | Set-Content -LiteralPath $policyPath
         InModuleScope LocalInbox -Parameters @{
             FixtureRoot = (Join-Path $TestDrive 'state'); PolicyPath = $policyPath
+            Workflow = $Workflow; Accepted = $Accepted
         } {
+            $script:planningWorkflow = $Workflow
             Mock Invoke-ScheduledLocalAction {
                 return @{ attempts = @{}; mode = 'observe'; executor_id = 'machine'; profile = $null }
             }
@@ -238,7 +245,10 @@ Describe 'GitHub pagination and validated intake' {
                     return ,@(@{ number = 5; user = @{ login = 'github-actions[bot]' }; body = (
                         Write-ScheduledRecord -Kind coverage -Record @{
                             schema_version = 1; repository = 'folo-rs/folo'; repository_id = 850321188
-                            last_plan = @{ planned_at = '2026-09-08T11:00:00Z'; source_sha = ('a' * 40) }
+                            last_plan = @{
+                                planned_at = '2026-09-08T11:00:00Z'; source_sha = ('a' * 40)
+                                workflow_path = ".github/workflows/$script:planningWorkflow"
+                            }
                         }) })
                 }
                 return ,@()
@@ -256,9 +266,14 @@ Describe 'GitHub pagination and validated intake' {
                 -StateRoot $FixtureRoot -PolicyPath $PolicyPath
             $result.successful_scan | Should -BeTrue
             $result.hosted_schedule_enabled | Should -BeTrue
-            [DateTimeOffset]$result.last_hosted_plan.planned_at | Should -Be ([DateTimeOffset]'2026-09-08T11:00:00Z')
+            if ($Accepted) {
+                [DateTimeOffset]$result.last_hosted_plan.planned_at | Should -Be ([DateTimeOffset]'2026-09-08T11:00:00Z')
+                @($result.blocked_conditions | Where-Object { $_.StartsWith('hosted-') }).Count | Should -Be 0
+            } else {
+                $result.last_hosted_plan | Should -BeNullOrEmpty
+                $result.blocked_conditions | Should -Contain hosted-planning-evidence-invalid
+            }
             $result.blocked_conditions | Should -Contain ai-triage-unavailable
-            @($result.blocked_conditions | Where-Object { $_.StartsWith('hosted-') }).Count | Should -Be 0
         }
     }
     It 'fails explicitly on authentication and never records successful scan output' {

--- a/scripts/scheduled/LocalInbox.psm1
+++ b/scripts/scheduled/LocalInbox.psm1
@@ -143,7 +143,8 @@ function Invoke-ScheduledInbox {
             $coverage = Read-ScheduledRecord -Text $coverageOwners[0].body -Kind coverage
             if ($coverage.repository -cne $policy.repository -or
                 $coverage.repository_id -ne $policy.repository_id -or
-                -not $coverage.Contains('last_plan') -or $null -eq $coverage.last_plan) {
+                -not $coverage.Contains('last_plan') -or $null -eq $coverage.last_plan -or
+                $coverage.last_plan['workflow_path'] -cne '.github/workflows/full-deep-validation.yml') {
                 throw [FormatException]::new('Missing authoritative hosted planning identity.')
             }
             $null = [DateTimeOffset]$coverage.last_plan.planned_at

--- a/scripts/scheduled/ScheduledContracts.Tests.ps1
+++ b/scripts/scheduled/ScheduledContracts.Tests.ps1
@@ -59,12 +59,17 @@ Describe 'Scheduled records' {
         $canonical.Count | Should -Be $values.Count
         @($canonical | ForEach-Object { $_.z }) | Should -Be (1..4096)
     }
-    It 'keeps hosted execution reporting and Local admission disabled in staged policy' {
+    It 'enables hosted execution and reporting without claiming Local readiness' {
         $policy = Get-ScheduledPolicy
-        $policy.rollout.hosted_execution_enabled | Should -BeFalse
-        $policy.rollout.reporting_enabled | Should -BeFalse
+        $policy.rollout.hosted_execution_enabled | Should -BeTrue
+        $policy.rollout.reporting_enabled | Should -BeTrue
+        $policy.rollout.ContainsKey('phase') | Should -BeFalse
+        @($policy.rollout.prerequisites.Values | Where-Object { $_ }).Count | Should -Be 0
         $policy.local.mode | Should -Be observe
         $policy.local.enrolled_machine_id | Should -BeNullOrEmpty
+        $policy.local.allowed_packages | Should -BeNullOrEmpty
+        $policy.local.allowed_checks | Should -BeNullOrEmpty
+        $policy.repair.allowed_packages | Should -BeNullOrEmpty
     }
     It 'validates hosted authorization switches independently' -TestCases @(
         @{ Execution = $false; Reporting = $false }

--- a/scripts/scheduled/ScheduledGitHub.Tests.ps1
+++ b/scripts/scheduled/ScheduledGitHub.Tests.ps1
@@ -369,7 +369,13 @@ Describe 'Archive extraction boundaries' {
                 Mock Get-ScheduledOwnedIssue { @() }
                 Mock Restore-ScheduledRunPublicationState {}
                 Mock Sync-ScheduledRunIntake {
-                    param($Run, $Plan, $Manifest, $Results, $Jobs, $EvidenceGaps, [switch] $Skipped)
+                    param($Policy, $Run, $Plan, $Manifest, $Results, $Jobs, $EvidenceGaps, $OutputDirectory,
+                        [switch] $Skipped, [switch] $Apply)
+                    if ($Apply) {
+                        Write-ScheduledRunJournal `
+                            -Path (Join-Path $OutputDirectory "publication-$($Policy.repository_id)-$($Run.workflow_id)-$($Run.id).json") `
+                            -Record @{ schema_version = 1; identity = @{ repository_id = $Policy.repository_id }; stage = 'prepared' }
+                    }
                     $script:capturedRunEvidence = @{
                         run = $Run; plan = $Plan; manifest = $Manifest; results = $Results
                         jobs = $Jobs; evidence_gaps = $EvidenceGaps
@@ -653,7 +659,14 @@ Describe 'Archive extraction boundaries' {
                 Mock Invoke-ScheduledGitHubApi {
                     @(@{ name = 'scheduled-coverage' }, @{ name = 'scheduled-health' })
                 } -ParameterFilter { $Endpoint -like '*/labels?*' }
-                Mock Invoke-ScheduledGitHubApi { @{ number = 42 } } -ParameterFilter { $Method -ceq 'POST' }
+                Mock Invoke-ScheduledGitHubApi {
+                    $script:createdCoverage = @{
+                        number = 42; user = @{ login = 'github-actions[bot]' }; body = $Body.body
+                    }
+                    @{ number = 42 }
+                } -ParameterFilter { $Method -ceq 'POST' }
+                Mock Invoke-ScheduledGitHubApi { $script:createdCoverage } `
+                    -ParameterFilter { $Endpoint -ceq 'repos/folo-rs/folo/issues/42' }
                 $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'report') -Apply
                 $report.problems | Should -BeNullOrEmpty
                 $report.applied | Should -BeTrue

--- a/scripts/scheduled/ScheduledGitHub.Tests.ps1
+++ b/scripts/scheduled/ScheduledGitHub.Tests.ps1
@@ -994,6 +994,29 @@ Describe 'Safe durable writes' {
                 $Method -ceq 'PATCH' -and $Body.body.Contains('Human before') -and $Body.body.EndsWith('Human after')
             }
         }
+        It 'does not require <ValueKind> bootstrap context when updating an existing issue' -TestCases @(
+            @{ ValueKind = 'omitted' }, @{ ValueKind = 'empty' }, @{ ValueKind = 'whitespace' },
+            @{ ValueKind = 'missing-path' }
+        ) {
+            param($ValueKind)
+            $policy.rollout.reporting_enabled = $true
+            $record.extra = 'update'
+            $arguments = @{ Policy = $policy; Issue = $issue; Record = $record; Kind = 'coverage'; Apply = $true }
+            if ($ValueKind -ne 'omitted') {
+                $value = switch ($ValueKind) {
+                    empty { '' }
+                    whitespace { ' ' }
+                    missing-path { Join-Path $TestDrive 'not-needed' }
+                }
+                $arguments.OutputDirectory = $value
+                $arguments.PublicationJournalPath = $value
+            }
+            (Sync-ScheduledIssue @arguments).action | Should -Be PATCH
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Method -ceq 'PATCH' -and $Endpoint -ceq 'repos/folo-rs/folo/issues/1'
+            }
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -like '*/labels*' }
+        }
         It 'refuses concurrent record changes without losing a human body edit' {
             $live = $issue.Clone()
             $live.body = Write-ScheduledRecord @{ schema_version = 1; different = $true } coverage

--- a/scripts/scheduled/ScheduledGitHub.Tests.ps1
+++ b/scripts/scheduled/ScheduledGitHub.Tests.ps1
@@ -445,10 +445,11 @@ Describe 'Archive extraction boundaries' {
                 Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Method -in @('POST', 'PATCH') }
                 Test-Path -LiteralPath (Join-Path $caseRoot 'report\report.json') | Should -BeTrue
             }
-            Describe 'Manual diagnostics with the checked-in policy' {
+            Describe 'Manual diagnostics with explicit disabled reporting' {
                 BeforeEach {
                     $script:apiPolicy = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'policy.json') -Raw |
                         ConvertFrom-Json -AsHashtable
+                    $apiPolicy.rollout.reporting_enabled = $false
                     $apiRun.name = 'Selected deep validation'
                     $apiRun.path = '.github/workflows/selected-deep-validation.yml'
                     $apiRun.event = 'workflow_dispatch'
@@ -521,8 +522,9 @@ Describe 'Archive extraction boundaries' {
                     Should -Invoke Sync-ScheduledRunIntake -Times 0
                 }
 
-                It 'keeps on-demand run intake available only with separately authorized writes' {
-                    $apiPolicy.rollout.reporting_enabled = $true
+                It 'allows manual run intake with checked-in hosted defaults but no repair or coverage access' {
+                    $script:apiPolicy = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'policy.json') -Raw |
+                        ConvertFrom-Json -AsHashtable
                     Mock Assert-ScheduledWriteController {}
                     Mock Get-ScheduledArtifact { throw [IO.IOException]::new('Missing check artifact.') } `
                         -ParameterFilter { $Name -like 'scheduled-result-*' }
@@ -648,6 +650,9 @@ Describe 'Archive extraction boundaries' {
             It 'routes enabled reporting without requiring hosted execution or the native App pilot' {
                 $apiPolicy.rollout.reporting_enabled = $true
                 Mock Assert-ScheduledWriteController {}
+                Mock Invoke-ScheduledGitHubApi {
+                    @(@{ name = 'scheduled-coverage' }, @{ name = 'scheduled-health' })
+                } -ParameterFilter { $Endpoint -like '*/labels?*' }
                 Mock Invoke-ScheduledGitHubApi { @{ number = 42 } } -ParameterFilter { $Method -ceq 'POST' }
                 $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'report') -Apply
                 $report.problems | Should -BeNullOrEmpty
@@ -692,6 +697,14 @@ Describe 'Archive extraction boundaries' {
                 Mock Invoke-ScheduledGitHubApi { $existingCoverage } -ParameterFilter { $Endpoint -ceq 'repos/folo-rs/folo/issues/99' }
                 $apiRun.name = 'Selected deep validation'; $apiRun.path = '.github/workflows/selected-deep-validation.yml'
                 $apiRun.event = 'push'; $apiPolicy.repair.allowed_packages = @()
+                $apiRun.workflow_id = 200
+                $apiRun.created_at = '2026-09-10T09:00:00Z'
+                $apiRun.run_started_at = '2026-09-10T10:00:00Z'
+                $apiRun.updated_at = '2026-09-10T12:00:00Z'
+                $apiPlan.planned_at = '2026-09-10T10:01:00Z'
+                Mock Invoke-ScheduledGitHubApi {
+                    @{ id = 200; name = 'Selected deep validation'; path = '.github/workflows/selected-deep-validation.yml' }
+                } -ParameterFilter { $Endpoint -like '*/actions/workflows/200' }
                 @{
                     action = 'completed'; workflow_run = $apiRun
                     repository = @{ id = 850321188; full_name = 'folo-rs/folo'; default_branch = 'main' }
@@ -706,8 +719,33 @@ Describe 'Archive extraction boundaries' {
                     $report.status | Should -Be not-run
                     $report.coverage.invalidation | Should -BeNullOrEmpty
                     (Get-ScheduledDigest $report.coverage.receipt) | Should -BeExactly (Get-ScheduledDigest $initial.coverage.receipt)
+                    $persisted = Read-ScheduledRecord $existingCoverage.body coverage
+                    (Get-ScheduledDigest $report.coverage.last_plan) | Should -BeExactly (Get-ScheduledDigest $persisted.last_plan)
+                    (Get-ScheduledDigest $report.coverage.planning) | Should -BeExactly (Get-ScheduledDigest $persisted.planning)
+                    $health = Get-ScheduledHealth -Coverage $report.coverage -Manifest $expectedManifest `
+                        -Planning $report.coverage.planning -Now ([datetimeoffset]$apiRun.updated_at) -LocalDisabled
+                    $health.components.planning.status | Should -Be unavailable
+                    $health.components.coverage.status | Should -Be fresh
                 }
                 Should -Invoke Get-ScheduledCheckResult -Times 32
+            }
+            It 'replaces a selected planning checkpoint with a full-workflow checkpoint' {
+                $initial = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'initial-full')
+                $initial.coverage.last_plan.workflow_path = '.github/workflows/selected-deep-validation.yml'
+                $initial.coverage.last_plan.workflow_id = 200
+                $initial.coverage.last_plan.created_at = '2026-09-10T10:00:00Z'
+                $initial.coverage.last_plan.planned_at = '2026-09-10T11:00:00Z'
+                $script:existingCoverage = @{
+                    number = 99; state = 'open'; user = @{ login = 'github-actions[bot]' }
+                    body = Write-ScheduledRecord $initial.coverage coverage
+                }
+                Mock Get-ScheduledOwnedIssue { @($existingCoverage) } -ParameterFilter { $Label -ceq 'scheduled-coverage' }
+                Mock Invoke-ScheduledGitHubApi { $existingCoverage } -ParameterFilter { $Endpoint -ceq 'repos/folo-rs/folo/issues/99' }
+                $report = Invoke-ScheduledReporting 'folo-rs/folo' $eventFile (Join-Path $caseRoot 'full')
+                $report.status | Should -Be passed
+                $report.coverage.last_plan.workflow_path | Should -BeExactly '.github/workflows/full-deep-validation.yml'
+                $report.coverage.last_plan.workflow_id | Should -Be 100
+                [datetimeoffset]$report.coverage.last_plan.planned_at | Should -Be ([datetimeoffset]$apiPlan.planned_at)
             }
             It 'retains run evidence and coverage when an existing repair confirmation is stale' {
                 $script:staleIssue = @{
@@ -1171,7 +1209,7 @@ Describe 'Read-only health adapter' {
                 repository = 'folo-rs/folo'; repository_id = 850321188
                 worker_login = 'sandersaares'; reporter_login = 'github-actions[bot]'
                 coverage = @{ expected_plan_gap_hours = 30; max_age_days = 7 }
-                local = @{ expected_poll_gap_minutes = 420; enrolled_machine_id = 'executor' }
+                local = @{ expected_poll_gap_minutes = 420; enrolled_machine_id = 'executor'; mode = 'observe' }
             }
             $manifest = Get-ScheduledCheckManifest -SourceSha ('a' * 40) -ControllerSha ('a' * 40) -ContractDigest ('c' * 64)
             $context = @{
@@ -1190,6 +1228,8 @@ Describe 'Read-only health adapter' {
                 -Context $context -IsAncestor { param($old, $new) $old -ceq $new }
             $healthCoverage.repository_id = 850321188
             $healthCoverage.planning = @{ outcome = 'not-run-unchanged'; completed_at = '2026-09-08T11:00:00Z' }
+            $healthCoverage.last_plan = $context.Clone()
+            $healthCoverage.last_plan.planned_at = $healthCoverage.planning.completed_at
             $healthCoverage.reporting = @{ outcome = 'passed'; completed_at = '2026-09-08T11:00:00Z' }
             $script:healthLocal = @{
                 schema_version = 1; repository = 'folo-rs/folo'; repository_id = 850321188; executor_id = 'executor'
@@ -1266,6 +1306,59 @@ Describe 'Read-only health adapter' {
             $health.components.reporting.status | Should -Be failed
             $health.healthy | Should -BeFalse
         }
+        It 'reports disabled Local health with the actual hosted-enabled defaults' {
+            $script:healthPolicy = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'policy.json') -Raw |
+                ConvertFrom-Json -AsHashtable
+            Mock Get-ScheduledOwnedIssue { throw 'Disabled Local operation must not require a health registration.' } `
+                -ParameterFilter { $Label -ceq 'scheduled-health' }
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.healthy | Should -BeTrue
+            $health.components.local_scan.status | Should -Be disabled
+            $health.components.coverage.status | Should -Be reused
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -like '*/comments*' }
+        }
+        It 'retains missing baseline and reporter failures while Local is deliberately off' {
+            $script:healthPolicy = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'policy.json') -Raw |
+                ConvertFrom-Json -AsHashtable
+            Mock Get-ScheduledOwnedIssue { @() } -ParameterFilter { $Label -ceq 'scheduled-coverage' }
+            Mock Invoke-ScheduledGitHubApi {
+                @{ workflow_runs = @(@{
+                    id = 13; run_attempt = 1; conclusion = 'failure'; updated_at = '2026-09-08T11:00:00Z'
+                }) }
+            } -ParameterFilter { $Endpoint -like '*/scheduled-report.yml/runs?*per_page=1' }
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.healthy | Should -BeFalse
+            $health.components.local_scan.status | Should -Be disabled
+            $health.components.coverage.status | Should -Be unavailable
+            $health.components.planning.status | Should -Be unavailable
+            $health.components.reporting.status | Should -Be failed
+        }
+        It 'does not accept selected-workflow activity as nightly planning freshness' {
+            $healthCoverage.last_plan.workflow_path = '.github/workflows/selected-deep-validation.yml'
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.healthy | Should -BeFalse
+            $health.components.planning.status | Should -Be unavailable
+        }
+        It 'reports a foreign coverage index rather than trusting its planning or receipt' {
+            $healthCoverage.repository_id = 123
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.status | Should -Be failed
+            $health.problems | Should -Not -BeNullOrEmpty
+        }
+        It 'requires an enrolled executor heartbeat even in <Mode> mode' -TestCases @(
+            @{ Mode = 'observe' }, @{ Mode = 'paused' }, @{ Mode = 'repair' }
+        ) {
+            param($Mode)
+            $healthPolicy.local.mode = $Mode
+            $healthLocal.last_successful_scan = '2026-09-01T11:00:00Z'
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.components.local_scan.status | Should -Be unavailable
+            $health.healthy | Should -BeFalse
+            $healthLocal.last_successful_scan = '2026-09-08T11:00:00Z'
+            $healthLocal.blocked_conditions = @('failed-scan')
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.components.local_scan.status | Should -Be failed
+        }
         It 'keeps cancelled and failed reporting origins visible after a later successful run' {
             Mock Invoke-ScheduledGitHubApi {
                 @(@{ total_count = 1; workflow_runs = @(@{
@@ -1313,6 +1406,20 @@ Describe 'Read-only health adapter' {
                 $health.problems.Count | Should -Be 1
             }
             Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Method -in @('POST', 'PATCH') }
+        }
+        It 'rejects a Local health surface that is not the coverage issue' {
+            Mock Get-ScheduledOwnedIssue { @(@{ number = 2; state = 'open' }) } `
+                -ParameterFilter { $Label -ceq 'scheduled-health' }
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.healthy | Should -BeFalse
+            $health.problems | Should -Not -BeNullOrEmpty
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -like '*/comments*' }
+        }
+        It 'does not confuse executor registration with a successful scan' {
+            $healthLocal.Remove('last_successful_scan')
+            $health = Get-ScheduledGitHubHealth 'folo-rs/folo' ([datetimeoffset]'2026-09-08T12:00:00Z')
+            $health.healthy | Should -BeFalse
+            $health.components.local_scan.status | Should -Be unavailable
         }
     }
 }

--- a/scripts/scheduled/ScheduledGitHub.psm1
+++ b/scripts/scheduled/ScheduledGitHub.psm1
@@ -377,6 +377,7 @@ function Sync-ScheduledIssue {
         [Parameter(Mandatory)][hashtable] $Record,
         [Parameter(Mandatory)][ValidateSet('reporter', 'coverage')][string] $Kind,
         [string] $OutputDirectory,
+        [string] $PublicationJournalPath,
         [switch] $Apply
     )
 
@@ -420,14 +421,55 @@ function Sync-ScheduledIssue {
     # below in this module.
     if ($Apply -and $Policy.rollout.reporting_enabled) {
         if ($null -eq $Issue) {
+            $journal = Get-Content -LiteralPath $PublicationJournalPath -Raw | ConvertFrom-Json -AsHashtable
+            if ($journal.schema_version -ne 1 -or $journal.identity.repository_id -ne $Policy.repository_id) {
+                throw [FormatException]::new('Coverage publication journal identity is invalid.')
+            }
             $api = {
                 param($Endpoint, $Method = 'GET', $Body, [switch] $Paginate)
                 Invoke-ScheduledGitHubApi -Endpoint $Endpoint -Method $Method -Body $Body -Paginate:$Paginate
             }
-            foreach ($label in $labels) {
-                Initialize-ScheduledReportingLabel -Policy $Policy -Name $label `
-                    -OutputDirectory $OutputDirectory -Api $api -Apply
+            $createdHere = -not $journal.ContainsKey('coverage_creation')
+            if ($createdHere) {
+                foreach ($label in $labels) {
+                    Initialize-ScheduledReportingLabel -Policy $Policy -Name $label `
+                        -OutputDirectory $OutputDirectory -Api $api -Apply
+                }
+                # Labels have unique names and can be retried. Issue creation does not: fence
+                # it in the same restored journal as run intake before sending its first POST.
+                # Ref: ../../.github/workflows/implementation.md#serialized-reporting.
+                $journal.coverage_creation = @{ issue_number = $null; stage = 'creating-issue' }
+                Write-ScheduledRunJournal -Path $PublicationJournalPath -Record $journal
+                try {
+                    $created = Invoke-ScheduledGitHubApi -Endpoint $endpoint -Method POST -Body $payload
+                    if ($created.number -le 0) { throw [FormatException]::new('Coverage issue response has no identity.') }
+                    $journal.coverage_creation.issue_number = $created.number
+                    Write-ScheduledRunJournal -Path $PublicationJournalPath -Record $journal
+                } catch [IO.IOException], [FormatException] {
+                    Write-Verbose 'Coverage issue creation response is uncertain; reconciling the owned issue before continuing.'
+                }
             }
+            $creation = $journal.coverage_creation
+            if ($creation.stage -cnotin @('creating-issue', 'complete')) {
+                throw [FormatException]::new('Coverage creation journal state is invalid.')
+            }
+            $coverageMatches = @(if ($null -ne $creation.issue_number) {
+                Invoke-ScheduledGitHubApi "repos/$($Policy.repository)/issues/$($creation.issue_number)"
+            } else { Get-ScheduledOwnedIssue -Policy $Policy -Label scheduled-coverage })
+            if ($coverageMatches.Count -ne 1) {
+                throw [IO.IOException]::new('Coverage issue creation remains unresolved; reconcile it before retrying. No further POST is permitted.')
+            }
+            $live = $coverageMatches[0]
+            $current = Read-ScheduledRecord -Text $live.body -Kind coverage
+            if ($live.user.login -cne $Policy.reporter_login -or
+                $current.repository -cne $Policy.repository -or $current.repository_id -ne $Policy.repository_id -or
+                (Get-ScheduledDigest $current) -cne (Get-ScheduledDigest (Read-ScheduledRecord $body coverage))) {
+                throw [FormatException]::new('Recovered coverage differs from the proposed record; replan using the current owned issue.')
+            }
+            $creation.stage = 'complete'
+            $creation.issue_number = $live.number
+            Write-ScheduledRunJournal -Path $PublicationJournalPath -Record $journal
+            return @{ action = if ($createdHere) { 'POST' } else { 'reconciled' }; number = $live.number }
         }
         $updated = Invoke-ScheduledGitHubApi -Endpoint $endpoint -Method $method -Body $payload
         return @{ action = $method; number = $updated.number }
@@ -750,7 +792,9 @@ function Invoke-ScheduledReporting {
             }
         }
         $report.actions += Sync-ScheduledIssue -Policy $policy -Issue $coverageIssue -Record $nextCoverage `
-            -Kind coverage -OutputDirectory $OutputDirectory -Apply:$applyWrites
+            -Kind coverage -OutputDirectory $OutputDirectory `
+            -PublicationJournalPath (Join-Path $OutputDirectory "publication-$($policy.repository_id)-$($run.workflow_id)-$($run.id).json") `
+            -Apply:$applyWrites
         $report.status = if ($intake.requires_triage) { 'reported' }
             elseif ($skipped) { 'not-run' } else { 'passed' }
         $report.applied = [bool]$applyWrites

--- a/scripts/scheduled/ScheduledGitHub.psm1
+++ b/scripts/scheduled/ScheduledGitHub.psm1
@@ -421,6 +421,15 @@ function Sync-ScheduledIssue {
     # below in this module.
     if ($Apply -and $Policy.rollout.reporting_enabled) {
         if ($null -eq $Issue) {
+            if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+                throw [ArgumentException]::new('Authorized new coverage publication requires OutputDirectory.', 'OutputDirectory')
+            }
+            if ([string]::IsNullOrWhiteSpace($PublicationJournalPath)) {
+                throw [ArgumentException]::new('Authorized new coverage publication requires PublicationJournalPath.', 'PublicationJournalPath')
+            }
+            if (-not (Test-Path -LiteralPath $PublicationJournalPath -PathType Leaf)) {
+                throw [IO.IOException]::new("Coverage publication journal is not an existing file: $PublicationJournalPath")
+            }
             $journal = Get-Content -LiteralPath $PublicationJournalPath -Raw | ConvertFrom-Json -AsHashtable
             if ($journal.schema_version -ne 1 -or $journal.identity.repository_id -ne $Policy.repository_id) {
                 throw [FormatException]::new('Coverage publication journal identity is invalid.')

--- a/scripts/scheduled/ScheduledGitHub.psm1
+++ b/scripts/scheduled/ScheduledGitHub.psm1
@@ -376,6 +376,7 @@ function Sync-ScheduledIssue {
         [AllowNull()][hashtable] $Issue,
         [Parameter(Mandatory)][hashtable] $Record,
         [Parameter(Mandatory)][ValidateSet('reporter', 'coverage')][string] $Kind,
+        [string] $OutputDirectory,
         [switch] $Apply
     )
 
@@ -418,6 +419,16 @@ function Sync-ScheduledIssue {
     # dry run regardless of `-Apply`, and the same rule gates the other reporting_enabled checks
     # below in this module.
     if ($Apply -and $Policy.rollout.reporting_enabled) {
+        if ($null -eq $Issue) {
+            $api = {
+                param($Endpoint, $Method = 'GET', $Body, [switch] $Paginate)
+                Invoke-ScheduledGitHubApi -Endpoint $Endpoint -Method $Method -Body $Body -Paginate:$Paginate
+            }
+            foreach ($label in $labels) {
+                Initialize-ScheduledReportingLabel -Policy $Policy -Name $label `
+                    -OutputDirectory $OutputDirectory -Api $api -Apply
+            }
+        }
         $updated = Invoke-ScheduledGitHubApi -Endpoint $endpoint -Method $method -Body $payload
         return @{ action = $method; number = $updated.number }
     }
@@ -710,7 +721,13 @@ function Invoke-ScheduledReporting {
         $nextCoverage = Merge-ScheduledCoverage -Coverage $coverage -Manifest $manifest -Results $results `
             -Context $context -IsAncestor $isAncestor -Skipped:$skipped
         $nextCoverage.repository_id = $policy.repository_id
-        if ($null -ne $validatedPlan -and (-not $nextCoverage.ContainsKey('last_plan') -or
+        # Only the recurring full workflow can renew scheduler freshness. Selected no-work
+        # plans on main pushes and manual diagnostics do not prove that the nightly timer runs.
+        # Ref: ../../.github/workflows/implementation.md#independent-health.
+        if ($scope -ceq 'full' -and $null -ne $validatedPlan -and
+            (-not $nextCoverage.ContainsKey('last_plan') -or
+            $null -eq $nextCoverage.last_plan -or
+            $nextCoverage.last_plan['workflow_path'] -cne '.github/workflows/full-deep-validation.yml' -or
             (Compare-ScheduledObservation $context $nextCoverage.last_plan) -gt 0)) {
             $nextCoverage.last_plan = $context.Clone()
             $nextCoverage.last_plan.planned_at = ([datetimeoffset]$validatedPlan.planned_at).ToString('o')
@@ -732,7 +749,8 @@ function Invoke-ScheduledReporting {
                 completed_at = $context.completed_at; run_id = $context.run_id; run_attempt = $context.run_attempt
             }
         }
-        $report.actions += Sync-ScheduledIssue -Policy $policy -Issue $coverageIssue -Record $nextCoverage -Kind coverage -Apply:$applyWrites
+        $report.actions += Sync-ScheduledIssue -Policy $policy -Issue $coverageIssue -Record $nextCoverage `
+            -Kind coverage -OutputDirectory $OutputDirectory -Apply:$applyWrites
         $report.status = if ($intake.requires_triage) { 'reported' }
             elseif ($skipped) { 'not-run' } else { 'passed' }
         $report.applied = [bool]$applyWrites
@@ -757,6 +775,11 @@ function Get-ScheduledGitHubHealth {
     if ($Repository -cne $policy.repository) { throw 'Repository differs from trusted policy.' }
     $staged = $policy.ContainsKey('rollout') -and
         $policy.rollout.hosted_execution_enabled -eq $false -and $policy.rollout.reporting_enabled -eq $false
+    # Enrollment means the executor owes a heartbeat even in observe/paused mode. Unenrolled
+    # inactive Local operation is not an expected service and must not fail hosted health.
+    # Ref: ../../.github/workflows/implementation.md#independent-health.
+    $localDisabled = [string]::IsNullOrWhiteSpace($policy.local.enrolled_machine_id) -and
+        $policy.local.mode -cin @('observe', 'paused')
     $scheduler = $null
     $coverage = $null
     $planning = $null
@@ -772,17 +795,24 @@ function Get-ScheduledGitHubHealth {
             -ContractDigest (Get-ScheduledContractDigest -Root $root)
         $issues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-coverage)
         if ($issues.Count -eq 0 -and $staged) {
-            $health = Get-ScheduledHealth -Scheduler $scheduler -Manifest $manifest -Now $Now -Staged
+            $health = Get-ScheduledHealth -Scheduler $scheduler -Manifest $manifest -Now $Now `
+                -Staged -LocalDisabled:$localDisabled
             $health.rollout = $policy.rollout
             $health.problems = @()
             return $health
         }
-        if ($issues.Count -ne 1) { throw [FormatException]::new('Coverage index is absent or ambiguous.') }
-        $coverage = Read-ScheduledRecord -Text $issues[0].body -Kind coverage
-        if ($coverage.repository -cne $Repository -or $coverage.repository_id -ne $policy.repository_id) {
-            throw [FormatException]::new('Coverage index repository differs from trusted policy.')
+        if ($issues.Count -gt 1) { throw [FormatException]::new('Coverage index is ambiguous.') }
+        if ($issues.Count -eq 1) {
+            $coverage = Read-ScheduledRecord -Text $issues[0].body -Kind coverage
+            if ($coverage.repository -cne $Repository -or $coverage.repository_id -ne $policy.repository_id) {
+                throw [FormatException]::new('Coverage index repository differs from trusted policy.')
+            }
+            if ($coverage.ContainsKey('planning') -and $coverage.ContainsKey('last_plan') -and
+                $null -ne $coverage.last_plan -and
+                $coverage.last_plan['workflow_path'] -ceq '.github/workflows/full-deep-validation.yml') {
+                $planning = $coverage.planning
+            }
         }
-        if ($coverage.ContainsKey('planning')) { $planning = $coverage.planning }
         # A reporter unable to write its durable state cannot record its own failure there.
         # Actions run metadata makes that failure visible without waiting for the receipt to age.
         $reportRuns = Invoke-ScheduledGitHubApi "repos/$Repository/actions/workflows/scheduled-report.yml/runs?branch=main&status=completed&per_page=1"
@@ -819,37 +849,40 @@ function Get-ScheduledGitHubHealth {
                 unresolved_runs = $unresolvedReports; latest_run = $reporting
             }
         }
-        $healthIssues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-health)
-        if ($healthIssues.Count -ne 1 -or $healthIssues[0].state -cne 'open') {
-            throw [FormatException]::new('The open reporter-owned health issue is absent or ambiguous.')
-        }
-        if ($healthIssues[0].number -ne $issues[0].number) {
-            throw [FormatException]::new('Coverage and executor health must share the registered issue.')
-        }
-        $pages = Invoke-ScheduledGitHubApi "repos/$Repository/issues/$($healthIssues[0].number)/comments?per_page=100" -Paginate
-        $healthComments = @($pages | ForEach-Object { $_ } | Where-Object {
-                $_.user.login -ceq $policy.worker_login -and ([string]$_.body).Contains('<!-- scheduled-health:')
-            })
-        if ($healthComments.Count -gt 1) { throw [FormatException]::new('Local health comment ownership is ambiguous.') }
-        if ($healthComments.Count -eq 1) {
-            $localRecord = Read-ScheduledRecord -Text $healthComments[0].body -Kind health
-            if ($localRecord.repository -ceq $Repository -and $localRecord.repository_id -eq $policy.repository_id -and
-                -not [string]::IsNullOrWhiteSpace($policy.local.enrolled_machine_id) -and
-                $localRecord.executor_id -ceq $policy.local.enrolled_machine_id) {
-                if ($localRecord.ContainsKey('last_successful_scan')) {
-                    $localScan = @{
-                        completed_at = $localRecord.last_successful_scan
-                        outcome = if ($localRecord.blocked_conditions.Count -gt 0) { 'failed' } else { 'passed' }
-                        details = $localRecord
-                    }
-                } else { $localScan = $localRecord }
+        if (-not $localDisabled) {
+            $healthIssues = @(Get-ScheduledOwnedIssue -Policy $policy -Label scheduled-health)
+            if ($healthIssues.Count -ne 1 -or $healthIssues[0].state -cne 'open') {
+                throw [FormatException]::new('The open reporter-owned health issue is absent or ambiguous.')
+            }
+            if ($issues.Count -ne 1 -or $healthIssues[0].number -ne $issues[0].number) {
+                throw [FormatException]::new('Coverage and executor health must share the registered issue.')
+            }
+            $pages = Invoke-ScheduledGitHubApi "repos/$Repository/issues/$($healthIssues[0].number)/comments?per_page=100" -Paginate
+            $healthComments = @($pages | ForEach-Object { $_ } | Where-Object {
+                    $_.user.login -ceq $policy.worker_login -and ([string]$_.body).Contains('<!-- scheduled-health:')
+                })
+            if ($healthComments.Count -gt 1) { throw [FormatException]::new('Local health comment ownership is ambiguous.') }
+            if ($healthComments.Count -eq 1) {
+                $localRecord = Read-ScheduledRecord -Text $healthComments[0].body -Kind health
+                if ($localRecord.repository -ceq $Repository -and $localRecord.repository_id -eq $policy.repository_id -and
+                    -not [string]::IsNullOrWhiteSpace($policy.local.enrolled_machine_id) -and
+                    $localRecord.executor_id -ceq $policy.local.enrolled_machine_id) {
+                    if ($localRecord.ContainsKey('last_successful_scan')) {
+                        $localScan = @{
+                            completed_at = $localRecord.last_successful_scan
+                            outcome = if ($localRecord.blocked_conditions.Count -gt 0) { 'failed' } else { 'passed' }
+                            details = $localRecord
+                        }
+                    } else { $localScan = $localRecord }
+                }
             }
         }
     } catch [FormatException], [ArgumentException], [IO.IOException] { $problems += $_.Exception.Message }
     $health = Get-ScheduledHealth -Scheduler $scheduler -Coverage $coverage -Manifest $manifest `
         -Planning $planning -Reporting $reporting -LocalScan $localScan -Now $Now `
         -ExpectedPlanGapHours $policy.coverage.expected_plan_gap_hours `
-        -ExpectedLocalGapMinutes $policy.local.expected_poll_gap_minutes -MaxAgeDays $policy.coverage.max_age_days -Staged:$staged
+        -ExpectedLocalGapMinutes $policy.local.expected_poll_gap_minutes -MaxAgeDays $policy.coverage.max_age_days `
+        -Staged:$staged -LocalDisabled:$localDisabled
     $health.problems = $problems
     if ($problems.Count -gt 0) { $health.status = 'failed'; $health.healthy = $false }
     if ($policy.ContainsKey('rollout')) { $health.rollout = $policy.rollout }

--- a/scripts/scheduled/ScheduledLabels.Tests.ps1
+++ b/scripts/scheduled/ScheduledLabels.Tests.ps1
@@ -191,6 +191,58 @@ Describe 'Coverage bootstrap at the actual issue-write boundary' {
             $journal.coverage_creation.stage | Should -Be complete
             $journal.coverage_creation.issue_number | Should -Be 42
         }
+        It 'rejects <ValueKind> <Name> before accessing GitHub for new authorized coverage' -TestCases @(
+            @{ Name = 'OutputDirectory'; ValueKind = 'omitted' }
+            @{ Name = 'OutputDirectory'; ValueKind = 'empty' }
+            @{ Name = 'OutputDirectory'; ValueKind = 'whitespace' }
+            @{ Name = 'PublicationJournalPath'; ValueKind = 'omitted' }
+            @{ Name = 'PublicationJournalPath'; ValueKind = 'empty' }
+            @{ Name = 'PublicationJournalPath'; ValueKind = 'whitespace' }
+        ) {
+            param($Name, $ValueKind)
+            $arguments = @{
+                Policy = $bootstrapPolicy; Issue = $null; Record = $record; Kind = 'coverage'
+                OutputDirectory = $TestDrive; PublicationJournalPath = $publicationPath; Apply = $true
+            }
+            switch ($ValueKind) {
+                omitted { $arguments.Remove($Name) }
+                empty { $arguments[$Name] = '' }
+                whitespace { $arguments[$Name] = ' ' }
+            }
+            $failure = { Sync-ScheduledIssue @arguments } |
+                Should -Throw -ExceptionType ([ArgumentException]) -PassThru
+            $failure.Exception.ParamName | Should -Be $Name
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0
+            $bootstrapWrites.Count | Should -Be 0
+        }
+        It 'does not require write context for new coverage with Apply=<Apply> and Reporting=<Reporting>' -TestCases @(
+            @{ Apply = $false; Reporting = $false }
+            @{ Apply = $false; Reporting = $true }
+            @{ Apply = $true; Reporting = $false }
+        ) {
+            param($Apply, $Reporting)
+            $bootstrapPolicy.rollout.reporting_enabled = $Reporting
+            $result = Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -Apply:$Apply
+            $result.action | Should -Be dry-run
+            $unusedPath = Join-Path $TestDrive 'not-needed'
+            (Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record -Kind coverage `
+                -OutputDirectory $unusedPath -PublicationJournalPath $unusedPath -Apply:$Apply).action |
+                Should -Be dry-run
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0
+        }
+        It 'rejects a <Kind> journal path with an IO error before reading it or accessing GitHub' -TestCases @(
+            @{ Kind = 'missing' }, @{ Kind = 'directory' }
+        ) {
+            param($Kind)
+            $path = if ($Kind -eq 'missing') { Join-Path $TestDrive 'missing-publication.json' } else { $TestDrive }
+            Mock Get-Content { throw 'Journal must not be read.' }
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record -Kind coverage `
+                -OutputDirectory $TestDrive -PublicationJournalPath $path -Apply } |
+                Should -Throw -ExceptionType ([IO.IOException])
+            Should -Invoke Get-Content -Times 0
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0
+        }
         It 'never attempts issue creation after label bootstrap fails' {
             $script:failLabelWrite = $true
             { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `

--- a/scripts/scheduled/ScheduledLabels.Tests.ps1
+++ b/scripts/scheduled/ScheduledLabels.Tests.ps1
@@ -120,13 +120,25 @@ Describe 'Coverage bootstrap at the actual issue-write boundary' {
     InModuleScope ScheduledGitHub {
         BeforeEach {
             $script:bootstrapPolicy = @{
-                repository = 'owner/repo'; reporter_login = 'github-actions[bot]'
+                repository = 'owner/repo'; repository_id = 123; reporter_login = 'github-actions[bot]'
                 rollout = @{ reporting_enabled = $true }
             }
             $script:bootstrapLabels = @{}
             $script:bootstrapWrites = [Collections.Generic.List[object]]::new()
             $script:failLabelWrite = $false
-            $script:record = @{ schema_version = 1; repository = 'owner/repo'; receipt = $null; invalidation = $null }
+            $script:loseCoverageReply = $false
+            $script:badCoverageNumber = $false
+            $script:hideCoverageIssue = $false
+            $script:coverageIssue = $null
+            $script:record = @{
+                schema_version = 1; repository = 'owner/repo'; repository_id = 123
+                receipt = $null; invalidation = $null
+            }
+            $script:publicationPath = Join-Path $TestDrive 'publication-123-456-789.json'
+            @{
+                schema_version = 1; identity = @{ repository_id = 123; workflow_id = 456; run_id = 789 }
+                stage = 'prepared'; issue_number = $null; pending_pages = @{}
+            } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $publicationPath
             Mock Invoke-ScheduledGitHubApi {
                 if ($Endpoint -eq 'repos/owner/repo/labels?per_page=100') {
                     return @($script:bootstrapLabels.Values)
@@ -139,12 +151,25 @@ Describe 'Coverage bootstrap at the actual issue-write boundary' {
                         return $Body
                     }
                     if ($Endpoint -eq 'repos/owner/repo/issues') {
+                        $intent = Get-Content -LiteralPath $publicationPath -Raw | ConvertFrom-Json -AsHashtable
+                        $intent.coverage_creation.stage | Should -Be creating-issue
                         foreach ($label in $Body.labels) {
                             if (-not $script:bootstrapLabels.ContainsKey($label)) { throw 'Required label is missing.' }
                         }
+                        $script:coverageIssue = @{
+                            number = 42; state = 'open'; user = @{ login = 'github-actions[bot]' }
+                            body = $Body.body
+                        }
+                        if ($script:loseCoverageReply) { throw [IO.IOException]::new('Lost coverage response.') }
+                        if ($script:badCoverageNumber) { return @{ number = 0 } }
                         return @{ number = 42 }
                     }
                 }
+                if ($Endpoint -eq 'repos/owner/repo/issues?labels=scheduled-coverage&state=all&per_page=100') {
+                    if ($script:hideCoverageIssue -or $null -eq $script:coverageIssue) { return @() }
+                    return @($script:coverageIssue)
+                }
+                if ($Endpoint -eq 'repos/owner/repo/issues/42') { return $script:coverageIssue }
                 if ($Endpoint -match '^repos/owner/repo/labels/(scheduled-[a-z-]+)$') {
                     if (-not $script:bootstrapLabels.ContainsKey($Matches[1])) { throw [IO.IOException]::new('Missing label.') }
                     return $script:bootstrapLabels[$Matches[1]]
@@ -154,7 +179,7 @@ Describe 'Coverage bootstrap at the actual issue-write boundary' {
         }
         It 'creates required coverage labels before the first issue without inventing a receipt' {
             $result = Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
-                -Kind coverage -OutputDirectory $TestDrive -Apply
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply
             $result.action | Should -Be POST
             $result.number | Should -Be 42
             @($bootstrapLabels.Keys | Sort-Object) | Should -Be @('scheduled-coverage', 'scheduled-health')
@@ -162,19 +187,138 @@ Describe 'Coverage bootstrap at the actual issue-write boundary' {
             $published = Read-ScheduledRecord -Text $bootstrapWrites[-1].body.body -Kind coverage
             $published.receipt | Should -BeNullOrEmpty
             $published.invalidation | Should -BeNullOrEmpty
+            $journal = Get-Content -LiteralPath $publicationPath -Raw | ConvertFrom-Json -AsHashtable
+            $journal.coverage_creation.stage | Should -Be complete
+            $journal.coverage_creation.issue_number | Should -Be 42
         }
         It 'never attempts issue creation after label bootstrap fails' {
             $script:failLabelWrite = $true
             { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
-                -Kind coverage -OutputDirectory $TestDrive -Apply } | Should -Throw
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
             Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -eq 'repos/owner/repo/issues' }
+            $journal = Get-Content -LiteralPath $publicationPath -Raw | ConvertFrom-Json -AsHashtable
+            $journal.ContainsKey('coverage_creation') | Should -BeFalse
+            $script:failLabelWrite = $false
+            (Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply).number |
+                Should -Be 42
         }
         It 'propagates issue publication failures after successful label bootstrap' {
             Mock Invoke-ScheduledGitHubApi { throw [IO.IOException]::new('Issue write denied.') } `
                 -ParameterFilter { $Endpoint -eq 'repos/owner/repo/issues' }
             { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
-                -Kind coverage -OutputDirectory $TestDrive -Apply } | Should -Throw
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
             $bootstrapLabels.Count | Should -Be 2
+        }
+        It 'reconciles a lost coverage-create response by rereading the owned issue' {
+            $script:loseCoverageReply = $true
+            $result = Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply
+            $result.number | Should -Be 42
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
+            $journal = Get-Content -LiteralPath $publicationPath -Raw | ConvertFrom-Json -AsHashtable
+            $journal.coverage_creation.stage | Should -Be complete
+            $journal.coverage_creation.issue_number | Should -Be 42
+            $journal.stage | Should -Be prepared
+        }
+        It 'reconciles a create response without an issue number rather than trusting it' {
+            $script:badCoverageNumber = $true
+            (Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply).number |
+                Should -Be 42
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
+        }
+        It 'rejects an invalid coverage journal <Field> before any new POST' -TestCases @(
+            @{ Field = 'identity' }, @{ Field = 'stage' }
+        ) {
+            param($Field)
+            $journal = Get-Content -LiteralPath $publicationPath -Raw | ConvertFrom-Json -AsHashtable
+            if ($Field -eq 'identity') { $journal.identity.repository_id = 999 }
+            else { $journal.coverage_creation = @{ stage = 'unexpected'; issue_number = $null } }
+            $journal | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $publicationPath
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0
+        }
+        It 'never repeats an unresolved coverage POST and resumes only once its issue is visible' {
+            $script:loseCoverageReply = $true; $script:hideCoverageIssue = $true
+            foreach ($retry in 1..2) {
+                { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                    -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
+            }
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
+            $script:hideCoverageIssue = $false
+            $result = Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply
+            $result.action | Should -Be reconciled
+            $result.number | Should -Be 42
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
+        }
+        It 'restores uncertain coverage creation on a fresh reporter attempt before allowing writes' {
+            $script:loseCoverageReply = $true; $script:hideCoverageIssue = $true
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
+            $script:previousOutput = $TestDrive
+            $freshOutput = Join-Path $TestDrive 'fresh-reporter'
+            $null = New-Item -ItemType Directory -Path $freshOutput
+            $script:publicationPath = Join-Path $freshOutput 'publication-123-456-789.json'
+            Mock Get-ScheduledArtifact { $script:previousOutput }
+            Mock Invoke-ScheduledGitHubApi {
+                @{
+                    id = 999; run_attempt = 1; repository = @{ id = 123 }; head_repository = @{ id = 123 }
+                    path = '.github/workflows/scheduled-report.yml'; head_branch = 'main'; status = 'completed'
+                }
+            } -ParameterFilter { $Endpoint -eq 'repos/owner/repo/actions/runs/999/attempts/1' }
+            Mock Invoke-ScheduledGitHubApi { @(@{ artifacts = @() }) } `
+                -ParameterFilter { $Endpoint -eq 'repos/owner/repo/actions/runs/999/artifacts?per_page=100' }
+            $savedRun = $env:GITHUB_RUN_ID; $savedAttempt = $env:GITHUB_RUN_ATTEMPT
+            try {
+                $env:GITHUB_RUN_ID = '999'; $env:GITHUB_RUN_ATTEMPT = '2'
+                Restore-ScheduledRunPublicationState -Policy $bootstrapPolicy `
+                    -Run @{ workflow_id = 456; id = 789 } -OutputDirectory $freshOutput
+            } finally {
+                $env:GITHUB_RUN_ID = $savedRun; $env:GITHUB_RUN_ATTEMPT = $savedAttempt
+            }
+            $restored = Get-Content -LiteralPath $publicationPath -Raw | ConvertFrom-Json -AsHashtable
+            $restored.stage | Should -Be prepared
+            $restored.coverage_creation.stage | Should -Be creating-issue
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $freshOutput -PublicationJournalPath $publicationPath -Apply } | Should -Throw
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
+        }
+        It 'uses a known issue number after its create response but failed readback' {
+            Mock Invoke-ScheduledGitHubApi { throw [IO.IOException]::new('Readback failed.') } `
+                -ParameterFilter { $Endpoint -eq 'repos/owner/repo/issues/42' }
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
+            Mock Invoke-ScheduledGitHubApi { $script:coverageIssue } `
+                -ParameterFilter { $Endpoint -eq 'repos/owner/repo/issues/42' }
+            (Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply).number |
+                Should -Be 42
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
+        }
+        It 'does not accept recovered coverage whose owned record changed' {
+            $null = Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply
+            $record.extra = 'newer-evidence'
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -PublicationJournalPath $publicationPath -Apply } | Should -Throw
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 1 -Exactly -ParameterFilter {
+                $Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST'
+            }
         }
     }
 }

--- a/scripts/scheduled/ScheduledLabels.Tests.ps1
+++ b/scripts/scheduled/ScheduledLabels.Tests.ps1
@@ -1,0 +1,180 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+# Exercises reporting label bootstrap with an in-memory API, including first publication,
+# write authorization, preserved operator metadata and raced/lost create responses.
+# No test may contact GitHub or require Local App configuration.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+$VerbosePreference = 'Continue'
+
+BeforeDiscovery { Import-Module (Join-Path $PSScriptRoot 'ScheduledGitHub.psm1') }
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'ScheduledGitHub.psm1')
+    Import-Module (Join-Path $PSScriptRoot 'ScheduledRunGitHub.psm1') -Force
+    function Invoke-LabelTestApi {
+        param($Endpoint, $Method = 'GET', $Body, [switch] $Paginate)
+        $script:calls.Add(@{ endpoint = $Endpoint; method = $Method; body = $Body })
+        if ($Endpoint -eq 'repos/owner/repo/labels?per_page=100') {
+            if (-not $Paginate) { throw 'Label lookup requires complete pagination.' }
+            if ($script:failRead) { throw [IO.IOException]::new('Inventory unavailable.') }
+            return ,@(@(@{ name = 'unrelated' }), @($script:labels.Values))
+        }
+        if ($Endpoint -eq 'repos/owner/repo/labels' -and $Method -eq 'POST') {
+            $journal = Get-Content -LiteralPath (Join-Path $script:output "label-$($Body.name).json") -Raw |
+                ConvertFrom-Json -AsHashtable
+            $journal.stage | Should -Be creating-label
+            if ($script:failCreate) { throw [IO.IOException]::new('Create denied.') }
+            $script:labels[$Body.name] = if ($script:race) {
+                @{ name = $Body.name; color = 'abcdef'; description = 'Operator created this label.' }
+            } else { $Body.Clone() }
+            if ($script:race -or $script:loseReply) { throw [IO.IOException]::new('Create response unavailable.') }
+            return $script:labels[$Body.name]
+        }
+        if ($Endpoint -match '^repos/owner/repo/labels/(scheduled-[a-z-]+)$') {
+            if ($script:wrongIdentity) { return @{ name = 'wrong-label' } }
+            if (-not $script:labels.ContainsKey($Matches[1])) { throw [IO.IOException]::new('Label not found.') }
+            return $script:labels[$Matches[1]]
+        }
+        throw "Unexpected label API call: $Method $Endpoint"
+    }
+}
+
+Describe 'Authorized reporting label bootstrap' {
+    BeforeEach {
+        $script:policy = @{ repository = 'owner/repo'; rollout = @{ reporting_enabled = $true } }
+        $script:labels = @{}
+        $script:calls = [Collections.Generic.List[object]]::new()
+        $script:output = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $output
+        $script:race = $false; $script:loseReply = $false; $script:failCreate = $false
+        $script:failRead = $false; $script:wrongIdentity = $false
+        $script:arguments = @{
+            Policy = $policy; OutputDirectory = $output; Api = ${function:Invoke-LabelTestApi}; Apply = $true
+        }
+    }
+    It 'creates only the required missing <Name> label and confirms it by unique name' -TestCases @(
+        @{ Name = 'scheduled-run-failure' }, @{ Name = 'scheduled-coverage' }, @{ Name = 'scheduled-health' }
+    ) {
+        param($Name)
+        Initialize-ScheduledReportingLabel @arguments -Name $Name
+        $labels.Keys | Should -Be @($Name)
+        $labels[$Name].description | Should -Not -BeNullOrEmpty
+        $calls.method | Should -Be @('GET', 'POST', 'GET')
+        $calls[-1].endpoint | Should -Be "repos/owner/repo/labels/$Name"
+        $journal = Get-Content -LiteralPath (Join-Path $output "label-$Name.json") -Raw | ConvertFrom-Json
+        $journal.stage | Should -Be complete
+        $journal.repository | Should -Be owner/repo
+        $calls.Clear()
+        Initialize-ScheduledReportingLabel @arguments -Name $Name
+        $calls.method | Should -Be @('GET')
+    }
+    It 'preserves existing label metadata even with different capitalization on a later page' {
+        $labels['scheduled-health'] = @{ name = 'Scheduled-Health'; color = '123abc'; description = 'Operator preference' }
+        Initialize-ScheduledReportingLabel @arguments -Name scheduled-health
+        $calls.method | Should -Be @('GET')
+        $labels['scheduled-health'].name | Should -BeExactly 'Scheduled-Health'
+        $labels['scheduled-health'].color | Should -BeExactly '123abc'
+        $labels['scheduled-health'].description | Should -BeExactly 'Operator preference'
+        @(Get-ChildItem -LiteralPath $output).Count | Should -Be 0
+    }
+    It 'does not access label state with Apply=<Apply> and Reporting=<Reporting>' -TestCases @(
+        @{ Apply = $false; Reporting = $false }
+        @{ Apply = $false; Reporting = $true }
+        @{ Apply = $true; Reporting = $false }
+    ) {
+        param($Apply, $Reporting)
+        $policy.rollout.reporting_enabled = $Reporting
+        $arguments.Apply = $Apply
+        Initialize-ScheduledReportingLabel @arguments -Name scheduled-health
+        $calls.Count | Should -Be 0
+        @(Get-ChildItem -LiteralPath $output).Count | Should -Be 0
+    }
+    It 'reconciles a <Situation> response without updating or repeating creation' -TestCases @(
+        @{ Situation = 'race' }, @{ Situation = 'lost' }
+    ) {
+        param($Situation)
+        $script:race = $Situation -eq 'race'
+        $script:loseReply = $Situation -eq 'lost'
+        Initialize-ScheduledReportingLabel @arguments -Name scheduled-health
+        $calls.method | Should -Be @('GET', 'POST', 'GET')
+        if ($race) { $labels['scheduled-health'].description | Should -BeExactly 'Operator created this label.' }
+    }
+    It 'fails explicitly on <Failure> and never records successful publication' -TestCases @(
+        @{ Failure = 'read' }, @{ Failure = 'create' }, @{ Failure = 'identity' }
+    ) {
+        param($Failure)
+        $script:failRead = $Failure -eq 'read'
+        $script:failCreate = $Failure -eq 'create'
+        $script:wrongIdentity = $Failure -eq 'identity'
+        { Initialize-ScheduledReportingLabel @arguments -Name scheduled-health } | Should -Throw
+        if ($failRead) {
+            $calls.method | Should -Be @('GET')
+        } else {
+            $journal = Get-Content -LiteralPath (Join-Path $output 'label-scheduled-health.json') -Raw | ConvertFrom-Json
+            $journal.stage | Should -Be creating-label
+        }
+    }
+}
+
+Describe 'Coverage bootstrap at the actual issue-write boundary' {
+    InModuleScope ScheduledGitHub {
+        BeforeEach {
+            $script:bootstrapPolicy = @{
+                repository = 'owner/repo'; reporter_login = 'github-actions[bot]'
+                rollout = @{ reporting_enabled = $true }
+            }
+            $script:bootstrapLabels = @{}
+            $script:bootstrapWrites = [Collections.Generic.List[object]]::new()
+            $script:failLabelWrite = $false
+            $script:record = @{ schema_version = 1; repository = 'owner/repo'; receipt = $null; invalidation = $null }
+            Mock Invoke-ScheduledGitHubApi {
+                if ($Endpoint -eq 'repos/owner/repo/labels?per_page=100') {
+                    return @($script:bootstrapLabels.Values)
+                }
+                if ($Method -eq 'POST') {
+                    $script:bootstrapWrites.Add(@{ endpoint = $Endpoint; body = $Body })
+                    if ($Endpoint -eq 'repos/owner/repo/labels') {
+                        if ($script:failLabelWrite) { throw [IO.IOException]::new('Label write denied.') }
+                        $script:bootstrapLabels[$Body.name] = $Body
+                        return $Body
+                    }
+                    if ($Endpoint -eq 'repos/owner/repo/issues') {
+                        foreach ($label in $Body.labels) {
+                            if (-not $script:bootstrapLabels.ContainsKey($label)) { throw 'Required label is missing.' }
+                        }
+                        return @{ number = 42 }
+                    }
+                }
+                if ($Endpoint -match '^repos/owner/repo/labels/(scheduled-[a-z-]+)$') {
+                    if (-not $script:bootstrapLabels.ContainsKey($Matches[1])) { throw [IO.IOException]::new('Missing label.') }
+                    return $script:bootstrapLabels[$Matches[1]]
+                }
+                throw "Unexpected coverage API call: $Method $Endpoint"
+            }
+        }
+        It 'creates required coverage labels before the first issue without inventing a receipt' {
+            $result = Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -Apply
+            $result.action | Should -Be POST
+            $result.number | Should -Be 42
+            @($bootstrapLabels.Keys | Sort-Object) | Should -Be @('scheduled-coverage', 'scheduled-health')
+            $bootstrapWrites[-1].endpoint | Should -BeExactly 'repos/owner/repo/issues'
+            $published = Read-ScheduledRecord -Text $bootstrapWrites[-1].body.body -Kind coverage
+            $published.receipt | Should -BeNullOrEmpty
+            $published.invalidation | Should -BeNullOrEmpty
+        }
+        It 'never attempts issue creation after label bootstrap fails' {
+            $script:failLabelWrite = $true
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -Apply } | Should -Throw
+            Should -Invoke Invoke-ScheduledGitHubApi -Times 0 -ParameterFilter { $Endpoint -eq 'repos/owner/repo/issues' }
+        }
+        It 'propagates issue publication failures after successful label bootstrap' {
+            Mock Invoke-ScheduledGitHubApi { throw [IO.IOException]::new('Issue write denied.') } `
+                -ParameterFilter { $Endpoint -eq 'repos/owner/repo/issues' }
+            { Sync-ScheduledIssue -Policy $bootstrapPolicy -Issue $null -Record $record `
+                -Kind coverage -OutputDirectory $TestDrive -Apply } | Should -Throw
+            $bootstrapLabels.Count | Should -Be 2
+        }
+    }
+}

--- a/scripts/scheduled/ScheduledReport.Tests.ps1
+++ b/scripts/scheduled/ScheduledReport.Tests.ps1
@@ -317,6 +317,27 @@ Describe 'Deterministic health' {
         $health.components.local_scan.status | Should -Be unavailable
         $health.healthy | Should -BeFalse
     }
+    It 'does not require disabled Local scans but still requires genuine hosted coverage and scheduling' {
+        $arguments = @{
+            Scheduler = @{ state = 'active' }; Coverage = $coverage; Manifest = $manifest
+            Planning = $fresh; Reporting = $fresh; Now = $now; LocalDisabled = $true
+        }
+        $health = Get-ScheduledHealth @arguments
+        $health.healthy | Should -BeTrue
+        $health.components.local_scan.status | Should -Be disabled
+        $arguments.Coverage = $null
+        $health = Get-ScheduledHealth @arguments
+        $health.healthy | Should -BeFalse
+        $health.components.coverage.status | Should -Be unavailable
+        $arguments.Coverage = $coverage
+        $arguments.Planning = @{ outcome = 'passed'; completed_at = '2026-09-01T00:00:00Z' }
+        (Get-ScheduledHealth @arguments).healthy | Should -BeFalse
+        $arguments.Planning = $fresh
+        $arguments.Scheduler.state = 'disabled_inactivity'
+        $health = Get-ScheduledHealth @arguments
+        $health.components.scheduler.status | Should -Be failed
+        $health.healthy | Should -BeFalse
+    }
     It 'uses independent freshness thresholds for hosted planning and local scans' {
         $observation = @{ outcome = 'passed'; completed_at = '2026-09-08T02:00:00Z' }
         $health = Get-ScheduledHealth -Planning $observation -Reporting $observation -LocalScan $observation `

--- a/scripts/scheduled/ScheduledReport.psm1
+++ b/scripts/scheduled/ScheduledReport.psm1
@@ -276,6 +276,7 @@ function Get-ScheduledHealth {
         [double] $ExpectedPlanGapHours = 30,
         [double] $ExpectedLocalGapMinutes = 420,
         [int] $MaxAgeDays = 7,
+        [switch] $LocalDisabled,
         [switch] $Staged
     )
 
@@ -284,7 +285,8 @@ function Get-ScheduledHealth {
         coverage = @{ status = 'unavailable'; reason = 'missing-coverage' }
         planning = Get-ScheduledComponentHealth $Planning $Now $ExpectedPlanGapHours
         reporting = Get-ScheduledComponentHealth $Reporting $Now $ExpectedPlanGapHours
-        local_scan = Get-ScheduledComponentHealth $LocalScan $Now ($ExpectedLocalGapMinutes / 60)
+        local_scan = if ($LocalDisabled) { @{ status = 'disabled'; reason = 'local-executor-not-expected' } }
+            else { Get-ScheduledComponentHealth $LocalScan $Now ($ExpectedLocalGapMinutes / 60) }
     }
     if ($null -ne $Scheduler -and $Scheduler.ContainsKey('state')) {
         $components.scheduler = @{
@@ -304,7 +306,7 @@ function Get-ScheduledHealth {
         }
     }
     $states = @($components.Values | ForEach-Object { $_.status })
-    $healthy = @($states | Where-Object { $_ -cnotin @('fresh', 'reused') }).Count -eq 0
+    $healthy = @($states | Where-Object { $_ -cnotin @('fresh', 'reused', 'disabled') }).Count -eq 0
     return @{
         schema_version = 1; checked_at = $Now.ToString('o'); components = $components
         healthy = $healthy

--- a/scripts/scheduled/ScheduledRunGitHub.psm1
+++ b/scripts/scheduled/ScheduledRunGitHub.psm1
@@ -457,4 +457,4 @@ function Initialize-ScheduledReportingLabel {
 }
 
 Export-ModuleMember -Function Get-ScheduledRunJobEvidence, Invoke-ScheduledRunRecord, Sync-ScheduledRunIntake,
-Initialize-ScheduledReportingLabel
+Initialize-ScheduledReportingLabel, Write-ScheduledRunJournal

--- a/scripts/scheduled/ScheduledRunGitHub.psm1
+++ b/scripts/scheduled/ScheduledRunGitHub.psm1
@@ -4,6 +4,7 @@
 # artifact exists. The reporter supplies its already validated run and its GitHub API callback;
 # this module never executes candidate code or decides which symptoms share a root cause.
 # Bounded log capture remains process orchestration; structured records are built by Rust.
+# Reporting label bootstrap shares the write authorization and durable journal boundary.
 # Ref: ../../.github/workflows/implementation.md#run-level-failure-intake.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -263,9 +264,6 @@ function Sync-ScheduledRunIntake {
     }
     $actions = [Collections.Generic.List[object]]::new()
     $issue = Get-ScheduledRunIssue -Policy $Policy -Identity $prepared.identity -Api $Api
-    if ($null -eq $issue -and -not $prepared.should_report) {
-        return @{ requires_triage = $false; actions = @(); digest = $prepared.digest }
-    }
     $applyWrites = $Apply -and $Policy.rollout.reporting_enabled
     $journalPath = Join-Path $OutputDirectory "publication-$($Policy.repository_id)-$($Run.workflow_id)-$($Run.id).json"
     $journal = @{
@@ -279,6 +277,15 @@ function Sync-ScheduledRunIntake {
             throw [FormatException]::new('Publication journal identity or schema is invalid.')
         }
         $journal.digest = $prepared.digest
+    }
+    if ($null -eq $issue -and -not $prepared.should_report) {
+        if ($journal.stage -cne 'prepared') {
+            throw [IO.IOException]::new('Prior run issue creation remains unresolved; reconcile it before retrying.')
+        }
+        # A clean execution can still fail while bootstrapping coverage labels. Retain the
+        # no-intake intent so a fresh reporter attempt can restore its publication state.
+        if ($applyWrites) { Write-ScheduledRunJournal -Path $journalPath -Record $journal }
+        return @{ requires_triage = $false; actions = @(); digest = $prepared.digest }
     }
     if ($null -eq $issue) {
         if ($journal.stage -cne 'prepared') {
@@ -295,6 +302,11 @@ function Sync-ScheduledRunIntake {
                 actions = @(@{ action = 'dry-run'; method = 'POST'; endpoint = "repos/$($Policy.repository)/issues"; payload = $payload })
             }
         }
+        # Persist recoverable pre-issue intent even if label bootstrap fails. The run issue
+        # has not been attempted yet, so a rerun can safely resume from this stage.
+        Write-ScheduledRunJournal -Path $journalPath -Record $journal
+        Initialize-ScheduledReportingLabel -Policy $Policy -Name scheduled-run-failure `
+            -OutputDirectory $OutputDirectory -Api $Api -Apply:$applyWrites
         $journal.stage = 'creating-issue'
         Write-ScheduledRunJournal -Path $journalPath -Record $journal
         try {
@@ -400,4 +412,49 @@ function Sync-ScheduledRunIntake {
     }
 }
 
-Export-ModuleMember -Function Get-ScheduledRunJobEvidence, Invoke-ScheduledRunRecord, Sync-ScheduledRunIntake
+function Initialize-ScheduledReportingLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable] $Policy,
+        [Parameter(Mandatory)][ValidateSet('scheduled-run-failure', 'scheduled-coverage', 'scheduled-health')][string] $Name,
+        [Parameter(Mandatory)][string] $OutputDirectory,
+        [Parameter(Mandatory)][scriptblock] $Api,
+        [switch] $Apply
+    )
+
+    # Label reads are part of publishing, not a prerequisite for read-only diagnostics.
+    # Ref: ../../.github/workflows/implementation.md#reporting-label-bootstrap.
+    if (-not $Apply -or -not $Policy.rollout.reporting_enabled) { return }
+    $endpoint = "repos/$($Policy.repository)/labels"
+    $pages = & $Api -Endpoint "${endpoint}?per_page=100" -Paginate
+    $existing = @($pages | ForEach-Object { $_ } | Where-Object { $_.name -ieq $Name })
+    if ($existing.Count -gt 0) { return }
+
+    # Only missing labels receive defaults. Color is neutral because labels identify record
+    # roles rather than severity; an operator's existing spelling/color/description is retained.
+    $descriptions = @{
+        'scheduled-run-failure' = 'Deep validation run evidence requiring operator analysis'
+        'scheduled-coverage' = 'Authoritative deep validation coverage'
+        'scheduled-health' = 'Scheduled validation and executor health'
+    }
+    $journalPath = Join-Path $OutputDirectory "label-$Name.json"
+    $journal = @{ schema_version = 1; repository = $Policy.repository; name = $Name; stage = 'creating-label' }
+    Write-ScheduledRunJournal -Path $journalPath -Record $journal
+    try {
+        $null = & $Api -Endpoint $endpoint -Method POST `
+            -Body @{ name = $Name; color = 'ededed'; description = $descriptions[$Name] }
+    } catch [IO.IOException] {
+        # GitHub enforces unique label names. A raced or lost create response is resolved by
+        # reading that name, never by updating its metadata or interpreting the error as success.
+        Write-Verbose "Label creation response for $Name is uncertain; reading its unique name before continuing."
+    }
+    $label = & $Api -Endpoint "$endpoint/$Name"
+    if ($null -eq $label -or $label.name -ine $Name) {
+        throw [FormatException]::new("GitHub did not confirm the required reporting label: $Name")
+    }
+    $journal.stage = 'complete'
+    Write-ScheduledRunJournal -Path $journalPath -Record $journal
+}
+
+Export-ModuleMember -Function Get-ScheduledRunJobEvidence, Invoke-ScheduledRunRecord, Sync-ScheduledRunIntake,
+Initialize-ScheduledReportingLabel

--- a/scripts/scheduled/ScheduledRunPublication.Tests.ps1
+++ b/scripts/scheduled/ScheduledRunPublication.Tests.ps1
@@ -180,6 +180,20 @@ Describe 'Durable run publication' {
             { Invoke-TestRunPublication } | Should -Throw
             $writes.Count | Should -Be 0
         }
+        It 'preserves the shared coverage-create fence when repeating clean run intake' {
+            $run.conclusion = 'success'; $results[0].outcome = 'passed'
+            $jobs[0].conclusion = 'success'; $jobs[0].steps[0].conclusion = 'success'
+            $null = Invoke-TestRunPublication
+            $journalPath = Join-Path $output 'publication-123-456-789.json'
+            $journal = Get-Content -LiteralPath $journalPath -Raw | ConvertFrom-Json -AsHashtable
+            $journal.coverage_creation = @{ stage = 'creating-issue'; issue_number = $null }
+            Write-ScheduledRunJournal -Path $journalPath -Record $journal
+            $null = Invoke-TestRunPublication
+            $saved = Get-Content -LiteralPath $journalPath -Raw | ConvertFrom-Json -AsHashtable
+            $saved.coverage_creation.stage | Should -Be creating-issue
+            $saved.coverage_creation.issue_number | Should -BeNullOrEmpty
+            $writes.Count | Should -Be 0
+        }
         It 'retains a retryable pre-issue journal after label publication fails' {
             $script:failLabelWrite = $true
             { Invoke-TestRunPublication } | Should -Throw

--- a/scripts/scheduled/ScheduledRunPublication.Tests.ps1
+++ b/scripts/scheduled/ScheduledRunPublication.Tests.ps1
@@ -16,7 +16,22 @@ Describe 'Durable run publication' {
                 if ($Method -in @('POST', 'PATCH')) {
                     $script:writes.Add(@{ endpoint = $Endpoint; method = $Method; body = (Copy-TestRunValue $Body) })
                 }
+                if ($Endpoint -eq 'repos/owner/repo/labels?per_page=100' -and $Method -eq 'GET') {
+                    if (-not $Paginate) { throw 'Label inventory must be paginated.' }
+                    return @($script:labels.Values)
+                }
+                if ($Endpoint -eq 'repos/owner/repo/labels' -and $Method -eq 'POST') {
+                    if ($script:failLabelWrite) { throw [IO.IOException]::new('Label publication failed.') }
+                    $script:labels[$Body.name] = Copy-TestRunValue $Body
+                    return $script:labels[$Body.name]
+                }
+                if ($Endpoint -eq 'repos/owner/repo/labels/scheduled-run-failure' -and $Method -eq 'GET') {
+                    return $script:labels['scheduled-run-failure']
+                }
                 if ($Endpoint -eq 'repos/owner/repo/issues' -and $Method -eq 'POST') {
+                    foreach ($label in $Body.labels) {
+                        if (-not $script:labels.ContainsKey($label)) { throw 'Required reporting label is missing.' }
+                    }
                     $script:nextIssue++
                     $number = $script:nextIssue
                     $script:issues[$number] = @{
@@ -108,10 +123,12 @@ Describe 'Durable run publication' {
                     excerpt = 'Invalid access.'; bytes = 15; truncated = $false; excerpt_truncated = $false }
             })
             $script:issues = @{}
+            $script:labels = @{}
             $script:comments = @{}
             $script:writes = [Collections.Generic.List[object]]::new()
             $script:nextIssue = 40; $script:nextComment = 100
             $script:loseIssueReply = $false; $script:losePageReply = $false
+            $script:failLabelWrite = $false
             $script:hidePageReply = $false; $script:hiddenPage = $null; $script:loseIndexReply = $false
             $script:hideIssueReply = $false; $script:hiddenIssue = $null; $script:failIndexWrite = $false
             $script:output = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
@@ -123,8 +140,10 @@ Describe 'Durable run publication' {
             $issues.Count | Should -Be 1
             $issues[41].title | Should -BeExactly 'Deep validation failed'
             $issues[41].labels.name | Should -Be @('scheduled-run-failure')
-            $writes[0].body.body | Should -Match 'publication is pending'
-            $writes[1].endpoint | Should -BeExactly 'repos/owner/repo/issues/41/comments'
+            $labels.Keys | Should -Be @('scheduled-run-failure')
+            $writes[0].endpoint | Should -BeExactly 'repos/owner/repo/labels'
+            $writes[1].body.body | Should -Match 'publication is pending'
+            $writes[2].endpoint | Should -BeExactly 'repos/owner/repo/issues/41/comments'
             $writes[-1].method | Should -BeExactly 'PATCH'
             $result.record.revisions.Count | Should -Be 1
             $issues[41].body | Should -Match 'Complete evidence revisions: 1'
@@ -147,6 +166,31 @@ Describe 'Durable run publication' {
             $jobs[0].conclusion = 'success'; $jobs[0].steps[0].conclusion = 'success'
             (Invoke-TestRunPublication).requires_triage | Should -BeFalse
             $writes.Count | Should -Be 0
+            $journal = Get-Content -LiteralPath (Join-Path $output 'publication-123-456-789.json') -Raw |
+                ConvertFrom-Json -AsHashtable
+            $journal.stage | Should -Be prepared
+            $journal.issue_number | Should -BeNullOrEmpty
+        }
+        It 'does not forget an uncertain issue write when a rerun passes' {
+            $script:hideIssueReply = $true
+            { Invoke-TestRunPublication } | Should -Throw
+            $run.conclusion = 'success'; $results[0].outcome = 'passed'
+            $jobs[0].conclusion = 'success'; $jobs[0].steps[0].conclusion = 'success'
+            $writes.Clear()
+            { Invoke-TestRunPublication } | Should -Throw
+            $writes.Count | Should -Be 0
+        }
+        It 'retains a retryable pre-issue journal after label publication fails' {
+            $script:failLabelWrite = $true
+            { Invoke-TestRunPublication } | Should -Throw
+            $issues.Count | Should -Be 0
+            $journal = Get-Content -LiteralPath (Join-Path $output 'publication-123-456-789.json') -Raw |
+                ConvertFrom-Json -AsHashtable
+            $journal.stage | Should -Be prepared
+            $script:failLabelWrite = $false
+            $result = Invoke-TestRunPublication
+            $result.record.revisions.Count | Should -Be 1
+            $issues.Count | Should -Be 1
         }
         It 'never writes while reporting is disabled or only a dry run is requested' {
             $policy.rollout.reporting_enabled = $false
@@ -161,7 +205,7 @@ Describe 'Durable run publication' {
             $result.record.revisions.Count | Should -Be 1
             $issues.Count | Should -Be 1
             $comments[41].Count | Should -Be 1
-            @($writes | Where-Object method -EQ POST).Count | Should -Be 2
+            @($writes | Where-Object method -EQ POST).Count | Should -Be 3
         }
         It 'blocks an unresolved page write until that operation can be reconciled' {
             $script:hidePageReply = $true

--- a/scripts/scheduled/ScheduledValidation.Tests.ps1
+++ b/scripts/scheduled/ScheduledValidation.Tests.ps1
@@ -159,14 +159,35 @@ Describe 'Hosted planning authorization' {
         }
     }
 
-    It 'keeps recurring execution disabled with the checked-in policy' {
+    It 'keeps recurring execution disabled when explicitly configured' {
+        $script:disabledPolicy = Get-ScheduledPolicy
+        $disabledPolicy.rollout.hosted_execution_enabled = $false
+        $disabledPolicy.rollout.reporting_enabled = $false
+        Mock Get-ScheduledPolicy -ModuleName ScheduledWorkflow { $disabledPolicy }
         $plan = Invoke-ScheduledPlanning -Mode full -EventPath $eventPath `
             -OutputDirectory (Join-Path $TestDrive 'plan') -Now '2026-09-08T12:00:00Z'
         $plan.decision.run | Should -BeFalse
         Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 0 -Exactly
     }
 
-    It 'runs fresh full manual checks without any rollout or cache prerequisite' {
+    It 'plans the full nightly suite with enabled defaults and no baseline or Local enrollment' {
+        $plan = Invoke-ScheduledPlanning -Mode full -EventPath $eventPath `
+            -OutputDirectory (Join-Path $TestDrive 'first-nightly') -Now '2026-09-08T12:00:00Z'
+        $plan.decision.run | Should -BeTrue
+        $plan.manifest.scope | Should -Be full
+        $plan.manifest.checks.Count | Should -Be 32
+        @($plan.manifest.checks.kind | Sort-Object -Unique) | Should -Be @('careful', 'miri', 'miri-many', 'mutants')
+        Should -Invoke Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow -Times 1
+        Should -Invoke Get-ScheduledConfirmationScope -ModuleName ScheduledWorkflow -Times 0
+    }
+
+    It 'runs fresh full manual checks with recurring execution=<Execution> and no cache prerequisite' -TestCases @(
+        @{ Execution = $false }, @{ Execution = $true }
+    ) {
+        param($Execution)
+        $script:manualPolicy = Get-ScheduledPolicy
+        $manualPolicy.rollout.hosted_execution_enabled = $Execution
+        Mock Get-ScheduledPolicy -ModuleName ScheduledWorkflow { $manualPolicy }
         $env:GITHUB_EVENT_NAME = 'workflow_dispatch'
         Mock Get-ScheduledCoverageIndex -ModuleName ScheduledWorkflow { throw 'Unrelated broken coverage index.' }
         $plan = Invoke-ScheduledPlanning -Mode full -EventPath $eventPath `
@@ -228,8 +249,8 @@ Describe 'Hosted planning authorization' {
             $policy.repair.allowed_packages | Should -BeNullOrEmpty
             $policy.local.allowed_packages | Should -BeNullOrEmpty
             $policy.local.enrolled_machine_id | Should -BeNullOrEmpty
-            $policy.rollout.hosted_execution_enabled | Should -BeFalse
-            $policy.rollout.reporting_enabled | Should -BeFalse
+            $policy.rollout.hosted_execution_enabled | Should -BeTrue
+            $policy.rollout.reporting_enabled | Should -BeTrue
             @($policy.rollout.prerequisites.Values | Where-Object { $_ }).Count | Should -Be 0
         }
 

--- a/scripts/scheduled/policy.json
+++ b/scripts/scheduled/policy.json
@@ -6,9 +6,8 @@
   "worker_login": "sandersaares",
   "managed_branch_prefix": "sandersaares-scheduled-repair-",
   "rollout": {
-    "phase": "staged",
-    "hosted_execution_enabled": false,
-    "reporting_enabled": false,
+    "hosted_execution_enabled": true,
+    "reporting_enabled": true,
     "prerequisites": {
       "execution_canary": false,
       "reporting_canary": false,


### PR DESCRIPTION
[Copilot speaking]

## Motivation

Nightly deep validation needs recurring execution and durable failure intake without depending on Local AI configuration or manually provisioned reporting labels.

## Result

The reviewed policy enables **Full deep validation** at the existing daily **02:41 UTC** schedule, covering Miri, many-seed Miri, mutation testing and careful checks. Complete compatible successes for unchanged main can still be reused within the seven-day maximum age; skips do not renew successful-execution age. Missing baseline coverage remains explicitly unavailable until a complete automatic full run succeeds.

Reporting is enabled independently of Local AI. Failed automatic runs and authorized manual diagnostics can produce **Deep validation failed** intake issues with durable evidence. Missing reporting labels are created at the actual issue-write boundary under the existing permission. Existing label metadata is preserved, and raced or lost creation responses are reconciled by reading the unique label name. Publication failures remain explicit, with recovery journals retained. Manual diagnostics still run fresh checks regardless of recurring authorization, may target a branch or PR commit while the controller remains on main, and cannot modify shared coverage or confirm repairs.

Hosted health treats an intentionally inactive, unenrolled Local executor as disabled rather than failed. Enrolled executors still require fresh successful heartbeats. Only automatic Full deep validation plans refresh nightly planning freshness; Selected deep validation activity cannot conceal a stopped nightly schedule. Missing coverage and genuine hosted failures remain visible.

These activation effects require a human merge. Local mode remains observe with no enrollment, pilot assertions remain false, and new repair admission remains blocked by `ai-triage-unavailable`. No native App automation is enabled, and no automatic source edits, repair PRs or merges are authorized. Until AI triage is implemented, the operator diagnoses and handles failure issues manually.

## Version/release plan

No released-content or crate-version changes. This PR changes repository automation, its regression coverage and operating documentation only; package sources, manifests, dependency declarations and lockfiles are unchanged.