### PR TITLE
CI: select tooling validation jobs by change domain

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -184,7 +184,7 @@ runs:
 
     - name: Cache actionlint and ShellCheck
       # just install-tools fetches pinned actionlint and ShellCheck as standalone binaries
-      # (scripts/install-actionlint.ps1, scripts/install-shellcheck.ps1) into ~/.cargo/bin on
+      # (scripts/setup/install-actionlint.ps1, scripts/setup/install-shellcheck.ps1) into ~/.cargo/bin on
       # every job and every platform. Unlike the cargo-installed tools that also live there,
       # these are plain downloaded files with no cargo install-metadata, so Swatinem/rust-cache's
       # bin caching never tracks them and they are otherwise re-downloaded and re-extracted every
@@ -202,7 +202,7 @@ runs:
         path: |
           ~/.cargo/bin/actionlint*
           ~/.cargo/bin/shellcheck*
-        key: lint-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/install-actionlint.ps1', 'scripts/install-shellcheck.ps1') }}
+        key: lint-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/setup/install-actionlint.ps1', 'scripts/setup/install-shellcheck.ps1') }}
 
     - name: Install just
       shell: bash

--- a/.github/actions/setup-workflow-lint/action.yml
+++ b/.github/actions/setup-workflow-lint/action.yml
@@ -1,0 +1,25 @@
+name: Setup workflow lint
+description: Install the pinned workflow linters without a Rust development environment
+
+runs:
+  using: composite
+  steps:
+    # Share portable binaries and their installer-owned pins with the complete setup action.
+    # Ref: .github/workflows/implementation.md#workflow-lint-environment.
+    - uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/bin/actionlint*
+          ~/.cargo/bin/shellcheck*
+        key: lint-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/setup/install-actionlint.ps1', 'scripts/setup/install-shellcheck.ps1') }}
+    - name: Install workflow linters
+      shell: pwsh
+      run: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        $bin = Join-Path $HOME '.cargo/bin'
+        $env:PATH = "$bin$([IO.Path]::PathSeparator)$env:PATH"
+        $bin | Add-Content -LiteralPath $env:GITHUB_PATH -Encoding utf8
+        ./scripts/setup/install-shellcheck.ps1 -Destination $bin
+        ./scripts/setup/install-actionlint.ps1 -Destination $bin

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -35,12 +35,14 @@ high-level design in `design.md` and per-job mechanics in inline YAML comments.
 
 ## Job gating
 
-- A job whose inputs are not Cargo packages (the workflow files, or anything under
-  `scripts/`) must run unconditionally - do not gate it on the `delta` job or `skip_all`, or
-  a change touching only those files would be validated by nothing. Package-scoped jobs gate
-  on `delta`. `validate-versions` is in this class: it generates release state for every publishable
-  package's released content against its version anchor, so delta's changed-package set
-  cannot skip a package that already needed an increment.
+- Gate non-Cargo checks on the explicit change plan, never on `delta.skip_all`.
+  Maintain script-domain inputs and shared consumers in `scripts/build/ValidationPlan.psm1`;
+  native-helper impact comes from Cargo delta and is unioned with path-selected domains.
+  New test domains must join the full-suite selection. Preserve full tooling validation on
+  pushes to `main`, and update the planner/fan-in tests when selection changes.
+- Keep `validate-versions` unconditional, including its live binstall metadata check. It generates
+  release state for every publishable package against its version anchor, so the PR's changed
+  package set cannot skip a package that already needed an increment.
 - Azure OIDC jobs (`test-azure`, `test-azure-gh`) must not run on `merge_group`. The test
   identity's federated subjects are `pull_request` and the `main` branch ref only.
 - A workflow edit must consume the consumer-contract package set from the release-plan report
@@ -55,7 +57,9 @@ high-level design in `design.md` and per-job mechanics in inline YAML comments.
   `if:` that can be false can only be required through this fan-in. Advisory jobs
   (`coverage-notify`) and `alert` stay off that list. If the new job has no skip
   condition, also add its id to `MUST_SUCCEED_JOBS` in that job so a skipped result cannot
-  green the fan-in.
+  green the fan-in. Change-selected jobs stay in `needs:` and must succeed whenever the plan
+  selects them; update `RequiredChecks.psm1` when adding a new planned job. Keep `changes` and
+  `delta` in the must-succeed list so unavailable plans cannot authorize skips.
 - Add the new job to the `alert` job's `needs:` list as well. That list covers everything worth
   an issue after a failed push to `main`, including the advisory jobs the fan-in excludes, so the
   two lists are maintained together rather than derived from each other. Never add

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -122,15 +122,27 @@ Clippy already guarantees.
 
 ## Selective validation
 
-Most jobs are package-scoped and skip packages a change does not touch: a `delta` job
-computes the affected set and downstream jobs consult it, so a one-package PR does not
-rebuild the workspace. The complement of this pattern is the rule that a job whose inputs
-are **not** Cargo packages — the workflow files themselves, or the standalone PowerShell
-under `scripts/` — must run unconditionally. Delta analysis reports "nothing affected" for
-such a change, so gating those jobs on it would leave the change validated by nothing.
-Release-plan generation (`validate-versions`) is in that class: it compares every
-publishable package's released content to that package's version anchor. Gating it on
-delta's changed-package set would skip a package that already needed an increment.
+Package-scoped jobs consume Cargo dependency impact, so a one-package PR does not rebuild
+the workspace. Non-Cargo checks have independent change domains: workflow lint consumes
+workflow and lint-tooling inputs, script analysis consumes scripts and analyzer inputs, and
+script tests consume their owning automation domains and shared dependencies. A change that
+touches only tooling must still receive the relevant checks even when Cargo selects nothing.
+
+Script tests run the union of selected domains, including integration tests for affected
+native helpers. Domain selection includes fixtures, configuration and shared consumers, not
+just the file containing a test. Shared validation machinery changes exercise every tooling
+check. Ordinary Rust source changes do not by themselves select unrelated tooling checks.
+
+Selection covers the complete pull request or merge-queue candidate, including deleted and
+renamed inputs. An unavailable change set is an error, not an empty selection. Pushes to
+`main` run the full set as a backstop. The workflow itself always starts, so required-check
+reporting does not depend on GitHub's workflow-level path filters.
+
+Release-plan generation (`validate-versions`) remains unconditional: it compares every
+publishable package's released content to that package's version anchor, not just to the PR
+base. Live binstall metadata validation accompanies it because Cargo target discovery can
+change release obligations without a manifest edit. Managed-repair context and its gate also
+remain unconditional because their inputs include registered state and PR metadata.
 
 ## Platform strategy
 
@@ -304,7 +316,9 @@ A ruleset that requires merge-blocking Standard validation therefore lists only 
 job is `if: always()`, `needs:` every merge-blocking job in Standard validation (including
 `validate-versions` and `semver-checks`), succeeds when every dependency reports `success` or an
 allowed `skipped`, and fails on `failure`, `cancelled`, or any other result.
-Unconditional gates may not skip. Advisory jobs stay off that list. `alert` stays off it
+Unconditional gates may not skip. Change-selected tooling jobs must succeed when selected;
+only an explicit no-work plan permits them to skip. Missing plans or dependencies fail the
+fan-in. Advisory jobs stay off that list. `alert` stays off it
 — it files issues on a failed push to `main`, it is not a merge gate.
 
 When a new merge-blocking job is added to Standard validation it is added to this `needs:` list; it

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -78,11 +78,54 @@ name and ruleset target are exactly `required-checks`.
 
 `standard-validation.yml` assigns each independently useful check to a separate job so GitHub reports the
 outcomes in parallel. Cargo-package jobs consume the affected-package set from the `delta`
-job. Repository-wide checks run without that gate.
+job. Non-Cargo checks use the independent path plan, supplemented by native-helper package
+impact for script integration tests. Release and managed-repair gates remain unconditional.
 
 Pull requests and merge-queue entries use the pruned validation set. Pushes to `main` use the
 full set. Queue delta analysis takes the event's base commit so its comparison cannot drift
 from the queued merge candidate.
+
+### Non-Cargo change planning
+
+The `changes` job runs `scripts/build/ValidationPlan.psm1` with Git and preinstalled
+PowerShell, before preparing a development environment. Rust is impractical at this boundary:
+installing its toolchains and build prerequisites merely to decide whether standalone lint
+should run would impose the setup cost this planner is intended to avoid.
+
+The planner reads immutable event SHAs from a full-history checkout. Pull requests compare
+their head with its merge base against the event's base SHA, covering all PR commits without
+including unrelated base-branch changes. Merge groups compare their exact base and combined
+head directly. Git emits NUL-delimited paths with rename detection disabled, so a move
+contributes both its removed path and its added path without filename quoting ambiguity.
+Unavailable revisions fail. Main pushes explicitly select the full suite.
+
+Script directories are coarse test domains. The module declares recipe ownership and
+cross-domain consumers, and defaults unfamiliar script/recipe locations to the full suite.
+Setup, shared utility, planner and fan-in changes select every tooling check. Fixtures select
+their owning tests; workflow changes also select the Pester workflow-contract tests. Analyzer
+configuration and script files select static analysis independently of the Pester scope.
+
+The `delta` job combines the path-selected domains with affected native helpers used by
+scheduled integration tests. Dependency impact comes from Cargo delta rather than treating
+every lockfile change as a full-script-suite trip wire. Live manifest changes also select the
+scheduled tests that read workspace metadata. The resulting domain array is explicit even
+when empty. `test-scripts` runs that union once; `just test-scripts "book release"` is the local
+equivalent, while an omitted argument retains full discovery. Unknown domains or explicit
+directories containing no tests fail rather than producing a successful empty run.
+
+Recipe files follow their automation responsibility: benchmark history and release commands
+have separate imports, while setup installers live beside the setup module. Workflow
+entrypoints stay in GitHub's required location. Co-location reduces selection coupling but
+does not replace declared dependencies.
+
+### Workflow lint environment
+
+`setup-workflow-lint` restores the same portable actionlint/ShellCheck cache as
+`setup-environment` and invokes the same pinned, checksum-verifying installers under
+`scripts/setup`. It needs neither Rust toolchain setup nor system package installation.
+The workflow invokes `actionlint -color` directly, matching `just validate-workflows` without
+installing Just solely to dispatch that command. Local full setup continues to install these
+same binaries, and the workflow-contract tests keep the command and cache keys aligned.
 
 ## Release validation
 
@@ -120,6 +163,11 @@ read-only, with no hidden preparation or dependency refresh.
 There is no separate version-approval prompt. The complete pull request and its
 Version/release plan section carry the human review of release impact.
 
+The unconditional `validate-versions` job also runs `validate-binstall` against the live
+workspace. Release-target and archive-shape obligations follow Cargo's discovered binary
+targets, including source additions that do not edit a manifest. The version report still runs
+after a binstall failure so semantic-version analysis can consume its output in the same run.
+
 Plan generation is verified by asserting properties of the generated plan over a matrix of report
 states, not only by testing individual guards. The properties are that every entry is well formed
 and names a known target, that no target receives two decision kinds, that no version moves
@@ -143,6 +191,12 @@ The `required-checks` job is the intended single ruleset target. Its `needs` gra
 every merge-blocking Standard validation job. `scripts/build/RequiredChecks.psm1` rejects failed,
 cancelled, missing, and unknown dependency results. It permits `skipped` only for jobs whose
 event, platform, or package scope legitimately excludes them.
+
+For tooling checks it reads the explicit `changes` plan and reconstructs script selection
+using `delta`'s affected-package output. The execution-domain output must agree with that
+selection. Every selected tooling job must succeed; every tooling dependency must be present,
+even when not selected. Both planners remain must-succeed dependencies, so a failed planner
+cannot turn downstream skips into merge approval.
 
 The classifier only observes what `needs` supplies, so it also rejects an unconditional gate
 that its must-succeed list names but the payload omits. A name that drifts out of the `needs:`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release
 # (rather than a separate tag-triggered workflow) is what lets the ambient
 # GITHUB_TOKEN suffice - no PAT or GitHub App token needed.
 #
-# The non-trivial logic lives in PowerShell `just` recipes (justfiles/just_automation.just)
+# The non-trivial logic lives in PowerShell `just` recipes (justfiles/just_release.just)
 # so it can be run and tested locally; the steps here are thin `just` calls.
 on:
   push:

--- a/.github/workflows/standard-validation.yml
+++ b/.github/workflows/standard-validation.yml
@@ -41,6 +41,31 @@ permissions:
   contents: read
 
 jobs:
+  # Git and preinstalled PowerShell are sufficient to scope non-Cargo checks before setup.
+  # Complete history supports the whole PR and the queue's immutable combined candidate.
+  # Ref: .github/workflows/implementation.md#non-cargo-change-planning.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      plan: ${{ steps.plan.outputs.plan }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Plan non-Cargo validation
+        id: plan
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          Import-Module ./scripts/build/ValidationPlan.psm1 -Force
+          $eventData = Get-Content -LiteralPath $env:GITHUB_EVENT_PATH -Raw | ConvertFrom-Json -AsHashtable
+          $plan = Get-ValidationWorkflowPlan -EventName $env:GITHUB_EVENT_NAME -EventData $eventData -Verbose
+          "plan=$(ConvertTo-Json -InputObject $plan -Compress)" |
+            Add-Content -LiteralPath $env:GITHUB_OUTPUT -Encoding utf8
+
   # Ordinary validation is shallow; only registered managed repairs need relevant deep scope.
   # Default-branch policy, not candidate edits, controls managed repair authorization.
   # Ref: .github/workflows/implementation.md#managed-repair-gate.
@@ -217,11 +242,13 @@ jobs:
   # commit the queue rebased onto) so scoping cannot drift from validate-versions.
   # On push to main (backstop), all packages are validated.
   delta:
+    needs: changes
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.compute.outputs.packages }}
       packages_json: ${{ steps.compute.outputs.packages_json }}
       skip_all: ${{ steps.compute.outputs.skip_all }}
+      script_domains: ${{ steps.scripts.outputs.domains }}
 
     steps:
       - name: Checkout repository
@@ -264,13 +291,29 @@ jobs:
             -BaselineRevision $env:DELTA_BASELINE |
             Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
 
-  # PowerShell test suite for the standalone scripts under scripts/ (the release-automation and
-  # binstall-validation modules), plus PSScriptAnalyzer static analysis of those scripts and the
-  # binstall-metadata check on the real workspace. Runs unconditionally - independent of the
-  # `delta` package analysis - because the scripts are not Cargo packages, so a change touching
-  # only scripts/ would otherwise be validated by nothing; the static-analysis and binstall checks
-  # ride along here because they reuse the same environment and are seconds long.
+      - name: Include affected native helpers in script scope
+        # Pester integration tests exercise real Rust helpers. Consume Cargo's dependency impact
+        # instead of making every lockfile edit trigger the full script suite.
+        # Ref: .github/workflows/implementation.md#non-cargo-change-planning.
+        id: scripts
+        shell: pwsh
+        env:
+          CHANGE_PLAN: ${{ needs.changes.outputs.plan }}
+          AFFECTED_PACKAGES: ${{ steps.compute.outputs.packages_json }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          Import-Module ./scripts/build/ValidationPlan.psm1 -Force
+          $domains = @(Get-ValidationScriptDomain -PlanJson $env:CHANGE_PLAN -AffectedPackageJson $env:AFFECTED_PACKAGES -Verbose)
+          "domains=$(ConvertTo-Json -InputObject $domains -Compress)" |
+            Add-Content -LiteralPath $env:GITHUB_OUTPUT -Encoding utf8
+
+  # Run the union of selected domains once. An empty Cargo delta cannot discard script inputs.
+  # Ref: .github/workflows/implementation.md#non-cargo-change-planning.
   test-scripts:
+    needs: delta
+    if: needs.delta.outputs.script_domains != '[]'
     runs-on: ubuntu-latest
 
     steps:
@@ -281,19 +324,33 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Run script test suites
-        run: just test-scripts
+        shell: pwsh
+        env:
+          SCRIPT_DOMAINS: ${{ needs.delta.outputs.script_domains }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $domains = @(ConvertFrom-Json -InputObject $env:SCRIPT_DOMAINS)
+          just test-scripts ($domains -join ' ')
 
+  # Static analysis has script/configuration inputs, not Cargo-package inputs.
+  # Ref: .github/workflows/implementation.md#non-cargo-change-planning.
+  validate-scripts:
+    needs: changes
+    if: fromJSON(needs.changes.outputs.plan).script_analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-environment
       - name: Validate scripts (PSScriptAnalyzer)
         run: just validate-scripts
 
-      - name: Validate binstall metadata
-        run: just validate-binstall
-
-  # Validates the GitHub Actions workflow files with actionlint. Runs unconditionally - independent
-  # of the `delta` package analysis - because the workflow files are not Cargo packages, so a
-  # change touching only .github/workflows/ would otherwise be validated by nothing. actionlint
-  # is a fast static check, so running it on every PR is cheap.
+  # Reuse the pinned standalone installers without restoring the Rust development environment.
+  # Ref: .github/workflows/implementation.md#workflow-lint-environment.
   validate-workflows:
+    needs: changes
+    if: fromJSON(needs.changes.outputs.plan).workflows
     runs-on: ubuntu-latest
 
     steps:
@@ -301,10 +358,15 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup environment
-        uses: ./.github/actions/setup-environment
+        uses: ./.github/actions/setup-workflow-lint
 
       - name: Validate workflows
-        run: just validate-workflows
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          actionlint -color
 
   # Workspace-wide release-plan generation: every publishable package's released content
   # versus its version anchor. Delta cannot narrow that set, so this job is not gated on
@@ -326,7 +388,14 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
+      # Live Cargo metadata belongs with unconditional release validation: target autodiscovery
+      # can change the binary set without a manifest edit.
+      # Ref: .github/workflows/implementation.md#release-validation.
+      - name: Validate binstall metadata
+        run: just validate-binstall
+
       - name: Check package versions
+        if: ${{ !cancelled() }}
         id: check
         env:
           # The release baseline is the tip of the branch releases are made from, which is
@@ -1038,8 +1107,10 @@ jobs:
     needs:
       - scheduled-context
       - scheduled-repair-gate
+      - changes
       - delta
       - test-scripts
+      - validate-scripts
       - validate-workflows
       - validate-versions
       - semver-checks
@@ -1072,7 +1143,7 @@ jobs:
         shell: pwsh
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
-          MUST_SUCCEED_JOBS: delta test-scripts validate-workflows validate-versions semver-checks scheduled-context scheduled-repair-gate
+          MUST_SUCCEED_JOBS: changes delta validate-versions semver-checks scheduled-context scheduled-repair-gate
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
@@ -1103,8 +1174,10 @@ jobs:
     needs:
       - scheduled-context
       - scheduled-repair-gate
+      - changes
       - delta
       - test-scripts
+      - validate-scripts
       - validate-workflows
       - validate-versions
       - semver-checks

--- a/docs/build-and-tooling.md
+++ b/docs/build-and-tooling.md
@@ -191,7 +191,7 @@ over everything under `scripts/`, gating on Error/Warning findings. The rule set
 `PSScriptAnalyzerSettings.psd1`, supplemented by repo-local custom rules in
 `scripts/analyzer/FoloAnalyzerRules.psm1` - which catch classes the built-in rules (and strict
 mode) miss, such as a `foreach` whose loop variable case-insensitively collides with the
-collection it enumerates. It runs as part of `just validate-local` and the CI `test-scripts` job.
+collection it enumerates. It runs as part of `just validate-local` and the CI `validate-scripts` job.
 Silence a genuine false positive with a justified
 `[Diagnostics.CodeAnalysis.SuppressMessageAttribute(...)]`, never by relaxing the gate; the tree
 is expected to be finding-free.
@@ -203,3 +203,10 @@ When the calling environment requires PowerShell, put nontrivial orchestration i
 a module under `scripts/`, covered by Pester (`just test-scripts`) and the analyzer.
 The recipe or workflow step then imports and invokes that boundary. A preamble and
 a command or two may stay inline.
+
+`just test-scripts` discovers the full PowerShell suite. Pass space-separated script-directory
+domains, for example `just test-scripts "book release"`, to run their union. CI selects these
+domains from changed inputs and native-helper dependency impact; script analysis and workflow
+lint have independent selections. Main pushes retain full validation. See
+[non-Cargo change planning](../.github/workflows/implementation.md#non-cargo-change-planning)
+for ownership, shared-input rules and the lightweight workflow-lint environment.

--- a/docs/cargo-delta.md
+++ b/docs/cargo-delta.md
@@ -71,3 +71,7 @@ Pull request and merge-queue builds use delta to validate only impacted packages
 builds act as a backstop and always validate the full workspace. If the backstop catches something
 that the delta build missed, the `delta.toml` configuration should be updated to prevent
 recurrence.
+
+Non-Cargo checks use independent change domains rather than `skip_all`. Script integration
+tests also consume the affected-package set for the native helpers they exercise. See
+[non-Cargo change planning](../.github/workflows/implementation.md#non-cargo-change-planning).

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -168,7 +168,7 @@ version edit, before pushing.
 
 Each step is a thin `pwsh` call into a `just` recipe; the publishing logic — deriving
 the binary crates, injecting `git_release_enable`, and the retry loop — lives in
-[`justfiles/just_automation.just`](../justfiles/just_automation.just), which delegates in
+[`justfiles/just_release.just`](../justfiles/just_release.just), which delegates in
 turn to the [`scripts/release/ReleaseAutomation.psm1`](../scripts/release/ReleaseAutomation.psm1)
 module, so it can be run and tested on a developer PC rather than only by pushing to `main`.
 The module is covered by a Pester suite run via `just test-scripts` (a required CI check); the

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ _default:
     @just --list
 
 import 'justfiles/just_basics.just'
-import 'justfiles/just_automation.just'
+import 'justfiles/just_bench_history.just'
 import 'justfiles/just_book.just'
 import 'justfiles/just_delta.just'
 import 'justfiles/just_quality.just'

--- a/justfiles/just_bench_history.just
+++ b/justfiles/just_bench_history.just
@@ -1,9 +1,9 @@
-# Recipes intended ONLY for automation (GitHub Actions), not local use. Each is
-# prefixed `gh-` to signal that. They assume the workspace's committed
-# `.cargo/bench_history.toml` already points at the prod Azure history store
-# (account folohistory) and that the runner is signed in to Azure. We may factor
-# these out into dedicated GitHub Actions later (see folo-rs/folo#284), so keep them
-# thin wrappers over the tool, free of local-developer conveniences.
+# Benchmark-history entry points for the bench-history, pr-bench-history and
+# bench-history-backfill GitHub workflows. The `gh-` recipes are CI-only; collection
+# and analysis use the prod Azure history store configured by `.cargo/bench_history.toml`
+# (account folohistory) and require the runner to be signed in to Azure. Keep these
+# wrappers over cargo-bench-history and the owning modules under scripts/bench-history/
+# free of local-developer conveniences.
 
 # Collects the whole workspace's benchmark history (excluding the slow, special-purpose
 # `benchmarks` package) with every selected package's Cargo features enabled, so targets guarded by
@@ -495,108 +495,3 @@ gh-flag-pr-comment-if-stale repo pr marker analyzed_sha body_file:
     } else {
         Write-Verbose "The composed results still describe the PR head (or the live head could not be read); posting as composed." -Verbose
     }
-
-# The release-automation logic lives in scripts/release/ReleaseAutomation.psm1, with a Pester
-# suite (scripts/release/ReleaseAutomation.Tests.ps1) that exercises it against fixtures via
-# `just test-scripts`. The recipes below are thin wrappers that import the module and call its
-# functions, which keeps the logic (crate derivation, config injection, retry loop, binary
-# reconciliation, and the triple -> runner mapping) testable on a developer PC rather than only
-# via a push to `main`.
-
-# Writes a CI-only copy of release-plz.toml to {{output}} with `git_release_enable = true`
-# set for each publishable binary crate (derived from cargo metadata), leaving everything
-# else untouched. The committed config keeps releases OFF at the workspace level so the many
-# library/`_impl` crates never spawn GitHub releases; enabling it only for the derived binary
-# crates means a newly-added binary tool is covered with no config edit and no library crate
-# is ever released. The caller writes this OUTSIDE the working tree so `cargo publish` never
-# sees a dirty repo. See .github/workflows/release.yml and docs/release-automation.md.
-[group('automation')]
-[script]
-gh-compose-release-config output:
-    Set-StrictMode -Version Latest
-    $ErrorActionPreference = "Stop"
-    $PSNativeCommandUseErrorActionPreference = $true
-    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
-
-    $crates = @(Get-PublishableBinaryCrate)
-    $crateNames = @($crates | ForEach-Object { $_.Name })
-    Write-Verbose "Publishable binary crates: $($crateNames -join ', ')" -Verbose
-    New-ReleasePlzConfig -SourcePath 'release-plz.toml' -OutputPath '{{output}}' -CrateName $crateNames
-    Write-Verbose "Wrote CI release-plz config to {{output}}." -Verbose
-
-    # Print the composed config so the CI log records exactly what release-plz will run with
-    # (which crates got `git_release_enable = true`), without needing to unpack the runner temp.
-    Write-Host "----- Composed CI release-plz config ({{output}}) -----"
-    Get-Content -Path '{{output}}' -Raw | Write-Host
-    Write-Host "----- End composed CI release-plz config -----"
-
-# Publishes changed crates to crates.io via release-plz using the composed CI config, with
-# bounded retries (3 attempts, 15 minutes apart) to ride out crates.io rate limits and the
-# short-lived OIDC token. release-plz is idempotent - it re-checks the registry and skips
-# already-published versions - so a retry (or a whole re-run) safely resumes a partially
-# published release, and each attempt mints a fresh OIDC token. NOT for local use: it
-# performs real publishes. See docs/release-automation.md.
-[group('automation')]
-[script]
-gh-release config:
-    Set-StrictMode -Version Latest
-    $ErrorActionPreference = "Stop"
-    $PSNativeCommandUseErrorActionPreference = $true
-    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
-
-    Invoke-ReleasePublish -ConfigPath '{{config}}'
-
-# Creates any GitHub release/tag that release-plz could not create because the matching crates.io
-# version was already published manually or before a partial failure. Each tag points at the
-# package's version anchor from cargo-release-plan, so it identifies the revision that introduced
-# the published version even when recovery happens after later unrelated merges. COMMIT is the
-# exact checked-out release-branch commit: it fixes the report baseline so a feature branch or a
-# later-moving remote-tracking ref cannot pair current manifest versions with older anchors.
-[group('automation')]
-[script]
-gh-create-missing-binary-releases COMMIT:
-    Set-StrictMode -Version Latest
-    $ErrorActionPreference = "Stop"
-    $PSNativeCommandUseErrorActionPreference = $true
-    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
-
-    $crates = @(Get-PublishableBinaryCrate)
-    $crateNames = @($crates | ForEach-Object { $_.Name })
-    Write-Verbose "Publishable binary crates: $($crateNames -join ', ')" -Verbose
-    if ($crates.Count -gt 0) {
-        Invoke-BinaryReleaseReconciliation -Crate $crates -Base "{{ COMMIT }}" -Verbose
-    }
-
-# Reconciles the desired prebuilt-binary archive and checksum pairs against each
-# published binary crate's GitHub release, and emits the matrix of incomplete
-# (crate, target) pairs still to build as the `matrix` / `has_binaries` step outputs
-# (also printed). Missing GitHub releases are an error because the workflow creates
-# them in the preceding step. This is what makes retries self-healing: a re-run
-# rebuilds only whatever is still missing, with no hardcoded crate list. See
-# .github/workflows/release.yml and docs/release-automation.md.
-[group('automation')]
-[script]
-gh-plan-release-binaries:
-    Set-StrictMode -Version Latest
-    $ErrorActionPreference = "Stop"
-    $PSNativeCommandUseErrorActionPreference = $true
-    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
-
-    # Get-MissingBinaryMatrix emits its decision history (per crate: expected tag, whether the
-    # release exists, and the per-target present/missing verdict) via Write-Verbose. This is an
-    # automation-only recipe, so always emit it: the reasoning is worth capturing in every run
-    # (CI log or a local diagnostic invocation), not just the final count.
-    $crates = @(Get-PublishableBinaryCrate)
-    $crateNames = @($crates | ForEach-Object { $_.Name })
-    Write-Verbose "Publishable binary crates: $($crateNames -join ', ')" -Verbose
-    # Wrap the entire conditional because PowerShell enumerates a branch-local array when the
-    # conditional writes to the pipeline, collapsing an empty result to $null under strict mode.
-    $rows = @(
-        if ($crates.Count -gt 0) {
-            Get-MissingBinaryMatrix -Crate $crates -Verbose
-        }
-    )
-
-    Write-Host "Incomplete (crate, target) asset pairs: $($rows.Count)"
-    Set-GitHubOutput -Name 'matrix' -Value (ConvertTo-MatrixJson -Row $rows)
-    Set-GitHubOutput -Name 'has_binaries' -Value $(if ($rows.Count -gt 0) { 'true' } else { 'false' })

--- a/justfiles/just_quality.just
+++ b/justfiles/just_quality.just
@@ -85,7 +85,7 @@ validate-workflows:
 # Validates that every publishable binary crate declares the `[package.metadata.binstall]` block
 # the release workflow relies on, so a binary crate can never ship without installable prebuilt
 # binaries (see scripts/release/BinstallValidation.psm1 and docs/release-automation.md). Fast and
-# repo-wide (not package-scoped); folded into the same CI job as the other script checks.
+# repo-wide (not package-scoped); runs with unconditional CI release validation.
 [group('quality')]
 [script]
 validate-binstall:

--- a/justfiles/just_release.just
+++ b/justfiles/just_release.just
@@ -1,3 +1,8 @@
+# Release validation and version-planning entry points for developers, the increment-versions
+# skill and CI. scripts/release/ReleasePlan.psm1 owns plan orchestration, with release policy
+# in cargo-release-plan. CI publication and binary reconciliation use
+# scripts/release/ReleaseAutomation.psm1 through the `gh-` recipes below.
+
 [group('release')]
 audit:
     cargo audit
@@ -242,3 +247,107 @@ apply-release-plan EXPANDED:
 
     Import-Module "{{ justfile_directory() }}/scripts/release/ReleasePlan.psm1" -Force
     Invoke-ApplyReleasePlan -ExpandedPath "{{ EXPANDED }}"
+
+# CI-only publication and binary-reconciliation entry points for .github/workflows/release.yml.
+# scripts/release/ReleaseAutomation.psm1 owns crate derivation, config injection, publication
+# retries, binary reconciliation and target-to-runner mapping. Its Pester suite exercises those
+# decisions through `just test-scripts`; the recipes only import and invoke the owning module.
+# See docs/release-automation.md for the release workflow's responsibilities.
+
+# Writes a CI-only copy of release-plz.toml to {{output}} with `git_release_enable = true`
+# set for each publishable binary crate (derived from cargo metadata), leaving everything
+# else untouched. The committed config keeps releases OFF at the workspace level so the many
+# library/`_impl` crates never spawn GitHub releases; enabling it only for the derived binary
+# crates means a newly-added binary tool is covered with no config edit and no library crate
+# is ever released. The caller writes this OUTSIDE the working tree so `cargo publish` never
+# sees a dirty repo. See .github/workflows/release.yml and docs/release-automation.md.
+[group('automation')]
+[script]
+gh-compose-release-config output:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
+
+    $crates = @(Get-PublishableBinaryCrate)
+    $crateNames = @($crates | ForEach-Object { $_.Name })
+    Write-Verbose "Publishable binary crates: $($crateNames -join ', ')" -Verbose
+    New-ReleasePlzConfig -SourcePath 'release-plz.toml' -OutputPath '{{output}}' -CrateName $crateNames
+    Write-Verbose "Wrote CI release-plz config to {{output}}." -Verbose
+
+    # Print the composed config so the CI log records exactly what release-plz will run with
+    # (which crates got `git_release_enable = true`), without needing to unpack the runner temp.
+    Write-Host "----- Composed CI release-plz config ({{output}}) -----"
+    Get-Content -Path '{{output}}' -Raw | Write-Host
+    Write-Host "----- End composed CI release-plz config -----"
+
+# Publishes changed crates to crates.io via release-plz using the composed CI config, with
+# bounded retries (3 attempts, 15 minutes apart) to ride out crates.io rate limits and the
+# short-lived OIDC token. release-plz is idempotent - it re-checks the registry and skips
+# already-published versions - so a retry (or a whole re-run) safely resumes a partially
+# published release, and each attempt mints a fresh OIDC token. NOT for local use: it
+# performs real publishes. See docs/release-automation.md.
+[group('automation')]
+[script]
+gh-release config:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
+
+    Invoke-ReleasePublish -ConfigPath '{{config}}'
+
+# Creates any GitHub release/tag that release-plz could not create because the matching crates.io
+# version was already published manually or before a partial failure. Each tag points at the
+# package's version anchor from cargo-release-plan, so it identifies the revision that introduced
+# the published version even when recovery happens after later unrelated merges. COMMIT is the
+# exact checked-out release-branch commit: it fixes the report baseline so a feature branch or a
+# later-moving remote-tracking ref cannot pair current manifest versions with older anchors.
+[group('automation')]
+[script]
+gh-create-missing-binary-releases COMMIT:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
+
+    $crates = @(Get-PublishableBinaryCrate)
+    $crateNames = @($crates | ForEach-Object { $_.Name })
+    Write-Verbose "Publishable binary crates: $($crateNames -join ', ')" -Verbose
+    if ($crates.Count -gt 0) {
+        Invoke-BinaryReleaseReconciliation -Crate $crates -Base "{{ COMMIT }}" -Verbose
+    }
+
+# Reconciles the desired prebuilt-binary archive and checksum pairs against each
+# published binary crate's GitHub release, and emits the matrix of incomplete
+# (crate, target) pairs still to build as the `matrix` / `has_binaries` step outputs
+# (also printed). Missing GitHub releases are an error because the workflow creates
+# them in the preceding step. This is what makes retries self-healing: a re-run
+# rebuilds only whatever is still missing, with no hardcoded crate list. See
+# .github/workflows/release.yml and docs/release-automation.md.
+[group('automation')]
+[script]
+gh-plan-release-binaries:
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+    $PSNativeCommandUseErrorActionPreference = $true
+    Import-Module ./scripts/release/ReleaseAutomation.psm1 -Force
+
+    # Get-MissingBinaryMatrix emits its decision history (per crate: expected tag, whether the
+    # release exists, and the per-target present/missing verdict) via Write-Verbose. This is an
+    # automation-only recipe, so always emit it: the reasoning is worth capturing in every run
+    # (CI log or a local diagnostic invocation), not just the final count.
+    $crates = @(Get-PublishableBinaryCrate)
+    $crateNames = @($crates | ForEach-Object { $_.Name })
+    Write-Verbose "Publishable binary crates: $($crateNames -join ', ')" -Verbose
+    # Wrap the entire conditional because PowerShell enumerates a branch-local array when the
+    # conditional writes to the pipeline, collapsing an empty result to $null under strict mode.
+    $rows = @(
+        if ($crates.Count -gt 0) {
+            Get-MissingBinaryMatrix -Crate $crates -Verbose
+        }
+    )
+
+    Write-Host "Incomplete (crate, target) asset pairs: $($rows.Count)"
+    Set-GitHubOutput -Name 'matrix' -Value (ConvertTo-MatrixJson -Row $rows)
+    Set-GitHubOutput -Name 'has_binaries' -Value $(if ($rows.Count -gt 0) { 'true' } else { 'false' })

--- a/justfiles/just_setup.just
+++ b/justfiles/just_setup.just
@@ -133,12 +133,12 @@ install-tools:
     # azcopy drives the bulk upload in the cargo-bench-history Azure stress harness
     # (`just bench-history-stress-azure`), which is on-demand only - no CI job needs it, so CI
     # sets skip_azcopy=true. It is not a cargo crate and has no installer, so a helper script
-    # fetches the pinned official binary; see scripts/install-azcopy.ps1 (including its rationale
+    # fetches the pinned official binary; see scripts/setup/install-azcopy.ps1 (including its rationale
     # for the destination). No-op when azcopy is already present.
     if ("{{skip_azcopy}}" -eq "true") {
         Write-Host "Skipping azcopy install (skip_azcopy=true)."
     } else {
-        & "{{justfile_directory()}}/scripts/install-azcopy.ps1"
+        & "{{justfile_directory()}}/scripts/setup/install-azcopy.ps1"
     }
 
     # Azurite is the Azure Blob storage emulator that backs the cargo-bench-history
@@ -205,14 +205,14 @@ install-tools:
     # Linux runners ship it, so the CI validate-workflows job shellchecks every bash step; installing
     # it here keeps local `just validate-workflows` faithful to CI instead of silently skipping those
     # checks. Like actionlint it is a pinned, checksum-verified standalone binary; see
-    # scripts/install-shellcheck.ps1. Installed on every platform with no CI skip. No-op when the
+    # scripts/setup/install-shellcheck.ps1. Installed on every platform with no CI skip. No-op when the
     # pinned ShellCheck is already present.
-    & "{{justfile_directory()}}/scripts/install-shellcheck.ps1"
+    & "{{justfile_directory()}}/scripts/setup/install-shellcheck.ps1"
 
     # actionlint validates the GitHub Actions workflow files (`just validate-workflows`, run both
     # locally and by the CI validate-workflows job). It is not a cargo crate and has no installer, so a
     # helper script fetches the pinned official binary and verifies its checksum; see
-    # scripts/install-actionlint.ps1. Unlike azcopy/Azurite this IS needed in CI (the workflow
+    # scripts/setup/install-actionlint.ps1. Unlike azcopy/Azurite this IS needed in CI (the workflow
     # validation job runs it), so it is installed on every platform with no CI skip. No-op when the
     # pinned actionlint is already present.
-    & "{{justfile_directory()}}/scripts/install-actionlint.ps1"
+    & "{{justfile_directory()}}/scripts/setup/install-actionlint.ps1"

--- a/justfiles/just_testing.just
+++ b/justfiles/just_testing.just
@@ -161,21 +161,20 @@ test FILTER="":
     }
     cargo +$env:RUST_MSRV nextest run {{ target_package }} --all-features {{ FILTER }} --locked --no-fail-fast
 
-# Run the PowerShell test suites for the standalone scripts under scripts/ (currently the
-# release-automation module, scripts/release/ReleaseAutomation.psm1). Uses Pester 5, installed by
-# `just install-tools`. The suites run real `cargo metadata` and file I/O against fixtures and
-# mock the tools that would touch crates.io / GitHub for real (`release-plz`, `gh`). Discovers
-# every *.Tests.ps1 under scripts/. See scripts/release/ReleaseAutomation.Tests.ps1.
+# Runs all script suites locally, or the union of space-separated script domains selected by CI.
+# Invalid explicit selections fail instead of producing a successful empty Pester run.
+# Ref: .github/workflows/implementation.md#non-cargo-change-planning.
 [group('testing')]
 [script]
-test-scripts:
+test-scripts DOMAINS='':
     Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
     $PSNativeCommandUseErrorActionPreference = $true
 
     Import-Module Pester -MinimumVersion 5.0 -Force
+    Import-Module ./scripts/build/ValidationPlan.psm1 -Force
     $config = New-PesterConfiguration
-    $config.Run.Path = 'scripts'
+    $config.Run.Path = @(Get-ScriptTestPath -Domains "{{DOMAINS}}")
     $config.Run.Exit = $true
     $config.Output.Verbosity = 'Detailed'
     Invoke-Pester -Configuration $config

--- a/scripts/bench-history/BenchHistoryPath.psm1
+++ b/scripts/bench-history/BenchHistoryPath.psm1
@@ -1,7 +1,7 @@
 #requires -Version 7
 
 # Output-directory preparation shared by the benchmark-history automation recipes in
-# justfiles/just_automation.just. Both analyze recipes (gh-analyze-bench-history,
+# justfiles/just_bench_history.just. Both analyze recipes (gh-analyze-bench-history,
 # gh-analyze-pr-bench-history) must ensure their scratch report directory exists before writing the
 # four report artefacts into it, and gh-write-bench-history-machine-key must ensure the parent
 # directory of the key file exists before writing the key.

--- a/scripts/build/RequiredChecks.Tests.ps1
+++ b/scripts/build/RequiredChecks.Tests.ps1
@@ -140,3 +140,73 @@ Describe 'Get-RequiredCheckFailure' {
         }
     }
 }
+
+Describe 'Planned tooling results' {
+    BeforeEach {
+        $script:plan = @{ workflows = $false; script_analysis = $false; script_domains = @() }
+        $script:needs = @{
+            changes = @{ result = 'success'; outputs = @{} }
+            delta = @{ result = 'success'; outputs = @{ packages_json = '[]'; script_domains = '[]' } }
+            'test-scripts' = @{ result = 'skipped' }
+            'validate-scripts' = @{ result = 'skipped' }
+            'validate-workflows' = @{ result = 'skipped' }
+        }
+        function Assert-PlannedResult {
+            $needs.changes.outputs.plan = ConvertTo-Json -InputObject $plan -Compress
+            Assert-RequiredCheck -NeedsJson (ConvertTo-Json -InputObject $needs -Depth 10) `
+                -MustSucceedJob @('changes', 'delta')
+        }
+    }
+
+    It 'accepts planned skips but rejects a selected workflow check that skipped' {
+        { Assert-PlannedResult } | Should -Not -Throw
+        $plan.workflows = $true
+        { Assert-PlannedResult } | Should -Throw
+        $needs['validate-workflows'].result = 'success'
+        { Assert-PlannedResult } | Should -Not -Throw
+    }
+
+    It 'requires script analysis when selected' {
+        $plan.script_analysis = $true
+        { Assert-PlannedResult } | Should -Throw
+        $needs['validate-scripts'].result = 'success'
+        { Assert-PlannedResult } | Should -Not -Throw
+    }
+
+    It 'requires path-selected script tests and rejects lost domains' {
+        $plan.script_domains = @('book')
+        { Assert-PlannedResult } | Should -Throw
+        $needs.delta.outputs.script_domains = '["book"]'
+        { Assert-PlannedResult } | Should -Throw
+        $needs['test-scripts'].result = 'success'
+        { Assert-PlannedResult } | Should -Not -Throw
+    }
+
+    It 'requires integration tests for an affected native helper' {
+        $needs.delta.outputs.packages_json = '["scheduled-mutation-config"]'
+        { Assert-PlannedResult } | Should -Throw
+        $needs.delta.outputs.script_domains = '["scheduled"]'
+        { Assert-PlannedResult } | Should -Throw
+        $needs['test-scripts'].result = 'success'
+        { Assert-PlannedResult } | Should -Not -Throw
+    }
+
+    It 'rejects omitted conditional jobs even for a no-work plan' -ForEach @(
+        'test-scripts', 'validate-scripts', 'validate-workflows'
+    ) {
+        $needs.Remove($_)
+        { Assert-PlannedResult } | Should -Throw
+    }
+
+    It 'rejects failed or cancelled planners even when all tooling jobs skipped' -ForEach @(
+        'failure', 'cancelled', 'skipped'
+    ) {
+        $needs.changes.result = $_
+        { Assert-PlannedResult } | Should -Throw
+    }
+
+    It 'rejects absent planner output' {
+        $needs.delta.outputs.Remove('script_domains')
+        { Assert-PlannedResult } | Should -Throw
+    }
+}

--- a/scripts/build/RequiredChecks.psm1
+++ b/scripts/build/RequiredChecks.psm1
@@ -11,6 +11,7 @@
 # .github/workflows/implementation.md.
 
 Set-StrictMode -Version Latest
+Import-Module (Join-Path $PSScriptRoot 'ValidationPlan.psm1')
 
 function Assert-RequiredCheck {
     # Throws when any merge-blocking dependency did not produce an allowed result, so the
@@ -82,6 +83,29 @@ function Get-RequiredCheckFailure {
         [System.StringComparer]::Ordinal)
 
     $failure = [System.Collections.Generic.List[string]]::new()
+    if ($mustSucceed.Contains('changes')) {
+        # Reconstruct the selection from both planners rather than allowing every conditional
+        # job to skip. Missing outputs, lost domains, or an omitted conditional dependency fail.
+        # Ref: .github/workflows/implementation.md#merge-blocking-result.
+        $planJson = [string] $needs.changes.outputs.plan
+        $plan = Read-ValidationPlan -Json $planJson
+        $expectedDomains = @(Get-ValidationScriptDomain -PlanJson $planJson `
+                -AffectedPackageJson $needs.delta.outputs.packages_json)
+        $actualDomains = @(Read-ScriptDomain -Value (
+                ConvertFrom-Json -InputObject $needs.delta.outputs.script_domains -NoEnumerate))
+        if (($expectedDomains -join ' ') -cne ($actualDomains -join ' ')) {
+            throw 'The script execution selection does not match the validation plan and Cargo delta.'
+        }
+        $selection = @{
+            'test-scripts' = $expectedDomains.Count -gt 0
+            'validate-scripts' = $plan.script_analysis
+            'validate-workflows' = $plan.workflows
+        }
+        foreach ($name in $selection.Keys) {
+            if ($name -cnotin $needs.PSObject.Properties.Name) { $failure.Add("$name=absent") }
+            if ($selection[$name]) { $null = $mustSucceed.Add($name) }
+        }
+    }
     foreach ($job in $needs.PSObject.Properties) {
         $result = ''
         if ($null -ne $job.Value -and

--- a/scripts/build/ValidationPlan.Tests.ps1
+++ b/scripts/build/ValidationPlan.Tests.ps1
@@ -1,0 +1,217 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Protects Standard validation's change domains, whole-candidate Git comparisons and explicit
+# no-work results. Native Git fixtures cover deletions/renames without GitHub or a Rust setup.
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'ValidationPlan.psm1') -Force
+    $script:allDomains = @('analyzer', 'bench-history', 'book', 'build', 'release', 'scheduled', 'setup', 'utility')
+    function ConvertTo-PlanJson($Plan) { ConvertTo-Json -InputObject $Plan -Compress }
+}
+
+Describe 'Non-Cargo change domains' {
+    It 'does not select tooling for ordinary Rust or documentation changes' {
+        $plan = Get-ValidationPlan -ChangedPath @('packages/events_once/src/lib.rs', 'README.md',
+            'docs/testing.md', '.github/workflows/design.md', 'Cargo.lock')
+        $plan.workflows | Should -BeFalse
+        $plan.script_analysis | Should -BeFalse
+        $plan.script_domains | Should -BeNullOrEmpty
+        ConvertTo-PlanJson $plan | Should -Match '"script_domains":\[\]'
+    }
+
+    It 'selects the owner and its consumers for <Path>' -ForEach @(
+        @{ Path = 'scripts/book/BookSite.psm1'; Domains = @('book'); Analysis = $true; Workflows = $false },
+        @{ Path = 'scripts/book/BookSite.Tests.ps1'; Domains = @('book'); Analysis = $true; Workflows = $false },
+        @{ Path = 'scripts/bench-history/fixtures/result.json'; Domains = @('bench-history'); Analysis = $false; Workflows = $false },
+        @{ Path = 'scripts/build/Miri.psm1'; Domains = @('build', 'scheduled'); Analysis = $true; Workflows = $false },
+        @{ Path = 'scripts/release/ReleasePlan.psm1'; Domains = @('release', 'scheduled'); Analysis = $true; Workflows = $false },
+        @{ Path = 'PSScriptAnalyzerSettings.psd1'; Domains = @('analyzer'); Analysis = $true; Workflows = $false },
+        @{ Path = '.github/workflows/release.yml'; Domains = @('scheduled'); Analysis = $false; Workflows = $true },
+        @{ Path = '.github/actionlint.yaml'; Domains = @('scheduled'); Analysis = $false; Workflows = $true },
+        @{ Path = '.github/actions/setup-workflow-lint/action.yml'; Domains = @('scheduled'); Analysis = $false; Workflows = $true },
+        @{ Path = 'justfiles/just_bench_history.just'; Domains = @('bench-history'); Analysis = $false; Workflows = $false },
+        @{ Path = 'justfiles/just_release.just'; Domains = @('release', 'scheduled'); Analysis = $false; Workflows = $false },
+        @{ Path = 'justfiles/just_quality.just'; Domains = @('build', 'scheduled'); Analysis = $true; Workflows = $true },
+        @{ Path = '.cargo/mutants.toml'; Domains = @('build', 'scheduled'); Analysis = $false; Workflows = $false },
+        @{ Path = 'Cargo.toml'; Domains = @('scheduled'); Analysis = $false; Workflows = $false },
+        @{ Path = 'packages/cpulist/Cargo.toml'; Domains = @('scheduled'); Analysis = $false; Workflows = $false },
+        @{ Path = 'packages/scheduled-mutation-config/dependency-contract.json'; Domains = @('scheduled'); Analysis = $false; Workflows = $false }
+    ) {
+        $plan = Get-ValidationPlan -ChangedPath @($Path)
+        $plan.script_domains | Should -Be $Domains
+        $plan.script_analysis | Should -Be $Analysis
+        $plan.workflows | Should -Be $Workflows
+    }
+
+    It 'selects every tooling check for shared input <_>' -ForEach @(
+        'scripts/build/ValidationPlan.psm1', 'scripts/build/ValidationPlan.Tests.ps1',
+        'scripts/build/RequiredChecks.psm1', 'scripts/build/RequiredChecks.Tests.ps1',
+        'scripts/setup/install-actionlint.ps1', 'scripts/setup/install-shellcheck.ps1',
+        'scripts/setup/RustToolchain.psm1', 'scripts/utility/Retry.psm1',
+        '.github/actions/setup-environment/action.yml', 'justfile',
+        'justfiles/just_setup.just', 'justfiles/just_testing.just', 'constants.env',
+        'rust-toolchain.toml', '.gitattributes', '.gitconfig'
+    ) {
+        $plan = Get-ValidationPlan -ChangedPath @($_)
+        $plan.workflows | Should -BeTrue
+        $plan.script_analysis | Should -BeTrue
+        $plan.script_domains | Should -Be $allDomains
+    }
+
+    It 'does not silently exclude unfamiliar scripts or recipes' -ForEach @(
+        'scripts/new-domain/New.Tests.ps1', 'scripts/standalone.ps1', 'justfiles/new.just'
+    ) {
+        (Get-ValidationPlan -ChangedPath @($_)).script_domains | Should -Be $allDomains
+    }
+
+    It 'unions and deduplicates domains' {
+        $plan = Get-ValidationPlan -ChangedPath @('scripts/book/BookSite.psm1',
+            'scripts/book/BookSite.Tests.ps1', 'scripts/build/Miri.psm1')
+        $plan.script_domains | Should -Be @('book', 'build', 'scheduled')
+    }
+
+    It 'runs all tooling on main without needing a comparison' {
+        $plan = Get-ValidationWorkflowPlan -EventName push -EventData @{ ref = 'refs/heads/main' }
+        $plan.workflows | Should -BeTrue
+        $plan.script_analysis | Should -BeTrue
+        $plan.script_domains | Should -Be $allDomains
+    }
+
+    It 'rejects unsupported workflow events and non-main pushes' {
+        { Get-ValidationWorkflowPlan -EventName workflow_dispatch -EventData @{} } | Should -Throw
+        { Get-ValidationWorkflowPlan -EventName push -EventData @{ ref = 'refs/heads/feature' } } | Should -Throw
+    }
+}
+
+Describe 'Cargo helper integration selection' {
+    It 'adds scheduled tests for affected helper <_>' -ForEach @(
+        'cargo-release-plan', 'scheduled-mutation-config', 'scheduled-run-record'
+    ) {
+        $plan = ConvertTo-PlanJson (Get-ValidationPlan -ChangedPath @('scripts/book/BookSite.psm1'))
+        $packages = ConvertTo-Json -InputObject @($_) -Compress
+        @(Get-ValidationScriptDomain -PlanJson $plan -AffectedPackageJson $packages) |
+            Should -Be @('book', 'scheduled')
+    }
+
+    It 'does not select scripts for unrelated Cargo dependency impact' {
+        $plan = ConvertTo-PlanJson (Get-ValidationPlan -ChangedPath @('Cargo.lock'))
+        @(Get-ValidationScriptDomain -PlanJson $plan -AffectedPackageJson '["events_once"]') |
+            Should -BeNullOrEmpty
+    }
+
+    It 'preserves path-selected scripts when Cargo selects nothing' {
+        $plan = ConvertTo-PlanJson (Get-ValidationPlan -ChangedPath @('scripts/book/BookSite.psm1'))
+        @(Get-ValidationScriptDomain -PlanJson $plan -AffectedPackageJson '[]') | Should -Be @('book')
+    }
+
+    It 'rejects missing or malformed package outputs' -ForEach @('', 'null', '{}', '"crate"', '[1]') {
+        $plan = ConvertTo-PlanJson (Get-ValidationPlan -ChangedPath @())
+        { Get-ValidationScriptDomain -PlanJson $plan -AffectedPackageJson $_ } | Should -Throw
+    }
+
+    It 'rejects missing or malformed path plans' -ForEach @(
+        '', 'null', '{}', '{"workflows":false,"script_analysis":false}',
+        '{"workflows":"false","script_analysis":false,"script_domains":[]}',
+        '{"workflows":false,"script_analysis":false,"script_domains":"book"}',
+        '{"workflows":false,"script_analysis":false,"script_domains":["unknown"]}'
+    ) {
+        { Read-ValidationPlan -Json $_ } | Should -Throw
+    }
+}
+
+Describe 'Explicit Pester scope' {
+    It 'retains the full local default' {
+        Get-ScriptTestPath -Root $TestDrive | Should -Be $TestDrive
+    }
+
+    It 'resolves and deduplicates selected suites and rejects unknown or empty domains' {
+        $path = Join-Path $TestDrive 'book'
+        $null = New-Item -ItemType Directory -Path $path -Force
+        Set-Content -LiteralPath (Join-Path $path 'Book.Tests.ps1') -Value '# fixture'
+        @(Get-ScriptTestPath -Domains 'book book' -Root $TestDrive) | Should -Be @($path)
+        { Get-ScriptTestPath -Domains 'unknown' -Root $TestDrive } | Should -Throw
+        { Get-ScriptTestPath -Domains 'release' -Root $TestDrive } | Should -Throw
+        $null = New-Item -ItemType Directory -Path (Join-Path $TestDrive 'release') -Force
+        { Get-ScriptTestPath -Domains 'release' -Root $TestDrive } | Should -Throw
+    }
+
+    It 'covers every current test directory with the full selection' {
+        $root = Join-Path $PSScriptRoot '..'
+        $actual = @(Get-ChildItem -LiteralPath $root -Directory | Where-Object {
+                @(Get-ChildItem -LiteralPath $_.FullName -Filter '*.Tests.ps1' -Recurse -File).Count -gt 0
+            } | ForEach-Object { $_.Name } | Sort-Object)
+        $actual | Should -Be $allDomains
+        @(Get-ScriptTestPath -Domains ($allDomains -join ' ')).Count | Should -Be $allDomains.Count
+    }
+}
+
+Describe 'Complete Git change sets' {
+    BeforeEach {
+        $repo = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $repo
+        Push-Location $repo
+        git init --quiet --initial-branch=main
+        git config user.name 'Validation fixture'
+        git config user.email 'fixture@example.invalid'
+        git config commit.gpgsign false
+        $null = New-Item -ItemType Directory -Path 'scripts/book', 'scripts/build', 'scripts/setup'
+        Set-Content -LiteralPath 'scripts/book/old name.ps1' -Value '# book fixture'
+        Set-Content -LiteralPath 'README.md' -Value 'fixture'
+        git add .
+        git commit --quiet -m 'Fixture baseline'
+        $base = git rev-parse HEAD
+        function Save-FixtureCommit {
+            git add --all
+            git commit --quiet -m 'Fixture change'
+            return git rev-parse HEAD
+        }
+        function Get-FixturePlan([string] $Kind, [string] $Base, [string] $Head) {
+            $eventData = if ($Kind -ceq 'pull_request') {
+                @{ pull_request = @{ base = @{ sha = $Base }; head = @{ sha = $Head } } }
+            } else {
+                @{ merge_group = @{ base_sha = $Base; head_sha = $Head } }
+            }
+            Get-ValidationWorkflowPlan -EventName $Kind -EventData $eventData
+        }
+    }
+    AfterEach { Pop-Location }
+
+    It 'includes early PR commits even when the latest commit only touches documentation' {
+        Add-Content -LiteralPath 'scripts/book/old name.ps1' -Value '# changed'
+        $null = Save-FixtureCommit
+        Add-Content -LiteralPath 'README.md' -Value 'later'
+        $head = Save-FixtureCommit
+        (Get-FixturePlan pull_request $base $head).script_domains | Should -Be @('book')
+    }
+
+    It 'excludes changes made only on the advanced PR base branch' {
+        Add-Content -LiteralPath 'scripts/book/old name.ps1' -Value '# changed'
+        $head = Save-FixtureCommit
+        git switch --quiet -c advanced-base $base
+        Set-Content -LiteralPath 'scripts/setup/unrelated.ps1' -Value '# base-only'
+        $newBase = Save-FixtureCommit
+        (Get-FixturePlan pull_request $newBase $head).script_domains | Should -Be @('book')
+    }
+
+    It 'includes both domains of a rename and the entire merge group' {
+        Move-Item -LiteralPath 'scripts/book/old name.ps1' -Destination 'scripts/build/new name.ps1'
+        $null = Save-FixtureCommit
+        Add-Content -LiteralPath 'README.md' -Value 'another queued change'
+        $head = Save-FixtureCommit
+        (Get-FixturePlan merge_group $base $head).script_domains | Should -Be @('book', 'build', 'scheduled')
+    }
+
+    It 'retains deletions and emits an explicit empty plan for identical commits' {
+        Remove-Item -LiteralPath 'scripts/book/old name.ps1'
+        $head = Save-FixtureCommit
+        (Get-FixturePlan pull_request $base $head).script_domains | Should -Be @('book')
+        $empty = Get-FixturePlan merge_group $head $head
+        $empty.script_domains | Should -BeNullOrEmpty
+        $empty.script_analysis | Should -BeFalse
+        $empty.workflows | Should -BeFalse
+    }
+
+    It 'fails for missing or unavailable event revisions' {
+        { Get-ValidationWorkflowPlan -EventName pull_request -EventData @{} } | Should -Throw
+        { Get-FixturePlan merge_group $base ('f' * 40) } | Should -Throw
+    }
+}

--- a/scripts/build/ValidationPlan.psm1
+++ b/scripts/build/ValidationPlan.psm1
@@ -1,0 +1,274 @@
+#requires -Version 7
+
+# Plans non-Cargo Standard validation before any toolchain is installed, using only Git and
+# the runner's PowerShell. Bootstrapping Rust here would defeat the lightweight selection of
+# workflow lint and script analysis. Cargo dependency impact is added by the existing delta job.
+# Ref: .github/workflows/implementation.md#non-cargo-change-planning.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+# Directories are test domains, not independent dependency islands. Shared consumers below
+# supplement the owning directory; unknown script/recipe locations select the full suite.
+$script:ScriptDomains = @('analyzer', 'bench-history', 'book', 'build', 'release', 'scheduled', 'setup', 'utility')
+$script:RecipeDomains = @{
+    'just_basics.just' = @('build', 'scheduled')
+    'just_bench_history.just' = @('bench-history')
+    'just_book.just' = @('book')
+    'just_delta.just' = @('build')
+    'just_quality.just' = @('build', 'scheduled')
+    'just_quality_mutants.just' = @('build', 'scheduled')
+    'just_release.just' = @('release')
+    'just_scheduled.just' = @('scheduled')
+}
+
+function Get-ValidationPlan {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $ChangedPath,
+        [switch] $Full
+    )
+
+    $domains = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $workflows = $Full.IsPresent
+    $analysis = $Full.IsPresent
+    if ($Full) { $domains.UnionWith([string[]] $script:ScriptDomains) }
+
+    foreach ($path in $ChangedPath) {
+        # These inputs define selection or the shared invocation environment. Changes to the
+        # planner and fan-in must exercise every selectable check, including their own tests.
+        $shared = $path -cin @('justfile', 'constants.env', 'rust-toolchain.toml', '.gitattributes', '.gitconfig') -or
+            $path -cmatch '^scripts/(build/(ValidationPlan|RequiredChecks)(\.Tests\.ps1|\.psm1)|setup/.+|utility/.+)$' -or
+            $path -cmatch '^justfiles/just_(setup|testing)\.just$' -or
+            $path -cmatch '^\.github/actions/setup-environment/'
+        if ($shared) {
+            $workflows = $true
+            $analysis = $true
+            $domains.UnionWith([string[]] $script:ScriptDomains)
+            Write-Verbose "'$path' changes shared validation machinery; selecting all tooling checks."
+            continue
+        }
+
+        if ($path -cmatch '^\.github/workflows/[^/]+\.ya?ml$' -or
+            $path -cmatch '^\.github/actions/.+\.ya?ml$' -or
+            $path -cin @('.github/actionlint.yaml', '.github/actionlint.yml')) {
+            $workflows = $true
+            # Pester also asserts the actual workflow contracts, not just script behavior.
+            $null = $domains.Add('scheduled')
+            Write-Verbose "'$path' is workflow/lint configuration; selecting workflow lint and workflow-contract tests."
+        }
+
+        if ($path -ceq 'PSScriptAnalyzerSettings.psd1') {
+            $analysis = $true
+            $null = $domains.Add('analyzer')
+            Write-Verbose "'$path' configures script analysis; selecting analysis and its rule tests."
+        }
+        if ($path -cmatch '^scripts/') {
+            if ($path -cmatch '\.ps(m1|d1|1)$') { $analysis = $true }
+            if ($path -cmatch '^scripts/([^/]+)/' -and $Matches[1] -cin $script:ScriptDomains) {
+                $null = $domains.Add($Matches[1])
+                Write-Verbose "'$path' belongs to script domain '$($Matches[1])'; selecting that domain's tests."
+            } else {
+                $domains.UnionWith([string[]] $script:ScriptDomains)
+                Write-Verbose "'$path' has no registered script domain; conservatively selecting every script suite."
+            }
+        }
+        if ($path -cmatch '^justfiles/(.+)$') {
+            $recipe = $Matches[1]
+            if ($script:RecipeDomains.ContainsKey($recipe)) {
+                $domains.UnionWith([string[]] $script:RecipeDomains[$recipe])
+                Write-Verbose "'$path' owns recipes for $($script:RecipeDomains[$recipe] -join ', '); selecting those suites."
+            } else {
+                $domains.UnionWith([string[]] $script:ScriptDomains)
+                Write-Verbose "'$path' has no registered recipe owner; conservatively selecting every script suite."
+            }
+            # The quality recipe owns both lint commands, including their arguments/settings.
+            if ($recipe -ceq 'just_quality.just') { $workflows = $true; $analysis = $true }
+        }
+        if ($path -cin @('delta.toml', '.cargo/mutants.toml', '.config/nextest.toml')) {
+            $null = $domains.Add('build')
+            Write-Verbose "'$path' configures build/check execution; selecting build-helper tests."
+        }
+        if ($path -ceq 'release-plz.toml') {
+            $null = $domains.Add('release')
+            Write-Verbose "'$path' configures release automation; selecting release tests."
+        }
+        if ($path -cmatch '^\.cargo/config(\.toml)?$') {
+            # Cargo fixture tests and real helper builds consume workspace Cargo configuration.
+            $domains.UnionWith([string[]] @('release', 'scheduled'))
+            Write-Verbose "'$path' affects Cargo fixture and native-helper execution; selecting release and scheduled tests."
+        }
+        if ($path -ceq 'Cargo.toml' -or $path -cmatch '^packages/[^/]+/Cargo\.toml$' -or
+            $path -ceq 'packages/scheduled-mutation-config/dependency-contract.json') {
+            # Scheduled integration tests read live workspace metadata and the decoder contract.
+            $null = $domains.Add('scheduled')
+            Write-Verbose "'$path' is a live metadata/decoder-contract input to scheduled integration tests."
+        }
+    }
+
+    # Scheduled execution imports build helpers; canonical version verification imports release
+    # helpers. Other cross-domain sharing goes through setup/utility and selects all above.
+    if ($domains.Contains('build') -or $domains.Contains('release')) {
+        $null = $domains.Add('scheduled')
+        Write-Verbose 'Scheduled tests consume build/release helpers; including that dependent domain.'
+    }
+    Write-Verbose "Tooling selection: workflows=$workflows, script analysis=$analysis, script domains=$(@($domains | Sort-Object) -join ', '). Inputs outside declared tooling domains are left to Cargo/package checks."
+    return @{
+        workflows = $workflows
+        script_analysis = $analysis
+        script_domains = @($domains | Sort-Object)
+    }
+}
+
+function Read-ValidationPlan {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][AllowEmptyString()][string] $Json)
+
+    $plan = ConvertFrom-Json -InputObject $Json -AsHashtable
+    if ($plan -isnot [hashtable] -or $plan.workflows -isnot [bool] -or
+        $plan.script_analysis -isnot [bool]) {
+        throw 'Validation plan must contain explicit workflow and script-analysis decisions.'
+    }
+    $null = Read-ScriptDomain -Value $plan.script_domains
+    return $plan
+}
+
+function Read-ScriptDomain {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][object] $Value)
+
+    if ($Value -isnot [array]) { throw 'Script domains must be an explicit array.' }
+    foreach ($domain in $Value) {
+        if ($domain -isnot [string] -or $domain -cnotin $script:ScriptDomains) {
+            throw "Unknown script test domain '$domain'."
+        }
+    }
+    return @($Value | Sort-Object -Unique)
+}
+
+function Get-ValidationScriptDomain {
+    # The delta job adds dependency-aware selection for native helpers exercised by Pester.
+    # In particular, an unrelated Cargo.lock edit is not a reason to run every script suite.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $PlanJson,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $AffectedPackageJson
+    )
+
+    $plan = Read-ValidationPlan -Json $PlanJson
+    $packages = ConvertFrom-Json -InputObject $AffectedPackageJson -NoEnumerate
+    if ($packages -isnot [array]) { throw 'Affected packages must be an explicit array.' }
+    $domains = @($plan.script_domains)
+    foreach ($package in $packages) {
+        if ($package -isnot [string]) { throw 'Affected package names must be strings.' }
+        if ($package -cin @('cargo-release-plan', 'scheduled-mutation-config', 'scheduled-run-record')) {
+            $domains += 'scheduled'
+            Write-Verbose "Cargo delta selected '$package'; selecting its scheduled-script integration tests."
+        }
+    }
+    return @($domains | Sort-Object -Unique)
+}
+
+function Get-ScriptTestPath {
+    # Local `just test-scripts` defaults to the full tree. Explicit domains must exist and contain
+    # tests: a misspelled or obsolete selection must not become a successful empty Pester run.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string] $Domains = '',
+        [string] $Root = (Join-Path $PSScriptRoot '..')
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Domains)) { return $Root }
+    $selected = @(Read-ScriptDomain -Value @($Domains -split '\s+' | Where-Object { $_ }))
+    foreach ($domain in $selected) {
+        $path = Join-Path $Root $domain
+        if (-not (Test-Path -LiteralPath $path -PathType Container) -or
+            @(Get-ChildItem -LiteralPath $path -Filter '*.Tests.ps1' -Recurse -File).Count -eq 0) {
+            throw "Selected script domain '$domain' contains no test suite."
+        }
+        $path
+    }
+}
+
+function Invoke-ValidationGit {
+    # Keep NUL-delimited Git output intact, including filenames with whitespace/newlines, and
+    # propagate native failures. PowerShell's line-oriented native pipeline cannot do that.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)][string[]] $Argument)
+
+    $start = [Diagnostics.ProcessStartInfo]::new('git')
+    $start.WorkingDirectory = (Get-Location).ProviderPath
+    $start.UseShellExecute = $false
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.StandardOutputEncoding = [Text.Encoding]::UTF8
+    foreach ($item in $Argument) { $start.ArgumentList.Add($item) }
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $start
+    try {
+        $null = $process.Start()
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        $output = $stdout.GetAwaiter().GetResult()
+        $errorText = $stderr.GetAwaiter().GetResult()
+        if ($process.ExitCode -ne 0) { throw "Git validation-scope lookup failed: $errorText" }
+        return $output
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Get-ValidationChangedPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][ValidateSet('pull_request', 'merge_group')][string] $EventName,
+        [Parameter(Mandatory)][hashtable] $EventData
+    )
+
+    if ($EventName -ceq 'pull_request') {
+        $base = $EventData.pull_request.base.sha
+        $head = $EventData.pull_request.head.sha
+    } else {
+        $base = $EventData.merge_group.base_sha
+        $head = $EventData.merge_group.head_sha
+    }
+    foreach ($revision in @($base, $head)) {
+        if ($revision -isnot [string] -or $revision -cnotmatch '^[0-9a-f]{40}$') {
+            throw 'Change planning requires the event base and head commit SHAs.'
+        }
+    }
+    if ($EventName -ceq 'pull_request') {
+        $base = (Invoke-ValidationGit -Argument @('merge-base', $base, $head)).Trim()
+    }
+    Write-Verbose "Comparing $EventName commits $base..$head; renames contribute both removed and added paths."
+    $output = Invoke-ValidationGit -Argument @('diff', '--no-ext-diff', '--no-renames', '--name-only', '-z', $base, $head, '--')
+    return $output.Split([char] 0, [StringSplitOptions]::RemoveEmptyEntries)
+}
+
+function Get-ValidationWorkflowPlan {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][ValidateSet('push', 'pull_request', 'merge_group')][string] $EventName,
+        [Parameter(Mandatory)][hashtable] $EventData
+    )
+
+    if ($EventName -ceq 'push') {
+        if ($EventData.ref -cne 'refs/heads/main') { throw 'Full validation is reserved for pushes to main.' }
+        Write-Verbose 'Push to main selects every tooling check as the full-validation backstop.'
+        return Get-ValidationPlan -ChangedPath @() -Full
+    }
+    $paths = @(Get-ValidationChangedPath -EventName $EventName -EventData $EventData)
+    return Get-ValidationPlan -ChangedPath $paths
+}
+
+Export-ModuleMember -Function Get-ValidationPlan, Read-ValidationPlan, Read-ScriptDomain,
+    Get-ValidationScriptDomain, Get-ScriptTestPath, Get-ValidationWorkflowPlan

--- a/scripts/release/ReleaseAutomation.psm1
+++ b/scripts/release/ReleaseAutomation.psm1
@@ -3,8 +3,8 @@
 # Release-automation logic for the `Release` GitHub workflow (.github/workflows/release.yml)
 # and the local `just check-never-published` recipe.
 #
-# The workflow steps and release recipes are thin `just` wrappers (in justfiles/just_automation.just
-# and justfiles/just_release.just) that import this module and call its functions, so the
+# The workflow steps and release recipes are thin `just` wrappers (in justfiles/just_release.just)
+# that import this module and call its functions, so the
 # non-trivial logic lives here where it can be exercised by the Pester suite
 # (ReleaseAutomation.Tests.ps1) against fixtures rather than only by pushing to `main`.
 #

--- a/scripts/scheduled/ScheduledValidation.Tests.ps1
+++ b/scripts/scheduled/ScheduledValidation.Tests.ps1
@@ -97,7 +97,7 @@ Describe 'Shallow hosted validation with managed deep evidence' {
 
     It 'retains every shallow job while removing ordinary deep jobs' {
         $expected = @('scheduled-context', 'scheduled-repair-checks', 'scheduled-repair-gate',
-            'scheduled-version-check', 'delta', 'test-scripts', 'validate-workflows',
+            'scheduled-version-check', 'changes', 'delta', 'test-scripts', 'validate-scripts', 'validate-workflows',
             'validate-versions', 'semver-checks', 'format-check', 'default-features-check',
             'check-external-types', 'clippy-dev', 'test-x64', 'test-docs', 'docs', 'test-arm',
             'machete', 'clippy-release', 'build-release', 'check-frozen', 'run-examples', 'hack',
@@ -106,6 +106,43 @@ Describe 'Shallow hosted validation with managed deep evidence' {
         $workflow | Should -Not -Match '(?m)^\s+run:.*\b(miri|miri-harder|mutants|careful)\b'
         $jobs['scheduled-repair-checks'] | Should -Match '(?m)^    uses: \./\.github/workflows/deep-checks\.yml\r?$'
         $jobs['scheduled-repair-checks'] | Should -Match "(?m)^    if: needs\.scheduled-context\.outputs\.run == 'true'\r?$"
+    }
+
+    It 'keeps change planning independent of Rust setup and combines both script selectors' {
+        $jobs.changes | Should -Not -Match 'setup-environment|(?m)^\s+(cargo|just) '
+        $jobs.changes | Should -Match 'fetch-depth: 0'
+        $jobs.changes | Should -Match 'Get-ValidationWorkflowPlan'
+        $jobs.delta | Should -Match '(?m)^    needs: changes\r?$'
+        $jobs.delta | Should -Match 'Get-ValidationScriptDomain'
+        $jobs['test-scripts'] | Should -Match "(?m)^    if: needs\.delta\.outputs\.script_domains != '\[\]'\r?$"
+        $jobs['validate-scripts'] | Should -Match 'if: fromJSON\(needs\.changes\.outputs\.plan\)\.script_analysis'
+        $jobs['validate-workflows'] | Should -Match 'if: fromJSON\(needs\.changes\.outputs\.plan\)\.workflows'
+        foreach ($name in @('test-scripts', 'validate-scripts', 'validate-workflows')) {
+            $jobs[$name] | Should -Not -Match 'needs\.delta\.outputs\.skip_all'
+        }
+    }
+
+    It 'uses the same lint command and installer pins without the Rust environment' {
+        $jobs['validate-workflows'] | Should -Match 'uses: \./\.github/actions/setup-workflow-lint'
+        $jobs['validate-workflows'] | Should -Not -Match 'uses: \./\.github/actions/setup-environment'
+        $jobs['validate-workflows'] | Should -Match '(?m)^          actionlint -color\r?$'
+        $recipes['validate-workflows'].body[-1][-1] | Should -BeExactly 'actionlint -color'
+        $light = Get-Content -LiteralPath (Join-Path $root '.github\actions\setup-workflow-lint\action.yml') -Raw
+        $full = Get-Content -LiteralPath (Join-Path $root '.github\actions\setup-environment\action.yml') -Raw
+        $light | Should -Not -Match 'cargo install|rustup |install-tools|apt-get'
+        $keyPattern = '(?m)^        key: lint-tools-.+\r?$'
+        [regex]::Match($light, $keyPattern).Value.TrimEnd("`r") |
+            Should -BeExactly ([regex]::Match($full, $keyPattern).Value.TrimEnd("`r"))
+        foreach ($name in @('actionlint', 'shellcheck')) {
+            $light | Should -Match "\./scripts/setup/install-$name\.ps1 -Destination"
+            Test-Path -LiteralPath (Join-Path $root "scripts/setup/install-$name.ps1") | Should -BeTrue
+        }
+    }
+
+    It 'keeps live binstall metadata validation with unconditional release validation' {
+        $jobs['test-scripts'] | Should -Not -Match 'validate-binstall'
+        $jobs['validate-versions'] | Should -Match 'run: just validate-binstall'
+        $jobs['validate-versions'] | Should -Not -Match '(?m)^    (if|needs):'
     }
 
     It 'keeps the required-checks and alert dependency sets complete' {
@@ -122,6 +159,13 @@ Describe 'Shallow hosted validation with managed deep evidence' {
         $jobs['required-checks'] | Should -Match '(?m)^    name: required-checks\r?$'
         $jobs['required-checks'] | Should -Match '(?m)^    if: always\(\)\r?$'
         $jobs['required-checks'] | Should -Match '(?m)^          MUST_SUCCEED_JOBS:.*\bscheduled-context\b.*\bscheduled-repair-gate\b'
+        $mustSucceed = [regex]::Match($jobs['required-checks'], '(?m)^          MUST_SUCCEED_JOBS: (.+)\r?$').Groups[1].Value -split '\s+'
+        foreach ($name in @('changes', 'delta', 'validate-versions', 'semver-checks')) {
+            $mustSucceed | Should -Contain $name
+        }
+        foreach ($name in @('test-scripts', 'validate-scripts', 'validate-workflows')) {
+            $mustSucceed | Should -Not -Contain $name
+        }
         $jobs['scheduled-repair-gate'] | Should -Match '(?m)^    if: always\(\)\r?$'
         $jobs['scheduled-repair-gate'] | Should -Match '(?m)^    needs: \[scheduled-context, scheduled-repair-checks, scheduled-version-check\]\r?$'
     }

--- a/scripts/setup/Installers.Tests.ps1
+++ b/scripts/setup/Installers.Tests.ps1
@@ -1,0 +1,33 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Smoke-tests the shared standalone installers from an unrelated working directory. Tool shims
+# report each script's own pin, so import/path resolution and idempotence need no downloads.
+BeforeAll {
+    function actionlint {}
+    function shellcheck {}
+    function azcopy {}
+}
+
+Describe 'Standalone setup installers' {
+    It 'imports its shared dependency and accepts installed <_> without changing the machine' -ForEach @(
+        'actionlint', 'shellcheck', 'azcopy'
+    ) {
+        $installer = Join-Path $PSScriptRoot "install-$_.ps1"
+        $text = Get-Content -LiteralPath $installer -Raw
+        $pin = [regex]::Match($text, '\$script:\w+Version = ''([^'']+)''').Groups[1].Value
+        $pin | Should -Not -BeNullOrEmpty
+        Mock actionlint { $pin }
+        Mock shellcheck { "version: $pin" }
+        Mock azcopy { "azcopy version $pin" }
+        Mock New-Item { throw 'An installed tool must not start installation.' }
+        Mock Invoke-WebRequest { throw 'Installer smoke tests must not download tools.' }
+        Push-Location $TestDrive
+        try {
+            & $installer -Destination (Join-Path $TestDrive 'unused') -Verbose:$false
+        } finally {
+            Pop-Location
+        }
+        Should -Invoke New-Item -Times 0 -Exactly
+        Should -Invoke Invoke-WebRequest -Times 0 -Exactly
+    }
+}

--- a/scripts/setup/install-actionlint.ps1
+++ b/scripts/setup/install-actionlint.ps1
@@ -42,14 +42,14 @@ param(
     [switch] $Force
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
-Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The archive download can hit a transient network/disk fault; Invoke-WithRetry re-fetches (and
 # re-verifies the checksum) rather than failing `just install-tools` on a single blip.
-Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
 
 # The pinned actionlint release. Keep $ActionlintVersion and the per-platform digests in
 # $ActionlintBuilds in sync - both come from one GitHub release of rhysd/actionlint.

--- a/scripts/setup/install-azcopy.ps1
+++ b/scripts/setup/install-azcopy.ps1
@@ -44,14 +44,14 @@ param(
     [switch] $Force
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
-Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The archive download can hit a transient network/disk fault; Invoke-WithRetry re-fetches (and
 # re-verifies the checksum) rather than failing `just install-tools` on a single blip.
-Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
 
 # The pinned azcopy release. Keep $AzCopyVersion and the per-platform digests in
 # $AzCopyBuilds in sync - both come from one GitHub release of azure-storage-azcopy.

--- a/scripts/setup/install-shellcheck.ps1
+++ b/scripts/setup/install-shellcheck.ps1
@@ -48,14 +48,14 @@ param(
     [switch] $Force
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
-Set-StrictMode -Version Latest
 $VerbosePreference = 'Continue'
 
 # The archive download can hit a transient network/disk fault; Invoke-WithRetry re-fetches (and
 # re-verifies the checksum) rather than failing `just install-tools` on a single blip.
-Import-Module (Join-Path $PSScriptRoot 'utility' 'Retry.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' 'utility' 'Retry.psm1') -Force
 
 # The pinned ShellCheck release. Keep $ShellcheckVersion and the per-platform digests in
 # $ShellcheckBuilds in sync - both come from one GitHub release of koalaman/shellcheck.


### PR DESCRIPTION
[Copilot speaking]

Standard validation should not spend runner time on script and workflow checks when a pull request only changes unrelated Rust code or documentation. Non-Cargo checks need independent change domains so tooling-only changes remain covered even when Cargo delta selects no packages.

## Approach

- A lightweight Git/PowerShell planner selects workflow lint, script analysis, and script-test domains from the complete PR or merge-queue change set, including deletions and both sides of renames.
- Script tests run the union of owning domains, shared consumers, and integration-test domains for affected Rust helpers. Cargo dependency impact supplements path selection rather than making every lockfile edit trigger the full script suite.
- Shared validation machinery changes select all tooling checks. Pushes to `main` retain full execution as a backstop.
- `required-checks` requires successful planners and selected jobs. Missing outputs, inconsistent script selections, and unexpected skips cannot approve a merge. The workflow itself remains unconditionally triggered.

## Tooling organization

Benchmark-history and release recipes have separate ownership, and standalone installers live with setup tooling. Workflow lint uses the same pinned actionlint/ShellCheck installers and cache as full setup without restoring the Rust development environment. Local `just test-scripts` retains full discovery and also accepts explicit space-separated domains.

Live binstall metadata validation accompanies unconditional version readiness because Cargo can discover new binary targets without a manifest edit. Version readiness and managed-repair gates remain independent of path filtering.

## Version/release plan

There are no released-content or version changes. All publishable packages remain unchanged, with no pending increments, version-group alignments, or first-publication handoffs required.