### PR TITLE
release-target-check: add harmless deep-validation leak canary

### DIFF
--- a/packages/release-target-check/src/metadata.rs
+++ b/packages/release-target-check/src/metadata.rs
@@ -146,7 +146,10 @@ mod tests {
             }],
             "unrelated": true
         });
-        let metadata = Metadata::parse(&serde_json::to_vec(&input).unwrap()).unwrap();
+        // Intentional deep-validation canary: leak only this test's small JSON fixture.
+        // Repair by retaining buffer ownership, not by suppressing Miri's leak detection.
+        let input = Box::leak(serde_json::to_vec(&input).unwrap().into_boxed_slice());
+        let metadata = Metadata::parse(input).unwrap();
         assert_eq!(metadata.workspace_root, PathBuf::from("workspace"));
         assert_eq!(
             metadata.packages.first().unwrap().manifest_path,


### PR DESCRIPTION
[Copilot speaking]

## Purpose

Exercise nightly Deep validation failure reporting, triage and repair with a deliberately introduced, harmless defect. This PR intentionally leaves a memory leak for the remediation workflow to fix after merge.

## Canary behavior

The metadata-decoding unit test in unpublished `release-target-check` leaks its small serialized JSON fixture through `Box::leak`. All existing assertions remain intact. The allocation exists only in the test process: the executable, release verification behavior and published packages are unchanged. There is no unsafe code, external side effect, timing dependency or checker-specific conditional behavior.

Ordinary native execution accepts this leak, whereas the nightly Miri recipe reports `memory leaked` after the test completes. Standard validation does not run Miri. The existing nightly matrix, diagnostics and report job are unchanged, so the failure follows the normal reporting path rather than a synthetic alert.

## Manual exercise and repair

Deep validation runs only against `main`. After merging, let the nightly run execute or dispatch **Actions -> Deep validation -> Run workflow** on `main`. Expect a `scheduled-run-failure` report identifying the metadata test's leaked allocation, followed by the normal triage into a `scheduled-finding` and a repair PR when the corresponding Local App automations run.

The intended repair retains ownership of the serialized buffer and borrows it for parsing, preserving the metadata assertions. Remove the canary comments with that repair; do not ignore the test or suppress Miri leak detection. Human approval and merge remain required. This PR does not dispatch a run or execute triage/repair itself.

## Version/release plan

No released-content or version changes. `release-target-check` has `publish = false` and remains at `0.0.0`. The expanded release plan is empty; all publishable packages are unchanged, with no dependent/group movements, pending increments or first-publication handoffs.