### PR TITLE
CI: move hack, machete and ARM tests to deep validation

### DIFF
--- a/.github/workflows/deep-validation.yml
+++ b/.github/workflows/deep-validation.yml
@@ -73,10 +73,96 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+  # Low-yield checks run at full workspace scope after the main-only plan gate.
+  # Ref: .github/workflows/design.md#shallow-and-deep-validation.
+  hack:
+    needs: plan
+    # Work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-environment
+      - name: Run hack on ${{ matrix.platform }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          just hack
+
+  machete:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS is excluded because maintainers lack a local PC for dependency trial and error.
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-environment
+      - name: Run machete on ${{ matrix.platform }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          just machete
+
+  # ARM64 exercises architecture-gated paths and supplies the MSRV runtime pass.
+  # macOS belongs here because its hosted runner is Apple Silicon.
+  # Ref: .github/workflows/design.md#platform-strategy.
+  test-arm:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-24.04-arm, windows-11-arm, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-environment
+        # Linux benchmark smoke tests execute Gungraun harnesses under Valgrind.
+        with:
+          install-valgrind: "true"
+      - name: Run tests on ${{ matrix.platform }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          just test
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/default/junit.xml
+          flags: ${{ matrix.platform }}
+          report_type: test_results
+      - name: Run benchmark targets on ${{ matrix.platform }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          just test-benches
+
   report:
     # This is a normal failure-reporting job in the same run, including planning/setup failures.
     # Ref: .github/workflows/implementation.md#failure-reporting.
-    needs: [plan, checks]
+    needs: [plan, checks, hack, machete, test-arm]
     if: failure()
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deep-validation.yml
+++ b/.github/workflows/deep-validation.yml
@@ -123,6 +123,10 @@ jobs:
   # Ref: .github/workflows/design.md#platform-strategy.
   test-arm:
     needs: plan
+    # Preserve panic diagnostics in job logs used by the failure reporter.
+    # Ref: .github/workflows/design.md#failure-diagnostics.
+    env:
+      RUST_BACKTRACE: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/design.md
+++ b/.github/workflows/design.md
@@ -34,6 +34,9 @@ GitHub-hosted workflows do not invoke AI. Final approval and merge remain human.
 **Standard validation** runs the ordinary shallow PR, push and merge-queue checks.
 **Deep validation** runs the full deep suite at the main commit selected by its event.
 Deep validation covers ordinary Miri, many-seed Miri, mutation testing and careful checks.
+It also runs feature-powerset compilation (`hack`), unused-dependency checks (`machete`)
+and ARM64 tests and benchmark smoke checks (`test-arm`). These lower-yield checks run
+nightly or on manual dispatch rather than on every push.
 Planning, check jobs and failure reporting belong to that same workflow.
 The local entry points have fixed meanings: `validate-local` is shallow and
 `validate-deep-local` is deep. Repair authors run relevant local deep checks against the
@@ -71,8 +74,8 @@ do not select permissions or opt out of jobs.
 
 Standard validation runs each `just` command as its own parallel job rather than one combined
 `validate-local` step. Parallelism gives faster feedback and pinpoints failures by check
-name instead of burying them in a monolithic log. The local recipes define which
-commands are shallow or deep, while workflow jobs own platform selection,
+name instead of burying them in a monolithic log. The local recipes define the local
+check suites, while workflow jobs own execution cadence, platform selection,
 prerequisites and evidence capture. Clippy stands in for a bare `cargo check` here: Clippy compiles the code as a
 prerequisite to linting it, so a standalone `check` job would only re-prove what a green
 Clippy already guarantees.
@@ -105,7 +108,8 @@ change release obligations without a manifest edit.
 Test passes are organised as an x86_64/ARM64 pair. The x64 pass carries coverage
 instrumentation (which needs a nightly-only toolchain component), while the ARM pass
 doubles as the MSRV pass and exists to exercise architecture-gated code that x86_64 runners
-never compile. macOS is Apple Silicon, so it rides the ARM pass. Scheduled Miri
+never compile. The x64 pass runs in Standard validation; the ARM pass runs in Deep
+validation. macOS is Apple Silicon, so it rides the ARM pass. Scheduled Miri
 coverage includes architecture-gated paths as declared by its manifest. Platform-agnostic checks
 (formatting, workflow validation, script tests) run on a single Linux runner because their result cannot
 vary by platform.
@@ -113,21 +117,21 @@ vary by platform.
 Not every shallow check earns its place on every pull request. The
 full shallow matrix runs on each push to `main`, but pull-request validation prunes the rarely-informative
 legs to cut runner cost, leaning on push-to-`main` as the backstop for what it drops. PRs run the
-test and docs suites only on the x86_64 Windows and Linux runners: the whole ARM pass (which carries the
-MSRV *test* run) and the macOS legs of the test and docs jobs wait for `main`, because
-architecture- and OS-gated behaviour rarely diverges on a PR and re-running the
-platform-independent test and doc suites on macOS almost never is informative.
+test and docs suites only on the x86_64 Windows and Linux runners. The macOS doctest and
+docs jobs wait for a push to `main`, because re-running these platform-independent
+suites on macOS is rarely informative.
 The release-profile Clippy pass is also main-only. The
-compile-oriented passes (dev Clippy, release build, frozen-minimum check, feature `hack`)
+compile-oriented passes (dev Clippy, release build, frozen-minimum check)
 deliberately keep their macOS leg on PRs, because a cheap macOS cross-compile still catches
 macOS-specific build breaks that the pruned runtime passes would not. MSRV *compilation*
 therefore stays covered on every PR by `check-frozen`, which compiles all targets on the
 MSRV toolchain against the frozen minimum-version lockfile even though the ARM MSRV test
-pass is `main`-only. Because a push to `main` is the first place the pruned checks can fail,
+pass runs in Deep validation. Because a push to `main` is the first place Standard
+validation's pruned checks can fail,
 that event — unlike a PR — files a tracking issue (see Failure alerting).
 
-The event split is expressed two ways: a job whose every leg is pruned on a PR (the ARM test
-pass or `clippy-release`) carries a whole-job `github.event_name ==
+The event split is expressed two ways: a job whose every leg is pruned on a PR
+(`clippy-release`) carries a whole-job `github.event_name ==
 'push'` guard, while a job that keeps some legs on a PR (macOS-dropping test/docs, the
 platform-specific compilation jobs) selects its platform list with a `fromJSON` conditional matrix
 keyed on the same event. Both reduce to "the full set on push, the pruned set on a PR".

--- a/.github/workflows/implementation.md
+++ b/.github/workflows/implementation.md
@@ -16,7 +16,7 @@ the installed App's scheduling controls.
 | `pr-bench-history.yml` / **PR Benchmark history** | PR opened/synchronized/reopened. | Advisory production-backed benchmark feedback for same-repository PRs. |
 
 ```text
-Deep validation on main: plan -> check matrix -> report failures -> run report issue
+Deep validation on main: plan -> check matrices -> report failures -> run report issue
 
 Local App triage -> run report -> existing or new problem issues
 Local App repair -> claimed problem issue -> PR -> human review and merge
@@ -231,6 +231,12 @@ reconstruct a test invocation or claim that a baseline ran.
 The full workflow executes every night, without persistent coverage receipts or
 successful-run reuse. Ordinary dependency/build caches remain available.
 
+The separate `hack`, `machete` and `test-arm` jobs depend on the same main-only plan
+gate and run their Just recipes over the full workspace. They retain independent
+platform matrices; the ARM test job also provisions Valgrind for benchmark smoke
+tests and uploads its JUnit results to Codecov. Their failures are reported from
+Actions job logs rather than the deep-check wrapper's summary artifacts.
+
 ### Manual checks
 
 Manually starting **Deep validation** on `main` runs the same full suite as the
@@ -243,7 +249,7 @@ platform coverage is disclosed for human review, not claimed as a passing result
 
 ### Failure reporting
 
-The `report` job depends on planning and the check matrix and runs on failure.
+The `report` job depends on planning and every check matrix and runs on failure.
 It uses the same main checkout as the other jobs. Its normal GitHub permissions
 allow reading Actions results and writing an issue. Preinstalled PowerShell and
 the GitHub CLI are sufficient, even when checker/toolchain setup failed.

--- a/.github/workflows/standard-validation.yml
+++ b/.github/workflows/standard-validation.yml
@@ -307,7 +307,7 @@ jobs:
         run: just default-features-check
 
   # Fails when a library's public API exposes an external type that is not on its allow-list, so an
-  # accidental addition to the external surface is caught in review. Modelled on `machete`: a
+  # accidental addition to the external surface is caught in review. Uses a
   # ubuntu + windows matrix, because the public surface is platform-dependent (cfg-gated items) and
   # macOS (also cfg(unix)) is redundant with ubuntu here. Delta-scoped like the other package jobs.
   check-external-types:
@@ -357,12 +357,12 @@ jobs:
   # panic. Uploads both the coverage report and the test results to Codecov.
   #
   # macOS is deliberately not here: GitHub's `macos-latest` runner is Apple Silicon (arm64),
-  # so macOS is exercised by the `test-arm` job instead. Keeping this job x86_64-only keeps
+  # so macOS is exercised by Deep validation's `test-arm` job. Keeping this job x86_64-only keeps
   # its name accurate and stops the matrix drifting as the `-latest` labels change.
   #
   # Coverage requires the nightly toolchain (llvm-tools-preview is installed only there via
   # `just install-tools`), so this is the nightly test pass. The MSRV test pass runs on the
-  # ARM runners (`test-arm`, push-to-`main` only), and MSRV compilation of every target is
+  # ARM runners in Deep validation, and MSRV compilation of every target is
   # covered by `check-frozen` (which compiles all targets on MSRV against the frozen minimums).
   # Paired with `test-arm`; both carry an explicit `-x64`/`-arm` suffix for symmetry.
   test-x64:
@@ -475,71 +475,6 @@ jobs:
       - name: Run docs-default-features on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" docs-default-features
 
-  # The ARM64 test pass (ubuntu-24.04-arm, windows-11-arm and macos-latest). Exercises
-  # ARM-specific code paths (anything gated behind cfg(target_arch = "aarch64") or similar)
-  # which x86_64 runners never compile or execute. macOS lives here too because GitHub's
-  # `macos-latest` runner is Apple Silicon (arm64). Also serves as the MSRV test pass (the
-  # x86_64 `test-x64` job runs on nightly so it can collect coverage). No coverage here:
-  # llvm-tools-preview-based instrumentation is gathered on x86_64 only. Paired with
-  # `test-x64`; both carry an explicit `-x64`/`-arm` suffix.
-  test-arm:
-    needs: [delta]
-    # Push-to-`main` only: every leg here is ARM or macOS, all pruned from PR validation.
-    if: github.event_name == 'push' && needs.delta.outputs.skip_all != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-24.04-arm, windows-11-arm, macos-latest]
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Setup environment
-        # The benchmark smoke check below runs every bench target once, and on Linux the
-        # `*_cg` targets are real Gungraun harnesses that execute under Valgrind.
-        uses: ./.github/actions/setup-environment
-        with:
-          install-valgrind: "true"
-
-      - name: Run tests on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" test
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/nextest/default/junit.xml
-          flags: ${{ matrix.platform }}
-          report_type: test_results
-
-      - name: Run benchmark targets on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" test-benches
-
-  machete:
-    needs: [delta]
-    if: needs.delta.outputs.skip_all != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        # macos-latest intentionally excluded because maintainers lack local PC to do the necessary "dependency trial and error" on.
-        platform: [ubuntu-latest, windows-latest]
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-
-      - name: Run machete on ${{ matrix.platform }}
-        run: just machete
-
   clippy-release:
     needs: [delta, clippy-dev]
     # Push-to-`main` only: release-profile Clippy rarely diverges from the dev pass on a PR.
@@ -628,28 +563,6 @@ jobs:
 
       - name: Run examples on ${{ matrix.platform }}
         run: just package="${{ needs.delta.outputs.packages }}" run-examples
-
-  hack:
-    needs: [delta]
-    if: needs.delta.outputs.skip_all != 'true'
-    # Work budget (~90 min) plus up to 90 min for a cold-cache setup-environment.
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-
-      - name: Run hack on ${{ matrix.platform }}
-        run: just package="${{ needs.delta.outputs.packages }}" hack
 
   # Azure Blob storage backend tests against the Azurite emulator.
   #
@@ -944,13 +857,10 @@ jobs:
       - test-x64
       - test-docs
       - docs
-      - test-arm
-      - machete
       - clippy-release
       - build-release
       - check-frozen
       - run-examples
-      - hack
       - test-azurite
       - test-azure
       - test-azure-gh
@@ -979,7 +889,7 @@ jobs:
   # File a GitHub issue whenever any job above fails on a push to `main`, so a push-to-main
   # failure is tracked rather than lost. PR runs surface a failure as the red check and need
   # no issue - and this workflow now leans more heavily on push-to-main as the backstop for
-  # the shallow checks pruned from PR validation (ARM, macOS test/docs, clippy-release),
+  # the shallow checks pruned from PR validation (macOS doctests/docs, clippy-release),
   # so a green PR does not imply those passed.
   #
   # A fresh issue is filed per failing run - no dedup, no auto-close - mirroring the release
@@ -1008,13 +918,10 @@ jobs:
       - test-x64
       - test-docs
       - docs
-      - test-arm
-      - machete
       - clippy-release
       - build-release
       - check-frozen
       - run-examples
-      - hack
       - test-azurite
       - test-azure
       - test-azure-gh

--- a/.github/workflows/standard-validation.yml
+++ b/.github/workflows/standard-validation.yml
@@ -307,8 +307,8 @@ jobs:
         run: just default-features-check
 
   # Fails when a library's public API exposes an external type that is not on its allow-list, so an
-  # accidental addition to the external surface is caught in review. Uses a
-  # ubuntu + windows matrix, because the public surface is platform-dependent (cfg-gated items) and
+  # accidental addition to the external surface is caught in review. Uses an
+  # Ubuntu + Windows matrix, because the public surface is platform-dependent (cfg-gated items) and
   # macOS (also cfg(unix)) is redundant with ubuntu here. Delta-scoped like the other package jobs.
   check-external-types:
     needs: [delta]
@@ -956,7 +956,7 @@ jobs:
           The Standard validation workflow failed on a push to ``main``.
 
           Push-to-``main`` validation is the backstop for the checks pruned from PR validation
-          (ARM and macOS test/docs runs and ``clippy-release``), so this failure may be
+          (macOS doctest/docs runs and ``clippy-release``), so this failure may be
           in a check a PR never ran.
 
           Failed run: $env:RUN_URL

--- a/docs/scheduled-validation.md
+++ b/docs/scheduled-validation.md
@@ -38,7 +38,8 @@ The local shallow and deep validation commands retain their separate meanings.
 
 **Standard validation** runs ordinary required checks.
 **[Deep validation](../.github/workflows/deep-validation.yml)** runs the complete
-Miri platform matrix, many-seed Miri cases, mutation shards and careful checks
+Miri platform matrix, many-seed Miri cases, mutation shards, careful checks,
+feature-powerset compilation, unused-dependency checks and ARM64 tests with benchmark smoke checks
 nightly on main. Every nightly run executes the checks; previous success does not
 skip a night. Ordinary dependency/build caches remain available.
 

--- a/scripts/build/ValidationWorkflow.Tests.ps1
+++ b/scripts/build/ValidationWorkflow.Tests.ps1
@@ -47,6 +47,13 @@ Describe 'Standard validation integration' {
         Get-WorkflowJob $standard 'validate-versions' | Should -Not -Match '(?m)^    if:'
     }
 
+    It 'describes only Standard validation checks in its failure issue' {
+        $alert = Get-WorkflowJob $standard 'alert'
+        $alert | Should -Not -Match '\bARM\b|\btest-arm\b|\bhack\b|\bmachete\b'
+        $alert | Should -Match 'macOS doctest/docs runs'
+        $alert | Should -Match 'clippy-release'
+    }
+
     It 'uses normal repository and event conditions for <_> regardless of branch names' -ForEach @('test-azure', 'test-azure-gh') {
         $job = Get-WorkflowJob $standard $_
         $job | Should -Not -Match 'scheduled-repair|github\.head_ref'

--- a/scripts/scheduled/ScheduledReport.Tests.ps1
+++ b/scripts/scheduled/ScheduledReport.Tests.ps1
@@ -105,7 +105,7 @@ Describe 'Same-workflow reporting' {
     It 'reports dependency failures as a job of Deep validation' {
         $workflow | Should -Match '(?m)^name: Deep validation\r?$'
         $workflow | Should -Match '(?m)^  report:'
-        $workflow | Should -Match 'needs: \[plan, checks\]'
+        $workflow | Should -Match 'needs: \[plan, checks, hack, machete, test-arm\]'
         $workflow | Should -Match 'if: failure\(\)'
         $workflow | Should -Match '\./scripts/scheduled/Invoke-ScheduledReport.ps1'
         $workflow | Should -Not -Match 'workflow_run:|path: controller|path: candidate'

--- a/scripts/scheduled/ScheduledValidation.Tests.ps1
+++ b/scripts/scheduled/ScheduledValidation.Tests.ps1
@@ -8,6 +8,7 @@ $PSNativeCommandUseErrorActionPreference = $true
 BeforeAll {
     $script:workflows = Join-Path $PSScriptRoot '..\..\.github\workflows'
     $script:workflow = Get-Content -LiteralPath (Join-Path $workflows 'deep-validation.yml') -Raw
+    $script:standard = Get-Content -LiteralPath (Join-Path $workflows 'standard-validation.yml') -Raw
 }
 
 Describe 'Hosted deep validation wiring' {
@@ -27,10 +28,38 @@ Describe 'Hosted deep validation wiring' {
         $workflow | Should -Match '(?m)^  plan:'
         $workflow | Should -Match '(?m)^  checks:'
         $workflow | Should -Match '(?m)^  report:'
-        $workflow | Should -Match 'needs: \[plan, checks\]'
+        $workflow | Should -Match 'needs: \[plan, checks, hack, machete, test-arm\]'
         $workflow | Should -Match 'if: failure\(\)'
         $workflow | Should -Match 'issues: write'
         $workflow | Should -Not -Match 'path: (controller|candidate)|uses: \./\.github/workflows/'
+    }
+
+    It 'runs <job> only in deep validation with its full platform and workspace scope' -ForEach @(
+        @{ job = 'hack'; platforms = 'ubuntu-latest, macos-latest, windows-latest'; recipes = @('hack') },
+        @{ job = 'machete'; platforms = 'ubuntu-latest, windows-latest'; recipes = @('machete') },
+        @{ job = 'test-arm'; platforms = 'ubuntu-24.04-arm, windows-11-arm, macos-latest'; recipes = @('test', 'test-benches') }
+    ) {
+        $pattern = '(?ms)^  ' + [regex]::Escape($job) + ':\r?\n(?<body>.*?)(?=^  [a-z][a-z0-9-]*:\r?$|\z)'
+        $match = [regex]::Match($workflow, $pattern)
+        $match.Success | Should -BeTrue
+        $body = $match.Groups['body'].Value
+        $body | Should -Match '(?m)^    needs: plan\r?$'
+        $body | Should -Not -Match '(?m)^    if:|needs\.delta|package='
+        $body | Should -Match ('platform: \[' + [regex]::Escape($platforms) + '\]')
+        $body | Should -Match 'fail-fast: false'
+        foreach ($recipe in $recipes) {
+            $body | Should -Match ('(?m)^          just ' + [regex]::Escape($recipe) + '\r?$')
+        }
+        $standard | Should -Not -Match ('(?m)^  ' + [regex]::Escape($job) + ':')
+        $standard | Should -Not -Match ('(?m)^      - ' + [regex]::Escape($job) + '\r?$')
+    }
+
+    It 'retains ARM benchmark prerequisites and test-result publishing' {
+        $arm = [regex]::Match($workflow, '(?ms)^  test-arm:\r?\n(?<body>.*?)(?=^  report:)').Groups['body'].Value
+        $arm | Should -Match 'install-valgrind: "true"'
+        $arm | Should -Match 'uses: codecov/codecov-action@'
+        $arm | Should -Match 'files: target/nextest/default/junit.xml'
+        $arm | Should -Match 'report_type: test_results'
     }
 
     It 'continues independent checks and preserves failures and diagnostics' {

--- a/scripts/scheduled/ScheduledValidation.Tests.ps1
+++ b/scripts/scheduled/ScheduledValidation.Tests.ps1
@@ -54,8 +54,9 @@ Describe 'Hosted deep validation wiring' {
         $standard | Should -Not -Match ('(?m)^      - ' + [regex]::Escape($job) + '\r?$')
     }
 
-    It 'retains ARM benchmark prerequisites and test-result publishing' {
+    It 'retains ARM panic diagnostics, benchmark prerequisites and test-result publishing' {
         $arm = [regex]::Match($workflow, '(?ms)^  test-arm:\r?\n(?<body>.*?)(?=^  report:)').Groups['body'].Value
+        $arm | Should -Match '(?m)^    env:\r?\n      RUST_BACKTRACE: "1"\r?$'
         $arm | Should -Match 'install-valgrind: "true"'
         $arm | Should -Match 'uses: codecov/codecov-action@'
         $arm | Should -Match 'files: target/nextest/default/junit.xml'


### PR DESCRIPTION
[Copilot speaking]

The `hack`, `machete` and `test-arm` checks are low-impact or rarely produce findings, so running them on every applicable push adds cost without enough useful feedback.

Move these jobs from Standard validation to Deep validation, where they run over the full workspace nightly or by manual dispatch on `main`. Preserve their platform matrices, ARM benchmark smoke checks and Codecov test-result uploads. Their failures feed the existing deep-validation failure reporter instead of Standard validation's required-checks and alerts.

Local Just recipes remain unchanged. MSRV compilation remains covered by Standard validation's `check-frozen`; the ARM MSRV runtime pass runs in Deep validation.

## Version/release plan

There are no released-content or version changes. All packages remain unchanged relative to their release anchors; no increments, group alignments, pending releases or first-publication handoffs are required.