### PR TITLE
scheduled-validation: preserve checker failures and evidence identity

### DIFF
--- a/.github/prompts/setup-scheduled-remediation.prompt.md
+++ b/.github/prompts/setup-scheduled-remediation.prompt.md
@@ -123,7 +123,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module .\scripts\scheduled\LocalSetup.psm1 -Force
-$inputData = Get-Content -LiteralPath "{{SETUP_INPUT_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module .\scripts\scheduled\ScheduledJson.psm1
+$inputData = Get-Content -LiteralPath "{{SETUP_INPUT_PATH}}" -Raw | ConvertFrom-ScheduledJson
 Get-ScheduledRoleSetupDecision -Role $inputData.role -Desired $inputData.desired `
     -Workflows $inputData.workflows -MetadataComplete $inputData.metadata_complete `
     -RegisteredProfile $inputData.registered_profile -SetupJournal $inputData.setup_journal |
@@ -149,7 +150,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module .\scripts\scheduled\LocalSetupState.psm1 -Force
-$inputData = Get-Content -LiteralPath "{{SETUP_INPUT_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module .\scripts\scheduled\ScheduledJson.psm1
+$inputData = Get-Content -LiteralPath "{{SETUP_INPUT_PATH}}" -Raw | ConvertFrom-ScheduledJson
 $path = Get-ScheduledSetupJournalPath -RepositoryId {{REPOSITORY_ID}}
 Invoke-ScheduledSetupJournal -Path $path -RepositoryId {{REPOSITORY_ID}} `
     -Role $inputData.role -Action begin-create `

--- a/.github/skills/scheduled-intake/SKILL.md
+++ b/.github/skills/scheduled-intake/SKILL.md
@@ -139,8 +139,9 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module .\scripts\scheduled\LocalLifecycle.psm1 -Force
-$state = Get-Content -LiteralPath "{{STATE_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
-$snapshot = Get-Content -LiteralPath "{{SNAPSHOT_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module .\scripts\scheduled\ScheduledJson.psm1
+$state = Get-Content -LiteralPath "{{STATE_PATH}}" -Raw | ConvertFrom-ScheduledJson
+$snapshot = Get-Content -LiteralPath "{{SNAPSHOT_PATH}}" -Raw | ConvertFrom-ScheduledJson
 $attempt = $state.attempts['{{ATTEMPT_ID}}']
 Get-ScheduledPullRequestDecision -Attempt $attempt -PullRequest $snapshot.pull_request `
     -MainSha $snapshot.main_sha -ContainsMain $snapshot.contains_main `
@@ -253,7 +254,8 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module .\scripts\scheduled\ScheduledContracts.psm1 -Force
 Import-Module .\scripts\scheduled\LocalHealth.psm1 -Force
-$state = Get-Content -LiteralPath "{{STATE_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module .\scripts\scheduled\ScheduledJson.psm1
+$state = Get-Content -LiteralPath "{{STATE_PATH}}" -Raw | ConvertFrom-ScheduledJson
 Sync-ScheduledRoleHealth -Context @{
     state_root = Split-Path -Parent "{{STATE_PATH}}"
     policy = Get-ScheduledPolicy

--- a/.github/skills/scheduled-repair/SKILL.md
+++ b/.github/skills/scheduled-repair/SKILL.md
@@ -189,7 +189,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module "{{TRUSTED_CONTROLLER_ROOT}}\scripts\scheduled\ScheduledVersion.psm1" -Force
-$evidence = Get-Content -LiteralPath "{{VERSION_EVIDENCE_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module "{{TRUSTED_CONTROLLER_ROOT}}\scripts\scheduled\ScheduledJson.psm1"
+$evidence = Get-Content -LiteralPath "{{VERSION_EVIDENCE_PATH}}" -Raw | ConvertFrom-ScheduledJson
 Assert-ScheduledCanonicalVersion -Root (Get-Location).Path -HeadSha '{{HEAD_SHA}}' `
     -BaseSha '{{BASE_SHA}}' -Evidence $evidence -ReleasePlanExecutable "{{RELEASE_PLAN_EXE}}" `
     -TrustedControllerRoot "{{TRUSTED_CONTROLLER_ROOT}}" -TemporaryRoot "{{TEMP_ROOT}}"
@@ -233,7 +234,8 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module .\scripts\scheduled\LocalState.psm1 -Force
 Import-Module .\scripts\scheduled\ScheduledContracts.psm1 -Force
-$state = Get-Content -LiteralPath "{{STATE_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module .\scripts\scheduled\ScheduledJson.psm1
+$state = Get-Content -LiteralPath "{{STATE_PATH}}" -Raw | ConvertFrom-ScheduledJson
 $policy = Get-ScheduledPolicy
 $worker = Get-ScheduledWorkerRecord -State $state -AttemptId '{{ATTEMPT_ID}}'
 $repair = Get-ScheduledRepairRecord -State $state -AttemptId '{{ATTEMPT_ID}}' -Policy $policy

--- a/.github/skills/scheduled-triage/SKILL.md
+++ b/.github/skills/scheduled-triage/SKILL.md
@@ -84,7 +84,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Import-Module .\scripts\scheduled\LocalTriagePolicy.psm1 -Force
-$native = Get-Content -LiteralPath "{{NATIVE_PROFILE_PATH}}" -Raw | ConvertFrom-Json -AsHashtable
+Import-Module .\scripts\scheduled\ScheduledJson.psm1
+$native = Get-Content -LiteralPath "{{NATIVE_PROFILE_PATH}}" -Raw | ConvertFrom-ScheduledJson
 @{
     automation_id = $native.automation_id
     prompt_digest = Get-ScheduledTriagePromptDigest $native.prompt

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -89,6 +89,10 @@ incomplete attempt invalidates it. Setup failures are execution problems, not a 
 package that setup prevented from running.
 Missing initial coverage remains unavailable, not a passing baseline. Nightly planning
 freshness belongs to automatic full checks; unrelated selected plans cannot refresh it.
+Checker failures remain failures through command wrappers independently of successful evidence
+preservation and reporting. Unsupported test targets are visible exclusions, not tests that
+passed. Consuming persisted evidence preserves its exact JSON string values and verifies its
+original identity rather than accepting a rewritten payload under a new checksum.
 An intentionally inactive, unenrolled Local executor is not an expected hosted-health component,
 while enrolled executors still require fresh successful heartbeats.
 Actual Actions jobs and steps are inventoried independently of checker artifacts.

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -276,6 +276,8 @@ their plan, result and raw evidence, not just a job conclusion.
 The scheduled Just recipes invoke standalone entrypoints as native PowerShell processes.
 Their nonzero status must cross every wrapper boundary into the calling workflow; preserving
 artifacts or successfully reporting a failure is independent of the check's pass/fail signal.
+Recipes explicitly exit with the child status, including on PowerShell versions without native
+error-preference support.
 
 ### Complete evidence and reuse
 

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -273,6 +273,9 @@ Each execution leg runs independently with fail-fast disabled so a failed shard 
 evidence from the rest of the manifest. The shared timeout accommodates mutation work and
 cold-cache setup. Always-upload steps include hidden artifact directories: failures still need
 their plan, result and raw evidence, not just a job conclusion.
+The scheduled Just recipes invoke standalone entrypoints as native PowerShell processes.
+Their nonzero status must cross every wrapper boundary into the calling workflow; preserving
+artifacts or successfully reporting a failure is independent of the check's pass/fail signal.
 
 ### Complete evidence and reuse
 
@@ -330,6 +333,13 @@ visible; successful intake of failures does not turn the source check green.
 Raw mutation outcomes come from `mutants.out`, not from a full-run `--json` option.
 An unmutated baseline is mandatory and a replay that matches no mutation is an error.
 Timeouts remain findings.
+The pinned cargo-mutants `Failure(i32)` status accepts any nonzero signed native exit code,
+including Windows exception statuses. Build failures, test failures and timeouts retain their
+distinct phase meanings; only a successful unmutated baseline establishes actionable mutations.
+Miri target discovery retains unsupported proc-macro unit harnesses as explicit not-applicable
+evidence, without invoking them. Supported integration targets in those packages still run.
+Unsupported-only selections do not establish tested coverage, and missing summaries for
+supported targets remain incomplete evidence.
 Ordinary empty mutation shards carry successful exact-scope discovery and explicit unmutated
 baseline evidence because the mutation tool does not run its baseline for an empty selection.
 The parser validates both before the leg can pass; zero-match exact replays remain failures.
@@ -388,6 +398,11 @@ before any checker result exists. Both reporting utilities are built from the
 trusted controller with its pinned toolchain and separate per-platform target
 directories, never from a candidate checkout or artifact.
 
+Hosted reporter serialization does not serialize Local triage's shared issue-body and state
+writes. Read/merge/PATCH sequences cannot atomically preserve concurrent owned-root updates or
+prevent stale closure of expanded scope. The issue PATCH endpoint does not document conditional
+write support. Safe cross-writer ownership remains a prerequisite to new repair admission.
+
 The per-run publication journal also fences creation of the shared coverage issue.
 Its `coverage_creation` intent is persisted after label bootstrap but before the
 issue POST, even when clean run intake itself remains in `prepared` state.
@@ -396,6 +411,17 @@ by the unique reporter-owned coverage record. Without a confirmed matching recor
 the reporter retains the fence instead of posting a duplicate. A fresh reporter
 attempt restores this same journal; repeating run intake preserves the coverage
 intent. Unique label names remain independently retryable before this issue fence.
+
+#### Lossless evidence transport
+
+`ScheduledJson.psm1` owns JSON-to-PowerShell conversion across native tools, GitHub readers,
+embedded records, publication journals, cache files and Local state/checkpoint copies.
+JSON strings remain strings with their exact content, including date-looking values in opaque
+checker and planner payloads. System.Text.Json is available in the supported PowerShell 7
+runtime and needs neither a Rust bootstrap nor the newer `ConvertFrom-Json -DateKind` option.
+Only numeric tokens use PowerShell's numeric conversion. Consumers still validate the original
+revision, publication-index and checkpoint digests; transport must not rehash changed evidence
+or normalize timestamp spelling to make verification succeed.
 
 #### Run-level failure intake
 

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -335,8 +335,8 @@ visible; successful intake of failures does not turn the source check green.
 Raw mutation outcomes come from `mutants.out`, not from a full-run `--json` option.
 An unmutated baseline is mandatory and a replay that matches no mutation is an error.
 Timeouts remain findings.
-The pinned cargo-mutants `Failure(i32)` status accepts any nonzero signed native exit code,
-including Windows exception statuses. Build failures, test failures and timeouts retain their
+The pinned cargo-mutants `Failure(i32)` status requires a nonzero integer within the signed
+native range, including Windows exception statuses. Build failures, test failures and timeouts retain their
 distinct phase meanings; only a successful unmutated baseline establishes actionable mutations.
 Miri target discovery retains unsupported proc-macro unit harnesses as explicit not-applicable
 evidence, without invoking them. Supported integration targets in those packages still run.

--- a/justfiles/just_scheduled.just
+++ b/justfiles/just_scheduled.just
@@ -9,6 +9,8 @@ scheduled-check:
     $PSNativeCommandUseErrorActionPreference = $true
     # A child script's exit does not terminate this Just script; use a native process boundary.
     pwsh -NoLogo -NoProfile -NonInteractive -File ./scripts/scheduled/Invoke-ScheduledCheck.ps1
+    # Propagate explicitly even on PowerShell versions without native-error preference support.
+    exit $LASTEXITCODE
 
 # Ref: .github/workflows/implementation.md#complete-evidence-and-reuse.
 # Fix expected scope before execution without renewing reused evidence.
@@ -19,6 +21,7 @@ scheduled-plan:
     $ErrorActionPreference = 'Stop'
     $PSNativeCommandUseErrorActionPreference = $true
     pwsh -NoLogo -NoProfile -NonInteractive -File ./scripts/scheduled/Invoke-ScheduledPlan.ps1
+    exit $LASTEXITCODE
 
 # Ref: .github/workflows/implementation.md#serialized-reporting.
 # Evaluate downloaded evidence as data; write authority belongs to the hosted caller.
@@ -29,6 +32,7 @@ scheduled-report:
     $ErrorActionPreference = 'Stop'
     $PSNativeCommandUseErrorActionPreference = $true
     pwsh -NoLogo -NoProfile -NonInteractive -File ./scripts/scheduled/Invoke-ScheduledReport.ps1
+    exit $LASTEXITCODE
 
 # Ref: docs/scheduled-validation.md#durable-ownership-and-native-calls.
 # Persist short transactions around native App calls without process-held claims.

--- a/justfiles/just_scheduled.just
+++ b/justfiles/just_scheduled.just
@@ -7,7 +7,8 @@ scheduled-check:
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
     $PSNativeCommandUseErrorActionPreference = $true
-    ./scripts/scheduled/Invoke-ScheduledCheck.ps1
+    # A child script's exit does not terminate this Just script; use a native process boundary.
+    pwsh -NoLogo -NoProfile -NonInteractive -File ./scripts/scheduled/Invoke-ScheduledCheck.ps1
 
 # Ref: .github/workflows/implementation.md#complete-evidence-and-reuse.
 # Fix expected scope before execution without renewing reused evidence.
@@ -17,7 +18,7 @@ scheduled-plan:
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
     $PSNativeCommandUseErrorActionPreference = $true
-    ./scripts/scheduled/Invoke-ScheduledPlan.ps1
+    pwsh -NoLogo -NoProfile -NonInteractive -File ./scripts/scheduled/Invoke-ScheduledPlan.ps1
 
 # Ref: .github/workflows/implementation.md#serialized-reporting.
 # Evaluate downloaded evidence as data; write authority belongs to the hosted caller.
@@ -27,7 +28,7 @@ scheduled-report:
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
     $PSNativeCommandUseErrorActionPreference = $true
-    ./scripts/scheduled/Invoke-ScheduledReport.ps1
+    pwsh -NoLogo -NoProfile -NonInteractive -File ./scripts/scheduled/Invoke-ScheduledReport.ps1
 
 # Ref: docs/scheduled-validation.md#durable-ownership-and-native-calls.
 # Persist short transactions around native App calls without process-held claims.

--- a/scripts/scheduled/Invoke-ScheduledCheck.ps1
+++ b/scripts/scheduled/Invoke-ScheduledCheck.ps1
@@ -26,8 +26,9 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 $VerbosePreference = 'Continue'
 Import-Module (Join-Path $PSScriptRoot 'ScheduledExecution.psm1') -Force
-$check = ConvertFrom-Json -InputObject $CheckJson -AsHashtable
-$manifest = ConvertFrom-Json -InputObject $ManifestJson -AsHashtable
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
+$check = ConvertFrom-ScheduledJson -InputObject $CheckJson
+$manifest = ConvertFrom-ScheduledJson -InputObject $ManifestJson
 $context = @{
     source_sha = $manifest.source_sha; controller_sha = $manifest.controller_sha
     check_contract_digest = $manifest.check_contract_digest

--- a/scripts/scheduled/LocalGitHub.psm1
+++ b/scripts/scheduled/LocalGitHub.psm1
@@ -1,6 +1,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 
 # Read-side GitHub adapter for the personal Local App executor (LocalInbox.psm1 and the
 # `scheduled-intake`/`scheduled-repair` skills call it between durable-state transactions; see
@@ -25,7 +26,7 @@ function Invoke-ScheduledApi {
     }
     $output = & gh @arguments
     if ($LASTEXITCODE -ne 0) { throw "GitHub read failed for $Endpoint." }
-    $value = ConvertFrom-Json -InputObject ($output -join "`n") -AsHashtable -NoEnumerate
+    $value = ConvertFrom-ScheduledJson -InputObject ($output -join "`n") -NoEnumerate
     if ($value -is [System.Collections.IDictionary] -and $value.Contains('errors')) {
         throw 'GraphQL returned incomplete data with errors.'
     }

--- a/scripts/scheduled/LocalSetupState.psm1
+++ b/scripts/scheduled/LocalSetupState.psm1
@@ -6,6 +6,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'LocalState.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledRunGitHub.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
@@ -90,7 +91,7 @@ function Invoke-ScheduledSetupJournal {
     $lock = [IO.File]::Open("$Path.lock", [IO.FileMode]::OpenOrCreate, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
     try {
         $journal = if (Test-Path -LiteralPath $Path) {
-            Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+            Get-Content -LiteralPath $Path -Raw | ConvertFrom-ScheduledJson
         } else { @{ schema_version = 1; repository_id = $RepositoryId; roles = @{} } }
         Assert-ScheduledSetupJournal $journal $RepositoryId
         if ($Action -ceq 'read') { return $journal }

--- a/scripts/scheduled/LocalState.psm1
+++ b/scripts/scheduled/LocalState.psm1
@@ -1,6 +1,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'LocalTriageState.psm1')
@@ -419,7 +420,7 @@ function Invoke-ScheduledLocalAction {
         $checkpointValidation = Get-ScheduledTriageCheckpointValidation $Data.checkpoint
     }
     if ($Action -ceq 'triage-claim') {
-        $claimState = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json -AsHashtable
+        $claimState = Get-Content -LiteralPath $path -Raw | ConvertFrom-ScheduledJson
         Assert-ScheduledLocalState $claimState
         $claimValidation = Get-ScheduledTriageClaimValidation $StateRoot $claimState.triage.scan $Data
         $claimData = @{}
@@ -433,7 +434,7 @@ function Invoke-ScheduledLocalAction {
         [IO.FileMode]::OpenOrCreate, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
     try {
         if (Test-Path -LiteralPath $path) {
-            $state = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json -AsHashtable
+            $state = Get-Content -LiteralPath $path -Raw | ConvertFrom-ScheduledJson
             Assert-ScheduledLocalState $state
             if ($state.repository_id -ne $Policy.repository_id -or $state.repository -cne $Policy.repository -or
                 $state.executor_id -cne $ExecutorId -or $state.login -cne $Login) {
@@ -549,7 +550,7 @@ function Get-ScheduledRepairRecord {
 function Invoke-ScheduledLocalRequest {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string] $RequestPath)
-    $request = Get-Content -LiteralPath $RequestPath -Raw | ConvertFrom-Json -AsHashtable
+    $request = Get-Content -LiteralPath $RequestPath -Raw | ConvertFrom-ScheduledJson
     Assert-LocalField $request @('policy_path', 'executor_id', 'login', 'action', 'data')
     $policy = Get-ScheduledPolicy -Path $request.policy_path
     $root = Get-ScheduledStateRoot -RepositoryId $policy.repository_id

--- a/scripts/scheduled/LocalTriage.psm1
+++ b/scripts/scheduled/LocalTriage.psm1
@@ -6,6 +6,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'LocalTriagePolicy.psm1')
 Import-Module (Join-Path $PSScriptRoot 'LocalTriageInbox.psm1')
@@ -51,7 +52,7 @@ function Invoke-ScheduledTriageRequest {
         [Parameter(Mandatory)][string] $RequestPath,
         [DateTimeOffset] $Now = [DateTimeOffset]::UtcNow
     )
-    $request = Get-Content -LiteralPath $RequestPath -Raw | ConvertFrom-Json -AsHashtable
+    $request = Get-Content -LiteralPath $RequestPath -Raw | ConvertFrom-ScheduledJson
     foreach ($field in @('action', 'executor_id', 'data')) {
         if (-not $request.ContainsKey($field)) { throw "Missing triage request field: $field" }
     }

--- a/scripts/scheduled/LocalTriageCache.psm1
+++ b/scripts/scheduled/LocalTriageCache.psm1
@@ -5,6 +5,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 
 function Get-ScheduledTriageCacheProjection {
@@ -33,7 +34,7 @@ function Get-ScheduledTriageSnapshotPath {
 function Read-ScheduledTriageSnapshot {
     param([string] $StateRoot, [string] $Id)
     $snapshot = Get-Content -LiteralPath (Get-ScheduledTriageSnapshotPath $StateRoot $Id) -Raw |
-        ConvertFrom-Json -AsHashtable
+        ConvertFrom-ScheduledJson
     if ((Get-ScheduledDigest $snapshot) -cne $Id) { throw 'Cached triage observation changed; repeat the complete scan.' }
     return $snapshot
 }

--- a/scripts/scheduled/LocalTriageCheckpoint.psm1
+++ b/scripts/scheduled/LocalTriageCheckpoint.psm1
@@ -5,6 +5,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledRecordTool.psm1')
 
@@ -14,7 +15,7 @@ function Get-ScheduledTriageCheckpointValidation {
         if (-not $Checkpoint.ContainsKey($name)) { throw [FormatException]::new("Checkpoint field is missing: $name") }
     }
     $inputDigest = Get-ScheduledDigest $Checkpoint
-    $snapshot = $Checkpoint | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+    $snapshot = $Checkpoint | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
     $snapshot.analysis = Invoke-ScheduledRecordTool -Package scheduled-triage-record -Request @{
         op = 'validate_analysis'; analysis = $snapshot.analysis
         evidence = $snapshot.evidence; index = $snapshot.index; basis = $snapshot.basis

--- a/scripts/scheduled/LocalTriagePolicy.psm1
+++ b/scripts/scheduled/LocalTriagePolicy.psm1
@@ -6,6 +6,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledTransport.psm1')
 
@@ -13,7 +14,7 @@ function Get-ScheduledTriagePolicy {
     [CmdletBinding()]
     [OutputType([hashtable])]
     param([string] $Path = (Join-Path $PSScriptRoot 'triage-policy.json'))
-    $policy = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+    $policy = Get-Content -LiteralPath $Path -Raw | ConvertFrom-ScheduledJson
     foreach ($field in @('schema_version', 'automation_name', 'automation_marker', 'cadence_cron',
             'mode', 'enrolled_machine_id', 'model', 'reasoning_effort', 'max_active_analyses',
             'max_starts_per_day', 'max_continuations_per_day', 'max_continuations_per_analysis',

--- a/scripts/scheduled/LocalTriageState.psm1
+++ b/scripts/scheduled/LocalTriageState.psm1
@@ -6,6 +6,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'LocalTriagePolicy.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledRecordTool.psm1')
@@ -153,7 +154,7 @@ function Assert-TriageOperation {
         ($null -ne $Operation.target_id -and [string]$Operation.target_id -cnotmatch '^[1-9][0-9]*$')) {
         throw 'Corrupt triage publication identity, kind, or stage.'
     }
-    $specification = $Operation | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+    $specification = $Operation | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
     foreach ($field in @('id', 'stage', 'spec_digest', 'receipt', 'superseded_by_index')) {
         $specification.Remove($field)
     }
@@ -463,7 +464,7 @@ function Invoke-ScheduledTriageStateChange {
             $analysis.checkpoint_digest = $CheckpointValidation.digest
             $analysis.completion = $null; $analysis.completion_digest = $null
             $analysis.phase = 'analyzing'
-            $comparisonIndex = $Data.checkpoint.index | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+            $comparisonIndex = $Data.checkpoint.index | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
             foreach ($entry in $comparisonIndex.entries) { $entry.full_read_digest = $null }
             $analysis.comparison = @{ index = $comparisonIndex; requires_reanalysis = $false; reason = $null }
             $analysis.comparison_digest = Get-ScheduledDigest $analysis.comparison
@@ -572,7 +573,7 @@ function Invoke-ScheduledTriageStateChange {
             Assert-TriageAdmission $State $Policy $TriagePolicy $Data
             $analysis = Get-TriageOwnedAnalysis $triage $Data
             Assert-TriageField $Data @('operation')
-            $operation = $Data.operation | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+            $operation = $Data.operation | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
             Assert-TriageField $operation @('key', 'kind', 'issue_number', 'target_id', 'payload',
                 'preimage', 'checkpoint', 'purpose')
             if ($null -eq $analysis.checkpoint -or

--- a/scripts/scheduled/ScheduledContracts.psm1
+++ b/scripts/scheduled/ScheduledContracts.psm1
@@ -10,6 +10,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 
 function ConvertTo-ScheduledCanonicalValue {
     [CmdletBinding()]
@@ -81,7 +82,7 @@ function Read-ScheduledRecord {
     $records = [regex]::Matches($Text, "<!-- scheduled-${Kind}:v1 (\{[^\r\n]*\}) -->")
     if ($records.Count -ne 1) { throw [FormatException]::new("Expected exactly one scheduled $Kind record.") }
     try {
-        $record = ConvertFrom-Json -InputObject $records[0].Groups[1].Value -AsHashtable
+        $record = ConvertFrom-ScheduledJson -InputObject $records[0].Groups[1].Value
     } catch [ArgumentException] {
         throw [FormatException]::new('Invalid scheduled record JSON.', $_.Exception)
     }
@@ -139,7 +140,7 @@ function Get-ScheduledPolicy {
     [OutputType([hashtable])]
     param([string] $Path = (Join-Path $PSScriptRoot 'policy.json'))
 
-    $policy = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+    $policy = Get-Content -LiteralPath $Path -Raw | ConvertFrom-ScheduledJson
     if ($policy.schema_version -ne 1 -or $policy.repository_id -le 0) {
         throw 'Unsupported scheduled policy or missing repository identity.'
     }

--- a/scripts/scheduled/ScheduledEntryPoints.Tests.ps1
+++ b/scripts/scheduled/ScheduledEntryPoints.Tests.ps1
@@ -1,18 +1,25 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 # Protects the entrypoint scripts' own contract with their calling workflow: launched as real
-# `pwsh` processes (not dot-sourced) against stub modules, so a mistake in exit-code mapping or
-# output-file writing - invisible to a module-level Pester test that only calls functions in
-# process - still fails here.
+# `pwsh` processes, directly and through the actual Just recipes, against stub modules.
+# Exit-code mapping or output-file mistakes invisible to an in-process module test still fail here.
 BeforeAll {
-    $script:entryRoot = Join-Path $TestDrive 'entrypoints'
-    New-Item -ItemType Directory -Path $entryRoot | Out-Null
+    $script:fixtureRoot = Join-Path $TestDrive 'entrypoints'
+    $script:entryRoot = Join-Path $fixtureRoot 'scripts\scheduled'
+    New-Item -ItemType Directory -Path $entryRoot -Force | Out-Null
+    $repository = Join-Path $PSScriptRoot '..\..'
+    Copy-Item -LiteralPath (Join-Path $repository 'justfile'), (Join-Path $repository 'constants.env') -Destination $fixtureRoot
+    Copy-Item -LiteralPath (Join-Path $repository 'justfiles') -Destination $fixtureRoot -Recurse
     Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'Invoke-ScheduledCheck.ps1'),
+        (Join-Path $PSScriptRoot 'ScheduledJson.psm1'),
         (Join-Path $PSScriptRoot 'Invoke-ScheduledPlan.ps1'),
         (Join-Path $PSScriptRoot 'Invoke-ScheduledHealth.ps1'),
         (Join-Path $PSScriptRoot 'Invoke-ScheduledReport.ps1') -Destination $entryRoot
     @'
 function Invoke-ScheduledCheck {
     param($Check, $SourceRoot, $OutputDirectory, $Toolchain, $RunContext)
+    $null = New-Item -ItemType Directory -Path $OutputDirectory -Force
+    @{ outcome = $env:SCHEDULED_TEST_OUTCOME } | ConvertTo-Json |
+        Set-Content -LiteralPath (Join-Path $OutputDirectory 'evidence.json')
     return @{ outcome = $env:SCHEDULED_TEST_OUTCOME }
 }
 function Get-ScheduledToolchain { param($Kind) return 'fixture-toolchain' }
@@ -35,23 +42,32 @@ Export-ModuleMember -Function Get-ScheduledGitHubHealth, Invoke-ScheduledReporti
     @'
 function Invoke-ScheduledPlanning {
     param($Mode, $EventPath, $OutputDirectory)
+    if ($env:SCHEDULED_TEST_OUTCOME -eq 'incomplete') { throw 'Planner failure canary.' }
     @{ mode = $Mode; event_path = $EventPath; output_directory = $OutputDirectory } | ConvertTo-Json -Compress
 }
 Export-ModuleMember -Function Invoke-ScheduledPlanning
 '@ | Set-Content -LiteralPath (Join-Path $entryRoot 'ScheduledWorkflow.psm1')
 
     function Invoke-EntryPointFixture {
-        param([string] $Name, [string] $Outcome, [string[]] $Arguments = @())
+        param([string] $Name, [string] $Outcome, [string[]] $Arguments = @(), [string] $Recipe = '')
         $start = [Diagnostics.ProcessStartInfo]::new()
         $start.FileName = (Get-Command pwsh).Source
         $start.UseShellExecute = $false
         $start.RedirectStandardOutput = $true
         $start.RedirectStandardError = $true
+        $start.WorkingDirectory = $fixtureRoot
         $start.Environment['SCHEDULED_TEST_OUTCOME'] = $Outcome
         $start.Environment['SCHEDULED_CHECK'] = '{"kind":"miri"}'
         $start.Environment['SCHEDULED_MANIFEST'] = '{"source_sha":"source","controller_sha":"controller","check_contract_digest":"digest"}'
         $start.Environment['GITHUB_STEP_SUMMARY'] = Join-Path $entryRoot "summary-$Outcome.md"
-        foreach ($argument in @('-NoProfile', '-File', (Join-Path $entryRoot $Name)) + $Arguments) {
+        $invocation = if ($Recipe -eq '') { @('-File', (Join-Path $entryRoot $Name)) + $Arguments }
+            else {
+                # The workflow's pwsh step invokes Just, whose [script] recipe invokes the
+                # entrypoint. Keep both process boundaries, not a rewritten recipe stand-in.
+                @('-Command', "Set-StrictMode -Version Latest; `$ErrorActionPreference = 'Stop'; " +
+                    "`$PSNativeCommandUseErrorActionPreference = `$true; just $Recipe; exit `$LASTEXITCODE")
+            }
+        foreach ($argument in @('-NoProfile') + $invocation) {
             $start.ArgumentList.Add($argument)
         }
         $process = [Diagnostics.Process]::new()
@@ -71,6 +87,36 @@ Export-ModuleMember -Function Invoke-ScheduledPlanning
 }
 
 Describe 'Hosted entrypoint exit contracts' {
+    It 'propagates <Outcome> through workflow PowerShell and the actual scheduled-check recipe' -TestCases @(
+        @{ Outcome = 'passed'; Code = 0 }
+        @{ Outcome = 'findings'; Code = 1 }
+        @{ Outcome = 'incomplete'; Code = 1 }
+        @{ Outcome = 'blocked'; Code = 1 }
+        @{ Outcome = 'execution-error'; Code = 1 }
+        @{ Outcome = 'not-applicable'; Code = 1 }
+    ) {
+        param($Outcome, $Code)
+        $result = Invoke-EntryPointFixture -Recipe scheduled-check -Outcome $Outcome
+        $result.code | Should -Be $Code
+        $result.stdout | Should -Match ('"outcome": "' + $Outcome + '"')
+        $evidence = Get-Content -LiteralPath (Join-Path $fixtureRoot '.scheduled-result\evidence.json') -Raw |
+            ConvertFrom-Json
+        $evidence.outcome | Should -Be $Outcome
+    }
+    It 'propagates reporting status <Outcome> through the actual scheduled-report recipe' -TestCases @(
+        @{ Outcome = 'reported'; Code = 0 }
+        @{ Outcome = 'incomplete'; Code = 1 }
+    ) {
+        param($Outcome, $Code)
+        (Invoke-EntryPointFixture -Recipe scheduled-report -Outcome $Outcome).code | Should -Be $Code
+    }
+    It 'propagates planner status <Outcome> through the actual scheduled-plan recipe' -TestCases @(
+        @{ Outcome = 'planned'; Code = 0 }
+        @{ Outcome = 'incomplete'; Code = 1 }
+    ) {
+        param($Outcome, $Code)
+        (Invoke-EntryPointFixture -Recipe scheduled-plan -Outcome $Outcome).code | Should -Be $Code
+    }
     It 'invokes the planner without extra permission switches for <Mode>' -TestCases @(
         @{ Mode = 'selected' }, @{ Mode = 'full' }, @{ Mode = 'validation' }
     ) {

--- a/scripts/scheduled/ScheduledEntryPoints.Tests.ps1
+++ b/scripts/scheduled/ScheduledEntryPoints.Tests.ps1
@@ -47,9 +47,18 @@ function Invoke-ScheduledPlanning {
 }
 Export-ModuleMember -Function Invoke-ScheduledPlanning
 '@ | Set-Content -LiteralPath (Join-Path $entryRoot 'ScheduledWorkflow.psm1')
+    # PowerShell 7 versions without native-error preference support still need the recipe's
+    # explicit exit. Disable only that feature in a copy of the actual recipe configuration.
+    $justfile = Get-Content -LiteralPath (Join-Path $fixtureRoot justfile) -Raw
+    $justfile.Replace("import 'justfiles/just_scheduled.just'", "import 'justfiles/just_scheduled_legacy.just'") |
+        Set-Content -LiteralPath (Join-Path $fixtureRoot justfile-legacy)
+    $recipes = Get-Content -LiteralPath (Join-Path $fixtureRoot 'justfiles\just_scheduled.just') -Raw
+    $recipes.Replace('$PSNativeCommandUseErrorActionPreference = $true', '$PSNativeCommandUseErrorActionPreference = $false') |
+        Set-Content -LiteralPath (Join-Path $fixtureRoot 'justfiles\just_scheduled_legacy.just')
 
     function Invoke-EntryPointFixture {
-        param([string] $Name, [string] $Outcome, [string[]] $Arguments = @(), [string] $Recipe = '')
+        param([string] $Name, [string] $Outcome, [string[]] $Arguments = @(), [string] $Recipe = '',
+            [switch] $WithoutNativeErrors)
         $start = [Diagnostics.ProcessStartInfo]::new()
         $start.FileName = (Get-Command pwsh).Source
         $start.UseShellExecute = $false
@@ -64,8 +73,9 @@ Export-ModuleMember -Function Invoke-ScheduledPlanning
             else {
                 # The workflow's pwsh step invokes Just, whose [script] recipe invokes the
                 # entrypoint. Keep both process boundaries, not a rewritten recipe stand-in.
+                $justArguments = if ($WithoutNativeErrors) { '--justfile justfile-legacy' } else { '' }
                 @('-Command', "Set-StrictMode -Version Latest; `$ErrorActionPreference = 'Stop'; " +
-                    "`$PSNativeCommandUseErrorActionPreference = `$true; just $Recipe; exit `$LASTEXITCODE")
+                    "`$PSNativeCommandUseErrorActionPreference = `$true; just $justArguments $Recipe; exit `$LASTEXITCODE")
             }
         foreach ($argument in @('-NoProfile') + $invocation) {
             $start.ArgumentList.Add($argument)
@@ -87,6 +97,21 @@ Export-ModuleMember -Function Invoke-ScheduledPlanning
 }
 
 Describe 'Hosted entrypoint exit contracts' {
+    It 'propagates <Recipe> outcome <Outcome> without native-error preference support' -TestCases @(
+        @{ Recipe = 'scheduled-check'; Outcome = 'passed'; Code = 0 }
+        @{ Recipe = 'scheduled-check'; Outcome = 'findings'; Code = 1 }
+        @{ Recipe = 'scheduled-check'; Outcome = 'incomplete'; Code = 1 }
+        @{ Recipe = 'scheduled-check'; Outcome = 'blocked'; Code = 1 }
+        @{ Recipe = 'scheduled-check'; Outcome = 'execution-error'; Code = 1 }
+        @{ Recipe = 'scheduled-check'; Outcome = 'not-applicable'; Code = 1 }
+        @{ Recipe = 'scheduled-report'; Outcome = 'reported'; Code = 0 }
+        @{ Recipe = 'scheduled-report'; Outcome = 'incomplete'; Code = 1 }
+        @{ Recipe = 'scheduled-plan'; Outcome = 'planned'; Code = 0 }
+        @{ Recipe = 'scheduled-plan'; Outcome = 'incomplete'; Code = 1 }
+    ) {
+        param($Recipe, $Outcome, $Code)
+        (Invoke-EntryPointFixture -Recipe $Recipe -Outcome $Outcome -WithoutNativeErrors).code | Should -Be $Code
+    }
     It 'propagates <Outcome> through workflow PowerShell and the actual scheduled-check recipe' -TestCases @(
         @{ Outcome = 'passed'; Code = 0 }
         @{ Outcome = 'findings'; Code = 1 }

--- a/scripts/scheduled/ScheduledExecution.Tests.ps1
+++ b/scripts/scheduled/ScheduledExecution.Tests.ps1
@@ -621,6 +621,8 @@ Describe 'Pinned cargo-mutants output classification' {
 
     It 'classifies an unmutated test failure or timeout as blocked, never as a mutant defect' -ForEach @(
         @{ Status = @{ Failure = 101 }; Summary = 'Failure'; Baseline = 'failed' },
+        @{ Status = @{ Failure = -1073740791 }; Summary = 'Failure'; Baseline = 'failed' },
+        @{ Status = @{ Failure = -1073741571 }; Summary = 'Failure'; Baseline = 'failed' },
         @{ Status = 'Timeout'; Summary = 'Timeout'; Baseline = 'timeout' }
     ) {
         $check = New-Check
@@ -655,19 +657,61 @@ Describe 'Pinned cargo-mutants output classification' {
         $result.findings.Count | Should -Be 0
     }
 
-    It 'accepts caught and unviable mutants when phase results and exit code agree' {
+    It 'accepts caught and unviable mutants with native failure status <FailureCode>' -ForEach @(
+        @{ FailureCode = 101 }, @{ FailureCode = -1073740791 }, @{ FailureCode = -1073741571 }
+    ) {
         $check = New-Check
         $path = New-Evidence $check 0
         Set-Lab $path {
             param($lab)
             $lab.outcomes[1].summary = 'CaughtMutant'
-            $lab.outcomes[1].phase_results[1].process_status = @{ Failure = 101 }
+            $lab.outcomes[1].phase_results[1].process_status = @{ Failure = $FailureCode }
             $lab.outcomes[2].summary = 'Unviable'
             $lab.outcomes[2].phase_results = @($lab.outcomes[2].phase_results[0])
-            $lab.outcomes[2].phase_results[0].process_status = @{ Failure = 101 }
+            $lab.outcomes[2].phase_results[0].process_status = @{ Failure = $FailureCode }
             $lab.missed = 0; $lab.timeout = 0; $lab.caught = 1; $lab.unviable = 1
         }
         (Get-ScheduledCheckResult $check $path $script:context).outcome | Should -Be 'passed'
+    }
+
+    It 'retains missed mutants beside signed Windows test failures from the pinned wire format' -ForEach @(
+        @{ FailureCode = -1073740791 }, @{ FailureCode = -1073741571 }
+    ) {
+        # These native status values occur in run 34574480961, attempt 1, Windows shard 8.
+        $check = New-Check
+        $path = New-Evidence $check 2
+        Set-Lab $path {
+            param($lab)
+            $lab.outcomes[2].summary = 'CaughtMutant'
+            $lab.outcomes[2].phase_results[1].process_status = @{ Failure = $FailureCode }
+            $lab.timeout = 0; $lab.caught = 1
+        }
+        $result = Get-ScheduledCheckResult $check $path $script:context
+        $result.outcome | Should -Be findings
+        $result.baseline | Should -Be passed
+        $result.findings.Count | Should -Be 1
+        $result.findings[0].summary | Should -Match '^MissedMutant:'
+    }
+
+    It 'rejects zero failure status and incomplete phase provenance' -ForEach @(
+        @{ Damage = 'zero' }, @{ Damage = 'missing-build' }, @{ Damage = 'failed-build-before-test' }
+    ) {
+        $check = New-Check
+        $path = New-Evidence $check 2
+        Set-Lab $path {
+            param($lab)
+            $scenario = $lab.outcomes[2]
+            $scenario.summary = 'CaughtMutant'; $lab.timeout = 0; $lab.caught = 1
+            $scenario.phase_results[1].process_status = @{ Failure = -1073740791 }
+            switch ($Damage) {
+                zero { $scenario.phase_results[1].process_status.Failure = 0 }
+                missing-build { $scenario.phase_results = @($scenario.phase_results[1]) }
+                failed-build-before-test { $scenario.phase_results[0].process_status = @{ Failure = -1073741571 } }
+            }
+        }
+        $result = Get-ScheduledCheckResult $check $path $script:context
+        $result.outcome | Should -Be incomplete
+        $result.findings.Count | Should -Be 0
     }
 
     It 'does not trust candidate evidence labels or command scope' {
@@ -1033,6 +1077,61 @@ Describe 'Miri and careful evidence' {
 }
 
 Describe 'Cargo test target scope' {
+    It 'retains unsupported proc-macro scope without executing its harness for <CheckKind>' -ForEach @(
+        @{ CheckKind = 'miri' }, @{ CheckKind = 'miri-many' }
+    ) {
+        # Source-shaped metadata and Miri output from run 34574480961/1, check-74.
+        Mock -ModuleName ScheduledExecution Invoke-ScheduledProcess {
+            param($OutputDirectory, $Name)
+            if ($Name -ne 'metadata') { throw 'Unsupported proc-macro harness was invoked.' }
+            $stdout = Join-Path $OutputDirectory "$Name.stdout"
+            $stderr = Join-Path $OutputDirectory "$Name.stderr"
+            Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'fixtures\execution\proc-macro-metadata.json') -Destination $stdout
+            Set-Content -LiteralPath $stderr -Value ''
+            return @{ exit_code = 0; stdout_path = $stdout; stderr_path = $stderr }
+        }
+        $check = New-Check $CheckKind
+        $check.packages = @('linked_macros')
+        $path = New-Output
+        $result = Invoke-ScheduledCheck $check $script:root $path $script:toolchain $script:context
+        $result.outcome | Should -Be not-applicable
+        $result.findings.Count | Should -Be 0
+        $result.unsupported_targets.Count | Should -Be 1
+        $result.unsupported_targets[0].package | Should -Be linked_macros
+        $result.unsupported_targets[0].target.kind | Should -Be lib
+        $result.unsupported_targets[0].outcome | Should -Be not-applicable
+        $result.unsupported_targets[0].summary | Should -Not -BeNullOrEmpty
+        (Get-ScheduledCheckResult $check $path $script:context).unsupported_targets |
+            ConvertTo-Json -Depth 10 | Should -BeExactly ($result.unsupported_targets | ConvertTo-Json -Depth 10)
+        Should -Invoke -ModuleName ScheduledExecution Invoke-ScheduledProcess -Exactly -Times 1
+    }
+
+    It 'runs supported integration targets in a proc-macro package and still requires their summaries' {
+        $check = New-Check miri
+        $check.packages = @('linked_macros')
+        $path = New-TestEvidence $check 0
+        $metadata = Get-Content (Join-Path $script:fixtures 'proc-macro-metadata.json') -Raw | ConvertFrom-Json -AsHashtable
+        $metadata.packages[0].targets += @{ kind = @('test'); name = 'macro_expansion'; test = $true }
+        Write-Json $metadata (Join-Path $path 'metadata.stdout')
+        $execution = Get-Content (Join-Path $path 'execution.json') -Raw | ConvertFrom-Json -AsHashtable
+        $execution.commands[0].target = @{ kind = 'test'; name = 'macro_expansion' }
+        $scope = $check.Clone(); $scope.target = $execution.commands[0].target
+        $execution.commands[0].command = Get-ScheduledCommand $scope $script:root $path $script:toolchain
+        Write-Json $execution (Join-Path $path 'execution.json')
+        Set-Content (Join-Path $path 'check-0.stdout') 'test result: ok. 1 passed; 0 failed;'
+        Set-Content (Join-Path $path 'check-0.stderr') ''
+        $result = Get-ScheduledCheckResult $check $path $script:context
+        $result.outcome | Should -Be passed
+        $result.unsupported_targets.Count | Should -Be 1
+        Set-Content (Join-Path $path 'check-0.stdout') ''
+        Copy-Item (Join-Path $script:fixtures 'proc-macro.stderr') (Join-Path $path 'check-0.stderr')
+        (Get-ScheduledCheckResult $check $path $script:context).outcome | Should -Be incomplete
+        # A scope missing the supported integration target must not inherit its package's skip.
+        $execution.commands = @()
+        Write-Json $execution (Join-Path $path 'execution.json')
+        (Get-ScheduledCheckResult $check $path $script:context).outcome | Should -Be incomplete
+    }
+
     It 'validates cpulist and rejects unknown crate names using the tested workspace metadata' {
         $path = New-Output
         & cargo metadata --manifest-path (Join-Path $script:root 'Cargo.toml') --format-version=1 --no-deps --locked |

--- a/scripts/scheduled/ScheduledExecution.Tests.ps1
+++ b/scripts/scheduled/ScheduledExecution.Tests.ps1
@@ -659,6 +659,7 @@ Describe 'Pinned cargo-mutants output classification' {
 
     It 'accepts caught and unviable mutants with native failure status <FailureCode>' -ForEach @(
         @{ FailureCode = 101 }, @{ FailureCode = -1073740791 }, @{ FailureCode = -1073741571 }
+        @{ FailureCode = [int]::MinValue }, @{ FailureCode = [int]::MaxValue }
     ) {
         $check = New-Check
         $path = New-Evidence $check 0
@@ -708,6 +709,33 @@ Describe 'Pinned cargo-mutants output classification' {
                 missing-build { $scenario.phase_results = @($scenario.phase_results[1]) }
                 failed-build-before-test { $scenario.phase_results[0].process_status = @{ Failure = -1073741571 } }
             }
+        }
+        $result = Get-ScheduledCheckResult $check $path $script:context
+        $result.outcome | Should -Be incomplete
+        $result.findings.Count | Should -Be 0
+    }
+
+    It 'rejects non-i32 failure evidence: <Case>' -ForEach @(
+        @{ Case = 'below minimum'; FailureValue = -2147483649L }
+        @{ Case = 'above maximum'; FailureValue = 2147483648L }
+        @{ Case = 'positive fraction'; FailureValue = 1.5 }
+        @{ Case = 'negative fraction'; FailureValue = -1.5 }
+        @{ Case = 'numeric string'; FailureValue = '101' }
+        @{ Case = 'true'; FailureValue = $true }
+        @{ Case = 'false'; FailureValue = $false }
+        @{ Case = 'empty array'; FailureValue = @() }
+        @{ Case = 'singleton array'; FailureValue = @(101) }
+        @{ Case = 'multiple values'; FailureValue = @(101, -1073740791) }
+        @{ Case = 'null'; FailureValue = $null }
+        @{ Case = 'zero'; FailureValue = 0 }
+    ) {
+        $check = New-Check
+        $path = New-Evidence $check 2
+        Set-Lab $path {
+            param($lab)
+            $lab.outcomes[2].summary = 'CaughtMutant'
+            $lab.outcomes[2].phase_results[1].process_status = @{ Failure = $FailureValue }
+            $lab.timeout = 0; $lab.caught = 1
         }
         $result = Get-ScheduledCheckResult $check $path $script:context
         $result.outcome | Should -Be incomplete

--- a/scripts/scheduled/ScheduledExecution.psm1
+++ b/scripts/scheduled/ScheduledExecution.psm1
@@ -522,7 +522,11 @@ function Get-ScheduledPhaseSummary {
         elseif ($status -is [hashtable] -and $status.ContainsKey('Failure')) {
             # Failure(i32) preserves native Windows statuses as signed values. The sign does
             # not distinguish a completed test failure from a timeout or a build failure.
-            if ($status.Failure -eq 0) { throw [FormatException]::new('Invalid failure exit code.') }
+            $failure = $status.Failure
+            if (($failure -isnot [int] -and $failure -isnot [long]) -or
+                $failure -lt [int]::MinValue -or $failure -gt [int]::MaxValue -or $failure -eq 0) {
+                throw [FormatException]::new('Invalid failure exit code.')
+            }
             if ($phase.phase -cne 'Test') { $buildFailed = $true }
         } elseif ($status -cne 'Success') {
             throw [FormatException]::new('Unclassified process termination.')

--- a/scripts/scheduled/ScheduledExecution.psm1
+++ b/scripts/scheduled/ScheduledExecution.psm1
@@ -8,6 +8,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\build\Mutants.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\build\Miri.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\build\CargoExecutable.psm1')
@@ -393,7 +394,7 @@ function Get-ScheduledMutationConfig {
         throw [FormatException]::new('Empty-shard baseline configuration differs from the controller.')
     }
     $json = Invoke-ScheduledMutationDecoder -Executable (Get-ScheduledMutationDecoder) -Text $Text
-    return ConvertFrom-Json -InputObject $json -AsHashtable
+    return ConvertFrom-ScheduledJson -InputObject $json
 }
 
 function Invoke-ScheduledMutationDecoder {
@@ -519,7 +520,9 @@ function Get-ScheduledPhaseSummary {
         $status = $phase.process_status
         if ($status -ceq 'Timeout') { $timeout = $true }
         elseif ($status -is [hashtable] -and $status.ContainsKey('Failure')) {
-            if ($status.Failure -le 0) { throw [FormatException]::new('Invalid failure exit code.') }
+            # Failure(i32) preserves native Windows statuses as signed values. The sign does
+            # not distinguish a completed test failure from a timeout or a build failure.
+            if ($status.Failure -eq 0) { throw [FormatException]::new('Invalid failure exit code.') }
             if ($phase.phase -cne 'Test') { $buildFailed = $true }
         } elseif ($status -cne 'Success') {
             throw [FormatException]::new('Unclassified process termination.')
@@ -565,12 +568,12 @@ function Get-ScheduledMutationResult {
         $Result.summary = 'Mutation output or selected-mutant inventory is missing.'
         return
     }
-    $lab = Get-Content -LiteralPath $outcomesPath -Raw | ConvertFrom-Json -AsHashtable
+    $lab = Get-Content -LiteralPath $outcomesPath -Raw | ConvertFrom-ScheduledJson
     $run = @($Execution.commands | Where-Object { $_.name -ceq 'check' })[0]
     if ($run.exit_code -ne $Execution.exit_code) {
         throw [FormatException]::new('Mutation command and aggregate exit code disagree.')
     }
-    $inventory = @(Get-Content -LiteralPath $inventoryPath -Raw | ConvertFrom-Json -AsHashtable)
+    $inventory = @(Get-Content -LiteralPath $inventoryPath -Raw | ConvertFrom-ScheduledJson)
     foreach ($name in @('outcomes', 'total_mutants', 'missed', 'caught', 'timeout', 'unviable',
             'success', 'end_time', 'cargo_mutants_version')) {
         if (-not $lab.ContainsKey($name)) { throw [FormatException]::new("Missing lab field: $name") }
@@ -614,7 +617,7 @@ function Get-ScheduledMutationResult {
         if (-not (Test-Path -LiteralPath $discoveryPath)) {
             throw [FormatException]::new('Replay discovery output is missing.')
         }
-        $discovered = @(Get-Content -LiteralPath $discoveryPath -Raw | ConvertFrom-Json -AsHashtable)
+        $discovered = @(Get-Content -LiteralPath $discoveryPath -Raw | ConvertFrom-ScheduledJson)
         if ($discovered.Count -ne 1 -or (Get-ScheduledMutantKey $discovered[0]) -cne $key) {
             throw [FormatException]::new('Replay discovery did not select the intended mutant.')
         }
@@ -905,7 +908,7 @@ function Get-ScheduledTestScope {
     )
 
     $metadata = Get-Content -LiteralPath (Join-Path $OutputDirectory 'metadata.stdout') -Raw |
-        ConvertFrom-Json -AsHashtable
+        ConvertFrom-ScheduledJson
     foreach ($key in @('version', 'packages', 'workspace_members')) {
         if (-not $metadata.ContainsKey($key)) { throw [FormatException]::new("Missing metadata field: $key") }
     }
@@ -922,7 +925,7 @@ function Get-ScheduledTestScope {
         if ($Check.packages.Count -gt 0 -and $package.name -cnotin $Check.packages) { continue }
         if ($Check.kind -eq 'careful') {
             if ($selected.ContainsKey($package.name)) { throw [FormatException]::new('Duplicate workspace package.') }
-            $selected.Add($package.name, @{ package = $package.name; target = $null })
+            $selected.Add($package.name, @{ package = $package.name; target = $null; unsupported_reason = '' })
             continue
         }
         foreach ($cargoTarget in $package.targets) {
@@ -945,7 +948,11 @@ function Get-ScheduledTestScope {
                 $targetKey -cne (Get-ScheduledTargetKey -Target $Check.target)) { continue }
             $key = ConvertTo-Json -InputObject @($package.name, $kind, $target.name) -Compress
             if ($selected.ContainsKey($key)) { throw [FormatException]::new('Duplicate Cargo test target.') }
-            $selected.Add($key, @{ package = $package.name; target = $target })
+            # Miri cannot run proc-macro unit-test harnesses. Keep their metadata identity
+            # visible without launching a command that cannot produce test-suite evidence.
+            # Integration tests in the same package remain independently supported targets.
+            $reason = if ($kinds -ccontains 'proc-macro') { 'Miri does not support proc-macro unit tests.' } else { '' }
+            $selected.Add($key, @{ package = $package.name; target = $target; unsupported_reason = $reason })
         }
     }
     if ($Check.ContainsKey('target') -and $selected.Count -ne 1) {
@@ -968,7 +975,11 @@ function Get-ScheduledPackageResult {
         $Result.summary = 'Workspace package inventory is missing.'
         return
     }
-    $scopes = @(Get-ScheduledTestScope -Check $Check -OutputDirectory $OutputDirectory)
+    $inventory = @(Get-ScheduledTestScope -Check $Check -OutputDirectory $OutputDirectory)
+    $Result.unsupported_targets = @($inventory | Where-Object { $_.unsupported_reason -ne '' } | ForEach-Object {
+        @{ package = $_.package; target = $_.target; outcome = 'not-applicable'; summary = $_.unsupported_reason }
+    })
+    $scopes = @($inventory | Where-Object { $_.unsupported_reason -eq '' })
     $runs = @($Execution.commands | Where-Object { $_.name -like 'check-*' })
     if ($scopes.Count -ne $runs.Count) {
         $Result.summary = 'Not every selected test target has completed evidence.'
@@ -1006,9 +1017,10 @@ function Get-ScheduledPackageResult {
     $Result.outcome = if ('execution-error' -in $outcomes) { 'execution-error' }
         elseif ('incomplete' -in $outcomes) { 'incomplete' }
         elseif ('findings' -in $outcomes) { 'findings' }
-        elseif ('passed' -in $outcomes -or ($scopes.Count -eq 0 -and $Check.kind -eq 'miri')) { 'passed' }
+        elseif ('passed' -in $outcomes -or ($scopes.Count -eq 0 -and
+                $Result.unsupported_targets.Count -eq 0 -and $Check.kind -eq 'miri')) { 'passed' }
         else { 'not-applicable' }
-    $Result.summary = "Test scope outcomes: $($outcomes -join ', ')."
+    $Result.summary = "Test scope outcomes: $($outcomes -join ', '). Unsupported targets: $($Result.unsupported_targets.Count)."
 }
 
 function Assert-ScheduledRecordedCommand {
@@ -1059,7 +1071,7 @@ function Get-ScheduledCheckResult {
     if (-not (Test-Path -LiteralPath $executionPath)) { return $result }
     try {
         $toolchain = Get-ScheduledExpectedToolchain -Kind $Check.kind -RunContext $RunContext
-        $execution = Get-Content -LiteralPath $executionPath -Raw | ConvertFrom-Json -AsHashtable
+        $execution = Get-Content -LiteralPath $executionPath -Raw | ConvertFrom-ScheduledJson
         foreach ($name in @('schema_version', 'stage', 'exit_code', 'completed', 'commands',
                 'source_root', 'output_directory', 'toolchain')) {
             if (-not $execution.ContainsKey($name)) { throw [FormatException]::new("Missing execution $name.") }
@@ -1181,7 +1193,7 @@ function Invoke-ScheduledCheck {
             $execution.exit_code = $step.exit_code
             Get-Content -LiteralPath $step.stdout_path, $step.stderr_path | Add-Content -LiteralPath $logPath
             if ($step.exit_code -ne 0) { $execution.completed = $true; return }
-            $selected = @(Get-Content -LiteralPath $step.stdout_path -Raw | ConvertFrom-Json -AsHashtable)
+            $selected = @(Get-Content -LiteralPath $step.stdout_path -Raw | ConvertFrom-ScheduledJson)
             if ($selected.Count -ne 1 -or
                 (Get-ScheduledMutantKey $selected[0]) -cne (Get-ScheduledMutantKey $Check.replay_mutant)) {
                 $execution.stage = 'replay-selection-mismatch'
@@ -1250,7 +1262,8 @@ function Invoke-ScheduledCheck {
             $execution.exit_code = $step.exit_code
             Get-Content -LiteralPath $step.stdout_path, $step.stderr_path | Add-Content -LiteralPath $logPath
             if ($step.exit_code -ne 0) { $execution.completed = $true; return }
-            $scopes = @(Get-ScheduledTestScope -Check $Check -OutputDirectory $OutputDirectory)
+            $scopes = @(Get-ScheduledTestScope -Check $Check -OutputDirectory $OutputDirectory |
+                Where-Object { $_.unsupported_reason -eq '' })
             $execution.stage = 'check'
             for ($index = 0; $index -lt $scopes.Count; $index++) {
                 $selected = $scopes[$index]

--- a/scripts/scheduled/ScheduledGate.psm1
+++ b/scripts/scheduled/ScheduledGate.psm1
@@ -11,6 +11,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledPlan.psm1')
 
@@ -170,7 +171,7 @@ function Invoke-ScheduledReadApi {
     $arguments = @('api', $Endpoint)
     if ($Paginate) { $arguments += @('--paginate', '--slurp') }
     $json = & gh @arguments
-    return ConvertFrom-Json -InputObject ($json -join "`n") -AsHashtable
+    return ConvertFrom-ScheduledJson -InputObject ($json -join "`n")
 }
 
 function Get-ScheduledQueueEntry {
@@ -194,7 +195,7 @@ query($owner:String!,$name:String!,$cursor:String) {
     do {
         $arguments = @('api', 'graphql', '-f', "query=$query", '-f', "owner=$($parts[0])", '-f', "name=$($parts[1])")
         if ($cursor) { $arguments += @('-f', "cursor=$cursor") }
-        $response = (& gh @arguments) -join "`n" | ConvertFrom-Json -AsHashtable
+        $response = (& gh @arguments) -join "`n" | ConvertFrom-ScheduledJson
         if ($response.ContainsKey('errors')) { throw 'Cannot establish merge queue membership.' }
         $connection = $response.data.repository.mergeQueue.entries
         $entries += $connection.nodes

--- a/scripts/scheduled/ScheduledGitHub.psm1
+++ b/scripts/scheduled/ScheduledGitHub.psm1
@@ -12,6 +12,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledPlan.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledReport.psm1')
@@ -35,7 +36,7 @@ function Invoke-ScheduledGhJson {
         throw [IO.IOException]::new('GitHub API request failed.', $_.Exception)
     }
     if ($LASTEXITCODE -ne 0) { throw [IO.IOException]::new('GitHub API request failed.') }
-    return ConvertFrom-Json -InputObject ($json -join "`n") -AsHashtable
+    return ConvertFrom-ScheduledJson -InputObject ($json -join "`n")
 }
 
 function Invoke-ScheduledGitHubApi {
@@ -286,7 +287,7 @@ function Restore-ScheduledRunPublicationState {
     }
     $reportPath = Join-Path $directory 'report.json'
     if (Test-Path -LiteralPath $reportPath) {
-        $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -AsHashtable
+        $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-ScheduledJson
         $hasRunIssue = $report.ContainsKey('run_intake') -and $null -ne $report.run_intake -and
             $report.run_intake.ContainsKey('number')
         if ($report.status -cin @('passed', 'not-run', 'reported') -and -not $hasRunIssue) { return }
@@ -446,7 +447,7 @@ function Sync-ScheduledIssue {
             if (-not (Test-Path -LiteralPath $PublicationJournalPath -PathType Leaf)) {
                 throw [IO.IOException]::new("Coverage publication journal is not an existing file: $PublicationJournalPath")
             }
-            $journal = Get-Content -LiteralPath $PublicationJournalPath -Raw | ConvertFrom-Json -AsHashtable
+            $journal = Get-Content -LiteralPath $PublicationJournalPath -Raw | ConvertFrom-ScheduledJson
             if ($journal.schema_version -ne 1 -or $journal.identity.repository_id -ne $Policy.repository_id) {
                 throw [FormatException]::new('Coverage publication journal identity is invalid.')
             }
@@ -521,7 +522,7 @@ function Invoke-ScheduledReporting {
         applied = $false; writes_authorized = $false
     }
     try {
-        $workflowEvent = Get-Content -LiteralPath $EventPath -Raw | ConvertFrom-Json -AsHashtable
+        $workflowEvent = Get-Content -LiteralPath $EventPath -Raw | ConvertFrom-ScheduledJson
         $eventRun = $workflowEvent.workflow_run
         $run = Invoke-ScheduledGitHubApi "repos/$Repository/actions/runs/$($eventRun.id)/attempts/$($eventRun.run_attempt)"
         $workflow = Invoke-ScheduledGitHubApi "repos/$Repository/actions/workflows/$($run.workflow_id)"
@@ -616,7 +617,7 @@ function Invoke-ScheduledReporting {
             $null = New-Item -ItemType Directory -Path $downloadRoot
             $planDirectory = Get-ScheduledArtifact -Run $run -Artifacts $artifacts -Policy $policy `
                 -Name "scheduled-plan-$($run.id)-$($run.run_attempt)" -OutputDirectory $downloadRoot
-            $plan = Get-Content -LiteralPath (Join-Path $planDirectory 'plan.json') -Raw | ConvertFrom-Json -AsHashtable
+            $plan = Get-Content -LiteralPath (Join-Path $planDirectory 'plan.json') -Raw | ConvertFrom-ScheduledJson
             foreach ($key in @('run_id', 'run_attempt', 'run_number')) {
                 if ($plan[$key] -ne $context[$key]) { throw [FormatException]::new('Plan belongs to another run attempt.') }
             }
@@ -746,7 +747,7 @@ function Invoke-ScheduledReporting {
                     }
                 }
                 if ($null -eq $confirmation) { continue }
-                $incoming = $entry.record | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+                $incoming = $entry.record | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
                 $incoming.source_sha = $manifest.source_sha
                 $incoming.controller_sha = $manifest.controller_sha
                 $incoming.check_contract_digest = $manifest.check_contract_digest

--- a/scripts/scheduled/ScheduledJson.Tests.ps1
+++ b/scripts/scheduled/ScheduledJson.Tests.ps1
@@ -1,0 +1,130 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+# Exercises the source-shaped timestamp that broke issue 569 through real native codecs,
+# GitHub adapters, embedded records, cache files and retained checkpoints. No live API writes
+# or AI role execution occur: the GitHub store and Local ownership are isolated test fixtures.
+BeforeAll {
+    foreach ($module in @('ScheduledJson', 'ScheduledContracts', 'ScheduledRecordTool',
+            'LocalGitHub', 'ScheduledGitHub', 'ScheduledGate', 'LocalTriageCache',
+            'LocalTriageCheckpoint', 'LocalTriagePublication')) {
+        Import-Module (Join-Path $PSScriptRoot "$module.psm1")
+    }
+    Import-Module (Join-Path $PSScriptRoot 'fixtures\TriageFixture.psm1')
+    # Exact planner timestamp representation from run 34574480961/1, not an injected clock.
+    $script:timestamp = '2026-09-11T07:27:47.8355988+00:00'
+    $script:payload = '{"planned_at":"2026-09-11T07:27:47.8355988+00:00","started_at":"2026-09-11T07:27:40Z",' +
+        '"values":[null,[],["2026-09-11"],true,false,34574480961,-1073740791,0.02],"empty":""}'
+}
+
+Describe 'Lossless scheduled JSON values' {
+    It 'retains strings, native numbers and nested array shape without date interpretation' {
+        $value = ConvertFrom-ScheduledJson $payload
+        $value.planned_at | Should -BeOfType string
+        $value.planned_at | Should -BeExactly $timestamp
+        $value.started_at | Should -BeExactly '2026-09-11T07:27:40Z'
+        $value.values.Count | Should -Be 8
+        $value.values[0] | Should -BeNullOrEmpty
+        ($value.values[1] -is [object[]]) | Should -BeTrue
+        $value.values[1].Count | Should -Be 0
+        ($value.values[2] -is [object[]]) | Should -BeTrue
+        $value.values[2][0] | Should -BeExactly '2026-09-11'
+        $value.values[3] | Should -BeTrue
+        $value.values[4] | Should -BeFalse
+        $value.values[5] | Should -BeOfType long
+        $value.values[5] | Should -Be 34574480961
+        $value.values[6] | Should -Be -1073740791
+        $value.values[7] | Should -Be 0.02
+        $value.empty | Should -BeExactly ''
+        $copy = $value | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
+        Get-ScheduledDigest $copy | Should -BeExactly (Get-ScheduledDigest $value)
+    }
+
+    It 'preserves empty and singleton top-level arrays when requested' {
+        $empty = ConvertFrom-ScheduledJson '[]' -NoEnumerate
+        ($empty -is [object[]]) | Should -BeTrue
+        $empty.Count | Should -Be 0
+        $nested = ConvertFrom-ScheduledJson '[[{"id":34574480961}]]' -NoEnumerate
+        $nested.Count | Should -Be 1
+        ($nested[0] -is [object[]]) | Should -BeTrue
+        $nested[0][0].id | Should -Be 34574480961
+        @(ConvertFrom-ScheduledJson '[]').Count | Should -Be 0
+    }
+
+    It 'rejects malformed JSON rather than returning a successful empty record' {
+        { ConvertFrom-ScheduledJson '{"planned_at":' } | Should -Throw -ExceptionType ([ArgumentException])
+    }
+
+    It 'preserves source-shaped timestamps through the <Module> GitHub reader' -ForEach @(
+        @{ Module = 'LocalGitHub' }, @{ Module = 'ScheduledGitHub' }, @{ Module = 'ScheduledGate' }
+    ) {
+        InModuleScope $Module -Parameters @{ Json = $payload; Timestamp = $timestamp; Owner = $Module } {
+            param($Json, $Timestamp, $Owner)
+            $script:responseJson = $Json
+            Mock gh { $global:LASTEXITCODE = 0; $script:responseJson }
+            $value = switch ($Owner) {
+                LocalGitHub { Invoke-ScheduledApi -Endpoint 'repos/owner/repo/issues/1' }
+                ScheduledGitHub { Invoke-ScheduledGhJson -Arguments @('api', 'repos/owner/repo/issues/1') }
+                ScheduledGate { Invoke-ScheduledReadApi -Endpoint 'repos/owner/repo/issues/1' }
+            }
+            $value.planned_at | Should -BeOfType string
+            $value.planned_at | Should -BeExactly $Timestamp
+            $value.values[5] | Should -Be 34574480961
+        }
+    }
+}
+
+Describe 'Lossless evidence consumption' {
+    It 'restores, persists, reads and renders the original revision and rejects real timestamp tampering' {
+        $fixture = Initialize-TriageFixture -Root (Join-Path $TestDrive 'evidence') `
+            -Plan @{ run = $true; planned_at = $timestamp }
+        $prepared = Invoke-ScheduledRecordTool -Package scheduled-run-record -Request @{
+            op = 'prepare'; evidence = $fixture.evidence
+        }
+        $restored = Invoke-ScheduledRecordTool -Package scheduled-run-record -Request @{
+            op = 'restore'; identity = $prepared.identity
+            comments = @($fixture.store.comments[20L] | ForEach-Object { @{ id = $_.id; body = $_.body } })
+        }
+        $restored.record.revisions[0].digest | Should -BeExactly $prepared.digest
+        $restored.record.revisions[0].evidence.attempt.plan.planned_at | Should -BeExactly $timestamp
+        $rendered = Invoke-ScheduledRecordTool -Package scheduled-run-record -Request @{ op = 'render'; record = $restored.record }
+        $snapshot = @{ record = $restored.record }
+        $pending = Write-ScheduledTriageSnapshotFile $fixture.context.state_root $snapshot scan $fixture.context.scan_token
+        Complete-ScheduledTriageSnapshotFile $fixture.context.state_root $pending.id $pending.temporary_path scan $pending.owner_token
+        $copy = Read-ScheduledTriageSnapshot $fixture.context.state_root $pending.id
+        $marker = Write-ScheduledRecord -Kind reporter -Record (@{ schema_version = 1 } + $copy)
+        $embedded = Read-ScheduledRecord -Kind reporter -Text $marker
+        $again = Invoke-ScheduledRecordTool -Package scheduled-run-record -Request @{ op = 'render'; record = $embedded.record }
+        $again.index_digest | Should -BeExactly $rendered.index_digest
+        $embedded.record.revisions[0].digest | Should -BeExactly $prepared.digest
+        # The instant is unchanged, but the JSON string is not. Never repair a checksum by
+        # silently rehashing altered evidence or normalizing timestamp representations.
+        $embedded.record.revisions[0].evidence.attempt.plan.planned_at = '2026-09-11T07:27:47.8355988Z'
+        { Invoke-ScheduledRecordTool -Package scheduled-run-record -Request @{ op = 'render'; record = $embedded.record } } |
+            Should -Throw
+        $cachePath = Get-ScheduledTriageSnapshotPath $fixture.context.state_root $pending.id
+        $copy.record = $embedded.record
+        $copy | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $cachePath
+        { Read-ScheduledTriageSnapshot $fixture.context.state_root $pending.id } | Should -Throw
+    }
+
+    It 'retains the validated checkpoint digest across state writes, reads and native validation' {
+        $fixture = Initialize-TriageFixture -Root (Join-Path $TestDrive 'checkpoint') `
+            -Plan @{ run = $true; planned_at = $timestamp }
+        $state = Get-ScheduledTriageValidatedState $fixture.context
+        $analysis = $state.triage.analyses[$fixture.context.analysis_id]
+        $original = $analysis.checkpoint_digest
+        $analysis.checkpoint.evidence.attempt.plan.planned_at | Should -BeExactly $timestamp
+        Assert-ScheduledTriageCheckpointContent $analysis.checkpoint $original
+        $candidate = Copy-TriageFixtureValue $analysis.checkpoint
+        $candidate.analysis.checkpoint = 2
+        $candidate.analysis.reason = $timestamp
+        $saved = Invoke-TriageTransaction $fixture.context triage-checkpoint @{ checkpoint = $candidate }
+        $read = Get-ScheduledTriageValidatedState $fixture.context
+        $retained = $read.triage.analyses[$fixture.context.analysis_id]
+        $retained.checkpoint.analysis.reason | Should -BeExactly $timestamp
+        $retained.checkpoint.evidence.attempt.plan.planned_at | Should -BeExactly $timestamp
+        $retained.checkpoint_digest | Should -BeExactly $saved.triage.analyses[$fixture.context.analysis_id].checkpoint_digest
+        $retained.checkpoint.evidence.attempt.plan.planned_at = '2026-09-11T07:27:47.8355988Z'
+        $read | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath (Join-Path $fixture.context.state_root state.json)
+        { Get-ScheduledTriageValidatedState $fixture.context } | Should -Throw
+    }
+}

--- a/scripts/scheduled/ScheduledJson.psm1
+++ b/scripts/scheduled/ScheduledJson.psm1
@@ -1,0 +1,65 @@
+#requires -Version 7
+# Preserves JSON strings at the scheduled GitHub, native-tool and local persistence boundaries.
+# These readers also run before Rust preparation. System.Text.Json is part of PowerShell 7's
+# runtime; it avoids the date coercion of ConvertFrom-Json without requiring PowerShell 7.5's
+# DateKind parameter. Domain validation and canonical digest verification remain with callers.
+# Ref: ../../.github/workflows/implementation.md#lossless-evidence-transport.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+function ConvertFrom-ScheduledJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)][AllowEmptyString()][string] $InputObject,
+        [switch] $NoEnumerate
+    )
+    process {
+        # Match the existing reader's nesting limit; callers retain their stricter wire limits.
+        $options = [System.Text.Json.JsonDocumentOptions]::new()
+        $options.MaxDepth = 1024
+        try {
+            $document = [System.Text.Json.JsonDocument]::Parse($InputObject, $options)
+        } catch [System.Text.Json.JsonException] {
+            throw [ArgumentException]::new('Invalid scheduled JSON.', $_.Exception)
+        }
+        try {
+            $value = ConvertFrom-ScheduledJsonElement $document.RootElement
+            if ($NoEnumerate) { return ,$value }
+            return $value
+        } finally { $document.Dispose() }
+    }
+}
+
+function ConvertFrom-ScheduledJsonElement {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseLiteralInitializerForHashtable', '',
+        Justification = 'JSON member names are case-sensitive; a literal hashtable can merge distinct keys.')]
+    [CmdletBinding()]
+    param([System.Text.Json.JsonElement] $Element)
+    switch ($Element.ValueKind) {
+        Object {
+            $value = [hashtable]::new([StringComparer]::Ordinal)
+            foreach ($property in $Element.EnumerateObject()) {
+                $value[$property.Name] = ConvertFrom-ScheduledJsonElement $property.Value
+            }
+            return $value
+        }
+        Array {
+            $value = [Collections.Generic.List[object]]::new()
+            foreach ($item in $Element.EnumerateArray()) {
+                $value.Add((ConvertFrom-ScheduledJsonElement $item))
+            }
+            return ,$value.ToArray()
+        }
+        String { return $Element.GetString() }
+        # Retain PowerShell's existing numeric representation, but never pass strings to its
+        # date-aware reader. In particular, run/job identifiers must remain integer values.
+        Number { return ConvertFrom-Json -InputObject $Element.GetRawText() }
+        True { return $true }
+        False { return $false }
+        Null { return $null }
+        default { throw [ArgumentException]::new('Unsupported scheduled JSON value.') }
+    }
+}
+
+Export-ModuleMember -Function ConvertFrom-ScheduledJson

--- a/scripts/scheduled/ScheduledPlan.Tests.ps1
+++ b/scripts/scheduled/ScheduledPlan.Tests.ps1
@@ -34,6 +34,9 @@ Describe 'Expected deep scope' {
             Should -Invoke Get-FileHash -Times 1 -ParameterFilter { $LiteralPath -like '*constants.env' }
             Should -Invoke Get-FileHash -Times 1 -ParameterFilter { $LiteralPath -like '*rust-toolchain.toml' }
             Should -Invoke Get-FileHash -Times 1 -ParameterFilter { $LiteralPath -like '*mutants.toml' }
+            Should -Invoke Get-FileHash -Times 1 -ParameterFilter { $LiteralPath -like '*ScheduledJson.psm1' }
+            Should -Invoke Get-FileHash -Times 1 -ParameterFilter { $LiteralPath -like '*Invoke-ScheduledCheck.ps1' }
+            Should -Invoke Get-FileHash -Times 1 -ParameterFilter { $LiteralPath -like '*just_scheduled.just' }
             Should -Invoke Get-FileHash -Times 1 -ParameterFilter {
                 $LiteralPath -like '*scheduled-mutation-config*Cargo.toml'
             }

--- a/scripts/scheduled/ScheduledPlan.psm1
+++ b/scripts/scheduled/ScheduledPlan.psm1
@@ -102,6 +102,8 @@ function Get-ScheduledContractDigest {
         '.github/workflows/deep-checks.yml', '.github/actions/setup-environment/action.yml',
         'scripts/scheduled/ScheduledContracts.psm1', 'scripts/scheduled/ScheduledPlan.psm1',
         'scripts/scheduled/ScheduledExecution.psm1', 'scripts/scheduled/ScheduledTransport.psm1',
+        'scripts/scheduled/ScheduledJson.psm1', 'scripts/scheduled/Invoke-ScheduledCheck.ps1',
+        'justfiles/just_scheduled.just',
         'packages/scheduled-mutation-config/Cargo.toml',
         'packages/scheduled-mutation-config/dependency-contract.json',
         'packages/scheduled-mutation-config/src/dependency_contract.rs',

--- a/scripts/scheduled/ScheduledRecordTool.psm1
+++ b/scripts/scheduled/ScheduledRecordTool.psm1
@@ -6,6 +6,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledTransport.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledExecution.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\build\CargoExecutable.psm1')
@@ -42,7 +43,7 @@ function Invoke-ScheduledRecordTool {
     }
     $json = Invoke-ScheduledJsonExecutable -Executable $script:executables[$Package] -Directory $root `
         -InputText ($Request | ConvertTo-Json -Depth 100 -Compress)
-    return ConvertFrom-Json -InputObject $json -AsHashtable
+    return ConvertFrom-ScheduledJson -InputObject $json
 }
 
 Export-ModuleMember -Function Invoke-ScheduledRecordTool

--- a/scripts/scheduled/ScheduledReport.psm1
+++ b/scripts/scheduled/ScheduledReport.psm1
@@ -9,6 +9,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledPlan.psm1')
 
@@ -52,7 +53,7 @@ function Merge-ScheduledObservation {
         throw [FormatException]::new('Observation lacks execution identity.')
     }
     Assert-ScheduledSha $Incoming.source_sha
-    $next = $Incoming | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+    $next = $Incoming | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
     if ($null -eq $Existing) {
         if ($Incoming.observation.outcome -cne 'findings') { return $null }
         $next.generation = 1
@@ -130,7 +131,7 @@ function Merge-ScheduledCoverage {
 
     $next = if ($null -eq $Coverage) {
         @{ schema_version = 1; repository = $Manifest.repository; receipt = $null; invalidation = $null }
-    } else { $Coverage | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable }
+    } else { $Coverage | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson }
     if ($Skipped) { return $next }
     if ($next.ContainsKey('observation') -and $null -ne $next.observation) {
         if ((Compare-ScheduledObservation $Context $next.observation) -le 0 -or

--- a/scripts/scheduled/ScheduledRunGitHub.psm1
+++ b/scripts/scheduled/ScheduledRunGitHub.psm1
@@ -9,6 +9,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledTransport.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledExecution.psm1')
@@ -245,7 +246,7 @@ function Sync-ScheduledRunIntake {
         stage = 'prepared'; issue_number = $null; operation_id = $null; pending_pages = @{}
     }
     if (Test-Path -LiteralPath $journalPath) {
-        $journal = Get-Content -LiteralPath $journalPath -Raw | ConvertFrom-Json -AsHashtable
+        $journal = Get-Content -LiteralPath $journalPath -Raw | ConvertFrom-ScheduledJson
         if ($journal.schema_version -ne 1 -or $journal.pending_pages -isnot [hashtable] -or
             (Get-ScheduledDigest $journal.identity) -cne (Get-ScheduledDigest $prepared.identity)) {
             throw [FormatException]::new('Publication journal identity or schema is invalid.')

--- a/scripts/scheduled/ScheduledVersion.psm1
+++ b/scripts/scheduled/ScheduledVersion.psm1
@@ -10,6 +10,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 
 function Assert-ScheduledVersionArtifact {
@@ -147,7 +148,7 @@ function Assert-ScheduledCanonicalVersion {
             # Export only after resolution reaches its fixed point: an initial group expansion
             # may omit binary lockfile effects. Apply still consumes the full captured artifact.
             & $ReleasePlanExecutable expand --plan $resolvedPath --out $expandedPath
-            $expanded = Get-Content -LiteralPath $expandedPath -Raw | ConvertFrom-Json -AsHashtable
+            $expanded = Get-Content -LiteralPath $expandedPath -Raw | ConvertFrom-ScheduledJson
             Assert-ScheduledVersionArtifact -Evidence $Evidence -BaseSha $BaseSha -Expanded $expanded
             & $AssertPublished $resolvedPath
             & $ReleasePlanExecutable apply --plan $resolvedPath
@@ -200,7 +201,7 @@ function Remove-ScheduledVersionReference {
 function Invoke-ScheduledVersionVerification {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string] $PlanPath)
-    $plan = Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-Json -AsHashtable
+    $plan = Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-ScheduledJson
     if (-not $plan.managed) { throw 'Canonical repair verification requires a managed candidate.' }
     $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
     $target = Join-Path $root 'target/scheduled-version'

--- a/scripts/scheduled/ScheduledWorkflow.psm1
+++ b/scripts/scheduled/ScheduledWorkflow.psm1
@@ -11,6 +11,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
+Import-Module (Join-Path $PSScriptRoot 'ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledContracts.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledPlan.psm1')
 Import-Module (Join-Path $PSScriptRoot 'ScheduledGate.psm1')
@@ -113,7 +114,7 @@ function Invoke-ScheduledPlanning {
         [Parameter(Mandatory)][string] $OutputDirectory,
         [datetimeoffset] $Now = [datetimeoffset]::UtcNow
     )
-    $workflowEvent = Get-Content -LiteralPath $EventPath -Raw | ConvertFrom-Json -AsHashtable
+    $workflowEvent = Get-Content -LiteralPath $EventPath -Raw | ConvertFrom-ScheduledJson
     $policy = Get-ScheduledPolicy
     if ($workflowEvent.repository.id -ne $policy.repository_id) { throw 'Wrong repository for scheduled controller.' }
     if ($Mode -ne 'validation' -and $env:GITHUB_REF -cne 'refs/heads/main') {
@@ -295,7 +296,7 @@ function Invoke-ScheduledGate {
         [Parameter(Mandatory)][int] $RunAttempt
     )
     if ($ContextResult -cne 'success') { throw 'Scheduled context did not succeed.' }
-    $plan = Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-Json -AsHashtable
+    $plan = Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-ScheduledJson
     if (-not $plan.managed) {
         Write-Verbose 'Ordinary validation: no managed repair evidence required.'
         return
@@ -303,7 +304,7 @@ function Invoke-ScheduledGate {
     if ($DeepResult -cne 'success') { throw "Relevant deep execution was $DeepResult." }
     $results = @()
     foreach ($file in Get-ChildItem -LiteralPath $ResultsDirectory -Filter evidence.json -Recurse -File) {
-        $results += Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-Json -AsHashtable
+        $results += Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-ScheduledJson
     }
     $verdict = Test-ScheduledRepairEvidence -Manifest $plan.manifest -Results $results -RunId $RunId -RunAttempt $RunAttempt
     if (-not $verdict.successful) { throw "Managed repair evidence rejected: $($verdict.problems -join '; ')" }

--- a/scripts/scheduled/fixtures/TriageFixture.psm1
+++ b/scripts/scheduled/fixtures/TriageFixture.psm1
@@ -8,13 +8,14 @@ $PSNativeCommandUseErrorActionPreference = $true
 Import-Module (Join-Path $PSScriptRoot '..\LocalState.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\LocalTriagePolicy.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\ScheduledContracts.psm1')
+Import-Module (Join-Path $PSScriptRoot '..\ScheduledJson.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\ScheduledRecordTool.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\LocalTriageInbox.psm1')
 Import-Module (Join-Path $PSScriptRoot '..\LocalTriagePublication.psm1')
 
 function Copy-TriageFixtureValue {
     param($Value)
-    return $Value | ConvertTo-Json -Depth 100 | ConvertFrom-Json -AsHashtable
+    return $Value | ConvertTo-Json -Depth 100 | ConvertFrom-ScheduledJson
 }
 
 function Initialize-TriageFixture {
@@ -24,7 +25,8 @@ function Initialize-TriageFixture {
         [ValidateRange(1, 2)][int] $ProblemCount = 1,
         [ValidateSet('', 'cancelled', 'failure')][string] $EmptyWorkflowConclusion = '',
         [switch] $PartialWithSupport,
-        [switch] $Unclaimed
+        [switch] $Unclaimed,
+        [hashtable] $Plan = @{ run = $true }
     )
     $policy = Get-ScheduledPolicy
     $policy.repository = 'owner/repository'; $policy.repository_id = 123
@@ -62,7 +64,7 @@ function Initialize-TriageFixture {
             run_attempt = 1; run_number = 42; created_at = '2026-09-09T01:00:00Z'
             started_at = '2026-09-09T01:00:01Z'; completed_at = '2026-09-09T01:00:02Z'
             workflow_conclusion = 'failure'; run_sha = 'a' * 40; controller_sha = 'a' * 40
-            manifest = @{ source_sha = 'a' * 40 }; plan = @{ run = $true }
+            manifest = @{ source_sha = 'a' * 40 }; plan = $Plan
             results = @(@{ check_id = 'setup'; outcome = 'execution-error' }); evidence_gaps = @()
             jobs = @(@{
                 id = 101; name = 'Setup'; status = 'completed'; conclusion = 'failure'

--- a/scripts/scheduled/fixtures/execution/proc-macro-metadata.json
+++ b/scripts/scheduled/fixtures/execution/proc-macro-metadata.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "workspace_members": ["path+file:///home/runner/work/folo/folo/candidate/packages/linked_macros#1.0.24"],
+  "packages": [
+    {
+      "id": "path+file:///home/runner/work/folo/folo/candidate/packages/linked_macros#1.0.24",
+      "name": "linked_macros",
+      "targets": [
+        {
+          "kind": ["proc-macro"],
+          "crate_types": ["proc-macro"],
+          "name": "linked_macros",
+          "src_path": "/home/runner/work/folo/folo/candidate/packages/linked_macros/src/lib.rs",
+          "edition": "2024",
+          "doc": false,
+          "doctest": true,
+          "test": true
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/scheduled/fixtures/execution/proc-macro.stderr
+++ b/scripts/scheduled/fixtures/execution/proc-macro.stderr
@@ -1,0 +1,1 @@
+Running unit tests of proc-macro crates is not currently supported by Miri.


### PR DESCRIPTION
[Copilot speaking]

## Motivation

The scheduled run recorded in #569 has successful GitHub jobs despite non-passed checker outcomes. Its durable evidence is intact, but consuming that evidence through PowerShell rewrites date-looking JSON strings and invalidates the original revision digest. Trustworthy execution signals and lossless consumption are prerequisites for later repair admission.

## Behavior

Scheduled command wrappers propagate the checker or reporter process status explicitly, including on PowerShell versions without native-error preference support. Preserving artifacts and successfully reporting a failure remain independent of the originating check's pass/fail result.

Miri uses Cargo metadata to retain unsupported proc-macro unit harnesses as explicit not-applicable evidence without executing them. Supported targets, including integration tests in proc-macro packages, still require complete execution evidence. Unsupported-only selections do not establish tested coverage.

Mutation decoding accepts the pinned tool's nonzero signed native failure statuses, preserving Windows findings while retaining baseline prerequisites, build/test phase provenance and timeout classification.

Scheduled native-tool, GitHub, embedded-record, journal, cache and Local state/checkpoint boundaries preserve JSON string contents exactly. Original revision, publication-index and checkpoint digests remain authoritative; altered evidence is rejected rather than normalized or rehashed. The shared reader uses the supported PowerShell 7 runtime without requiring the newer DateKind parameter.

## Scope boundaries

This is evidence-correctness work, not triage or repair admission. `reserve-attempt` remains unconditionally `ai-triage-unavailable`; unenrolled/observe policies and disabled automation remain unchanged. #569 remains open for complete diagnosis and canonical problem reconciliation.

Safe reporter/triage cross-writer ownership remains a separate prerequisite: shared issue-body/state read/merge/PATCH operations can still overwrite a concurrent owned-root update or close expanded scope. This PR does not claim to resolve [the retained ownership race](https://github.com/folo-rs/folo/pull/568#discussion_r3987674937), introduce conditional PATCH assumptions or add remote coordination permissions.

## Version/release plan

There are no released-content or version changes. The complete resolved plan is empty, every publishable package remains unchanged against its release anchor, and no dependent/group alignment or first publication is required. These repository automation and documentation changes do not release a crate.